### PR TITLE
Rename chunk to chunk_size for all tensor expressions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,7 +155,7 @@ After all mars processes are started, users can run
 .. code-block:: python
 
     sess = new_session('http://<web_ip>:<ui_port>')
-    a = mt.ones((2000, 2000), chunks=200)
+    a = mt.ones((2000, 2000), chunk_size=200)
     b = mt.inner(a, a)
     sess.run(b)
 

--- a/docs/source/distributed/prepare.rst
+++ b/docs/source/distributed/prepare.rst
@@ -3,7 +3,7 @@
 Graph Preparation
 =================
 When a tensor graph is submitted into Mars scheduler, a graph comprises of
-operands and chunks will be generated given ``chunks`` parameters passed in
+operands and chunks will be generated given ``chunk_size`` parameters passed in
 data sources.
 
 Graph Compose
@@ -16,8 +16,8 @@ without branches. For example, when executing code
 .. code-block:: python
 
     import mars.tensor as mt
-    a = mt.random.rand(100, chunks=100)
-    b = mt.random.rand(100, chunks=100)
+    a = mt.random.rand(100, chunk_size=100)
+    b = mt.random.rand(100, chunk_size=100)
     c = (a + b).sum()
 
 Mars will compose operand ADD and SUM into one FUSE node. RAND operands are

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -17,7 +17,7 @@ After installation, you can simply open a Python console and run
     import mars.tensor as mt
     from mars.session import new_session
 
-    a = mt.ones((5, 5), chunks=3)
+    a = mt.ones((5, 5), chunk_size=3)
     b = a * 4
     # if there isn't a local session,
     # execute will create a default one first
@@ -98,7 +98,7 @@ After all Mars processes are started, you can open a Python console and run
     import mars.tensor as mt
     from mars.session import new_session
     sess = new_session('http://<web_ip>:<ui_port>')
-    a = mt.ones((2000, 2000), chunks=200)
+    a = mt.ones((2000, 2000), chunk_size=200)
     b = mt.inner(a, a)
     sess.run(b)
 

--- a/docs/source/tensor/datasource.rst
+++ b/docs/source/tensor/datasource.rst
@@ -40,7 +40,7 @@ multi-dimensional tensor will be supported later soon.
 Chunks
 ------
 
-In mars tensor, we tile a tensor into small chunks. Argument ``chunks`` is not always required,
+In mars tensor, we tile a tensor into small chunks. Argument ``chunk_size`` is not always required,
 a chunk's bytes occupation will be 128M for the default setting.
 However, user can specify each chunk's size in a more flexible way which may be adaptive to the data scale.
 The fact is that chunk's size may effect heavily on the performance of execution.
@@ -48,8 +48,8 @@ The fact is that chunk's size may effect heavily on the performance of execution
 The options or arguments which will effect the chunk's size are listed below:
 
 - Change ``options.tensor.chunk_size_limit`` which is 128*1024*1024(128M) by default.
-- Specify ``chunks`` as integer, like ``5000``, means chunk's size is 5000 at most for all dimensions
-- Specify ``chunks`` as tuple, like ``(5000, 3000)``
+- Specify ``chunk_size`` as integer, like ``5000``, means chunk's size is 5000 at most for all dimensions
+- Specify ``chunk_size`` as tuple, like ``(5000, 3000)``
 - Explicitly define sizes of all chunks along all dimensions, like ``((5000, 5000, 2000), (2000, 1000))``
 
 Chunks Examples
@@ -68,9 +68,9 @@ Assume we have such a tensor with the data shown below.
     4 2 4 6 2 0
     6 8 2 6 5 4
 
-We will show how different ``chunks=`` arguments will tile the tensor.
+We will show how different ``chunk_size=`` arguments will tile the tensor.
 
-``chunks=3``:
+``chunk_size=3``:
 
 .. code-block:: python
 
@@ -85,7 +85,7 @@ We will show how different ``chunks=`` arguments will tile the tensor.
     4 2 4  6 2 0
     6 8 2  6 5 4
 
-``chunks=2``:
+``chunk_size=2``:
 
 .. code-block:: python
 
@@ -101,7 +101,7 @@ We will show how different ``chunks=`` arguments will tile the tensor.
     4 2  4 6  2 0
     6 8  2 6  5 4
 
-``chunks=(3, 2)``:
+``chunk_size=(3, 2)``:
 
 .. code-block:: python
 
@@ -116,7 +116,7 @@ We will show how different ``chunks=`` arguments will tile the tensor.
     4 2  4 6  2 0
     6 8  2 6  5 4
 
-``chunks=((3, 1, 2, 2), (3, 2, 1))``:
+``chunk_size=((3, 1, 2, 2), (3, 2, 1))``:
 
 .. code-block:: python
 

--- a/docs/source/tensor/execution.rst
+++ b/docs/source/tensor/execution.rst
@@ -30,7 +30,7 @@ More than one mars tensors can be passed to ``session.run``, and calculate the r
 
 .. code-block:: python
 
-   >>> a = mt.ones((5, 5), chunks=3)
+   >>> a = mt.ones((5, 5), chunk_size=3)
    >>> b = a + 1
    >>> c = a * 4
    >>> sess.run(b, c)

--- a/mars/config.py
+++ b/mars/config.py
@@ -290,8 +290,8 @@ default_options.register_option('grpc.channel_options', {
 })
 
 # Tensor
-default_options.register_option('tensor.chunks', None, validator=any_validator(is_null, is_integer), serialize=True)
-default_options.register_option('tensor.chunk_size_limit', 128 * 1024 ** 2, validator=(is_integer, is_float))
+default_options.register_option('tensor.chunk_size', None, validator=any_validator(is_null, is_integer), serialize=True)
+default_options.register_option('tensor.chunk_store_limit', 128 * 1024 ** 2, validator=(is_integer, is_float))
 default_options.register_option('tensor.rechunk.threshold', 4, validator=is_integer, serialize=True)
 default_options.register_option('tensor.rechunk.chunk_size_limit', int(1e8), validator=is_integer, serialize=True)
 default_options.register_option('tensor.combine_size', 4, validator=is_integer, serialize=True)

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -65,7 +65,7 @@ class Test(unittest.TestCase):
             with new_session(endpoint) as session:
                 api = session._api
 
-                t = mt.ones((3, 3), chunks=2)
+                t = mt.ones((3, 3), chunk_size=2)
                 result = session.run(t)
 
                 np.testing.assert_array_equal(result, np.ones((3, 3)))
@@ -75,13 +75,13 @@ class Test(unittest.TestCase):
     def testLocalClusterWithWeb(self):
         with new_cluster(scheduler_n_process=2, worker_n_process=3, web=True) as cluster:
             with cluster.session as session:
-                t = mt.ones((3, 3), chunks=2)
+                t = mt.ones((3, 3), chunk_size=2)
                 result = session.run(t)
 
                 np.testing.assert_array_equal(result, np.ones((3, 3)))
 
             with new_session('http://' + cluster._web_endpoint) as session:
-                t = mt.ones((3, 3), chunks=2)
+                t = mt.ones((3, 3), chunk_size=2)
                 result = session.run(t)
 
                 np.testing.assert_array_equal(result, np.ones((3, 3)))
@@ -128,7 +128,7 @@ class Test(unittest.TestCase):
         with new_cluster(scheduler_n_process=2, worker_n_process=2) as cluster:
             session = cluster.session
 
-            t = mt.random.rand(20, 5, chunks=5)
+            t = mt.random.rand(20, 5, chunk_size=5)
             r = mt.linalg.svd(t)
 
             res = session.run((t,) + r)

--- a/mars/operands/base.py
+++ b/mars/operands/base.py
@@ -304,13 +304,13 @@ class Rechunk(HasInput):
     _op_type_ = OperandDef.RECHUNK
 
     _input = KeyField('input')
-    _chunks = AnyField('chunks')
+    _chunk_size = AnyField('chunk_size')
     _threshold = Int32Field('threshold')
     _chunk_size_limit = Int64Field('chunk_size_limit')
 
     @property
-    def chunks(self):
-        return self._chunks
+    def chunk_size(self):
+        return self._chunk_size
 
     @property
     def threshold(self):

--- a/mars/scheduler/tests/test_graph.py
+++ b/mars/scheduler/tests/test_graph.py
@@ -30,8 +30,8 @@ class Test(unittest.TestCase):
         session_id = str(uuid.uuid4())
         graph_key = str(uuid.uuid4())
 
-        arr = mt.random.randint(10, size=(10, 8), chunks=4)
-        arr_add = mt.random.randint(10, size=(10, 8), chunks=4)
+        arr = mt.random.randint(10, size=(10, 8), chunk_size=4)
+        arr_add = mt.random.randint(10, size=(10, 8), chunk_size=4)
         arr2 = arr + arr_add
 
         graph = arr2.build_graph(compose=False)
@@ -104,7 +104,7 @@ class Test(unittest.TestCase):
         session_id = str(uuid.uuid4())
         graph_key = str(uuid.uuid4())
 
-        arr = mt.ones(12, chunks=4)
+        arr = mt.ones(12, chunk_size=4)
         arr_split = mt.split(arr, 2)
         arr_sum = arr_split[0] + arr_split[1]
 
@@ -178,7 +178,7 @@ class Test(unittest.TestCase):
         session_id = str(uuid.uuid4())
         graph_key = str(uuid.uuid4())
 
-        arr = mt.ones((5, 5), chunks=3)
+        arr = mt.ones((5, 5), chunk_size=3)
         arr2 = mt.concatenate((arr, arr))
 
         graph = arr2.build_graph(compose=False)

--- a/mars/scheduler/tests/test_main.py
+++ b/mars/scheduler/tests/test_main.py
@@ -140,8 +140,8 @@ class Test(unittest.TestCase):
                                                 uid=SessionActor.gen_name(session_id),
                                                 address=scheduler_address,
                                                 session_id=session_id)
-        a = ones((100, 100), chunks=30) * 2 * 1 + 1
-        b = ones((100, 100), chunks=30) * 2 * 1 + 1
+        a = ones((100, 100), chunk_size=30) * 2 * 1 + 1
+        b = ones((100, 100), chunk_size=30) * 2 * 1 + 1
         c = (a * b * 2 + 1).sum()
         graph = c.build_graph()
         targets = [c.key]
@@ -164,8 +164,8 @@ class Test(unittest.TestCase):
         state = self.wait_for_termination(session_ref, graph_key)
         self.assertEqual(state, GraphState.FAILED)
 
-        a = ones((100, 50), chunks=30) * 2 + 1
-        b = ones((50, 200), chunks=30) * 2 + 1
+        a = ones((100, 50), chunk_size=30) * 2 + 1
+        b = ones((50, 200), chunk_size=30) * 2 + 1
         c = a.dot(b)
         graph = c.build_graph()
         targets = [c.key]

--- a/mars/scheduler/tests/test_operand.py
+++ b/mars/scheduler/tests/test_operand.py
@@ -151,8 +151,8 @@ class Test(unittest.TestCase):
     @mock.patch(OperandActor.__module__ + '.OperandActor._get_raw_execution_ref')
     @mock.patch(OperandActor.__module__ + '.OperandActor._free_worker_data')
     def testOperandActor(self, *_):
-        arr = mt.random.randint(10, size=(10, 8), chunks=4)
-        arr_add = mt.random.randint(10, size=(10, 8), chunks=4)
+        arr = mt.random.randint(10, size=(10, 8), chunk_size=4)
+        arr_add = mt.random.randint(10, size=(10, 8), chunk_size=4)
         arr2 = arr + arr_add
 
         session_id = str(uuid.uuid4())
@@ -163,7 +163,7 @@ class Test(unittest.TestCase):
     @mock.patch(OperandActor.__module__ + '.OperandActor._get_raw_execution_ref')
     @mock.patch(OperandActor.__module__ + '.OperandActor._free_worker_data')
     def testOperandActorWithSameKey(self, *_):
-        arr = mt.ones((5, 5), chunks=3)
+        arr = mt.ones((5, 5), chunk_size=3)
         arr2 = mt.concatenate((arr, arr))
 
         session_id = str(uuid.uuid4())
@@ -174,8 +174,8 @@ class Test(unittest.TestCase):
     @mock.patch(OperandActor.__module__ + '.OperandActor._get_raw_execution_ref')
     @mock.patch(OperandActor.__module__ + '.OperandActor._free_worker_data')
     def testOperandActorWithRetry(self, *_):
-        arr = mt.random.randint(10, size=(10, 8), chunks=4)
-        arr_add = mt.random.randint(10, size=(10, 8), chunks=4)
+        arr = mt.random.randint(10, size=(10, 8), chunk_size=4)
+        arr_add = mt.random.randint(10, size=(10, 8), chunk_size=4)
         arr2 = arr + arr_add
 
         session_id = str(uuid.uuid4())
@@ -190,8 +190,8 @@ class Test(unittest.TestCase):
     @mock.patch(OperandActor.__module__ + '.OperandActor._get_raw_execution_ref')
     @mock.patch(OperandActor.__module__ + '.OperandActor._free_worker_data')
     def testOperandActorWithRetryAndFail(self, *_):
-        arr = mt.random.randint(10, size=(10, 8), chunks=4)
-        arr_add = mt.random.randint(10, size=(10, 8), chunks=4)
+        arr = mt.random.randint(10, size=(10, 8), chunk_size=4)
+        arr_add = mt.random.randint(10, size=(10, 8), chunk_size=4)
         arr2 = arr + arr_add
 
         session_id = str(uuid.uuid4())
@@ -209,8 +209,8 @@ class Test(unittest.TestCase):
         import logging
         logging.basicConfig(level=logging.DEBUG)
 
-        arr = mt.random.randint(10, size=(10, 8), chunks=4)
-        arr_add = mt.random.randint(10, size=(10, 8), chunks=4)
+        arr = mt.random.randint(10, size=(10, 8), chunk_size=4)
+        arr_add = mt.random.randint(10, size=(10, 8), chunk_size=4)
         arr2 = arr + arr_add
 
         session_id = str(uuid.uuid4())

--- a/mars/tensor/execution/tests/test_arithmetic_execute.py
+++ b/mars/tensor/execution/tests/test_arithmetic_execute.py
@@ -39,7 +39,7 @@ class Test(unittest.TestCase):
         return True
 
     def testBaseExecution(self):
-        arr = ones((10, 8), chunks=2)
+        arr = ones((10, 8), chunk_size=2)
         arr2 = arr + 1
 
         res = self.executor.execute_tensor(arr2)
@@ -47,7 +47,7 @@ class Test(unittest.TestCase):
         self.assertTrue((res[0] == np.ones((2, 2)) + 1).all())
 
         data = np.random.random((10, 8, 3))
-        arr = tensor(data, chunks=2)
+        arr = tensor(data, chunk_size=2)
         arr2 = arr + 1
 
         res = self.executor.execute_tensor(arr2)
@@ -71,8 +71,8 @@ class Test(unittest.TestCase):
         data1 = np.random.random((5, 9, 4))
         data2 = np.random.random((5, 9, 4))
         rand = np.random.random()
-        arr1 = tensor(data1, chunks=3)
-        arr2 = tensor(data2, chunks=3)
+        arr1 = tensor(data1, chunk_size=3)
+        arr2 = tensor(data2, chunk_size=3)
 
         _new_unary_ufunc = UNARY_UFUNC - _sp_unary_ufunc
         for func in _new_unary_ufunc:
@@ -102,8 +102,8 @@ class Test(unittest.TestCase):
         data1 = np.random.randint(2, 10, size=(10, 10, 10))
         data2 = np.random.randint(2, 10, size=(10, 10, 10))
         rand = np.random.randint(1, 10)
-        arr1 = tensor(data1, chunks=3)
-        arr2 = tensor(data2, chunks=3)
+        arr1 = tensor(data1, chunk_size=3)
+        arr2 = tensor(data2, chunk_size=3)
 
         for func in _sp_unary_ufunc:
             res_tensor = func(arr1)
@@ -164,8 +164,8 @@ class Test(unittest.TestCase):
         data1 = sps.random(5, 9, density=.1)
         data2 = sps.random(5, 9, density=.2)
         rand = np.random.random()
-        arr1 = tensor(data1, chunks=3)
-        arr2 = tensor(data2, chunks=3)
+        arr1 = tensor(data1, chunk_size=3)
+        arr2 = tensor(data2, chunk_size=3)
 
         _new_unary_ufunc = UNARY_UFUNC - _sp_unary_ufunc
         for func in _new_unary_ufunc:
@@ -195,8 +195,8 @@ class Test(unittest.TestCase):
         data1 = np.random.randint(2, 10, size=(10, 10))
         data2 = np.random.randint(2, 10, size=(10, 10))
         rand = np.random.randint(1, 10)
-        arr1 = tensor(data1, chunks=3).tosparse()
-        arr2 = tensor(data2, chunks=3).tosparse()
+        arr1 = tensor(data1, chunk_size=3).tosparse()
+        arr2 = tensor(data2, chunk_size=3).tosparse()
 
         for func in _sp_unary_ufunc:
             res_tensor = func(arr1)
@@ -225,22 +225,22 @@ class Test(unittest.TestCase):
         data1 = np.random.random((5, 9, 4))
         data2 = np.random.random((9, 4))
 
-        arr1 = tensor(data1.copy(), chunks=3)
-        arr2 = tensor(data2.copy(), chunks=3)
+        arr1 = tensor(data1.copy(), chunk_size=3)
+        arr2 = tensor(data2.copy(), chunk_size=3)
 
         add(arr1, arr2, out=arr1)
         res = self.executor.execute_tensor(arr1, concat=True)[0]
         self.assertTrue(np.array_equal(res, data1 + data2))
 
-        arr1 = tensor(data1.copy(), chunks=3)
-        arr2 = tensor(data2.copy(), chunks=3)
+        arr1 = tensor(data1.copy(), chunk_size=3)
+        arr2 = tensor(data2.copy(), chunk_size=3)
 
         arr3 = add(arr1, arr2, out=arr1.astype('i4'), casting='unsafe')
         res = self.executor.execute_tensor(arr3, concat=True)[0]
         np.testing.assert_array_equal(res, (data1 + data2).astype('i4'))
 
-        arr1 = tensor(data1.copy(), chunks=3)
-        arr2 = tensor(data2.copy(), chunks=3)
+        arr1 = tensor(data1.copy(), chunk_size=3)
+        arr2 = tensor(data2.copy(), chunk_size=3)
 
         arr3 = truediv(arr1, arr2, out=arr1, where=arr2 > .5)
         res = self.executor.execute_tensor(arr3, concat=True)[0]
@@ -250,7 +250,7 @@ class Test(unittest.TestCase):
     def testFrexpExecution(self):
         data1 = np.random.random((5, 9, 4))
 
-        arr1 = tensor(data1.copy(), chunks=3)
+        arr1 = tensor(data1.copy(), chunk_size=3)
 
         o1, o2 = frexp(arr1)
         o = o1 + o2
@@ -259,9 +259,9 @@ class Test(unittest.TestCase):
         expected = sum(np.frexp(data1))
         self.assertTrue(np.allclose(res, expected))
 
-        arr1 = tensor(data1.copy(), chunks=3)
-        o1 = zeros(data1.shape, chunks=3)
-        o2 = zeros(data1.shape, dtype='i8', chunks=3)
+        arr1 = tensor(data1.copy(), chunk_size=3)
+        o1 = zeros(data1.shape, chunk_size=3)
+        o2 = zeros(data1.shape, dtype='i8', chunk_size=3)
         frexp(arr1, o1, o2)
         o = o1 + o2
 
@@ -271,7 +271,7 @@ class Test(unittest.TestCase):
 
         data1 = sps.random(5, 9, density=.1)
 
-        arr1 = tensor(data1.copy(), chunks=3)
+        arr1 = tensor(data1.copy(), chunk_size=3)
 
         o1, o2 = frexp(arr1)
         o = o1 + o2
@@ -283,7 +283,7 @@ class Test(unittest.TestCase):
     def testModfExecution(self):
         data1 = np.random.random((5, 9))
 
-        arr1 = tensor(data1.copy(), chunks=3)
+        arr1 = tensor(data1.copy(), chunk_size=3)
 
         o1, o2 = modf(arr1)
         o = o1 + o2
@@ -292,9 +292,9 @@ class Test(unittest.TestCase):
         expected = sum(np.modf(data1))
         self.assertTrue(np.allclose(res, expected))
 
-        arr1 = tensor(data1.copy(), chunks=3)
-        o1 = zeros(data1.shape, chunks=3)
-        o2 = zeros(data1.shape, chunks=3)
+        arr1 = tensor(data1.copy(), chunk_size=3)
+        o1 = zeros(data1.shape, chunk_size=3)
+        o2 = zeros(data1.shape, chunk_size=3)
         modf(arr1, o1, o2)
         o = o1 + o2
 
@@ -304,7 +304,7 @@ class Test(unittest.TestCase):
 
         data1 = sps.random(5, 9, density=.1)
 
-        arr1 = tensor(data1.copy(), chunks=3)
+        arr1 = tensor(data1.copy(), chunk_size=3)
 
         o1, o2 = modf(arr1)
         o = o1 + o2
@@ -316,7 +316,7 @@ class Test(unittest.TestCase):
     def testClipExecution(self):
         a_data = np.arange(10)
 
-        a = tensor(a_data.copy(), chunks=3)
+        a = tensor(a_data.copy(), chunk_size=3)
 
         b = clip(a, 1, 8)
 
@@ -324,7 +324,7 @@ class Test(unittest.TestCase):
         expected = np.clip(a_data, 1, 8)
         self.assertTrue(np.array_equal(res, expected))
 
-        a = tensor(a_data.copy(), chunks=3)
+        a = tensor(a_data.copy(), chunk_size=3)
         clip(a, 3, 6, out=a)
 
         res = self.executor.execute_tensor(a, concat=True)[0]
@@ -332,9 +332,9 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res, expected))
 
         with option_context() as options:
-            options.tensor.chunks = 3
+            options.tensor.chunk_size = 3
 
-            a = tensor(a_data.copy(), chunks=3)
+            a = tensor(a_data.copy(), chunk_size=3)
             b = clip(a, [3, 4, 1, 1, 1, 4, 4, 4, 4, 4], 8)
 
             res = self.executor.execute_tensor(b, concat=True)[0]
@@ -343,7 +343,7 @@ class Test(unittest.TestCase):
 
             # test sparse clip
             a_data = sps.csr_matrix([[0, 2, 8], [0, 0, -1]])
-            a = tensor(a_data, chunks=3)
+            a = tensor(a_data, chunk_size=3)
             b_data = sps.csr_matrix([[0, 3, 0], [1, 0, -2]])
 
             c = clip(a, b_data, 4)
@@ -354,7 +354,7 @@ class Test(unittest.TestCase):
 
     def testAroundExecution(self):
         data = np.random.randn(10, 20)
-        x = tensor(data, chunks=3)
+        x = tensor(data, chunk_size=3)
 
         t = x.round(2)
 
@@ -364,7 +364,7 @@ class Test(unittest.TestCase):
         np.testing.assert_allclose(res, expected)
 
         data = sps.random(10, 20, density=.2)
-        x = tensor(data, chunks=3)
+        x = tensor(data, chunk_size=3)
 
         t = x.round(2)
 
@@ -377,8 +377,8 @@ class Test(unittest.TestCase):
         data = np.array([1.05, 1.0, 1.01, np.nan])
         data2 = np.array([1.04, 1.0, 1.03, np.nan])
 
-        x = tensor(data, chunks=2)
-        y = tensor(data2, chunks=3)
+        x = tensor(data, chunk_size=2)
+        y = tensor(data2, chunk_size=3)
 
         z = isclose(x, y, atol=.01)
 
@@ -399,8 +399,8 @@ class Test(unittest.TestCase):
         data = sps.csr_matrix(np.array([0, 1.0, 1.01, np.nan]))
         data2 = sps.csr_matrix(np.array([0, 1.0, 1.03, np.nan]))
 
-        x = tensor(data, chunks=2)
-        y = tensor(data2, chunks=3)
+        x = tensor(data, chunk_size=2)
+        y = tensor(data2, chunk_size=3)
 
         z = isclose(x, y, atol=.01)
 
@@ -417,7 +417,7 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(res, expected)
 
     def testDtypeExecution(self):
-        a = ones((10, 20), dtype='f4', chunks=5)
+        a = ones((10, 20), dtype='f4', chunk_size=5)
 
         c = truediv(a, 2, dtype='f8')
 
@@ -435,7 +435,7 @@ class Test(unittest.TestCase):
 
     def testSetGetRealExecution(self):
         a_data = np.array([1+2j, 3+4j, 5+6j])
-        a = tensor(a_data, chunks=2)
+        a = tensor(a_data, chunk_size=2)
 
         res = self.executor.execute_tensor(a.real, concat=True)[0]
         expected = a_data.real
@@ -485,7 +485,7 @@ class Test(unittest.TestCase):
 
     def testSetGetImagExecution(self):
         a_data = np.array([1+2j, 3+4j, 5+6j])
-        a = tensor(a_data, chunks=2)
+        a = tensor(a_data, chunk_size=2)
 
         res = self.executor.execute_tensor(a.imag, concat=True)[0]
         expected = a_data.imag

--- a/mars/tensor/execution/tests/test_base_execute.py
+++ b/mars/tensor/execution/tests/test_base_execute.py
@@ -36,7 +36,7 @@ class Test(unittest.TestCase):
 
     def testRechunkExecution(self):
         raw = np.random.random((11, 8))
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
         arr2 = arr.rechunk(4)
 
         res = self.executor.execute_tensor(arr2)
@@ -49,8 +49,8 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res[5], raw[8:, 4:]))
 
     def testCopytoExecution(self):
-        a = ones((2, 3), chunks=1)
-        b = tensor([3, -1, 3], chunks=2)
+        a = ones((2, 3), chunk_size=1)
+        b = tensor([3, -1, 3], chunk_size=2)
 
         copyto(a, b, where=b > 1)
 
@@ -61,14 +61,14 @@ class Test(unittest.TestCase):
 
     def testAstypeExecution(self):
         raw = np.random.random((10, 5))
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
         arr2 = arr.astype('i8')
 
         res = self.executor.execute_tensor(arr2, concat=True)
         self.assertTrue(np.array_equal(res[0], raw.astype('i8')))
 
         raw = sps.random(10, 5, density=.2)
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
         arr2 = arr.astype('i8')
 
         res = self.executor.execute_tensor(arr2, concat=True)
@@ -76,7 +76,7 @@ class Test(unittest.TestCase):
 
     def testTransposeExecution(self):
         raw = np.random.random((11, 8, 5))
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
         arr2 = transpose(arr)
 
         res = self.executor.execute_tensor(arr2, concat=True)
@@ -90,7 +90,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res[0], raw.transpose(1, 2, 0)))
 
         raw = sps.random(11, 8)
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
         arr2 = transpose(arr)
 
         self.assertTrue(arr2.issparse())
@@ -101,7 +101,7 @@ class Test(unittest.TestCase):
 
     def testSwapaxesExecution(self):
         raw = np.random.random((11, 8, 5))
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
         arr2 = arr.swapaxes(2, 0)
 
         res = self.executor.execute_tensor(arr2, concat=True)
@@ -109,7 +109,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res[0], raw.swapaxes(2, 0)))
 
         raw = sps.random(11, 8, density=.2)
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
         arr2 = arr.swapaxes(1, 0)
 
         res = self.executor.execute_tensor(arr2, concat=True)
@@ -117,7 +117,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res[0].toarray(), raw.toarray().swapaxes(1, 0)))
 
     def testMoveaxisExecution(self):
-        x = zeros((3, 4, 5), chunks=2)
+        x = zeros((3, 4, 5), chunk_size=2)
 
         t = moveaxis(x, 0, -1)
 
@@ -141,7 +141,7 @@ class Test(unittest.TestCase):
 
     def testBroadcastToExecution(self):
         raw = np.random.random((10, 5, 1))
-        arr = tensor(raw, chunks=2)
+        arr = tensor(raw, chunk_size=2)
         arr2 = broadcast_to(arr, (5, 10, 5, 6))
 
         res = self.executor.execute_tensor(arr2, concat=True)
@@ -150,9 +150,9 @@ class Test(unittest.TestCase):
 
     def testBroadcastArraysExecutions(self):
         x_data = [[1, 2, 3]]
-        x = tensor(x_data, chunks=1)
+        x = tensor(x_data, chunk_size=1)
         y_data = [[1], [2], [3]]
-        y = tensor(y_data, chunks=2)
+        y = tensor(y_data, chunk_size=2)
 
         a = broadcast_arrays(x, y)
 
@@ -167,7 +167,7 @@ class Test(unittest.TestCase):
         raw_x = np.random.rand(4, 1)
         raw_y = np.random.rand(4, 4)
 
-        cond, x, y = tensor(raw_cond, chunks=2), tensor(raw_x, chunks=2), tensor(raw_y, chunks=2)
+        cond, x, y = tensor(raw_cond, chunk_size=2), tensor(raw_x, chunk_size=2), tensor(raw_y, chunk_size=2)
 
         arr = where(cond, x, y)
         res = self.executor.execute_tensor(arr, concat=True)
@@ -177,7 +177,7 @@ class Test(unittest.TestCase):
         raw_x = sps.random(4, 1, density=.1)
         raw_y = sps.random(4, 4, density=.1)
 
-        cond, x, y = tensor(raw_cond, chunks=2), tensor(raw_x, chunks=2), tensor(raw_y, chunks=2)
+        cond, x, y = tensor(raw_cond, chunk_size=2), tensor(raw_x, chunk_size=2), tensor(raw_y, chunk_size=2)
 
         arr = where(cond, x, y)
         res = self.executor.execute_tensor(arr, concat=True)[0]
@@ -186,7 +186,7 @@ class Test(unittest.TestCase):
 
     def testReshapeExecution(self):
         raw_data = np.random.rand(10, 20, 30)
-        x = tensor(raw_data, chunks=6)
+        x = tensor(raw_data, chunk_size=6)
 
         y = x.reshape(-1, 30)
 
@@ -209,7 +209,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res[0], raw_data.ravel()))
 
         raw_data = np.random.rand(30, 100, 20)
-        x = tensor(raw_data, chunks=6)
+        x = tensor(raw_data, chunk_size=6)
 
         y = x.reshape(-1, 20, 5, 5, 4)
 
@@ -228,7 +228,7 @@ class Test(unittest.TestCase):
 
     def testExpandDimsExecution(self):
         raw_data = np.random.rand(10, 20, 30)
-        x = tensor(raw_data, chunks=6)
+        x = tensor(raw_data, chunk_size=6)
 
         y = expand_dims(x, 1)
 
@@ -262,7 +262,7 @@ class Test(unittest.TestCase):
             expand_dims(x, 4)
 
     def testRollAxisExecution(self):
-        x = ones((3, 4, 5, 6), chunks=1)
+        x = ones((3, 4, 5, 6), chunk_size=1)
         y = rollaxis(x, 3, 1)
 
         res = self.executor.execute_tensor(y, concat=True)
@@ -270,8 +270,8 @@ class Test(unittest.TestCase):
 
     def testAtleast1dExecution(self):
         x = 1
-        y = ones(3, chunks=2)
-        z = ones((3, 4), chunks=2)
+        y = ones(3, chunk_size=2)
+        z = ones((3, 4), chunk_size=2)
 
         t = atleast_1d(x, y, z)
 
@@ -283,8 +283,8 @@ class Test(unittest.TestCase):
 
     def testAtleast2dExecution(self):
         x = 1
-        y = ones(3, chunks=2)
-        z = ones((3, 4), chunks=2)
+        y = ones(3, chunk_size=2)
+        z = ones((3, 4), chunk_size=2)
 
         t = atleast_2d(x, y, z)
 
@@ -296,8 +296,8 @@ class Test(unittest.TestCase):
 
     def testAtleast3dExecution(self):
         x = 1
-        y = ones(3, chunks=2)
-        z = ones((3, 4), chunks=2)
+        y = ones(3, chunk_size=2)
+        z = ones((3, 4), chunk_size=2)
 
         t = atleast_3d(x, y, z)
 
@@ -308,7 +308,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res[2], np.atleast_3d(np.ones((3, 4)))))
 
     def testArgwhereExecution(self):
-        x = arange(6, chunks=2).reshape(2, 3)
+        x = arange(6, chunk_size=2).reshape(2, 3)
         t = argwhere(x > 1)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
@@ -317,7 +317,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res, expected))
 
     def testArraySplitExecution(self):
-        x = arange(48, chunks=3).reshape(2, 3, 8)
+        x = arange(48, chunk_size=3).reshape(2, 3, 8)
         ss = array_split(x, 3, axis=2)
 
         res = [self.executor.execute_tensor(i, concat=True)[0] for i in ss]
@@ -333,7 +333,7 @@ class Test(unittest.TestCase):
         [np.testing.assert_equal(r, e) for r, e in zip(res, expected)]
 
     def testSplitExecution(self):
-        x = arange(48, chunks=3).reshape(2, 3, 8)
+        x = arange(48, chunk_size=3).reshape(2, 3, 8)
         ss = split(x, 4, axis=2)
 
         res = [self.executor.execute_tensor(i, concat=True)[0] for i in ss]
@@ -349,7 +349,7 @@ class Test(unittest.TestCase):
         [np.testing.assert_equal(r, e) for r, e in zip(res, expected)]
 
         # hsplit
-        x = arange(120, chunks=3).reshape(2, 12, 5)
+        x = arange(120, chunk_size=3).reshape(2, 12, 5)
         ss = hsplit(x, 4)
 
         res = [self.executor.execute_tensor(i, concat=True)[0] for i in ss]
@@ -358,7 +358,7 @@ class Test(unittest.TestCase):
         [np.testing.assert_equal(r, e) for r, e in zip(res, expected)]
 
         # vsplit
-        x = arange(48, chunks=3).reshape(8, 3, 2)
+        x = arange(48, chunk_size=3).reshape(8, 3, 2)
         ss = vsplit(x, 4)
 
         res = [self.executor.execute_tensor(i, concat=True)[0] for i in ss]
@@ -367,7 +367,7 @@ class Test(unittest.TestCase):
         [np.testing.assert_equal(r, e) for r, e in zip(res, expected)]
 
         # dsplit
-        x = arange(48, chunks=3).reshape(2, 3, 8)
+        x = arange(48, chunk_size=3).reshape(2, 3, 8)
         ss = dsplit(x, 4)
 
         res = [self.executor.execute_tensor(i, concat=True)[0] for i in ss]
@@ -376,7 +376,7 @@ class Test(unittest.TestCase):
         [np.testing.assert_equal(r, e) for r, e in zip(res, expected)]
 
         x_data = sps.random(12, 8, density=.1)
-        x = tensor(x_data, chunks=3)
+        x = tensor(x_data, chunk_size=3)
         ss = split(x, 4, axis=0)
 
         res = [self.executor.execute_tensor(i, concat=True)[0] for i in ss]
@@ -385,7 +385,7 @@ class Test(unittest.TestCase):
         [np.testing.assert_equal(r.toarray(), e) for r, e in zip(res, expected)]
 
     def testRollExecution(self):
-        x = arange(10, chunks=2)
+        x = arange(10, chunk_size=2)
 
         t = roll(x, 2)
 
@@ -415,7 +415,7 @@ class Test(unittest.TestCase):
 
     def testSqueezeExecution(self):
         data = np.array([[[0], [1], [2]]])
-        x = tensor(data, chunks=1)
+        x = tensor(data, chunk_size=1)
 
         t = squeeze(x)
 
@@ -430,7 +430,7 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(res, expected)
 
     def testPtpExecution(self):
-        x = arange(4, chunks=1).reshape(2, 2)
+        x = arange(4, chunk_size=1).reshape(2, 2)
 
         t = ptp(x, axis=0)
 
@@ -452,7 +452,7 @@ class Test(unittest.TestCase):
 
     def testDiffExecution(self):
         data = np.array([1, 2, 4, 7, 0])
-        x = tensor(data, chunks=2)
+        x = tensor(data, chunk_size=2)
 
         t = diff(x)
 
@@ -467,7 +467,7 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(res, expected)
 
         data = np.array([[1, 3, 6, 10], [0, 5, 6, 8]])
-        x = tensor(data, chunks=2)
+        x = tensor(data, chunk_size=2)
 
         t = diff(x)
 
@@ -490,7 +490,7 @@ class Test(unittest.TestCase):
 
     def testEdiff1d(self):
         data = np.array([1, 2, 4, 7, 0])
-        x = tensor(data, chunks=2)
+        x = tensor(data, chunk_size=2)
 
         t = ediff1d(x)
 
@@ -498,8 +498,8 @@ class Test(unittest.TestCase):
         expected = np.ediff1d(data)
         np.testing.assert_equal(res, expected)
 
-        to_begin = tensor(-99, chunks=2)
-        to_end = tensor([88, 99], chunks=2)
+        to_begin = tensor(-99, chunk_size=2)
+        to_end = tensor([88, 99], chunk_size=2)
         t = ediff1d(x, to_begin=to_begin, to_end=to_end)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
@@ -508,7 +508,7 @@ class Test(unittest.TestCase):
 
         data = [[1, 2, 4], [1, 6, 24]]
 
-        t = ediff1d(tensor(data, chunks=2))
+        t = ediff1d(tensor(data, chunk_size=2))
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.ediff1d(data)
@@ -516,7 +516,7 @@ class Test(unittest.TestCase):
 
     def testDigitizeExecution(self):
         data = np.array([0.2, 6.4, 3.0, 1.6])
-        x = tensor(data, chunks=2)
+        x = tensor(data, chunk_size=2)
         bins = np.array([0.0, 1.0, 2.5, 4.0, 10.0])
         inds = digitize(x, bins)
 
@@ -524,7 +524,7 @@ class Test(unittest.TestCase):
         expected = np.digitize(data, bins)
         np.testing.assert_equal(res, expected)
 
-        b = tensor(bins, chunks=2)
+        b = tensor(bins, chunk_size=2)
         inds = digitize(x, b)
 
         res = self.executor.execute_tensor(inds, concat=True)[0]
@@ -532,7 +532,7 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(res, expected)
 
         data = np.array([1.2, 10.0, 12.4, 15.5, 20.])
-        x = tensor(data, chunks=2)
+        x = tensor(data, chunk_size=2)
         bins = np.array([0, 5, 10, 15, 20])
         inds = digitize(x, bins, right=True)
 
@@ -547,7 +547,7 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(res, expected)
 
         data = sps.random(10, 1, density=.1) * 12
-        x = tensor(data, chunks=2)
+        x = tensor(data, chunk_size=2)
         bins = np.array([1.0, 2.0, 2.5, 4.0, 10.0])
         inds = digitize(x, bins)
 
@@ -556,32 +556,32 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(res.toarray(), expected)
 
     def testAverageExecution(self):
-        data = arange(1, 5, chunks=1)
+        data = arange(1, 5, chunk_size=1)
         t = average(data)
 
         res = self.executor.execute_tensor(t)[0]
         expected = np.average(np.arange(1, 5))
         self.assertEqual(res, expected)
 
-        t = average(arange(1, 11, chunks=2), weights=arange(10, 0, -1, chunks=2))
+        t = average(arange(1, 11, chunk_size=2), weights=arange(10, 0, -1, chunk_size=2))
 
         res = self.executor.execute_tensor(t)[0]
         expected = np.average(range(1, 11), weights=range(10, 0, -1))
         self.assertEqual(res, expected)
 
-        data = arange(6, chunks=2).reshape((3, 2))
-        t = average(data, axis=1, weights=tensor([1./4, 3./4], chunks=2))
+        data = arange(6, chunk_size=2).reshape((3, 2))
+        t = average(data, axis=1, weights=tensor([1./4, 3./4], chunk_size=2))
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.average(np.arange(6).reshape(3, 2), axis=1, weights=(1./4, 3./4))
         np.testing.assert_equal(res, expected)
 
         with self.assertRaises(TypeError):
-            average(data, weights=tensor([1./4, 3./4], chunks=2))
+            average(data, weights=tensor([1./4, 3./4], chunk_size=2))
 
     def testCovExecution(self):
         data = np.array([[0, 2], [1, 1], [2, 0]]).T
-        x = tensor(data, chunks=1)
+        x = tensor(data, chunk_size=1)
 
         t = cov(x)
 
@@ -591,8 +591,8 @@ class Test(unittest.TestCase):
 
         data_x = [-2.1, -1, 4.3]
         data_y = [3,  1.1,  0.12]
-        x = tensor(data_x, chunks=1)
-        y = tensor(data_y, chunks=1)
+        x = tensor(data_x, chunk_size=1)
+        y = tensor(data_y, chunk_size=1)
 
         X = stack((x, y), axis=0)
         t = cov(x, y)
@@ -602,8 +602,8 @@ class Test(unittest.TestCase):
     def testCorrcoefExecution(self):
         data_x = [-2.1, -1, 4.3]
         data_y = [3, 1.1, 0.12]
-        x = tensor(data_x, chunks=1)
-        y = tensor(data_y, chunks=1)
+        x = tensor(data_x, chunk_size=1)
+        y = tensor(data_y, chunk_size=1)
 
         t = corrcoef(x, y)
 
@@ -612,7 +612,7 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(res, expected)
 
     def testFlipExecution(self):
-        a = arange(8, chunks=2).reshape((2, 2, 2))
+        a = arange(8, chunk_size=2).reshape((2, 2, 2))
 
         t = flip(a, 0)
 
@@ -646,7 +646,7 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(res, expected)
 
         x_data = np.random.randn(20, 30)
-        x = tensor(x_data, chunks=(3, 4))
+        x = tensor(x_data, chunk_size=(3, 4))
 
         t = repeat(x, 2)
 
@@ -666,14 +666,14 @@ class Test(unittest.TestCase):
         expected = np.repeat(x_data, np.arange(20), axis=0)
         np.testing.assert_equal(res, expected)
 
-        t = repeat(x, arange(20, chunks=5), axis=0)
+        t = repeat(x, arange(20, chunk_size=5), axis=0)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.repeat(x_data, np.arange(20), axis=0)
         np.testing.assert_equal(res, expected)
 
         x_data = sps.random(20, 30, density=.1)
-        x = tensor(x_data, chunks=(3, 4))
+        x = tensor(x_data, chunk_size=(3, 4))
 
         t = repeat(x, 2, axis=1)
 
@@ -683,7 +683,7 @@ class Test(unittest.TestCase):
 
     def testTileExecution(self):
         a_data = np.array([0, 1, 2])
-        a = tensor(a_data, chunks=2)
+        a = tensor(a_data, chunk_size=2)
 
         t = tile(a, 2)
 
@@ -704,7 +704,7 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(res, expected)
 
         b_data = np.array([[1, 2], [3, 4]])
-        b = tensor(b_data, chunks=1)
+        b = tensor(b_data, chunk_size=1)
 
         t = tile(b, 2)
 
@@ -719,7 +719,7 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(res, expected)
 
         c_data = np.array([1, 2, 3, 4])
-        c = tensor(c_data, chunks=3)
+        c = tensor(c_data, chunk_size=3)
 
         t = tile(c, (4, 1))
 
@@ -728,7 +728,7 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(res, expected)
 
     def testIsInExecution(self):
-        element = 2 * arange(4, chunks=1).reshape((2, 2))
+        element = 2 * arange(4, chunk_size=1).reshape((2, 2))
         test_elements = [1, 2, 4, 8]
 
         mask = isin(element, test_elements)

--- a/mars/tensor/execution/tests/test_core_execute.py
+++ b/mars/tensor/execution/tests/test_core_execute.py
@@ -30,7 +30,7 @@ class Test(unittest.TestCase):
         self.session._sess = local_session
 
     def testDecref(self):
-        a = ones((10, 20), chunks=5)
+        a = ones((10, 20), chunk_size=5)
         b = a + 1
 
         b.execute(session=self.session)

--- a/mars/tensor/execution/tests/test_cupy_execute.py
+++ b/mars/tensor/execution/tests/test_cupy_execute.py
@@ -27,8 +27,8 @@ class Test(unittest.TestCase):
         self.executor = Executor('cupy')
 
     def testElementwise(self):
-        t1 = ones((10000, 5000), chunks=500, gpu=True)
-        t2 = ones(5000, chunks=500, gpu=True)
+        t1 = ones((10000, 5000), chunk_size=500, gpu=True)
+        t2 = ones(5000, chunk_size=500, gpu=True)
         t = (t1 - t2) / sqrt(t2 * (1 - t2) * len(t2))
 
         g = t.build_graph(tiled=True)

--- a/mars/tensor/execution/tests/test_datasource_execute.py
+++ b/mars/tensor/execution/tests/test_datasource_execute.py
@@ -33,7 +33,7 @@ class Test(TestBase):
 
     def testCreateSparseExecution(self):
         mat = sps.csr_matrix([[0, 0, 2], [2, 0, 0]])
-        t = tensor(mat, dtype='f8', chunks=2)
+        t = tensor(mat, dtype='f8', chunk_size=2)
 
         res = self.executor.execute_tensor(t)
         self.assertIsInstance(res[0], SparseNDArray)
@@ -50,7 +50,7 @@ class Test(TestBase):
         np.testing.assert_array_equal(res[0].toarray(), expected[..., :2].toarray())
         np.testing.assert_array_equal(res[1].toarray(), expected[..., 2:].toarray())
 
-        t3 = tensor(np.array([[0, 0, 2], [2, 0, 0]]), chunks=2).tosparse()
+        t3 = tensor(np.array([[0, 0, 2], [2, 0, 0]]), chunk_size=2).tosparse()
 
         res = self.executor.execute_tensor(t3)
         self.assertIsInstance(res[0], SparseNDArray)
@@ -59,7 +59,7 @@ class Test(TestBase):
         np.testing.assert_array_equal(res[1].toarray(), mat[..., 2:].toarray())
 
     def testZerosExecution(self):
-        t = zeros((20, 30), dtype='i8', chunks=5)
+        t = zeros((20, 30), dtype='i8', chunk_size=5)
 
         res = self.executor.execute_tensor(t, concat=True)
         self.assertTrue(np.array_equal(res[0], np.zeros((20, 30), dtype='i8')))
@@ -70,20 +70,20 @@ class Test(TestBase):
         self.assertTrue(np.array_equal(res[0], np.zeros((20, 30), dtype='i8')))
         self.assertEqual(res[0].dtype, np.int64)
 
-        t = zeros((20, 30), dtype='i4', chunks=5, sparse=True)
+        t = zeros((20, 30), dtype='i4', chunk_size=5, sparse=True)
         res = self.executor.execute_tensor(t, concat=True)
 
         self.assertEqual(res[0].nnz, 0)
 
     def testEmptyExecution(self):
-        t = empty((20, 30), dtype='i8', chunks=5)
+        t = empty((20, 30), dtype='i8', chunk_size=5)
 
         res = self.executor.execute_tensor(t, concat=True)
         self.assertEqual(res[0].shape, (20, 30))
         self.assertEqual(res[0].dtype, np.int64)
         self.assertFalse(np.array_equal(res, np.zeros((20, 30))))
 
-        t = empty((20, 30), chunks=5)
+        t = empty((20, 30), chunk_size=5)
 
         res = self.executor.execute_tensor(t, concat=True)
         self.assertFalse(np.allclose(res, np.zeros((20, 30))))
@@ -94,35 +94,35 @@ class Test(TestBase):
         self.assertEqual(res[0].dtype, np.float64)
 
     def testFullExecution(self):
-        t = full((2, 2), 1, dtype='f4', chunks=1)
+        t = full((2, 2), 1, dtype='f4', chunk_size=1)
 
         res = self.executor.execute_tensor(t, concat=True)
         self.assertTrue(np.array_equal(res[0], np.full((2, 2), 1, dtype='f4')))
 
-        t = full((2, 2), [1, 2], dtype='f8', chunks=1)
+        t = full((2, 2), [1, 2], dtype='f8', chunk_size=1)
 
         res = self.executor.execute_tensor(t, concat=True)
         self.assertTrue(np.array_equal(res[0], np.full((2, 2), [1, 2], dtype='f8')))
 
     def testArangeExecution(self):
-        t = arange(1, 20, 3, chunks=2)
+        t = arange(1, 20, 3, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.array_equal(res, np.arange(1, 20, 3)))
 
-        t = arange(1, 20, .3, chunks=4)
+        t = arange(1, 20, .3, chunk_size=4)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.arange(1, 20, .3)
         self.assertTrue(np.allclose(res, expected))
 
-        t = arange(1.0, 1.8, .3, chunks=4)
+        t = arange(1.0, 1.8, .3, chunk_size=4)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.arange(1.0, 1.8, .3)
         self.assertTrue(np.allclose(res, expected))
 
-        t = arange('1066-10-13', '1066-10-31', dtype=np.datetime64, chunks=3)
+        t = arange('1066-10-13', '1066-10-31', dtype=np.datetime64, chunk_size=3)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.arange('1066-10-13', '1066-10-31', dtype=np.datetime64)
@@ -130,7 +130,7 @@ class Test(TestBase):
 
     def testDiagExecution(self):
         # 2-d  6 * 6
-        a = arange(36, chunks=2).reshape(6, 6)
+        a = arange(36, chunk_size=2).reshape(6, 6)
 
         d = diag(a)
         res = self.executor.execute_tensor(d, concat=True)[0]
@@ -158,7 +158,7 @@ class Test(TestBase):
         np.testing.assert_equal(res, expected)
 
         # 2-d  4 * 9
-        a = arange(36, chunks=2).reshape(4, 9)
+        a = arange(36, chunk_size=2).reshape(4, 9)
 
         d = diag(a)
         res = self.executor.execute_tensor(d, concat=True)[0]
@@ -186,7 +186,7 @@ class Test(TestBase):
         np.testing.assert_equal(res, expected)
 
         # 1-d
-        a = arange(5, chunks=2)
+        a = arange(5, chunk_size=2)
 
         d = diag(a)
         res = self.executor.execute_tensor(d, concat=True)[0]
@@ -244,26 +244,26 @@ class Test(TestBase):
         np.testing.assert_equal(res.toarray(), expected)
 
     def testDiagflatExecution(self):
-        a = diagflat([[1, 2], [3, 4]], chunks=1)
+        a = diagflat([[1, 2], [3, 4]], chunk_size=1)
 
         res = self.executor.execute_tensor(a, concat=True)[0]
         expected = np.diagflat([[1, 2], [3, 4]])
         np.testing.assert_equal(res, expected)
 
-        d = tensor([[1, 2], [3, 4]], chunks=1)
+        d = tensor([[1, 2], [3, 4]], chunk_size=1)
         a = diagflat(d)
 
         res = self.executor.execute_tensor(a, concat=True)[0]
         expected = np.diagflat([[1, 2], [3, 4]])
         np.testing.assert_equal(res, expected)
 
-        a = diagflat([1, 2], 1, chunks=1)
+        a = diagflat([1, 2], 1, chunk_size=1)
 
         res = self.executor.execute_tensor(a, concat=True)[0]
         expected = np.diagflat([1, 2], 1)
         np.testing.assert_equal(res, expected)
 
-        d = tensor([[1, 2]], chunks=1)
+        d = tensor([[1, 2]], chunk_size=1)
         a = diagflat(d, 1)
 
         res = self.executor.execute_tensor(a, concat=True)[0]
@@ -271,55 +271,55 @@ class Test(TestBase):
         np.testing.assert_equal(res, expected)
 
     def testEyeExecution(self):
-        t = eye(5, chunks=2)
+        t = eye(5, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5)
         np.testing.assert_equal(res, expected)
 
-        t = eye(5, k=1, chunks=2)
+        t = eye(5, k=1, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, k=1)
         np.testing.assert_equal(res, expected)
 
-        t = eye(5, k=2, chunks=2)
+        t = eye(5, k=2, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, k=2)
         np.testing.assert_equal(res, expected)
 
-        t = eye(5, k=-1, chunks=2)
+        t = eye(5, k=-1, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, k=-1)
         np.testing.assert_equal(res, expected)
 
-        t = eye(5, k=-3, chunks=2)
+        t = eye(5, k=-3, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, k=-3)
         np.testing.assert_equal(res, expected)
 
-        t = eye(5, M=3, k=1, chunks=2)
+        t = eye(5, M=3, k=1, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, M=3, k=1)
         np.testing.assert_equal(res, expected)
 
-        t = eye(5, M=3, k=-3, chunks=2)
+        t = eye(5, M=3, k=-3, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, M=3, k=-3)
         np.testing.assert_equal(res, expected)
 
-        t = eye(5, M=7, k=1, chunks=2)
+        t = eye(5, M=7, k=1, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, M=7, k=1)
         np.testing.assert_equal(res, expected)
 
-        t = eye(5, M=8, k=-3, chunks=2)
+        t = eye(5, M=8, k=-3, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, M=8, k=-3)
@@ -331,63 +331,63 @@ class Test(TestBase):
         self.assertEqual(res.dtype, np.int_)
 
         # test sparse
-        t = eye(5, sparse=True, chunks=2)
+        t = eye(5, sparse=True, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5)
         self.assertIsInstance(res, SparseNDArray)
         np.testing.assert_equal(res.toarray(), expected)
 
-        t = eye(5, k=1, sparse=True, chunks=2)
+        t = eye(5, k=1, sparse=True, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, k=1)
         self.assertIsInstance(res, SparseNDArray)
         np.testing.assert_equal(res.toarray(), expected)
 
-        t = eye(5, k=2, sparse=True, chunks=2)
+        t = eye(5, k=2, sparse=True, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, k=2)
         self.assertIsInstance(res, SparseNDArray)
         np.testing.assert_equal(res.toarray(), expected)
 
-        t = eye(5, k=-1, sparse=True, chunks=2)
+        t = eye(5, k=-1, sparse=True, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, k=-1)
         self.assertIsInstance(res, SparseNDArray)
         np.testing.assert_equal(res.toarray(), expected)
 
-        t = eye(5, k=-3, sparse=True, chunks=2)
+        t = eye(5, k=-3, sparse=True, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, k=-3)
         self.assertIsInstance(res, SparseNDArray)
         np.testing.assert_equal(res.toarray(), expected)
 
-        t = eye(5, M=3, k=1, sparse=True, chunks=2)
+        t = eye(5, M=3, k=1, sparse=True, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, M=3, k=1)
         self.assertIsInstance(res, SparseNDArray)
         np.testing.assert_equal(res.toarray(), expected)
 
-        t = eye(5, M=3, k=-3, sparse=True, chunks=2)
+        t = eye(5, M=3, k=-3, sparse=True, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, M=3, k=-3)
         self.assertIsInstance(res, SparseNDArray)
         np.testing.assert_equal(res.toarray(), expected)
 
-        t = eye(5, M=7, k=1, sparse=True, chunks=2)
+        t = eye(5, M=7, k=1, sparse=True, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, M=7, k=1)
         self.assertIsInstance(res, SparseNDArray)
         np.testing.assert_equal(res.toarray(), expected)
 
-        t = eye(5, M=8, k=-3, sparse=True, chunks=2)
+        t = eye(5, M=8, k=-3, sparse=True, chunk_size=2)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         expected = np.eye(5, M=8, k=-3)
@@ -395,27 +395,27 @@ class Test(TestBase):
         np.testing.assert_equal(res.toarray(), expected)
 
     def testLinspaceExecution(self):
-        a = linspace(2.0, 9.0, num=11, chunks=3)
+        a = linspace(2.0, 9.0, num=11, chunk_size=3)
 
         res = self.executor.execute_tensor(a, concat=True)[0]
         expected = np.linspace(2.0, 9.0, num=11)
         np.testing.assert_allclose(res, expected)
 
-        a = linspace(2.0, 9.0, num=11, endpoint=False, chunks=3)
+        a = linspace(2.0, 9.0, num=11, endpoint=False, chunk_size=3)
 
         res = self.executor.execute_tensor(a, concat=True)[0]
         expected = np.linspace(2.0, 9.0, num=11, endpoint=False)
         np.testing.assert_allclose(res, expected)
 
-        a = linspace(2.0, 9.0, num=11, chunks=3, dtype=int)
+        a = linspace(2.0, 9.0, num=11, chunk_size=3, dtype=int)
 
         res = self.executor.execute_tensor(a, concat=True)[0]
         self.assertEqual(res.dtype, np.int_)
 
     def testMeshgridExecution(self):
-        a = arange(5, chunks=2)
-        b = arange(6, 12, chunks=3)
-        c = arange(12, 19, chunks=4)
+        a = arange(5, chunk_size=2)
+        b = arange(6, 12, chunk_size=3)
+        c = arange(12, 19, chunk_size=4)
 
         A, B, C = meshgrid(a, b, c)
 
@@ -477,7 +477,7 @@ class Test(TestBase):
         np.testing.assert_equal(C_res, C_expected)
 
     def testIndicesExecution(self):
-        grid = indices((2, 3), chunks=1)
+        grid = indices((2, 3), chunk_size=1)
 
         res = self.executor.execute_tensor(grid, concat=True)[0]
         expected = np.indices((2, 3))
@@ -490,7 +490,7 @@ class Test(TestBase):
         np.testing.assert_equal(res, expected[1])
 
     def testTriuExecution(self):
-        a = arange(24, chunks=2).reshape(2, 3, 4)
+        a = arange(24, chunk_size=2).reshape(2, 3, 4)
 
         t = triu(a)
 
@@ -523,7 +523,7 @@ class Test(TestBase):
         np.testing.assert_equal(res, expected)
 
         # test sparse
-        a = arange(12, chunks=2).reshape(3, 4).tosparse()
+        a = arange(12, chunk_size=2).reshape(3, 4).tosparse()
 
         t = triu(a)
 
@@ -561,7 +561,7 @@ class Test(TestBase):
         np.testing.assert_equal(res, expected)
 
     def testTrilExecution(self):
-        a = arange(24, chunks=2).reshape(2, 3, 4)
+        a = arange(24, chunk_size=2).reshape(2, 3, 4)
 
         t = tril(a)
 
@@ -593,7 +593,7 @@ class Test(TestBase):
         expected = np.tril(np.arange(24).reshape(2, 3, 4), k=-2)
         np.testing.assert_equal(res, expected)
 
-        a = arange(12, chunks=2).reshape(3, 4).tosparse()
+        a = arange(12, chunk_size=2).reshape(3, 4).tosparse()
 
         t = tril(a)
 

--- a/mars/tensor/execution/tests/test_fft_execute.py
+++ b/mars/tensor/execution/tests/test_fft_execute.py
@@ -30,7 +30,7 @@ class Test(unittest.TestCase):
 
     def testFFTExecution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 4, 30))
+        t = tensor(raw, chunk_size=(4, 4, 30))
 
         r = fft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -48,7 +48,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(res, expected))
 
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 4, 4))
+        t = tensor(raw, chunk_size=(4, 4, 4))
 
         r = fft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -67,7 +67,7 @@ class Test(unittest.TestCase):
 
     def testIFFTExecution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 4, 30))
+        t = tensor(raw, chunk_size=(4, 4, 30))
 
         r = ifft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -85,7 +85,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(res, expected))
 
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 4, 5))
+        t = tensor(raw, chunk_size=(4, 4, 5))
 
         r = ifft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -104,7 +104,7 @@ class Test(unittest.TestCase):
 
     def testFFT2Execution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 20, 30))
+        t = tensor(raw, chunk_size=(4, 20, 30))
 
         r = fft2(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -127,7 +127,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(res, expected))
 
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 5, 6))
+        t = tensor(raw, chunk_size=(4, 5, 6))
 
         r = fft2(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -151,7 +151,7 @@ class Test(unittest.TestCase):
 
     def testIFFT2Execution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 20, 30))
+        t = tensor(raw, chunk_size=(4, 20, 30))
 
         r = ifft2(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -174,7 +174,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(res, expected))
 
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 3, 5))
+        t = tensor(raw, chunk_size=(4, 3, 5))
 
         r = ifft2(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -198,7 +198,7 @@ class Test(unittest.TestCase):
 
     def testFFTNExecution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(10, 20, 30))
+        t = tensor(raw, chunk_size=(10, 20, 30))
 
         r = fftn(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -221,7 +221,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(res, expected))
 
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(3, 3, 4))
+        t = tensor(raw, chunk_size=(3, 3, 4))
 
         r = fftn(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -245,7 +245,7 @@ class Test(unittest.TestCase):
 
     def testIFFTNExecution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(10, 20, 30))
+        t = tensor(raw, chunk_size=(10, 20, 30))
 
         r = ifftn(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -268,7 +268,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(res, expected))
 
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(3, 4, 7))
+        t = tensor(raw, chunk_size=(3, 4, 7))
 
         r = ifftn(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -292,7 +292,7 @@ class Test(unittest.TestCase):
 
     def testRFFTExecution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 4, 30))
+        t = tensor(raw, chunk_size=(4, 4, 30))
 
         r = rfft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -311,7 +311,7 @@ class Test(unittest.TestCase):
 
     def testIRFFTExecution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 4, 30))
+        t = tensor(raw, chunk_size=(4, 4, 30))
 
         r = irfft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -330,7 +330,7 @@ class Test(unittest.TestCase):
 
     def testRFFT2Execution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 20, 30))
+        t = tensor(raw, chunk_size=(4, 20, 30))
 
         r = rfft2(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -354,7 +354,7 @@ class Test(unittest.TestCase):
 
     def testIRFFT2Execution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 20, 30))
+        t = tensor(raw, chunk_size=(4, 20, 30))
 
         r = irfft2(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -378,7 +378,7 @@ class Test(unittest.TestCase):
 
     def testRFFTNExecution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(10, 20, 30))
+        t = tensor(raw, chunk_size=(10, 20, 30))
 
         r = rfftn(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -402,7 +402,7 @@ class Test(unittest.TestCase):
 
     def testIRFFTNExecution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(10, 20, 30))
+        t = tensor(raw, chunk_size=(10, 20, 30))
 
         r = irfftn(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -426,7 +426,7 @@ class Test(unittest.TestCase):
 
     def testHFFTExecution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 4, 30))
+        t = tensor(raw, chunk_size=(4, 4, 30))
 
         r = hfft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -445,7 +445,7 @@ class Test(unittest.TestCase):
 
     def testIHFFTExecution(self):
         raw = np.random.rand(10, 20, 30)
-        t = tensor(raw, chunks=(4, 4, 30))
+        t = tensor(raw, chunk_size=(4, 4, 30))
 
         r = ihfft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -468,35 +468,35 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(res, expected))
 
     def testFFTFreqExecution(self):
-        t = fftfreq(10, .1, chunks=3)
+        t = fftfreq(10, .1, chunk_size=3)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.allclose(res, np.fft.fftfreq(10, .1)))
 
-        t = fftfreq(11, .01, chunks=3)
+        t = fftfreq(11, .01, chunk_size=3)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.allclose(res, np.fft.fftfreq(11, .01)))
 
     def testRFFTFreqExecution(self):
-        t = rfftfreq(20, .1, chunks=3)
+        t = rfftfreq(20, .1, chunk_size=3)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.allclose(res, np.fft.rfftfreq(20, .1)))
 
-        t = rfftfreq(21, .01, chunks=3)
+        t = rfftfreq(21, .01, chunk_size=3)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.allclose(res, np.fft.rfftfreq(21, .01)))
 
     def testFFTShiftExecution(self):
-        t = fftfreq(10, .1, chunks=3)
+        t = fftfreq(10, .1, chunk_size=3)
         r = fftshift(t)
 
         res = self.executor.execute_tensor(r, concat=True)[0]
         self.assertTrue(np.allclose(res, np.fft.fftshift(np.fft.fftfreq(10, .1))))
 
-        freqs = fftfreq(9, d=1./9, chunks=2).reshape(3, 3)
+        freqs = fftfreq(9, d=1./9, chunk_size=2).reshape(3, 3)
         r = fftshift(freqs, axes=(1,))
 
         res = self.executor.execute_tensor(r, concat=True)[0]
@@ -504,7 +504,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(res, expected))
 
     def testIFFTShiftExecution(self):
-        t = fftfreq(9, d=1./9, chunks=2).reshape(3, 3)
+        t = fftfreq(9, d=1./9, chunk_size=2).reshape(3, 3)
         r = ifftshift(t)
 
         res = self.executor.execute_tensor(r, concat=True)[0]

--- a/mars/tensor/execution/tests/test_index_execute.py
+++ b/mars/tensor/execution/tests/test_index_execute.py
@@ -30,15 +30,15 @@ from mars.config import options
 class Test(unittest.TestCase):
     def setUp(self):
         self.executor = Executor('numpy')
-        self.old_chunk = options.tensor.chunks
-        options.tensor.chunks = 10
+        self.old_chunk = options.tensor.chunk_size
+        options.tensor.chunk_size = 10
 
     def tearDown(self):
-        options.tensor.chunks = self.old_chunk
+        options.tensor.chunk_size = self.old_chunk
 
     def testBoolIndexingExecution(self):
         raw = np.random.random((11, 8, 12, 14))
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         index = arr < .5
         arr2 = arr[index]
@@ -46,7 +46,7 @@ class Test(unittest.TestCase):
 
         self.assertTrue(np.array_equal(np.sort(np.concatenate(res)), np.sort(raw[raw < .5])))
 
-        index2 = tensor(raw[:, :, 0, 0], chunks=3) < .5
+        index2 = tensor(raw[:, :, 0, 0], chunk_size=3) < .5
         arr3 = arr[index2]
         res = self.executor.execute_tensor(arr3)
 
@@ -54,7 +54,7 @@ class Test(unittest.TestCase):
 
     def testFancyIndexingExecution(self):
         raw = np.random.random((11, 8, 12, 14))
-        arr = tensor(raw, chunks=(2, 3, 2, 3))
+        arr = tensor(raw, chunk_size=(2, 3, 2, 3))
 
         index = [8, 10, 3, 1, 9, 10]
         arr2 = arr[index]
@@ -76,7 +76,7 @@ class Test(unittest.TestCase):
 
     def testSliceExecution(self):
         raw = np.random.random((11, 8, 12, 14))
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         arr2 = arr[2:9:2, 3:7, -1:-9:-2, 12:-11:-4]
         res = self.executor.execute_tensor(arr2, concat=True)
@@ -84,7 +84,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res[0], raw[2:9:2, 3:7, -1:-9:-2, 12:-11:-4]))
 
         raw = sps.random(12, 14, density=.1)
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         arr2 = arr[-1:-9:-2, 12:-11:-4]
         res = self.executor.execute_tensor(arr2, concat=True)[0]
@@ -93,17 +93,17 @@ class Test(unittest.TestCase):
 
     def testMixedIndexingExecution(self):
         raw = np.random.random((11, 8, 12, 13))
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         raw_cond = raw[0, :, 0, 0] < .5
-        cond = tensor(raw[0, :, 0, 0], chunks=3) < .5
+        cond = tensor(raw[0, :, 0, 0], chunk_size=3) < .5
         arr2 = arr[10::-2, cond, None, ..., :5]
         res = self.executor.execute_tensor(arr2, concat=True)
 
         self.assertTrue(np.array_equal(res[0], raw[10::-2, raw_cond, None, ..., :5]))
 
         b_raw = np.random.random(8)
-        cond = tensor(b_raw, chunks=2) < .5
+        cond = tensor(b_raw, chunk_size=2) < .5
         arr3 = arr[-2::-3, cond, ...]
         res = self.executor.execute_tensor(arr3, concat=True)
 
@@ -111,7 +111,7 @@ class Test(unittest.TestCase):
 
     def testSetItemExecution(self):
         raw = data = np.random.randint(0, 10, size=(11, 8, 12, 13))
-        arr = tensor(raw.copy(), chunks=3)
+        arr = tensor(raw.copy(), chunk_size=3)
         raw = raw.copy()
 
         idx = slice(2, 9, 2), slice(3, 7), slice(-1, -9, -2), 2
@@ -124,11 +124,11 @@ class Test(unittest.TestCase):
         raw = data
         shape = raw[idx].shape
 
-        arr2 = tensor(raw.copy(), chunks=3)
+        arr2 = tensor(raw.copy(), chunk_size=3)
         raw = raw.copy()
 
         replace = np.random.randint(10, 20, size=shape[:-1] + (1,)).astype('f4')
-        arr2[idx] = tensor(replace, chunks=4)
+        arr2[idx] = tensor(replace, chunk_size=4)
         res = self.executor.execute_tensor(arr2, concat=True)
 
         raw[idx] = replace
@@ -136,7 +136,7 @@ class Test(unittest.TestCase):
 
     def testTakeExecution(self):
         data = np.random.rand(10, 20, 30)
-        t = tensor(data, chunks=10)
+        t = tensor(data, chunk_size=10)
 
         a = t.take([4, 1, 2, 6, 200])
 
@@ -152,7 +152,7 @@ class Test(unittest.TestCase):
 
     def testCompressExecution(self):
         data = np.array([[1, 2], [3, 4], [5, 6]])
-        a = tensor(data, chunks=1)
+        a = tensor(data, chunk_size=1)
 
         t = compress([0, 1], a, axis=0)
 
@@ -189,7 +189,7 @@ class Test(unittest.TestCase):
 
     def testExtractExecution(self):
         data = np.arange(12).reshape((3, 4))
-        a = tensor(data, chunks=2)
+        a = tensor(data, chunk_size=2)
         condition = mod(a, 3) == 0
 
         t = extract(condition, a)
@@ -199,7 +199,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res, expected))
 
     def testChooseExecution(self):
-        options.tensor.chunks = 2
+        options.tensor.chunk_size = 2
 
         choices = [[0, 1, 2, 3], [10, 11, 12, 13],
                    [20, 21, 22, 23], [30, 31, 32, 33]]
@@ -242,7 +242,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res, expected))
 
     def testUnravelExecution(self):
-        a = tensor([22, 41, 37], chunks=1)
+        a = tensor([22, 41, 37], chunk_size=1)
         t = stack(unravel_index(a, (7, 6)))
 
         res = self.executor.execute_tensor(t, concat=True)[0]
@@ -252,7 +252,7 @@ class Test(unittest.TestCase):
 
     def testNonzeroExecution(self):
         data = np.array([[1, 0, 0], [0, 2, 0], [1, 1, 0]])
-        x = tensor(data, chunks=2)
+        x = tensor(data, chunk_size=2)
         t = hstack(nonzero(x))
 
         res = self.executor.execute_tensor(t, concat=True)[0]
@@ -261,7 +261,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res, expected))
 
     def testFlatnonzeroExecution(self):
-        x = arange(-2, 3, chunks=2)
+        x = arange(-2, 3, chunk_size=2)
 
         t = flatnonzero(x)
 

--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -34,21 +34,21 @@ class Test(unittest.TestCase):
     def testQRExecution(self):
         data = np.random.randn(18, 6)
 
-        a = tensor(data, chunks=(3, 6))
+        a = tensor(data, chunk_size=(3, 6))
         q, r = qr(a)
         t = q.dot(r)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.allclose(res, data))
 
-        a = tensor(data, chunks=(9, 6))
+        a = tensor(data, chunk_size=(9, 6))
         q, r = qr(a)
         t = q.dot(r)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.allclose(res, data))
 
-        a = tensor(data, chunks=3)
+        a = tensor(data, chunk_size=3)
         q, r = qr(a)
         t = q.dot(r)
 
@@ -58,21 +58,21 @@ class Test(unittest.TestCase):
     def testSVDExecution(self):
         data = np.random.randn(18, 6) + 1j * np.random.randn(18, 6)
 
-        a = tensor(data, chunks=(9, 6))
+        a = tensor(data, chunk_size=(9, 6))
         U, s, V = svd(a)
         t = U.dot(diag(s).dot(V))
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.allclose(res, data))
 
-        a = tensor(data, chunks=(18, 6))
+        a = tensor(data, chunk_size=(18, 6))
         U, s, V = svd(a)
         t = U.dot(diag(s).dot(V))
 
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.allclose(res, data))
 
-        a = tensor(data, chunks=(2, 6))
+        a = tensor(data, chunk_size=(2, 6))
         U, s, V = svd(a)
         t = U.dot(diag(s).dot(V))
 
@@ -82,7 +82,7 @@ class Test(unittest.TestCase):
     def testCholeskyExecution(self):
         data = np.array([[1, -2j], [2j, 5]])
 
-        a = tensor(data, chunks=1)
+        a = tensor(data, chunk_size=1)
 
         L = cholesky(a, lower=True)
         t = L.dot(L.T.conj())
@@ -97,7 +97,7 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.allclose(res, data))
 
-        a = tensor(data, chunks=2)
+        a = tensor(data, chunk_size=2)
 
         L = cholesky(a, lower=True)
         U = cholesky(a)
@@ -106,7 +106,7 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(t, concat=True)[0]
         np.testing.assert_allclose(res, data)
 
-        a = tensor(data, chunks=(1, 2))
+        a = tensor(data, chunk_size=(1, 2))
 
         L = cholesky(a, lower=True)
         U = cholesky(a)
@@ -119,7 +119,7 @@ class Test(unittest.TestCase):
         np.random.seed(1)
 
         data = np.random.randint(1, 10, (6, 6))
-        a = tensor(data, chunks=2)
+        a = tensor(data, chunk_size=2)
 
         P, L, U = lu(a)
         t = P.dot(L).dot(U)
@@ -127,7 +127,7 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(t, concat=True)[0]
         np.testing.assert_allclose(res, data)
 
-        a = tensor(data, chunks=1)
+        a = tensor(data, chunk_size=1)
 
         P, L, U = lu(a)
         t = P.dot(L).dot(U)
@@ -135,7 +135,7 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(t, concat=True)[0]
         np.testing.assert_allclose(res, data)
 
-        a = tensor(data, chunks=(1, 2))
+        a = tensor(data, chunk_size=(1, 2))
 
         P, L, U = lu(a)
         t = P.dot(L).dot(U)
@@ -143,7 +143,7 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(t, concat=True)[0]
         np.testing.assert_allclose(res, data)
 
-        a = tensor(data, chunks=3)
+        a = tensor(data, chunk_size=3)
         P, L, U = lu(a)
         t = P.dot(L).dot(U)
 
@@ -157,8 +157,8 @@ class Test(unittest.TestCase):
         data1 = np.random.randint(1, 10, (20, 20))
         data2 = np.random.randint(1, 10, (20, ))
 
-        A = tensor(data1, chunks=20)
-        b = tensor(data2, chunks=20)
+        A = tensor(data1, chunk_size=20)
+        b = tensor(data2, chunk_size=20)
 
         x = solve_triangular(A, b)
         t = triu(A).dot(x)
@@ -172,8 +172,8 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(t, concat=True)[0]
         np.testing.assert_allclose(res, data2)
 
-        A = tensor(data1, chunks=10)
-        b = tensor(data2, chunks=10)
+        A = tensor(data1, chunk_size=10)
+        b = tensor(data2, chunk_size=10)
 
         x = solve_triangular(A, b)
         t = triu(A).dot(x)
@@ -190,8 +190,8 @@ class Test(unittest.TestCase):
         data1 = np.random.randint(1, 10, (10, 10))
         data2 = np.random.randint(1, 10, (10, 5))
 
-        A = tensor(data1, chunks=10)
-        b = tensor(data2, chunks=10)
+        A = tensor(data1, chunk_size=10)
+        b = tensor(data2, chunk_size=10)
 
         x = solve_triangular(A, b)
         t = triu(A).dot(x)
@@ -205,8 +205,8 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(t, concat=True)[0]
         np.testing.assert_allclose(res, data2)
 
-        A = tensor(data1, chunks=3)
-        b = tensor(data2, chunks=3)
+        A = tensor(data1, chunk_size=3)
+        b = tensor(data2, chunk_size=3)
 
         x = solve_triangular(A, b)
         t = triu(A).dot(x)
@@ -227,8 +227,8 @@ class Test(unittest.TestCase):
         data1 = np.random.randint(1, 10, (20, 20))
         data2 = np.random.randint(1, 10, (20, ))
 
-        A = tensor(data1, chunks=5)
-        b = tensor(data2, chunks=5)
+        A = tensor(data1, chunk_size=5)
+        b = tensor(data2, chunk_size=5)
 
         x = solve(A, b)
 
@@ -239,8 +239,8 @@ class Test(unittest.TestCase):
 
         data2 = np.random.randint(1, 10, (20, 5))
 
-        A = tensor(data1, chunks=5)
-        b = tensor(data2, chunks=5)
+        A = tensor(data1, chunk_size=5)
+        b = tensor(data2, chunk_size=5)
 
         x = solve(A, b)
 
@@ -251,8 +251,8 @@ class Test(unittest.TestCase):
 
         data2 = np.random.randint(1, 10, (20, 20))
 
-        A = tensor(data1, chunks=5)
-        b = tensor(data2, chunks=5)
+        A = tensor(data1, chunk_size=5)
+        b = tensor(data2, chunk_size=5)
 
         x = solve(A, b)
 
@@ -270,8 +270,8 @@ class Test(unittest.TestCase):
         data1 = data_l.dot(data_l.T)
         data2 = np.random.randint(1, 10, (20, ))
 
-        A = tensor(data1, chunks=5)
-        b = tensor(data2, chunks=5)
+        A = tensor(data1, chunk_size=5)
+        b = tensor(data2, chunk_size=5)
 
         x = solve(A, b, sym_pos=True)
 
@@ -286,7 +286,7 @@ class Test(unittest.TestCase):
 
         data = np.random.randint(1, 10, (20, 20))
 
-        A = tensor(data, chunks=5)
+        A = tensor(data, chunk_size=5)
         inv_A = inv(A)
 
         res = self.executor.execute_tensor(inv_A, concat=True)[0]
@@ -298,8 +298,8 @@ class Test(unittest.TestCase):
         d = np.arange(9) - 4
         d2 = d.reshape(3, 3)
 
-        ma = [tensor(d, chunks=2), tensor(d, chunks=9),
-              tensor(d2, chunks=(2, 3)), tensor(d2, chunks=3)]
+        ma = [tensor(d, chunk_size=2), tensor(d, chunk_size=9),
+              tensor(d2, chunk_size=(2, 3)), tensor(d2, chunk_size=3)]
 
         for i, a in enumerate(ma):
             data = d if i < 2 else d2
@@ -321,7 +321,7 @@ class Test(unittest.TestCase):
         res = np.linalg.norm(d)
         self.assertEqual(expected, res)
 
-        d = uniform(-0.5, 0.5, size=(500, 2), chunks=50)
+        d = uniform(-0.5, 0.5, size=(500, 2), chunk_size=50)
         inside = (norm(d, axis=1) < 0.5).sum().astype(float)
         t = inside / 500 * 4
         res = self.executor.execute_tensor(t)[0]
@@ -329,9 +329,9 @@ class Test(unittest.TestCase):
 
     def testTensordotExecution(self):
         a_data = np.arange(60).reshape(3, 4, 5)
-        a = tensor(a_data, chunks=2)
+        a = tensor(a_data, chunk_size=2)
         b_data = np.arange(24).reshape(4, 3, 2)
-        b = tensor(b_data, chunks=2)
+        b = tensor(b_data, chunk_size=2)
 
         axes = ([1, 0], [0, 1])
         c = tensordot(a, b, axes=axes)
@@ -341,8 +341,8 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res[1], expected[2:4, :]))
         self.assertTrue(np.array_equal(res[2], expected[4:, :]))
 
-        a = ones((1000, 2000), chunks=500)
-        b = ones((2000, 100), chunks=500)
+        a = ones((1000, 2000), chunk_size=500)
+        b = ones((2000, 100), chunk_size=500)
         c = dot(a, b)
         res = self.executor.execute_tensor(c)
         expected = np.dot(np.ones((1000, 2000)), np.ones((2000, 100)))
@@ -350,31 +350,31 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(res[0], expected[:500, :]))
         self.assertTrue(np.array_equal(res[1], expected[500:, :]))
 
-        a = ones((10, 8), chunks=2)
-        b = ones((8, 10), chunks=2)
+        a = ones((10, 8), chunk_size=2)
+        b = ones((8, 10), chunk_size=2)
         c = a.dot(b)
         res = self.executor.execute_tensor(c)
         self.assertEqual(len(res), 25)
         for r in res:
             self.assertTrue(np.array_equal(r, np.tile([8], [2, 2])))
 
-        a = ones((500, 500), chunks=500)
-        b = ones((500, 100), chunks=500)
+        a = ones((500, 500), chunk_size=500)
+        b = ones((500, 100), chunk_size=500)
         c = a.dot(b)
         res = self.executor.execute_tensor(c)
         self.assertTrue(np.array_equal(res[0], np.tile([500], [500, 100])))
 
         raw_a = np.random.random((100, 200, 50))
         raw_b = np.random.random((200, 10, 100))
-        a = tensor(raw_a, chunks=50)
-        b = tensor(raw_b, chunks=33)
+        a = tensor(raw_a, chunk_size=50)
+        b = tensor(raw_b, chunk_size=33)
         c = tensordot(a, b, axes=((0, 1), (2, 0)))
         res = self.executor.execute_tensor(c, concat=True)
         expected = np.tensordot(raw_a, raw_b, axes=(c.op.a_axes, c.op.b_axes))
         self.assertTrue(np.allclose(res[0], expected))
 
-        a = ones((1000, 2000), chunks=500)
-        b = ones((100, 2000), chunks=500)
+        a = ones((1000, 2000), chunk_size=500)
+        b = ones((100, 2000), chunk_size=500)
         c = inner(a, b)
         res = self.executor.execute_tensor(c)
         expected = np.inner(np.ones((1000, 2000)), np.ones((100, 2000)))
@@ -385,8 +385,8 @@ class Test(unittest.TestCase):
     def testSparseDotExecution(self):
         a_data = sps.random(5, 9, density=.1)
         b_data = sps.random(9, 10, density=.2)
-        a = tensor(a_data, chunks=2)
-        b = tensor(b_data, chunks=3)
+        a = tensor(a_data, chunk_size=2)
+        b = tensor(b_data, chunk_size=3)
 
         c = dot(a, b)
 
@@ -421,8 +421,8 @@ class Test(unittest.TestCase):
     def testVdotExecution(self):
         a_data = np.array([1 + 2j, 3 + 4j])
         b_data = np.array([5 + 6j, 7 + 8j])
-        a = tensor(a_data, chunks=1)
-        b = tensor(b_data, chunks=1)
+        a = tensor(a_data, chunk_size=1)
+        b = tensor(b_data, chunk_size=1)
 
         t = vdot(a, b)
 
@@ -432,8 +432,8 @@ class Test(unittest.TestCase):
 
         a_data = np.array([[1, 4], [5, 6]])
         b_data = np.array([[4, 1], [2, 2]])
-        a = tensor(a_data, chunks=1)
-        b = tensor(b_data, chunks=1)
+        a = tensor(a_data, chunk_size=1)
+        b = tensor(b_data, chunk_size=1)
 
         t = vdot(a, b)
 
@@ -445,8 +445,8 @@ class Test(unittest.TestCase):
         data_a = np.random.randn(10, 20)
         data_b = np.random.randn(20)
 
-        a = tensor(data_a, chunks=2)
-        b = tensor(data_b, chunks=3)
+        a = tensor(data_a, chunk_size=2)
+        b = tensor(data_b, chunk_size=3)
         c = matmul(a, b)
 
         res = self.executor.execute_tensor(c, concat=True)[0]
@@ -456,8 +456,8 @@ class Test(unittest.TestCase):
         data_a = np.random.randn(10, 20)
         data_b = np.random.randn(10)
 
-        a = tensor(data_a, chunks=2)
-        b = tensor(data_b, chunks=3)
+        a = tensor(data_a, chunk_size=2)
+        b = tensor(data_b, chunk_size=3)
         c = matmul(b, a)
 
         res = self.executor.execute_tensor(c, concat=True)[0]
@@ -467,16 +467,16 @@ class Test(unittest.TestCase):
         data_a = np.random.randn(15, 1, 20, 30)
         data_b = np.random.randn(1, 11, 30, 20)
 
-        a = tensor(data_a, chunks=12)
-        b = tensor(data_b, chunks=13)
+        a = tensor(data_a, chunk_size=12)
+        b = tensor(data_b, chunk_size=13)
         c = matmul(a, b)
 
         res = self.executor.execute_tensor(c, concat=True)[0]
         expected = np.matmul(data_a, data_b)
         np.testing.assert_allclose(res, expected, atol=.0001)
 
-        a = arange(2 * 2 * 4, chunks=1).reshape((2, 2, 4))
-        b = arange(2 * 2 * 4, chunks=1).reshape((2, 4, 2))
+        a = arange(2 * 2 * 4, chunk_size=1).reshape((2, 2, 4))
+        b = arange(2 * 2 * 4, chunk_size=1).reshape((2, 4, 2))
         c = matmul(a, b)
 
         res = self.executor.execute_tensor(c, concat=True)[0]
@@ -487,8 +487,8 @@ class Test(unittest.TestCase):
         data_a = sps.random(10, 20)
         data_b = sps.random(20, 5)
 
-        a = tensor(data_a, chunks=2)
-        b = tensor(data_b, chunks=3)
+        a = tensor(data_a, chunk_size=2)
+        b = tensor(data_b, chunk_size=3)
         c = matmul(a, b)
 
         res = self.executor.execute_tensor(c, concat=True)[0]

--- a/mars/tensor/execution/tests/test_merge_execute.py
+++ b/mars/tensor/execution/tests/test_merge_execute.py
@@ -33,9 +33,9 @@ class Test(unittest.TestCase):
         b_data = np.random.rand(10, 20, 40)
         c_data = np.random.rand(10, 20, 50)
 
-        a = tensor(a_data, chunks=5)
-        b = tensor(b_data, chunks=6)
-        c = tensor(c_data, chunks=7)
+        a = tensor(a_data, chunk_size=5)
+        b = tensor(b_data, chunk_size=6)
+        c = tensor(c_data, chunk_size=7)
 
         d = concatenate([a, b, c], axis=-1)
         res = self.executor.execute_tensor(d, concat=True)[0]
@@ -46,9 +46,9 @@ class Test(unittest.TestCase):
         b_data = sps.rand(10, 40)
         c_data = sps.rand(10, 50)
 
-        a = tensor(a_data, chunks=5)
-        b = tensor(b_data, chunks=6)
-        c = tensor(c_data, chunks=7)
+        a = tensor(a_data, chunk_size=5)
+        b = tensor(b_data, chunk_size=6)
+        c = tensor(c_data, chunk_size=7)
 
         d = concatenate([a, b, c], axis=-1)
         res = self.executor.execute_tensor(d, concat=True)[0]
@@ -57,7 +57,7 @@ class Test(unittest.TestCase):
 
     def testStackExecution(self):
         raw = [np.random.randn(3, 4) for _ in range(10)]
-        arrs = [tensor(a, chunks=3) for a in raw]
+        arrs = [tensor(a, chunk_size=3) for a in raw]
 
         arr2 = stack(arrs)
         res = self.executor.execute_tensor(arr2, concat=True)
@@ -75,8 +75,8 @@ class Test(unittest.TestCase):
         a_data = np.random.rand(10)
         b_data = np.random.rand(20)
 
-        a = tensor(a_data, chunks=4)
-        b = tensor(b_data, chunks=4)
+        a = tensor(a_data, chunk_size=4)
+        b = tensor(b_data, chunk_size=4)
 
         c = hstack([a, b])
         res = self.executor.execute_tensor(c, concat=True)[0]
@@ -86,8 +86,8 @@ class Test(unittest.TestCase):
         a_data = np.random.rand(10, 20)
         b_data = np.random.rand(10, 5)
 
-        a = tensor(a_data, chunks=3)
-        b = tensor(b_data, chunks=4)
+        a = tensor(a_data, chunk_size=3)
+        b = tensor(b_data, chunk_size=4)
 
         c = hstack([a, b])
         res = self.executor.execute_tensor(c, concat=True)[0]
@@ -98,8 +98,8 @@ class Test(unittest.TestCase):
         a_data = np.random.rand(10)
         b_data = np.random.rand(10)
 
-        a = tensor(a_data, chunks=4)
-        b = tensor(b_data, chunks=4)
+        a = tensor(a_data, chunk_size=4)
+        b = tensor(b_data, chunk_size=4)
 
         c = vstack([a, b])
         res = self.executor.execute_tensor(c, concat=True)[0]
@@ -109,8 +109,8 @@ class Test(unittest.TestCase):
         a_data = np.random.rand(10, 20)
         b_data = np.random.rand(5, 20)
 
-        a = tensor(a_data, chunks=3)
-        b = tensor(b_data, chunks=4)
+        a = tensor(a_data, chunk_size=3)
+        b = tensor(b_data, chunk_size=4)
 
         c = vstack([a, b])
         res = self.executor.execute_tensor(c, concat=True)[0]
@@ -121,8 +121,8 @@ class Test(unittest.TestCase):
         a_data = np.random.rand(10)
         b_data = np.random.rand(10)
 
-        a = tensor(a_data, chunks=4)
-        b = tensor(b_data, chunks=4)
+        a = tensor(a_data, chunk_size=4)
+        b = tensor(b_data, chunk_size=4)
 
         c = dstack([a, b])
         res = self.executor.execute_tensor(c, concat=True)[0]
@@ -132,8 +132,8 @@ class Test(unittest.TestCase):
         a_data = np.random.rand(10, 20)
         b_data = np.random.rand(10, 20)
 
-        a = tensor(a_data, chunks=3)
-        b = tensor(b_data, chunks=4)
+        a = tensor(a_data, chunk_size=3)
+        b = tensor(b_data, chunk_size=4)
 
         c = dstack([a, b])
         res = self.executor.execute_tensor(c, concat=True)[0]
@@ -143,8 +143,8 @@ class Test(unittest.TestCase):
     def testColumnStackExecution(self):
         a_data = np.array((1, 2, 3))
         b_data = np.array((2, 3, 4))
-        a = tensor(a_data, chunks=1)
-        b = tensor(b_data, chunks=2)
+        a = tensor(a_data, chunk_size=1)
+        b = tensor(b_data, chunk_size=2)
 
         c = column_stack((a, b))
         res = self.executor.execute_tensor(c, concat=True)[0]
@@ -153,8 +153,8 @@ class Test(unittest.TestCase):
 
         a_data = np.random.rand(4, 2, 3)
         b_data = np.random.rand(4, 2, 3)
-        a = tensor(a_data, chunks=1)
-        b = tensor(b_data, chunks=2)
+        a = tensor(a_data, chunk_size=1)
+        b = tensor(b_data, chunk_size=2)
 
         c = column_stack((a, b))
         res = self.executor.execute_tensor(c, concat=True)[0]

--- a/mars/tensor/execution/tests/test_numexpr_execute.py
+++ b/mars/tensor/execution/tests/test_numexpr_execute.py
@@ -32,8 +32,8 @@ class Test(unittest.TestCase):
 
         raw1 = np.random.randint(10, size=(10, 10, 10))
         raw2 = np.random.randint(10, size=(10, 10, 10))
-        arr1 = tensor(raw1, chunks=3)
-        arr2 = tensor(raw2, chunks=3)
+        arr1 = tensor(raw1, chunk_size=3)
+        arr2 = tensor(raw2, chunk_size=3)
 
         arr3 = arr1 + arr2 + 10
         arr4 = 10 + arr1 + arr2
@@ -57,7 +57,7 @@ class Test(unittest.TestCase):
 
         for i, j in itertools.permutations(range(len(_new_unary_ufunc)), 2):
             raw = np.random.random((8, 8, 8))
-            arr1 = tensor(raw, chunks=4)
+            arr1 = tensor(raw, chunk_size=4)
 
             func1 = _new_unary_ufunc[i]
             func2 = _new_unary_ufunc[j]
@@ -67,7 +67,7 @@ class Test(unittest.TestCase):
             np.testing.assert_allclose(res[0], res_cmp[0])
 
         raw = np.random.randint(100, size=(8, 8, 8))
-        arr1 = tensor(raw, chunks=4)
+        arr1 = tensor(raw, chunk_size=4)
         arr2 = arccosh(1 + abs(invert(arr1)))
         res = executor_numexpr.execute_tensor(arr2, concat=True)
         res_cmp = self.executor.execute_tensor(arr2, concat=True)
@@ -83,7 +83,7 @@ class Test(unittest.TestCase):
 
         for i, j in itertools.permutations(range(len(_new_bin_ufunc)), 2):
             raw = np.random.random((9, 9, 9))
-            arr1 = tensor(raw, chunks=5)
+            arr1 = tensor(raw, chunk_size=5)
 
             func1 = _new_bin_ufunc[i]
             func2 = _new_bin_ufunc[j]
@@ -94,7 +94,7 @@ class Test(unittest.TestCase):
 
         for i, j in itertools.permutations(range(len(_sp_bin_ufunc)), 2):
             raw = np.random.randint(1, 100, size=(10, 10, 10))
-            arr1 = tensor(raw, chunks=3)
+            arr1 = tensor(raw, chunk_size=3)
 
             func1 = _sp_bin_ufunc[i]
             func2 = _sp_bin_ufunc[j]
@@ -106,8 +106,8 @@ class Test(unittest.TestCase):
     def testReductionExecution(self):
         raw1 = np.random.randint(5, size=(8, 8, 8))
         raw2 = np.random.randint(5, size=(8, 8, 8))
-        arr1 = tensor(raw1, chunks=3)
-        arr2 = tensor(raw2, chunks=3)
+        arr1 = tensor(raw1, chunk_size=3)
+        arr2 = tensor(raw2, chunk_size=3)
 
         res1 = self.executor.execute_tensor((arr1 + 1).sum(keepdims=True))
         res2 = self.executor.execute_tensor((arr1 + 1).prod(keepdims=True))
@@ -137,7 +137,7 @@ class Test(unittest.TestCase):
 
     def testBoolReductionExecution(self):
         raw = np.random.randint(5, size=(8, 8, 8))
-        arr = tensor(raw, chunks=2)
+        arr = tensor(raw, chunk_size=2)
 
         res = self.executor.execute_tensor((arr > 3).sum(axis=1), concat=True)
         np.testing.assert_array_equal(res[0], (raw > 3).sum(axis=1))

--- a/mars/tensor/execution/tests/test_prefetch.py
+++ b/mars/tensor/execution/tests/test_prefetch.py
@@ -60,8 +60,8 @@ class Test(unittest.TestCase):
         self.executor = Executor('numpy', storage=MockStorage(), prefetch=True)
 
     def testPrefetch(self):
-        t1 = ones((10, 8), chunks=10)
-        t2 = ones((1, 8), chunks=10)
+        t1 = ones((10, 8), chunk_size=10)
+        t2 = ones((1, 8), chunk_size=10)
         t3 = t1 + t2
 
         self.executor.execute_tensor(t3)

--- a/mars/tensor/execution/tests/test_random_execute.py
+++ b/mars/tensor/execution/tests/test_random_execute.py
@@ -30,7 +30,7 @@ class Test(unittest.TestCase):
         self.executor = Executor('numpy')
 
     def testRandExecution(self):
-        arr = tensor.random.rand(10, 20, chunks=3, dtype='f4')
+        arr = tensor.random.rand(10, 20, chunk_size=3, dtype='f4')
         res = self.executor.execute_tensor(arr, concat=True)[0]
         self.assertEqual(res.shape, (10, 20))
         self.assertTrue(np.all(res < 1))
@@ -38,10 +38,10 @@ class Test(unittest.TestCase):
         self.assertEqual(res.dtype, np.float32)
 
     def testRandnExecution(self):
-        arr = tensor.random.randn(10, 20, chunks=3)
+        arr = tensor.random.randn(10, 20, chunk_size=3)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (10, 20))
 
-        arr = tensor.random.randn(10, 20, chunks=5).tiles()
+        arr = tensor.random.randn(10, 20, chunk_size=5).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -49,17 +49,17 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).randn(5, 5)))
 
     def testRandintExecution(self):
-        arr = tensor.random.randint(0, 2, size=(10, 30), chunks=3)
+        arr = tensor.random.randint(0, 2, size=(10, 30), chunk_size=3)
         res = self.executor.execute_tensor(arr, concat=True)[0]
         self.assertEqual(res.shape, (10, 30))
         self.assertTrue(np.all(res >= 0))
         self.assertTrue(np.all(res < 2))
 
     def testRandomIntegersExecution(self):
-        arr = tensor.random.random_integers(0, 10, size=(10, 20), chunks=3)
+        arr = tensor.random.random_integers(0, 10, size=(10, 20), chunk_size=3)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (10, 20))
 
-        arr = tensor.random.random_integers(0, 10, size=(10, 20), chunks=5).tiles()
+        arr = tensor.random.random_integers(0, 10, size=(10, 20), chunk_size=5).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -67,10 +67,10 @@ class Test(unittest.TestCase):
             np.testing.assert_equal(res, np.random.RandomState(0).random_integers(0, 10, size=(5, 5)))
 
     def testRandomSampleExecution(self):
-        arr = tensor.random.random_sample(size=(10, 20), chunks=3)
+        arr = tensor.random.random_sample(size=(10, 20), chunk_size=3)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (10, 20))
 
-        arr = tensor.random.random_sample(size=(10, 20), chunks=5).tiles()
+        arr = tensor.random.random_sample(size=(10, 20), chunk_size=5).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -78,10 +78,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).random_sample(size=(5, 5))))
 
     def testRandomExecution(self):
-        arr = tensor.random.random(size=(10, 20), chunks=3)
+        arr = tensor.random.random(size=(10, 20), chunk_size=3)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (10, 20))
 
-        arr = tensor.random.random(size=(10, 20), chunks=5).tiles()
+        arr = tensor.random.random(size=(10, 20), chunk_size=5).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -89,10 +89,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).random_sample(size=(5, 5))))
 
     def testRandfExecution(self):
-        arr = tensor.random.ranf(size=(10, 20), chunks=3)
+        arr = tensor.random.ranf(size=(10, 20), chunk_size=3)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (10, 20))
 
-        arr = tensor.random.ranf(size=(10, 20), chunks=5).tiles()
+        arr = tensor.random.ranf(size=(10, 20), chunk_size=5).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -100,10 +100,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).random_sample(size=(5, 5))))
 
     def testSampleExecution(self):
-        arr = tensor.random.sample(size=(10, 20), chunks=3)
+        arr = tensor.random.sample(size=(10, 20), chunk_size=3)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (10, 20))
 
-        arr = tensor.random.sample(size=(10, 20), chunks=5).tiles()
+        arr = tensor.random.sample(size=(10, 20), chunk_size=5).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -111,20 +111,20 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).random_sample(size=(5, 5))))
 
     def testChoiceExecution(self):
-        arr = tensor.random.choice(5, size=3, chunks=1)
+        arr = tensor.random.choice(5, size=3, chunk_size=1)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (3,))
 
-        arr = tensor.random.choice(5, size=(15,), chunks=5).tiles()
+        arr = tensor.random.choice(5, size=(15,), chunk_size=5).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).choice(5, size=(5,))))
 
-        arr = tensor.random.choice([1, 4, 9], size=3, chunks=1)
+        arr = tensor.random.choice([1, 4, 9], size=3, chunk_size=1)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (3,))
 
-        arr = tensor.random.choice([1, 4, 9], size=(15,), chunks=5).tiles()
+        arr = tensor.random.choice([1, 4, 9], size=(15,), chunk_size=5).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -132,12 +132,12 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).choice([1, 4, 9], size=(5,))))
 
         with self.assertRaises(ValueError):
-            tensor.random.choice([1, 3, 4], size=5, replace=False, chunks=2)
+            tensor.random.choice([1, 3, 4], size=5, replace=False, chunk_size=2)
 
-        arr = tensor.random.choice([1, 4, 9], size=3, replace=False, chunks=1)
+        arr = tensor.random.choice([1, 4, 9], size=3, replace=False, chunk_size=1)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (3,))
 
-        arr = tensor.random.choice([1, 4, 9], size=(3,), replace=False, chunks=1).tiles()
+        arr = tensor.random.choice([1, 4, 9], size=(3,), replace=False, chunk_size=1).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -145,10 +145,10 @@ class Test(unittest.TestCase):
             self.assertTrue(
                 np.array_equal(res, np.random.RandomState(0).choice([1, 4, 9], size=(1,), replace=False)))
 
-        arr = tensor.random.choice([1, 4, 9], size=3, p=[.2, .5, .3], chunks=1)
+        arr = tensor.random.choice([1, 4, 9], size=3, p=[.2, .5, .3], chunk_size=1)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (3,))
 
-        arr = tensor.random.choice([1, 4, 9], size=(15,), chunks=5, p=[.2, .5, .3]).tiles()
+        arr = tensor.random.choice([1, 4, 9], size=(15,), chunk_size=5, p=[.2, .5, .3]).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -158,7 +158,7 @@ class Test(unittest.TestCase):
                                                                     p=[.2, .5, .3])))
 
     def testSparseRandintExecution(self):
-        arr = tensor.random.randint(1, 2, size=(30, 50), density=.1, chunks=10, dtype='f4')
+        arr = tensor.random.randint(1, 2, size=(30, 50), density=.1, chunk_size=10, dtype='f4')
         res = self.executor.execute_tensor(arr, concat=True)[0]
         self.assertTrue(issparse(res))
         self.assertEqual(res.shape, (30, 50))
@@ -167,19 +167,19 @@ class Test(unittest.TestCase):
         self.assertAlmostEqual((res >= 1).toarray().sum(), 30 * 50 * .1, delta=20)
 
     def testBetaExecute(self):
-        arr = tensor.random.beta(1, 2, chunks=2).tiles()
+        arr = tensor.random.beta(1, 2, chunk_size=2).tiles()
         arr.chunks[0].op._state = State(np.random.RandomState(0))
 
         self.assertEqual(self.executor.execute_tensor(arr)[0], np.random.RandomState(0).beta(1, 2))
 
-        arr = tensor.random.beta([1, 2], [3, 4], chunks=2).tiles()
+        arr = tensor.random.beta([1, 2], [3, 4], chunk_size=2).tiles()
         arr.chunks[0].op._state = State(np.random.RandomState(0))
 
         self.assertTrue(np.array_equal(self.executor.execute_tensor(arr)[0],
                                        np.random.RandomState(0).beta([1, 2], [3, 4])))
 
-        arr = tensor.random.beta([[2, 3]], from_ndarray([[4, 6], [5, 2]], chunks=2),
-                                 chunks=1, size=(3, 2, 2)).tiles()
+        arr = tensor.random.beta([[2, 3]], from_ndarray([[4, 6], [5, 2]], chunk_size=2),
+                                 chunk_size=1, size=(3, 2, 2)).tiles()
         for c in arr.chunks:
             c.op._state = State(np.random.RandomState(0))
 
@@ -190,18 +190,18 @@ class Test(unittest.TestCase):
         self.assertEqual(res[0, 1, 0], np.random.RandomState(0).beta(2, 5))
         self.assertEqual(res[0, 1, 1], np.random.RandomState(0).beta(3, 2))
 
-        arr = tensor.random.RandomState(0).beta([[3, 4]], [[1], [2]], chunks=1)
+        arr = tensor.random.RandomState(0).beta([[3, 4]], [[1], [2]], chunk_size=1)
         tensor.random.seed(0)
-        arr2 = tensor.random.beta([[3, 4]], [[1], [2]], chunks=1)
+        arr2 = tensor.random.beta([[3, 4]], [[1], [2]], chunk_size=1)
 
         self.assertTrue(np.array_equal(self.executor.execute_tensor(arr, concat=True)[0],
                                        self.executor.execute_tensor(arr2, concat=True)[0]))
 
     def testBinomialExecute(self):
-        arr = tensor.random.binomial(10, .5, 100, chunks=10)
+        arr = tensor.random.binomial(10, .5, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.binomial(10, .5, 100, chunks=10).tiles()
+        arr = tensor.random.binomial(10, .5, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -209,10 +209,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).binomial(10, .5, 10)))
 
     def testChisquareExecute(self):
-        arr = tensor.random.chisquare(2, 100, chunks=10)
+        arr = tensor.random.chisquare(2, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.chisquare(2, 100, chunks=10).tiles()
+        arr = tensor.random.chisquare(2, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -220,10 +220,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).chisquare(2, 10)))
 
     def testDirichletExecute(self):
-        arr = tensor.random.dirichlet((10, 5, 3), 100, chunks=10)
+        arr = tensor.random.dirichlet((10, 5, 3), 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100, 3))
 
-        arr = tensor.random.dirichlet((10, 5, 3), 100, chunks=10).tiles()
+        arr = tensor.random.dirichlet((10, 5, 3), 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -231,10 +231,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).dirichlet((10, 5, 3), 10)))
 
     def testExponentialExecute(self):
-        arr = tensor.random.exponential(1.0, 100, chunks=10)
+        arr = tensor.random.exponential(1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.exponential(1.0, 100, chunks=10).tiles()
+        arr = tensor.random.exponential(1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -242,10 +242,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).exponential(1.0, 10)))
 
     def testFExecute(self):
-        arr = tensor.random.f(1.0, 2.0, 100, chunks=10)
+        arr = tensor.random.f(1.0, 2.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.f(1.0, 2.0, 100, chunks=10).tiles()
+        arr = tensor.random.f(1.0, 2.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -253,10 +253,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).f(1.0, 2.0, 10)))
 
     def testGammaExecute(self):
-        arr = tensor.random.gamma(1.0, 2.0, 100, chunks=10)
+        arr = tensor.random.gamma(1.0, 2.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.gamma(1.0, 2.0, 100, chunks=10).tiles()
+        arr = tensor.random.gamma(1.0, 2.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -264,10 +264,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).gamma(1.0, 2.0, 10)))
 
     def testGeometricExecution(self):
-        arr = tensor.random.geometric(1.0, 100, chunks=10)
+        arr = tensor.random.geometric(1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.geometric(1.0, 100, chunks=10).tiles()
+        arr = tensor.random.geometric(1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -275,10 +275,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).geometric(1.0, 10)))
 
     def testGumbelExecution(self):
-        arr = tensor.random.gumbel(.5, 1.0, 100, chunks=10)
+        arr = tensor.random.gumbel(.5, 1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.gumbel(.5, 1.0, 100, chunks=10).tiles()
+        arr = tensor.random.gumbel(.5, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -286,10 +286,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).gumbel(.5, 1.0, 10)))
 
     def testHypergeometricExecution(self):
-        arr = tensor.random.hypergeometric(10, 20, 15, 100, chunks=10)
+        arr = tensor.random.hypergeometric(10, 20, 15, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.hypergeometric(10, 20, 15, 100, chunks=10).tiles()
+        arr = tensor.random.hypergeometric(10, 20, 15, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -297,10 +297,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).hypergeometric(10, 20, 15, 10)))
 
     def testLaplaceExecution(self):
-        arr = tensor.random.laplace(.5, 1.0, 100, chunks=10)
+        arr = tensor.random.laplace(.5, 1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.laplace(.5, 1.0, 100, chunks=10).tiles()
+        arr = tensor.random.laplace(.5, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -308,10 +308,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).laplace(.5, 1.0, 10)))
 
     def testLogisticExecution(self):
-        arr = tensor.random.logistic(.5, 1.0, 100, chunks=10)
+        arr = tensor.random.logistic(.5, 1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.logistic(.5, 1.0, 100, chunks=10).tiles()
+        arr = tensor.random.logistic(.5, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -319,10 +319,10 @@ class Test(unittest.TestCase):
             np.testing.assert_equal(res, np.random.RandomState(0).logistic(.5, 1.0, 10))
 
     def testLognormalExecution(self):
-        arr = tensor.random.lognormal(.5, 1.0, 100, chunks=10)
+        arr = tensor.random.lognormal(.5, 1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.lognormal(.5, 1.0, 100, chunks=10).tiles()
+        arr = tensor.random.lognormal(.5, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -330,10 +330,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).lognormal(.5, 1.0, 10)))
 
     def testLogseriesExecution(self):
-        arr = tensor.random.logseries(.5, 100, chunks=10)
+        arr = tensor.random.logseries(.5, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.logseries(.5, 100, chunks=10).tiles()
+        arr = tensor.random.logseries(.5, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -341,11 +341,11 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).logseries(.5, 10)))
 
     def testMultinomialExecution(self):
-        arr = tensor.random.multinomial(10, [.2, .5, .3], 100, chunks=10)
+        arr = tensor.random.multinomial(10, [.2, .5, .3], 100, chunk_size=10)
         self.assertEqual(arr.shape, (100, 3))
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100, 3))
 
-        arr = tensor.random.multinomial(10, [.2, .5, .3], 100, chunks=10).tiles()
+        arr = tensor.random.multinomial(10, [.2, .5, .3], 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -353,10 +353,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).multinomial(10, [.2, .5, .3], 10)))
 
     def testMultivariateNormalExecution(self):
-        arr = tensor.random.multivariate_normal([1, 2], [[1, 0], [0, 1]], 100, chunks=10)
+        arr = tensor.random.multivariate_normal([1, 2], [[1, 0], [0, 1]], 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100, 2))
 
-        arr = tensor.random.multivariate_normal([1, 2], [[1, 0], [0, 1]], 100, chunks=10).tiles()
+        arr = tensor.random.multivariate_normal([1, 2], [[1, 0], [0, 1]], 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -365,10 +365,10 @@ class Test(unittest.TestCase):
                 [1, 2], [[1, 0], [0, 1]], 10)))
 
     def testNegativeBinomialExecution(self):
-        arr = tensor.random.negative_binomial(5, 1.0, 100, chunks=10)
+        arr = tensor.random.negative_binomial(5, 1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.negative_binomial(5, 1.0, 100, chunks=10).tiles()
+        arr = tensor.random.negative_binomial(5, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -376,10 +376,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).negative_binomial(5, 1.0, 10)))
 
     def testNoncentralChisquareExecution(self):
-        arr = tensor.random.noncentral_chisquare(.5, 1.0, 100, chunks=10)
+        arr = tensor.random.noncentral_chisquare(.5, 1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.noncentral_chisquare(.5, 1.0, 100, chunks=10).tiles()
+        arr = tensor.random.noncentral_chisquare(.5, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -387,10 +387,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).noncentral_chisquare(.5, 1.0, 10)))
 
     def testNoncentralFExecution(self):
-        arr = tensor.random.noncentral_f(1.5, 1.0, 1.1, 100, chunks=10)
+        arr = tensor.random.noncentral_f(1.5, 1.0, 1.1, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.noncentral_f(1.5, 1.0, 1.1, 100, chunks=10).tiles()
+        arr = tensor.random.noncentral_f(1.5, 1.0, 1.1, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -398,10 +398,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).noncentral_f(1.5, 1.0, 1.1, 10)))
 
     def testNormalExecute(self):
-        arr = tensor.random.normal(10, 1.0, 100, chunks=10)
+        arr = tensor.random.normal(10, 1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.normal(10, 1.0, 100, chunks=10).tiles()
+        arr = tensor.random.normal(10, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -409,10 +409,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).normal(10, 1.0, 10)))
 
     def testParetoExecute(self):
-        arr = tensor.random.pareto(1.0, 100, chunks=10)
+        arr = tensor.random.pareto(1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.pareto(1.0, 100, chunks=10).tiles()
+        arr = tensor.random.pareto(1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -420,10 +420,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).pareto(1.0, 10)))
 
     def testPoissonExecute(self):
-        arr = tensor.random.poisson(1.0, 100, chunks=10)
+        arr = tensor.random.poisson(1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.poisson(1.0, 100, chunks=10).tiles()
+        arr = tensor.random.poisson(1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -431,10 +431,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).poisson(1.0, 10)))
 
     def testPowerExecute(self):
-        arr = tensor.random.power(1.0, 100, chunks=10)
+        arr = tensor.random.power(1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.power(1.0, 100, chunks=10).tiles()
+        arr = tensor.random.power(1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -442,10 +442,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).power(1.0, 10)))
 
     def testRayleighExecute(self):
-        arr = tensor.random.rayleigh(1.0, 100, chunks=10)
+        arr = tensor.random.rayleigh(1.0, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.rayleigh(1.0, 100, chunks=10).tiles()
+        arr = tensor.random.rayleigh(1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -453,10 +453,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).rayleigh(1.0, 10)))
 
     def testStandardCauchyExecute(self):
-        arr = tensor.random.standard_cauchy(100, chunks=10)
+        arr = tensor.random.standard_cauchy(100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.standard_cauchy(100, chunks=10).tiles()
+        arr = tensor.random.standard_cauchy(100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -464,10 +464,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).standard_cauchy(10)))
 
     def testStandardExponentialExecute(self):
-        arr = tensor.random.standard_exponential(100, chunks=10)
+        arr = tensor.random.standard_exponential(100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.standard_exponential(100, chunks=10).tiles()
+        arr = tensor.random.standard_exponential(100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -475,10 +475,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).standard_exponential(10)))
 
     def testStandardGammaExecute(self):
-        arr = tensor.random.standard_gamma(.1, 100, chunks=10)
+        arr = tensor.random.standard_gamma(.1, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.standard_gamma(.1, 100, chunks=10).tiles()
+        arr = tensor.random.standard_gamma(.1, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -486,10 +486,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).standard_gamma(.1, 10)))
 
     def testStandardNormalExecute(self):
-        arr = tensor.random.standard_normal(100, chunks=10)
+        arr = tensor.random.standard_normal(100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.standard_normal(100, chunks=10).tiles()
+        arr = tensor.random.standard_normal(100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -497,10 +497,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).standard_normal(10)))
 
     def testStandardTExecute(self):
-        arr = tensor.random.standard_t(.1, 100, chunks=10)
+        arr = tensor.random.standard_t(.1, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.standard_t(.1, 100, chunks=10).tiles()
+        arr = tensor.random.standard_t(.1, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -508,10 +508,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).standard_t(.1, 10)))
 
     def testTriangularExecute(self):
-        arr = tensor.random.triangular(.1, .2, .3, 100, chunks=10)
+        arr = tensor.random.triangular(.1, .2, .3, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.triangular(.1, .2, .3, 100, chunks=10).tiles()
+        arr = tensor.random.triangular(.1, .2, .3, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -519,10 +519,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).triangular(.1, .2, .3, 10)))
 
     def testUniformExecute(self):
-        arr = tensor.random.uniform(.1, .2, 100, chunks=10)
+        arr = tensor.random.uniform(.1, .2, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.uniform(.1, .2, 100, chunks=10).tiles()
+        arr = tensor.random.uniform(.1, .2, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -530,10 +530,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).uniform(.1, .2, 10)))
 
     def testVonmisesExecute(self):
-        arr = tensor.random.vonmises(.1, .2, 100, chunks=10)
+        arr = tensor.random.vonmises(.1, .2, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.vonmises(.1, .2, 100, chunks=10).tiles()
+        arr = tensor.random.vonmises(.1, .2, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -541,10 +541,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).vonmises(.1, .2, 10)))
 
     def testWaldExecute(self):
-        arr = tensor.random.wald(.1, .2, 100, chunks=10)
+        arr = tensor.random.wald(.1, .2, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.wald(.1, .2, 100, chunks=10).tiles()
+        arr = tensor.random.wald(.1, .2, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -552,10 +552,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).wald(.1, .2, 10)))
 
     def testWeibullExecute(self):
-        arr = tensor.random.weibull(.1, 100, chunks=10)
+        arr = tensor.random.weibull(.1, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.weibull(.1, 100, chunks=10).tiles()
+        arr = tensor.random.weibull(.1, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 
@@ -563,10 +563,10 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).weibull(.1, 10)))
 
     def testZipfExecute(self):
-        arr = tensor.random.zipf(1.1, 100, chunks=10)
+        arr = tensor.random.zipf(1.1, 100, chunk_size=10)
         self.assertEqual(self.executor.execute_tensor(arr, concat=True)[0].shape, (100,))
 
-        arr = tensor.random.zipf(1.1, 100, chunks=10).tiles()
+        arr = tensor.random.zipf(1.1, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
             chunk.op._state = State(np.random.RandomState(0))
 

--- a/mars/tensor/execution/tests/test_reduction_execute.py
+++ b/mars/tensor/execution/tests/test_reduction_execute.py
@@ -30,18 +30,18 @@ class Test(unittest.TestCase):
         self.executor = Executor('numpy')
 
     def testSumProdExecution(self):
-        arr = ones((10, 8), chunks=3)
+        arr = ones((10, 8), chunk_size=3)
         self.assertEqual([80], self.executor.execute_tensor(arr.sum()))
         self.assertEqual((10,) * 8,
                          tuple(np.concatenate(self.executor.execute_tensor(arr.sum(axis=0)))))
 
-        arr = ones((3, 3), chunks=2)
+        arr = ones((3, 3), chunk_size=2)
         self.assertEqual([512], self.executor.execute_tensor((arr * 2).prod()))
         self.assertEqual((8,) * 3,
                          tuple(np.concatenate(self.executor.execute_tensor((arr * 2).prod(axis=0)))))
 
         raw = sps.random(10, 20, density=.1)
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
         res = self.executor.execute_tensor(arr.sum())[0]
 
         self.assertAlmostEqual(res, raw.sum())
@@ -49,7 +49,7 @@ class Test(unittest.TestCase):
     def testMaxMinExecution(self):
         raw = np.random.randint(10000, size=(10, 10, 10))
 
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         self.assertEqual([raw.max()], self.executor.execute_tensor(arr.max()))
         self.assertEqual([raw.min()], self.executor.execute_tensor(arr.min()))
@@ -66,7 +66,7 @@ class Test(unittest.TestCase):
 
         raw = sps.random(10, 10, density=.5)
 
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         self.assertEqual([raw.max()], self.executor.execute_tensor(arr.max()))
         self.assertEqual([raw.min()], self.executor.execute_tensor(arr.min()))
@@ -77,9 +77,9 @@ class Test(unittest.TestCase):
         raw3 = np.array([[True, False, True, False], [True, True, True, True],
                          [False, False, False, False], [False, True, False, True]])
 
-        arr1 = tensor(raw1, chunks=3)
-        arr2 = tensor(raw2, chunks=3)
-        arr3 = tensor(raw3, chunks=4)
+        arr1 = tensor(raw1, chunk_size=3)
+        arr2 = tensor(raw2, chunk_size=3)
+        arr3 = tensor(raw3, chunk_size=4)
 
         self.assertFalse(self.executor.execute_tensor(arr1.all())[0])
         self.assertTrue(self.executor.execute_tensor(arr2.all())[0])
@@ -92,7 +92,7 @@ class Test(unittest.TestCase):
 
         raw = sps.random(10, 10, density=.5) > .5
 
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         self.assertEqual(raw.A.all(), self.executor.execute_tensor(arr.all())[0])
         self.assertEqual(raw.A.any(), self.executor.execute_tensor(arr.any())[0])
@@ -101,7 +101,7 @@ class Test(unittest.TestCase):
         raw1 = np.random.random((20, 25))
         raw2 = np.random.randint(10, size=(20, 25))
 
-        arr1 = tensor(raw1, chunks=3)
+        arr1 = tensor(raw1, chunk_size=3)
 
         res1 = self.executor.execute_tensor(arr1.mean())
         expected1 = raw1.mean()
@@ -115,7 +115,7 @@ class Test(unittest.TestCase):
         expected3 = raw1.mean(axis=1, keepdims=True)
         self.assertTrue(np.allclose(np.concatenate(res3), expected3))
 
-        arr2 = tensor(raw2, chunks=3)
+        arr2 = tensor(raw2, chunk_size=3)
 
         res1 = self.executor.execute_tensor(arr2.mean())
         expected1 = raw2.mean()
@@ -131,13 +131,13 @@ class Test(unittest.TestCase):
 
         raw1 = sps.random(20, 25, density=.1)
 
-        arr1 = tensor(raw1, chunks=3)
+        arr1 = tensor(raw1, chunk_size=3)
 
         res1 = self.executor.execute_tensor(arr1.mean())
         expected1 = raw1.mean()
         self.assertTrue(np.allclose(res1[0], expected1))
 
-        arr2 = tensor(raw1, chunks=30)
+        arr2 = tensor(raw1, chunk_size=30)
 
         res1 = self.executor.execute_tensor(arr2.mean())
         expected1 = raw1.mean()
@@ -150,7 +150,7 @@ class Test(unittest.TestCase):
         raw1 = np.random.random((20, 25))
         raw2 = np.random.randint(10, size=(20, 25))
 
-        arr1 = tensor(raw1, chunks=3)
+        arr1 = tensor(raw1, chunk_size=3)
 
         res1 = self.executor.execute_tensor(arr1.var())
         expected1 = raw1.var()
@@ -164,7 +164,7 @@ class Test(unittest.TestCase):
         expected3 = raw1.var(axis=1, keepdims=True)
         self.assertTrue(np.allclose(np.concatenate(res3), expected3))
 
-        arr2 = tensor(raw2, chunks=3)
+        arr2 = tensor(raw2, chunk_size=3)
 
         res1 = self.executor.execute_tensor(arr2.var())
         expected1 = raw2.var()
@@ -184,13 +184,13 @@ class Test(unittest.TestCase):
 
         raw1 = sps.random(20, 25, density=.1)
 
-        arr1 = tensor(raw1, chunks=3)
+        arr1 = tensor(raw1, chunk_size=3)
 
         res1 = self.executor.execute_tensor(arr1.var())
         expected1 = raw1.toarray().var()
         self.assertTrue(np.allclose(res1[0], expected1))
 
-        arr2 = tensor(raw1, chunks=30)
+        arr2 = tensor(raw1, chunk_size=30)
 
         res1 = self.executor.execute_tensor(arr2.var())
         expected1 = raw1.toarray().var()
@@ -203,7 +203,7 @@ class Test(unittest.TestCase):
         raw1 = np.random.random((20, 25))
         raw2 = np.random.randint(10, size=(20, 25))
 
-        arr1 = tensor(raw1, chunks=3)
+        arr1 = tensor(raw1, chunk_size=3)
 
         res1 = self.executor.execute_tensor(arr1.std())
         expected1 = raw1.std()
@@ -217,7 +217,7 @@ class Test(unittest.TestCase):
         expected3 = raw1.std(axis=1, keepdims=True)
         self.assertTrue(np.allclose(np.concatenate(res3), expected3))
 
-        arr2 = tensor(raw2, chunks=3)
+        arr2 = tensor(raw2, chunk_size=3)
 
         res1 = self.executor.execute_tensor(arr2.std())
         expected1 = raw2.std()
@@ -237,13 +237,13 @@ class Test(unittest.TestCase):
 
         raw1 = sps.random(20, 25, density=.1)
 
-        arr1 = tensor(raw1, chunks=3)
+        arr1 = tensor(raw1, chunk_size=3)
 
         res1 = self.executor.execute_tensor(arr1.std())
         expected1 = raw1.toarray().std()
         self.assertTrue(np.allclose(res1[0], expected1))
 
-        arr2 = tensor(raw1, chunks=30)
+        arr2 = tensor(raw1, chunk_size=30)
 
         res1 = self.executor.execute_tensor(arr2.std())
         expected1 = raw1.toarray().std()
@@ -255,7 +255,7 @@ class Test(unittest.TestCase):
     def testArgReduction(self):
         raw = np.random.random((20, 20, 20))
 
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         self.assertEqual(raw.argmax(),
                          self.executor.execute_tensor(arr.argmax())[0])
@@ -275,7 +275,7 @@ class Test(unittest.TestCase):
         raw_format[np.unravel_index(random_max, raw_format.shape)] = 2
 
         raw = raw_format.tocoo()
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         self.assertEqual(raw.argmax(),
                          self.executor.execute_tensor(arr.argmax())[0])
@@ -285,7 +285,7 @@ class Test(unittest.TestCase):
     def testNanReduction(self):
         raw = np.random.choice(a=[0, 1, np.nan], size=(10, 10), p=[0.3, 0.4, 0.3])
 
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         self.assertEqual(np.nansum(raw), self.executor.execute_tensor(nansum(arr))[0])
         self.assertEqual(np.nanprod(raw), self.executor.execute_tensor(nanprod(arr))[0])
@@ -297,7 +297,7 @@ class Test(unittest.TestCase):
         self.assertAlmostEqual(np.nanstd(raw), self.executor.execute_tensor(nanstd(arr))[0])
         self.assertAlmostEqual(np.nanstd(raw, ddof=1), self.executor.execute_tensor(nanstd(arr, ddof=1))[0])
 
-        arr = tensor(raw, chunks=10)
+        arr = tensor(raw, chunk_size=10)
 
         self.assertEqual(np.nansum(raw), self.executor.execute_tensor(nansum(arr))[0])
         self.assertEqual(np.nanprod(raw), self.executor.execute_tensor(nanprod(arr))[0])
@@ -311,12 +311,12 @@ class Test(unittest.TestCase):
 
         raw = np.random.random((10, 10))
         raw[:3, :3] = np.nan
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
         self.assertEqual(np.nanargmin(raw), self.executor.execute_tensor(nanargmin(arr))[0])
         self.assertEqual(np.nanargmax(raw), self.executor.execute_tensor(nanargmax(arr))[0])
 
         raw = np.full((10, 10), np.nan)
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         self.assertEqual(0, self.executor.execute_tensor(nansum(arr))[0])
         self.assertEqual(1, self.executor.execute_tensor(nanprod(arr))[0])
@@ -328,7 +328,7 @@ class Test(unittest.TestCase):
 
         raw = sps.random(10, 10, density=.1, format='csr')
         raw[:3, :3] = np.nan
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         self.assertAlmostEqual(np.nansum(raw.A), self.executor.execute_tensor(nansum(arr))[0])
         self.assertAlmostEqual(np.nanprod(raw.A), self.executor.execute_tensor(nanprod(arr))[0])
@@ -346,7 +346,7 @@ class Test(unittest.TestCase):
     def testCumReduction(self):
         raw = np.random.randint(5, size=(8, 8, 8))
 
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         res1 = self.executor.execute_tensor(arr.cumsum(axis=1), concat=True)
         res2 = self.executor.execute_tensor(arr.cumprod(axis=1), concat=True)
@@ -357,7 +357,7 @@ class Test(unittest.TestCase):
 
         raw = sps.random(8, 8, density=.1)
 
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         res1 = self.executor.execute_tensor(arr.cumsum(axis=1), concat=True)
         res2 = self.executor.execute_tensor(arr.cumprod(axis=1), concat=True)
@@ -370,7 +370,7 @@ class Test(unittest.TestCase):
         raw = np.random.randint(5, size=(8, 8, 8))
         raw[:2, 2:4, 4:6] = np.nan
 
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         res1 = self.executor.execute_tensor(nancumsum(arr, axis=1), concat=True)
         res2 = self.executor.execute_tensor(nancumprod(arr, axis=1), concat=True)
@@ -382,7 +382,7 @@ class Test(unittest.TestCase):
         raw = sps.random(8, 8, density=.1, format='lil')
         raw[:2, 2:4] = np.nan
 
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
 
         res1 = self.executor.execute_tensor(nancumsum(arr, axis=1), concat=True)[0]
         res2 = self.executor.execute_tensor(nancumprod(arr, axis=1), concat=True)[0]
@@ -394,8 +394,8 @@ class Test(unittest.TestCase):
     def testOutReductionExecution(self):
         raw = np.random.randint(5, size=(8, 8, 8))
 
-        arr = tensor(raw, chunks=3)
-        arr2 = ones((8, 8), dtype='i8', chunks=3)
+        arr = tensor(raw, chunk_size=3)
+        arr2 = ones((8, 8), dtype='i8', chunk_size=3)
         arr.sum(axis=1, out=arr2)
 
         res = self.executor.execute_tensor(arr2, concat=True)[0]
@@ -406,7 +406,7 @@ class Test(unittest.TestCase):
     def testOutCumReductionExecution(self):
         raw = np.random.randint(5, size=(8, 8, 8))
 
-        arr = tensor(raw, chunks=3)
+        arr = tensor(raw, chunk_size=3)
         arr.cumsum(axis=0, out=arr)
 
         res = self.executor.execute_tensor(arr, concat=True)[0]
@@ -417,7 +417,7 @@ class Test(unittest.TestCase):
     def testCountNonzeroExecution(self):
         raw = [[0, 1, 7, 0, 0], [3, 0, 0, 2, 19]]
 
-        arr = tensor(raw, chunks=2)
+        arr = tensor(raw, chunk_size=2)
         t = count_nonzero(arr)
 
         res = self.executor.execute_tensor(t)[0]
@@ -438,7 +438,7 @@ class Test(unittest.TestCase):
 
         raw = sps.csr_matrix(raw)
 
-        arr = tensor(raw, chunks=2)
+        arr = tensor(raw, chunk_size=2)
         t = count_nonzero(arr)
 
         res = self.executor.execute_tensor(t)[0]
@@ -458,32 +458,32 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(res, expected)
 
     def testAllcloseExecution(self):
-        a = tensor([1e10, 1e-7], chunks=1)
-        b = tensor([1.00001e10, 1e-8], chunks=1)
+        a = tensor([1e10, 1e-7], chunk_size=1)
+        b = tensor([1.00001e10, 1e-8], chunk_size=1)
 
         t = allclose(a, b)
 
         res = self.executor.execute_tensor(t)[0]
         self.assertFalse(res)
 
-        a = tensor([1e10, 1e-8], chunks=1)
-        b = tensor([1.00001e10, 1e-9], chunks=1)
+        a = tensor([1e10, 1e-8], chunk_size=1)
+        b = tensor([1.00001e10, 1e-9], chunk_size=1)
 
         t = allclose(a, b)
 
         res = self.executor.execute_tensor(t)[0]
         self.assertTrue(res)
 
-        a = tensor([1.0, np.nan], chunks=1)
-        b = tensor([1.0, np.nan], chunks=1)
+        a = tensor([1.0, np.nan], chunk_size=1)
+        b = tensor([1.0, np.nan], chunk_size=1)
 
         t = allclose(a, b, equal_nan=True)
 
         res = self.executor.execute_tensor(t)[0]
         self.assertTrue(res)
 
-        a = tensor(sps.csr_matrix([[1e10, 1e-7], [0, 0]]), chunks=1)
-        b = tensor(sps.csr_matrix([[1.00001e10, 1e-8], [0, 0]]), chunks=1)
+        a = tensor(sps.csr_matrix([[1e10, 1e-7], [0, 0]]), chunk_size=1)
+        b = tensor(sps.csr_matrix([[1.00001e10, 1e-8], [0, 0]]), chunk_size=1)
 
         t = allclose(a, b)
 
@@ -491,8 +491,8 @@ class Test(unittest.TestCase):
         self.assertFalse(res)
 
     def testArrayEqual(self):
-        a = ones((10, 5), chunks=1)
-        b = ones((10, 5), chunks=2)
+        a = ones((10, 5), chunk_size=1)
+        b = ones((10, 5), chunk_size=2)
 
         c = array_equal(a, b)
 

--- a/mars/tensor/expressions/datasource/arange.py
+++ b/mars/tensor/expressions/datasource/arange.py
@@ -63,7 +63,7 @@ class TensorArange(TensorNoInput):
     def tile(cls, op):
         tensor = op.outputs[0]
 
-        chunk_length = tensor.params.raw_chunks or options.tensor.chunks
+        chunk_length = tensor.params.raw_chunk_size or options.tensor.chunk_size
         chunk_length = decide_chunk_sizes(tensor.shape, chunk_length, tensor.dtype.itemsize)
 
         start, stop, step = tensor.op.start, tensor.op.stop, tensor.op.step
@@ -197,4 +197,4 @@ def arange(*args, **kwargs):
 
     op = TensorArange(start, stop, step, dtype=dtype, gpu=kwargs.get('gpu', False))
     shape = (size,)
-    return op(shape, chunks=kwargs.pop('chunks', None))
+    return op(shape, chunk_size=kwargs.pop('chunk_size', None))

--- a/mars/tensor/expressions/datasource/arange.py
+++ b/mars/tensor/expressions/datasource/arange.py
@@ -20,7 +20,7 @@ import numpy as np
 from .... import opcodes as OperandDef
 from ....serialize import AnyField
 from ....config import options
-from ..utils import decide_chunks
+from ..utils import decide_chunk_sizes
 from .core import TensorNoInput
 
 
@@ -64,7 +64,7 @@ class TensorArange(TensorNoInput):
         tensor = op.outputs[0]
 
         chunk_length = tensor.params.raw_chunks or options.tensor.chunks
-        chunk_length = decide_chunks(tensor.shape, chunk_length, tensor.dtype.itemsize)
+        chunk_length = decide_chunk_sizes(tensor.shape, chunk_length, tensor.dtype.itemsize)
 
         start, stop, step = tensor.op.start, tensor.op.stop, tensor.op.step
 

--- a/mars/tensor/expressions/datasource/core.py
+++ b/mars/tensor/expressions/datasource/core.py
@@ -24,7 +24,7 @@ from ....operands import DataSource
 from ....compat import izip
 from ....config import options
 from ....tiles import NotSupportTile
-from ..utils import normalize_shape, decide_chunks
+from ..utils import normalize_shape, decide_chunk_sizes
 from ..core import TensorOperandMixin
 
 
@@ -46,8 +46,8 @@ class TensorDataSource(DataSource, TensorOperandMixin):
     def tile(cls, op):
         tensor = op.outputs[0]
 
-        chunk_size = tensor.params.raw_chunks or options.tensor.chunks
-        chunk_size = decide_chunks(tensor.shape, chunk_size, tensor.dtype.itemsize)
+        chunk_size = tensor.params.raw_chunk_size or options.tensor.chunk_size
+        chunk_size = decide_chunk_sizes(tensor.shape, chunk_size, tensor.dtype.itemsize)
         chunk_size_idxes = (range(len(size)) for size in chunk_size)
 
         out_chunks = []
@@ -71,9 +71,9 @@ class TensorNoInput(TensorDataSource):
         if inputs and len(inputs) > 0:
             raise ValueError("Tensor data source has no inputs")
 
-    def __call__(self, shape, chunks=None):
+    def __call__(self, shape, chunk_size=None):
         shape = normalize_shape(shape)
-        return self.new_tensor(None, shape, raw_chunks=chunks)
+        return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
 
 
 class TensorHasInput(TensorDataSource):

--- a/mars/tensor/expressions/datasource/diag.py
+++ b/mars/tensor/expressions/datasource/diag.py
@@ -129,8 +129,8 @@ class TensorDiag(TensorDiagBase, TensorHasInput):
         op = TensorDiag(k=chunk_k, dtype=op.dtype, gpu=op.gpu, sparse=op.sparse)
         return op.new_chunk([input_chunk], chunk_shape, index=chunk_idx)
 
-    def __call__(self, v, shape, chunks=None):
-        return self.new_tensor([v], shape, raw_chunks=chunks)
+    def __call__(self, v, shape, chunk_size=None):
+        return self.new_tensor([v], shape, raw_chunk_size=chunk_size)
 
     @classmethod
     def tile(cls, op):
@@ -178,7 +178,7 @@ class TensorDiag(TensorDiagBase, TensorHasInput):
         return getattr(self, '_k', 0)
 
 
-def diag(v, k=0, sparse=None, gpu=False, chunks=None):
+def diag(v, k=0, sparse=None, gpu=False, chunk_size=None):
     """
     Extract a diagonal or construct a diagonal tensor.
 
@@ -199,7 +199,7 @@ def diag(v, k=0, sparse=None, gpu=False, chunks=None):
         Create sparse tensor if True, False as default
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
 
     Returns
@@ -242,7 +242,7 @@ def diag(v, k=0, sparse=None, gpu=False, chunks=None):
         v = tensor(v).op.data
         diag_v = get_array_module(v).diag(v, k=k)
         sparse = sparse if sparse is not None else issparse(v)
-        return tensor(diag_v, gpu=gpu, sparse=sparse, chunks=chunks)
+        return tensor(diag_v, gpu=gpu, sparse=sparse, chunk_size=chunk_size)
 
     sparse = sparse if sparse is not None else v.issparse()
 

--- a/mars/tensor/expressions/datasource/diagflat.py
+++ b/mars/tensor/expressions/datasource/diagflat.py
@@ -19,7 +19,7 @@ from .array import tensor as astensor
 from .diag import diag
 
 
-def diagflat(v, k=0, sparse=None, gpu=None, chunks=None):
+def diagflat(v, k=0, sparse=None, gpu=None, chunk_size=None):
     """
     Create a two-dimensional tensor with the flattened input as a diagonal.
 
@@ -36,7 +36,7 @@ def diagflat(v, k=0, sparse=None, gpu=None, chunks=None):
         Create sparse tensor if True, False as default
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
 
     Returns
@@ -68,4 +68,4 @@ def diagflat(v, k=0, sparse=None, gpu=None, chunks=None):
     """
     if not isinstance(v, Tensor):
         v = astensor(v).op.data
-    return diag(v.flatten(), k=k, sparse=sparse, gpu=gpu, chunks=chunks)
+    return diag(v.flatten(), k=k, sparse=sparse, gpu=gpu, chunk_size=chunk_size)

--- a/mars/tensor/expressions/datasource/empty.py
+++ b/mars/tensor/expressions/datasource/empty.py
@@ -49,7 +49,7 @@ class TensorEmpty(TensorEmptyBase, TensorNoInput):
         super(TensorEmpty, self).__init__(_dtype=dtype, _gpu=gpu, **kw)
 
 
-def empty(shape, dtype=None, chunks=None, gpu=False):
+def empty(shape, dtype=None, chunk_size=None, gpu=False):
     """
     Return a new tensor of given shape and type, without initializing entries.
 
@@ -59,7 +59,7 @@ def empty(shape, dtype=None, chunks=None, gpu=False):
         Shape of the empty tensor
     dtype : data-type, optional
         Desired output data-type.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -94,7 +94,7 @@ def empty(shape, dtype=None, chunks=None, gpu=False):
            [  496041986,    19249760]])                     #random
     """
     op = TensorEmpty(dtype=dtype, gpu=gpu)
-    return op(shape, chunks=chunks)
+    return op(shape, chunk_size=chunk_size)
 
 
 class TensorEmptyLike(TensorEmptyBase, TensorLike):

--- a/mars/tensor/expressions/datasource/eye.py
+++ b/mars/tensor/expressions/datasource/eye.py
@@ -19,7 +19,7 @@ import numpy as np
 from .... import opcodes as OperandDef
 from ....serialize import Int32Field
 from ....config import options
-from ..utils import decide_chunks
+from ..utils import decide_chunk_sizes
 from .diag import TensorDiagBase
 from .core import TensorNoInput
 
@@ -40,8 +40,8 @@ class TensorEye(TensorNoInput, TensorDiagBase):
     @classmethod
     def _get_nsplits(cls, op):
         tensor = op.outputs[0]
-        chunk_size = tensor.params.raw_chunks or options.tensor.chunks
-        return decide_chunks(tensor.shape, chunk_size, tensor.dtype.itemsize)
+        chunk_size = tensor.params.raw_chunk_size or options.tensor.chunk_size
+        return decide_chunk_sizes(tensor.shape, chunk_size, tensor.dtype.itemsize)
 
     @classmethod
     def _get_chunk(cls, op, chunk_k, chunk_shape, chunk_idx):
@@ -53,7 +53,7 @@ class TensorEye(TensorNoInput, TensorDiagBase):
         return TensorDiagBase.tile(op)
 
 
-def eye(N, M=None, k=0, dtype=None, sparse=False, gpu=False, chunks=None):
+def eye(N, M=None, k=0, dtype=None, sparse=False, gpu=False, chunk_size=None):
     """
     Return a 2-D tensor with ones on the diagonal and zeros elsewhere.
 
@@ -73,7 +73,7 @@ def eye(N, M=None, k=0, dtype=None, sparse=False, gpu=False, chunks=None):
         Create sparse tensor if True, False as default
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
 
     Returns
@@ -105,4 +105,4 @@ def eye(N, M=None, k=0, dtype=None, sparse=False, gpu=False, chunks=None):
 
     shape = (N, M)
     op = TensorEye(k, dtype=dtype, gpu=gpu, sparse=sparse)
-    return op(shape, chunks=chunks)
+    return op(shape, chunk_size=chunk_size)

--- a/mars/tensor/expressions/datasource/full.py
+++ b/mars/tensor/expressions/datasource/full.py
@@ -41,7 +41,7 @@ class TensorFull(TensorNoInput):
         return self._fill_value
 
 
-def full(shape, fill_value, dtype=None, chunks=None, gpu=False):
+def full(shape, fill_value, dtype=None, chunk_size=None, gpu=False):
     """
     Return a new tensor of given shape and type, filled with `fill_value`.
 
@@ -54,7 +54,7 @@ def full(shape, fill_value, dtype=None, chunks=None, gpu=False):
     dtype : data-type, optional
         The desired data-type for the tensor  The default, `None`, means
          `np.array(fill_value).dtype`.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -89,7 +89,7 @@ def full(shape, fill_value, dtype=None, chunks=None, gpu=False):
     v = np.asarray(fill_value)
     if len(v.shape) > 0:
         from ..base import broadcast_to
-        return broadcast_to(tensor(v, dtype=dtype, chunks=chunks, gpu=gpu), shape)
+        return broadcast_to(tensor(v, dtype=dtype, chunk_size=chunk_size, gpu=gpu), shape)
 
     op = TensorFull(fill_value, dtype=dtype, gpu=gpu)
-    return op(shape, chunks=chunks)
+    return op(shape, chunk_size=chunk_size)

--- a/mars/tensor/expressions/datasource/identity.py
+++ b/mars/tensor/expressions/datasource/identity.py
@@ -17,7 +17,7 @@
 from .eye import eye
 
 
-def identity(n, dtype=None, sparse=False, gpu=False, chunks=None):
+def identity(n, dtype=None, sparse=False, gpu=False, chunk_size=None):
     """
     Return the identity tensor.
 
@@ -53,4 +53,4 @@ def identity(n, dtype=None, sparse=False, gpu=False, chunks=None):
            [ 0.,  0.,  1.]])
 
     """
-    return eye(n, dtype=dtype, sparse=sparse, gpu=gpu, chunks=chunks)
+    return eye(n, dtype=dtype, sparse=sparse, gpu=gpu, chunk_size=chunk_size)

--- a/mars/tensor/expressions/datasource/indices.py
+++ b/mars/tensor/expressions/datasource/indices.py
@@ -39,7 +39,7 @@ class TensorIndices(TensorNoInput):
         return self._dimensions
 
 
-def indices(dimensions, dtype=int, chunks=None):
+def indices(dimensions, dtype=int, chunk_size=None):
     """
     Return a tensor representing the indices of a grid.
 
@@ -52,7 +52,7 @@ def indices(dimensions, dtype=int, chunks=None):
         The shape of the grid.
     dtype : dtype, optional
         Data type of the result.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
 
     Returns
@@ -105,15 +105,15 @@ def indices(dimensions, dtype=int, chunks=None):
 
     dimensions = tuple(dimensions)
     dtype = np.dtype(dtype)
-    raw_chunks = chunks
-    if chunks is not None and isinstance(chunks, Iterable):
-        chunks = tuple(chunks)
+    raw_chunk_size = chunk_size
+    if chunk_size is not None and isinstance(chunk_size, Iterable):
+        chunk_size = tuple(chunk_size)
     else:
-        chunks = (chunks,) * len(dimensions)
+        chunk_size = (chunk_size,) * len(dimensions)
 
     xi = []
-    for ch, dim in zip(chunks, dimensions):
-        xi.append(arange(dim, dtype=dtype, chunks=ch))
+    for ch, dim in zip(chunk_size, dimensions):
+        xi.append(arange(dim, dtype=dtype, chunk_size=ch))
 
     grid = None
     if np.prod(dimensions):
@@ -122,10 +122,10 @@ def indices(dimensions, dtype=int, chunks=None):
     if grid:
         grid = stack(grid)
     else:
-        if raw_chunks is None:
-            empty_chunks = None
+        if raw_chunk_size is None:
+            empty_chunk_size = None
         else:
-            empty_chunks = (1,) + chunks
-        grid = empty((len(dimensions),) + dimensions, dtype=dtype, chunks=empty_chunks)
+            empty_chunk_size = (1,) + chunk_size
+        grid = empty((len(dimensions),) + dimensions, dtype=dtype, chunk_size=empty_chunk_size)
 
     return grid

--- a/mars/tensor/expressions/datasource/linspace.py
+++ b/mars/tensor/expressions/datasource/linspace.py
@@ -19,7 +19,7 @@ import numpy as np
 from .... import opcodes as OperandDef
 from ....serialize import Int64Field, BoolField
 from ....config import options
-from ..utils import decide_chunks
+from ..utils import decide_chunk_sizes
 from .core import TensorNoInput
 
 
@@ -49,8 +49,8 @@ class TensorLinspace(TensorNoInput):
     def tile(cls, op):
         tensor = op.outputs[0]
 
-        chunk_length = tensor.params.raw_chunks or options.tensor.chunks
-        chunk_length = decide_chunks(tensor.shape, chunk_length, tensor.dtype.itemsize)
+        chunk_length = tensor.params.raw_chunk_size or options.tensor.chunk_size
+        chunk_length = decide_chunk_sizes(tensor.shape, chunk_length, tensor.dtype.itemsize)
 
         start, stop, num, endpoint = \
             tensor.op.start, tensor.op.stop, tensor.op.num, tensor.op.endpoint
@@ -94,7 +94,7 @@ class TensorLinspace(TensorNoInput):
 
 
 def linspace(start, stop, num=50, endpoint=True, retstep=False,
-             dtype=None, gpu=False, chunks=None):
+             dtype=None, gpu=False, chunk_size=None):
     """
     Return evenly spaced numbers over a specified interval.
 
@@ -125,7 +125,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False,
         type from the other input arguments.
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
 
     Returns
@@ -180,7 +180,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False,
 
     op = TensorLinspace(start, stop, num, endpoint, dtype=dtype, gpu=gpu)
     shape = (num,)
-    ret = op(shape, chunks=chunks)
+    ret = op(shape, chunk_size=chunk_size)
 
     if not retstep:
         return ret

--- a/mars/tensor/expressions/datasource/ones.py
+++ b/mars/tensor/expressions/datasource/ones.py
@@ -30,7 +30,7 @@ class TensorOnes(TensorNoInput):
         super(TensorOnes, self).__init__(_dtype=dtype, _gpu=gpu, **kw)
 
 
-def ones(shape, dtype=None, chunks=None, gpu=False):
+def ones(shape, dtype=None, chunk_size=None, gpu=False):
     """
     Return a new tensor of given shape and type, filled with ones.
 
@@ -41,7 +41,7 @@ def ones(shape, dtype=None, chunks=None, gpu=False):
     dtype : data-type, optional
         The desired data-type for the tensor, e.g., `mt.int8`.  Default is
         `mt.float64`.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -76,7 +76,7 @@ def ones(shape, dtype=None, chunks=None, gpu=False):
 
     """
     op = TensorOnes(dtype=dtype, gpu=gpu)
-    return op(shape, chunks=chunks)
+    return op(shape, chunk_size=chunk_size)
 
 
 class TensorOnesLike(TensorLike):

--- a/mars/tensor/expressions/datasource/zeros.py
+++ b/mars/tensor/expressions/datasource/zeros.py
@@ -31,7 +31,7 @@ class TensorZeros(TensorNoInput):
         super(TensorZeros, self).__init__(_dtype=dtype, _gpu=gpu, _sparse=sparse, **kw)
 
 
-def zeros(shape, dtype=None, chunks=None, gpu=False, sparse=False):
+def zeros(shape, dtype=None, chunk_size=None, gpu=False, sparse=False):
     """
     Return a new tensor of given shape and type, filled with zeros.
 
@@ -42,7 +42,7 @@ def zeros(shape, dtype=None, chunks=None, gpu=False, sparse=False):
     dtype : data-type, optional
         The desired data-type for the array, e.g., `mt.int8`.  Default is
         `mt.float64`.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -87,7 +87,7 @@ def zeros(shape, dtype=None, chunks=None, gpu=False, sparse=False):
 
     """
     op = TensorZeros(dtype=dtype, gpu=gpu, sparse=sparse)
-    return op(shape, chunks=chunks)
+    return op(shape, chunk_size=chunk_size)
 
 
 class TensorZerosLike(TensorLike):

--- a/mars/tensor/expressions/fft/core.py
+++ b/mars/tensor/expressions/fft/core.py
@@ -16,7 +16,7 @@
 
 from collections import Iterable
 
-from ..utils import validate_axis, decide_chunks, recursive_tile
+from ..utils import validate_axis, decide_chunk_sizes, recursive_tile
 from ..core import TensorOperandMixin
 
 
@@ -35,7 +35,7 @@ class TensorFFTMixin(TensorOperandMixin):
         if in_tensor.chunk_shape[axis] != 1:
             # fft requires only 1 chunk for the specified axis, so we do rechunk first
             chunks = {validate_axis(in_tensor.ndim, axis): in_tensor.shape[axis]}
-            new_chunks = decide_chunks(in_tensor.shape, chunks, in_tensor.dtype.itemsize)
+            new_chunks = decide_chunk_sizes(in_tensor.shape, chunks, in_tensor.dtype.itemsize)
             in_tensor = in_tensor.rechunk(new_chunks).single_tiles()
 
         out_chunks = []
@@ -72,7 +72,7 @@ class TensorFFTNMixin(TensorOperandMixin):
         axes = op.axes
 
         if any(in_tensor.chunk_shape[axis] != 1 for axis in axes):
-            new_chunks = decide_chunks(
+            new_chunks = decide_chunk_sizes(
                 in_tensor.shape, {validate_axis(in_tensor.ndim, axis): in_tensor.shape[axis] for axis in axes},
                 in_tensor.dtype.itemsize)
             in_tensor = in_tensor.rechunk(new_chunks).single_tiles()

--- a/mars/tensor/expressions/fft/fftfreq.py
+++ b/mars/tensor/expressions/fft/fftfreq.py
@@ -27,9 +27,9 @@ class TensorFFTFreq(fftop.FFTFreq, TensorFFTMixin):
     def __init__(self, n=None, d=None, dtype=None, gpu=False, **kw):
         super(TensorFFTFreq, self).__init__(_n=n, _d=d, _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, chunks=None):
+    def __call__(self, chunk_size=None):
         shape = (self.n,)
-        return self.new_tensor(None, shape, raw_chunks=chunks)
+        return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
 
     @classmethod
     def tile(cls, op):
@@ -62,7 +62,7 @@ class TensorFFTFreqChunk(fftop.FFTFreqChunk, TensorOperandMixin):
         raise NotSupportTile('FFTFreqChunk is a chunk operand which does not support tile')
 
 
-def fftfreq(n, d=1.0, gpu=False, chunks=None):
+def fftfreq(n, d=1.0, gpu=False, chunk_size=None):
     """
     Return the Discrete Fourier Transform sample frequencies.
 
@@ -83,7 +83,7 @@ def fftfreq(n, d=1.0, gpu=False, chunks=None):
         Sample spacing (inverse of the sampling rate). Defaults to 1.
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
 
     Returns
@@ -106,4 +106,4 @@ def fftfreq(n, d=1.0, gpu=False, chunks=None):
     """
     n, d = int(n), float(d)
     op = TensorFFTFreq(n=n, d=d, dtype=np.dtype(float), gpu=gpu)
-    return op(chunks)
+    return op(chunk_size)

--- a/mars/tensor/expressions/fft/fftfreq.py
+++ b/mars/tensor/expressions/fft/fftfreq.py
@@ -35,7 +35,7 @@ class TensorFFTFreq(fftop.FFTFreq, TensorFFTMixin):
     def tile(cls, op):
         tensor = op.outputs[0]
         in_tensor = arange(op.n, gpu=op.gpu, dtype=op.dtype,
-                           chunks=tensor.params.raw_chunks).single_tiles()
+                           chunks=tensor.params.raw_chunk_size).single_tiles()
 
         out_chunks = []
         for c in in_tensor.chunks:

--- a/mars/tensor/expressions/fft/rfftfreq.py
+++ b/mars/tensor/expressions/fft/rfftfreq.py
@@ -25,15 +25,15 @@ class TensorRFFTFreq(fftop.RFFTFreq, TensorOperandMixin):
     def __init__(self, n=None, d=None, dtype=None, gpu=False, **kw):
         super(TensorRFFTFreq, self).__init__(_n=n, _d=d, _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, chunks=None):
+    def __call__(self, chunk_size=None):
         shape = (self.n // 2 + 1,)
-        return self.new_tensor(None, shape, raw_chunks=chunks)
+        return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
 
     @classmethod
     def tile(cls, op):
         tensor = op.outputs[0]
         t = arange(tensor.shape[0], dtype=op.dtype, gpu=op.gpu,
-                   chunks=tensor.params.raw_chunks).single_tiles()
+                   chunk_size=tensor.params.raw_chunk_size).single_tiles()
         t = t / (op.n * op.d)
         t.single_tiles()
 
@@ -42,7 +42,7 @@ class TensorRFFTFreq(fftop.RFFTFreq, TensorOperandMixin):
                                   chunks=t.chunks, nsplits=t.nsplits, **tensor.params)
 
 
-def rfftfreq(n, d=1.0, gpu=False, chunks=None):
+def rfftfreq(n, d=1.0, gpu=False, chunk_size=None):
     """
     Return the Discrete Fourier Transform sample frequencies
     (for usage with rfft, irfft).
@@ -67,7 +67,7 @@ def rfftfreq(n, d=1.0, gpu=False, chunks=None):
         Sample spacing (inverse of the sampling rate). Defaults to 1.
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
 
     Returns
@@ -93,4 +93,4 @@ def rfftfreq(n, d=1.0, gpu=False, chunks=None):
     """
     n, d = int(n), float(d)
     op = TensorRFFTFreq(n=n, d=d, dtype=np.dtype(float), gpu=gpu)
-    return op(chunks=chunks)
+    return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/indexing/nonzero.py
+++ b/mars/tensor/expressions/indexing/nonzero.py
@@ -43,7 +43,7 @@ class TensorNonzero(Nonzero, TensorOperandMixin):
 
         flattened = in_tensor.astype(bool).flatten()
         recursive_tile(flattened)
-        indices = arange(flattened.size, dtype=np.intp, chunks=flattened.nsplits)
+        indices = arange(flattened.size, dtype=np.intp, chunk_size=flattened.nsplits)
         indices = indices[flattened]
         dim_indices = unravel_index(indices, in_tensor.shape)
         [recursive_tile(ind) for ind in dim_indices]

--- a/mars/tensor/expressions/linalg/core.py
+++ b/mars/tensor/expressions/linalg/core.py
@@ -17,7 +17,7 @@
 import numpy as np
 
 from ....compat import izip
-from ..utils import decide_chunks
+from ..utils import decide_chunk_sizes
 from ..core import TensorOperandMixin
 
 
@@ -49,8 +49,8 @@ class TSQR(TensorOperandMixin):
         q_dtype, r_dtype = tinyq.dtype, tinyr.dtype
 
         if a.chunk_shape[1] != 1:
-            new_chunks = decide_chunks(a.shape, {1: a.shape[1]}, a.dtype.itemsize)
-            a = a.rechunk(new_chunks).single_tiles()
+            new_chunk_size = decide_chunk_sizes(a.shape, {1: a.shape[1]}, a.dtype.itemsize)
+            a = a.rechunk(new_chunk_size).single_tiles()
 
         # stage 1, map phase
         stage1_q_chunks, stage1_r_chunks = stage1_chunks = [[], []]  # Q and R chunks

--- a/mars/tensor/expressions/linalg/inv.py
+++ b/mars/tensor/expressions/linalg/inv.py
@@ -57,4 +57,4 @@ def inv(a):
     from ..datasource import eye
 
     a = astensor(a)
-    return solve(a, eye(a.shape[0], chunks=a.params.raw_chunks))
+    return solve(a, eye(a.shape[0], chunk_size=a.params.raw_chunk_size))

--- a/mars/tensor/expressions/random/beta.py
+++ b/mars/tensor/expressions/random/beta.py
@@ -29,11 +29,11 @@ class TensorBeta(operands.Beta, TensorRandomOperandMixin):
         super(TensorBeta, self).__init__(_state=state, _size=size,
                                          _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, a, b, chunks=None):
-        return self.new_tensor([a, b], None, raw_chunks=chunks)
+    def __call__(self, a, b, chunk_size=None):
+        return self.new_tensor([a, b], None, raw_chunk_size=chunk_size)
 
 
-def beta(random_state, a, b, size=None, chunks=None, gpu=None, **kw):
+def beta(random_state, a, b, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a Beta distribution.
 
@@ -62,7 +62,7 @@ def beta(random_state, a, b, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``a`` and ``b`` are both scalars.
         Otherwise, ``mt.broadcast(a, b).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -77,4 +77,4 @@ def beta(random_state, a, b, size=None, chunks=None, gpu=None, **kw):
             handle_array(a), handle_array(b), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorBeta(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(a, b, chunks=chunks)
+    return op(a, b, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/binomial.py
+++ b/mars/tensor/expressions/random/binomial.py
@@ -29,11 +29,11 @@ class TensorBinomial(operands.Binomial, TensorRandomOperandMixin):
         super(TensorBinomial, self).__init__(_state=state, _size=size,
                                              _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, n, p, chunks=None):
-        return self.new_tensor([n, p], None, raw_chunks=chunks)
+    def __call__(self, n, p, chunk_size=None):
+        return self.new_tensor([n, p], None, raw_chunk_size=chunk_size)
 
 
-def binomial(random_state, n, p, size=None, chunks=None, gpu=None, **kw):
+def binomial(random_state, n, p, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a binomial distribution.
 
@@ -54,7 +54,7 @@ def binomial(random_state, n, p, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``n`` and ``p`` are both scalars.
         Otherwise, ``mt.broadcast(n, p).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -126,4 +126,4 @@ def binomial(random_state, n, p, size=None, chunks=None, gpu=None, **kw):
             handle_array(n), handle_array(p), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorBinomial(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(n, p, chunks=chunks)
+    return op(n, p, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/chisquare.py
+++ b/mars/tensor/expressions/random/chisquare.py
@@ -29,11 +29,11 @@ class TensorChisquare(operands.Chisquare, TensorRandomOperandMixin):
         super(TensorChisquare, self).__init__(_state=state, _size=size,
                                               _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, df, chunks=None):
-        return self.new_tensor([df], self._size, raw_chunks=chunks)
+    def __call__(self, df, chunk_size=None):
+        return self.new_tensor([df], self._size, raw_chunk_size=chunk_size)
 
 
-def chisquare(random_state, df, size=None, chunks=None, gpu=None, **kw):
+def chisquare(random_state, df, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a chi-square distribution.
 
@@ -51,7 +51,7 @@ def chisquare(random_state, df, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``df`` is a scalar.  Otherwise,
         ``mt.array(df).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -104,4 +104,4 @@ def chisquare(random_state, df, size=None, chunks=None, gpu=None, **kw):
             handle_array(df), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorChisquare(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(df, chunks=chunks)
+    return op(df, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/choice.py
+++ b/mars/tensor/expressions/random/choice.py
@@ -36,11 +36,11 @@ class TensorChoice(operands.Choice, TensorRandomOperandMixin):
         super(TensorChoice, self).__init__(_state=state, _size=size,
                                            _replace=replace, _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, a, p, chunks=None):
-        return self.new_tensor([a, p], None, raw_chunks=chunks)
+    def __call__(self, a, p, chunk_size=None):
+        return self.new_tensor([a, p], None, raw_chunk_size=chunk_size)
 
 
-def choice(random_state, a, size=None, replace=True, p=None, chunks=None, gpu=None, **kw):
+def choice(random_state, a, size=None, replace=True, p=None, chunk_size=None, gpu=None, **kw):
     """
     Generates a random sample from a given 1-D array
 
@@ -59,7 +59,7 @@ def choice(random_state, a, size=None, replace=True, p=None, chunks=None, gpu=No
         The probabilities associated with each entry in a.
         If not given the sample assumes a uniform distribution over all
         entries in a.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -122,12 +122,12 @@ def choice(random_state, a, size=None, replace=True, p=None, chunks=None, gpu=No
     if isinstance(a, Integral):
         if a <= 0:
             raise ValueError('a must be greater than 0')
-        a = arange(a, chunks=chunks)
+        a = arange(a, chunk_size=chunk_size)
         dtype = np.random.choice(1, size=(), p=np.array([1]) if p is not None else p).dtype
     else:
         if not isinstance(a, TENSOR_TYPE):
             a = np.asarray(a)
-        a = array(a, chunks=a.size).rechunk(a.size)  # do rechunk if a is already a tensor
+        a = array(a, chunk_size=a.size).rechunk(a.size)  # do rechunk if a is already a tensor
         if a.ndim != 1:
             raise ValueError('a must be one dimensional')
         dtype = a.dtype
@@ -137,7 +137,7 @@ def choice(random_state, a, size=None, replace=True, p=None, chunks=None, gpu=No
             p = np.asarray(p)
             if not np.isclose(p.sum(), 1, rtol=1e-7, atol=0):
                 raise ValueError('probabilities do not sum to 1')
-            p = array(p, chunks=p.size)
+            p = array(p, chunk_size=p.size)
         else:
             p = p.rechunk(p.size)
         if p.ndim != 1:
@@ -157,4 +157,4 @@ def choice(random_state, a, size=None, replace=True, p=None, chunks=None, gpu=No
     size = random_state._handle_size(size)
     op = TensorChoice(state=random_state._state, replace=replace,
                       size=size, dtype=dtype, gpu=gpu, **kw)
-    return op(a, p, chunks=chunks)
+    return op(a, p, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/core.py
+++ b/mars/tensor/expressions/random/core.py
@@ -24,7 +24,7 @@ from ....config import options
 from ....compat import irange, izip
 from ....operands.random import State
 from ...core import TENSOR_TYPE, CHUNK_TYPE
-from ..utils import decide_chunks, random_state_data, broadcast_shape
+from ..utils import decide_chunk_sizes, random_state_data, broadcast_shape
 from ..core import TensorOperandMixin
 from ..datasource import tensor as astensor
 from ..base import broadcast_to
@@ -92,7 +92,7 @@ class TensorRandomOperandMixin(TensorOperandMixin):
     def tile(cls, op):
         tensor = op.outputs[0]
         chunks = tensor.params.raw_chunks or options.tensor.chunks
-        nsplits = decide_chunks(tensor.shape, chunks, tensor.dtype.itemsize)
+        nsplits = decide_chunk_sizes(tensor.shape, chunks, tensor.dtype.itemsize)
         fields = getattr(op, '_input_fields_', [])
         to_one_chunk_fields = set(getattr(op, '_into_one_chunk_fields_', list()))
 

--- a/mars/tensor/expressions/random/core.py
+++ b/mars/tensor/expressions/random/core.py
@@ -91,8 +91,8 @@ class TensorRandomOperandMixin(TensorOperandMixin):
     @classmethod
     def tile(cls, op):
         tensor = op.outputs[0]
-        chunks = tensor.params.raw_chunks or options.tensor.chunks
-        nsplits = decide_chunk_sizes(tensor.shape, chunks, tensor.dtype.itemsize)
+        chunk_size = tensor.params.raw_chunk_size or options.tensor.chunk_size
+        nsplits = decide_chunk_sizes(tensor.shape, chunk_size, tensor.dtype.itemsize)
         fields = getattr(op, '_input_fields_', [])
         to_one_chunk_fields = set(getattr(op, '_into_one_chunk_fields_', list()))
 
@@ -159,14 +159,14 @@ class TensorRandomOperandMixin(TensorOperandMixin):
         return broadcast_shape(*shapes)
 
     @classmethod
-    def _handle_arg(cls, arg, chunks):
+    def _handle_arg(cls, arg, chunk_size):
         if isinstance(arg, (list, np.ndarray)):
-            arg = astensor(arg, chunks=chunks)
+            arg = astensor(arg, chunk_size=chunk_size)
 
         return arg
 
     @contextmanager
-    def _get_inputs_shape_by_given_fields(self, inputs, shape, raw_chunks=None, tensor=True):
+    def _get_inputs_shape_by_given_fields(self, inputs, shape, raw_chunk_size=None, tensor=True):
         fields = getattr(self, '_input_fields_', [])
         to_one_chunk_fields = set(getattr(self, '_into_one_chunk_fields_', list()))
 
@@ -180,7 +180,7 @@ class TensorRandomOperandMixin(TensorOperandMixin):
                         if isinstance(val, list):
                             val = np.asarray(val)
                         if tensor:
-                            val = self._handle_arg(val, raw_chunks)
+                            val = self._handle_arg(val, raw_chunk_size)
                     if isinstance(val, TENSOR_TYPE + CHUNK_TYPE):
                         field_to_obj[field] = val
                         if field not in to_one_chunk_fields:
@@ -208,8 +208,8 @@ class TensorRandomOperandMixin(TensorOperandMixin):
                 setattr(self, field, next(inputs_iter))
 
     def new_tensors(self, inputs, shape, **kw):
-        raw_chunks = kw.get('chunks', None)
-        with self._get_inputs_shape_by_given_fields(inputs, shape, raw_chunks, True) as (inputs, shape):
+        raw_chunk_size = kw.get('chunk_size', None)
+        with self._get_inputs_shape_by_given_fields(inputs, shape, raw_chunk_size, True) as (inputs, shape):
             return super(TensorRandomOperandMixin, self).new_tensors(inputs, shape, **kw)
 
     def new_chunks(self, inputs, shape, **kw):

--- a/mars/tensor/expressions/random/dirichlet.py
+++ b/mars/tensor/expressions/random/dirichlet.py
@@ -39,14 +39,14 @@ class TensorDirichlet(operands.Dirichlet, TensorRandomOperandMixin):
         shape = super(TensorDirichlet, self)._get_shape(inputs)
         return shape + (len(self._alpha),)
 
-    def __call__(self, chunks=None):
-        return self.new_tensor(None, None, raw_chunks=chunks)
+    def __call__(self, chunk_size=None):
+        return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
     @classmethod
     def tile(cls, op):
         tensor = op.outputs[0]
-        chunks = tensor.params.raw_chunks or options.tensor.chunks
-        nsplits = decide_chunk_sizes(tensor.shape[:-1], chunks, tensor.dtype.itemsize)
+        chunk_size = tensor.params.raw_chunk_size or options.tensor.chunk_size
+        nsplits = decide_chunk_sizes(tensor.shape[:-1], chunk_size, tensor.dtype.itemsize)
         nsplits += ((len(op.alpha),),)
 
         idxes = list(itertools.product(*[irange(len(s)) for s in nsplits]))
@@ -71,7 +71,7 @@ class TensorDirichlet(operands.Dirichlet, TensorRandomOperandMixin):
                                   chunks=out_chunks, nsplits=nsplits)
 
 
-def dirichlet(random_state, alpha, size=None, chunks=None, gpu=None, **kw):
+def dirichlet(random_state, alpha, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from the Dirichlet distribution.
 
@@ -89,7 +89,7 @@ def dirichlet(random_state, alpha, size=None, chunks=None, gpu=None, **kw):
         Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
         ``m * n * k`` samples are drawn.  Default is None, in which case a
         single value is returned.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -149,4 +149,4 @@ def dirichlet(random_state, alpha, size=None, chunks=None, gpu=None, **kw):
         kw['dtype'] = np.random.RandomState().dirichlet(alpha, size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorDirichlet(state=random_state._state, alpha=alpha, size=size, gpu=gpu, **kw)
-    return op(chunks=chunks)
+    return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/dirichlet.py
+++ b/mars/tensor/expressions/random/dirichlet.py
@@ -23,7 +23,7 @@ from .... import operands
 from ....config import options
 from ....operands.random import State
 from ....compat import irange, izip
-from ..utils import decide_chunks, random_state_data
+from ..utils import decide_chunk_sizes, random_state_data
 from .core import TensorRandomOperandMixin
 
 
@@ -46,7 +46,7 @@ class TensorDirichlet(operands.Dirichlet, TensorRandomOperandMixin):
     def tile(cls, op):
         tensor = op.outputs[0]
         chunks = tensor.params.raw_chunks or options.tensor.chunks
-        nsplits = decide_chunks(tensor.shape[:-1], chunks, tensor.dtype.itemsize)
+        nsplits = decide_chunk_sizes(tensor.shape[:-1], chunks, tensor.dtype.itemsize)
         nsplits += ((len(op.alpha),),)
 
         idxes = list(itertools.product(*[irange(len(s)) for s in nsplits]))

--- a/mars/tensor/expressions/random/exponential.py
+++ b/mars/tensor/expressions/random/exponential.py
@@ -29,11 +29,11 @@ class TensorExponential(operands.Exponential, TensorRandomOperandMixin):
         super(TensorExponential, self).__init__(_state=state, _size=size,
                                                 _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, scale, chunks=None):
-        return self.new_tensor([scale], self._size, raw_chunks=chunks)
+    def __call__(self, scale, chunk_size=None):
+        return self.new_tensor([scale], self._size, raw_chunk_size=chunk_size)
 
 
-def exponential(random_state, scale=1.0, size=None, chunks=None, gpu=None, **kw):
+def exponential(random_state, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from an exponential distribution.
 
@@ -60,7 +60,7 @@ def exponential(random_state, scale=1.0, size=None, chunks=None, gpu=None, **kw)
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``scale`` is a scalar.  Otherwise,
         ``np.array(scale).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -84,4 +84,4 @@ def exponential(random_state, scale=1.0, size=None, chunks=None, gpu=None, **kw)
             handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorExponential(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(scale, chunks=chunks)
+    return op(scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/f.py
+++ b/mars/tensor/expressions/random/f.py
@@ -29,11 +29,11 @@ class TensorF(operands.F, TensorRandomOperandMixin):
         super(TensorF, self).__init__(_state=state, _size=size, _dtype=dtype,
                                       _gpu=gpu, **kw)
 
-    def __call__(self, dfnum, dfden, chunks=None):
-        return self.new_tensor([dfnum, dfden], None, raw_chunks=chunks)
+    def __call__(self, dfnum, dfden, chunk_size=None):
+        return self.new_tensor([dfnum, dfden], None, raw_chunk_size=chunk_size)
 
 
-def f(random_state, dfnum, dfden, size=None, chunks=None, gpu=None, **kw):
+def f(random_state, dfnum, dfden, size=None, chunk_size=None, gpu=None, **kw):
     """
     Draw samples from an F distribution.
 
@@ -58,7 +58,7 @@ def f(random_state, dfnum, dfden, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``dfnum`` and ``dfden`` are both scalars.
         Otherwise, ``np.broadcast(dfnum, dfden).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -124,4 +124,4 @@ def f(random_state, dfnum, dfden, size=None, chunks=None, gpu=None, **kw):
             handle_array(dfnum), handle_array(dfden), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorF(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(dfnum, dfden, chunks=chunks)
+    return op(dfnum, dfden, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/gamma.py
+++ b/mars/tensor/expressions/random/gamma.py
@@ -29,11 +29,11 @@ class TensorGamma(operands.Gamma, TensorRandomOperandMixin):
         super(TensorGamma, self).__init__(_state=state, _size=size, _dtype=dtype,
                                           _gpu=gpu, **kw)
 
-    def __call__(self, shape, scale, chunks=None):
-        return self.new_tensor([shape, scale], None, raw_chunks=chunks)
+    def __call__(self, shape, scale, chunk_size=None):
+        return self.new_tensor([shape, scale], None, raw_chunk_size=chunk_size)
 
 
-def gamma(random_state, shape, scale=1.0, size=None, chunks=None, gpu=None, **kw):
+def gamma(random_state, shape, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a Gamma distribution.
 
@@ -53,7 +53,7 @@ def gamma(random_state, shape, scale=1.0, size=None, chunks=None, gpu=None, **kw
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``shape`` and ``scale`` are both scalars.
         Otherwise, ``np.broadcast(shape, scale).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -115,4 +115,4 @@ def gamma(random_state, shape, scale=1.0, size=None, chunks=None, gpu=None, **kw
             handle_array(shape), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorGamma(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(shape, scale, chunks=chunks)
+    return op(shape, scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/geometric.py
+++ b/mars/tensor/expressions/random/geometric.py
@@ -29,11 +29,11 @@ class TensorGeometric(operands.Geometric, TensorRandomOperandMixin):
         super(TensorGeometric, self).__init__(_state=state, _size=size, _dtype=dtype,
                                               _gpu=gpu, **kw)
 
-    def __call__(self, p, chunks=None):
-        return self.new_tensor([p], None, raw_chunks=chunks)
+    def __call__(self, p, chunk_size=None):
+        return self.new_tensor([p], None, raw_chunk_size=chunk_size)
 
 
-def geometric(random_state, p, size=None, chunks=None, gpu=None, **kw):
+def geometric(random_state, p, size=None, chunk_size=None, gpu=None, **kw):
     """
     Draw samples from the geometric distribution.
 
@@ -58,7 +58,7 @@ def geometric(random_state, p, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``p`` is a scalar.  Otherwise,
         ``mt.array(p).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -87,4 +87,4 @@ def geometric(random_state, p, size=None, chunks=None, gpu=None, **kw):
             handle_array(p), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorGeometric(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(p, chunks=chunks)
+    return op(p, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/gumbel.py
+++ b/mars/tensor/expressions/random/gumbel.py
@@ -29,11 +29,11 @@ class TensorGumbel(operands.Gumbel, TensorRandomOperandMixin):
         super(TensorGumbel, self).__init__(_state=state, _size=size, _dtype=dtype,
                                            _gpu=gpu, **kw)
 
-    def __call__(self, loc, scale, chunks=None):
-        return self.new_tensor([loc, scale], None, raw_chunks=chunks)
+    def __call__(self, loc, scale, chunk_size=None):
+        return self.new_tensor([loc, scale], None, raw_chunk_size=chunk_size)
 
 
-def gumbel(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, **kw):
+def gumbel(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a Gumbel distribution.
 
@@ -52,7 +52,7 @@ def gumbel(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, *
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``loc`` and ``scale`` are both scalars.
         Otherwise, ``np.broadcast(loc, scale).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -154,4 +154,4 @@ def gumbel(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, *
             handle_array(loc), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorGumbel(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(loc, scale, chunks=chunks)
+    return op(loc, scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/hypergeometric.py
+++ b/mars/tensor/expressions/random/hypergeometric.py
@@ -29,11 +29,11 @@ class TensorHypergeometric(operands.Hypergeometric, TensorRandomOperandMixin):
         super(TensorHypergeometric, self).__init__(_state=state, _size=size,
                                                    _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, ngood, nbad, nsample, chunks=None):
-        return self.new_tensor([ngood, nbad, nsample], None, raw_chunks=chunks)
+    def __call__(self, ngood, nbad, nsample, chunk_size=None):
+        return self.new_tensor([ngood, nbad, nsample], None, raw_chunk_size=chunk_size)
 
 
-def hypergeometric(random_state, ngood, nbad, nsample, size=None, chunks=None, gpu=None, **kw):
+def hypergeometric(random_state, ngood, nbad, nsample, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a Hypergeometric distribution.
 
@@ -57,7 +57,7 @@ def hypergeometric(random_state, ngood, nbad, nsample, size=None, chunks=None, g
         a single value is returned if ``ngood``, ``nbad``, and ``nsample``
         are all scalars.  Otherwise, ``np.broadcast(ngood, nbad, nsample).size``
         samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -129,4 +129,4 @@ def hypergeometric(random_state, ngood, nbad, nsample, size=None, chunks=None, g
             handle_array(ngood), handle_array(nbad), handle_array(nsample), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorHypergeometric(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(ngood, nbad, nsample, chunks=chunks)
+    return op(ngood, nbad, nsample, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/laplace.py
+++ b/mars/tensor/expressions/random/laplace.py
@@ -29,11 +29,11 @@ class TensorLaplace(operands.Laplace, TensorRandomOperandMixin):
         super(TensorLaplace, self).__init__(_state=state, _size=size,
                                             _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, loc, scale, chunks=None):
-        return self.new_tensor([loc, scale], None, raw_chunks=chunks)
+    def __call__(self, loc, scale, chunk_size=None):
+        return self.new_tensor([loc, scale], None, raw_chunk_size=chunk_size)
 
 
-def laplace(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, **kw):
+def laplace(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from the Laplace or double exponential distribution with
     specified location (or mean) and scale (decay).
@@ -120,4 +120,4 @@ def laplace(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, 
             handle_array(loc), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorLaplace(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(loc, scale, chunks=chunks)
+    return op(loc, scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/logistic.py
+++ b/mars/tensor/expressions/random/logistic.py
@@ -29,8 +29,8 @@ class TensorLogistic(operands.Logistic, TensorRandomOperandMixin):
         super(TensorLogistic, self).__init__(_state=state, _size=size,
                                              _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, loc, scale, chunks=None):
-        return self.new_tensor([loc, scale], None, raw_chunks=chunks)
+    def __call__(self, loc, scale, chunk_size=None):
+        return self.new_tensor([loc, scale], None, raw_chunk_size=chunk_size)
 
 
 def logistic(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, **kw):
@@ -52,7 +52,7 @@ def logistic(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None,
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``loc`` and ``scale`` are both scalars.
         Otherwise, ``np.broadcast(loc, scale).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -116,4 +116,4 @@ def logistic(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None,
             handle_array(loc), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorLogistic(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(loc, scale, chunks=chunks)
+    return op(loc, scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/logistic.py
+++ b/mars/tensor/expressions/random/logistic.py
@@ -33,7 +33,7 @@ class TensorLogistic(operands.Logistic, TensorRandomOperandMixin):
         return self.new_tensor([loc, scale], None, raw_chunk_size=chunk_size)
 
 
-def logistic(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, **kw):
+def logistic(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a logistic distribution.
 

--- a/mars/tensor/expressions/random/lognormal.py
+++ b/mars/tensor/expressions/random/lognormal.py
@@ -29,11 +29,11 @@ class TensorLognormal(operands.Lognormal, TensorRandomOperandMixin):
         super(TensorLognormal, self).__init__(_state=state, _size=size, _dtype=dtype,
                                               _gpu=gpu, **kw)
 
-    def __call__(self, mean, sigma, chunks=None):
-        return self.new_tensor([mean, sigma], None, raw_chunks=chunks)
+    def __call__(self, mean, sigma, chunk_size=None):
+        return self.new_tensor([mean, sigma], None, raw_chunk_size=chunk_size)
 
 
-def lognormal(random_state, mean=0.0, sigma=1.0, size=None, chunks=None, gpu=None, **kw):
+def lognormal(random_state, mean=0.0, sigma=1.0, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a log-normal distribution.
 
@@ -54,7 +54,7 @@ def lognormal(random_state, mean=0.0, sigma=1.0, size=None, chunks=None, gpu=Non
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``mean`` and ``sigma`` are both scalars.
         Otherwise, ``np.broadcast(mean, sigma).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -146,4 +146,4 @@ def lognormal(random_state, mean=0.0, sigma=1.0, size=None, chunks=None, gpu=Non
             handle_array(mean), handle_array(sigma), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorLognormal(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(mean, sigma, chunks=chunks)
+    return op(mean, sigma, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/logseries.py
+++ b/mars/tensor/expressions/random/logseries.py
@@ -29,11 +29,11 @@ class TensorLogseries(operands.Logseries, TensorRandomOperandMixin):
         super(TensorLogseries, self).__init__(_state=state, _size=size, _dtype=dtype,
                                               _gpu=gpu, **kw)
 
-    def __call__(self, p, chunks=None):
-        return self.new_tensor([p], None, raw_chunks=chunks)
+    def __call__(self, p, chunk_size=None):
+        return self.new_tensor([p], None, raw_chunk_size=chunk_size)
 
 
-def logseries(random_state, p, size=None, chunks=None, gpu=None, **kw):
+def logseries(random_state, p, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a logarithmic series distribution.
 
@@ -49,7 +49,7 @@ def logseries(random_state, p, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``p`` is a scalar.  Otherwise,
         ``np.array(p).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -116,4 +116,4 @@ def logseries(random_state, p, size=None, chunks=None, gpu=None, **kw):
             handle_array(p), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorLogseries(state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(p, chunks=chunks)
+    return op(p, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/multinomial.py
+++ b/mars/tensor/expressions/random/multinomial.py
@@ -29,7 +29,7 @@ class TensorMultinomial(operands.Multinomial, TensorRandomOperandMixin):
         super(TensorMultinomial, self).__init__(_n=n, _pvals=pvals, _state=state,
                                                 _size=size, _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, chunks=None):
+    def __call__(self, chunk_size=None):
         if self._size is None:
             shape = (len(self._pvals),)
         else:
@@ -37,10 +37,10 @@ class TensorMultinomial(operands.Multinomial, TensorRandomOperandMixin):
                 shape = tuple(self._size) + (len(self._pvals),)
             except TypeError:
                 shape = (self._size, len(self._pvals))
-        return self.new_tensor(None, shape, raw_chunks=chunks)
+        return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
 
 
-def multinomial(random_state, n, pvals, size=None, chunks=None, gpu=None, **kw):
+def multinomial(random_state, n, pvals, size=None, chunk_size=None, gpu=None, **kw):
     """
     Draw samples from a multinomial distribution.
 
@@ -65,7 +65,7 @@ def multinomial(random_state, n, pvals, size=None, chunks=None, gpu=None, **kw):
         Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
         ``m * n * k`` samples are drawn.  Default is None, in which case a
         single value is returned.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -124,5 +124,5 @@ def multinomial(random_state, n, pvals, size=None, chunks=None, gpu=None, **kw):
         kw['dtype'] = np.random.RandomState().multinomial(n, pvals, size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorMultinomial(n=n, pvals=pvals, state=random_state._state, size=size, gpu=gpu, **kw)
-    return op(chunks=chunks)
+    return op(chunk_size=chunk_size)
 

--- a/mars/tensor/expressions/random/multivariate_normal.py
+++ b/mars/tensor/expressions/random/multivariate_normal.py
@@ -36,7 +36,7 @@ class TensorMultivariateNormal(operands.MultivariateNormal, TensorRandomOperandM
                                                        _check_valid=check_valid, _tol=tol,
                                                        _state=state, _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, chunks=None):
+    def __call__(self, chunk_size=None):
         N = self._mean.size
         if self._size is None:
             shape = (N,)
@@ -46,13 +46,13 @@ class TensorMultivariateNormal(operands.MultivariateNormal, TensorRandomOperandM
             except TypeError:
                 shape = (self._size, N)
 
-        return self.new_tensor(None, shape, raw_chunks=chunks)
+        return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
 
     @classmethod
     def tile(cls, op):
         tensor = op.outputs[0]
-        chunks = tensor.params.raw_chunks or options.tensor.chunks
-        nsplits = decide_chunk_sizes(tensor.shape[:-1], chunks, tensor.dtype.itemsize) + ((tensor.shape[-1],),)
+        chunk_size = tensor.params.raw_chunk_size or options.tensor.chunk_size
+        nsplits = decide_chunk_sizes(tensor.shape[:-1], chunk_size, tensor.dtype.itemsize) + ((tensor.shape[-1],),)
 
         mean_chunk = op.mean.chunks[0] if hasattr(op.mean, 'chunks') else op.mean
         cov_chunk = op.cov.chunks[0] if hasattr(op.cov, 'chunks') else op.cov
@@ -76,7 +76,7 @@ class TensorMultivariateNormal(operands.MultivariateNormal, TensorRandomOperandM
 
 
 def multivariate_normal(random_state, mean, cov, size=None, check_valid=None, tol=None,
-                        chunks=None, gpu=None, **kw):
+                        chunk_size=None, gpu=None, **kw):
     """
     Draw random samples from a multivariate normal distribution.
 
@@ -103,7 +103,7 @@ def multivariate_normal(random_state, mean, cov, size=None, check_valid=None, to
         Behavior when the covariance matrix is not positive semidefinite.
     tol : float, optional
         Tolerance when checking the singular values in covariance matrix.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -199,4 +199,4 @@ def multivariate_normal(random_state, mean, cov, size=None, check_valid=None, to
     size = random_state._handle_size(size)
     op = TensorMultivariateNormal(mean=mean, cov=cov, size=size, check_valid=check_valid,
                                   tol=tol, state=random_state._state, gpu=gpu, **kw)
-    return op(chunks=chunks)
+    return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/multivariate_normal.py
+++ b/mars/tensor/expressions/random/multivariate_normal.py
@@ -22,7 +22,7 @@ from .... import operands
 from ....config import options
 from ....compat import irange, izip
 from ....operands.random import State
-from ..utils import decide_chunks, random_state_data
+from ..utils import decide_chunk_sizes, random_state_data
 from .core import TensorRandomOperandMixin
 
 
@@ -52,7 +52,7 @@ class TensorMultivariateNormal(operands.MultivariateNormal, TensorRandomOperandM
     def tile(cls, op):
         tensor = op.outputs[0]
         chunks = tensor.params.raw_chunks or options.tensor.chunks
-        nsplits = decide_chunks(tensor.shape[:-1], chunks, tensor.dtype.itemsize) + ((tensor.shape[-1],),)
+        nsplits = decide_chunk_sizes(tensor.shape[:-1], chunks, tensor.dtype.itemsize) + ((tensor.shape[-1],),)
 
         mean_chunk = op.mean.chunks[0] if hasattr(op.mean, 'chunks') else op.mean
         cov_chunk = op.cov.chunks[0] if hasattr(op.cov, 'chunks') else op.cov

--- a/mars/tensor/expressions/random/negative_binomial.py
+++ b/mars/tensor/expressions/random/negative_binomial.py
@@ -29,11 +29,11 @@ class TensorNegativeBinomial(operands.NegativeBinomial, TensorRandomOperandMixin
         super(TensorNegativeBinomial, self).__init__(_size=size, _state=state, _dtype=dtype,
                                                      _gpu=gpu, **kw)
 
-    def __call__(self, n, p, chunks=None):
-        return self.new_tensor([n, p], None, raw_chunks=chunks)
+    def __call__(self, n, p, chunk_size=None):
+        return self.new_tensor([n, p], None, raw_chunk_size=chunk_size)
 
 
-def negative_binomial(random_state, n, p, size=None, chunks=None, gpu=None, **kw):
+def negative_binomial(random_state, n, p, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a negative binomial distribution.
 
@@ -53,7 +53,7 @@ def negative_binomial(random_state, n, p, size=None, chunks=None, gpu=None, **kw
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``n`` and ``p`` are both scalars.
         Otherwise, ``np.broadcast(n, p).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -112,4 +112,4 @@ def negative_binomial(random_state, n, p, size=None, chunks=None, gpu=None, **kw
             handle_array(n), handle_array(p), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorNegativeBinomial(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(n, p, chunks=chunks)
+    return op(n, p, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/noncentral_chisquare.py
+++ b/mars/tensor/expressions/random/noncentral_chisquare.py
@@ -29,11 +29,11 @@ class TensorNoncentralChisquare(operands.NoncentralChisquare, TensorRandomOperan
         super(TensorNoncentralChisquare, self).__init__(_size=size, _state=state, _dtype=dtype,
                                                         _gpu=gpu, **kw)
 
-    def __call__(self, df, nonc, chunks=None):
-        return self.new_tensor([df, nonc], None, raw_chunks=chunks)
+    def __call__(self, df, nonc, chunk_size=None):
+        return self.new_tensor([df, nonc], None, raw_chunk_size=chunk_size)
 
 
-def noncentral_chisquare(random_state, df, nonc, size=None, chunks=None, gpu=None, **kw):
+def noncentral_chisquare(random_state, df, nonc, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a noncentral chi-square distribution.
 
@@ -51,7 +51,7 @@ def noncentral_chisquare(random_state, df, nonc, size=None, chunks=None, gpu=Non
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``df`` and ``nonc`` are both scalars.
         Otherwise, ``mt.broadcast(df, nonc).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -119,4 +119,4 @@ def noncentral_chisquare(random_state, df, nonc, size=None, chunks=None, gpu=Non
             handle_array(df), handle_array(nonc), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorNoncentralChisquare(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(df, nonc, chunks=chunks)
+    return op(df, nonc, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/noncentral_f.py
+++ b/mars/tensor/expressions/random/noncentral_f.py
@@ -29,11 +29,11 @@ class TensorNoncentralF(operands.NoncentralF, TensorRandomOperandMixin):
         super(TensorNoncentralF, self).__init__(_size=size, _state=state, _dtype=dtype,
                                                 _gpu=gpu, **kw)
 
-    def __call__(self, dfnum, dfden, nonc, chunks=None):
-        return self.new_tensor([dfnum, dfden, nonc], None, raw_chunks=chunks)
+    def __call__(self, dfnum, dfden, nonc, chunk_size=None):
+        return self.new_tensor([dfnum, dfden, nonc], None, raw_chunk_size=chunk_size)
 
 
-def noncentral_f(random_state, dfnum, dfden, nonc, size=None, chunks=None, gpu=None, **kw):
+def noncentral_f(random_state, dfnum, dfden, nonc, size=None, chunk_size=None, gpu=None, **kw):
     """
     Draw samples from the noncentral F distribution.
 
@@ -57,7 +57,7 @@ def noncentral_f(random_state, dfnum, dfden, nonc, size=None, chunks=None, gpu=N
         a single value is returned if ``dfnum``, ``dfden``, and ``nonc``
         are all scalars.  Otherwise, ``np.broadcast(dfnum, dfden, nonc).size``
         samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -110,4 +110,4 @@ def noncentral_f(random_state, dfnum, dfden, nonc, size=None, chunks=None, gpu=N
             handle_array(dfnum), handle_array(dfden), handle_array(nonc), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorNoncentralF(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(dfnum, dfden, nonc, chunks=chunks)
+    return op(dfnum, dfden, nonc, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/normal.py
+++ b/mars/tensor/expressions/random/normal.py
@@ -29,11 +29,11 @@ class TensorNormal(operands.Normal, TensorRandomOperandMixin):
         super(TensorNormal, self).__init__(_size=size, _state=state, _dtype=dtype,
                                            _gpu=gpu, **kw)
 
-    def __call__(self, loc, scale, chunks=None):
-        return self.new_tensor([loc, scale], None, raw_chunks=chunks)
+    def __call__(self, loc, scale, chunk_size=None):
+        return self.new_tensor([loc, scale], None, raw_chunk_size=chunk_size)
 
 
-def normal(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, **kw):
+def normal(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw random samples from a normal (Gaussian) distribution.
 
@@ -58,7 +58,7 @@ def normal(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, *
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``loc`` and ``scale`` are both scalars.
         Otherwise, ``mt.broadcast(loc, scale).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -130,4 +130,4 @@ def normal(random_state, loc=0.0, scale=1.0, size=None, chunks=None, gpu=None, *
             handle_array(loc), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorNormal(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(loc, scale, chunks=chunks)
+    return op(loc, scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/pareto.py
+++ b/mars/tensor/expressions/random/pareto.py
@@ -29,11 +29,11 @@ class TensorPareto(operands.Pareto, TensorRandomOperandMixin):
         super(TensorPareto, self).__init__(_size=size, _state=state, _dtype=dtype,
                                            _gpu=gpu, **kw)
 
-    def __call__(self, a, chunks=None):
-        return self.new_tensor([a], None, raw_chunks=chunks)
+    def __call__(self, a, chunk_size=None):
+        return self.new_tensor([a], None, raw_chunk_size=chunk_size)
 
 
-def pareto(random_state, a, size=None, chunks=None, gpu=None, **kw):
+def pareto(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a Pareto II or Lomax distribution with
     specified shape.
@@ -64,7 +64,7 @@ def pareto(random_state, a, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``a`` is a scalar.  Otherwise,
         ``mt.array(a).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -134,4 +134,4 @@ def pareto(random_state, a, size=None, chunks=None, gpu=None, **kw):
             handle_array(a), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorPareto(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(a, chunks=chunks)
+    return op(a, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/poisson.py
+++ b/mars/tensor/expressions/random/poisson.py
@@ -29,11 +29,11 @@ class TensorPoisson(operands.Poisson, TensorRandomOperandMixin):
         super(TensorPoisson, self).__init__(_size=size, _state=state, _dtype=dtype,
                                             _gpu=gpu, **kw)
 
-    def __call__(self, lam, chunks=None):
-        return self.new_tensor([lam], None, raw_chunks=chunks)
+    def __call__(self, lam, chunk_size=None):
+        return self.new_tensor([lam], None, raw_chunk_size=chunk_size)
 
 
-def poisson(random_state, lam=1.0, size=None, chunks=None, gpu=None, **kw):
+def poisson(random_state, lam=1.0, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a Poisson distribution.
 
@@ -50,7 +50,7 @@ def poisson(random_state, lam=1.0, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``lam`` is a scalar. Otherwise,
         ``mt.array(lam).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -106,4 +106,4 @@ def poisson(random_state, lam=1.0, size=None, chunks=None, gpu=None, **kw):
             handle_array(lam), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorPoisson(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(lam, chunks=chunks)
+    return op(lam, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/power.py
+++ b/mars/tensor/expressions/random/power.py
@@ -29,11 +29,11 @@ class TensorRandomPower(operands.RandomPower, TensorRandomOperandMixin):
         super(TensorRandomPower, self).__init__(_size=size, _state=state, _dtype=dtype,
                                                 _gpu=gpu, **kw)
 
-    def __call__(self, a, chunks=None):
-        return self.new_tensor([a], None, raw_chunks=chunks)
+    def __call__(self, a, chunk_size=None):
+        return self.new_tensor([a], None, raw_chunk_size=chunk_size)
 
 
-def power(random_state, a, size=None, chunks=None, gpu=None, **kw):
+def power(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
     """
     Draws samples in [0, 1] from a power distribution with positive
     exponent a - 1.
@@ -49,7 +49,7 @@ def power(random_state, a, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``a`` is a scalar.  Otherwise,
         ``mt.array(a).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -136,4 +136,4 @@ def power(random_state, a, size=None, chunks=None, gpu=None, **kw):
             handle_array(a), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorRandomPower(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(a, chunks=chunks)
+    return op(a, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/rand.py
+++ b/mars/tensor/expressions/random/rand.py
@@ -26,8 +26,8 @@ class TensorRand(operands.Rand, TensorRandomOperandMixin):
         super(TensorRand, self).__init__(_state=state, _size=size,
                                          _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, chunks=None):
-        return self.new_tensor(None, None, raw_chunks=chunks)
+    def __call__(self, chunk_size=None):
+        return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
 def rand(random_state, *dn, **kw):
@@ -72,6 +72,6 @@ def rand(random_state, *dn, **kw):
         raise TypeError("'tuple' object cannot be interpreted as an integer")
     if 'dtype' not in kw:
         kw['dtype'] = np.dtype('f8')
-    chunks = kw.pop('chunks', None)
+    chunk_size = kw.pop('chunk_size', None)
     op = TensorRand(state=random_state._state, size=dn, **kw)
-    return op(chunks=chunks)
+    return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/randint.py
+++ b/mars/tensor/expressions/random/randint.py
@@ -31,12 +31,12 @@ class TensorRandint(operands.Randint, TensorRandomOperandMixin):
                                             _sparse=sparse, _density=density,
                                             _gpu=gpu, **kw)
 
-    def __call__(self, chunks=None):
-        return self.new_tensor(None, None, raw_chunks=chunks)
+    def __call__(self, chunk_size=None):
+        return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
 def randint(random_state, low, high=None, size=None, dtype='l', density=None,
-            chunks=None, gpu=None, **kw):
+            chunk_size=None, gpu=None, **kw):
     """
     Return random integers from `low` (inclusive) to `high` (exclusive).
 
@@ -64,7 +64,7 @@ def randint(random_state, low, high=None, size=None, dtype='l', density=None,
         on the platform. The default value is 'np.int'.
     density: float, optional
         if density specified, a sparse tensor will be created
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -101,4 +101,4 @@ def randint(random_state, low, high=None, size=None, dtype='l', density=None,
     size = random_state._handle_size(size)
     op = TensorRandint(state=random_state._state, low=low, high=high, size=size, dtype=dtype,
                        gpu=gpu, sparse=sparse, density=density, **kw)
-    return op(chunks=chunks)
+    return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/randn.py
+++ b/mars/tensor/expressions/random/randn.py
@@ -26,8 +26,8 @@ class TensorRandn(operands.Randn, TensorRandomOperandMixin):
         super(TensorRandn, self).__init__(_state=state, _size=size,
                                           _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, chunks=None):
-        return self.new_tensor(None, None, raw_chunks=chunks)
+    def __call__(self, chunk_size=None):
+        return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
 def randn(random_state, *dn, **kw):
@@ -85,7 +85,7 @@ def randn(random_state, *dn, **kw):
         raise TypeError("'tuple' object cannot be interpreted as an integer")
     if 'dtype' not in kw:
         kw['dtype'] = np.dtype('f8')
-    chunks = kw.pop('chunks', None)
+    chunk_size = kw.pop('chunk_size', None)
     op = TensorRandn(state=random_state._state, size=dn, **kw)
-    return op(chunks=chunks)
+    return op(chunk_size=chunk_size)
 

--- a/mars/tensor/expressions/random/random_integers.py
+++ b/mars/tensor/expressions/random/random_integers.py
@@ -30,11 +30,11 @@ class TensorRandomIntegers(operands.RandomIntegers, TensorRandomOperandMixin):
                                                    _dtype=dtype, _low=low, _high=high,
                                                    _gpu=gpu, **kw)
 
-    def __call__(self, chunks=None):
-        return self.new_tensor(None, None, raw_chunks=chunks)
+    def __call__(self, chunk_size=None):
+        return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
-def random_integers(random_state, low, high=None, size=None, chunks=None, gpu=None, **kw):
+def random_integers(random_state, low, high=None, size=None, chunk_size=None, gpu=None, **kw):
     """
     Random integers of type mt.int between `low` and `high`, inclusive.
 
@@ -59,7 +59,7 @@ def random_integers(random_state, low, high=None, size=None, chunks=None, gpu=No
         Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
         ``m * n * k`` samples are drawn.  Default is None, in which case a
         single value is returned.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -118,4 +118,4 @@ def random_integers(random_state, low, high=None, size=None, chunks=None, gpu=No
     size = random_state._handle_size(size)
     op = TensorRandomIntegers(state=random_state._state, size=size, dtype=np.dtype(int),
                               low=low, high=high, gpu=gpu, **kw)
-    return op(chunks=chunks)
+    return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/random_sample.py
+++ b/mars/tensor/expressions/random/random_sample.py
@@ -29,11 +29,11 @@ class TensorRandomSample(operands.RandomSample, TensorRandomOperandMixin):
         super(TensorRandomSample, self).__init__(_state=state, _size=size,
                                                  _dtype=dtype, _gpu=gpu, **kw)
 
-    def __call__(self, chunks):
-        return self.new_tensor(None, None, raw_chunks=chunks)
+    def __call__(self, chunk_size):
+        return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
-def random_sample(random_state, size=None, chunks=None, gpu=None, **kw):
+def random_sample(random_state, size=None, chunk_size=None, gpu=None, **kw):
     """
     Return random floats in the half-open interval [0.0, 1.0).
 
@@ -49,7 +49,7 @@ def random_sample(random_state, size=None, chunks=None, gpu=None, **kw):
         Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
         ``m * n * k`` samples are drawn.  Default is None, in which case a
         single value is returned.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -82,4 +82,4 @@ def random_sample(random_state, size=None, chunks=None, gpu=None, **kw):
         kw['dtype'] = np.dtype('f8')
     size = random_state._handle_size(size)
     op = TensorRandomSample(state=random_state._state, size=size, **kw)
-    return op(chunks=chunks)
+    return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/rayleigh.py
+++ b/mars/tensor/expressions/random/rayleigh.py
@@ -29,11 +29,11 @@ class TensorRayleigh(operands.Rayleigh, TensorRandomOperandMixin):
         super(TensorRayleigh, self).__init__(_size=size, _state=state, _dtype=dtype,
                                              _gpu=gpu, **kw)
 
-    def __call__(self, scale, chunks=None):
-        return self.new_tensor([scale], None, raw_chunks=chunks)
+    def __call__(self, scale, chunk_size=None):
+        return self.new_tensor([scale], None, raw_chunk_size=chunk_size)
 
 
-def rayleigh(random_state, scale=1.0, size=None, chunks=None, gpu=None, **kw):
+def rayleigh(random_state, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a Rayleigh distribution.
 
@@ -49,7 +49,7 @@ def rayleigh(random_state, scale=1.0, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``scale`` is a scalar.  Otherwise,
         ``mt.array(scale).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -104,4 +104,4 @@ def rayleigh(random_state, scale=1.0, size=None, chunks=None, gpu=None, **kw):
             handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorRayleigh(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(scale, chunks=chunks)
+    return op(scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/standard_cauchy.py
+++ b/mars/tensor/expressions/random/standard_cauchy.py
@@ -28,11 +28,11 @@ class TensorStandardCauchy(operands.StandardCauchy, TensorRandomOperandMixin):
         super(TensorStandardCauchy, self).__init__(_size=size, _state=state, _dtype=dtype,
                                                    _gpu=gpu, **kw)
 
-    def __call__(self, chunks=None):
-        return self.new_tensor(None, None, raw_chunks=chunks)
+    def __call__(self, chunk_size=None):
+        return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
-def standard_cauchy(random_state, size=None, chunks=None, gpu=None, **kw):
+def standard_cauchy(random_state, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a standard Cauchy distribution with mode = 0.
 
@@ -44,7 +44,7 @@ def standard_cauchy(random_state, size=None, chunks=None, gpu=None, **kw):
         Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
         ``m * n * k`` samples are drawn.  Default is None, in which case a
         single value is returned.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -101,4 +101,4 @@ def standard_cauchy(random_state, size=None, chunks=None, gpu=None, **kw):
         kw['dtype'] = np.random.RandomState().standard_cauchy(size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorStandardCauchy(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(chunks=chunks)
+    return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/standard_exponential.py
+++ b/mars/tensor/expressions/random/standard_exponential.py
@@ -28,11 +28,11 @@ class TensorStandardExponential(operands.StandardExponential, TensorRandomOperan
         super(TensorStandardExponential, self).__init__(_size=size, _state=state, _dtype=dtype,
                                                         _gpu=gpu, **kw)
 
-    def __call__(self, chunks=None):
-        return self.new_tensor(None, None, raw_chunks=chunks)
+    def __call__(self, chunk_size=None):
+        return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
-def standard_exponential(random_state, size=None, chunks=None, gpu=None, **kw):
+def standard_exponential(random_state, size=None, chunk_size=None, gpu=None, **kw):
     """
     Draw samples from the standard exponential distribution.
 
@@ -45,7 +45,7 @@ def standard_exponential(random_state, size=None, chunks=None, gpu=None, **kw):
         Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
         ``m * n * k`` samples are drawn.  Default is None, in which case a
         single value is returned.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -66,4 +66,4 @@ def standard_exponential(random_state, size=None, chunks=None, gpu=None, **kw):
         kw['dtype'] = np.random.RandomState().standard_exponential(size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorStandardExponential(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(chunks=chunks)
+    return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/standard_gamma.py
+++ b/mars/tensor/expressions/random/standard_gamma.py
@@ -29,11 +29,11 @@ class TensorStandardGamma(operands.StandardGamma, TensorRandomOperandMixin):
         super(TensorStandardGamma, self).__init__(_size=size, _state=state, _dtype=dtype,
                                                   _gpu=gpu, **kw)
 
-    def __call__(self, shape, chunks=None):
-        return self.new_tensor([shape], None, raw_chunks=chunks)
+    def __call__(self, shape, chunk_size=None):
+        return self.new_tensor([shape], None, raw_chunk_size=chunk_size)
 
 
-def standard_gamma(random_state, shape, size=None, chunks=None, gpu=None, **kw):
+def standard_gamma(random_state, shape, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a standard Gamma distribution.
 
@@ -49,7 +49,7 @@ def standard_gamma(random_state, shape, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``shape`` is a scalar.  Otherwise,
         ``mt.array(shape).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -110,4 +110,4 @@ def standard_gamma(random_state, shape, size=None, chunks=None, gpu=None, **kw):
             handle_array(shape), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorStandardGamma(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(shape, chunks=chunks)
+    return op(shape, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/standard_normal.py
+++ b/mars/tensor/expressions/random/standard_normal.py
@@ -28,11 +28,11 @@ class TensorStandardNormal(operands.StandardNormal, TensorRandomOperandMixin):
         super(TensorStandardNormal, self).__init__(_size=size, _state=state, _dtype=dtype,
                                                    _gpu=gpu, **kw)
 
-    def __call__(self, chunks=None):
-        return self.new_tensor(None, None, raw_chunks=chunks)
+    def __call__(self, chunk_size=None):
+        return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
-def standard_normal(random_state, size=None, chunks=None, gpu=None, **kw):
+def standard_normal(random_state, size=None, chunk_size=None, gpu=None, **kw):
     """
     Draw samples from a standard Normal distribution (mean=0, stdev=1).
 
@@ -42,7 +42,7 @@ def standard_normal(random_state, size=None, chunks=None, gpu=None, **kw):
         Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
         ``m * n * k`` samples are drawn.  Default is None, in which case a
         single value is returned.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -70,4 +70,4 @@ def standard_normal(random_state, size=None, chunks=None, gpu=None, **kw):
         kw['dtype'] = np.random.RandomState().standard_normal(size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorStandardNormal(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(chunks=chunks)
+    return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/standard_t.py
+++ b/mars/tensor/expressions/random/standard_t.py
@@ -29,11 +29,11 @@ class TensorStandardT(operands.StandardT, TensorRandomOperandMixin):
         super(TensorStandardT, self).__init__(_size=size, _state=state, _dtype=dtype,
                                               _gpu=gpu, **kw)
 
-    def __call__(self, df, chunks=None):
-        return self.new_tensor([df], None, raw_chunks=chunks)
+    def __call__(self, df, chunk_size=None):
+        return self.new_tensor([df], None, raw_chunk_size=chunk_size)
 
 
-def standard_t(random_state, df, size=None, chunks=None, gpu=None, **kw):
+def standard_t(random_state, df, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a standard Student's t distribution with `df` degrees
     of freedom.
@@ -51,7 +51,7 @@ def standard_t(random_state, df, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``df`` is a scalar.  Otherwise,
         ``mt.array(df).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -129,4 +129,4 @@ def standard_t(random_state, df, size=None, chunks=None, gpu=None, **kw):
             handle_array(df), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorStandardT(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(df, chunks=chunks)
+    return op(df, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/triangular.py
+++ b/mars/tensor/expressions/random/triangular.py
@@ -29,11 +29,11 @@ class TensorTriangular(operands.Triangular, TensorRandomOperandMixin):
         super(TensorTriangular, self).__init__(_size=size, _state=state, _dtype=dtype,
                                                _gpu=gpu, **kw)
 
-    def __call__(self, left, mode, right, chunks=None):
-        return self.new_tensor([left, mode, right], None, raw_chunks=chunks)
+    def __call__(self, left, mode, right, chunk_size=None):
+        return self.new_tensor([left, mode, right], None, raw_chunk_size=chunk_size)
 
 
-def triangular(random_state, left, mode, right, size=None, chunks=None, gpu=None, **kw):
+def triangular(random_state, left, mode, right, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from the triangular distribution over the
     interval ``[left, right]``.
@@ -58,7 +58,7 @@ def triangular(random_state, left, mode, right, size=None, chunks=None, gpu=None
         a single value is returned if ``left``, ``mode``, and ``right``
         are all scalars.  Otherwise, ``mt.broadcast(left, mode, right).size``
         samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -103,4 +103,4 @@ def triangular(random_state, left, mode, right, size=None, chunks=None, gpu=None
             handle_array(left), handle_array(mode), handle_array(right), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorTriangular(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(left, mode, right, chunks=chunks)
+    return op(left, mode, right, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/uniform.py
+++ b/mars/tensor/expressions/random/uniform.py
@@ -29,11 +29,11 @@ class TensorUniform(operands.Uniform, TensorRandomOperandMixin):
         super(TensorUniform, self).__init__(_size=size, _state=state, _dtype=dtype,
                                             _gpu=gpu, **kw)
 
-    def __call__(self, low, high, chunks=None):
-        return self.new_tensor([low, high], None, raw_chunks=chunks)
+    def __call__(self, low, high, chunk_size=None):
+        return self.new_tensor([low, high], None, raw_chunk_size=chunk_size)
 
 
-def uniform(random_state, low=0.0, high=1.0, size=None, chunks=None, gpu=None, **kw):
+def uniform(random_state, low=0.0, high=1.0, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a uniform distribution.
 
@@ -55,7 +55,7 @@ def uniform(random_state, low=0.0, high=1.0, size=None, chunks=None, gpu=None, *
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``low`` and ``high`` are both scalars.
         Otherwise, ``mt.broadcast(low, high).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -118,4 +118,4 @@ def uniform(random_state, low=0.0, high=1.0, size=None, chunks=None, gpu=None, *
             handle_array(low), handle_array(high), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorUniform(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(low, high, chunks=chunks)
+    return op(low, high, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/vonmises.py
+++ b/mars/tensor/expressions/random/vonmises.py
@@ -29,11 +29,11 @@ class TensorVonmises(operands.Vonmises, TensorRandomOperandMixin):
         super(TensorVonmises, self).__init__(_size=size, _state=state, _dtype=dtype,
                                              _gpu=gpu, **kw)
 
-    def __call__(self, mu, kappa, chunks=None):
-        return self.new_tensor([mu, kappa], None, raw_chunks=chunks)
+    def __call__(self, mu, kappa, chunk_size=None):
+        return self.new_tensor([mu, kappa], None, raw_chunk_size=chunk_size)
 
 
-def vonmises(random_state, mu, kappa, size=None, chunks=None, gpu=None, **kw):
+def vonmises(random_state, mu, kappa, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a von Mises distribution.
 
@@ -56,7 +56,7 @@ def vonmises(random_state, mu, kappa, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``mu`` and ``kappa`` are both scalars.
         Otherwise, ``np.broadcast(mu, kappa).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -120,4 +120,4 @@ def vonmises(random_state, mu, kappa, size=None, chunks=None, gpu=None, **kw):
 
     size = random_state._handle_size(size)
     op = TensorVonmises(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(mu, kappa, chunks=chunks)
+    return op(mu, kappa, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/wald.py
+++ b/mars/tensor/expressions/random/wald.py
@@ -29,11 +29,11 @@ class TensorWald(operands.Wald, TensorRandomOperandMixin):
         super(TensorWald, self).__init__(_size=size, _state=state, _dtype=dtype,
                                          _gpu=gpu, **kw)
 
-    def __call__(self, mean, scale, chunks=None):
-        return self.new_tensor([mean, scale], None, raw_chunks=chunks)
+    def __call__(self, mean, scale, chunk_size=None):
+        return self.new_tensor([mean, scale], None, raw_chunk_size=chunk_size)
 
 
-def wald(random_state, mean, scale, size=None, chunks=None, gpu=None, **kw):
+def wald(random_state, mean, scale, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a Wald, or inverse Gaussian, distribution.
 
@@ -57,7 +57,7 @@ def wald(random_state, mean, scale, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``mean`` and ``scale`` are both scalars.
         Otherwise, ``np.broadcast(mean, scale).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -103,4 +103,4 @@ def wald(random_state, mean, scale, size=None, chunks=None, gpu=None, **kw):
             handle_array(mean), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorWald(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(mean, scale, chunks=chunks)
+    return op(mean, scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/weibull.py
+++ b/mars/tensor/expressions/random/weibull.py
@@ -29,11 +29,11 @@ class TensorWeibull(operands.Weibull, TensorRandomOperandMixin):
         super(TensorWeibull, self).__init__(_size=size, _state=state, _dtype=dtype,
                                             _gpu=gpu, **kw)
 
-    def __call__(self, a, chunks=None):
-        return self.new_tensor([a], None, raw_chunks=chunks)
+    def __call__(self, a, chunk_size=None):
+        return self.new_tensor([a], None, raw_chunk_size=chunk_size)
 
 
-def weibull(random_state, a, size=None, chunks=None, gpu=None, **kw):
+def weibull(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a Weibull distribution.
 
@@ -56,7 +56,7 @@ def weibull(random_state, a, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``a`` is a scalar.  Otherwise,
         ``mt.array(a).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -134,4 +134,4 @@ def weibull(random_state, a, size=None, chunks=None, gpu=None, **kw):
             handle_array(a), size=(0,)).dtype
     size = random_state._handle_size(size)
     op = TensorWeibull(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(a, chunks=chunks)
+    return op(a, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/zipf.py
+++ b/mars/tensor/expressions/random/zipf.py
@@ -29,11 +29,11 @@ class TensorZipf(operands.Zipf, TensorRandomOperandMixin):
         super(TensorZipf, self).__init__(_size=size, _state=state, _dtype=dtype,
                                          _gpu=gpu, **kw)
 
-    def __call__(self, a, chunks=None):
-        return self.new_tensor([a], None, raw_chunks=chunks)
+    def __call__(self, a, chunk_size=None):
+        return self.new_tensor([a], None, raw_chunk_size=chunk_size)
 
 
-def zipf(random_state, a, size=None, chunks=None, gpu=None, **kw):
+def zipf(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
     r"""
     Draw samples from a Zipf distribution.
 
@@ -54,7 +54,7 @@ def zipf(random_state, a, size=None, chunks=None, gpu=None, **kw):
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
         a single value is returned if ``a`` is a scalar. Otherwise,
         ``mt.array(a).size`` samples are drawn.
-    chunks : int or tuple of int or tuple of ints, optional
+    chunk_size : int or tuple of int or tuple of ints, optional
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
@@ -116,4 +116,4 @@ def zipf(random_state, a, size=None, chunks=None, gpu=None, **kw):
 
     size = random_state._handle_size(size)
     op = TensorZipf(size=size, state=random_state._state, gpu=gpu, **kw)
-    return op(a, chunks=chunks)
+    return op(a, chunk_size=chunk_size)

--- a/mars/tensor/expressions/rechunk/rechunk.py
+++ b/mars/tensor/expressions/rechunk/rechunk.py
@@ -24,7 +24,7 @@ import numpy as np
 from ....config import options
 from ....compat import six, izip, lzip, reduce
 from ....operands import Rechunk
-from ..utils import decide_chunks, calc_sliced_size
+from ..utils import decide_chunk_sizes, calc_sliced_size
 from ..core import TensorOperandMixin
 
 
@@ -75,7 +75,7 @@ def _get_nsplits(tensor, new_chunks):
     else:
         chunks = new_chunks
 
-    return decide_chunks(tensor.shape, chunks, tensor.dtype.itemsize)
+    return decide_chunk_sizes(tensor.shape, chunks, tensor.dtype.itemsize)
 
 
 def _largest_chunk_size(nsplits):

--- a/mars/tensor/expressions/tests/test_arithmetic.py
+++ b/mars/tensor/expressions/tests/test_arithmetic.py
@@ -30,8 +30,8 @@ from mars.operands import Add, AddConstant, SubConstant, Log, IscloseConstant, I
 
 class Test(unittest.TestCase):
     def testAdd(self):
-        t1 = ones((3, 4), chunks=2)
-        t2 = ones(4, chunks=2)
+        t1 = ones((3, 4), chunk_size=2)
+        t2 = ones(4, chunk_size=2)
         t3 = t1 + t2
         k1 = t3.key
         t3.tiles()
@@ -63,7 +63,7 @@ class Test(unittest.TestCase):
         t5.tiles()
         self.assertEqual(t4.chunks[0].inputs, [t1.chunks[0].data])
 
-        t1 = tensor([[0, 1, 0], [1, 0, 0]], chunks=2).tosparse()
+        t1 = tensor([[0, 1, 0], [1, 0, 0]], chunk_size=2).tosparse()
 
         t = t1 + 1
         self.assertFalse(t.issparse())
@@ -76,7 +76,7 @@ class Test(unittest.TestCase):
         self.assertTrue(t.issparse())
         self.assertIs(type(t), SparseTensor)
 
-        t2 = tensor([[1, 0, 0]], chunks=2).tosparse()
+        t2 = tensor([[1, 0, 0]], chunk_size=2).tosparse()
 
         t = t1 + t2
         self.assertTrue(t.issparse())
@@ -85,7 +85,7 @@ class Test(unittest.TestCase):
         t.tiles()
         self.assertTrue(t.chunks[0].op.sparse)
 
-        t3 = tensor([1, 1, 1], chunks=2)
+        t3 = tensor([1, 1, 1], chunk_size=2)
         t = t1 + t3
         self.assertFalse(t.issparse())
         self.assertIs(type(t), Tensor)
@@ -94,7 +94,7 @@ class Test(unittest.TestCase):
         self.assertFalse(t.chunks[0].op.sparse)
 
     def testMultiply(self):
-        t1 = tensor([[0, 1, 0], [1, 0, 0]], chunks=2).tosparse()
+        t1 = tensor([[0, 1, 0], [1, 0, 0]], chunk_size=2).tosparse()
 
         t = t1 * 10
         self.assertTrue(t.issparse())
@@ -103,7 +103,7 @@ class Test(unittest.TestCase):
         t.tiles()
         self.assertTrue(t.chunks[0].op.sparse)
 
-        t2 = tensor([[1, 0, 0]], chunks=2).tosparse()
+        t2 = tensor([[1, 0, 0]], chunk_size=2).tosparse()
 
         t = t1 * t2
         self.assertTrue(t.issparse())
@@ -112,7 +112,7 @@ class Test(unittest.TestCase):
         t.tiles()
         self.assertTrue(t.chunks[0].op.sparse)
 
-        t3 = tensor([1, 1, 1], chunks=2)
+        t3 = tensor([1, 1, 1], chunk_size=2)
         t = t1 * t3
         self.assertTrue(t.issparse())
         self.assertIs(type(t), SparseTensor)
@@ -121,7 +121,7 @@ class Test(unittest.TestCase):
         self.assertTrue(t.chunks[0].op.sparse)
 
     def testDivide(self):
-        t1 = tensor([[0, 1, 0], [1, 0, 0]], chunks=2).tosparse()
+        t1 = tensor([[0, 1, 0], [1, 0, 0]], chunk_size=2).tosparse()
 
         t = t1 / 10
         self.assertTrue(t.issparse())
@@ -130,7 +130,7 @@ class Test(unittest.TestCase):
         t.tiles()
         self.assertTrue(t.chunks[0].op.sparse)
 
-        t2 = tensor([[1, 0, 0]], chunks=2).tosparse()
+        t2 = tensor([[1, 0, 0]], chunk_size=2).tosparse()
 
         t = t1 / t2
         self.assertFalse(t.issparse())
@@ -139,7 +139,7 @@ class Test(unittest.TestCase):
         t.tiles()
         self.assertFalse(t.chunks[0].op.sparse)
 
-        t3 = tensor([1, 1, 1], chunks=2)
+        t3 = tensor([1, 1, 1], chunk_size=2)
         t = t1 / t3
         self.assertFalse(t.issparse())
         self.assertIs(type(t), Tensor)
@@ -174,8 +174,8 @@ class Test(unittest.TestCase):
         add(t1, np.timedelta64(1, 'D'), out=t1)
 
     def testAddWithOut(self):
-        t1 = ones((3, 4), chunks=2)
-        t2 = ones(4, chunks=2)
+        t1 = ones((3, 4), chunk_size=2)
+        t2 = ones(4, chunk_size=2)
 
         t3 = add(t1, t2, out=t1)
 
@@ -183,7 +183,7 @@ class Test(unittest.TestCase):
         self.assertEqual(t1.op.out.key, t1.op.lhs.key)
         self.assertIs(t3, t1)
         self.assertEqual(t3.shape, (3, 4))
-        self.assertEqual(t3.op.lhs.params.raw_chunks, 2)
+        self.assertEqual(t3.op.lhs.params.raw_chunk_size, 2)
         self.assertIs(t3.op.rhs, t2.data)
         self.assertNotEqual(t3.key, t3.op.lhs.key)
 
@@ -201,8 +201,8 @@ class Test(unittest.TestCase):
         with self.assertRaises(TypeError):
             truediv(t1, t2, out=t1.astype('i8'))
 
-        t1 = ones((3, 4), chunks=2, dtype=float)
-        t2 = ones(4, chunks=2, dtype=int)
+        t1 = ones((3, 4), chunk_size=2, dtype=float)
+        t2 = ones(4, chunk_size=2, dtype=int)
 
         t3 = add(t2, 1, out=t1)
         self.assertEqual(t3.shape, (3, 4))
@@ -216,19 +216,19 @@ class Test(unittest.TestCase):
         self.assertEqual(t3.dtype, y.dtype)
 
     def testLogWithOut(self):
-        t1 = ones((3, 4), chunks=2)
+        t1 = ones((3, 4), chunk_size=2)
 
         t2 = log(t1, out=t1)
 
         self.assertIsInstance(t2.op, Log)
         self.assertEqual(t1.op.out.key, t1.op.input.key)
         self.assertIs(t2, t1)
-        self.assertEqual(t2.op.input.params.raw_chunks, 2)
+        self.assertEqual(t2.op.input.params.raw_chunk_size, 2)
         self.assertNotEqual(t2.key, t2.op.input.key)
 
     def testCopyAdd(self):
-        t1 = ones((3, 4), chunks=2)
-        t2 = ones(4, chunks=2)
+        t1 = ones((3, 4), chunk_size=2)
+        t2 = ones(4, chunk_size=2)
         t3 = t1 + t2
         t3.tiles()
 
@@ -241,16 +241,16 @@ class Test(unittest.TestCase):
         self.assertIsInstance(new_c.inputs[1].op, TensorFetchChunk)
 
     def testCompare(self):
-        t1 = ones(4, chunks=2) * 2
-        t2 = ones(4, chunks=2)
+        t1 = ones(4, chunk_size=2) * 2
+        t2 = ones(4, chunk_size=2)
         t3 = t1 > t2
         t3.tiles()
         self.assertEqual(len(t3.chunks), 2)
         self.assertIsInstance(t3.op, operands.GreaterThan)
 
     def testUnifyChunkAdd(self):
-        t1 = ones(4, chunks=2)
-        t2 = ones(1, chunks=1)
+        t1 = ones(4, chunk_size=2)
+        t2 = ones(1, chunk_size=1)
 
         t3 = t1 + t2
         t3.tiles()
@@ -263,8 +263,8 @@ class Test(unittest.TestCase):
     def testTensordot(self):
         from mars.tensor.expressions.linalg import tensordot, dot, inner
 
-        t1 = ones((3, 4, 6), chunks=2)
-        t2 = ones((4, 3, 5), chunks=2)
+        t1 = ones((3, 4, 6), chunk_size=2)
+        t2 = ones((4, 3, 5), chunk_size=2)
         t3 = tensordot(t1, t2, axes=((0, 1), (1, 0)))
 
         self.assertEqual(t3.shape, (6, 5))
@@ -274,41 +274,41 @@ class Test(unittest.TestCase):
         self.assertEqual(t3.shape, (6, 5))
         self.assertEqual(len(t3.chunks), 9)
 
-        a = ones((10000, 20000), chunks=5000)
-        b = ones((20000, 1000), chunks=5000)
+        a = ones((10000, 20000), chunk_size=5000)
+        b = ones((20000, 1000), chunk_size=5000)
 
         with self.assertRaises(ValueError):
             tensordot(a, b)
 
-        a = ones(10, chunks=2)
-        b = ones((10, 20), chunks=2)
+        a = ones(10, chunk_size=2)
+        b = ones((10, 20), chunk_size=2)
         c = dot(a, b)
         self.assertEqual(c.shape, (20,))
         c.tiles()
         self.assertEqual(c.shape, tuple(sum(s) for s in c.nsplits))
 
-        a = ones((10, 20), chunks=2)
-        b = ones(20, chunks=2)
+        a = ones((10, 20), chunk_size=2)
+        b = ones(20, chunk_size=2)
         c = dot(a, b)
         self.assertEqual(c.shape, (10,))
         c.tiles()
         self.assertEqual(c.shape, tuple(sum(s) for s in c.nsplits))
 
-        v = ones((100, 100), chunks=10)
+        v = ones((100, 100), chunk_size=10)
         tv = v.dot(v)
         self.assertEqual(tv.shape, (100, 100))
         tv.tiles()
         self.assertEqual(tv.shape, tuple(sum(s) for s in tv.nsplits))
 
-        a = ones((10, 20), chunks=2)
-        b = ones((30, 20), chunks=2)
+        a = ones((10, 20), chunk_size=2)
+        b = ones((30, 20), chunk_size=2)
         c = inner(a, b)
         self.assertEqual(c.shape, (10, 30))
         c.tiles()
         self.assertEqual(c.shape, tuple(sum(s) for s in c.nsplits))
 
     def testDot(self):
-        t1 = tensor([[0, 1, 0], [1, 0, 0]], chunks=2).tosparse()
+        t1 = tensor([[0, 1, 0], [1, 0, 0]], chunk_size=2).tosparse()
         t2 = t1.T
 
         self.assertTrue(t1.dot(t2).issparse())
@@ -317,7 +317,7 @@ class Test(unittest.TestCase):
         self.assertIs(type(t1.dot(t2, sparse=False)), Tensor)
 
     def testFrexp(self):
-        t1 = ones((3, 4, 5), chunks=2)
+        t1 = ones((3, 4, 5), chunk_size=2)
         op_type = type(t1.op)
 
         o1, o2 = frexp(t1)
@@ -333,7 +333,7 @@ class Test(unittest.TestCase):
         self.assertIsNot(o2.inputs[0], t1)
 
     def testDtype(self):
-        t1 = ones((2, 3), dtype='f4', chunks=2)
+        t1 = ones((2, 3), dtype='f4', chunk_size=2)
 
         t = truediv(t1, 2, dtype='f8')
 
@@ -343,7 +343,7 @@ class Test(unittest.TestCase):
             truediv(t1, 2, dtype='i4')
 
     def testNegative(self):
-        t1 = tensor([[0, 1, 0], [1, 0, 0]], chunks=2).tosparse()
+        t1 = tensor([[0, 1, 0], [1, 0, 0]], chunk_size=2).tosparse()
 
         t = negative(t1)
         self.assertTrue(t.issparse())
@@ -353,14 +353,14 @@ class Test(unittest.TestCase):
         self.assertTrue(t.chunks[0].op.sparse)
 
     def testCos(self):
-        t1 = tensor([[0, 1, 0], [1, 0, 0]], chunks=2).tosparse()
+        t1 = tensor([[0, 1, 0], [1, 0, 0]], chunk_size=2).tosparse()
 
         t = cos(t1)
         self.assertFalse(t.issparse())
         self.assertIs(type(t), Tensor)
 
     def testAround(self):
-        t1 = ones((2, 3), dtype='f4', chunks=2)
+        t1 = ones((2, 3), dtype='f4', chunk_size=2)
 
         t = around(t1, decimals=3)
 
@@ -371,7 +371,7 @@ class Test(unittest.TestCase):
         self.assertEqual(t.chunks[0].op.decimals, 3)
 
     def testIsclose(self):
-        t1 = ones((2, 3), dtype='f4', chunks=2)
+        t1 = ones((2, 3), dtype='f4', chunk_size=2)
 
         atol = 1e-4
         rtol = 1e-5
@@ -391,8 +391,8 @@ class Test(unittest.TestCase):
         self.assertEqual(t.chunks[0].op.rtol, rtol)
         self.assertEqual(t.chunks[0].op.equal_nan, equal_nan)
 
-        t1 = ones((2, 3), dtype='f4', chunks=2)
-        t2 = ones((2, 3), dtype='f4', chunks=2)
+        t1 = ones((2, 3), dtype='f4', chunk_size=2)
+        t2 = ones((2, 3), dtype='f4', chunk_size=2)
 
         atol = 1e-4
         rtol = 1e-5
@@ -416,8 +416,8 @@ class Test(unittest.TestCase):
         a_data = [[1, 0], [0, 1]]
         b_data = [[4, 1], [2, 2]]
 
-        a = tensor(a_data, chunks=1)
-        b = tensor(b_data, chunks=1)
+        a = tensor(a_data, chunk_size=1)
+        b = tensor(b_data, chunk_size=1)
 
         t = matmul(a, b)
 
@@ -426,7 +426,7 @@ class Test(unittest.TestCase):
         self.assertEqual(t.shape, tuple(sum(s) for s in t.nsplits))
 
         b_data = [1, 2]
-        b = tensor(b_data, chunks=1)
+        b = tensor(b_data, chunk_size=1)
 
         t = matmul(a, b)
 
@@ -443,8 +443,8 @@ class Test(unittest.TestCase):
         a_data = np.arange(2 * 2 * 4).reshape((2, 2, 4))
         b_data = np.arange(2 * 2 * 4).reshape((2, 4, 2))
 
-        a = tensor(a_data, chunks=1)
-        b = tensor(b_data, chunks=1)
+        a = tensor(a_data, chunk_size=1)
+        b = tensor(b_data, chunk_size=1)
 
         t = matmul(a, b)
 
@@ -452,7 +452,7 @@ class Test(unittest.TestCase):
         t.tiles()
         self.assertEqual(t.shape, tuple(sum(s) for s in t.nsplits))
 
-        t = matmul(tensor([2j, 3j], chunks=1), tensor([2j, 3j], chunks=1))
+        t = matmul(tensor([2j, 3j], chunk_size=1), tensor([2j, 3j], chunk_size=1))
 
         self.assertEqual(t.shape, ())
         t.tiles()
@@ -464,11 +464,11 @@ class Test(unittest.TestCase):
         with self.assertRaises(ValueError):
             matmul(np.random.randn(2, 3, 4), np.random.randn(3, 4, 3))
 
-        t = matmul(tensor(np.random.randn(2, 3, 4), chunks=2),
-                   tensor(np.random.randn(3, 1, 4, 3), chunks=3))
+        t = matmul(tensor(np.random.randn(2, 3, 4), chunk_size=2),
+                   tensor(np.random.randn(3, 1, 4, 3), chunk_size=3))
         self.assertEqual(t.shape, (3, 2, 3, 3))
 
-        v = ones((100, 100), chunks=10)
+        v = ones((100, 100), chunk_size=10)
         tv = matmul(v, v)
         self.assertEqual(tv.shape, (100, 100))
         tv.tiles()
@@ -476,13 +476,13 @@ class Test(unittest.TestCase):
 
     def testGetSetReal(self):
         a_data = np.array([1+2j, 3+4j, 5+6j])
-        a = tensor(a_data, chunks=2)
+        a = tensor(a_data, chunk_size=2)
 
         with self.assertRaises(ValueError):
             a.real = [2, 4]
 
     def testBuildMode(self):
-        t1 = ones((2, 3), chunks=2)
+        t1 = ones((2, 3), chunk_size=2)
         self.assertTrue(t1 == 2)
 
         with build_mode():

--- a/mars/tensor/expressions/tests/test_base.py
+++ b/mars/tensor/expressions/tests/test_base.py
@@ -26,7 +26,7 @@ from mars.operands.base import CopyTo
 
 class Test(unittest.TestCase):
     def testArray(self):
-        a = tensor([0, 1, 2], chunks=2)
+        a = tensor([0, 1, 2], chunk_size=2)
 
         b = array(a)
         self.assertIsNot(a, b)
@@ -35,14 +35,14 @@ class Test(unittest.TestCase):
         self.assertIs(a, c)
 
     def testCopyto(self):
-        a = ones((10, 20), chunks=3)
-        b = ones(10, chunks=4)
+        a = ones((10, 20), chunk_size=3)
+        b = ones(10, chunk_size=4)
 
         with self.assertRaises(ValueError):
             copyto(a, b)
 
         tp = type(a.op)
-        b = ones(20, chunks=4)
+        b = ones(20, chunk_size=4)
         copyto(a, b)
 
         self.assertIsInstance(a.op, CopyTo)
@@ -54,13 +54,13 @@ class Test(unittest.TestCase):
         self.assertIsInstance(a.chunks[0].op, CopyTo)
         self.assertEqual(len(a.chunks[0].inputs), 2)
 
-        a = ones((10, 20), chunks=3, dtype='i4')
-        b = ones(20, chunks=4, dtype='f8')
+        a = ones((10, 20), chunk_size=3, dtype='i4')
+        b = ones(20, chunk_size=4, dtype='f8')
 
         with self.assertRaises(TypeError):
             copyto(a, b)
 
-        b = ones(20, chunks=4, dtype='i4')
+        b = ones(20, chunk_size=4, dtype='i4')
         copyto(a, b, where=b>0)
 
         self.assertIsNotNone(a.op.where)
@@ -74,7 +74,7 @@ class Test(unittest.TestCase):
             copyto(a, a, where=np.ones(30, dtype='?'))
 
     def testAstype(self):
-        arr = ones((10, 20, 30), chunks=3)
+        arr = ones((10, 20, 30), chunk_size=3)
 
         arr2 = arr.astype(np.int32)
         arr2.tiles()
@@ -87,7 +87,7 @@ class Test(unittest.TestCase):
             arr.astype(np.int32, casting='safe')
 
     def testTranspose(self):
-        arr = ones((10, 20, 30), chunks=[4, 3, 5])
+        arr = ones((10, 20, 30), chunk_size=[4, 3, 5])
 
         arr2 = transpose(arr)
         arr2.tiles()
@@ -125,7 +125,7 @@ class Test(unittest.TestCase):
         self.assertEqual(arr5.chunks[-1].shape, (5, 2, 2))
 
     def testSwapaxes(self):
-        arr = ones((10, 20, 30), chunks=[4, 3, 5])
+        arr = ones((10, 20, 30), chunk_size=[4, 3, 5])
         arr2 = arr.swapaxes(0, 1)
         arr2.tiles()
 
@@ -133,7 +133,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(arr.chunks), len(arr2.chunks))
 
     def testBroadcastTo(self):
-        arr = ones((10, 5), chunks=2)
+        arr = ones((10, 5), chunk_size=2)
         arr2 = broadcast_to(arr, (20, 10, 5))
         arr2.tiles()
 
@@ -141,7 +141,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(arr2.chunks), len(arr.chunks))
         self.assertEqual(arr2.chunks[0].shape, (20, 2, 2))
 
-        arr = ones((10, 5, 1), chunks=2)
+        arr = ones((10, 5, 1), chunk_size=2)
         arr3 = broadcast_to(arr, (5, 10, 5, 6))
         arr3.tiles()
 
@@ -150,7 +150,7 @@ class Test(unittest.TestCase):
         self.assertEqual(arr3.nsplits, ((5,), (2, 2, 2, 2, 2), (2, 2, 1), (6,)))
         self.assertEqual(arr3.chunks[0].shape, (5, 2, 2, 6))
 
-        arr = ones((10, 1), chunks=2)
+        arr = ones((10, 1), chunk_size=2)
         arr4 = broadcast_to(arr, (20, 10, 5))
         arr4.tiles()
 
@@ -165,9 +165,9 @@ class Test(unittest.TestCase):
             broadcast_to(arr, (5, 1))
 
     def testWhere(self):
-        cond = tensor([[True, False], [False, True]], chunks=1)
-        x = tensor([1, 2], chunks=1)
-        y = tensor([3, 4], chunks=1)
+        cond = tensor([[True, False], [False, True]], chunk_size=1)
+        x = tensor([1, 2], chunk_size=1)
+        y = tensor([3, 4], chunk_size=1)
 
         arr = where(cond, x, y)
         arr.tiles()
@@ -195,7 +195,7 @@ class Test(unittest.TestCase):
         self.assertEqual(y.dtype, np.float64)
 
     def testArgwhere(self):
-        cond = tensor([[True, False], [False, True]], chunks=1)
+        cond = tensor([[True, False], [False, True]], chunk_size=1)
         indices = argwhere(cond)
 
         self.assertTrue(np.isnan(indices.shape[0]))
@@ -206,7 +206,7 @@ class Test(unittest.TestCase):
         self.assertEqual(indices.nsplits[1], (1, 1))
 
     def testArraySplit(self):
-        a = arange(8, chunks=2)
+        a = arange(8, chunk_size=2)
 
         splits = array_split(a, 3)
         self.assertEqual(len(splits), 3)
@@ -217,7 +217,7 @@ class Test(unittest.TestCase):
         self.assertEqual(splits[1].nsplits, ((1, 2),))
         self.assertEqual(splits[2].nsplits, ((2,),))
 
-        a = arange(7, chunks=2)
+        a = arange(7, chunk_size=2)
 
         splits = array_split(a, 3)
         self.assertEqual(len(splits), 3)
@@ -229,7 +229,7 @@ class Test(unittest.TestCase):
         self.assertEqual(splits[2].nsplits, ((1, 1),))
 
     def testSplit(self):
-        a = arange(9, chunks=2)
+        a = arange(9, chunk_size=2)
 
         splits = split(a, 3)
         self.assertEqual(len(splits), 3)
@@ -240,7 +240,7 @@ class Test(unittest.TestCase):
         self.assertEqual(splits[1].nsplits, ((1, 2),))
         self.assertEqual(splits[2].nsplits, ((2, 1),))
 
-        a = arange(8, chunks=2)
+        a = arange(8, chunk_size=2)
 
         splits = split(a, [3, 5, 6, 10])
         self.assertEqual(len(splits), 5)
@@ -275,7 +275,7 @@ class Test(unittest.TestCase):
         self.assertEqual(t.shape, (1, 3))
 
     def testDigitize(self):
-        x = tensor(np.array([0.2, 6.4, 3.0, 1.6]), chunks=2)
+        x = tensor(np.array([0.2, 6.4, 3.0, 1.6]), chunk_size=2)
         bins = np.array([0.0, 1.0, 2.5, 4.0, 10.0])
         inds = digitize(x, bins)
         self.assertEqual(inds.shape, (4,))
@@ -295,7 +295,7 @@ class Test(unittest.TestCase):
         self.assertEqual(r, e)
 
     def testRepeat(self):
-        a = arange(10, chunks=2).reshape(2, 5)
+        a = arange(10, chunk_size=2).reshape(2, 5)
 
         t = repeat(a, 3)
         self.assertEqual(t.shape, (30,))
@@ -312,20 +312,20 @@ class Test(unittest.TestCase):
         with self.assertRaises(ValueError):
             repeat(a, [3, 4], axis=1)
 
-        a = tensor(np.random.randn(10), chunks=5)
+        a = tensor(np.random.randn(10), chunk_size=5)
 
         t = repeat(a, 3)
         t.tiles()
         self.assertEqual(sum(t.nsplits[0]), 30)
 
-        a = tensor(np.random.randn(100), chunks=10)
+        a = tensor(np.random.randn(100), chunk_size=10)
 
         t = repeat(a, 3)
         t.tiles()
         self.assertEqual(sum(t.nsplits[0]), 300)
 
     def testIsIn(self):
-        element = 2 * arange(4, chunks=1).reshape(2, 2)
+        element = 2 * arange(4, chunk_size=1).reshape(2, 2)
         test_elements = [1, 2, 4, 8]
 
         mask = isin(element, test_elements)
@@ -339,7 +339,7 @@ class Test(unittest.TestCase):
         self.assertIs(mask.chunks[0].inputs[0], element.chunks[0].data)
 
         element = 2 * arange(4, chunks=1).reshape(2, 2)
-        test_elements = tensor([1, 2, 4, 8], chunks=2)
+        test_elements = tensor([1, 2, 4, 8], chunk_size=2)
 
         mask = isin(element, test_elements, invert=True)
         self.assertEqual(mask.shape, (2, 2))

--- a/mars/tensor/expressions/tests/test_core.py
+++ b/mars/tensor/expressions/tests/test_core.py
@@ -36,7 +36,7 @@ from mars.tests.core import TestBase
 
 class Test(TestBase):
     def testChunkSerialize(self):
-        t = ones((10, 3), chunks=(5, 2)).tiles()
+        t = ones((10, 3), chunk_size=(5, 2)).tiles()
 
         # pb
         chunk = t.chunks[0]
@@ -66,7 +66,7 @@ class Test(TestBase):
         self.assertEqual(chunk.shape, chunk2.shape)
         self.assertEqual(chunk.op.dtype, chunk2.op.dtype)
 
-        t = tensor(np.random.random((10, 3)), chunks=(5, 2)).tiles()
+        t = tensor(np.random.random((10, 3)), chunk_size=(5, 2)).tiles()
 
         # pb
         chunk = t.chunks[0]
@@ -96,7 +96,7 @@ class Test(TestBase):
         self.assertEqual(chunk.shape, chunk2.shape)
         self.assertTrue(np.array_equal(chunk.op.data, chunk2.op.data))
 
-        t = (tensor(np.random.random((10, 3)), chunks=(5, 2)) + 1).tiles()
+        t = (tensor(np.random.random((10, 3)), chunk_size=(5, 2)) + 1).tiles()
 
         # pb
         chunk1 = t.chunks[0]
@@ -135,8 +135,8 @@ class Test(TestBase):
                          composed_chunk2.composed[0].inputs[0].key)
         self.assertEqual(composed_chunk.inputs[-1].key, composed_chunk2.inputs[-1].key)
 
-        t1 = ones((10, 3), chunks=2)
-        t2 = ones((3, 5), chunks=2)
+        t1 = ones((10, 3), chunk_size=2)
+        t2 = ones((3, 5), chunk_size=2)
         c = dot(t1, t2).tiles().chunks[0].inputs[0]
 
         # pb
@@ -152,17 +152,17 @@ class Test(TestBase):
     def testTensorSerialize(self):
         from mars.tensor import split
 
-        t = ones((10, 10, 8), chunks=(3, 3, 5))
+        t = ones((10, 10, 8), chunk_size=(3, 3, 5))
 
         serials = self._pb_serial(t)
         dt = self._pb_deserial(serials)[t.data]
 
-        self.assertEqual(dt.params.raw_chunks, (3, 3, 5))
+        self.assertEqual(dt.params.raw_chunk_size, (3, 3, 5))
 
         serials = self._json_serial(t)
         dt = self._json_deserial(serials)[t.data]
 
-        self.assertEqual(dt.params.raw_chunks, (3, 3, 5))
+        self.assertEqual(dt.params.raw_chunk_size, (3, 3, 5))
 
         t2, _ = split(t, 2)
 
@@ -170,7 +170,7 @@ class Test(TestBase):
         dt = self._pb_deserial(serials)[t2.data]
         self.assertEqual(dt.op.indices_or_sections, 2)
 
-        t2, _, _ = split(t, ones(2, chunks=2))
+        t2, _, _ = split(t, ones(2, chunk_size=2))
 
         serials = self._pb_serial(t2)
         dt = self._pb_deserial(serials)[t2.data]
@@ -178,28 +178,28 @@ class Test(TestBase):
             self.assertIn(dt.op.indices_or_sections, dt.inputs)
 
     def testOnes(self):
-        tensor = ones((10, 10, 8), chunks=(3, 3, 5))
+        tensor = ones((10, 10, 8), chunk_size=(3, 3, 5))
         tensor.tiles()
         self.assertEqual(tensor.shape, (10, 10, 8))
         self.assertEqual(len(tensor.chunks), 32)
 
-        tensor = ones((10, 3), chunks=(4, 2))
+        tensor = ones((10, 3), chunk_size=(4, 2))
         tensor.tiles()
         self.assertEqual(tensor.shape, (10, 3))
 
         chunk = tensor.cix[1, 1]
         self.assertEqual(tensor.get_chunk_slices(chunk.index), (slice(4, 8), slice(2, 3)))
 
-        tensor = ones((10, 5), chunks=(2, 3), gpu=True)
+        tensor = ones((10, 5), chunk_size=(2, 3), gpu=True)
         tensor.tiles()
 
         self.assertTrue(tensor.op.gpu)
         self.assertTrue(tensor.chunks[0].op.gpu)
 
-        tensor1 = ones((10, 10, 8), chunks=(3, 3, 5))
+        tensor1 = ones((10, 10, 8), chunk_size=(3, 3, 5))
         tensor1.tiles()
 
-        tensor2 = ones((10, 10, 8), chunks=(3, 3, 5))
+        tensor2 = ones((10, 10, 8), chunk_size=(3, 3, 5))
         tensor2.tiles()
 
         self.assertEqual(tensor1.chunks[0].op.key, tensor2.chunks[0].op.key)
@@ -214,18 +214,18 @@ class Test(TestBase):
         from mars.tensor.expressions.base.broadcast_to import TensorBroadcastTo
 
         data = np.random.random((10, 3))
-        t = tensor(data, chunks=2)
+        t = tensor(data, chunk_size=2)
         t.tiles()
         self.assertTrue((t.chunks[0].op.data == data[:2, :2]).all())
         self.assertTrue((t.chunks[1].op.data == data[:2, 2:3]).all())
         self.assertTrue((t.chunks[2].op.data == data[2:4, :2]).all())
         self.assertTrue((t.chunks[3].op.data == data[2:4, 2:3]).all())
 
-        self.assertEqual(t.key, tensor(data, chunks=2).tiles().key)
-        self.assertNotEqual(t.key, tensor(data, chunks=3).tiles().key)
-        self.assertNotEqual(t.key, tensor(np.random.random((10, 3)), chunks=2).tiles().key)
+        self.assertEqual(t.key, tensor(data, chunk_size=2).tiles().key)
+        self.assertNotEqual(t.key, tensor(data, chunk_size=3).tiles().key)
+        self.assertNotEqual(t.key, tensor(np.random.random((10, 3)), chunk_size=2).tiles().key)
 
-        t = tensor(data, chunks=2, gpu=True)
+        t = tensor(data, chunk_size=2, gpu=True)
         t.tiles()
 
         self.assertTrue(t.op.gpu)
@@ -244,7 +244,7 @@ class Test(TestBase):
             full((2, 2), [1.0, 2.0, 3.0], dtype='f4')
 
     def testTensorGraphSerialize(self):
-        t = ones((10, 3), chunks=(5, 2)) + tensor(np.random.random((10, 3)), chunks=(5, 2))
+        t = ones((10, 3), chunk_size=(5, 2)) + tensor(np.random.random((10, 3)), chunk_size=(5, 2))
         graph = t.build_graph(tiled=False)
 
         pb = graph.to_pb()
@@ -268,7 +268,7 @@ class Test(TestBase):
         self.assertEqual(sorted(i.key for i in t.inputs), sorted(i.key for i in t2.inputs))
 
     def testTensorGraphTiledSerialize(self):
-        t = ones((10, 3), chunks=(5, 2)) + tensor(np.random.random((10, 3)), chunks=(5, 2))
+        t = ones((10, 3), chunk_size=(5, 2)) + tensor(np.random.random((10, 3)), chunk_size=(5, 2))
         graph = t.build_graph(tiled=True)
 
         pb = graph.to_pb()
@@ -291,7 +291,7 @@ class Test(TestBase):
         self.assertEqual(chunk.shape, chunk2.shape)
         self.assertEqual(sorted(i.key for i in chunk.inputs), sorted(i.key for i in chunk2.inputs))
 
-        t = ones((10, 3), chunks=(5, 2)) + 2
+        t = ones((10, 3), chunk_size=(5, 2)) + 2
         graph = t.build_graph(tiled=True)
 
         pb = graph.to_pb()
@@ -309,7 +309,7 @@ class Test(TestBase):
         self.assertEqual(sorted(i.key for i in chunk.composed), sorted(i.key for i in chunk2.composed))
 
     def testUfunc(self):
-        t = ones((3, 10), chunks=2)
+        t = ones((3, 10), chunk_size=2)
 
         x = np.add(t, [[1], [2], [3]])
         self.assertIsInstance(x, Tensor)
@@ -318,7 +318,7 @@ class Test(TestBase):
         self.assertIsInstance(x, Tensor)
 
     def testArange(self):
-        t = arange(10, chunks=3)
+        t = arange(10, chunk_size=3)
         t.tiles()
 
         self.assertEqual(t.shape, (10,))
@@ -326,7 +326,7 @@ class Test(TestBase):
         self.assertEqual(t.chunks[1].op.start, 3)
         self.assertEqual(t.chunks[1].op.stop, 6)
 
-        t = arange(0, 10, 3, chunks=2)
+        t = arange(0, 10, 3, chunk_size=2)
         t.tiles()
 
         self.assertEqual(t.shape, (4,))
@@ -345,14 +345,14 @@ class Test(TestBase):
 
     def testDiag(self):
         # test 2-d, shape[0] == shape[1], k == 0
-        v = tensor(np.arange(16).reshape(4, 4), chunks=2)
+        v = tensor(np.arange(16).reshape(4, 4), chunk_size=2)
         t = diag(v)
 
         self.assertEqual(t.shape, (4,))
         t.tiles()
         self.assertEqual(t.nsplits, ((2, 2),))
 
-        v = tensor(np.arange(16).reshape(4, 4), chunks=(2, 3))
+        v = tensor(np.arange(16).reshape(4, 4), chunk_size=(2, 3))
         t = diag(v)
 
         self.assertEqual(t.shape, (4,))
@@ -360,7 +360,7 @@ class Test(TestBase):
         self.assertEqual(t.nsplits, ((2, 1, 1),))
 
         # test 1-d, k == 0
-        v = tensor(np.arange(3), chunks=2)
+        v = tensor(np.arange(3), chunk_size=2)
         t = diag(v, sparse=True)
 
         self.assertEqual(t.shape, (3, 3))
@@ -371,14 +371,14 @@ class Test(TestBase):
         self.assertTrue(t.chunks[0].op.sparse)
 
         # test 2-d, shape[0] != shape[1]
-        v = tensor(np.arange(24).reshape(4, 6), chunks=2)
+        v = tensor(np.arange(24).reshape(4, 6), chunk_size=2)
         t = diag(v)
 
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6)).shape)
         t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
 
-        v = tensor(np.arange(24).reshape(4, 6), chunks=2)
+        v = tensor(np.arange(24).reshape(4, 6), chunk_size=2)
 
         t = diag(v, k=1)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=1).shape)
@@ -401,7 +401,7 @@ class Test(TestBase):
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
 
     def testLinspace(self):
-        a = linspace(2.0, 3.0, num=5, chunks=2)
+        a = linspace(2.0, 3.0, num=5, chunk_size=2)
 
         self.assertEqual(a.shape, (5,))
 
@@ -414,7 +414,7 @@ class Test(TestBase):
         self.assertEqual(a.chunks[2].op.start, 3.)
         self.assertEqual(a.chunks[2].op.stop, 3.)
 
-        a = linspace(2.0, 3.0, num=5, endpoint=False, chunks=2)
+        a = linspace(2.0, 3.0, num=5, endpoint=False, chunk_size=2)
 
         self.assertEqual(a.shape, (5,))
 
@@ -427,12 +427,12 @@ class Test(TestBase):
         self.assertEqual(a.chunks[2].op.start, 2.8)
         self.assertEqual(a.chunks[2].op.stop, 2.8)
 
-        _, step = linspace(2.0, 3.0, num=5, chunks=2, retstep=True)
+        _, step = linspace(2.0, 3.0, num=5, chunk_size=2, retstep=True)
         self.assertEqual(step, .25)
 
     def testTriuTril(self):
         a_data = np.arange(12).reshape(4, 3)
-        a = tensor(a_data, chunks=2)
+        a = tensor(a_data, chunk_size=2)
 
         t = triu(a)
         t.tiles()
@@ -499,8 +499,8 @@ class Test(TestBase):
         self.assertIsInstance(t.chunks[3].op, TensorZeros)
 
     def testSetTensorInputs(self):
-        t1 = tensor([1, 2], chunks=2)
-        t2 = tensor([2, 3], chunks=2)
+        t1 = tensor([1, 2], chunk_size=2)
+        t2 = tensor([2, 3], chunk_size=2)
         t3 = t1 + t2
 
         t1c = copy(t1)
@@ -517,8 +517,8 @@ class Test(TestBase):
         with self.assertRaises(ValueError):
             t3.inputs = []
 
-        t1 = tensor([1, 2], chunks=2)
-        t2 = tensor([True, False], chunks=2)
+        t1 = tensor([1, 2], chunk_size=2)
+        t2 = tensor([True, False], chunk_size=2)
         t3 = t1[t2]
 
         t1c = copy(t1)
@@ -531,7 +531,7 @@ class Test(TestBase):
             self.assertIs(t3c.op.indexes[0], t2c.data)
 
     def testFromSpmatrix(self):
-        t = tensor(sps.csr_matrix([[0, 0, 1], [1, 0, 0]], dtype='f8'), chunks=2)
+        t = tensor(sps.csr_matrix([[0, 0, 1], [1, 0, 0]], dtype='f8'), chunk_size=2)
 
         self.assertIsInstance(t, SparseTensor)
         self.assertIsInstance(t.op, CSRMatrixDataSource)
@@ -549,7 +549,7 @@ class Test(TestBase):
         self.assertTrue(np.array_equal(t.chunks[0].op.shape, m.shape))
 
     def testFromDense(self):
-        t = fromdense(tensor([[0, 0, 1], [1, 0, 0]], chunks=2))
+        t = fromdense(tensor([[0, 0, 1], [1, 0, 0]], chunk_size=2))
 
         self.assertIsInstance(t, SparseTensor)
         self.assertIsInstance(t.op, DenseToSparse)
@@ -560,7 +560,7 @@ class Test(TestBase):
         self.assertIsInstance(t.op, DenseToSparse)
 
     def testOnesLike(self):
-        t1 = tensor([[0, 0, 1], [1, 0, 0]], chunks=2).tosparse()
+        t1 = tensor([[0, 0, 1], [1, 0, 0]], chunk_size=2).tosparse()
         t = ones_like(t1, dtype='f8')
 
         self.assertIsInstance(t, SparseTensor)

--- a/mars/tensor/expressions/tests/test_fft.py
+++ b/mars/tensor/expressions/tests/test_fft.py
@@ -24,42 +24,42 @@ from mars.tensor import fft
 
 class Test(unittest.TestCase):
     def testStandardFFT(self):
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.fft(t)
         self.assertEqual(t1.shape, (10, 20, 30))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ifft(t)
         self.assertEqual(t1.shape, (10, 20, 30))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.fft2(t, s=(23, 21))
         self.assertEqual(t1.shape, (10, 23, 21))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ifft2(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, (10, 11, 9))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.fftn(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, (10, 11, 9))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ifftn(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, (10, 11, 9))
@@ -67,42 +67,42 @@ class Test(unittest.TestCase):
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
     def testRealFFT(self):
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.rfft(t)
         self.assertEqual(t1.shape, np.fft.rfft(np.ones(t.shape)).shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.irfft(t)
         self.assertEqual(t1.shape, np.fft.irfft(np.ones(t.shape)).shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.rfft2(t, s=(23, 21))
         self.assertEqual(t1.shape, np.fft.rfft2(np.ones(t.shape), s=(23, 21)).shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.irfft2(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.irfft2(np.ones(t.shape), s=(11, 9), axes=(1, 2)).shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.rfftn(t, s=(11, 30), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.rfftn(np.ones(t.shape), s=(11, 30), axes=(1, 2)).shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.irfftn(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.irfftn(np.ones(t.shape), s=(11, 9), axes=(1, 2)).shape)
@@ -110,28 +110,28 @@ class Test(unittest.TestCase):
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
     def testHermitianFFT(self):
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.hfft(t)
         self.assertEqual(t1.shape, np.fft.hfft(np.ones(t.shape)).shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.hfft(t, n=100)
         self.assertEqual(t1.shape, np.fft.hfft(np.ones(t.shape), n=100).shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ihfft(t)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape)).shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
-        t = ones((10, 20, 30), chunks=(3, 20, 30))
+        t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ihfft(t, n=100)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape), n=100).shape)

--- a/mars/tensor/expressions/tests/test_linalg.py
+++ b/mars/tensor/expressions/tests/test_linalg.py
@@ -24,7 +24,7 @@ from mars.graph import DirectedGraph
 
 class Test(unittest.TestCase):
     def testQR(self):
-        a = mt.random.rand(9, 6, chunks=(3, 6))
+        a = mt.random.rand(9, 6, chunk_size=(3, 6))
         q, r = mt.linalg.qr(a)
 
         self.assertEqual(q.shape, (9, 6))
@@ -38,7 +38,7 @@ class Test(unittest.TestCase):
     def testNorm(self):
         data = np.random.rand(9, 6)
 
-        a = mt.tensor(data, chunks=(2, 6))
+        a = mt.tensor(data, chunk_size=(2, 6))
 
         for ord in (None, 'nuc', np.inf, -np.inf, 0, 1, -1, 2, -2):
             for axis in (0, 1, (0, 1)):
@@ -51,7 +51,7 @@ class Test(unittest.TestCase):
                         continue
 
     def testSVD(self):
-        a = mt.random.rand(9, 6, chunks=(3, 6))
+        a = mt.random.rand(9, 6, chunk_size=(3, 6))
         U, s, V = mt.linalg.svd(a)
 
         self.assertEqual(U.shape, (9, 6))
@@ -66,7 +66,7 @@ class Test(unittest.TestCase):
         self.assertEqual(s.ndim, 1)
         self.assertEqual(len(s.chunks[0].index), 1)
 
-        a = mt.random.rand(9, 6, chunks=(9, 6))
+        a = mt.random.rand(9, 6, chunk_size=(9, 6))
         U, s, V = mt.linalg.svd(a)
 
         self.assertEqual(U.shape, (9, 6))
@@ -82,7 +82,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(s.chunks[0].index), 1)
 
         rs = mt.random.RandomState(1)
-        a = rs.rand(9, 6, chunks=(3, 6))
+        a = rs.rand(9, 6, chunk_size=(3, 6))
         U, s, V = mt.linalg.svd(a)
 
         # test tensor graph
@@ -106,7 +106,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(set([o.op for o in new_outputs])), 3)
 
     def testLU(self):
-        a = mt.random.randint(1, 10, (6, 6), chunks=3)
+        a = mt.random.randint(1, 10, (6, 6), chunk_size=3)
         p, l, u = mt.linalg.lu(a)
         l.tiles()
 
@@ -121,14 +121,14 @@ class Test(unittest.TestCase):
 
         self.assertEqual(x.shape, (20, ))
 
-        a = mt.random.randint(1, 10, (20, 20), chunks=5)
-        b = mt.random.randint(1, 10, (20, 3), chunks=5)
+        a = mt.random.randint(1, 10, (20, 20), chunk_size=5)
+        b = mt.random.randint(1, 10, (20, 3), chunk_size=5)
         x = mt.linalg.solve(a, b).tiles()
 
         self.assertEqual(x.shape, (20, 3))
 
     def testInv(self):
-        a = mt.random.randint(1, 10, (20, 20), chunks=4)
+        a = mt.random.randint(1, 10, (20, 20), chunk_size=4)
         a_inv = mt.linalg.inv(a).tiles()
 
         self.assertEqual(a_inv.shape, (20, 20))

--- a/mars/tensor/expressions/tests/test_merge.py
+++ b/mars/tensor/expressions/tests/test_merge.py
@@ -24,32 +24,32 @@ from mars.tensor.expressions.merge import concatenate, stack
 
 class Test(unittest.TestCase):
     def testConcatenate(self):
-        a = ones((10, 20, 30), chunks=10)
-        b = ones((20, 20, 30), chunks=20)
+        a = ones((10, 20, 30), chunk_size=10)
+        b = ones((20, 20, 30), chunk_size=20)
 
         c = concatenate([a, b])
         self.assertEqual(c.shape, (30, 20, 30))
 
-        a = ones((10, 20, 30), chunks=10)
-        b = ones((10, 20, 40), chunks=20)
+        a = ones((10, 20, 30), chunk_size=10)
+        b = ones((10, 20, 40), chunk_size=20)
 
         c = concatenate([a, b], axis=-1)
         self.assertEqual(c.shape, (10, 20, 70))
 
         with self.assertRaises(ValueError):
-            a = ones((10, 20, 30), chunks=10)
-            b = ones((20, 30, 30), chunks=20)
+            a = ones((10, 20, 30), chunk_size=10)
+            b = ones((20, 30, 30), chunk_size=20)
 
             concatenate([a, b])
 
         with self.assertRaises(ValueError):
-            a = ones((10, 20, 30), chunks=10)
-            b = ones((20, 20), chunks=20)
+            a = ones((10, 20, 30), chunk_size=10)
+            b = ones((20, 20), chunk_size=20)
 
             concatenate([a, b])
 
-        a = ones((10, 20, 30), chunks=5)
-        b = ones((20, 20, 30), chunks=10)
+        a = ones((10, 20, 30), chunk_size=5)
+        b = ones((20, 20, 30), chunk_size=10)
 
         c = concatenate([a, b]).tiles()
         self.assertEqual(c.chunk_shape[0], 4)
@@ -60,7 +60,7 @@ class Test(unittest.TestCase):
         self.assertEqual(c.cix[1, 0, 0].key, a.cix[1, 0, 0].key)
 
     def testStack(self):
-        raw_arrs = [ones((3, 4), chunks=2) for _ in range(10)]
+        raw_arrs = [ones((3, 4), chunk_size=2) for _ in range(10)]
         arr2 = stack(raw_arrs, axis=0)
 
         self.assertEqual(arr2.shape, (10, 3, 4))
@@ -83,7 +83,7 @@ class Test(unittest.TestCase):
         self.assertEqual(arr4.nsplits, ((2, 1), (2, 2), (1,) * 10))
 
         with self.assertRaises(ValueError):
-            raw_arrs2 = [ones((3, 4), chunks=2), ones((4, 3), chunks=2)]
+            raw_arrs2 = [ones((3, 4), chunk_size=2), ones((4, 3), chunk_size=2)]
             stack(raw_arrs2)
 
         with self.assertRaises(np.AxisError):

--- a/mars/tensor/expressions/tests/test_random.py
+++ b/mars/tensor/expressions/tests/test_random.py
@@ -23,8 +23,8 @@ from mars.tensor.expressions.tests.test_core import TestBase
 
 class Test(TestBase):
     def testRandomSerialize(self):
-        arr = RandomState(0).beta([[2, 3]], from_ndarray([[4, 6], [5, 2]], chunks=2),
-            chunks=1, size=(3, 2, 2)).tiles()
+        arr = RandomState(0).beta([[2, 3]], from_ndarray([[4, 6], [5, 2]], chunk_size=2),
+            chunk_size=1, size=(3, 2, 2)).tiles()
         chunk = arr.chunks[0]
 
         self.assertEqual(chunk.op.dtype, np.dtype('f8'))
@@ -41,35 +41,35 @@ class Test(TestBase):
 
         self.assertIsNotNone(arr.dtype)
 
-        arr = beta(1, 2, chunks=2).tiles()
+        arr = beta(1, 2, chunk_size=2).tiles()
 
         self.assertEqual(arr.shape, ())
         self.assertEqual(len(arr.chunks), 1)
         self.assertEqual(arr.chunks[0].shape, ())
         self.assertEqual(arr.chunks[0].op.dtype, np.dtype('f8'))
 
-        arr = beta([1, 2], [3, 4], chunks=2).tiles()
+        arr = beta([1, 2], [3, 4], chunk_size=2).tiles()
 
         self.assertEqual(arr.shape, (2,))
         self.assertEqual(len(arr.chunks), 1)
         self.assertEqual(arr.chunks[0].shape, (2,))
         self.assertEqual(arr.chunks[0].op.dtype, np.dtype('f8'))
 
-        arr = beta([[2, 3]], from_ndarray([[4, 6], [5, 2]], chunks=2),
-                   chunks=1, size=(3, 2, 2)).tiles()
+        arr = beta([[2, 3]], from_ndarray([[4, 6], [5, 2]], chunk_size=2),
+                   chunk_size=1, size=(3, 2, 2)).tiles()
 
         self.assertEqual(arr.shape, (3, 2, 2))
         self.assertEqual(len(arr.chunks), 12)
         self.assertEqual(arr.chunks[0].op.dtype, np.dtype('f8'))
 
     def testChoice(self):
-        t = choice(5, chunks=1)
+        t = choice(5, chunk_size=1)
         self.assertEqual(t.shape, ())
         t.tiles()
         self.assertEqual(t.nsplits, ())
         self.assertEqual(len(t.chunks), 1)
 
-        t = choice(5, 3, chunks=1)
+        t = choice(5, 3, chunk_size=1)
         self.assertEqual(t.shape, (3,))
         t.tiles()
         self.assertEqual(t.nsplits, ((1, 1, 1),))
@@ -81,7 +81,7 @@ class Test(TestBase):
         mean = [0, 0]
         cov = [[1, 0], [0, 100]]
 
-        t = multivariate_normal(mean, cov, 5000, chunks=500)
+        t = multivariate_normal(mean, cov, 5000, chunk_size=500)
         self.assertEqual(t.shape, (5000, 2))
         self.assertEqual(t.op.size, (5000,))
 
@@ -93,7 +93,7 @@ class Test(TestBase):
         self.assertEqual(c.op.size, (500,))
 
     def testRandint(self):
-        arr = randint(1, 2, size=(10, 9), dtype='f8', density=.01, chunks=2).tiles()
+        arr = randint(1, 2, size=(10, 9), dtype='f8', density=.01, chunk_size=2).tiles()
 
         self.assertEqual(arr.shape, (10, 9))
         self.assertEqual(len(arr.chunks), 25)

--- a/mars/tensor/expressions/tests/test_rechunk.py
+++ b/mars/tensor/expressions/tests/test_rechunk.py
@@ -23,7 +23,7 @@ from mars.tensor.expressions.rechunk.rechunk import compute_rechunk
 
 class Test(unittest.TestCase):
     def testComputeRechunk(self):
-        tensor = ones((12, 8), chunks=((4, 4, 3, 1), (3, 3, 2)))
+        tensor = ones((12, 8), chunk_size=((4, 4, 3, 1), (3, 3, 2)))
         tensor.tiles()
         new_tensor = compute_rechunk(tensor, ((9, 2, 1), (2, 1, 4, 1)))
 
@@ -44,7 +44,7 @@ class Test(unittest.TestCase):
                          (slice(None, None, None), slice(1, None, None)))
 
     def testRechunk(self):
-        tensor = ones((12, 9), chunks=4)
+        tensor = ones((12, 9), chunk_size=4)
         new_tensor = tensor.rechunk(3)
         new_tensor.tiles()
 

--- a/mars/tensor/expressions/tests/test_reduction.py
+++ b/mars/tensor/expressions/tests/test_reduction.py
@@ -32,66 +32,66 @@ class Test(unittest.TestCase):
         any = lambda x, *args, **kwargs: x.any(*args, **kwargs).tiles()
 
         for f in [sum, max, min, all, any]:
-            res = f(ones((8, 8), chunks=8))
+            res = f(ones((8, 8), chunk_size=8))
             self.assertEqual(res.shape, ())
 
-            res = f(ones((10, 8), chunks=3))
+            res = f(ones((10, 8), chunk_size=3))
             self.assertIsNotNone(res.dtype)
             self.assertEqual(res.shape, ())
 
-            res = f(ones((10, 8), chunks=3), axis=0)
+            res = f(ones((10, 8), chunk_size=3), axis=0)
             self.assertEqual(res.shape, (8,))
 
-            res = f(ones((10, 8), chunks=3), axis=1)
+            res = f(ones((10, 8), chunk_size=3), axis=1)
             self.assertEqual(res.shape, (10,))
 
-            res = f(ones((10, 8), chunks=3), keepdims=True)
+            res = f(ones((10, 8), chunk_size=3), keepdims=True)
             self.assertEqual(res.shape, (1, 1))
 
-            res = f(ones((10, 8), chunks=3), axis=0, keepdims=True)
+            res = f(ones((10, 8), chunk_size=3), axis=0, keepdims=True)
             self.assertEqual(res.shape, (1, 8))
 
-            res = f(ones((10, 8), chunks=3), axis=1, keepdims=True)
+            res = f(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
             self.assertEqual(res.shape, (10, 1))
 
-            res = f(ones((10, 8, 10), chunks=3), axis=1)
+            res = f(ones((10, 8, 10), chunk_size=3), axis=1)
             self.assertEqual(res.shape, (10, 10))
 
-            res = f(ones((10, 8, 10), chunks=3), axis=1, keepdims=True)
+            res = f(ones((10, 8, 10), chunk_size=3), axis=1, keepdims=True)
             self.assertEqual(res.shape, (10, 1, 10))
 
-            res = f(ones((10, 8, 10), chunks=3), axis=(0, 2))
+            res = f(ones((10, 8, 10), chunk_size=3), axis=(0, 2))
             self.assertEqual(res.shape, (8,))
 
-            res = f(ones((10, 8, 10), chunks=3), axis=(0, 2), keepdims=True)
+            res = f(ones((10, 8, 10), chunk_size=3), axis=(0, 2), keepdims=True)
             self.assertEqual(res.shape, (1, 8, 1))
 
     def testMeanReduction(self):
         mean = lambda x, *args, **kwargs: x.mean(*args, **kwargs).tiles()
 
-        res = mean(ones((10, 8), chunks=3))
+        res = mean(ones((10, 8), chunk_size=3))
         self.assertEqual(res.shape, ())
         self.assertIsNotNone(res.dtype)
         self.assertIsInstance(res.chunks[0].op, Mean)
         self.assertIsInstance(res.chunks[0].inputs[0].op, Concatenate)
         self.assertIsInstance(res.chunks[0].inputs[0].inputs[0].op, MeanCombine)
 
-        res = mean(ones((8, 8), chunks=8))
+        res = mean(ones((8, 8), chunk_size=8))
         self.assertEqual(res.shape, ())
 
-        res = mean(ones((10, 8), chunks=3), axis=0)
+        res = mean(ones((10, 8), chunk_size=3), axis=0)
         self.assertEqual(res.shape, (8,))
 
-        res = mean(ones((10, 8), chunks=3), axis=1)
+        res = mean(ones((10, 8), chunk_size=3), axis=1)
         self.assertEqual(res.shape, (10,))
 
-        res = mean(ones((10, 8), chunks=3), keepdims=True)
+        res = mean(ones((10, 8), chunk_size=3), keepdims=True)
         self.assertEqual(res.shape, (1, 1))
 
-        res = mean(ones((10, 8), chunks=3), axis=0, keepdims=True)
+        res = mean(ones((10, 8), chunk_size=3), axis=0, keepdims=True)
         self.assertEqual(res.shape, (1, 8))
 
-        res = mean(ones((10, 8), chunks=3), axis=1, keepdims=True)
+        res = mean(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
         self.assertEqual(res.shape, (10, 1))
         self.assertIsInstance(res.chunks[0].op, Mean)
         self.assertIsInstance(res.chunks[0].inputs[0].op, Concatenate)
@@ -101,8 +101,8 @@ class Test(unittest.TestCase):
         argmax = lambda x, *args, **kwargs: x.argmax(*args, **kwargs).tiles()
         argmin = lambda x, *args, **kwargs: x.argmin(*args, **kwargs).tiles()
 
-        res1 = argmax(ones((10, 8, 10), chunks=3))
-        res2 = argmin(ones((10, 8, 10), chunks=3))
+        res1 = argmax(ones((10, 8, 10), chunk_size=3))
+        res2 = argmin(ones((10, 8, 10), chunk_size=3))
         self.assertEqual(res1.shape, ())
         self.assertIsNotNone(res1.dtype)
         self.assertEqual(res2.shape, ())
@@ -113,8 +113,8 @@ class Test(unittest.TestCase):
         self.assertIsInstance(res1.chunks[0].inputs[0].inputs[0].op, ArgmaxCombine)
         self.assertIsInstance(res2.chunks[0].inputs[0].inputs[0].op, ArgminCombine)
 
-        res1 = argmax(ones((10, 8), chunks=3), axis=1, keepdims=True)
-        res2 = argmin(ones((10, 8), chunks=3), axis=1, keepdims=True)
+        res1 = argmax(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
+        res2 = argmin(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
         self.assertEqual(res1.shape, (10, 1))
         self.assertEqual(res2.shape, (10, 1))
         self.assertIsInstance(res1.chunks[0].op, Argmax)
@@ -124,22 +124,22 @@ class Test(unittest.TestCase):
         self.assertIsInstance(res1.chunks[0].inputs[0].inputs[0].op, ArgmaxChunk)
         self.assertIsInstance(res2.chunks[0].inputs[0].inputs[0].op, ArgminChunk)
 
-        self.assertRaises(TypeError, lambda: argmax(ones((10, 8, 10), chunks=3), axis=(0, 1)))
-        self.assertRaises(TypeError, lambda: argmin(ones((10, 8, 10), chunks=3), axis=(0, 1)))
+        self.assertRaises(TypeError, lambda: argmax(ones((10, 8, 10), chunk_size=3), axis=(0, 1)))
+        self.assertRaises(TypeError, lambda: argmin(ones((10, 8, 10), chunk_size=3), axis=(0, 1)))
 
     def testCumReduction(self):
         cumsum = lambda x, *args, **kwargs: x.cumsum(*args, **kwargs).tiles()
         cumprod = lambda x, *args, **kwargs: x.cumprod(*args, **kwargs).tiles()
 
-        res1 = cumsum(ones((10, 8), chunks=3), axis=0)
-        res2 = cumprod(ones((10, 8), chunks=3), axis=0)
+        res1 = cumsum(ones((10, 8), chunk_size=3), axis=0)
+        res2 = cumprod(ones((10, 8), chunk_size=3), axis=0)
         self.assertEqual(res1.shape, (10, 8))
         self.assertIsNotNone(res1.dtype)
         self.assertEqual(res2.shape, (10, 8))
         self.assertIsNotNone(res2.dtype)
 
-        res1 = cumsum(ones((10, 8, 8), chunks=3), axis=1)
-        res2 = cumprod(ones((10, 8, 8), chunks=3), axis=1)
+        res1 = cumsum(ones((10, 8, 8), chunk_size=3), axis=1)
+        res2 = cumprod(ones((10, 8, 8), chunk_size=3), axis=1)
         self.assertEqual(res1.shape, (10, 8, 8))
         self.assertEqual(res2.shape, (10, 8, 8))
 
@@ -152,9 +152,9 @@ class Test(unittest.TestCase):
     def testVarReduction(self):
         var = lambda x, *args, **kwargs: x.var(*args, **kwargs).tiles()
 
-        res1 = var(ones((10, 8), chunks=3), ddof=2)
+        res1 = var(ones((10, 8), chunk_size=3), ddof=2)
         self.assertEqual(res1.shape, ())
         self.assertEqual(res1.op.ddof, 2)
 
-        res1 = var(ones((10, 8, 8), chunks=3), axis=1)
+        res1 = var(ones((10, 8, 8), chunk_size=3), axis=1)
         self.assertEqual(res1.shape, (10, 8))

--- a/mars/tensor/expressions/tests/test_reshape.py
+++ b/mars/tensor/expressions/tests/test_reshape.py
@@ -21,21 +21,21 @@ from mars.tensor.expressions.datasource import ones
 
 class Test(unittest.TestCase):
     def testReshape(self):
-        a = ones((10, 20, 30), chunks=5)
+        a = ones((10, 20, 30), chunk_size=5)
         b = a.reshape(10, 600)
 
         b.tiles()
 
         self.assertEqual(tuple(sum(s) for s in b.nsplits), (10, 600))
 
-        a = ones((10, 600), chunks=5)
+        a = ones((10, 600), chunk_size=5)
         b = a.reshape(10, 30, 20)
 
         b.tiles()
 
         self.assertEqual(tuple(sum(s) for s in b.nsplits), (10, 30, 20))
 
-        a = ones((10, 600), chunks=5)
+        a = ones((10, 600), chunk_size=5)
         a.shape = [10, 30, 20]
 
         a.tiles()

--- a/mars/tensor/expressions/tests/test_utils.py
+++ b/mars/tensor/expressions/tests/test_utils.py
@@ -143,8 +143,8 @@ class Test(unittest.TestCase):
         self.assertEqual(decide_unify_split((1, 5, 1, 2), (2, 4, 3), (9,)), (1, 1, 4, 1, 2))
 
     def testUnifyChunks(self):
-        t1 = ones((10, 8), chunks=3).tiles()
-        t2 = ones((10, 8), chunks=2).tiles()
+        t1 = ones((10, 8), chunk_size=3).tiles()
+        t2 = ones((10, 8), chunk_size=2).tiles()
 
         new_t1, new_t2 = unify_chunks(t1, t2)
         self.assertEqual(new_t1.nsplits, ((2, 1, 1, 2, 2, 1, 1), (2, 1, 1, 2, 2)))
@@ -152,38 +152,38 @@ class Test(unittest.TestCase):
         self.assertEqual(new_t2.nsplits, ((2, 1, 1, 2, 2, 1, 1), (2, 1, 1, 2, 2)))
         self.assertIs(new_t2.inputs[0], t2.data)
 
-        t1 = ones((10, 8), chunks=4).tiles()
-        t2 = ones((10, 8), chunks=2).tiles()
+        t1 = ones((10, 8), chunk_size=4).tiles()
+        t2 = ones((10, 8), chunk_size=2).tiles()
 
         new_t1, new_t2 = unify_chunks(t1, t2)
         self.assertEqual(new_t1.nsplits, ((2, 2, 2, 2, 2), (2, 2, 2, 2)))
         self.assertIs(new_t1.inputs[0], t1.data)
         self.assertIs(new_t2, t2)
 
-        t1 = ones((10, 8), chunks=[4, 3]).tiles()
-        t2 = ones((10, 8), chunks=2).tiles()
+        t1 = ones((10, 8), chunk_size=[4, 3]).tiles()
+        t2 = ones((10, 8), chunk_size=2).tiles()
 
         new_t1, new_t2 = unify_chunks((t1, (0,)), (t2, (0,)))
         self.assertEqual(new_t1.nsplits, ((2, 2, 2, 2, 2), (3, 3, 2)))
         self.assertIs(new_t1.inputs[0], t1.data)
         self.assertIs(new_t2, t2)
 
-        t1 = ones((10, 8), chunks=[4, 2]).tiles()
-        t2 = ones((10, 8), chunks=[4, 4]).tiles()
+        t1 = ones((10, 8), chunk_size=[4, 2]).tiles()
+        t2 = ones((10, 8), chunk_size=[4, 4]).tiles()
 
         new_t1, new_t2 = unify_chunks((t1, (1, 0)), (t2, (1, 0)))
         self.assertIs(t1, new_t1)
         self.assertEqual(new_t2.nsplits, ((4, 4, 2), (2, 2, 2, 2)))
 
-        t1 = ones((10, 8), chunks=2).tiles()
-        t2 = ones(1, chunks=1).tiles()
+        t1 = ones((10, 8), chunk_size=2).tiles()
+        t2 = ones(1, chunk_size=1).tiles()
 
         new_t1, new_t2 = unify_chunks((t1, (1, 0)), t2)
         self.assertIs(new_t1, t1)
         self.assertIs(new_t2, t2)
 
-        t1 = ones((10, 8), chunks=2).tiles()
-        t2 = ones(8, chunks=3).tiles()
+        t1 = ones((10, 8), chunk_size=2).tiles()
+        t2 = ones(8, chunk_size=3).tiles()
 
         new_t1, new_t2 = unify_chunks((t1, (1, 0)), t2)
         self.assertEqual(new_t1.nsplits, ((2, 2, 2, 2, 2), (2, 1, 1, 2, 2)))

--- a/mars/tensor/expressions/tests/test_utils.py
+++ b/mars/tensor/expressions/tests/test_utils.py
@@ -19,19 +19,19 @@ from numbers import Integral
 
 import numpy as np
 
-from mars.tensor.expressions.utils import normalize_chunks, broadcast_shape, \
+from mars.tensor.expressions.utils import normalize_chunk_sizes, broadcast_shape, \
     replace_ellipsis, calc_sliced_size, slice_split, decide_unify_split, unify_chunks, \
-    split_index_into_chunks, decide_chunks
+    split_index_into_chunks, decide_chunk_sizes
 from mars.tensor.expressions.datasource import ones
 from mars.config import option_context
 
 
 class Test(unittest.TestCase):
     def testNormalizeChunks(self):
-        self.assertEqual(((2, 2, 1), (2, 2, 2)), normalize_chunks((5, 6), (2, 2)))
+        self.assertEqual(((2, 2, 1), (2, 2, 2)), normalize_chunk_sizes((5, 6), (2, 2)))
         with self.assertRaises(ValueError):
-            normalize_chunks((4, 6), ((2, 2, 1), (2, 2, 2)))
-        self.assertEqual(((10, 10, 10), (5,)), normalize_chunks((30, 5), 10))
+            normalize_chunk_sizes((4, 6), ((2, 2, 1), (2, 2, 2)))
+        self.assertEqual(((10, 10, 10), (5,)), normalize_chunk_sizes((30, 5), 10))
 
     def testBroadcastShape(self):
         self.assertEqual((4, 3), broadcast_shape((4, 3), (3,)))
@@ -212,32 +212,32 @@ class Test(unittest.TestCase):
 
     def testDecideChunks(self):
         with option_context() as options:
-            options.tensor.chunk_size_limit = 64
+            options.tensor.chunk_store_limit = 64
 
             itemsize = 1
             shape = (10, 20, 30)
-            nsplit = decide_chunks(shape, None, itemsize)
+            nsplit = decide_chunk_sizes(shape, None, itemsize)
             [self.assertTrue(all(isinstance(i, Integral) for i in ns)) for ns in nsplit]
             self.assertEqual(shape, tuple(sum(ns) for ns in nsplit))
-            self.assertGreaterEqual(options.tensor.chunk_size_limit, itemsize * np.prod([np.max(a) for a in nsplit]))
+            self.assertGreaterEqual(options.tensor.chunk_store_limit, itemsize * np.prod([np.max(a) for a in nsplit]))
 
             itemsize = 2
             shape = (20, 30, 40)
-            nsplit = decide_chunks(shape, {1: 4}, itemsize)
+            nsplit = decide_chunk_sizes(shape, {1: 4}, itemsize)
             [self.assertTrue(all(isinstance(i, Integral) for i in ns)) for ns in nsplit]
             self.assertEqual(shape, tuple(sum(ns) for ns in nsplit))
-            self.assertGreaterEqual(options.tensor.chunk_size_limit, itemsize * np.prod([np.max(a) for a in nsplit]))
+            self.assertGreaterEqual(options.tensor.chunk_store_limit, itemsize * np.prod([np.max(a) for a in nsplit]))
 
             itemsize = 2
             shape = (20, 30, 40)
-            nsplit = decide_chunks(shape, [2, 3], itemsize)
+            nsplit = decide_chunk_sizes(shape, [2, 3], itemsize)
             [self.assertTrue(all(isinstance(i, Integral) for i in ns)) for ns in nsplit]
             self.assertEqual(shape, tuple(sum(ns) for ns in nsplit))
-            self.assertGreaterEqual(options.tensor.chunk_size_limit, itemsize * np.prod([np.max(a) for a in nsplit]))
+            self.assertGreaterEqual(options.tensor.chunk_store_limit, itemsize * np.prod([np.max(a) for a in nsplit]))
 
             itemsize = 2
             shape = (20, 30, 40)
-            nsplit = decide_chunks(shape, [20, 3], itemsize)
+            nsplit = decide_chunk_sizes(shape, [20, 3], itemsize)
             [self.assertTrue(all(isinstance(i, Integral) for i in ns)) for ns in nsplit]
             self.assertEqual(shape, tuple(sum(ns) for ns in nsplit))
             self.assertEqual(120, itemsize * np.prod([np.max(a) for a in nsplit]))  # 20 * 3 * 1 * 2 exceeds limitation

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -33,20 +33,20 @@ def normalize_shape(shape):
         return shape,
 
 
-def normalize_chunks(shape, chunks):
+def normalize_chunk_sizes(shape, chunk_size):
     shape = normalize_shape(shape)
-    if not isinstance(chunks, tuple):
-        if isinstance(chunks, Iterable):
-            chunks = tuple(chunks)
-        elif isinstance(chunks, six.integer_types):
-            chunks = (chunks,) * len(shape)
+    if not isinstance(chunk_size, tuple):
+        if isinstance(chunk_size, Iterable):
+            chunk_size = tuple(chunk_size)
+        elif isinstance(chunk_size, six.integer_types):
+            chunk_size = (chunk_size,) * len(shape)
 
-    if len(shape) != len(chunks):
+    if len(shape) != len(chunk_size):
         raise ValueError('Chunks must have the same dimemsion, '
-                         'got shape: %s, chunks: %s' % (shape, chunks))
+                         'got shape: %s, chunks: %s' % (shape, chunk_size))
 
     chunk_sizes = []
-    for size, chunk in izip(shape, chunks):
+    for size, chunk in izip(shape, chunk_size):
         if isinstance(chunk, Iterable):
             if not isinstance(chunk, tuple):
                 chunk = tuple(chunk)
@@ -390,34 +390,34 @@ def recursive_tile(tensor):
     return tensor
 
 
-def decide_chunks(shape, chunks, itemsize):
+def decide_chunk_sizes(shape, chunk_size, itemsize):
     from ...config import options
 
-    if chunks is not None:
-        if isinstance(chunks, Iterable):
-            if not isinstance(chunks, dict):
-                chunks = {i: c for i, c in enumerate(chunks)}
-        elif isinstance(chunks, six.integer_types):
-            chunks = {i: chunks for i in range(len(shape))}
+    if chunk_size is not None:
+        if isinstance(chunk_size, Iterable):
+            if not isinstance(chunk_size, dict):
+                chunk_size = {i: c for i, c in enumerate(chunk_size)}
+        elif isinstance(chunk_size, six.integer_types):
+            chunk_size = {i: chunk_size for i in range(len(shape))}
         else:
-            raise TypeError('chunks must be iterable, got {0}'.format(type(chunks)))
+            raise TypeError('chunks must be iterable, got {0}'.format(type(chunk_size)))
 
-    if chunks is None:
-        chunks = dict()
+    if chunk_size is None:
+        chunk_size = dict()
 
-    nleft = len(shape) - len(chunks)
+    nleft = len(shape) - len(chunk_size)
 
     if nleft < 0:
         raise ValueError("chunks have more dimensions than input tensor")
 
     if nleft == 0:
-        return normalize_chunks(shape, tuple(chunks[j] for j in range(len(shape))))
+        return normalize_chunk_sizes(shape, tuple(chunk_size[j] for j in range(len(shape))))
 
-    max_chunk_size = options.tensor.chunk_size_limit
+    max_chunk_size = options.tensor.chunk_store_limit
 
     # normalize the dimension which specified first
-    dim_to_normalized = {i: normalize_chunks((shape[i],), (c,))[0]
-                         for i, c in six.iteritems(chunks)}
+    dim_to_normalized = {i: normalize_chunk_sizes((shape[i],), (c,))[0]
+                         for i, c in six.iteritems(chunk_size)}
 
     left = {j: [] for j in range(len(shape)) if j not in dim_to_normalized}
     left_unsplit = {j: shape[j] for j in left}
@@ -436,4 +436,3 @@ def decide_chunks(shape, chunks, itemsize):
             break
 
     return tuple(dim_to_normalized[i] for i in range(len(dim_to_normalized)))
-

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -31,7 +31,7 @@ class Test(unittest.TestCase):
         data = np.random.random((5, 9))
 
         # test multiple outputs
-        arr1 = mt.tensor(data.copy(), chunks=3)
+        arr1 = mt.tensor(data.copy(), chunk_size=3)
         result = mt.modf(arr1).execute()
         expected = np.modf(data)
 
@@ -39,14 +39,14 @@ class Test(unittest.TestCase):
         np.testing.assert_array_equal(result[1], expected[1])
 
         # test 1 output
-        arr2 = mt.tensor(data.copy(), chunks=3)
+        arr2 = mt.tensor(data.copy(), chunk_size=3)
         result = ((arr2 + 1) * 2).execute()
         expected = (data + 1) * 2
 
         np.testing.assert_array_equal(result, expected)
 
         # test multiple outputs, but only execute 1
-        arr3 = mt.tensor(data.copy(), chunks=3)
+        arr3 = mt.tensor(data.copy(), chunk_size=3)
         arrs = mt.split(arr3, 3, axis=1)
         result = arrs[0].execute()
         expected = np.split(data, 3, axis=1)[0]

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -152,8 +152,8 @@ class Test(unittest.TestCase):
         service_ep = 'http://127.0.0.1:' + self.web_port
         with new_session(service_ep) as sess:
             self.assertEqual(sess.count_workers(), 1)
-            a = mt.ones((100, 100), chunks=30)
-            b = mt.ones((100, 100), chunks=30)
+            a = mt.ones((100, 100), chunk_size=30)
+            b = mt.ones((100, 100), chunk_size=30)
             c = a.dot(b)
             value = sess.run(c)
             assert_array_equal(value, np.ones((100, 100)) * 100)
@@ -164,8 +164,8 @@ class Test(unittest.TestCase):
 
             va = np.random.randint(0, 10000, (100, 100))
             vb = np.random.randint(0, 10000, (100, 100))
-            a = mt.array(va, chunks=30)
-            b = mt.array(vb, chunks=30)
+            a = mt.array(va, chunk_size=30)
+            b = mt.array(vb, chunk_size=30)
             c = a.dot(b)
             value = sess.run(c, timeout=120)
             assert_array_equal(value, va.dot(vb))
@@ -187,7 +187,7 @@ class Test(unittest.TestCase):
 
         # test default session run with multiple inputs
         with new_session(service_ep).as_default() as sess:
-            a = mt.ones((20, 10), chunks=10)
+            a = mt.ones((20, 10), chunk_size=10)
             u, s, v = (mt.linalg.svd(a)).execute()
             np.testing.assert_allclose(u.dot(np.diag(s).dot(v)), np.ones((20, 10)))
 
@@ -260,8 +260,8 @@ class TestWithMockServer(unittest.TestCase):
         with new_session(self._service_ep) as sess:
             self.assertEqual(sess.count_workers(), 1)
 
-            a = mt.ones((100, 100), chunks=30)
-            b = mt.ones((100, 100), chunks=30)
+            a = mt.ones((100, 100), chunk_size=30)
+            b = mt.ones((100, 100), chunk_size=30)
             c = a.dot(b)
 
             result = sess.run(c, timeout=120)

--- a/mars/worker/tests/test_execution.py
+++ b/mars/worker/tests/test_execution.py
@@ -38,8 +38,8 @@ class ExecuteTestActor(WorkerActor):
     def run_test(self):
         import mars.tensor as mt
         from mars.tensor.expressions.datasource import TensorOnes, TensorFetchChunk
-        arr = mt.ones((10, 8), chunks=10)
-        arr_add = mt.ones((10, 8), chunks=10)
+        arr = mt.ones((10, 8), chunk_size=10)
+        arr_add = mt.ones((10, 8), chunk_size=10)
         arr2 = arr + arr_add
         graph = arr2.build_graph(compose=False, tiled=True)
 

--- a/mars/worker/tests/test_main.py
+++ b/mars/worker/tests/test_main.py
@@ -96,8 +96,8 @@ class Test(unittest.TestCase):
                 gl = gevent.spawn(waiter)
                 gl.join()
 
-                a = mt.ones((100, 50), chunks=30)
-                b = mt.ones((50, 200), chunks=30)
+                a = mt.ones((100, 50), chunk_size=30)
+                b = mt.ones((50, 200), chunk_size=30)
                 result = a.dot(b)
 
                 graph = result.build_graph(tiled=True)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Rename `chunk` to `chunk_size` for all tensor expressions, because `chunks` may mislead users as number of chunks etc.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

resolve #48 
