### PR TITLE
Remove sudo in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,22 @@ language: python
 
 matrix:
   include:
-    - sudo: required
-      os: linux
+    - os: linux
       python: "2.7"
       services:
         - docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp27-cp27mu
-    - sudo: required
-      os: linux
+    - os: linux
       python: "3.5"
       services:
         - docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp35-cp35m
-    - sudo: required
-      os: linux
+    - os: linux
       python: "3.6"
       services:
         - docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp36-cp36m
-    - sudo: required
-      os: linux
+    - os: linux
       python: "3.7"
       dist: xenial
       services:


### PR DESCRIPTION


<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

The 'sudo' is now deprecated in Traivs, remove it. Refer to: [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
