### PR TITLE
Fix Index and IndexSetValue operand when new chunks without indexes parameter

### DIFF
--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -189,7 +189,7 @@ class Test(unittest.TestCase):
     def testExecutableTuple(self):
         with new_cluster(scheduler_n_process=2, worker_n_process=2, web=True) as cluster:
             with new_session('http://' + cluster._web_endpoint).as_default() as _:
-                a = mt.ones((20, 10), chunks=10)
+                a = mt.ones((20, 10), chunk_size=10)
                 u, s, v = (mt.linalg.svd(a)).execute()
                 np.testing.assert_allclose(u.dot(np.diag(s).dot(v)), np.ones((20, 10)))
 

--- a/mars/tensor/execution/indexing.py
+++ b/mars/tensor/execution/indexing.py
@@ -32,7 +32,7 @@ def _index(ctx, chunk):
 def _index_set_value(ctx, chunk):
     indexes = [ctx[index.key] if hasattr(index, 'key') else index
                for index in chunk.op.indexes]
-    input = ctx[chunk.inputs[0].key]
+    input = ctx[chunk.inputs[0].key].copy()
     value = ctx[chunk.op.value.key] if hasattr(chunk.op.value, 'key') else chunk.op.value
     if hasattr(input, 'flags') and not input.flags.writeable:
         input.setflags(write=True)

--- a/mars/tensor/execution/tests/test_index_execute.py
+++ b/mars/tensor/execution/tests/test_index_execute.py
@@ -110,6 +110,14 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res[0], raw[-2::-3, b_raw < .5, ...]))
 
     def testSetItemExecution(self):
+        import mars.tensor as mt
+        a = mt.random.rand(10, 5)
+        idx = slice(0, 5), slice(0, 5)
+
+        a[idx] = mt.tensor(mt.ones((5, 5)))
+        r = self.executor.execute_tensor(a, concat=True)
+        pass
+
         raw = data = np.random.randint(0, 10, size=(11, 8, 12, 13))
         arr = tensor(raw.copy(), chunks=3)
         raw = raw.copy()

--- a/mars/tensor/execution/tests/test_index_execute.py
+++ b/mars/tensor/execution/tests/test_index_execute.py
@@ -110,14 +110,6 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res[0], raw[-2::-3, b_raw < .5, ...]))
 
     def testSetItemExecution(self):
-        import mars.tensor as mt
-        a = mt.random.rand(10, 5)
-        idx = slice(0, 5), slice(0, 5)
-
-        a[idx] = mt.tensor(mt.ones((5, 5)))
-        r = self.executor.execute_tensor(a, concat=True)
-        pass
-
         raw = data = np.random.randint(0, 10, size=(11, 8, 12, 13))
         arr = tensor(raw.copy(), chunk_size=3)
         raw = raw.copy()

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -49,7 +49,6 @@ class TensorIndex(Index, TensorOperandMixin):
         new_indexes = [next(inputs_iter) if isinstance(index, (BaseWithKey, Entity)) else index
                        for index in self._indexes]
         self._indexes = new_indexes
-        return inputs
 
     def new_tensors(self, inputs, shape, **kw):
         indexes = kw.pop('indexes', None)

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -37,6 +37,12 @@ class TensorIndex(Index, TensorOperandMixin):
 
     @contextlib.contextmanager
     def _handle_params(self, inputs, indexes):
+        """
+        Index operator is special, it has additional parameter `indexes` which may also be tensor type,
+        normally, this indexes is provided when called by `tile` or `TensorIndex.__call__`, however, calls
+        in `GraphActor.get_executable_operand_dag` only provide inputs, in such situation, we need get `indexes`
+        from operand itself and replace tensor-liked indexes by new one in `inputs`.
+        """
         if indexes is not None:
             indexes_inputs = [ind for ind in indexes if isinstance(ind, (BaseWithKey, Entity))]
             inputs = inputs + indexes_inputs

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -34,29 +34,29 @@ class TensorIndex(Index, TensorOperandMixin):
     def __init__(self, dtype=None, sparse=False, **kw):
         super(TensorIndex, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
 
-    @classmethod
-    def _handle_inputs(cls, inputs):
-        tensor, indexes = inputs
-        indexes_inputs = [ind for ind in indexes if isinstance(ind, (BaseWithKey, Entity))]
-        return [tensor] + indexes_inputs
+    def _handle_inputs(self, inputs):
+        if len(inputs) == 1:
+            # get indexes from existed op
+            indexes_inputs = [ind for ind in self._indexes if isinstance(ind, (BaseWithKey, Entity))]
+            return inputs + indexes_inputs
+        else:
+            tensor, indexes = inputs
+            indexes_inputs = [ind for ind in indexes if isinstance(ind, (BaseWithKey, Entity))]
+            self._indexes = indexes
+            return [tensor] + indexes_inputs
 
     def _set_inputs(self, inputs):
         super(TensorIndex, self)._set_inputs(inputs)
-        self._input = self._inputs[0]
         indexes_iter = iter(self._inputs[1:])
         new_indexes = [next(indexes_iter) if isinstance(index, (BaseWithKey, Entity)) else index
                        for index in self._indexes]
         self._indexes = new_indexes
 
     def new_tensors(self, inputs, shape, **kw):
-        tensor, indexes = inputs
-        self._indexes = indexes
         inputs = self._handle_inputs(inputs)
         return super(TensorIndex, self).new_tensors(inputs, shape, **kw)
 
     def new_chunks(self, inputs, shape, **kw):
-        chunk, indexes = inputs
-        self._indexes = indexes
         inputs = self._handle_inputs(inputs)
         return super(TensorIndex, self).new_chunks(inputs, shape, **kw)
 

--- a/mars/tensor/expressions/indexing/setitem.py
+++ b/mars/tensor/expressions/indexing/setitem.py
@@ -33,6 +33,11 @@ class TensorIndexSetValue(IndexSetValue, TensorOperandMixin):
 
     @contextlib.contextmanager
     def _handle_params(self, inputs, indexes, value):
+        """
+        TensorIndexSetValue operator is like Index operand, it has additional parameter `indexes` and `value`, all of
+        them may be tensor type. As explained in TensorIndex, when indexes and value are not provided, we should get
+        from operand itself and replace tensor-liked objects by iterating over inputs.
+        """
         if indexes is not None and value is not None:
             indexes_inputs = [ind for ind in indexes if isinstance(ind, TENSOR_TYPE + CHUNK_TYPE)]
             inputs += indexes_inputs

--- a/mars/tensor/expressions/tests/test_base.py
+++ b/mars/tensor/expressions/tests/test_base.py
@@ -338,7 +338,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(mask.op.test_elements.chunks), 1)
         self.assertIs(mask.chunks[0].inputs[0], element.chunks[0].data)
 
-        element = 2 * arange(4, chunks=1).reshape(2, 2)
+        element = 2 * arange(4, chunk_size=1).reshape(2, 2)
         test_elements = tensor([1, 2, 4, 8], chunk_size=2)
 
         mask = isin(element, test_elements, invert=True)

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -170,11 +170,6 @@ class Test(unittest.TestCase):
             value = sess.run(c, timeout=120)
             assert_array_equal(value, va.dot(vb))
 
-            # test test multiple outputs
-            a = mt.random.rand(10, 10)
-            U, s, V, raw = sess.run(list(mt.linalg.svd(a)) + [a])
-            np.testing.assert_allclose(U.dot(np.diag(s).dot(V)), raw)
-
             # check web UI requests
             res = requests.get(service_ep)
             self.assertEqual(res.status_code, 200)
@@ -184,22 +179,6 @@ class Test(unittest.TestCase):
 
             res = requests.get(service_ep + '/worker')
             self.assertEqual(res.status_code, 200)
-
-        # test those tensors whose inputs has non-tensor parameters
-        with new_session(service_ep) as sess:
-            a = mt.random.rand(10, 5)
-            idx = slice(0, 5), slice(0, 5)
-            a[idx] = 2
-            a_splits = mt.split(a, 2)
-            r1, r2 = sess.run(a_splits[0], a[idx])
-            np.testing.assert_array_equal(r1, r2)
-            np.testing.assert_array_equal(r1, np.ones((5, 5)) * 2)
-
-        # test default session run with multiple inputs
-        with new_session(service_ep).as_default() as sess:
-            a = mt.ones((20, 10), chunks=10)
-            u, s, v = (mt.linalg.svd(a)).execute()
-            np.testing.assert_allclose(u.dot(np.diag(s).dot(v)), np.ones((20, 10)))
 
 
 class MockResponse:

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -185,6 +185,16 @@ class Test(unittest.TestCase):
             res = requests.get(service_ep + '/worker')
             self.assertEqual(res.status_code, 200)
 
+        # test those tensors whose inputs has non-tensor parameters
+        with new_session(service_ep) as sess:
+            a = mt.random.rand(10, 5)
+            idx = slice(0, 5), slice(0, 5)
+            a[idx] = 2
+            a_splits = mt.split(a, 2)
+            r1, r2 = sess.run(a_splits[0], a[idx])
+            np.testing.assert_array_equal(r1, r2)
+            np.testing.assert_array_equal(r1, np.ones((5, 5)) * 2)
+
         # test default session run with multiple inputs
         with new_session(service_ep).as_default() as sess:
             a = mt.ones((20, 10), chunks=10)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

`Index` operand has a special input `indexes` which may be not a tensor type, so we will handle it before `new_tensors` or `new_chunks`. however, when `new_chunks` is called in `GraphActor.get_executable_operand_dag`, only input tensor will be pass, we need get `indexes` from operand itself.

`IndexSetValue` is the same as `index` except that it has another parameter `value`.

## Related issue number

resolve #64 
