### PR TITLE
Implement __array__ protocol for Tensor

### DIFF
--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -546,6 +546,12 @@ class Tensor(Entity):
 
         self._data = set_imag(self._data, new_imag).data
 
+    def __array__(self, dtype=None):
+        ret = np.asarray(self.execute())
+        if dtype is not None:
+            ret = ret.astype(dtype)
+        return ret
+
 
 class SparseTensor(Tensor):
     __slots__ = ()

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -547,10 +547,7 @@ class Tensor(Entity):
         self._data = set_imag(self._data, new_imag).data
 
     def __array__(self, dtype=None):
-        ret = np.asarray(self.execute())
-        if dtype is not None:
-            ret = ret.astype(dtype)
-        return ret
+        return np.asarray(self.execute(), dtype=dtype)
 
 
 class SparseTensor(Tensor):

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -162,3 +162,24 @@ class Test(unittest.TestCase):
         arr3 = arr2.reshape((5, 5))
         expected = np.ones((5, 5))
         np.testing.assert_array_equal(arr3.execute(), expected)
+
+    def testArrayProtocol(self):
+        arr = mt.ones((10, 20))
+
+        result = np.asarray(arr)
+        np.testing.assert_array_equal(result, np.ones((10, 20)))
+
+        arr2 = mt.ones((10, 20))
+
+        result = np.asarray(arr2, mt.bool_)
+        np.testing.assert_array_equal(result, np.ones((10, 20), dtype=np.bool_))
+
+        arr3 = mt.ones((10, 20)).sum()
+
+        result = np.asarray(arr3)
+        np.testing.assert_array_equal(result, np.asarray(200))
+
+        arr4 = mt.ones((10, 20)).sum()
+
+        result = np.asarray(arr4, dtype=np.float_)
+        np.testing.assert_array_equal(result, np.asarray(200, dtype=np.float_))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Implement the `__array__` protocol, so that `numpy.asarray` can convert mars tensor to numpy ndarray.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolve #125 
