### PR TITLE
fix KeyError in stop_graph when graph preparation failed

### DIFF
--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -182,6 +182,8 @@ class GraphActor(SchedulerActor):
         self.state = GraphState.CANCELLING
 
         for chunk in self.get_chunk_graph():
+            if chunk.op.key not in self._operand_infos:
+                continue
             if self._operand_infos[chunk.op.key]['state'] in \
                     (OperandState.READY, OperandState.RUNNING, OperandState.FINISHED):
                 # we only need to stop on ready, running and finished operands

--- a/mars/web/api.py
+++ b/mars/web/api.py
@@ -106,6 +106,8 @@ class GraphApiHandler(ApiRequestHandler):
             self.write(json.dumps(dict(state='failed')))
         elif state == GraphState.CANCELLED:
             self.write(json.dumps(dict(state='cancelled')))
+        elif state == GraphState.CANCELLING:
+            self.write(json.dumps(dict(state='cancelling')))
         elif state == GraphState.PREPARING:
             self.write(json.dumps(dict(state='preparing')))
 

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -95,7 +95,7 @@ class Session(object):
                         continue
                     elif resp_json['state'] == 'success':
                         break
-                    elif resp_json['state'] == 'cancelled':
+                    elif resp_json['state'] == ('cancelled', 'cancelling'):
                         raise ExecutionInterrupted
                     elif resp_json['state'] == 'failed':
                         # TODO add traceback


### PR DESCRIPTION
`GraphActor.stop_graph` will raise `KeyError` when operand actor hasn't been created.

fix #19 