### PR TITLE
remove support code for py26

### DIFF
--- a/mars/actors/pool/tests/test_gevent_pool.py
+++ b/mars/actors/pool/tests/test_gevent_pool.py
@@ -19,10 +19,11 @@ import itertools
 import hashlib
 import uuid
 import time
+import unittest
 
 import gevent
 
-from mars.compat import unittest, six, BrokenPipeError
+from mars.compat import six, BrokenPipeError
 from mars.actors import create_actor_pool as new_actor_pool, Actor, ActorNotExist, Distributor, new_client
 from mars.actors.pool.gevent_pool import Dispatcher, Connections
 from mars.utils import to_binary

--- a/mars/compat/__init__.py
+++ b/mars/compat/__init__.py
@@ -31,13 +31,7 @@ from unicodedata import east_asian_width
 
 from ..lib import six
 
-PY26 = six.PY2 and sys.version_info[1] == 6
 PY27 = six.PY2 and sys.version_info[1] == 7
-LESS_PY26 = sys.version_info[:2] < (2, 6)
-LESS_PY32 = sys.version_info[:2] < (3, 2)
-LESS_PY33 = sys.version_info[:2] < (3, 3)
-LESS_PY34 = sys.version_info[:2] < (3, 4)
-LESS_PY35 = sys.version_info[:2] < (3, 5)
 PYPY = platform.python_implementation().lower() == 'pypy'
 
 SEEK_SET = 0
@@ -71,23 +65,21 @@ if six.PY3:
     StringIO = io.StringIO
     BytesIO = io.BytesIO
 
-    if LESS_PY34:
+    if PY27:
         from ..lib import enum
     else:
         import enum
 
-    if LESS_PY33:
+    if PY27:
         try:
             import cdecimal as decimal
 
             DECIMAL_TYPES.append(decimal.Decimal)
-        except:
+        except ImportError:
             import decimal
     else:
         import decimal
 
-    import unittest
-    import unittest.mock as mock
     from collections import OrderedDict
 
     OrderedDict3 = OrderedDict
@@ -176,36 +168,12 @@ else:
         else:
             return len(data)
 
-    if PY26:
-        warnings.warn('Python 2.6 is no longer supported by the Python core team. A future version of Mars ' +
-                      'will drop support for this version.')
+    from collections import OrderedDict
 
-        try:
-            import unittest2 as unittest
-            import unittest2.mock as mock
-        except ImportError:
-            pass
+    dictconfig = lambda config: logging.config.dictConfig(config)
 
-        try:
-            from ordereddict import OrderedDict
-        except ImportError:
-            raise
-
-        def total_seconds(self):
-            return self.days * 86400.0 + self.seconds + self.microseconds * 1.0e-6
-    else:
-        try:
-            import unittest
-            import mock
-        except ImportError:
-            pass
-
-        from collections import OrderedDict
-
-        dictconfig = lambda config: logging.config.dictConfig(config)
-
-        from datetime import timedelta
-        total_seconds = timedelta.total_seconds
+    from datetime import timedelta
+    total_seconds = timedelta.total_seconds
 
     import __builtin__ as builtins  # don't remove
     from ..lib import futures  # don't remove
@@ -243,18 +211,6 @@ else:
         for element in it:
             total = func(total, element)
             yield total
-
-if PY26:
-    try:
-        import simplejson as json
-    except ImportError:
-        pass
-if PY26 or LESS_PY32:
-    try:
-        from .tests.dictconfig import dictConfig
-        dictconfig = lambda config: dictConfig(config)
-    except ImportError:
-        pass
 
 if six.PY3:
     from contextlib import suppress
@@ -482,7 +438,7 @@ except ImportError:
                     gc.enable()
 
 
-__all__ = ['sys', 'builtins', 'logging.config', 'unittest', 'mock', 'OrderedDict', 'dictconfig', 'suppress',
+__all__ = ['sys', 'builtins', 'logging.config', 'OrderedDict', 'dictconfig', 'suppress',
            'reduce', 'reload_module', 'Queue', 'PriorityQueue', 'Empty', 'ElementTree', 'ElementTreeParseError',
            'urlretrieve', 'pickle', 'urlencode', 'urlparse', 'unquote', 'quote', 'quote_plus', 'parse_qsl',
            'Enum', 'ConfigParser', 'decimal', 'Decimal', 'DECIMAL_TYPES', 'FixedOffset', 'utc', 'finalize',

--- a/mars/lib/sparse/tests/test_coo.py
+++ b/mars/lib/sparse/tests/test_coo.py
@@ -1,9 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 
 from mars.lib.sparse.core import issparse
 import mars.lib.sparse as mls
 from mars.tests.core import TestBase
-from mars.compat import unittest
 
 DEBUG = True
 

--- a/mars/lib/sparse/tests/test_sparse.py
+++ b/mars/lib/sparse/tests/test_sparse.py
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import numpy as np
 import scipy.sparse as sps
 
-from mars.compat import unittest
 from mars.tests.core import TestBase
-from mars.compat import unittest
 from mars.lib.sparse import SparseNDArray
 from mars.lib.sparse.core import issparse
 import mars.lib.sparse as mls

--- a/mars/scheduler/tests/test_assigner.py
+++ b/mars/scheduler/tests/test_assigner.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 import uuid
+
 import gevent
 
 from mars.cluster_info import ClusterInfoActor
 from mars.scheduler import ResourceActor, AssignerActor, KVStoreActor
 from mars.actors import FunctionActor, create_actor_pool
-from mars.compat import unittest
 
 
 class PromiseReplyTestActor(FunctionActor):

--- a/mars/scheduler/tests/test_graph.py
+++ b/mars/scheduler/tests/test_graph.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import uuid
+import unittest
+
 import gevent
 
 import mars.tensor as mt
@@ -20,7 +22,6 @@ from mars.cluster_info import ClusterInfoActor
 from mars.scheduler import GraphActor, ResourceActor, KVStoreActor, AssignerActor
 from mars.utils import serialize_graph, deserialize_graph
 from mars.actors import create_actor_pool
-from mars.compat import unittest
 
 
 class Test(unittest.TestCase):

--- a/mars/scheduler/tests/test_main.py
+++ b/mars/scheduler/tests/test_main.py
@@ -19,6 +19,7 @@ import subprocess
 import uuid
 import json
 import signal
+import unittest
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -26,7 +27,6 @@ import gevent
 
 from mars.serialize.dataserializer import loads
 from mars.config import options
-from mars.compat import unittest
 from mars.tensor.expressions.datasource import ones
 from mars.utils import get_next_port
 from mars.actors.core import new_client

--- a/mars/scheduler/tests/test_operand.py
+++ b/mars/scheduler/tests/test_operand.py
@@ -14,6 +14,7 @@
 
 import sys
 import time
+import unittest
 import uuid
 from collections import defaultdict
 
@@ -26,7 +27,7 @@ from mars.errors import ExecutionInterrupted
 from mars.scheduler import OperandActor, ResourceActor, GraphActor, AssignerActor, KVStoreActor
 from mars.utils import serialize_graph, deserialize_graph
 from mars.actors import create_actor_pool
-from mars.compat import unittest, mock
+from mars.tests.core import mock
 
 
 class FakeExecutionActor(promise.PromiseActor):

--- a/mars/scheduler/tests/test_resource.py
+++ b/mars/scheduler/tests/test_resource.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 import uuid
+
 import gevent
 
 from mars.scheduler import ResourceActor
 from mars.actors import create_actor_pool
-from mars.compat import unittest
 
 
 class Test(unittest.TestCase):

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -17,6 +17,7 @@
 import json
 import os
 import tempfile
+import unittest
 
 import numpy as np
 
@@ -25,7 +26,7 @@ try:
 except ImportError:
     pyarrow = None
 
-from mars.compat import unittest, six, OrderedDict, BytesIO
+from mars.compat import six, OrderedDict, BytesIO
 from mars.lib import sparse
 from mars.serialize.core import Serializable, IdentityField, StringField, Int32Field, BytesField, \
     KeyField, ReferenceField, OneOfField, ListField, NDArrayField, DictField, TupleField, \

--- a/mars/tensor/execution/optimizes/tests/test_compose.py
+++ b/mars/tensor/execution/optimizes/tests/test_compose.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2018 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 from mars.compat import lmap
-from mars.compat import unittest
 from mars.tensor.execution.core import Executor
 from mars.tensor.expressions.arithmetic import TensorTreeAdd
 from mars.tensor.expressions.indexing import TensorSlice

--- a/mars/tensor/execution/tests/test_arithmetic_execute.py
+++ b/mars/tensor/execution/tests/test_arithmetic_execute.py
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import numpy as np
 import scipy.sparse as sps
 
-from mars.compat import unittest, six
+from mars.compat import six
 from mars.tensor.execution.core import Executor
 from mars.tensor.expressions.datasource import ones, tensor, zeros
 from mars.tensor.expressions.arithmetic import add, truediv, frexp, \

--- a/mars/tensor/execution/tests/test_base_execute.py
+++ b/mars/tensor/execution/tests/test_base_execute.py
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import numpy as np
 import scipy.sparse as sps
 
-from mars.compat import unittest
 from mars.tensor.execution.core import Executor
 from mars import tensor as mt
 from mars.tensor.expressions.datasource import tensor, ones, zeros, arange

--- a/mars/tensor/execution/tests/test_core_execute.py
+++ b/mars/tensor/execution/tests/test_core_execute.py
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mars.compat import unittest
+import unittest
+
 from mars.tensor.execution.core import Executor
 from mars.tensor import ones
 from mars.session import LocalSession, Session

--- a/mars/tensor/execution/tests/test_cupy_execute.py
+++ b/mars/tensor/execution/tests/test_cupy_execute.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 
-from mars.compat import unittest
 from mars.tensor.execution.core import Executor
 from mars.tensor.execution.cp import _evaluate
 from mars.tensor.expressions.datasource import ones

--- a/mars/tensor/execution/tests/test_fft_execute.py
+++ b/mars/tensor/execution/tests/test_fft_execute.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 
 import numpy as np
 
-from mars.compat import unittest
 from mars.tensor.execution.core import Executor
 from mars.tensor.expressions.datasource import tensor
 from mars.tensor.expressions.fft import fft, ifft, fft2, ifft2, fftn, ifftn, rfft, irfft, rfft2, irfft2, \

--- a/mars/tensor/execution/tests/test_index_execute.py
+++ b/mars/tensor/execution/tests/test_index_execute.py
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 
 import numpy as np
 import scipy.sparse as sps
 
-from mars.compat import unittest
 from mars.tensor.execution.core import Executor
 from mars.tensor.expressions.datasource import tensor, arange
 from mars.tensor.expressions.indexing import take, compress, extract, choose, \

--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 
 import numpy as np
 import scipy.sparse as sps
 
-from mars.compat import unittest
 from mars.tensor.execution.core import Executor
 from mars.tensor.expressions.datasource import tensor, diag, ones, arange
 from mars.tensor.expressions.linalg import qr, svd, cholesky, norm, lu, \

--- a/mars/tensor/execution/tests/test_merge_execute.py
+++ b/mars/tensor/execution/tests/test_merge_execute.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2018 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 
 import numpy as np
 import scipy.sparse as sps
 
-from mars.compat import unittest
 from mars.tensor.execution.core import Executor
 from mars.tensor.expressions.datasource import tensor
 from mars.tensor.expressions.merge import concatenate, stack, hstack, vstack, dstack, column_stack

--- a/mars/tensor/execution/tests/test_numexpr_execute.py
+++ b/mars/tensor/execution/tests/test_numexpr_execute.py
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import itertools
 import numpy as np
 
-from mars.compat import unittest
 from mars.tensor.execution.core import Executor
 from mars.tensor.expressions.datasource import tensor
 

--- a/mars/tensor/execution/tests/test_prefetch.py
+++ b/mars/tensor/execution/tests/test_prefetch.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2018 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 import threading
+import unittest
 
-from mars.compat import unittest
 from mars.tensor.execution.core import Executor
 from mars.tensor.expressions.datasource import ones
 

--- a/mars/tensor/execution/tests/test_random_execute.py
+++ b/mars/tensor/execution/tests/test_random_execute.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 
 import numpy as np
 
-from mars.compat import unittest
 from mars.tensor.execution.core import Executor
 from mars.operands.random import State
 from mars.tensor.expressions.datasource import tensor as from_ndarray

--- a/mars/tensor/execution/tests/test_reduction_execute.py
+++ b/mars/tensor/execution/tests/test_reduction_execute.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2018 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 
 import numpy as np
 import scipy.sparse as sps
 
-from mars.compat import unittest
 from mars.tensor.execution.core import Executor
 from mars.tensor.expressions.datasource import ones, tensor
 from mars.tensor.expressions.reduction import mean, nansum, nanmax, nanmin, nanmean, nanprod, nanargmax, \

--- a/mars/tensor/expressions/lib/tests/test_index_tricks.py
+++ b/mars/tensor/expressions/lib/tests/test_index_tricks.py
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mars.compat import unittest
+import unittest
+
 from mars.tensor.expressions.lib import nd_grid
 
 

--- a/mars/tensor/expressions/tests/test_arithmetic.py
+++ b/mars/tensor/expressions/tests/test_arithmetic.py
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import numpy as np
 
 from mars import operands
-from mars.compat import unittest
 from mars.tensor.expressions.datasource import array, ones, tensor, empty
 from mars.tensor.expressions.datasource.core import TensorFetchChunk
 from mars.tensor.expressions.arithmetic import add, subtract, truediv, log, frexp, around, \

--- a/mars/tensor/expressions/tests/test_base.py
+++ b/mars/tensor/expressions/tests/test_base.py
@@ -1,22 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2018 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import numpy as np
 
-from mars.compat import unittest
 from mars.tensor.expressions.datasource import ones, tensor, arange, array, asarray
 from mars.tensor.expressions.base import transpose, broadcast_to, where, argwhere, array_split, \
     split, squeeze, digitize, result_type, repeat, copyto, isin

--- a/mars/tensor/expressions/tests/test_fft.py
+++ b/mars/tensor/expressions/tests/test_fft.py
@@ -1,22 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2018 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import numpy as np
 
-from mars.compat import unittest
 from mars.tensor.expressions.datasource import ones
 from mars.tensor import fft
 

--- a/mars/tensor/expressions/tests/test_indexing.py
+++ b/mars/tensor/expressions/tests/test_indexing.py
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import numpy as np
 
-from mars.compat import unittest
 from mars.tensor.expressions.datasource import ones, tensor
 from mars.tensor.expressions.datasource.ones import TensorOnes
 from mars.tensor.expressions.indexing import choose, unravel_index, nonzero

--- a/mars/tensor/expressions/tests/test_linalg.py
+++ b/mars/tensor/expressions/tests/test_linalg.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 
 import numpy as np
 
-from mars.compat import unittest
 import mars.tensor as mt
 
 

--- a/mars/tensor/expressions/tests/test_merge.py
+++ b/mars/tensor/expressions/tests/test_merge.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2018 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 
 import numpy as np
 
-from mars.compat import unittest
 from mars.tensor.expressions.datasource import ones
 from mars.tensor.expressions.merge import concatenate, stack
 

--- a/mars/tensor/expressions/tests/test_rechunk.py
+++ b/mars/tensor/expressions/tests/test_rechunk.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 
-from mars.compat import unittest
 from mars.tensor.expressions.datasource import ones
 from mars.tensor.expressions.indexing.slice import TensorSlice
 from mars.tensor.expressions.rechunk.rechunk import compute_rechunk

--- a/mars/tensor/expressions/tests/test_reduction.py
+++ b/mars/tensor/expressions/tests/test_reduction.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2018 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mars.compat import unittest
+import unittest
+
 from mars.tensor.expressions.datasource import ones, tensor
 from mars.operands import MeanCombine, MeanChunk, Mean, Concatenate, Argmax, Argmin,\
     ArgmaxChunk, ArgmaxCombine, ArgminChunk, ArgminCombine

--- a/mars/tensor/expressions/tests/test_reshape.py
+++ b/mars/tensor/expressions/tests/test_reshape.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 
-from mars.compat import unittest
 from mars.tensor.expressions.datasource import ones
 
 

--- a/mars/tensor/expressions/tests/test_utils.py
+++ b/mars/tensor/expressions/tests/test_utils.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2018 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 from numbers import Integral
 
 import numpy as np
 
-from mars.compat import unittest
 from mars.tensor.expressions.utils import normalize_chunks, broadcast_shape, \
     replace_ellipsis, calc_sliced_size, slice_split, decide_unify_split, unify_chunks, \
     split_index_into_chunks, decide_chunks

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -19,6 +19,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+import unittest
 from contextlib import contextmanager
 from collections import Iterable
 from weakref import ReferenceType
@@ -33,6 +34,16 @@ from mars.core import BaseWithKey
 from mars.compat import six
 from mars.serialize import serializes, deserializes, \
     ProtobufSerializeProvider, JsonSerializeProvider
+
+
+if compat.PY27:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+else:
+    from unittest import mock
+    _mock = mock
 
 
 @contextmanager
@@ -75,7 +86,7 @@ def gen_test(timeout=10):
     return _
 
 
-class TestCase(compat.unittest.TestCase):
+class TestCase(unittest.TestCase):
     pass
 
 
@@ -87,7 +98,7 @@ class MultiGetDict(dict):
         return super(MultiGetDict, self).__getitem__(item)
 
 
-class TestBase(compat.unittest.TestCase):
+class TestBase(unittest.TestCase):
     def setUp(self):
         self.pb_serialize = lambda *args, **kw: \
             serializes(ProtobufSerializeProvider(), *args, **kw)

--- a/mars/tests/test_distributor.py
+++ b/mars/tests/test_distributor.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mars.compat import unittest
+import unittest
+
 from mars.distributor import BaseDistributor
 
 

--- a/mars/tests/test_graph.py
+++ b/mars/tests/test_graph.py
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mars.compat import unittest
+import unittest
+
 from mars.graph import DAG, GraphContainsCycleError
 
 

--- a/mars/tests/test_promise.py
+++ b/mars/tests/test_promise.py
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import gc
 import functools
 import threading
 import time
+import unittest
 import weakref
 
 import gevent
 
 from mars.actors import create_actor_pool
-from mars.compat import unittest, Queue
+from mars.compat import Queue
 from mars import promise
 
 

--- a/mars/worker/tests/base.py
+++ b/mars/worker/tests/base.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import os
+import unittest
 
 from mars.config import options
-from mars.compat import unittest
 from mars.utils import classproperty
 
 

--- a/mars/worker/tests/test_chunkholder.py
+++ b/mars/worker/tests/test_chunkholder.py
@@ -19,13 +19,14 @@ from functools import partial
 import gevent
 
 from mars.actors import create_actor_pool
-from mars.compat import six, mock
+from mars.compat import six
 from mars.config import options
 from mars.utils import get_next_port, calc_data_size
 from mars import promise
 from mars.errors import StoreFull, SpillExhausted
 from mars.cluster_info import ClusterInfoActor
 from mars.scheduler.kvstore import KVStoreActor
+from mars.tests.core import mock
 from mars.worker.tests.base import WorkerCase
 from mars.worker import *
 from mars.worker.utils import WorkerActor

--- a/mars/worker/tests/test_dispatcher.py
+++ b/mars/worker/tests/test_dispatcher.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import time
+import unittest
 from functools import partial
 
 import gevent
 
-from mars.compat import unittest, mock
+from mars.tests.core import mock
 from mars.utils import get_next_port
 from mars.actors import create_actor_pool
 from mars.promise import PromiseActor

--- a/mars/worker/tests/test_main.py
+++ b/mars/worker/tests/test_main.py
@@ -17,12 +17,12 @@ import sys
 import signal
 import subprocess
 import time
+import unittest
 import uuid
 
 import gevent
 
 from mars.actors import FunctionActor, create_actor_pool
-from mars.compat import unittest
 from mars.config import options
 from mars.utils import get_next_port, serialize_graph
 from mars.cluster_info import ClusterInfoActor


### PR DESCRIPTION
Remove support code for Python 2.6 and move compatibility code for unittest.mock into mars.tests.core.