### PR TITLE
Fix execute method of ExecutableTuple

### DIFF
--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -460,12 +460,12 @@ class TensorData(SerializableWithKey, Tilesable):
 
 
 class ExecutableTuple(tuple):
-    def execute(self, session=None, n_parallel=None):
+    def execute(self, session=None, **kw):
         from ..session import Session
 
         if session is None:
             session = Session.default_or_local()
-        return session.run(*self, n_parallel=n_parallel)
+        return session.run(*self, **kw)
 
 
 class ChunksIndexer(object):

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -185,6 +185,12 @@ class Test(unittest.TestCase):
             res = requests.get(service_ep + '/worker')
             self.assertEqual(res.status_code, 200)
 
+        # test default session run with multiple inputs
+        with new_session(service_ep).as_default() as sess:
+            a = mt.ones((20, 10), chunks=10)
+            u, s, v = (mt.linalg.svd(a)).execute()
+            np.testing.assert_allclose(u.dot(np.diag(s).dot(v)), np.ones((20, 10)))
+
 
 class MockResponse:
     def __init__(self, status_code, json_text=None, data=None):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

remove `n_parallel` in method `ExecutableTuple .execute` that make tensor tuple executable when default session is web session. for example:
```
In [1]: from mars.session import new_session

In [2]: import mars.tensor as mt

In [3]: sess = new_session('http://0.0.0.0:12345').as_default()

In [4]: mt.linalg.svd(mt.random.rand(5, 5)).execute()
Out[4]: 
[array([[-0.45379165,  0.36902001, -0.61379637,  0.05699746,  0.52716475],
        [-0.2773592 ,  0.00516561, -0.30709199,  0.61963784, -0.66692477],
        [-0.60954901,  0.47904603,  0.49533444, -0.30122631, -0.25074173],
        [-0.366785  , -0.37958852,  0.47355348,  0.54936446,  0.44195826],
        [-0.45941679, -0.7001607 , -0.24359684, -0.4693204 , -0.13823948]]),
 array([2.57692364, 0.66406779, 0.56091901, 0.25509547, 0.13434668]),
 array([[-0.44804643, -0.59556564, -0.24152198, -0.53443815, -0.31717339],
        [ 0.56371947, -0.32970547,  0.45609053,  0.04643677, -0.60277667],
        [-0.20827308,  0.2231636 , -0.47783298,  0.52066176, -0.63828466],
        [-0.65816345, -0.02188516,  0.68668088,  0.30186918, -0.06071472],
        [ 0.07012807, -0.69736283, -0.18383028,  0.59161289,  0.35350778]])]

```

## Related issue number

resolve #63 
