### PR TITLE
try catch ImportError if mock not installed(#2)

### DIFF
--- a/mars/compat/__init__.py
+++ b/mars/compat/__init__.py
@@ -194,8 +194,12 @@ else:
         def total_seconds(self):
             return self.days * 86400.0 + self.seconds + self.microseconds * 1.0e-6
     else:
-        import unittest
-        import mock
+        try:
+            import unittest
+            import mock
+        except ImportError:
+            pass
+
         from collections import OrderedDict
 
         dictconfig = lambda config: logging.config.dictConfig(config)


### PR DESCRIPTION
For python 2.7, mock is only required for unittest, but we did not catch the ImportError, so if the mock not installed, the error will be raised if try to import mars.tensor