### PR TITLE
Add travis config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,12 +1,14 @@
 [run]
 branch = True
 concurrency = multiprocessing,gevent
-plugins = Cython.Coverage
-
-[report]
+include =
+    mars/*
 omit =
     mars/lib/functools32/*
     mars/lib/futures/*
-    mars/protos/*
     mars/lib/enum.py
     mars/lib/six.py
+    mars/lib/tblib/*
+    mars/lib/uhashring/*
+    mars/serialize/protos/*
+    */tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+
+matrix:
+  include:
+    - os: linux
+      python: "3.7"
+      dist: xenial
+      sudo: true
+    - os: osx
+      language: generic
+      env: PYTHON=2.7.12
+    - os: osx
+      language: generic
+      env: PYTHON=3.5.3
+    - os: osx
+      language: generic
+      env: PYTHON=3.6.1
+    - os: osx
+      language: generic
+      env: PYTHON=3.7.0
+
+before_install:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then source ./bin/travis-prepare-osx.sh; fi
+  - pip install --upgrade pip setuptools wheel
+
+# command to install dependencies
+install:
+  - pip install -r requirements-dev.txt
+  - pip install -r requirements-extra.txt
+  - pip install coveralls
+  - python setup.py build_ext -i
+
+# command to run tests
+script:
+  pytest --timeout=1500 --forked --cov-config .coveragerc --cov=mars mars
+
+after_success:
+  - coveralls
+  - ./bin/travis-upload.sh
+# Add env var to detect it during build
+env: TRAVIS=True

--- a/bin/travis-prepare-osx.sh
+++ b/bin/travis-prepare-osx.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+    set -e
+
+    ulimit -n 1024
+
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+    PYENV_ROOT="$HOME/.pyenv"
+    PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init -)"
+
+    function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+
+    if version_gt "3.0" "$PYTHON" ; then
+        curl -O https://bootstrap.pypa.io/get-pip.py
+        python get-pip.py --user
+    else
+        pyenv install $PYTHON
+        pyenv global $PYTHON
+    fi
+fi
+
+#check python version
+python -V

--- a/bin/travis-upload.sh
+++ b/bin/travis-upload.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+python setup.py sdist --formats=gztar
+python setup.py bdist_wheel
+
+for whl in dist/*.whl; do
+	auditwheel repair $whl -w dist/
+done
+rm dist/*-linux*.whl
+
+echo "[distutils]"                                  > ~/.pypirc
+echo "index-servers ="                             >> ~/.pypirc
+echo "    pypi"                                    >> ~/.pypirc
+echo "[pypi]"                                      >> ~/.pypirc
+echo "repository=https://upload.pypi.org/legacy/"  >> ~/.pypirc
+echo "username=pyodps"                             >> ~/.pypirc
+echo "password=$PASSWD"                            >> ~/.pypirc
+python -m pip install twine
+if [ "$TRAVIS_TAG" ]; then
+  python -m twine upload -r pypi --skip-existing dist/*.tar.gz;
+else
+  echo "Not on a tag, won't deploy to pypi";
+fi

--- a/mars/actors/pool/gevent_pool.pyx
+++ b/mars/actors/pool/gevent_pool.pyx
@@ -395,6 +395,13 @@ class Connections(object):
 
             return self._connect(conn, lock)
 
+    def __del__(self):
+        for c, _ in self.conn_locks.values():
+            try:
+                c.close()
+            except:
+                pass
+
 
 cdef class ActorRemoteHelper:
     """

--- a/mars/scheduler/resource.py
+++ b/mars/scheduler/resource.py
@@ -52,6 +52,9 @@ class ResourceActor(SchedulerActor):
         timeout = options.scheduler.status_timeout
         for worker in list(self._meta_cache.keys()):
             worker_meta = self._meta_cache[worker]
+            if 'update_time' not in worker_meta:
+                continue
+
             last_time = datetime.strptime(worker_meta['update_time'], '%Y-%m-%d %H:%M:%S')
             time_delta = timedelta(seconds=timeout)
             if last_time + time_delta < datetime.now():

--- a/mars/scheduler/tests/test_operand.py
+++ b/mars/scheduler/tests/test_operand.py
@@ -134,8 +134,11 @@ class Test(unittest.TestCase):
                         final_keys.add(c.op.key)
 
                 graph_ref.create_operand_actors()
+                start_time = time.time()
                 while True:
                     gevent.sleep(0.1)
+                    if time.time() - start_time > 30:
+                        raise SystemError('Wait for execution finish timeout')
                     if kv_store_ref.read('/sessions/%s/graph/%s/state' % (session_id, graph_key)).value.lower() \
                             in ('succeeded', 'failed', 'cancelled'):
                         break
@@ -256,7 +259,9 @@ class Test(unittest.TestCase):
                     gevent.sleep(0.1)
                     if not cancel_called and time.time() > start_time + 0.8:
                         cancel_called = True
-                        graph_ref.stop_graph()
+                        graph_ref.stop_graph(_tell=True)
+                    if time.time() - start_time > 30:
+                        raise SystemError('Wait for execution finish timeout')
                     if kv_store_ref.read('/sessions/%s/graph/%s/state' % (session_id, graph_key)).value.lower() \
                             in ('succeeded', 'failed', 'cancelled'):
                         break

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -399,7 +399,7 @@ def deserialize_graph(graph_b64):
     from .serialize.protos.graph_pb2 import GraphDef
     from .graph import DirectedGraph
     try:
-        json_obj = json.loads(graph_b64)
+        json_obj = json.loads(to_str(graph_b64))
         return DirectedGraph.from_json(json_obj)
     except (SyntaxError, ValueError):
         g = GraphDef()

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -21,7 +21,7 @@ import logging
 
 import requests
 
-from ..compat import six
+from ..compat import six, TimeoutError
 from ..serialize import dataserializer
 from ..errors import ExecutionInterrupted
 
@@ -111,6 +111,8 @@ class Session(object):
                     if resp.status_code >= 400:
                         raise SystemError('Failed to stop graph execution. Code: %d, Reason: %s, Content:\n%s' %
                                           (resp.status_code, resp.reason, resp.text))
+            if time.time() - exec_start_time > timeout:
+                raise TimeoutError
             data_list = []
             for tk in targets:
                 resp = self._req_session.get(session_url + '/graph/' + graph_key + '/data/' + tk)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,9 @@
-numpy>=1.8.0
+numpy>=1.14.0
 requests>=2.4.0
 pyarrow>=0.11.0
 cython>=0.29
+mock>=2.0.0
+pytest>=3.5.0
+pytest-cov>=2.5.0
+pytest-timeout>=1.2.0
+pytest-xdist>=1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.8.0
+numpy>=1.14.0
 requests>=2.4.0
 pyarrow>=0.11.0


### PR DESCRIPTION
appveyor.yml not included temporarily, as we need to test Mars in Windows without plasma_store.

Altered cases:

* test_gevent_pool.py::Test::testRemoteConnections

  Under MacOS in Travis CI, the number of connections exceeds the system limitation.

* scheduler/test_main.py::Test::testMain

  Sometimes KVStoreActor is not ready when the worker is about to register.

* test_promise::Test::testAll

  Orders of latter ```gen_promise``` and prior ```thread_body``` may change randomly, which is consistent with the expectation.

Fixed cases:

* test_api::Test::testApi

  Web session does not handle timeout properly.

* test_operand.py::Test::testOperandActorWithCancel

  stop_graph sometimes get stuck due to sync operation.

Changed dependency:

* numpy >= 1.14, as pyarrow depends on the new API.