### PR TITLE
Support set endpoint for web session to reuse the session but with a different web

### DIFF
--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -193,10 +193,6 @@ class LocalDistributedClusterClient(object):
     def web_endpoint(self):
         return self._web_endpoint
 
-    @web_endpoint.setter
-    def web_endpoint(self, web_endpoint):
-        self._web_endpoint = web_endpoint
-
     @property
     def session(self):
         return self._session

--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -193,6 +193,10 @@ class LocalDistributedClusterClient(object):
     def web_endpoint(self):
         return self._web_endpoint
 
+    @web_endpoint.setter
+    def web_endpoint(self, web_endpoint):
+        self._web_endpoint = web_endpoint
+
     @property
     def session(self):
         return self._session

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -34,6 +34,15 @@ class LocalClusterSession(object):
         # create session on the cluster side
         self._api.create_session(self._session_id)
 
+    @property
+    def endpoint(self):
+        return self._endpoint
+
+    @endpoint.setter
+    def endpoint(self, endpoint):
+        self._endpoint = endpoint
+        self._api = MarsAPI(self._endpoint)
+
     def run(self, *tensors, **kw):
         timeout = kw.pop('timeout', -1)
         if kw:

--- a/mars/session.py
+++ b/mars/session.py
@@ -14,14 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import uuid
-import json
-import time
 import numpy as np
-
-from .api import MarsAPI
-from .scheduler.graph import GraphState
-from .serialize import dataserializer
 
 
 class LocalSession(object):
@@ -37,6 +30,8 @@ class LocalSession(object):
 
     @endpoint.setter
     def endpoint(self, endpoint):
+        if endpoint is not None:
+            raise ValueError('Local session cannot set endpoint')
         self._endpoint = endpoint
 
     def run(self, *tensors, **kw):
@@ -103,6 +98,12 @@ class Session(object):
             return ret
         return ret[0]
 
+    def endpoint(self):
+        return self._sess.endpoint
+
+    def set_endpoint(self, endpoint):
+        self._sess.endpoint = endpoint
+
     def decref(self, *keys):
         if hasattr(self._sess, 'decref'):
             self._sess.decref(*keys)
@@ -113,12 +114,6 @@ class Session(object):
             return obj
         except AttributeError:
             raise
-
-    def __setattr__(self, key, value):
-        if key == 'endpoint':
-            return setattr(self._sess, key, value)
-        else:
-            object.__setattr__(self, key, value)
 
     def __enter__(self):
         self._sess.__enter__()

--- a/mars/session.py
+++ b/mars/session.py
@@ -29,6 +29,15 @@ class LocalSession(object):
         from .tensor.execution.core import Executor
 
         self._executor = Executor()
+        self._endpoint = None
+
+    @property
+    def endpoint(self):
+        return self._endpoint
+
+    @endpoint.setter
+    def endpoint(self, endpoint):
+        self._endpoint = endpoint
 
     def run(self, *tensors, **kw):
         if self._executor is None:
@@ -107,10 +116,7 @@ class Session(object):
 
     def __setattr__(self, key, value):
         if key == 'endpoint':
-            try:
-                return setattr(self._sess, key, value)
-            except AttributeError:
-                raise
+            return setattr(self._sess, key, value)
         else:
             object.__setattr__(self, key, value)
 

--- a/mars/session.py
+++ b/mars/session.py
@@ -98,10 +98,12 @@ class Session(object):
             return ret
         return ret[0]
 
+    @property
     def endpoint(self):
         return self._sess.endpoint
 
-    def set_endpoint(self, endpoint):
+    @endpoint.setter
+    def endpoint(self, endpoint):
         self._sess.endpoint = endpoint
 
     def decref(self, *keys):

--- a/mars/session.py
+++ b/mars/session.py
@@ -105,6 +105,15 @@ class Session(object):
         except AttributeError:
             raise
 
+    def __setattr__(self, key, value):
+        if key == 'endpoint':
+            try:
+                return setattr(self._sess, key, value)
+            except AttributeError:
+                raise
+        else:
+            object.__setattr__(self, key, value)
+
     def __enter__(self):
         self._sess.__enter__()
         return self

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -45,6 +45,14 @@ class Session(object):
     def session_id(self):
         return self._session_id
 
+    @property
+    def endpoint(self):
+        return self._endpoint
+
+    @endpoint.setter
+    def endpoint(self, url):
+        self._endpoint = url
+
     def _main(self):
         resp = self._req_session.post(self._endpoint + '/api/session', self._args)
         if resp.status_code >= 400:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Add endpoint setter in web session so that it still works if web endpoint changed.
