### PR TITLE
Use property instead of weak-key dict to store cix

### DIFF
--- a/mars/graph.pyx
+++ b/mars/graph.pyx
@@ -18,7 +18,8 @@ import logging
 from collections import deque
 
 from .compat import six, Enum
-from .serialize import Serializable, ValueType, ProviderType, \
+from .serialize import Serializable
+from .serialize.core cimport ValueType, ProviderType, \
     OneOfField, ListField, Int8Field
 
 logger = logging.getLogger(__name__)
@@ -315,15 +316,15 @@ cdef class DirectedGraph:
             elif isinstance(node, TENSOR_TYPE):
                 node = node.data if isinstance(node, Tensor) else node
                 if level is None:
-                    level = SerialiableGraph.Level.TENSOR
+                    level = SerializableGraph.Level.TENSOR
                 for c in (node.chunks or ()):
                     add_obj(c)
                 add_obj(node)
             else:
                 raise TypeError('Unknown node type to serialize: {0}'.format(type(node)))
 
-        s_graph = SerialiableGraph(_nodes=nodes)
-        s_graph.level = level if level is not None else SerialiableGraph.Level.CHUNK
+        s_graph = SerializableGraph(_nodes=nodes)
+        s_graph.level = level if level is not None else SerializableGraph.Level.CHUNK
         return s_graph
 
     @classmethod
@@ -388,7 +389,7 @@ cdef class DirectedGraph:
         from .tensor.core import ChunkData, TensorData
 
         graph = cls()
-        node_type = TensorData if s_graph.level == SerialiableGraph.Level.TENSOR else ChunkData
+        node_type = TensorData if s_graph.level == SerializableGraph.Level.TENSOR else ChunkData
         for node in s_graph.nodes:
             if isinstance(node, node_type):
                 graph.add_node(node)
@@ -405,7 +406,7 @@ cdef class DirectedGraph:
     @classmethod
     def from_pb(cls, pb_obj):
         try:
-            return cls.deserialize(SerialiableGraph.from_pb(pb_obj))
+            return cls.deserialize(SerializableGraph.from_pb(pb_obj))
         except KeyError as e:
             logger.error('Failed to deserialize graph, graph_def: {0}'.format(pb_obj))
             raise
@@ -415,7 +416,7 @@ cdef class DirectedGraph:
 
     @classmethod
     def from_json(cls, json_obj):
-        return cls.deserialize(SerialiableGraph.from_json(json_obj))
+        return cls.deserialize(SerializableGraph.from_json(json_obj))
 
     def compose(self, list keys=None):
         from .fuse import Fusion
@@ -495,7 +496,7 @@ class SerializableGraphNode(Serializable):
         return getattr(self, '_node', None)
 
 
-class SerialiableGraph(Serializable):
+class SerializableGraph(Serializable):
     class Level(Enum):
         CHUNK = 0
         TENSOR = 1
@@ -510,11 +511,11 @@ class SerialiableGraph(Serializable):
 
             return GraphDef
 
-        return super(SerialiableGraph, cls).cls(provider)
+        return super(SerializableGraph, cls).cls(provider)
 
     @property
     def level(self):
-        return SerialiableGraph.Level(self._level)
+        return SerializableGraph.Level(self._level)
 
     @level.setter
     def level(self, level):

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -125,7 +125,8 @@ class Chunk(Entity):
 
 
 class TensorData(SerializableWithKey, Tilesable):
-    __slots__ = '__weakref__', '_siblings'
+    __slots__ = '__weakref__', '_siblings', '_cix'
+    _no_copy_attrs_ = SerializableWithKey._no_copy_attrs_ | {'_cix'}
 
     # required fields
     _shape = TupleField('shape', ValueType.int64,
@@ -266,10 +267,9 @@ class TensorData(SerializableWithKey, Tilesable):
             return ChunksIndexer(self)
 
         try:
-            if self not in _tensor_to_chunk_indexer:
-                _tensor_to_chunk_indexer[self] = ChunksIndexer(self)
-
-            return _tensor_to_chunk_indexer[self]
+            if getattr(self, '_cix', None) is None:
+                self._cix = ChunksIndexer(self)
+            return self._cix
         except (TypeError, ValueError):
             return ChunksIndexer(self)
 
@@ -544,7 +544,6 @@ class SparseTensor(Tensor):
 TENSOR_TYPE = (Tensor, TensorData)
 CHUNK_TYPE = (Chunk, ChunkData)
 
-_tensor_to_chunk_indexer = WeakKeyDictionary()
 _threading_local = threading.local()
 
 


### PR DESCRIPTION
## What do these changes do?

Use property instead of weak-key dict to store cix in order to accelerate. This avoids __eq__() calls in WeakKeyDictionary when seeking items and can reduce the time of tiling by at least 50%.

## Related issue number

N/A
