### PR TITLE
Use number of cores as n_parallel for local session by default

### DIFF
--- a/mars/session.py
+++ b/mars/session.py
@@ -16,6 +16,11 @@
 
 import numpy as np
 
+try:
+    from .resource import cpu_count
+except ImportError:
+    from multiprocessing import cpu_count
+
 
 class LocalSession(object):
     def __init__(self):
@@ -37,6 +42,8 @@ class LocalSession(object):
     def run(self, *tensors, **kw):
         if self._executor is None:
             raise RuntimeError('Session has closed')
+        if 'n_parallel' not in kw:
+            kw['n_parallel'] = cpu_count()
         return self._executor.execute_tensors(tensors, **kw)
 
     def decref(self, *keys):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Use number of cores as n_parallel for local session by default.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolve #81 
