### PR TITLE
Support QR decomposition on short-and-fat tensor(sfqr method)

### DIFF
--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -55,6 +55,23 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.allclose(res, data))
 
+        # test for Short-and-Fat QR
+        data = np.random.randn(6, 18)
+
+        a = tensor(data, chunk_size=(6, 9))
+        q, r = qr(a, method='sfqr')
+        t = q.dot(r)
+
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        self.assertTrue(np.allclose(res, data))
+
+        a = tensor(data, chunk_size=(3, 3))
+        q, r = qr(a, method='sfqr')
+        t = q.dot(r)
+
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        self.assertTrue(np.allclose(res, data))
+
     def testSVDExecution(self):
         data = np.random.randn(18, 6) + 1j * np.random.randn(18, 6)
 
@@ -73,6 +90,15 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(res, data))
 
         a = tensor(data, chunk_size=(2, 6))
+        U, s, V = svd(a)
+        t = U.dot(diag(s).dot(V))
+
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        self.assertTrue(np.allclose(res, data))
+
+        data = np.random.randn(6, 18) + 1j * np.random.randn(6, 18)
+
+        a = tensor(data)
         U, s, V = svd(a)
         t = U.dot(diag(s).dot(V))
 

--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -72,6 +72,13 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.allclose(res, data))
 
+        a = tensor(data, chunk_size=(6, 3))
+        q, r = qr(a, method='sfqr')
+        t = q.dot(r)
+
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        self.assertTrue(np.allclose(res, data))
+
     def testSVDExecution(self):
         data = np.random.randn(18, 6) + 1j * np.random.randn(18, 6)
 

--- a/mars/tensor/expressions/linalg/core.py
+++ b/mars/tensor/expressions/linalg/core.py
@@ -39,12 +39,18 @@ class SFQR(object):
         tinyq, tinyr = np.linalg.qr(np.ones((1, 1), dtype=a.dtype))
         q_dtype, r_dtype = tinyq.dtype, tinyr.dtype
 
+        need_rechunk = False
+        rechunk_size = dict()
         if a.chunk_shape[0] != 1:
-            new_chunks = decide_chunk_sizes(a.shape, {1: a.shape[0]}, a.dtype.itemsize)
-            a = a.rechunk(new_chunks).single_tiles()
+            need_rechunk = True
+            rechunk_size[0] = a.shape[0]
 
         if len(a.chunks) > 1 and a.chunks[0].shape[0] > a.chunks[0].shape[1]:
-            new_chunks = decide_chunk_sizes(a.shape, {1: a.shape[0]}, a.dtype.itemsize)
+            need_rechunk = True
+            rechunk_size[1] = a.shape[0]
+
+        if need_rechunk:
+            new_chunks = decide_chunk_sizes(a.shape, rechunk_size, a.dtype.itemsize)
             a = a.rechunk(new_chunks).single_tiles()
 
         # A_1's QR decomposition

--- a/mars/tensor/expressions/linalg/core.py
+++ b/mars/tensor/expressions/linalg/core.py
@@ -39,17 +39,14 @@ class SFQR(object):
         tinyq, tinyr = np.linalg.qr(np.ones((1, 1), dtype=a.dtype))
         q_dtype, r_dtype = tinyq.dtype, tinyr.dtype
 
-        need_rechunk = False
         rechunk_size = dict()
         if a.chunk_shape[0] != 1:
-            need_rechunk = True
             rechunk_size[0] = a.shape[0]
 
         if len(a.chunks) > 1 and a.chunks[0].shape[0] > a.chunks[0].shape[1]:
-            need_rechunk = True
             rechunk_size[1] = a.shape[0]
 
-        if need_rechunk:
+        if rechunk_size:
             new_chunks = decide_chunk_sizes(a.shape, rechunk_size, a.dtype.itemsize)
             a = a.rechunk(new_chunks).single_tiles()
 

--- a/mars/tensor/expressions/linalg/core.py
+++ b/mars/tensor/expressions/linalg/core.py
@@ -43,6 +43,10 @@ class SFQR(object):
             new_chunks = decide_chunk_sizes(a.shape, {1: a.shape[0]}, a.dtype.itemsize)
             a = a.rechunk(new_chunks).single_tiles()
 
+        if len(a.chunks) > 1 and a.chunks[0].shape[0] > a.chunks[0].shape[1]:
+            new_chunks = decide_chunk_sizes(a.shape, {1: a.shape[0]}, a.dtype.itemsize)
+            a = a.rechunk(new_chunks).single_tiles()
+
         # A_1's QR decomposition
         r_chunks = []
         first_chunk = a.chunks[0]

--- a/mars/tensor/expressions/linalg/core.py
+++ b/mars/tensor/expressions/linalg/core.py
@@ -21,7 +21,7 @@ from ..utils import decide_chunk_sizes
 from ..core import TensorOperandMixin
 
 
-class TSQR(TensorOperandMixin):
+class QRBase(TensorOperandMixin):
     __slots__ = ()
 
     @classmethod
@@ -30,6 +30,67 @@ class TSQR(TensorOperandMixin):
 
     @classmethod
     def tile(cls, op):
+        if op.method == 'tsqr':
+            return cls.tsqr_tile(op)
+        elif op.method == 'sfqr':
+            return cls.sfqr_tile(op)
+        else:
+            raise NotImplementedError('Only tsqr and sfqr method supported for now')
+
+    @classmethod
+    def sfqr_tile(cls, op):
+        """
+        Short-and-Fat QR
+
+        Q [R_1 R_2 ...] = [A_1 A_2 ...]
+        """
+        from .qr import TensorQR
+        from .dot import TensorDot
+        from ..base import TensorTranspose
+
+        a = op.input
+
+        tinyq, tinyr = np.linalg.qr(np.ones((1, 1), dtype=a.dtype))
+        q_dtype, r_dtype = tinyq.dtype, tinyr.dtype
+
+        if a.chunk_shape[0] != 1:
+            new_chunks = decide_chunk_sizes(a.shape, {1: a.shape[0]}, a.dtype.itemsize)
+            a = a.rechunk(new_chunks).single_tiles()
+
+        # A_1's QR decomposition
+        r_chunks = []
+        first_chunk = a.chunks[0]
+        x, y = first_chunk.shape
+        q_shape = first_chunk.shape if x > y else (x, x)
+        r_shape = first_chunk.shape if x < y else (y, y)
+        qr_op = TensorQR()
+        q_chunk, r_chunk = qr_op.new_chunks([first_chunk], (q_shape, r_shape),
+                                            index=(0, 0),
+                                            kws=[{'side': 'q', 'dtype': q_dtype},
+                                                 {'side': 'r', 'dtype': r_dtype}])
+        # q is an orthogonal matrix, so q.T and inverse of q is equal
+        trans_op = TensorTranspose()
+        q_transpose = trans_op.new_chunk([q_chunk], q_chunk.shape)
+        r_chunks.append(r_chunk)
+
+        r_rest = [TensorDot().new_chunk([q_transpose, c], (q_transpose.shape[0], c.shape[1]),
+                                        index=c.index) for c in a.chunks[1:]]
+        r_chunks.extend(r_rest)
+
+        q, r = op.outputs
+        new_op = op.copy()
+        q_nsplits = ((q_chunk.shape[0],), (q_chunk.shape[1],))
+        r_nsplits = ((1,), (c.shape[1] for c in r_chunks))
+        kws = [
+            # Q
+            {'chunks': [q_chunk], 'nsplits': q_nsplits, 'dtype': q.dtype},
+            # R, calculate from stage2
+            {'chunks': r_chunks, 'nsplits': r_nsplits, 'dtype': r.dtype}
+        ]
+        return new_op.new_tensors(op.inputs, [q.shape, r.shape], kws=kws)
+
+    @classmethod
+    def tsqr_tile(cls, op):
         from ..merge.concatenate import TensorConcatenate
         from ..indexing.slice import TensorSlice
         from .dot import TensorDot
@@ -90,6 +151,7 @@ class TSQR(TensorOperandMixin):
         if not calc_svd:
             q, r = op.outputs
             new_op = op.copy()
+            # unify_nsplits will get nsplits by chunk shape if it was set to (1,)
             q_nsplits = ((c.shape[0] for c in stage3_q_chunks), (1,))
             r_nsplits = ((stage2_r_chunk.shape[0],), (stage2_r_chunk.shape[1],))
             kws = [

--- a/mars/tensor/expressions/linalg/qr.py
+++ b/mars/tensor/expressions/linalg/qr.py
@@ -20,10 +20,11 @@ from numpy.linalg import LinAlgError
 from .... import operands
 from ...core import ExecutableTuple
 from ..datasource import tensor as astensor
-from .core import QRBase
+from ..core import TensorOperandMixin
+from .core import SFQR, TSQR
 
 
-class TensorQR(operands.QR, QRBase):
+class TensorQR(operands.QR, TensorOperandMixin):
     def __init__(self, method=None, dtype=None, **kw):
         super(TensorQR, self).__init__(_method=method, _dtype=dtype, **kw)
 
@@ -67,8 +68,12 @@ class TensorQR(operands.QR, QRBase):
                 {'chunks': [r_chunk], 'nsplits': ((1,), (1,)), 'dtype': r_dtype}
             ]
             return new_op.new_tensors(op.inputs, [q_shape, r_shape], kws=kws)
+        elif op.method == 'tsqr':
+            return TSQR.tile(op)
+        elif op.method == 'sfqr':
+            return SFQR.tile(op)
         else:
-            return super(TensorQR, cls).tile(op)
+            raise NotImplementedError('Only tsqr method supported for now')
 
 
 def qr(a, method='tsqr'):

--- a/mars/tensor/expressions/linalg/qr.py
+++ b/mars/tensor/expressions/linalg/qr.py
@@ -98,6 +98,10 @@ def qr(a, method='tsqr'):
             IEEE International Conference on Big Data, 2013.
             http://arxiv.org/abs/1301.1071
 
+        FSQR is a QR decomposition for fat and short matrix:
+            A = [A1, A2, A3, ...], A1 may be decomposed as A1 = Q1 * R1,
+            for A = Q * R, Q = Q1, R = [R1, R2, R3, ...] where A2 = Q1 * R2, A3 = Q1 * R3, ...
+
     Returns
     -------
     q : Tensor of float or complex, optional

--- a/mars/tensor/expressions/linalg/qr.py
+++ b/mars/tensor/expressions/linalg/qr.py
@@ -20,10 +20,10 @@ from numpy.linalg import LinAlgError
 from .... import operands
 from ...core import ExecutableTuple
 from ..datasource import tensor as astensor
-from .core import TSQR
+from .core import QRBase
 
 
-class TensorQR(operands.QR, TSQR):
+class TensorQR(operands.QR, QRBase):
     def __init__(self, method=None, dtype=None, **kw):
         super(TensorQR, self).__init__(_method=method, _dtype=dtype, **kw)
 
@@ -67,11 +67,8 @@ class TensorQR(operands.QR, TSQR):
                 {'chunks': [r_chunk], 'nsplits': ((1,), (1,)), 'dtype': r_dtype}
             ]
             return new_op.new_tensors(op.inputs, [q_shape, r_shape], kws=kws)
-        elif op.method == 'tsqr':
-            return super(TensorQR, cls).tile(op)
-        # TODO(hks): support sfqr(short-and-fat qr)
         else:
-            raise NotImplementedError('Only tsqr method supported for now')
+            return super(TensorQR, cls).tile(op)
 
 
 def qr(a, method='tsqr'):
@@ -85,7 +82,7 @@ def qr(a, method='tsqr'):
     ----------
     a : array_like, shape (M, N)
         Matrix to be factored.
-    method: {'tsqr'}, optional
+    method: {'tsqr', 'sfqr'}, optional
         method to calculate qr factorization, tsqr as default
 
         TSQR is presented in:

--- a/mars/tensor/expressions/linalg/svd.py
+++ b/mars/tensor/expressions/linalg/svd.py
@@ -20,10 +20,10 @@ from numpy.linalg import LinAlgError
 from .... import operands
 from ...core import ExecutableTuple
 from ..datasource import tensor as astensor
-from .core import TSQR
+from .core import QRBase
 
 
-class TensorSVD(operands.SVD, TSQR):
+class TensorSVD(operands.SVD, QRBase):
     def __init__(self, method=None, dtype=None, **kw):
         super(TensorSVD, self).__init__(_method=method, _dtype=dtype, **kw)
 
@@ -44,9 +44,17 @@ class TensorSVD(operands.SVD, TSQR):
 
         tiny_U, tiny_s, tiny_V = np.linalg.svd(np.ones((1, 1), dtype=a.dtype))
 
-        U_shape = a.shape
-        s_shape = (a.shape[1],)
-        V_shape = (a.shape[1],) * 2
+        # if a's shape is (6, 18), U's shape is (6, 6), s's shape is (6,), V's shape is (6, 18)
+        # if a's shape is (18, 6), U's shape is (18, 6), s's shape is (6,), V's shape is (6, 6)
+        x, y = a.shape
+        if x > y:
+            U_shape = (x, y)
+            s_shape = (y, )
+            V_shape = (y, y)
+        else:
+            U_shape = (x, x)
+            s_shape = (x, )
+            V_shape = (x, y)
         U, s, V = self.new_tensors([a], (U_shape, s_shape, V_shape),
                                    kws=[
                                        {'side': 'U', 'dtype': tiny_U.dtype},

--- a/mars/tensor/expressions/linalg/svd.py
+++ b/mars/tensor/expressions/linalg/svd.py
@@ -20,10 +20,11 @@ from numpy.linalg import LinAlgError
 from .... import operands
 from ...core import ExecutableTuple
 from ..datasource import tensor as astensor
-from .core import QRBase
+from ..core import TensorOperandMixin
+from .core import TSQR
 
 
-class TensorSVD(operands.SVD, QRBase):
+class TensorSVD(operands.SVD, TensorOperandMixin):
     def __init__(self, method=None, dtype=None, **kw):
         super(TensorSVD, self).__init__(_method=method, _dtype=dtype, **kw)
 
@@ -91,7 +92,7 @@ class TensorSVD(operands.SVD, QRBase):
             ]
             return new_op.new_tensors(op.inputs, [U_shape, s_shape, V_shape], kws=kws)
         elif op.method == 'tsqr':
-            return super(TensorSVD, cls).tile(op)
+            return TSQR.tile(op)
         else:
             raise NotImplementedError('Only tsqr method supported for now')
 

--- a/mars/tensor/expressions/tests/test_linalg.py
+++ b/mars/tensor/expressions/tests/test_linalg.py
@@ -35,6 +35,18 @@ class Test(unittest.TestCase):
         self.assertEqual(len(q.chunks), 3)
         self.assertEqual(len(r.chunks), 1)
 
+        # for Short-and-Fat QR
+        a = mt.random.rand(6, 9, chunk_size=(6, 3))
+        q, r = mt.linalg.qr(a, method='sfqr')
+
+        self.assertEqual(q.shape, (6, 6))
+        self.assertEqual(r.shape, (6, 9))
+
+        q.tiles()
+
+        self.assertEqual(len(q.chunks), 1)
+        self.assertEqual(len(r.chunks), 3)
+
     def testNorm(self):
         data = np.random.rand(9, 6)
 
@@ -80,6 +92,13 @@ class Test(unittest.TestCase):
 
         self.assertEqual(s.ndim, 1)
         self.assertEqual(len(s.chunks[0].index), 1)
+
+        a = mt.random.rand(6, 9, chunk_size=(6, 9))
+        U, s, V = mt.linalg.svd(a)
+
+        self.assertEqual(U.shape, (6, 6))
+        self.assertEqual(s.shape, (6,))
+        self.assertEqual(V.shape, (6, 9))
 
         rs = mt.random.RandomState(1)
         a = rs.rand(9, 6, chunk_size=(3, 6))

--- a/mars/tensor/expressions/tests/test_linalg.py
+++ b/mars/tensor/expressions/tests/test_linalg.py
@@ -36,6 +36,18 @@ class Test(unittest.TestCase):
         self.assertEqual(len(r.chunks), 1)
 
         # for Short-and-Fat QR
+        a = mt.random.rand(6, 18, chunk_size=(6, 6))
+        q, r = mt.linalg.qr(a, method='sfqr')
+
+        self.assertEqual(q.shape, (6, 6))
+        self.assertEqual(r.shape, (6, 18))
+
+        q.tiles()
+
+        self.assertEqual(len(q.chunks), 1)
+        self.assertEqual(len(r.chunks), 3)
+
+        # chunk width less than height
         a = mt.random.rand(6, 9, chunk_size=(6, 3))
         q, r = mt.linalg.qr(a, method='sfqr')
 
@@ -45,7 +57,18 @@ class Test(unittest.TestCase):
         q.tiles()
 
         self.assertEqual(len(q.chunks), 1)
-        self.assertEqual(len(r.chunks), 3)
+        self.assertEqual(len(r.chunks), 2)
+
+        a = mt.random.rand(9, 6, chunk_size=(9, 3))
+        q, r = mt.linalg.qr(a, method='sfqr')
+
+        self.assertEqual(q.shape, (9, 6))
+        self.assertEqual(r.shape, (6, 6))
+
+        q.tiles()
+
+        self.assertEqual(len(q.chunks), 1)
+        self.assertEqual(len(r.chunks), 1)
 
     def testNorm(self):
         data = np.random.rand(9, 6)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Add 'sfqr' method for `mt.linalg.qr`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
resolve #114 