### PR TITLE
Fix web session when submit multiply tensors

### DIFF
--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -24,6 +24,7 @@ import requests
 from ..compat import six, TimeoutError
 from ..serialize import dataserializer
 from ..errors import ExecutionInterrupted
+from ..graph import DirectedGraph
 
 logger = logging.getLogger(__name__)
 
@@ -51,12 +52,14 @@ class Session(object):
         content = json.loads(resp.text)
         self._session_id = content['session_id']
 
-    def run(self, tensors, compose=True, wait=True, timeout=-1):
-        from ..graph import DirectedGraph
-        graph = DirectedGraph()
+    def run(self, *tensors, **kw):
+        timeout = kw.pop('timeout', -1)
+        compose = kw.pop('compose', True)
+        wait = kw.pop('wait', True)
+        if kw:
+            raise TypeError('run got unexpected key arguments {0}'.format(', '.join(kw.keys())))
 
-        if not isinstance(tensors, (list, tuple, set)):
-            tensors = [tensors]
+        graph = DirectedGraph()
         for t in tensors:
             graph = t.build_graph(graph=graph, tiled=False, compose=compose)
         targets = [t.key for t in tensors]

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -167,6 +167,11 @@ class Test(unittest.TestCase):
             value = sess.run(c, timeout=120)
             assert_array_equal(value, va.dot(vb))
 
+            # test test multiple outputs
+            a = mt.random.rand(10, 10)
+            U, s, V, raw = sess.run(list(mt.linalg.svd(a)) + [a])
+            np.testing.assert_allclose(U.dot(np.diag(s).dot(V)), raw)
+
             # check web UI requests
             res = requests.get(service_ep)
             self.assertEqual(res.status_code, 200)


### PR DESCRIPTION
Web session `run` method signature is now same as local session's.
resolve #30 