### PR TITLE
Support execute tensor without fetching data

### DIFF
--- a/mars/api.py
+++ b/mars/api.py
@@ -94,11 +94,11 @@ class MarsAPI(object):
         state = GraphState(state.lower())
         return state
 
-    def fetch_data(self, session_id, graph_key, tensor_key):
+    def fetch_data(self, session_id, graph_key, tensor_key, wait=True):
         graph_uid = GraphActor.gen_name(session_id, graph_key)
         graph_address = self.cluster_info.get_scheduler(graph_uid)
         result_ref = self.actor_client.create_actor(ResultReceiverActor, address=graph_address)
-        return result_ref.fetch_tensor(session_id, graph_key, tensor_key)
+        return result_ref.fetch_tensor(session_id, graph_key, tensor_key, _wait=wait)
 
     def delete_data(self, session_id, graph_key, tensor_key):
         graph_uid = GraphActor.gen_name(session_id, graph_key)

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -221,6 +221,14 @@ class Test(unittest.TestCase):
                 np.testing.assert_array_equal(a_result1, a_result2)
                 np.testing.assert_array_equal(b_result, np.ones((10, 10)))
 
+    def testRunWithoutFetch(self):
+        with new_cluster(scheduler_n_process=2, worker_n_process=2) as cluster:
+            session = cluster.session
+
+            a = mt.ones((10, 20)) + 1
+            self.assertIsNone(session.run(a, fetch=False))
+            np.testing.assert_array_equal(a.execute(session=session), np.ones((10, 20)) + 1)
+
     def testGraphFail(self):
         op = SerializeMustFailOperand(f=3)
         tensor = op.new_tensor(None, (3, 3))

--- a/mars/session.py
+++ b/mars/session.py
@@ -16,6 +16,7 @@
 
 import numpy as np
 
+from .compat import OrderedDict
 try:
     from .resource import cpu_count
 except ImportError:  # pragma: no cover
@@ -46,26 +47,12 @@ class LocalSession(object):
             kw['n_parallel'] = cpu_count()
         return self._executor.execute_tensors(tensors, **kw)
 
-    def fetch(self, tensor):
-        from .tensor.expressions.datasource import TensorFetchChunk
-
+    def fetch(self, *tensors, **kw):
         if self._executor is None:
             raise RuntimeError('Session has closed')
-
-        if len(tensor.chunks) == 1:
-            return self._executor.chunk_result[tensor.chunks[0].key]
-
-        chunks = []
-        for c in tensor.chunks:
-            op = TensorFetchChunk(dtype=c.dtype, to_fetch_key=c.key)
-            chunk = op.new_chunk(None, c.shape, index=c.index, _key=c.key)
-            chunks.append(chunk)
-
-        new_op = tensor.op.copy()
-        tensor = new_op.new_tensor([None], tensor.shape, chunks=chunks,
-                                   nsplits=tensor.nsplits)
-
-        return self._executor.execute_tensor(tensor, concat=True)[0]
+        if 'n_parallel' not in kw:
+            kw['n_parallel'] = cpu_count()
+        return self._executor.fetch_tensors(tensors, **kw)
 
     def decref(self, *keys):
         self._executor.decref(*keys)
@@ -100,6 +87,7 @@ class Session(object):
     def run(self, *tensors, **kw):
         from . import tensor as mt
 
+        fetch = kw.get('fetch', True)
         ret_list = False
         if len(tensors) == 1 and isinstance(tensors[0], (tuple, list)):
             ret_list = True
@@ -108,44 +96,49 @@ class Session(object):
             ret_list = True
 
         tensors = tuple(mt.tensor(t) for t in tensors)
-        run_tensors = []
-        fetch_results = dict()
+        results = [None] * len(tensors)
+        idx_to_run_tensors = OrderedDict()
+        idx_to_fetch_tensors = OrderedDict()
 
         # those executed tensors should fetch data directly, submit the others
-        for t in tensors:
+        for i, t in enumerate(tensors):
             if t.key in self._executed_keys:
-                fetch_results[t.key] = self.fetch(t)
+                idx_to_fetch_tensors[i] = t
             else:
-                run_tensors.append(t)
-        if all([t.key in fetch_results for t in tensors]):
-            results = [fetch_results[t.key] for t in tensors]
-            return results if ret_list else results[0]
+                idx_to_run_tensors[i] = t
 
-        result = self._sess.run(*run_tensors, **kw)
-        self._executed_keys.update(t.key for t in run_tensors)
-        for t in run_tensors:
-            t._execute_session = self
+        # execute the non-executed tensors
+        if idx_to_run_tensors:
+            execute_result = self._sess.run(*idx_to_run_tensors.values(), **kw)
+            if execute_result:
+                # fetch is True
+                for j, result in zip(idx_to_run_tensors, execute_result):
+                    results[j] = result
+            run_tensors = list(idx_to_run_tensors.values())
+            self._executed_keys.update(t.key for t in run_tensors)
+            for t in run_tensors:
+                t._execute_session = self
 
-        ret = []
-        for r, t in zip(result, tensors):
-            if r is None:
-                ret.append(r)
-                continue
-            if t.isscalar() and hasattr(r, 'item'):
-                ret.append(np.asscalar(r))
-            else:
-                ret.append(r)
+        if fetch:
+            # do fetch
+            if idx_to_fetch_tensors:
+                for j, result in zip(idx_to_fetch_tensors,
+                                     self._sess.fetch(*idx_to_fetch_tensors.values(), **kw)):
+                    results[j] = result
 
-        results = []
-        result_iter = iter(ret)
-        for k in [t.key for t in tensors]:
-            if k in fetch_results:
-                results.append(fetch_results[k])
-            else:
-                results.append(next(result_iter))
-        if ret_list:
-            return results
-        return results[0]
+            ret = []
+            for r, t in zip(results, tensors):
+                if r is None:
+                    ret.append(r)
+                    continue
+                if t.isscalar() and hasattr(r, 'item'):
+                    ret.append(np.asscalar(r))
+                else:
+                    ret.append(r)
+
+            if ret_list:
+                return ret
+            return ret[0]
 
     def fetch(self, tensor):
         if tensor.key not in self._executed_keys:

--- a/mars/session.py
+++ b/mars/session.py
@@ -159,11 +159,8 @@ class Session(object):
             self._sess.decref(*keys)
 
     def __getattr__(self, attr):
-        try:
-            obj = self._sess.__getattribute__(attr)
-            return obj
-        except AttributeError:
-            raise
+        obj = self._sess.__getattribute__(attr)
+        return obj
 
     def __enter__(self):
         self._sess.__enter__()

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -116,13 +116,16 @@ class Test(unittest.TestCase):
 
     def testExecuteNotFetch(self):
         data = np.random.random((5, 9))
+        sess = Session.default_or_local()
 
         arr1 = mt.tensor(data, chunk_size=2) * 2
+
+        with self.assertRaises(ValueError):
+            sess.fetch(arr1)
 
         self.assertIsNone(arr1.execute(fetch=False))
 
         # modify result
-        sess = Session.default_or_local()
         executor = sess._sess._executor
         executor.chunk_result[arr1.chunks[0].key] = data[:2, :2] * 3
 

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 
 import mars.tensor as mt
-from mars.session import new_session
+from mars.session import new_session, Session
 
 
 class Test(unittest.TestCase):
@@ -29,6 +29,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.isscalar(res))
         self.assertLess(res, 200)
 
+    def testMultipleOutputExecute(self):
         data = np.random.random((5, 9))
 
         # test multiple outputs
@@ -54,6 +55,9 @@ class Test(unittest.TestCase):
 
         np.testing.assert_array_equal(result, expected)
 
+    def testReExecuteSame(self):
+        data = np.random.random((5, 9))
+
         # test run the same tensor
         arr4 = mt.tensor(data.copy(), chunk_size=3) + 1
         result1 = arr4.execute()
@@ -73,8 +77,15 @@ class Test(unittest.TestCase):
         np.testing.assert_array_equal(result1, expected)
 
         result2 = arr4.execute()
-
         np.testing.assert_array_equal(result1, result2)
+
+        # modify result
+        sess = Session.default_or_local()
+        executor = sess._sess._executor
+        executor.chunk_result[arr4.chunks[0].key] = data + 2
+
+        result3 = arr4.execute()
+        np.testing.assert_array_equal(result3, data + 2)
 
         # test run same key tensor
         arr5 = mt.ones((10, 10), chunk_size=3)
@@ -85,6 +96,40 @@ class Test(unittest.TestCase):
         result2 = arr6.execute()
 
         np.testing.assert_array_equal(result1, result2)
+
+    def testExecuteBothExecutedAndNot(self):
+        data = np.random.random((5, 9))
+
+        arr1 = mt.tensor(data, chunk_size=4) * 2
+        arr2 = mt.tensor(data) + 1
+
+        np.testing.assert_array_equal(arr2.execute(), data + 1)
+
+        # modify result
+        sess = Session.default_or_local()
+        executor = sess._sess._executor
+        executor.chunk_result[arr2.chunks[0].key] = data + 2
+
+        results = sess.run(arr1, arr2)
+        np.testing.assert_array_equal(results[0], data * 2)
+        np.testing.assert_array_equal(results[1], data + 2)
+
+    def testExecuteNotFetch(self):
+        data = np.random.random((5, 9))
+
+        arr1 = mt.tensor(data, chunk_size=2) * 2
+
+        self.assertIsNone(arr1.execute(fetch=False))
+
+        # modify result
+        sess = Session.default_or_local()
+        executor = sess._sess._executor
+        executor.chunk_result[arr1.chunks[0].key] = data[:2, :2] * 3
+
+        expected = data * 2
+        expected[:2, :2] = data[:2, :2] * 3
+
+        np.testing.assert_array_equal(arr1.execute(), expected)
 
     def testClosedSession(self):
         session = new_session()

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -273,3 +273,7 @@ class TestWithMockServer(unittest.TestCase):
 
             result = sess.run(c, timeout=120)
             assert_array_equal(result, np.ones((100, 100)) * 100)
+
+            d = a * 100
+            self.assertIsNone(sess.run(d, fetch=False, timeout=120))
+            assert_array_equal(sess.run(d, timeout=120), np.ones((100, 100)) * 100)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Add `fetch` parameter to `execute` and `session.run` to support execute tensor without fetching data. Also refine `session.fetch` to support fetch a few tensors at same time.

This is an enhancement for the #80 .

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolve #84 
