### PR TITLE
Check parameters for rand and randn

### DIFF
--- a/mars/tensor/expressions/random/beta.py
+++ b/mars/tensor/expressions/random/beta.py
@@ -33,7 +33,7 @@ class TensorBeta(operands.Beta, TensorRandomOperandMixin):
         return self.new_tensor([a, b], None, raw_chunk_size=chunk_size)
 
 
-def beta(random_state, a, b, size=None, chunk_size=None, gpu=None, **kw):
+def beta(random_state, a, b, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a Beta distribution.
 
@@ -66,15 +66,17 @@ def beta(random_state, a, b, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
     out : Tensor or scalar
         Drawn samples from the parameterized beta distribution.
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().beta(
+    if dtype is None:
+        dtype = np.random.RandomState().beta(
             handle_array(a), handle_array(b), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorBeta(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorBeta(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(a, b, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/binomial.py
+++ b/mars/tensor/expressions/random/binomial.py
@@ -33,7 +33,7 @@ class TensorBinomial(operands.Binomial, TensorRandomOperandMixin):
         return self.new_tensor([n, p], None, raw_chunk_size=chunk_size)
 
 
-def binomial(random_state, n, p, size=None, chunk_size=None, gpu=None, **kw):
+def binomial(random_state, n, p, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a binomial distribution.
 
@@ -58,6 +58,8 @@ def binomial(random_state, n, p, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -121,9 +123,9 @@ def binomial(random_state, n, p, size=None, chunk_size=None, gpu=None, **kw):
     >>> (mt.sum(mt.random.binomial(9, 0.1, 20000) == 0)/20000.).execute()
     # answer = 0.38885, or 38%.
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().binomial(
+    if dtype is None:
+        dtype = np.random.RandomState().binomial(
             handle_array(n), handle_array(p), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorBinomial(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorBinomial(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(n, p, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/chisquare.py
+++ b/mars/tensor/expressions/random/chisquare.py
@@ -33,7 +33,7 @@ class TensorChisquare(operands.Chisquare, TensorRandomOperandMixin):
         return self.new_tensor([df], self._size, raw_chunk_size=chunk_size)
 
 
-def chisquare(random_state, df, size=None, chunk_size=None, gpu=None, **kw):
+def chisquare(random_state, df, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a chi-square distribution.
 
@@ -55,6 +55,8 @@ def chisquare(random_state, df, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -99,9 +101,9 @@ def chisquare(random_state, df, size=None, chunk_size=None, gpu=None, **kw):
     >>> mt.random.chisquare(2,4).execute()
     array([ 1.89920014,  9.00867716,  3.13710533,  5.62318272])
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().chisquare(
+    if dtype is None:
+        dtype = np.random.RandomState().chisquare(
             handle_array(df), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorChisquare(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorChisquare(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(df, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/choice.py
+++ b/mars/tensor/expressions/random/choice.py
@@ -40,7 +40,7 @@ class TensorChoice(operands.Choice, TensorRandomOperandMixin):
         return self.new_tensor([a, p], None, raw_chunk_size=chunk_size)
 
 
-def choice(random_state, a, size=None, replace=True, p=None, chunk_size=None, gpu=None, **kw):
+def choice(random_state, a, size=None, replace=True, p=None, chunk_size=None, gpu=None):
     """
     Generates a random sample from a given 1-D array
 
@@ -156,5 +156,5 @@ def choice(random_state, a, size=None, replace=True, p=None, chunk_size=None, gp
 
     size = random_state._handle_size(size)
     op = TensorChoice(state=random_state._state, replace=replace,
-                      size=size, dtype=dtype, gpu=gpu, **kw)
+                      size=size, dtype=dtype, gpu=gpu)
     return op(a, p, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/dirichlet.py
+++ b/mars/tensor/expressions/random/dirichlet.py
@@ -71,7 +71,7 @@ class TensorDirichlet(operands.Dirichlet, TensorRandomOperandMixin):
                                   chunks=out_chunks, nsplits=nsplits)
 
 
-def dirichlet(random_state, alpha, size=None, chunk_size=None, gpu=None, **kw):
+def dirichlet(random_state, alpha, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from the Dirichlet distribution.
 
@@ -93,6 +93,8 @@ def dirichlet(random_state, alpha, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -145,8 +147,8 @@ def dirichlet(random_state, alpha, size=None, chunk_size=None, gpu=None, **kw):
         alpha = tuple(alpha)
     else:
         raise TypeError('`alpha` should be an array')
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().dirichlet(alpha, size=(0,)).dtype
+    if dtype is None:
+        dtype = np.random.RandomState().dirichlet(alpha, size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorDirichlet(state=random_state._state, alpha=alpha, size=size, gpu=gpu, **kw)
+    op = TensorDirichlet(state=random_state._state, alpha=alpha, size=size, gpu=gpu, dtype=dtype)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/exponential.py
+++ b/mars/tensor/expressions/random/exponential.py
@@ -33,7 +33,7 @@ class TensorExponential(operands.Exponential, TensorRandomOperandMixin):
         return self.new_tensor([scale], self._size, raw_chunk_size=chunk_size)
 
 
-def exponential(random_state, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
+def exponential(random_state, scale=1.0, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from an exponential distribution.
 
@@ -64,6 +64,8 @@ def exponential(random_state, scale=1.0, size=None, chunk_size=None, gpu=None, *
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -79,9 +81,9 @@ def exponential(random_state, scale=1.0, size=None, chunk_size=None, gpu=None, *
     .. [3] Wikipedia, "Exponential distribution",
            http://en.wikipedia.org/wiki/Exponential_distribution
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().exponential(
+    if dtype is None:
+        dtype = np.random.RandomState().exponential(
             handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorExponential(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorExponential(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/f.py
+++ b/mars/tensor/expressions/random/f.py
@@ -33,7 +33,7 @@ class TensorF(operands.F, TensorRandomOperandMixin):
         return self.new_tensor([dfnum, dfden], None, raw_chunk_size=chunk_size)
 
 
-def f(random_state, dfnum, dfden, size=None, chunk_size=None, gpu=None, **kw):
+def f(random_state, dfnum, dfden, size=None, chunk_size=None, gpu=None, dtype=None):
     """
     Draw samples from an F distribution.
 
@@ -62,6 +62,8 @@ def f(random_state, dfnum, dfden, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -119,9 +121,9 @@ def f(random_state, dfnum, dfden, size=None, chunk_size=None, gpu=None, **kw):
     the measured value is 36, so the null hypothesis is rejected at the 1%
     level.
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().f(
+    if dtype is None:
+        dtype = np.random.RandomState().f(
             handle_array(dfnum), handle_array(dfden), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorF(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorF(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(dfnum, dfden, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/gamma.py
+++ b/mars/tensor/expressions/random/gamma.py
@@ -33,7 +33,7 @@ class TensorGamma(operands.Gamma, TensorRandomOperandMixin):
         return self.new_tensor([shape, scale], None, raw_chunk_size=chunk_size)
 
 
-def gamma(random_state, shape, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
+def gamma(random_state, shape, scale=1.0, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a Gamma distribution.
 
@@ -57,6 +57,8 @@ def gamma(random_state, shape, scale=1.0, size=None, chunk_size=None, gpu=None, 
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -110,9 +112,9 @@ def gamma(random_state, shape, scale=1.0, size=None, chunk_size=None, gpu=None, 
     >>> plt.plot(bins, y, linewidth=2, color='r')
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().gamma(
+    if dtype is None:
+        dtype = np.random.RandomState().gamma(
             handle_array(shape), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorGamma(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorGamma(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(shape, scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/geometric.py
+++ b/mars/tensor/expressions/random/geometric.py
@@ -33,7 +33,7 @@ class TensorGeometric(operands.Geometric, TensorRandomOperandMixin):
         return self.new_tensor([p], None, raw_chunk_size=chunk_size)
 
 
-def geometric(random_state, p, size=None, chunk_size=None, gpu=None, **kw):
+def geometric(random_state, p, size=None, chunk_size=None, gpu=None, dtype=None):
     """
     Draw samples from the geometric distribution.
 
@@ -62,6 +62,8 @@ def geometric(random_state, p, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -82,9 +84,9 @@ def geometric(random_state, p, size=None, chunk_size=None, gpu=None, **kw):
     >>> ((z == 1).sum() / 10000.).execute()
     0.34889999999999999 #random
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().geometric(
+    if dtype is None:
+        dtype = np.random.RandomState().geometric(
             handle_array(p), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorGeometric(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorGeometric(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(p, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/gumbel.py
+++ b/mars/tensor/expressions/random/gumbel.py
@@ -33,7 +33,7 @@ class TensorGumbel(operands.Gumbel, TensorRandomOperandMixin):
         return self.new_tensor([loc, scale], None, raw_chunk_size=chunk_size)
 
 
-def gumbel(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
+def gumbel(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a Gumbel distribution.
 
@@ -56,6 +56,8 @@ def gumbel(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=Non
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -149,9 +151,9 @@ def gumbel(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=Non
     ...          linewidth=2, color='g')
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().gumbel(
+    if dtype is None:
+        dtype = np.random.RandomState().gumbel(
             handle_array(loc), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorGumbel(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorGumbel(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(loc, scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/hypergeometric.py
+++ b/mars/tensor/expressions/random/hypergeometric.py
@@ -33,7 +33,7 @@ class TensorHypergeometric(operands.Hypergeometric, TensorRandomOperandMixin):
         return self.new_tensor([ngood, nbad, nsample], None, raw_chunk_size=chunk_size)
 
 
-def hypergeometric(random_state, ngood, nbad, nsample, size=None, chunk_size=None, gpu=None, **kw):
+def hypergeometric(random_state, ngood, nbad, nsample, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a Hypergeometric distribution.
 
@@ -61,6 +61,8 @@ def hypergeometric(random_state, ngood, nbad, nsample, size=None, chunk_size=Non
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -124,9 +126,9 @@ def hypergeometric(random_state, ngood, nbad, nsample, size=None, chunk_size=Non
     >>> (mt.sum(s>=12)/100000. + mt.sum(s<=3)/100000.).execute()
     #   answer = 0.003 ... pretty unlikely!
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().hypergeometric(
+    if dtype is None:
+        dtype = np.random.RandomState().hypergeometric(
             handle_array(ngood), handle_array(nbad), handle_array(nsample), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorHypergeometric(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorHypergeometric(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(ngood, nbad, nsample, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/laplace.py
+++ b/mars/tensor/expressions/random/laplace.py
@@ -33,7 +33,7 @@ class TensorLaplace(operands.Laplace, TensorRandomOperandMixin):
         return self.new_tensor([loc, scale], None, raw_chunk_size=chunk_size)
 
 
-def laplace(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
+def laplace(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from the Laplace or double exponential distribution with
     specified location (or mean) and scale (decay).
@@ -58,6 +58,8 @@ def laplace(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=No
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -115,9 +117,9 @@ def laplace(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=No
     ...      mt.exp(-(x - loc)**2 / (2 * scale**2)))
     >>> plt.plot(x.execute(),g.execute())
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().laplace(
+    if dtype is None:
+        dtype = np.random.RandomState().laplace(
             handle_array(loc), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorLaplace(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorLaplace(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(loc, scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/logistic.py
+++ b/mars/tensor/expressions/random/logistic.py
@@ -33,7 +33,7 @@ class TensorLogistic(operands.Logistic, TensorRandomOperandMixin):
         return self.new_tensor([loc, scale], None, raw_chunk_size=chunk_size)
 
 
-def logistic(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
+def logistic(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a logistic distribution.
 
@@ -56,6 +56,8 @@ def logistic(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=N
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -111,9 +113,9 @@ def logistic(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=N
     ... logist(bins, loc, scale).max().execute())
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().logistic(
+    if dtype is None:
+        dtype = np.random.RandomState().logistic(
             handle_array(loc), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorLogistic(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorLogistic(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(loc, scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/lognormal.py
+++ b/mars/tensor/expressions/random/lognormal.py
@@ -33,7 +33,7 @@ class TensorLognormal(operands.Lognormal, TensorRandomOperandMixin):
         return self.new_tensor([mean, sigma], None, raw_chunk_size=chunk_size)
 
 
-def lognormal(random_state, mean=0.0, sigma=1.0, size=None, chunk_size=None, gpu=None, **kw):
+def lognormal(random_state, mean=0.0, sigma=1.0, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a log-normal distribution.
 
@@ -58,6 +58,8 @@ def lognormal(random_state, mean=0.0, sigma=1.0, size=None, chunk_size=None, gpu
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -141,9 +143,9 @@ def lognormal(random_state, mean=0.0, sigma=1.0, size=None, chunk_size=None, gpu
     >>> plt.plot(x.execute(), pdf.execute(), color='r', linewidth=2)
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().lognormal(
+    if dtype is None:
+        dtype = np.random.RandomState().lognormal(
             handle_array(mean), handle_array(sigma), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorLognormal(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorLognormal(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(mean, sigma, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/logseries.py
+++ b/mars/tensor/expressions/random/logseries.py
@@ -33,7 +33,7 @@ class TensorLogseries(operands.Logseries, TensorRandomOperandMixin):
         return self.new_tensor([p], None, raw_chunk_size=chunk_size)
 
 
-def logseries(random_state, p, size=None, chunk_size=None, gpu=None, **kw):
+def logseries(random_state, p, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a logarithmic series distribution.
 
@@ -53,6 +53,8 @@ def logseries(random_state, p, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -111,9 +113,9 @@ def logseries(random_state, p, size=None, chunk_size=None, gpu=None, **kw):
     ...          logseries(bins, a).max()).execute(), 'r')
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().logseries(
+    if dtype is None:
+        dtype = np.random.RandomState().logseries(
             handle_array(p), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorLogseries(state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorLogseries(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(p, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/multinomial.py
+++ b/mars/tensor/expressions/random/multinomial.py
@@ -40,7 +40,7 @@ class TensorMultinomial(operands.Multinomial, TensorRandomOperandMixin):
         return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
 
 
-def multinomial(random_state, n, pvals, size=None, chunk_size=None, gpu=None, **kw):
+def multinomial(random_state, n, pvals, size=None, chunk_size=None, gpu=None, dtype=None):
     """
     Draw samples from a multinomial distribution.
 
@@ -69,6 +69,8 @@ def multinomial(random_state, n, pvals, size=None, chunk_size=None, gpu=None, **
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -120,9 +122,9 @@ def multinomial(random_state, n, pvals, size=None, chunk_size=None, gpu=None, **
     """
     n = int(n)
     pvals = tuple(pvals)
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().multinomial(n, pvals, size=(0,)).dtype
+    if dtype is None:
+        dtype = np.random.RandomState().multinomial(n, pvals, size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorMultinomial(n=n, pvals=pvals, state=random_state._state, size=size, gpu=gpu, **kw)
+    op = TensorMultinomial(n=n, pvals=pvals, state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(chunk_size=chunk_size)
 

--- a/mars/tensor/expressions/random/multivariate_normal.py
+++ b/mars/tensor/expressions/random/multivariate_normal.py
@@ -76,7 +76,7 @@ class TensorMultivariateNormal(operands.MultivariateNormal, TensorRandomOperandM
 
 
 def multivariate_normal(random_state, mean, cov, size=None, check_valid=None, tol=None,
-                        chunk_size=None, gpu=None, **kw):
+                        chunk_size=None, gpu=None, dtype=None):
     """
     Draw random samples from a multivariate normal distribution.
 
@@ -107,6 +107,8 @@ def multivariate_normal(random_state, mean, cov, size=None, check_valid=None, to
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -188,15 +190,15 @@ def multivariate_normal(random_state, mean, cov, size=None, check_valid=None, to
     if len(set(mean.shape + cov.shape)) != 1:
         raise ValueError('mean and cov must have same length')
 
-    if 'dtype' not in kw:
+    if dtype is None:
         small_kw = {}
         if check_valid:
             small_kw['check_valid'] = check_valid
         if tol:
             small_kw['tol'] = tol
-        kw['dtype'] = np.random.multivariate_normal(mean, cov, size=(0,), **small_kw).dtype
+        dtype = np.random.multivariate_normal(mean, cov, size=(0,), **small_kw).dtype
 
     size = random_state._handle_size(size)
     op = TensorMultivariateNormal(mean=mean, cov=cov, size=size, check_valid=check_valid,
-                                  tol=tol, state=random_state._state, gpu=gpu, **kw)
+                                  tol=tol, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/negative_binomial.py
+++ b/mars/tensor/expressions/random/negative_binomial.py
@@ -33,7 +33,7 @@ class TensorNegativeBinomial(operands.NegativeBinomial, TensorRandomOperandMixin
         return self.new_tensor([n, p], None, raw_chunk_size=chunk_size)
 
 
-def negative_binomial(random_state, n, p, size=None, chunk_size=None, gpu=None, **kw):
+def negative_binomial(random_state, n, p, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a negative binomial distribution.
 
@@ -57,6 +57,8 @@ def negative_binomial(random_state, n, p, size=None, chunk_size=None, gpu=None, 
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -107,9 +109,9 @@ def negative_binomial(random_state, n, p, size=None, chunk_size=None, gpu=None, 
     ...    probability = (mt.sum(s<i) / 100000.).execute()
     ...    print i, "wells drilled, probability of one success =", probability
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().negative_binomial(
+    if dtype is None:
+        dtype = np.random.RandomState().negative_binomial(
             handle_array(n), handle_array(p), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorNegativeBinomial(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorNegativeBinomial(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(n, p, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/noncentral_chisquare.py
+++ b/mars/tensor/expressions/random/noncentral_chisquare.py
@@ -33,7 +33,7 @@ class TensorNoncentralChisquare(operands.NoncentralChisquare, TensorRandomOperan
         return self.new_tensor([df, nonc], None, raw_chunk_size=chunk_size)
 
 
-def noncentral_chisquare(random_state, df, nonc, size=None, chunk_size=None, gpu=None, **kw):
+def noncentral_chisquare(random_state, df, nonc, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a noncentral chi-square distribution.
 
@@ -55,6 +55,8 @@ def noncentral_chisquare(random_state, df, nonc, size=None, chunk_size=None, gpu
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -114,9 +116,9 @@ def noncentral_chisquare(random_state, df, nonc, size=None, chunk_size=None, gpu
     ...                   bins=200, normed=True)
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().noncentral_chisquare(
+    if dtype is None:
+        dtype = np.random.RandomState().noncentral_chisquare(
             handle_array(df), handle_array(nonc), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorNoncentralChisquare(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorNoncentralChisquare(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(df, nonc, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/noncentral_f.py
+++ b/mars/tensor/expressions/random/noncentral_f.py
@@ -33,7 +33,7 @@ class TensorNoncentralF(operands.NoncentralF, TensorRandomOperandMixin):
         return self.new_tensor([dfnum, dfden, nonc], None, raw_chunk_size=chunk_size)
 
 
-def noncentral_f(random_state, dfnum, dfden, nonc, size=None, chunk_size=None, gpu=None, **kw):
+def noncentral_f(random_state, dfnum, dfden, nonc, size=None, chunk_size=None, gpu=None, dtype=None):
     """
     Draw samples from the noncentral F distribution.
 
@@ -61,6 +61,8 @@ def noncentral_f(random_state, dfnum, dfden, nonc, size=None, chunk_size=None, g
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -105,9 +107,9 @@ def noncentral_f(random_state, dfnum, dfden, nonc, size=None, chunk_size=None, g
     >>> plt.plot(NF[1][1:], NF[0])
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().noncentral_f(
+    if dtype is None:
+        dtype = np.random.RandomState().noncentral_f(
             handle_array(dfnum), handle_array(dfden), handle_array(nonc), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorNoncentralF(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorNoncentralF(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(dfnum, dfden, nonc, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/normal.py
+++ b/mars/tensor/expressions/random/normal.py
@@ -33,7 +33,7 @@ class TensorNormal(operands.Normal, TensorRandomOperandMixin):
         return self.new_tensor([loc, scale], None, raw_chunk_size=chunk_size)
 
 
-def normal(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
+def normal(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw random samples from a normal (Gaussian) distribution.
 
@@ -62,6 +62,8 @@ def normal(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=Non
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -125,9 +127,9 @@ def normal(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=Non
     ...          linewidth=2, color='r')
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().normal(
+    if dtype is None:
+        dtype = np.random.RandomState().normal(
             handle_array(loc), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorNormal(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorNormal(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(loc, scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/pareto.py
+++ b/mars/tensor/expressions/random/pareto.py
@@ -33,7 +33,7 @@ class TensorPareto(operands.Pareto, TensorRandomOperandMixin):
         return self.new_tensor([a], None, raw_chunk_size=chunk_size)
 
 
-def pareto(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
+def pareto(random_state, a, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a Pareto II or Lomax distribution with
     specified shape.
@@ -68,6 +68,8 @@ def pareto(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -129,9 +131,9 @@ def pareto(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
     >>> plt.plot(bins, max(count)*fit/max(fit), linewidth=2, color='r')
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().pareto(
+    if dtype is None:
+        dtype = np.random.RandomState().pareto(
             handle_array(a), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorPareto(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorPareto(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(a, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/poisson.py
+++ b/mars/tensor/expressions/random/poisson.py
@@ -33,7 +33,7 @@ class TensorPoisson(operands.Poisson, TensorRandomOperandMixin):
         return self.new_tensor([lam], None, raw_chunk_size=chunk_size)
 
 
-def poisson(random_state, lam=1.0, size=None, chunk_size=None, gpu=None, **kw):
+def poisson(random_state, lam=1.0, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a Poisson distribution.
 
@@ -54,7 +54,8 @@ def poisson(random_state, lam=1.0, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
-
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -101,9 +102,9 @@ def poisson(random_state, lam=1.0, size=None, chunk_size=None, gpu=None, **kw):
 
     >>> s = mt.random.poisson(lam=(100., 500.), size=(100, 2))
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().poisson(
+    if dtype is None:
+        dtype = np.random.RandomState().poisson(
             handle_array(lam), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorPoisson(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorPoisson(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(lam, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/power.py
+++ b/mars/tensor/expressions/random/power.py
@@ -33,7 +33,7 @@ class TensorRandomPower(operands.RandomPower, TensorRandomOperandMixin):
         return self.new_tensor([a], None, raw_chunk_size=chunk_size)
 
 
-def power(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
+def power(random_state, a, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draws samples in [0, 1] from a power distribution with positive
     exponent a - 1.
@@ -53,6 +53,8 @@ def power(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -131,9 +133,9 @@ def power(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
     >>> plt.plot(xx.execute(),powpdf,'r-')
     >>> plt.title('inverse of stats.pareto(5)')
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().power(
+    if dtype is None:
+        dtype = np.random.RandomState().power(
             handle_array(a), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorRandomPower(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorRandomPower(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(a, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/rand.py
+++ b/mars/tensor/expressions/random/rand.py
@@ -63,7 +63,7 @@ def rand(random_state, *dn, **kw):
     --------
     >>> import mars.tensor as mt
 
-    >>> mt.random.rand(3,2).execute()
+    >>> mt.random.rand(3, 2).execute()
     array([[ 0.14022471,  0.96360618],  #random
            [ 0.37601032,  0.25528411],  #random
            [ 0.49313049,  0.94909878]]) #random
@@ -73,5 +73,10 @@ def rand(random_state, *dn, **kw):
     if 'dtype' not in kw:
         kw['dtype'] = np.dtype('f8')
     chunk_size = kw.pop('chunk_size', None)
+
+    for key in kw:
+        if not key.startswith('_'):
+            raise ValueError('rand got unexpected key arguments {0}'.format(key))
+
     op = TensorRand(state=random_state._state, size=dn, **kw)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/rand.py
+++ b/mars/tensor/expressions/random/rand.py
@@ -73,10 +73,10 @@ def rand(random_state, *dn, **kw):
     if 'dtype' not in kw:
         kw['dtype'] = np.dtype('f8')
     chunk_size = kw.pop('chunk_size', None)
+    op = TensorRand(state=random_state._state, size=dn, **kw)
 
-    for key in kw:
+    for key in op.params:
         if not key.startswith('_'):
             raise ValueError('rand got unexpected key arguments {0}'.format(key))
 
-    op = TensorRand(state=random_state._state, size=dn, **kw)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/randint.py
+++ b/mars/tensor/expressions/random/randint.py
@@ -36,7 +36,7 @@ class TensorRandint(operands.Randint, TensorRandomOperandMixin):
 
 
 def randint(random_state, low, high=None, size=None, dtype='l', density=None,
-            chunk_size=None, gpu=None, **kw):
+            chunk_size=None, gpu=None):
     """
     Return random integers from `low` (inclusive) to `high` (exclusive).
 
@@ -68,6 +68,8 @@ def randint(random_state, low, high=None, size=None, dtype='l', density=None,
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -100,5 +102,5 @@ def randint(random_state, low, high=None, size=None, dtype='l', density=None,
     sparse = bool(density)
     size = random_state._handle_size(size)
     op = TensorRandint(state=random_state._state, low=low, high=high, size=size, dtype=dtype,
-                       gpu=gpu, sparse=sparse, density=density, **kw)
+                       gpu=gpu, sparse=sparse, density=density)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/randn.py
+++ b/mars/tensor/expressions/random/randn.py
@@ -86,6 +86,11 @@ def randn(random_state, *dn, **kw):
     if 'dtype' not in kw:
         kw['dtype'] = np.dtype('f8')
     chunk_size = kw.pop('chunk_size', None)
+
+    for key in kw:
+        if not key.startswith('_'):
+            raise ValueError('randn got unexpected key arguments {0}'.format(key))
+
     op = TensorRandn(state=random_state._state, size=dn, **kw)
     return op(chunk_size=chunk_size)
 

--- a/mars/tensor/expressions/random/randn.py
+++ b/mars/tensor/expressions/random/randn.py
@@ -91,7 +91,7 @@ def randn(random_state, *dn, **kw):
 
     for key in op.params:
         if not key.startswith('_'):
-            raise ValueError('rand got unexpected key arguments {0}'.format(key))
+            raise ValueError('randn got unexpected key arguments {0}'.format(key))
 
     return op(chunk_size=chunk_size)
 

--- a/mars/tensor/expressions/random/randn.py
+++ b/mars/tensor/expressions/random/randn.py
@@ -87,10 +87,11 @@ def randn(random_state, *dn, **kw):
         kw['dtype'] = np.dtype('f8')
     chunk_size = kw.pop('chunk_size', None)
 
-    for key in kw:
-        if not key.startswith('_'):
-            raise ValueError('randn got unexpected key arguments {0}'.format(key))
-
     op = TensorRandn(state=random_state._state, size=dn, **kw)
+
+    for key in op.params:
+        if not key.startswith('_'):
+            raise ValueError('rand got unexpected key arguments {0}'.format(key))
+
     return op(chunk_size=chunk_size)
 

--- a/mars/tensor/expressions/random/random_integers.py
+++ b/mars/tensor/expressions/random/random_integers.py
@@ -34,7 +34,7 @@ class TensorRandomIntegers(operands.RandomIntegers, TensorRandomOperandMixin):
         return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
-def random_integers(random_state, low, high=None, size=None, chunk_size=None, gpu=None, **kw):
+def random_integers(random_state, low, high=None, size=None, chunk_size=None, gpu=None):
     """
     Random integers of type mt.int between `low` and `high`, inclusive.
 
@@ -63,6 +63,8 @@ def random_integers(random_state, low, high=None, size=None, chunk_size=None, gp
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -117,5 +119,5 @@ def random_integers(random_state, low, high=None, size=None, chunk_size=None, gp
     """
     size = random_state._handle_size(size)
     op = TensorRandomIntegers(state=random_state._state, size=size, dtype=np.dtype(int),
-                              low=low, high=high, gpu=gpu, **kw)
+                              low=low, high=high, gpu=gpu)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/random_integers.py
+++ b/mars/tensor/expressions/random/random_integers.py
@@ -63,8 +63,6 @@ def random_integers(random_state, low, high=None, size=None, chunk_size=None, gp
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
-    dtype : data-type, optional
-      Data-type of the returned tensor.
 
     Returns
     -------

--- a/mars/tensor/expressions/random/random_sample.py
+++ b/mars/tensor/expressions/random/random_sample.py
@@ -33,7 +33,7 @@ class TensorRandomSample(operands.RandomSample, TensorRandomOperandMixin):
         return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
-def random_sample(random_state, size=None, chunk_size=None, gpu=None, **kw):
+def random_sample(random_state, size=None, chunk_size=None, gpu=None, dtype=None):
     """
     Return random floats in the half-open interval [0.0, 1.0).
 
@@ -53,6 +53,8 @@ def random_sample(random_state, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -78,8 +80,8 @@ def random_sample(random_state, size=None, chunk_size=None, gpu=None, **kw):
            [-2.99091858, -0.79479508],
            [-1.23204345, -1.75224494]])
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.dtype('f8')
+    if dtype is None:
+        dtype = np.dtype('f8')
     size = random_state._handle_size(size)
-    op = TensorRandomSample(state=random_state._state, size=size, **kw)
+    op = TensorRandomSample(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/rayleigh.py
+++ b/mars/tensor/expressions/random/rayleigh.py
@@ -33,7 +33,7 @@ class TensorRayleigh(operands.Rayleigh, TensorRandomOperandMixin):
         return self.new_tensor([scale], None, raw_chunk_size=chunk_size)
 
 
-def rayleigh(random_state, scale=1.0, size=None, chunk_size=None, gpu=None, **kw):
+def rayleigh(random_state, scale=1.0, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a Rayleigh distribution.
 
@@ -53,6 +53,8 @@ def rayleigh(random_state, scale=1.0, size=None, chunk_size=None, gpu=None, **kw
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -99,9 +101,9 @@ def rayleigh(random_state, scale=1.0, size=None, chunk_size=None, gpu=None, **kw
     >>> (100.*mt.sum(s>3)/1000000.).execute()
     0.087300000000000003
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().rayleigh(
+    if dtype is None:
+        dtype = np.random.RandomState().rayleigh(
             handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorRayleigh(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorRayleigh(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/standard_cauchy.py
+++ b/mars/tensor/expressions/random/standard_cauchy.py
@@ -32,7 +32,7 @@ class TensorStandardCauchy(operands.StandardCauchy, TensorRandomOperandMixin):
         return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
-def standard_cauchy(random_state, size=None, chunk_size=None, gpu=None, **kw):
+def standard_cauchy(random_state, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a standard Cauchy distribution with mode = 0.
 
@@ -48,6 +48,8 @@ def standard_cauchy(random_state, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -97,8 +99,8 @@ def standard_cauchy(random_state, size=None, chunk_size=None, gpu=None, **kw):
     >>> plt.hist(s.execute(), bins=100)
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().standard_cauchy(size=(0,)).dtype
+    if dtype is None:
+        dtype = np.random.RandomState().standard_cauchy(size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorStandardCauchy(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorStandardCauchy(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/standard_exponential.py
+++ b/mars/tensor/expressions/random/standard_exponential.py
@@ -32,7 +32,7 @@ class TensorStandardExponential(operands.StandardExponential, TensorRandomOperan
         return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
-def standard_exponential(random_state, size=None, chunk_size=None, gpu=None, **kw):
+def standard_exponential(random_state, size=None, chunk_size=None, gpu=None, dtype=None):
     """
     Draw samples from the standard exponential distribution.
 
@@ -49,6 +49,8 @@ def standard_exponential(random_state, size=None, chunk_size=None, gpu=None, **k
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -62,8 +64,8 @@ def standard_exponential(random_state, size=None, chunk_size=None, gpu=None, **k
     >>> import mars.tensor as mt
     >>> n = mt.random.standard_exponential((3, 8000))
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().standard_exponential(size=(0,)).dtype
+    if dtype is None:
+        dtype = np.random.RandomState().standard_exponential(size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorStandardExponential(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorStandardExponential(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/standard_gamma.py
+++ b/mars/tensor/expressions/random/standard_gamma.py
@@ -33,7 +33,7 @@ class TensorStandardGamma(operands.StandardGamma, TensorRandomOperandMixin):
         return self.new_tensor([shape], None, raw_chunk_size=chunk_size)
 
 
-def standard_gamma(random_state, shape, size=None, chunk_size=None, gpu=None, **kw):
+def standard_gamma(random_state, shape, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a standard Gamma distribution.
 
@@ -53,6 +53,8 @@ def standard_gamma(random_state, shape, size=None, chunk_size=None, gpu=None, **
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -105,9 +107,9 @@ def standard_gamma(random_state, shape, size=None, chunk_size=None, gpu=None, **
     >>> plt.plot(bins, y.execute(), linewidth=2, color='r')
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().standard_gamma(
+    if dtype is None:
+        dtype = np.random.RandomState().standard_gamma(
             handle_array(shape), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorStandardGamma(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorStandardGamma(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(shape, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/standard_normal.py
+++ b/mars/tensor/expressions/random/standard_normal.py
@@ -32,7 +32,7 @@ class TensorStandardNormal(operands.StandardNormal, TensorRandomOperandMixin):
         return self.new_tensor(None, None, raw_chunk_size=chunk_size)
 
 
-def standard_normal(random_state, size=None, chunk_size=None, gpu=None, **kw):
+def standard_normal(random_state, size=None, chunk_size=None, gpu=None, dtype=None):
     """
     Draw samples from a standard Normal distribution (mean=0, stdev=1).
 
@@ -46,6 +46,8 @@ def standard_normal(random_state, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -66,8 +68,8 @@ def standard_normal(random_state, size=None, chunk_size=None, gpu=None, **kw):
     >>> s.shape
     (3, 4, 2)
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().standard_normal(size=(0,)).dtype
+    if dtype is None:
+        dtype = np.random.RandomState().standard_normal(size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorStandardNormal(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorStandardNormal(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/standard_t.py
+++ b/mars/tensor/expressions/random/standard_t.py
@@ -33,7 +33,7 @@ class TensorStandardT(operands.StandardT, TensorRandomOperandMixin):
         return self.new_tensor([df], None, raw_chunk_size=chunk_size)
 
 
-def standard_t(random_state, df, size=None, chunk_size=None, gpu=None, **kw):
+def standard_t(random_state, df, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a standard Student's t distribution with `df` degrees
     of freedom.
@@ -55,6 +55,8 @@ def standard_t(random_state, df, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -124,9 +126,9 @@ def standard_t(random_state, df, size=None, chunk_size=None, gpu=None, **kw):
     So the p-value is about 0.009, which says the null hypothesis has a
     probability of about 99% of being true.
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().standard_t(
+    if dtype is None:
+        dtype = np.random.RandomState().standard_t(
             handle_array(df), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorStandardT(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorStandardT(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(df, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/triangular.py
+++ b/mars/tensor/expressions/random/triangular.py
@@ -33,7 +33,7 @@ class TensorTriangular(operands.Triangular, TensorRandomOperandMixin):
         return self.new_tensor([left, mode, right], None, raw_chunk_size=chunk_size)
 
 
-def triangular(random_state, left, mode, right, size=None, chunk_size=None, gpu=None, **kw):
+def triangular(random_state, left, mode, right, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from the triangular distribution over the
     interval ``[left, right]``.
@@ -62,6 +62,8 @@ def triangular(random_state, left, mode, right, size=None, chunk_size=None, gpu=
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -98,9 +100,9 @@ def triangular(random_state, left, mode, right, size=None, chunk_size=None, gpu=
     ...              normed=True)
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().triangular(
+    if dtype is None:
+        dtype = np.random.RandomState().triangular(
             handle_array(left), handle_array(mode), handle_array(right), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorTriangular(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorTriangular(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(left, mode, right, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/uniform.py
+++ b/mars/tensor/expressions/random/uniform.py
@@ -33,7 +33,7 @@ class TensorUniform(operands.Uniform, TensorRandomOperandMixin):
         return self.new_tensor([low, high], None, raw_chunk_size=chunk_size)
 
 
-def uniform(random_state, low=0.0, high=1.0, size=None, chunk_size=None, gpu=None, **kw):
+def uniform(random_state, low=0.0, high=1.0, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a uniform distribution.
 
@@ -59,6 +59,8 @@ def uniform(random_state, low=0.0, high=1.0, size=None, chunk_size=None, gpu=Non
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -113,9 +115,9 @@ def uniform(random_state, low=0.0, high=1.0, size=None, chunk_size=None, gpu=Non
     >>> plt.plot(bins, mt.ones_like(bins).execute(), linewidth=2, color='r')
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().uniform(
+    if dtype is None:
+        dtype = np.random.RandomState().uniform(
             handle_array(low), handle_array(high), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorUniform(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorUniform(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(low, high, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/vonmises.py
+++ b/mars/tensor/expressions/random/vonmises.py
@@ -33,7 +33,7 @@ class TensorVonmises(operands.Vonmises, TensorRandomOperandMixin):
         return self.new_tensor([mu, kappa], None, raw_chunk_size=chunk_size)
 
 
-def vonmises(random_state, mu, kappa, size=None, chunk_size=None, gpu=None, **kw):
+def vonmises(random_state, mu, kappa, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a von Mises distribution.
 
@@ -60,6 +60,8 @@ def vonmises(random_state, mu, kappa, size=None, chunk_size=None, gpu=None, **kw
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -114,10 +116,10 @@ def vonmises(random_state, mu, kappa, size=None, chunk_size=None, gpu=None, **kw
     >>> plt.plot(x.execute(), y.execute(), linewidth=2, color='r')
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().vonmises(
+    if dtype is None:
+        dtype = np.random.RandomState().vonmises(
             handle_array(mu), handle_array(kappa), size=(0,)).dtype
 
     size = random_state._handle_size(size)
-    op = TensorVonmises(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorVonmises(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(mu, kappa, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/wald.py
+++ b/mars/tensor/expressions/random/wald.py
@@ -33,7 +33,7 @@ class TensorWald(operands.Wald, TensorRandomOperandMixin):
         return self.new_tensor([mean, scale], None, raw_chunk_size=chunk_size)
 
 
-def wald(random_state, mean, scale, size=None, chunk_size=None, gpu=None, **kw):
+def wald(random_state, mean, scale, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a Wald, or inverse Gaussian, distribution.
 
@@ -61,6 +61,8 @@ def wald(random_state, mean, scale, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -98,9 +100,9 @@ def wald(random_state, mean, scale, size=None, chunk_size=None, gpu=None, **kw):
     >>> h = plt.hist(mt.random.wald(3, 2, 100000).execute(), bins=200, normed=True)
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().wald(
+    if dtype is None:
+        dtype = np.random.RandomState().wald(
             handle_array(mean), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorWald(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorWald(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(mean, scale, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/weibull.py
+++ b/mars/tensor/expressions/random/weibull.py
@@ -33,7 +33,7 @@ class TensorWeibull(operands.Weibull, TensorRandomOperandMixin):
         return self.new_tensor([a], None, raw_chunk_size=chunk_size)
 
 
-def weibull(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
+def weibull(random_state, a, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a Weibull distribution.
 
@@ -60,6 +60,8 @@ def weibull(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -129,9 +131,9 @@ def weibull(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
     >>> plt.plot(x.execute(), (weib(x, 1., 5.)*scale).execute())
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().weibull(
+    if dtype is None:
+        dtype = np.random.RandomState().weibull(
             handle_array(a), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorWeibull(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorWeibull(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(a, chunk_size=chunk_size)

--- a/mars/tensor/expressions/random/zipf.py
+++ b/mars/tensor/expressions/random/zipf.py
@@ -33,7 +33,7 @@ class TensorZipf(operands.Zipf, TensorRandomOperandMixin):
         return self.new_tensor([a], None, raw_chunk_size=chunk_size)
 
 
-def zipf(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
+def zipf(random_state, a, size=None, chunk_size=None, gpu=None, dtype=None):
     r"""
     Draw samples from a Zipf distribution.
 
@@ -58,6 +58,8 @@ def zipf(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
         Desired chunk size on each dimension
     gpu : bool, optional
         Allocate the tensor on GPU if True, False as default
+    dtype : data-type, optional
+      Data-type of the returned tensor.
 
     Returns
     -------
@@ -110,10 +112,10 @@ def zipf(random_state, a, size=None, chunk_size=None, gpu=None, **kw):
     >>> plt.plot(x.execute(), (y/mt.max(y)).execute(), linewidth=2, color='r')
     >>> plt.show()
     """
-    if 'dtype' not in kw:
-        kw['dtype'] = np.random.RandomState().zipf(
+    if dtype is None:
+        dtype = np.random.RandomState().zipf(
             handle_array(a), size=(0,)).dtype
 
     size = random_state._handle_size(size)
-    op = TensorZipf(size=size, state=random_state._state, gpu=gpu, **kw)
+    op = TensorZipf(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
     return op(a, chunk_size=chunk_size)

--- a/mars/tensor/expressions/tests/test_random.py
+++ b/mars/tensor/expressions/tests/test_random.py
@@ -105,7 +105,7 @@ class Test(TestBase):
 
     def testUnexpectedKey(self):
         with self.assertRaises(ValueError):
-            arr = rand(10, 10, chunks=5)
+            rand(10, 10, chunks=5)
 
         with self.assertRaises(ValueError):
-            arr = randn(10, 10, chunks=5)
+            randn(10, 10, chunks=5)

--- a/mars/tensor/expressions/tests/test_random.py
+++ b/mars/tensor/expressions/tests/test_random.py
@@ -16,7 +16,7 @@
 
 import numpy as np
 
-from mars.tensor.expressions.random import RandomState, beta, rand, choice, multivariate_normal, randint
+from mars.tensor.expressions.random import RandomState, beta, rand, choice, multivariate_normal, randint, randn
 from mars.tensor.expressions.datasource import tensor as from_ndarray
 from mars.tensor.expressions.tests.test_core import TestBase
 
@@ -102,3 +102,10 @@ class Test(TestBase):
         self.assertEqual(arr.chunks[0].op.low, 1)
         self.assertEqual(arr.chunks[0].op.high, 2)
         self.assertEqual(arr.chunks[0].op.density, .01)
+
+    def testUnexpectedKey(self):
+        with self.assertRaises(ValueError):
+            arr = rand(10, 10, chunks=5)
+
+        with self.assertRaises(ValueError):
+            arr = randn(10, 10, chunks=5)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Check `mt.random.rand` and `mt.random.randn` parameters and raises `ValueError` if argument key not starts with '_' except `chunk_size`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
fixes #91 