### PR TITLE
add virtualenv test & fix some warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,20 +46,30 @@ before_install:
 
 # command to install dependencies
 install:
+  - export DEFAULT_VENV=$VIRTUAL_ENV
   - pip install -r requirements-dev.txt
   - pip install -r requirements-extra.txt
-  - pip install coveralls
+  - pip install virtualenv coveralls
+  - virtualenv venv
+  - source venv/bin/activate
+  - pip install -r requirements.txt
+  - pip install pytest pytest-timeout
+  - if [ -z "$DEFAULT_VENV" ]; then deactivate; else source $DEFAULT_VENV/bin/activate; fi
   - python setup.py build_ext -i
 
 # command to run tests
 script:
   mkdir -p build &&
-  pytest --cov-report= --cov-config .coveragerc-tensor --cov=mars --timeout=1500 mars/tensor &&
+  pytest --cov-report= --cov-config .coveragerc-tensor --cov=mars --timeout=1500 -W ignore::PendingDeprecationWarning mars/tensor &&
   mv .coverage build/.coverage.tensor.file &&
-  pytest --cov-report= --cov-config .coveragerc --cov=mars --timeout=1500 --forked
+  pytest --cov-report= --cov-config .coveragerc --cov=mars --timeout=1500 --forked -W ignore::PendingDeprecationWarning
     $(find mars -maxdepth 1 -mindepth 1 -type d -not -path "mars/tensor" -not -path "*__pycache__*") &&
   mv .coverage build/.coverage.main.file &&
-  coverage combine build/ && coverage report --fail-under=80
+  coverage combine build/ && coverage report --fail-under=80 &&
+  export DEFAULT_VENV=$VIRTUAL_ENV &&
+  source venv/bin/activate &&
+  pytest --timeout=1500 mars/tests/test_session.py &&
+  if [ -z "$DEFAULT_VENV" ]; then deactivate; else source $DEFAULT_VENV/bin/activate; fi
 
 after_success:
   - coveralls

--- a/mars/session.py
+++ b/mars/session.py
@@ -14,14 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import uuid
-import json
-import time
 import numpy as np
-
-from .api import MarsAPI
-from .scheduler.graph import GraphState
-from .serialize import dataserializer
 
 
 class LocalSession(object):

--- a/mars/tensor/execution/indexing.py
+++ b/mars/tensor/execution/indexing.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2018 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,7 @@ from ...compat import izip
 
 
 def _slice(ctx, chunk):
-    ctx[chunk.key] = ctx[chunk.inputs[0].key][chunk.op.slices]
+    ctx[chunk.key] = ctx[chunk.inputs[0].key][tuple(chunk.op.slices)]
 
 
 def _index(ctx, chunk):

--- a/mars/tensor/execution/optimizes/tests/test_compose.py
+++ b/mars/tensor/execution/optimizes/tests/test_compose.py
@@ -33,7 +33,7 @@ class Test(unittest.TestCase):
         test compose in build graph and optimize
         """
 
-        """
+        r"""
         graph(@: node, #: composed_node):
 
         @ --> @ --> @   ========>    #     
@@ -51,7 +51,7 @@ class Test(unittest.TestCase):
         composed_nodes = graph.compose(keys=[chunks[1].key])
         self.assertEqual(len(composed_nodes), 0)
 
-        """
+        r"""
         graph(@: node, #: composed_node):
 
         @             @              @       @
@@ -97,7 +97,7 @@ class Test(unittest.TestCase):
 
         # test optimizer compose
 
-        """
+        r"""
         graph(@: node, S: Slice Chunk, #: composed_node):
 
         @                   @              @             @
@@ -123,7 +123,7 @@ class Test(unittest.TestCase):
         composed_nodes = optimizer.compose()
         self.assertTrue(composed_nodes[0].composed == chunks[2:4])
 
-        """
+        r"""
             graph(@: node, S: Slice Chunk, #: composed_node):
 
             @ --> @ --> S --> @  ========>  # --> S --> @
@@ -142,7 +142,7 @@ class Test(unittest.TestCase):
         self.assertTrue(composed_nodes[0].composed == chunks[:2])
         self.assertTrue(len(composed_nodes) == 1)
 
-        """
+        r"""
             graph(@: node, S: Slice Chunk, #: composed_node):
 
             @ --> @ --> S --> @ --> @   ========>  # --> S --> #

--- a/mars/tensor/execution/reduction.py
+++ b/mars/tensor/execution/reduction.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2018 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -213,8 +213,9 @@ def _handle_arg_combine(arg_op):
                 if xp != np:
                     inds = [xp.asarray(it) for it in inds]
                 inds.insert(axis, local_args)
-                vals = vals[inds]
-                arg = arg[inds]
+                inds_tuple = tuple(inds)
+                vals = vals[inds_tuple]
+                arg = arg[inds_tuple]
                 if keepdims:
                     vals = xp.expand_dims(vals, axis)
                     arg = xp.expand_dims(arg, axis)
@@ -241,7 +242,7 @@ def _handle_arg(arg_op):
                 if xp != np:
                     inds = [xp.asarray(it) for it in inds]
                 inds.insert(axis, local_args)
-                arg = arg[inds]
+                arg = arg[tuple(inds)]
                 if keepdims:
                     arg = xp.expand_dims(arg, axis)
             ctx[chunk.key] = arg
@@ -310,7 +311,7 @@ def _count_nonzero(ctx, chunk):
             slcs = [slice(None)] * chunk.inputs[0].ndim
             for ax in chunk.op.axis:
                 slcs[ax] = np.newaxis
-            nz = xp.asarray(nz)[slcs]
+            nz = xp.asarray(nz)[tuple(slcs)]
 
         ctx[chunk.key] = nz
 

--- a/mars/tensor/expressions/arithmetic/abs.py
+++ b/mars/tensor/expressions/arithmetic/abs.py
@@ -34,7 +34,7 @@ class TensorAbs(operands.Abs, TensorUnaryOp):
 
 @infer_dtype(np.abs)
 def abs(x, out=None, where=None, **kwargs):
-    """
+    r"""
     Calculate the absolute value element-wise.
 
     Parameters

--- a/mars/tensor/expressions/arithmetic/absolute.py
+++ b/mars/tensor/expressions/arithmetic/absolute.py
@@ -34,7 +34,7 @@ class TensorAbsolute(operands.Absolute, TensorUnaryOp):
 
 @infer_dtype(np.absolute)
 def absolute(x, out=None, where=None, **kwargs):
-    """
+    r"""
     Calculate the absolute value element-wise.
 
     Parameters

--- a/mars/tensor/expressions/arithmetic/exp.py
+++ b/mars/tensor/expressions/arithmetic/exp.py
@@ -34,7 +34,7 @@ class TensorExp(operands.Exp, TensorUnaryOp):
 
 @infer_dtype(np.exp)
 def exp(x, out=None, where=None, **kwargs):
-    """
+    r"""
     Calculate the exponential of all elements in the input tensor.
 
     Parameters

--- a/mars/tensor/expressions/arithmetic/power.py
+++ b/mars/tensor/expressions/arithmetic/power.py
@@ -51,7 +51,7 @@ class TensorPowConstant(operands.PowConstant, TensorConstant):
 
 @infer_dtype(np.power)
 def power(x1, x2, out=None, where=None, **kwargs):
-    """
+    r"""
     First tensor elements raised to powers from second tensor, element-wise.
 
     Raise each base in `x1` to the positionally-corresponding power in

--- a/mars/tensor/expressions/arithmetic/sign.py
+++ b/mars/tensor/expressions/arithmetic/sign.py
@@ -34,7 +34,7 @@ class TensorSign(operands.Sign, TensorUnaryOp):
 
 @infer_dtype(np.sign)
 def sign(x, out=None, where=None, **kwargs):
-    """
+    r"""
     Returns an element-wise indication of the sign of a number.
 
     The `sign` function returns ``-1 if x < 0, 0 if x==0, 1 if x > 0``.  nan

--- a/mars/tensor/expressions/arithmetic/sinc.py
+++ b/mars/tensor/expressions/arithmetic/sinc.py
@@ -34,7 +34,7 @@ class TensorSinc(operands.Sinc, TensorUnaryOp):
 
 @infer_dtype(np.sinc)
 def sinc(x, **kwargs):
-    """
+    r"""
     Return the sinc function.
 
     The sinc function is :math:`\\sin(\\pi x)/(\\pi x)`.

--- a/mars/tensor/expressions/base/corrcoef.py
+++ b/mars/tensor/expressions/base/corrcoef.py
@@ -18,14 +18,14 @@ from .cov import cov
 
 
 def corrcoef(x, y=None, rowvar=True):
-    """
+    r"""
     Return Pearson product-moment correlation coefficients.
 
     Please refer to the documentation for `cov` for more detail.  The
     relationship between the correlation coefficient matrix, `R`, and the
     covariance matrix, `C`, is
 
-    .. math:: R_{ij} = \\frac{ C_{ij} } { \\sqrt{ C_{ii} * C_{jj} } }
+    .. math:: R_{ij} = \frac{ C_{ij} } { \sqrt{ C_{ii} * C_{jj} } }
 
     The values of `R` are between -1 and 1, inclusive.
 

--- a/mars/tensor/expressions/linalg/norm.py
+++ b/mars/tensor/expressions/linalg/norm.py
@@ -133,7 +133,7 @@ class TensorNorm(operands.Norm, TensorOperandMixin):
 
 
 def norm(x, ord=None, axis=None, keepdims=False):
-    """
+    r"""
     Matrix or vector norm.
 
     This function is able to return one of eight different matrix norms,

--- a/mars/tensor/expressions/random/beta.py
+++ b/mars/tensor/expressions/random/beta.py
@@ -34,7 +34,7 @@ class TensorBeta(operands.Beta, TensorRandomOperandMixin):
 
 
 def beta(random_state, a, b, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a Beta distribution.
 
     The Beta distribution is a special case of the Dirichlet distribution,

--- a/mars/tensor/expressions/random/binomial.py
+++ b/mars/tensor/expressions/random/binomial.py
@@ -34,7 +34,7 @@ class TensorBinomial(operands.Binomial, TensorRandomOperandMixin):
 
 
 def binomial(random_state, n, p, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a binomial distribution.
 
     Samples are drawn from a binomial distribution with specified

--- a/mars/tensor/expressions/random/chisquare.py
+++ b/mars/tensor/expressions/random/chisquare.py
@@ -34,7 +34,7 @@ class TensorChisquare(operands.Chisquare, TensorRandomOperandMixin):
 
 
 def chisquare(random_state, df, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a chi-square distribution.
 
     When `df` independent random variables, each with standard normal

--- a/mars/tensor/expressions/random/dirichlet.py
+++ b/mars/tensor/expressions/random/dirichlet.py
@@ -72,7 +72,7 @@ class TensorDirichlet(operands.Dirichlet, TensorRandomOperandMixin):
 
 
 def dirichlet(random_state, alpha, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from the Dirichlet distribution.
 
     Draw `size` samples of dimension k from a Dirichlet distribution. A

--- a/mars/tensor/expressions/random/exponential.py
+++ b/mars/tensor/expressions/random/exponential.py
@@ -34,7 +34,7 @@ class TensorExponential(operands.Exponential, TensorRandomOperandMixin):
 
 
 def exponential(random_state, scale=1.0, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from an exponential distribution.
 
     Its probability density function is

--- a/mars/tensor/expressions/random/gamma.py
+++ b/mars/tensor/expressions/random/gamma.py
@@ -34,7 +34,7 @@ class TensorGamma(operands.Gamma, TensorRandomOperandMixin):
 
 
 def gamma(random_state, shape, scale=1.0, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a Gamma distribution.
 
     Samples are drawn from a Gamma distribution with specified parameters,

--- a/mars/tensor/expressions/random/gumbel.py
+++ b/mars/tensor/expressions/random/gumbel.py
@@ -34,7 +34,7 @@ class TensorGumbel(operands.Gumbel, TensorRandomOperandMixin):
 
 
 def gumbel(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a Gumbel distribution.
 
     Draw samples from a Gumbel distribution with specified location and

--- a/mars/tensor/expressions/random/hypergeometric.py
+++ b/mars/tensor/expressions/random/hypergeometric.py
@@ -34,7 +34,7 @@ class TensorHypergeometric(operands.Hypergeometric, TensorRandomOperandMixin):
 
 
 def hypergeometric(random_state, ngood, nbad, nsample, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a Hypergeometric distribution.
 
     Samples are drawn from a hypergeometric distribution with specified

--- a/mars/tensor/expressions/random/laplace.py
+++ b/mars/tensor/expressions/random/laplace.py
@@ -34,7 +34,7 @@ class TensorLaplace(operands.Laplace, TensorRandomOperandMixin):
 
 
 def laplace(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from the Laplace or double exponential distribution with
     specified location (or mean) and scale (decay).
 

--- a/mars/tensor/expressions/random/logistic.py
+++ b/mars/tensor/expressions/random/logistic.py
@@ -34,7 +34,7 @@ class TensorLogistic(operands.Logistic, TensorRandomOperandMixin):
 
 
 def logistic(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a logistic distribution.
 
     Samples are drawn from a logistic distribution with specified

--- a/mars/tensor/expressions/random/lognormal.py
+++ b/mars/tensor/expressions/random/lognormal.py
@@ -34,7 +34,7 @@ class TensorLognormal(operands.Lognormal, TensorRandomOperandMixin):
 
 
 def lognormal(random_state, mean=0.0, sigma=1.0, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a log-normal distribution.
 
     Draw samples from a log-normal distribution with specified mean,

--- a/mars/tensor/expressions/random/logseries.py
+++ b/mars/tensor/expressions/random/logseries.py
@@ -34,7 +34,7 @@ class TensorLogseries(operands.Logseries, TensorRandomOperandMixin):
 
 
 def logseries(random_state, p, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a logarithmic series distribution.
 
     Samples are drawn from a log series distribution with specified

--- a/mars/tensor/expressions/random/negative_binomial.py
+++ b/mars/tensor/expressions/random/negative_binomial.py
@@ -34,7 +34,7 @@ class TensorNegativeBinomial(operands.NegativeBinomial, TensorRandomOperandMixin
 
 
 def negative_binomial(random_state, n, p, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a negative binomial distribution.
 
     Samples are drawn from a negative binomial distribution with specified

--- a/mars/tensor/expressions/random/noncentral_chisquare.py
+++ b/mars/tensor/expressions/random/noncentral_chisquare.py
@@ -34,7 +34,7 @@ class TensorNoncentralChisquare(operands.NoncentralChisquare, TensorRandomOperan
 
 
 def noncentral_chisquare(random_state, df, nonc, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a noncentral chi-square distribution.
 
     The noncentral :math:`\chi^2` distribution is a generalisation of

--- a/mars/tensor/expressions/random/normal.py
+++ b/mars/tensor/expressions/random/normal.py
@@ -34,7 +34,7 @@ class TensorNormal(operands.Normal, TensorRandomOperandMixin):
 
 
 def normal(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw random samples from a normal (Gaussian) distribution.
 
     The probability density function of the normal distribution, first

--- a/mars/tensor/expressions/random/pareto.py
+++ b/mars/tensor/expressions/random/pareto.py
@@ -34,7 +34,7 @@ class TensorPareto(operands.Pareto, TensorRandomOperandMixin):
 
 
 def pareto(random_state, a, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a Pareto II or Lomax distribution with
     specified shape.
 

--- a/mars/tensor/expressions/random/poisson.py
+++ b/mars/tensor/expressions/random/poisson.py
@@ -34,7 +34,7 @@ class TensorPoisson(operands.Poisson, TensorRandomOperandMixin):
 
 
 def poisson(random_state, lam=1.0, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a Poisson distribution.
 
     The Poisson distribution is the limit of the binomial distribution

--- a/mars/tensor/expressions/random/randn.py
+++ b/mars/tensor/expressions/random/randn.py
@@ -31,7 +31,7 @@ class TensorRandn(operands.Randn, TensorRandomOperandMixin):
 
 
 def randn(random_state, *dn, **kw):
-    """
+    r"""
     Return a sample (or samples) from the "standard normal" distribution.
 
     If positive, int_like or int-convertible arguments are provided,

--- a/mars/tensor/expressions/random/rayleigh.py
+++ b/mars/tensor/expressions/random/rayleigh.py
@@ -34,7 +34,7 @@ class TensorRayleigh(operands.Rayleigh, TensorRandomOperandMixin):
 
 
 def rayleigh(random_state, scale=1.0, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a Rayleigh distribution.
 
     The :math:`\chi` and Weibull distributions are generalizations of the

--- a/mars/tensor/expressions/random/standard_cauchy.py
+++ b/mars/tensor/expressions/random/standard_cauchy.py
@@ -33,7 +33,7 @@ class TensorStandardCauchy(operands.StandardCauchy, TensorRandomOperandMixin):
 
 
 def standard_cauchy(random_state, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a standard Cauchy distribution with mode = 0.
 
     Also known as the Lorentz distribution.

--- a/mars/tensor/expressions/random/standard_gamma.py
+++ b/mars/tensor/expressions/random/standard_gamma.py
@@ -34,7 +34,7 @@ class TensorStandardGamma(operands.StandardGamma, TensorRandomOperandMixin):
 
 
 def standard_gamma(random_state, shape, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a standard Gamma distribution.
 
     Samples are drawn from a Gamma distribution with specified parameters,

--- a/mars/tensor/expressions/random/standard_t.py
+++ b/mars/tensor/expressions/random/standard_t.py
@@ -34,7 +34,7 @@ class TensorStandardT(operands.StandardT, TensorRandomOperandMixin):
 
 
 def standard_t(random_state, df, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a standard Student's t distribution with `df` degrees
     of freedom.
 

--- a/mars/tensor/expressions/random/triangular.py
+++ b/mars/tensor/expressions/random/triangular.py
@@ -34,7 +34,7 @@ class TensorTriangular(operands.Triangular, TensorRandomOperandMixin):
 
 
 def triangular(random_state, left, mode, right, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from the triangular distribution over the
     interval ``[left, right]``.
 

--- a/mars/tensor/expressions/random/uniform.py
+++ b/mars/tensor/expressions/random/uniform.py
@@ -34,7 +34,7 @@ class TensorUniform(operands.Uniform, TensorRandomOperandMixin):
 
 
 def uniform(random_state, low=0.0, high=1.0, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a uniform distribution.
 
     Samples are uniformly distributed over the half-open interval

--- a/mars/tensor/expressions/random/vonmises.py
+++ b/mars/tensor/expressions/random/vonmises.py
@@ -34,7 +34,7 @@ class TensorVonmises(operands.Vonmises, TensorRandomOperandMixin):
 
 
 def vonmises(random_state, mu, kappa, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a von Mises distribution.
 
     Samples are drawn from a von Mises distribution with specified mode

--- a/mars/tensor/expressions/random/wald.py
+++ b/mars/tensor/expressions/random/wald.py
@@ -34,7 +34,7 @@ class TensorWald(operands.Wald, TensorRandomOperandMixin):
 
 
 def wald(random_state, mean, scale, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a Wald, or inverse Gaussian, distribution.
 
     As the scale approaches infinity, the distribution becomes more like a

--- a/mars/tensor/expressions/random/weibull.py
+++ b/mars/tensor/expressions/random/weibull.py
@@ -34,7 +34,7 @@ class TensorWeibull(operands.Weibull, TensorRandomOperandMixin):
 
 
 def weibull(random_state, a, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a Weibull distribution.
 
     Draw samples from a 1-parameter Weibull distribution with the given

--- a/mars/tensor/expressions/random/zipf.py
+++ b/mars/tensor/expressions/random/zipf.py
@@ -34,7 +34,7 @@ class TensorZipf(operands.Zipf, TensorRandomOperandMixin):
 
 
 def zipf(random_state, a, size=None, chunks=None, gpu=None, **kw):
-    """
+    r"""
     Draw samples from a Zipf distribution.
 
     Samples are drawn from a Zipf distribution with specified parameter

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -20,17 +20,13 @@ import subprocess
 import tempfile
 import time
 import unittest
-from contextlib import contextmanager
 from collections import Iterable
 from weakref import ReferenceType
 
 import numpy as np
-from tornado import gen
-from tornado.ioloop import IOLoop
 
 from mars import compat
 from mars.compat import zip_longest
-from mars.core import BaseWithKey
 from mars.compat import six
 from mars.serialize import serializes, deserializes, \
     ProtobufSerializeProvider, JsonSerializeProvider
@@ -44,46 +40,6 @@ if compat.PY27:
 else:
     from unittest import mock
     _mock = mock
-
-
-@contextmanager
-def pristine_loop():
-    IOLoop.clear_instance()
-    IOLoop.clear_current()
-    loop = IOLoop()
-    loop.make_current()
-    try:
-        yield loop
-    finally:
-        loop.close(all_fds=True)
-        IOLoop.clear_instance()
-        IOLoop.clear_current()
-
-
-def gen_test(timeout=10):
-    """ Coroutine test
-
-    @gen_test(timeout=5)
-    def test_foo():
-        yield ...  # use tornado coroutines
-    """
-    def _(func):
-        def test_func(*args, **kwargs):
-            with pristine_loop() as loop:
-
-                def f():
-                    return func(*args, **kwargs)
-
-                cor = gen.coroutine(f)
-                try:
-                    loop.run_sync(cor, timeout=timeout)
-                finally:
-                    loop.stop()
-
-        test_func.__name__ = func.__name__
-        test_func.__doc__ = func.__doc__
-        return test_func
-    return _
 
 
 class TestCase(unittest.TestCase):

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import numpy as np
 
 import mars.tensor as mt
-from mars.tests.core import TestBase
 
 
-class Test(TestBase):
+class Test(unittest.TestCase):
     def testSessionExecute(self):
         a = mt.random.rand(10, 20)
         res = a.sum().execute()


### PR DESCRIPTION
## What do these changes do?

1. Add virtualenv test to mock client user's operation
2. fix escape sequence warnings and "non-tuple sequence for multidimensional indexing" warnings, suppress PendingDeprecationWarning as it is caused by scipy.sparse.

## Related issue number

fixes #52, fixes #53