### PR TITLE
Fix setitem and getitem generate same operand key

### DIFF
--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -197,13 +197,14 @@ class Test(unittest.TestCase):
                 np.testing.assert_array_equal(r, np.ones((5, 5)) * 2)
 
             with new_session(cluster.endpoint) as session3:
-                a = mt.ones((100, 5))
+                a = mt.random.rand(100, 5)
 
                 slice1 = a[:10]
                 slice2 = a[10:20]
-                r1, r2 = session3.run(slice1, slice2)
+                r1, r2, expected = session3.run(slice1, slice2, a)
 
-                np.testing.assert_array_equal(r1, r2)
+                np.testing.assert_array_equal(r1, expected[:10])
+                np.testing.assert_array_equal(r2, expected[10:20])
 
     def testExecutableTuple(self):
         with new_cluster(scheduler_n_process=2, worker_n_process=2, web=True) as cluster:

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -196,6 +196,15 @@ class Test(unittest.TestCase):
 
                 np.testing.assert_array_equal(r, np.ones((5, 5)) * 2)
 
+            with new_session(cluster.endpoint) as session3:
+                a = mt.ones((100, 5))
+
+                slice1 = a[:10]
+                slice2 = a[10:20]
+                r1, r2 = session3.run(slice1, slice2)
+
+                np.testing.assert_array_equal(r1, r2)
+
     def testExecutableTuple(self):
         with new_cluster(scheduler_n_process=2, worker_n_process=2, web=True) as cluster:
             with new_session('http://' + cluster._web_endpoint).as_default():

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -206,6 +206,16 @@ class Test(unittest.TestCase):
                 np.testing.assert_array_equal(r1, expected[:10])
                 np.testing.assert_array_equal(r2, expected[10:20])
 
+            with new_session(cluster.endpoint) as session4:
+                a = mt.random.rand(100, 5)
+
+                a[:10] = mt.ones((10, 5))
+                a[10:20] = 2
+                r = session4.run(a)
+
+                np.testing.assert_array_equal(r[:10], np.ones((10, 5)))
+                np.testing.assert_array_equal(r[10:20], np.ones((10, 5)) * 2)
+
     def testExecutableTuple(self):
         with new_cluster(scheduler_n_process=2, worker_n_process=2, web=True) as cluster:
             with new_session('http://' + cluster._web_endpoint).as_default():

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -45,8 +45,6 @@ class TensorIndex(Index, TensorOperandMixin):
         """
         if indexes is not None:
             self._indexes = indexes
-
-        if indexes is not None:
             indexes_inputs = [ind for ind in indexes if isinstance(ind, (BaseWithKey, Entity))]
             inputs = inputs + indexes_inputs
         yield inputs

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -44,12 +44,12 @@ class TensorIndex(Index, TensorOperandMixin):
         from operand itself and replace tensor-liked indexes by new one in `inputs`.
         """
         if indexes is not None:
+            self._indexes = indexes
+
+        if indexes is not None:
             indexes_inputs = [ind for ind in indexes if isinstance(ind, (BaseWithKey, Entity))]
             inputs = inputs + indexes_inputs
         yield inputs
-
-        if indexes is not None:
-            self._indexes = indexes
 
         inputs_iter = iter(self._inputs[1:])
         new_indexes = [next(inputs_iter) if isinstance(index, (BaseWithKey, Entity)) else index

--- a/mars/tensor/expressions/indexing/setitem.py
+++ b/mars/tensor/expressions/indexing/setitem.py
@@ -38,6 +38,11 @@ class TensorIndexSetValue(IndexSetValue, TensorOperandMixin):
         them may be tensor type. As explained in TensorIndex, when indexes and value are not provided, we should get
         from operand itself and replace tensor-liked objects by iterating over inputs.
         """
+        if indexes is not None:
+            self._indexes = indexes
+        if value is not None:
+            self._value = value
+
         if indexes is not None and value is not None:
             indexes_inputs = [ind for ind in indexes if isinstance(ind, TENSOR_TYPE + CHUNK_TYPE)]
             inputs += indexes_inputs
@@ -45,10 +50,6 @@ class TensorIndexSetValue(IndexSetValue, TensorOperandMixin):
                 inputs += [value]
         yield inputs
 
-        if indexes is not None:
-            self._indexes = indexes
-        if value is not None:
-            self._value = value
         inputs_iter = iter(self._inputs[1:])
         new_indexes = [next(inputs_iter) if isinstance(index, (BaseWithKey, Entity)) else index
                        for index in self._indexes]

--- a/mars/tensor/expressions/indexing/setitem.py
+++ b/mars/tensor/expressions/indexing/setitem.py
@@ -38,12 +38,10 @@ class TensorIndexSetValue(IndexSetValue, TensorOperandMixin):
         them may be tensor type. As explained in TensorIndex, when indexes and value are not provided, we should get
         from operand itself and replace tensor-liked objects by iterating over inputs.
         """
-        if indexes is not None:
+        if indexes is not None and value is not None:
             self._indexes = indexes
-        if value is not None:
             self._value = value
 
-        if indexes is not None and value is not None:
             indexes_inputs = [ind for ind in indexes if isinstance(ind, TENSOR_TYPE + CHUNK_TYPE)]
             inputs += indexes_inputs
             if isinstance(value, TENSOR_TYPE + CHUNK_TYPE):

--- a/mars/tensor/expressions/tests/test_indexing.py
+++ b/mars/tensor/expressions/tests/test_indexing.py
@@ -221,4 +221,4 @@ class Test(unittest.TestCase):
         t_slice1 = t[:5]
         t_slice2 = t[5:]
 
-        self.assertNotEqual(t_slice1.op.key, t_slice2.op.key,)
+        self.assertNotEqual(t_slice1.op.key, t_slice2.op.key)

--- a/mars/tensor/expressions/tests/test_indexing.py
+++ b/mars/tensor/expressions/tests/test_indexing.py
@@ -215,3 +215,10 @@ class Test(unittest.TestCase):
         y = nonzero(x)
 
         self.assertEqual(len(y), 2)
+
+    def testOperandKey(self):
+        t = ones((10, 2), chunk_size=5)
+        t_slice1 = t[:5]
+        t_slice2 = t[5:]
+
+        self.assertNotEqual(t_slice1.op.key, t_slice2.op.key,)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Set `indexes` or `value` before generate operand key in `TensorIndexSetValue` and `TensorIndex` if they are provided.

## Related issue number

fixes #98 
