### PR TITLE
Fix stop graph failed due to failure of serialization

### DIFF
--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -31,13 +31,13 @@ from mars.worker.dispatcher import DispatchActor
 
 
 def _on_deserialize_fail(x):
-    raise ValueError('intend to throw error on' + str(x))
+    raise TypeError('intend to throw error on' + str(x))
 
 
 class SerializeMustFailOperand(Operand, TensorElementWise):
-    _op_id_ = 356789
+    _op_type_ = 356789
 
-    _f = Int64Field('f')
+    _f = Int64Field('f', on_deserialize=_on_deserialize_fail)
 
     def __init__(self, f=None, **kw):
         super(SerializeMustFailOperand, self).__init__(_f=f, **kw)

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -160,4 +160,5 @@ class Test(unittest.TestCase):
         tensor = op.new_tensor(None, (3, 3))
 
         with new_cluster(scheduler_n_process=2, worker_n_process=2) as cluster:
-            cluster.session.run(tensor)
+            with self.assertRaises(SystemError):
+                cluster.session.run(tensor)

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -14,18 +14,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 import unittest
 
 import numpy as np
 
 from mars import tensor as mt
+from mars.operands import Operand
+from mars.tensor.expressions.arithmetic.core import TensorElementWise
+from mars.serialize import Int64Field
 from mars.config import options
 from mars.session import new_session, Session
 from mars.deploy.local.core import new_cluster, LocalDistributedCluster, gen_endpoint
 from mars.cluster_info import ClusterInfoActor
 from mars.scheduler.session import SessionManagerActor
 from mars.worker.dispatcher import DispatchActor
+
+
+def _on_deserialize_fail(x):
+    raise ValueError('intend to throw error on' + str(x))
+
+
+class SerializeMustFailOperand(Operand, TensorElementWise):
+    _op_id_ = 356789
+
+    _f = Int64Field('f')
+
+    def __init__(self, f=None, **kw):
+        super(SerializeMustFailOperand, self).__init__(_f=f, **kw)
 
 
 class Test(unittest.TestCase):
@@ -139,3 +154,10 @@ class Test(unittest.TestCase):
 
                 np.testing.assert_allclose(U_result, U_expected)
                 np.testing.assert_allclose(s_result, s_expectd)
+
+    def testGraphFail(self):
+        op = SerializeMustFailOperand(f=3)
+        tensor = op.new_tensor(None, (3, 3))
+
+        with new_cluster(scheduler_n_process=2, worker_n_process=2) as cluster:
+            cluster.session.run(tensor)

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -192,7 +192,13 @@ class GraphActor(SchedulerActor):
         from .operand import OperandActor
         self.state = GraphState.CANCELLING
 
-        for chunk in self.get_chunk_graph():
+        try:
+            chunk_graph = self.get_chunk_graph()
+        except KeyError:
+            self.state = GraphState.CANCELLED
+            return
+
+        for chunk in chunk_graph:
             if chunk.op.key not in self._operand_infos:
                 continue
             if self._operand_infos[chunk.op.key]['state'] in \


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
When the graph is deserializing and failed, the stop graph is also failed cuz it cannot fetch the chunk graph to do some clear job which make the client hang, fix it and add a test for it.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
fix #19 
