### PR TITLE
Add 'rough_nbytes' for tensor data type

### DIFF
--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -242,13 +242,14 @@ class Test(unittest.TestCase):
                 c = b.reshape((4, 4))
                 self.assertEqual(c.shape, (4, 4))
 
+            # test unknown-shape fusion
             with new_session('http://' + cluster._web_endpoint) as session2:
                 a = mt.random.rand(8, 8, chunk_size=4)
                 a[2:6, 2:6] = mt.ones((4, 4)) * 2
-                b = mt.sum(a[a > 1] - 1)
+                b = (a[a > 1] - 1) * 2
 
                 r = session2.run(b)
-                self.assertEqual(r, 16)
+                np.testing.assert_array_equal(r, np.ones((16,)) * 2)
 
     def testExecutableTuple(self):
         with new_cluster(scheduler_n_process=2, worker_n_process=2, web=True) as cluster:

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -27,12 +27,9 @@ from mars.serialize import Int64Field
 from mars.config import options
 from mars.session import new_session, Session
 from mars.deploy.local.core import new_cluster, LocalDistributedCluster, gen_endpoint
-from mars.deploy.local.session import LocalClusterSession
 from mars.cluster_info import ClusterInfoActor
 from mars.scheduler import SessionManagerActor
 from mars.worker.dispatcher import DispatchActor
-from mars.api import MarsAPI
-from mars.tests.core import patch_method
 
 
 def _on_deserialize_fail(x):
@@ -219,14 +216,8 @@ class Test(unittest.TestCase):
                 np.testing.assert_array_equal(r[:10], np.ones((10, 5)))
                 np.testing.assert_array_equal(r[10:20], np.ones((10, 5)) * 2)
 
-    # TODO: remove patch if issue(https://github.com/mars-project/mars/issues/117) fixed
-    @patch_method(MarsAPI.get_tensor_nsplits)
-    @patch_method(LocalClusterSession.run)
-    @patch_method(LocalClusterSession._get_graph_key)
     def testBoolIndexingExecute(self, *_):
-        mock_nsplits = ((4, 4, 4, 4),)
-        MarsAPI.get_tensor_nsplits.return_value = mock_nsplits
-        with new_cluster(scheduler_n_process=2, worker_n_process=2) as cluster:
+        with new_cluster(scheduler_n_process=2, worker_n_process=2, web=True) as cluster:
             a = mt.random.rand(8, 8, chunk_size=4)
             a[2:6, 2:6] = mt.ones((4, 4)) * 2
             b = a[a > 1]
@@ -236,7 +227,28 @@ class Test(unittest.TestCase):
             self.assertEqual(b.shape, (16,))
 
             c = b.reshape((4, 4))
+
             self.assertEqual(c.shape, (4, 4))
+
+            with new_session('http://' + cluster._web_endpoint) as session2:
+                a = mt.random.rand(8, 8, chunk_size=4)
+                a[2:6, 2:6] = mt.ones((4, 4)) * 2
+                b = a[a > 1]
+                self.assertEqual(b.shape, (np.nan,))
+
+                session2.run(b, fetch=False)
+                self.assertEqual(b.shape, (16,))
+
+                c = b.reshape((4, 4))
+                self.assertEqual(c.shape, (4, 4))
+
+            with new_session('http://' + cluster._web_endpoint) as session2:
+                a = mt.random.rand(8, 8, chunk_size=4)
+                a[2:6, 2:6] = mt.ones((4, 4)) * 2
+                b = mt.sum(a[a > 1] - 1)
+
+                r = session2.run(b)
+                self.assertEqual(r, 16)
 
     def testExecutableTuple(self):
         with new_cluster(scheduler_n_process=2, worker_n_process=2, web=True) as cluster:

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -639,7 +639,7 @@ class GraphActor(SchedulerActor):
                     if chunk_graph.count_successors(pn) > 1:
                         shared_input_chunk_keys.add(pn.key)
                 successor_keys.update(pn.op.key for pn in chunk_graph.iter_successors(c))
-                chunk_key_sizes.update((co.key, co.nbytes) for co in c.op.outputs)
+                chunk_key_sizes.update((co.key, co.rough_nbytes) for co in c.op.outputs)
 
             io_meta = dict(
                 predecessors=list(predecessor_keys),
@@ -770,7 +770,7 @@ class GraphActor(SchedulerActor):
             op_ref.free_data(_tell=True)
 
     def get_tensor_chunk_indexes(self, tensor_key):
-        return OrderedDict((c.key, c.index) for c in self._tensor_to_tiled[tensor_key][-1].chunks)
+        return OrderedDict((c.key, c.index) for c in self._get_tensor_by_key(tensor_key).chunks)
 
     def build_tensor_merge_graph(self, tensor_key):
         from ..tensor.expressions.merge.concatenate import TensorConcatenate

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -545,7 +545,6 @@ class GraphActor(SchedulerActor):
             key_transfers = defaultdict(lambda: 0)
             for pred in undigraph.iter_predecessors(v):
                 if pred.op.key in full_assigns:
-                    print(pred.op)
                     key_transfers[full_assigns[pred.op.key]] += pred.rough_nbytes
             if not key_transfers:
                 continue

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -545,6 +545,7 @@ class GraphActor(SchedulerActor):
             key_transfers = defaultdict(lambda: 0)
             for pred in undigraph.iter_predecessors(v):
                 if pred.op.key in full_assigns:
+                    print(pred.op)
                     key_transfers[full_assigns[pred.op.key]] += pred.rough_nbytes
             if not key_transfers:
                 continue

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -545,7 +545,7 @@ class GraphActor(SchedulerActor):
             key_transfers = defaultdict(lambda: 0)
             for pred in undigraph.iter_predecessors(v):
                 if pred.op.key in full_assigns:
-                    key_transfers[full_assigns[pred.op.key]] += pred.nbytes
+                    key_transfers[full_assigns[pred.op.key]] += pred.rough_nbytes
             if not key_transfers:
                 continue
             max_transfer = max(key_transfers.values())

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -30,7 +30,7 @@ from ..tiles import Tilesable, handler
 from ..serialize import SerializableWithKey, ValueType, ProviderType, \
     ListField, TupleField, DictField, DataTypeField, KeyField, BoolField
 from ..utils import AttributeDict, on_serialize_shape, on_deserialize_shape, tokenize
-from .expressions.utils import get_chunk_slices
+from .expressions.utils import get_chunk_slices, calc_rough_shape
 
 
 class ChunkData(SerializableWithKey):
@@ -107,16 +107,7 @@ class ChunkData(SerializableWithKey):
 
     @property
     def rough_shape(self):
-        if np.nan in self.shape:
-            inputs = self.inputs or []
-            inputs_shape = tuple(t.rough_shape for t in inputs)
-            shape = self.op.calc_shape(*inputs_shape)
-            if np.nan in shape:
-                return self.op.calc_rough_shape(*inputs_shape)
-            else:
-                return shape
-        else:
-            return self.shape
+        return calc_rough_shape(self)
 
     @property
     def composed(self):
@@ -210,16 +201,7 @@ class TensorData(SerializableWithKey, Tilesable):
 
     @property
     def rough_shape(self):
-        if np.nan in self.shape:
-            inputs = self.inputs or []
-            inputs_shape = tuple(t.rough_shape for t in inputs)
-            shape = self.op.calc_shape(*inputs_shape)
-            if np.nan in shape:
-                return self.op.calc_rough_shape(*inputs_shape)
-            else:
-                return shape
-        else:
-            return self.shape
+        return calc_rough_shape(self)
 
     @property
     def chunk_shape(self):

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -102,6 +102,16 @@ class ChunkData(SerializableWithKey):
         return np.prod(self.shape) * self.dtype.itemsize
 
     @property
+    def rough_nbytes(self):
+        if np.isnan(self.nbytes):
+            try:
+                return self.op._calc_rough_nbytes()
+            except AttributeError:
+                return sum([inp.rough_nbytes for inp in self.op.inputs])
+        else:
+            return self.nbytes
+
+    @property
     def composed(self):
         return getattr(self, '_composed', None)
 
@@ -186,6 +196,17 @@ class TensorData(SerializableWithKey, Tilesable):
     @property
     def nbytes(self):
         return np.prod(self.shape) * self.dtype.itemsize
+
+    @property
+    def rough_nbytes(self):
+        if np.isnan(self.nbytes):
+            try:
+                return self.op._calc_rough_nbytes()
+            except AttributeError:
+                return sum([inp.rough_nbytes for inp in self.op.inputs])
+        else:
+            return self.nbytes
+
 
     @property
     def chunk_shape(self):

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -103,13 +103,23 @@ class ChunkData(SerializableWithKey):
 
     @property
     def rough_nbytes(self):
-        if np.isnan(self.nbytes):
-            try:
-                return self.op._calc_rough_nbytes()
-            except AttributeError:
-                return sum([inp.rough_nbytes for inp in self.op.inputs])
+        return np.prod(self.rough_shape) * self.dtype.itemsize
+
+    @property
+    def rough_shape(self):
+        if np.nan in self.shape:
+            inputs = self.inputs or []
+            inputs_shape = tuple(t.rough_shape for t in inputs)
+            shape = self.op.calc_shape(*inputs_shape)
+            if np.nan in shape:
+                try:
+                    return self.op.calc_rough_shape(*inputs_shape)
+                except AttributeError:
+                    raise
+            else:
+                return shape
         else:
-            return self.nbytes
+            return self.shape
 
     @property
     def composed(self):
@@ -199,14 +209,23 @@ class TensorData(SerializableWithKey, Tilesable):
 
     @property
     def rough_nbytes(self):
-        if np.isnan(self.nbytes):
-            try:
-                return self.op._calc_rough_nbytes()
-            except AttributeError:
-                return sum([inp.rough_nbytes for inp in self.op.inputs])
-        else:
-            return self.nbytes
+        return np.prod(self.rough_shape) * self.dtype.itemsize
 
+    @property
+    def rough_shape(self):
+        if np.nan in self.shape:
+            inputs = self.inputs or []
+            inputs_shape = tuple(t.rough_shape for t in inputs)
+            shape = self.op.calc_shape(*inputs_shape)
+            if np.nan in shape:
+                try:
+                    return self.op.calc_rough_shape(*inputs_shape)
+                except AttributeError:
+                    raise
+            else:
+                return shape
+        else:
+            return self.shape
 
     @property
     def chunk_shape(self):

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -112,10 +112,7 @@ class ChunkData(SerializableWithKey):
             inputs_shape = tuple(t.rough_shape for t in inputs)
             shape = self.op.calc_shape(*inputs_shape)
             if np.nan in shape:
-                try:
-                    return self.op.calc_rough_shape(*inputs_shape)
-                except AttributeError:
-                    raise
+                return self.op.calc_rough_shape(*inputs_shape)
             else:
                 return shape
         else:
@@ -218,10 +215,7 @@ class TensorData(SerializableWithKey, Tilesable):
             inputs_shape = tuple(t.rough_shape for t in inputs)
             shape = self.op.calc_shape(*inputs_shape)
             if np.nan in shape:
-                try:
-                    return self.op.calc_rough_shape(*inputs_shape)
-                except AttributeError:
-                    raise
+                return self.op.calc_rough_shape(*inputs_shape)
             else:
                 return shape
         else:

--- a/mars/tensor/expressions/arithmetic/add.py
+++ b/mars/tensor/expressions/arithmetic/add.py
@@ -17,7 +17,7 @@
 import numpy as np
 
 from .... import operands
-from ..utils import infer_dtype
+from ..utils import infer_dtype, broadcast_shape
 from .core import TensorBinOp, TensorConstant, TensorElementWise
 
 
@@ -108,3 +108,6 @@ def radd(x1, x2, **kwargs):
 class TensorTreeAdd(operands.TreeAdd, TensorElementWise):
     def __init__(self, dtype=None, sparse=False, **kw):
         super(TensorTreeAdd, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
+
+    def calc_shape(self, *inputs_shape):
+        return broadcast_shape(*inputs_shape)

--- a/mars/tensor/expressions/base/argwhere.py
+++ b/mars/tensor/expressions/base/argwhere.py
@@ -29,6 +29,10 @@ class TensorArgwhere(Argwhere, TensorOperandMixin):
     def __init__(self, dtype=None, **kw):
         super(TensorArgwhere, self).__init__(_dtype=dtype, **kw)
 
+    def _calc_rough_nbytes(self):
+        rough_shape = (np.prod(self.input.shape), self.input.ndim)
+        return np.prod(rough_shape) * self.input.dtype.itemsize
+
     def _set_inputs(self, inputs):
         super(TensorArgwhere, self)._set_inputs(inputs)
         self._input = self._inputs[0]

--- a/mars/tensor/expressions/base/argwhere.py
+++ b/mars/tensor/expressions/base/argwhere.py
@@ -29,9 +29,13 @@ class TensorArgwhere(Argwhere, TensorOperandMixin):
     def __init__(self, dtype=None, **kw):
         super(TensorArgwhere, self).__init__(_dtype=dtype, **kw)
 
-    def _calc_rough_nbytes(self):
-        rough_shape = (np.prod(self.input.shape), self.input.ndim)
-        return np.prod(rough_shape) * self.outputs[0].dtype.itemsize
+    def calc_rough_shape(self, *inputs_shape):
+        rough_shape = (np.prod(inputs_shape[0]), self.input.ndim)
+        return rough_shape
+
+    def calc_shape(self, *inputs_shape):
+        shape = (np.nan, len(inputs_shape[0]))
+        return shape
 
     def _set_inputs(self, inputs):
         super(TensorArgwhere, self)._set_inputs(inputs)

--- a/mars/tensor/expressions/base/argwhere.py
+++ b/mars/tensor/expressions/base/argwhere.py
@@ -31,7 +31,7 @@ class TensorArgwhere(Argwhere, TensorOperandMixin):
 
     def _calc_rough_nbytes(self):
         rough_shape = (np.prod(self.input.shape), self.input.ndim)
-        return np.prod(rough_shape) * self.input.dtype.itemsize
+        return np.prod(rough_shape) * self.outputs[0].dtype.itemsize
 
     def _set_inputs(self, inputs):
         super(TensorArgwhere, self)._set_inputs(inputs)
@@ -111,5 +111,5 @@ def argwhere(a):
 
     """
     a = astensor(a).astype(bool)
-    op = TensorArgwhere(np.intp)
+    op = TensorArgwhere(np.dtype(np.intp))
     return op(a)

--- a/mars/tensor/expressions/base/astype.py
+++ b/mars/tensor/expressions/base/astype.py
@@ -30,6 +30,9 @@ class TensorAstype(Astype, TensorOperandMixin):
         super(TensorAstype, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def calc_shape(self, *inputs_shape):
+        return inputs_shape[0]
+
     def __call__(self, tensor, copy=True):
         t = self.new_tensor([tensor], tensor.shape)
         if copy:

--- a/mars/tensor/expressions/base/broadcast_to.py
+++ b/mars/tensor/expressions/base/broadcast_to.py
@@ -28,6 +28,9 @@ class TensorBroadcastTo(BroadcastTo, TensorOperandMixin):
         super(TensorBroadcastTo, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def calc_shape(self, *inputs_shape):
+        return self.outputs[0].shape
+
     def __call__(self, tensor, shape):
         return self.new_tensor([tensor], shape)
 

--- a/mars/tensor/expressions/base/copyto.py
+++ b/mars/tensor/expressions/base/copyto.py
@@ -56,6 +56,9 @@ class TensorCopyTo(CopyTo, TensorOperandMixin):
 
         return src, dst, where
 
+    def calc_shape(self, *inputs_shape):
+        return inputs_shape[1]
+
     def __call__(self, *inputs):
         from ..core import Tensor
 
@@ -106,7 +109,7 @@ class TensorCopyTo(CopyTo, TensorOperandMixin):
         for out_idx in itertools.product(*(map(range, out_chunk_shape))):
             in_chunks = [t.cix[get_index(out_idx[-t.ndim:], t)] if t.ndim != 0 else t.chunks[0]
                          for t in inputs]
-            out_chunk = op.copy().reset_key().new_chunk(in_chunks, in_chunks[0].shape, index=out_idx)
+            out_chunk = op.copy().reset_key().new_chunk(in_chunks, in_chunks[1].shape, index=out_idx)
             out_chunks.append(out_chunk)
             for i, idx, s in zip(itertools.count(0), out_idx, out_chunk.shape):
                 nsplits[i][idx] = s

--- a/mars/tensor/expressions/base/digitize.py
+++ b/mars/tensor/expressions/base/digitize.py
@@ -32,6 +32,10 @@ class TensorDigitize(Digitize, TensorOperandMixin):
         if len(inputs) > 1:
             self._bins = self._inputs[1]
 
+    @classmethod
+    def calc_shape(cls, *inputs_shape):
+        return inputs_shape[0]
+
     def __call__(self, x, bins):
         x = astensor(x)
         inputs = [x]

--- a/mars/tensor/expressions/base/isin.py
+++ b/mars/tensor/expressions/base/isin.py
@@ -33,6 +33,9 @@ class TensorIsIn(IsIn, TensorOperandMixin):
         self._element = self._inputs[0]
         self._test_elements = self._inputs[1]
 
+    def calc_shape(self, *inputs_shape):
+        return inputs_shape[0]
+
     def __call__(self, element, test_elements):
         element, test_elements = astensor(element), ravel(astensor(test_elements))
 

--- a/mars/tensor/expressions/base/repeat.py
+++ b/mars/tensor/expressions/base/repeat.py
@@ -46,17 +46,10 @@ class TensorRepeat(Repeat, TensorOperandMixin):
         input_shape = (np.prod(inputs_shape[0]),) if self._axis is None else inputs_shape[0]
         if len(inputs_shape) == 1:
             repeats = self._repeats
-            size = input_shape[ax] * repeats
-            if not isinstance(repeats, Integral):
-                repeats = np.asarray(repeats)
-                if repeats.size == 1:
-                    repeats = int(repeats[0])
-                    size = repeats * input_shape[ax]
-                elif input_shape[ax] == 1:
-                    size = int(repeats.sum())
-                else:
-                    size = repeats.sum()
-
+            if isinstance(repeats, np.ndarray):
+                size = repeats.sum()
+            else:
+                size = input_shape[ax] * repeats
             return input_shape[:ax] + (size,) + input_shape[ax + 1:]
         else:
             return input_shape[:ax] + (np.nan,) + input_shape[ax + 1:]
@@ -81,9 +74,10 @@ class TensorRepeat(Repeat, TensorOperandMixin):
                     size = repeats.sum()
             else:
                 size = np.nan
-            if repeats.ndim != 1:
-                raise ValueError('repeats should be 1-d tensor')
-            broadcast_shape(repeats.shape, a.shape[ax: ax + 1])
+            if not isinstance(repeats, Integral):
+                if repeats.ndim != 1:
+                    raise ValueError('repeats should be 1-d tensor')
+                broadcast_shape(repeats.shape, a.shape[ax: ax + 1])
         else:
             size = a.shape[axis or 0] * repeats
 

--- a/mars/tensor/expressions/base/split.py
+++ b/mars/tensor/expressions/base/split.py
@@ -33,6 +33,9 @@ class TensorSplit(Split, TensorOperandMixin):
         if len(self._inputs) > 1:
             self._indices_or_sections = self._inputs[1]
 
+    def calc_shape(self, *inputs_shape):
+        return tuple(out.shape for out in self.outputs)
+
     def __call__(self, a, indices_or_sections, is_split=False):
         axis = self._axis
         size = a.shape[axis]

--- a/mars/tensor/expressions/base/squeeze.py
+++ b/mars/tensor/expressions/base/squeeze.py
@@ -48,6 +48,9 @@ class TensorSqueeze(Squeeze, TensorOperandMixin):
         super(TensorSqueeze, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def calc_shape(self, *inputs_shape):
+        return _get_squeeze_shape(inputs_shape[0], self.axis)[0]
+
     def __call__(self, a, shape):
         return self.new_tensor([a], shape)
 

--- a/mars/tensor/expressions/base/swapaxes.py
+++ b/mars/tensor/expressions/base/swapaxes.py
@@ -31,6 +31,9 @@ class TensorSwapAxes(SwapAxes, TensorOperandMixin):
         super(TensorSwapAxes, self).__init__(_axis1=axis1, _axis2=axis2, _dtype=dtype,
                                              _sparse=sparse, **kw)
 
+    def calc_shape(self, *inputs_shape):
+        return _swap(inputs_shape[0], self.axis1, self.axis2)
+
     def __call__(self, a):
         shape = _swap(a.shape, self.axis1, self.axis2)
         return self.new_tensor([a], shape)
@@ -49,7 +52,7 @@ class TensorSwapAxes(SwapAxes, TensorOperandMixin):
             chunk_shape = _swap(c.shape, axis1, axis2)
             chunk_idx = _swap(c.index, axis1, axis2)
             chunk_op = op.copy().reset_key()
-            out_chunk =  chunk_op.new_chunk([c], chunk_shape, index=chunk_idx)
+            out_chunk = chunk_op.new_chunk([c], chunk_shape, index=chunk_idx)
             out_chunks.append(out_chunk)
 
         new_op = op.copy()

--- a/mars/tensor/expressions/base/transpose.py
+++ b/mars/tensor/expressions/base/transpose.py
@@ -32,6 +32,9 @@ class TensorTranspose(Transpose, TensorOperandMixin):
         super(TensorTranspose, self).__init__(_axes=axes, _dtype=dtype,
                                               _sparse=sparse, **kw)
 
+    def calc_shape(self, *inputs_shape):
+        return _reorder(inputs_shape[0], self._axes)
+
     def __call__(self, a):
         shape = _reorder(a.shape, self._axes)
         return self.new_tensor([a], shape)

--- a/mars/tensor/expressions/base/where.py
+++ b/mars/tensor/expressions/base/where.py
@@ -37,6 +37,9 @@ class TensorWhere(Where, TensorOperandMixin):
         self._x = self._inputs[1]
         self._y = self._inputs[2]
 
+    def calc_shape(self, *inputs_shape):
+        return broadcast_shape(inputs_shape[1], inputs_shape[2])
+
     def __call__(self, condition, x, y, shape=None):
         shape = shape or broadcast_shape(x.shape, y.shape)
         return self.new_tensor([condition, x, y], shape)
@@ -54,7 +57,7 @@ class TensorWhere(Where, TensorOperandMixin):
         for out_index in itertools.product(*(map(range, out_chunk_shape))):
             in_chunks = [t.cix[get_index(out_index[-t.ndim:], t)] if t.ndim != 0 else t.chunks[0]
                          for t in inputs]
-            chunk_shape = broadcast_shape(*(c.shape for c in in_chunks))
+            chunk_shape = broadcast_shape(*(c.shape for c in in_chunks[1:]))
             out_chunk = op.copy().reset_key().new_chunk(in_chunks, chunk_shape, index=out_index)
             out_chunks.append(out_chunk)
             for i, idx, s in zip(itertools.count(0), out_index, out_chunk.shape):

--- a/mars/tensor/expressions/core.py
+++ b/mars/tensor/expressions/core.py
@@ -117,3 +117,6 @@ class TensorOperandMixin(object):
             raise TypeError('cannot new chunk with more than 1 outputs')
 
         return self.new_tensors(inputs, shape, dtype=dtype, **kw)[0]
+
+    def calc_shape(self, *inputs_shape):
+        raise NotImplemented

--- a/mars/tensor/expressions/core.py
+++ b/mars/tensor/expressions/core.py
@@ -119,4 +119,4 @@ class TensorOperandMixin(object):
         return self.new_tensors(inputs, shape, dtype=dtype, **kw)[0]
 
     def calc_shape(self, *inputs_shape):
-        raise NotImplemented
+        raise NotImplementedError

--- a/mars/tensor/expressions/datasource/core.py
+++ b/mars/tensor/expressions/datasource/core.py
@@ -71,6 +71,9 @@ class TensorNoInput(TensorDataSource):
         if inputs and len(inputs) > 0:
             raise ValueError("Tensor data source has no inputs")
 
+    def calc_shape(self, *inputs_shape):
+        return self.outputs[0].shape
+
     def __call__(self, shape, chunk_size=None):
         shape = normalize_shape(shape)
         return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
@@ -104,6 +107,9 @@ class TensorHasInput(TensorDataSource):
         new_op = op.copy()
         return new_op.new_tensors(op.inputs, op.outputs[0].shape, chunks=out_chunks,
                                   nsplits=op.input.nsplits)
+
+    def calc_shape(self, *inputs_shape):
+        return inputs_shape[0]
 
     def __call__(self, a):
         return self.new_tensor([a], a.shape)

--- a/mars/tensor/expressions/fft/core.py
+++ b/mars/tensor/expressions/fft/core.py
@@ -23,6 +23,9 @@ from ..core import TensorOperandMixin
 class TensorFFTMixin(TensorOperandMixin):
     __slots__ = ()
 
+    def calc_shape(self, *inputs_shape):
+        return self._get_shape(self, inputs_shape[0])
+
     @classmethod
     def _get_shape(cls, op, shape):
         raise NotImplementedError
@@ -61,6 +64,9 @@ def validate_fft(tensor, axis=-1, norm=None):
 
 class TensorFFTNMixin(TensorOperandMixin):
     __slots__ = ()
+
+    def calc_shape(self, *inputs_shape):
+        return self._get_shape(self, inputs_shape[0])
 
     @classmethod
     def _get_shape(cls, op, shape):
@@ -111,6 +117,9 @@ def validate_fftn(tensor, s=None, axes=None, norm=None):
 
 class TensorFFTShiftMixin(TensorOperandMixin):
     __slots__ = ()
+
+    def calc_shape(self, *inputs_shape):
+        return inputs_shape[0]
 
     @classmethod
     def _is_inverse(cls):

--- a/mars/tensor/expressions/fft/fftfreq.py
+++ b/mars/tensor/expressions/fft/fftfreq.py
@@ -31,6 +31,9 @@ class TensorFFTFreq(fftop.FFTFreq, TensorFFTMixin):
         shape = (self.n,)
         return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
 
+    def calc_shape(self, *inputs_shape):
+        return self.n,
+
     @classmethod
     def tile(cls, op):
         tensor = op.outputs[0]
@@ -52,6 +55,9 @@ class TensorFFTFreq(fftop.FFTFreq, TensorFFTMixin):
 class TensorFFTFreqChunk(fftop.FFTFreqChunk, TensorOperandMixin):
     def __init__(self, n=None, d=None, dtype=None, **kw):
         super(TensorFFTFreqChunk, self).__init__(_n=n, _d=d, _dtype=dtype, **kw)
+
+    def calc_shape(self, *inputs_shape):
+        return inputs_shape[0]
 
     def _set_inputs(self, inputs):
         super(TensorFFTFreqChunk, self)._set_inputs(inputs)

--- a/mars/tensor/expressions/fft/rfftfreq.py
+++ b/mars/tensor/expressions/fft/rfftfreq.py
@@ -29,6 +29,9 @@ class TensorRFFTFreq(fftop.RFFTFreq, TensorOperandMixin):
         shape = (self.n // 2 + 1,)
         return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
 
+    def calc_shape(self, *inputs_shape):
+        return self.n // 2 + 1,
+
     @classmethod
     def tile(cls, op):
         tensor = op.outputs[0]

--- a/mars/tensor/expressions/fuse/core.py
+++ b/mars/tensor/expressions/fuse/core.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from .... import operands
 from ....tiles import NotSupportTile
 from ..core import TensorOperandMixin
@@ -22,6 +24,28 @@ from ..core import TensorOperandMixin
 class TensorFuseChunk(operands.Fuse, TensorOperandMixin):
     def __init__(self, dtype=None, **kw):
         super(TensorFuseChunk, self).__init__(_dtype=dtype, **kw)
+
+    def calc_rough_shape(self, *inputs_shape):
+        in_shapes = inputs_shape
+        out_shape = None
+
+        # TODO: the logic will be changed when fusion is not only straight line
+        for c in self.outputs[0].composed:
+            out_shape = c.op.calc_shape(*in_shapes)
+            if np.nan in out_shape:
+                out_shape = c.op.calc_rough_shape(*inputs_shape)
+            in_shapes = [out_shape]
+        return out_shape
+
+    def calc_shape(self, *inputs_shape):
+        in_shapes = inputs_shape
+        out_shape = None
+
+        # TODO: the logic will be changed when fusion is not only straight line
+        for c in self.outputs[0].composed:
+            out_shape = c.op.calc_shape(*in_shapes)
+            in_shapes = [out_shape]
+        return out_shape
 
     @classmethod
     def tile(cls, op):

--- a/mars/tensor/expressions/indexing/choose.py
+++ b/mars/tensor/expressions/indexing/choose.py
@@ -31,6 +31,9 @@ class TensorChoose(Choose, TensorOperandMixin):
         self._a = self._inputs[0]
         self._choices = self._inputs[1:]
 
+    def calc_shape(self, *inputs_shape):
+        return broadcast_shape(inputs_shape[0], *inputs_shape[1:])
+
     def __call__(self, a, choices):
         inputs = [a] + choices
         shape = broadcast_shape(a.shape, *[c.shape for c in choices])

--- a/mars/tensor/expressions/indexing/core.py
+++ b/mars/tensor/expressions/indexing/core.py
@@ -118,3 +118,14 @@ def process_index(tensor, item):
     if missing < 0:
         raise IndexError('too many indices for tensor')
     return index + (slice(None),) * missing
+
+
+def get_rough_size(in_tensor_shape, indexes, shape):
+    rough_size = np.nanprod(shape)
+
+    new_indexes = [index for index in indexes if index is not None]
+    for idx, index in enumerate(new_indexes):
+        if isinstance(index, TENSOR_TYPE):
+            rough_size *= np.nanprod(in_tensor_shape[idx: (idx + index.ndim)])
+
+    return rough_size

--- a/mars/tensor/expressions/indexing/core.py
+++ b/mars/tensor/expressions/indexing/core.py
@@ -118,14 +118,3 @@ def process_index(tensor, item):
     if missing < 0:
         raise IndexError('too many indices for tensor')
     return index + (slice(None),) * missing
-
-
-def get_rough_size(in_tensor_shape, indexes, shape):
-    rough_size = np.nanprod(shape)
-
-    new_indexes = [index for index in indexes if index is not None]
-    for idx, index in enumerate(new_indexes):
-        if isinstance(index, TENSOR_TYPE):
-            rough_size *= np.nanprod(in_tensor_shape[idx: (idx + index.ndim)])
-
-    return rough_size

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -28,12 +28,18 @@ from ...core import TENSOR_TYPE
 from ..utils import unify_chunks, split_index_into_chunks, is_asc_sorted, \
     slice_split, calc_sliced_size
 from ..core import TensorOperandMixin
-from .core import process_index, get_index_and_shape
+from .core import process_index, get_index_and_shape, get_rough_size
 
 
 class TensorIndex(Index, TensorOperandMixin):
     def __init__(self, dtype=None, sparse=False, **kw):
         super(TensorIndex, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
+
+    def _calc_rough_nbytes(self):
+        shape = self.outputs[0].shape
+        indexes = self.indexes
+        rough_size = get_rough_size(self.input.shape, indexes, shape)
+        return rough_size * self.input.dtype.itemsize
 
     @contextlib.contextmanager
     def _handle_params(self, inputs, indexes):

--- a/mars/tensor/expressions/indexing/nonzero.py
+++ b/mars/tensor/expressions/indexing/nonzero.py
@@ -32,6 +32,12 @@ class TensorNonzero(Nonzero, TensorOperandMixin):
         super(TensorNonzero, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def calc_rough_shape(self, *inputs_shape):
+        return np.prod(inputs_shape[0]),
+
+    def calc_shape(self, *inputs_shape):
+        return np.nan,
+
     def __call__(self, a):
         return ExecutableTuple(self.new_tensors([a], shape=(np.nan,), output_limit=a.ndim))
 

--- a/mars/tensor/expressions/indexing/nonzero.py
+++ b/mars/tensor/expressions/indexing/nonzero.py
@@ -32,7 +32,8 @@ class TensorNonzero(Nonzero, TensorOperandMixin):
         super(TensorNonzero, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_rough_shape(self, *inputs_shape):
+    @staticmethod
+    def calc_rough_shape(*inputs_shape):
         return np.prod(inputs_shape[0]),
 
     def calc_shape(self, *inputs_shape):

--- a/mars/tensor/expressions/indexing/setitem.py
+++ b/mars/tensor/expressions/indexing/setitem.py
@@ -67,6 +67,9 @@ class TensorIndexSetValue(IndexSetValue, TensorOperandMixin):
         with self._handle_params(inputs, indexes, value) as mix_inputs:
             return super(TensorIndexSetValue, self).new_chunks(mix_inputs, shape, **kw)
 
+    def calc_shape(self, *inputs_shape):
+        return inputs_shape[0]
+
     def __call__(self, a, index, value):
         return self.new_tensor([a], a.shape, indexes=index, value=value)
 
@@ -109,7 +112,7 @@ def _setitem(a, item, value):
     from ..base import broadcast_to
 
     index = process_index(a, item)
-    index, shape = get_index_and_shape(a, index)
+    index, shape = get_index_and_shape(a.shape, index)
 
     for ix in index:
         if not isinstance(ix, (slice, Integral)):

--- a/mars/tensor/expressions/indexing/setitem.py
+++ b/mars/tensor/expressions/indexing/setitem.py
@@ -23,19 +23,13 @@ from ....operands import IndexSetValue
 from ....core import BaseWithKey, Entity
 from ...core import TENSOR_TYPE, CHUNK_TYPE
 from ..core import TensorOperandMixin
-from .core import process_index, get_index_and_shape, get_rough_size
+from .core import process_index, get_index_and_shape
 from .getitem import TensorIndex
 
 
 class TensorIndexSetValue(IndexSetValue, TensorOperandMixin):
     def __init__(self, dtype=None, sparse=False, **kw):
         super(TensorIndexSetValue, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
-
-    def _calc_rough_nbytes(self):
-        shape = self.outputs[0].shape
-        indexes = self.indexes
-        rough_size = get_rough_size(self.input.shape, indexes, shape)
-        return rough_size * self.input.dtype.itemsize
 
     @contextlib.contextmanager
     def _handle_params(self, inputs, indexes, value):

--- a/mars/tensor/expressions/indexing/setitem.py
+++ b/mars/tensor/expressions/indexing/setitem.py
@@ -23,13 +23,19 @@ from ....operands import IndexSetValue
 from ....core import BaseWithKey, Entity
 from ...core import TENSOR_TYPE, CHUNK_TYPE
 from ..core import TensorOperandMixin
-from .core import process_index, get_index_and_shape
+from .core import process_index, get_index_and_shape, get_rough_size
 from .getitem import TensorIndex
 
 
 class TensorIndexSetValue(IndexSetValue, TensorOperandMixin):
     def __init__(self, dtype=None, sparse=False, **kw):
         super(TensorIndexSetValue, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
+
+    def _calc_rough_nbytes(self):
+        shape = self.outputs[0].shape
+        indexes = self.indexes
+        rough_size = get_rough_size(self.input.shape, indexes, shape)
+        return rough_size * self.input.dtype.itemsize
 
     @contextlib.contextmanager
     def _handle_params(self, inputs, indexes, value):

--- a/mars/tensor/expressions/indexing/slice.py
+++ b/mars/tensor/expressions/indexing/slice.py
@@ -14,14 +14,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from ....operands import Slice
 from ..core import TensorOperandMixin
+from ..utils import calc_sliced_size
 
 
 class TensorSlice(Slice, TensorOperandMixin):
     def __init__(self, slices=None, dtype=None, sparse=False, **kw):
         super(TensorSlice, self).__init__(_slices=slices, _dtype=dtype,
                                           _sparse=sparse, **kw)
+
+    def calc_shape(self, *inputs_shape):
+        input_shape = inputs_shape[0]
+        shape = []
+        idx = 0
+        for s in self._slices:
+            if s is None:
+                shape.append(1)
+            elif isinstance(s, slice):
+                if np.isnan(input_shape[idx]):
+                    shape.append(np.nan)
+                else:
+                    shape.append(calc_sliced_size(input_shape[idx], s))
+                idx += 1
+        shape.extend(list(input_shape[idx:]))
+        return tuple(shape)
 
     def _set_inputs(self, inputs):
         super(TensorSlice, self)._set_inputs(inputs)

--- a/mars/tensor/expressions/indexing/unravel_index.py
+++ b/mars/tensor/expressions/indexing/unravel_index.py
@@ -32,6 +32,9 @@ class TensorUnravelIndex(UnravelIndex, TensorOperandMixin):
         super(TensorUnravelIndex, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def calc_shape(self, *inputs_shape):
+        return inputs_shape[0]
+
     def __call__(self, indices):
         kws = [{'pos': i} for i in range(len(self._dims))]
         return ExecutableTuple(self.new_tensors([indices], indices.shape, kws=kws, output_limit=len(kws)))

--- a/mars/tensor/expressions/linalg/cholesky.py
+++ b/mars/tensor/expressions/linalg/cholesky.py
@@ -40,6 +40,9 @@ class TensorCholesky(operands.Cholesky, TensorOperandMixin):
         super(TensorCholesky, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def calc_shape(self, *inputs_shape):
+        return inputs_shape[0]
+
     def __call__(self, a):
         return self.new_tensor([a], a.shape)
 

--- a/mars/tensor/expressions/linalg/core.py
+++ b/mars/tensor/expressions/linalg/core.py
@@ -54,8 +54,7 @@ class SFQR(object):
         r_chunks = []
         first_chunk = a.chunks[0]
         x, y = first_chunk.shape
-        q_shape = first_chunk.shape if x > y else (x, x)
-        r_shape = first_chunk.shape if x < y else (y, y)
+        q_shape, r_shape = (first_chunk.shape, (y, y)) if x > y else ((x, x), first_chunk.shape)
         qr_op = TensorQR()
         q_chunk, r_chunk = qr_op.new_chunks([first_chunk], (q_shape, r_shape),
                                             index=(0, 0),
@@ -107,8 +106,7 @@ class TSQR(object):
         stage1_q_chunks, stage1_r_chunks = stage1_chunks = [[], []]  # Q and R chunks
         for c in a.chunks:
             x, y = c.shape
-            q_shape = c.shape if x > y else (x, x)
-            r_shape = c.shape if x < y else (y, y)
+            q_shape, r_shape = (c.shape, (y, y)) if x > y else ((x, x), c.shape)
             qr_op = TensorQR()
             qr_chunks = qr_op.new_chunks([c], [q_shape, r_shape], index=c.index,
                                          kws=[{'side': 'q', 'dtype': q_dtype},

--- a/mars/tensor/expressions/linalg/dot.py
+++ b/mars/tensor/expressions/linalg/dot.py
@@ -25,6 +25,15 @@ class TensorDot(operands.Dot, TensorOperandMixin):
     def __init__(self, dtype=None, sparse=False, **kw):
         super(TensorDot, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
 
+    def calc_shape(self, *inputs_shape):
+        a_shape = inputs_shape[0]
+        b_shape = inputs_shape[1]
+        a_axes = len(a_shape) - 1
+        b_axes = len(b_shape) - 2
+        shape = tuple(s for i, s in enumerate(a_shape) if i != a_axes) + \
+            tuple(s for i, s in enumerate(b_shape) if i != b_axes)
+        return shape
+
     def _set_inputs(self, inputs):
         super(TensorDot, self)._set_inputs(inputs)
         self._a, self._b = self._inputs

--- a/mars/tensor/expressions/linalg/lu.py
+++ b/mars/tensor/expressions/linalg/lu.py
@@ -31,6 +31,9 @@ class TensorLU(operands.LU, TensorOperandMixin):
         super(TensorLU, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def calc_shape(self, *inputs_shape):
+        return inputs_shape[0]
+
     def __call__(self, a):
         import scipy.linalg
 

--- a/mars/tensor/expressions/linalg/matmul.py
+++ b/mars/tensor/expressions/linalg/matmul.py
@@ -36,6 +36,12 @@ class TensorMatmul(operands.Matmul, TensorOperandMixin):
         self._a = self._inputs[0]
         self._b = self._inputs[1]
 
+    def calc_shape(self, *inputs_shape):
+        a_shape = inputs_shape[0]
+        b_shape = inputs_shape[1]
+        shape = broadcast_shape(a_shape[:-2], b_shape[:-2]) + (a_shape[-2], b_shape[-1])
+        return shape
+
     def __call__(self, a, b, out=None):
         from ..base import broadcast_to
 

--- a/mars/tensor/expressions/linalg/norm.py
+++ b/mars/tensor/expressions/linalg/norm.py
@@ -23,6 +23,7 @@ from .... import operands
 from ..utils import recursive_tile
 from ..core import TensorOperandMixin
 from ..arithmetic import sqrt
+from ..datasource import empty
 from ..datasource import tensor as astensor
 from .svd import svd
 
@@ -35,6 +36,11 @@ class TensorNorm(operands.Norm, TensorOperandMixin):
     def _set_inputs(self, inputs):
         super(TensorNorm, self)._set_inputs(inputs)
         self._input = self._inputs[0]
+
+    def calc_shape(self, *inputs_shape):
+        r = empty(inputs_shape[0], dtype=self.dtype)
+        shape = self._norm(r, self._ord, self._axis, self._keepdims).shape
+        return shape
 
     def __call__(self, x):
         r = x.astype(self.dtype)

--- a/mars/tensor/expressions/linalg/qr.py
+++ b/mars/tensor/expressions/linalg/qr.py
@@ -32,6 +32,11 @@ class TensorQR(operands.QR, TensorOperandMixin):
         super(TensorQR, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def calc_shape(self, *inputs_shape):
+        input_shape = inputs_shape[0]
+        x, y = input_shape
+        return (input_shape, (y, y)) if x > y else ((x, x), input_shape)
+
     def __call__(self, a):
         a = astensor(a)
 
@@ -42,8 +47,7 @@ class TensorQR(operands.QR, TensorOperandMixin):
         tiny_q, tiny_r = np.linalg.qr(np.ones((1, 1), dtype=a.dtype))
 
         x, y = a.shape
-        q_shape = a.shape if x > y else (x, x)
-        r_shape = a.shape if x < y else (y, y)
+        q_shape, r_shape = (a.shape, (y, y)) if x > y else ((x, x), a.shape)
         q, r = self.new_tensors([a], (q_shape, r_shape),
                                 kws=[{'side': 'q', 'dtype': tiny_q.dtype},
                                      {'side': 'r', 'dtype': tiny_r.dtype}])

--- a/mars/tensor/expressions/linalg/solve_triangular.py
+++ b/mars/tensor/expressions/linalg/solve_triangular.py
@@ -30,6 +30,11 @@ class TensorSolveTriangular(operands.SolveTriangular, TensorOperandMixin):
         super(TensorSolveTriangular, self)._set_inputs(inputs)
         self._a, self._b = self._inputs
 
+    def calc_shape(self, *inputs_shape):
+        a_shape = inputs_shape[0]
+        b_shape = inputs_shape[1]
+        return (a_shape[1],) if len(b_shape) == 1 else (a_shape[1], b_shape[1])
+
     def __call__(self, a, b):
         shape = (a.shape[1],) if len(b.shape) == 1 else (a.shape[1], b.shape[1])
         return self.new_tensor([a, b], shape)

--- a/mars/tensor/expressions/linalg/svd.py
+++ b/mars/tensor/expressions/linalg/svd.py
@@ -36,6 +36,18 @@ class TensorSVD(operands.SVD, TensorOperandMixin):
         super(TensorSVD, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def calc_shape(self, *inputs_shape):
+        x, y = inputs_shape[0]
+        if x > y:
+            U_shape = (x, y)
+            s_shape = (y, )
+            V_shape = (y, y)
+        else:
+            U_shape = (x, x)
+            s_shape = (x, )
+            V_shape = (x, y)
+        return U_shape, s_shape, V_shape
+
     def __call__(self, a):
         a = astensor(a)
 

--- a/mars/tensor/expressions/linalg/tensordot.py
+++ b/mars/tensor/expressions/linalg/tensordot.py
@@ -37,6 +37,13 @@ class TensorTensorDot(operands.TensorDot, TensorOperandMixin):
         self._a = self._inputs[0]
         self._b = self._inputs[1]
 
+    def calc_shape(self, *inputs_shape):
+        a_shape = inputs_shape[0]
+        b_shape = inputs_shape[1]
+        shape = tuple(s for i, s in enumerate(a_shape) if i not in set(self._a_axes)) + \
+            tuple(s for i, s in enumerate(b_shape) if i not in set(self._b_axes))
+        return shape
+
     def __call__(self, a, b):
         shape = tuple(s for i, s in enumerate(a.shape) if i not in set(self._a_axes)) + \
             tuple(s for i, s in enumerate(b.shape) if i not in set(self._b_axes))

--- a/mars/tensor/expressions/merge/concatenate.py
+++ b/mars/tensor/expressions/merge/concatenate.py
@@ -29,6 +29,14 @@ class TensorConcatenate(Concatenate, TensorOperandMixin):
         super(TensorConcatenate, self).__init__(_axis=axis, _dtype=dtype,
                                                 _sparse=sparse, **kw)
 
+    def calc_shape(self, *inputs_shape):
+        inputs_shape = [s for s in inputs_shape if 0 not in s]
+        first_shape = inputs_shape[0]
+        axis = self._axis or 0
+        shape = [0 if i == axis else first_shape[i] for i in range(len(first_shape))]
+        shape[axis] = sum(s[axis] for s in inputs_shape)
+        return tuple(shape)
+
     def __call__(self, tensors):
         if len(set(t.ndim for t in tensors)) != 1:
             raise ValueError('all the input tensors must have same number of dimensions')

--- a/mars/tensor/expressions/merge/stack.py
+++ b/mars/tensor/expressions/merge/stack.py
@@ -29,6 +29,11 @@ class TensorStack(Stack, TensorOperandMixin):
         super(TensorStack, self).__init__(_axis=axis, _dtype=dtype,
                                           _sparse=sparse, **kw)
 
+    def calc_shape(self, *inputs_shape):
+        fisrt_shape = inputs_shape[0]
+        axis = self._axis
+        return fisrt_shape[:axis] + (len(inputs_shape),) + fisrt_shape[axis:]
+
     def __call__(self, tensors):
         shape = tensors[0].shape[:self._axis] + (len(tensors),) + tensors[0].shape[self._axis:]
         return self.new_tensor(tensors, shape)

--- a/mars/tensor/expressions/random/choice.py
+++ b/mars/tensor/expressions/random/choice.py
@@ -36,6 +36,9 @@ class TensorChoice(operands.Choice, TensorRandomOperandMixin):
         super(TensorChoice, self).__init__(_state=state, _size=size,
                                            _replace=replace, _dtype=dtype, _gpu=gpu, **kw)
 
+    def calc_shape(self, *inputs_shape):
+        return self._size or ()
+
     def __call__(self, a, p, chunk_size=None):
         return self.new_tensor([a, p], None, raw_chunk_size=chunk_size)
 

--- a/mars/tensor/expressions/random/core.py
+++ b/mars/tensor/expressions/random/core.py
@@ -158,6 +158,9 @@ class TensorRandomOperandMixin(TensorOperandMixin):
             shapes.append(getattr(self, '_size'))
         return broadcast_shape(*shapes)
 
+    def calc_shape(self, *inputs_shape):
+        return self._get_shape(list(inputs_shape))
+
     @classmethod
     def _handle_arg(cls, arg, chunk_size):
         if isinstance(arg, (list, np.ndarray)):

--- a/mars/tensor/expressions/random/multivariate_normal.py
+++ b/mars/tensor/expressions/random/multivariate_normal.py
@@ -36,6 +36,9 @@ class TensorMultivariateNormal(operands.MultivariateNormal, TensorRandomOperandM
                                                        _check_valid=check_valid, _tol=tol,
                                                        _state=state, _dtype=dtype, _gpu=gpu, **kw)
 
+    def calc_shape(self, *inputs_shape):
+        return self.outputs[0].shape
+
     def __call__(self, chunk_size=None):
         N = self._mean.size
         if self._size is None:

--- a/mars/tensor/expressions/rechunk/rechunk.py
+++ b/mars/tensor/expressions/rechunk/rechunk.py
@@ -37,6 +37,9 @@ class TensorRechunk(Rechunk, TensorOperandMixin):
         super(TensorRechunk, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def calc_shape(self, *inputs_shape):
+        return inputs_shape[0]
+
     def __call__(self, tensor):
         return self.new_tensor([tensor], tensor.shape)
 

--- a/mars/tensor/expressions/reduction/core.py
+++ b/mars/tensor/expressions/reduction/core.py
@@ -34,6 +34,21 @@ class TensorReduction(TensorOperandMixin):
     def _is_cum(cls):
         return False
 
+    def calc_shape(self, *inputs_shape):
+        input_shape = inputs_shape[0]
+        if self._is_cum():
+            return input_shape
+        else:
+            axis = getattr(self, 'axis')
+            keepdims = getattr(self, 'keepdims', None)
+
+            axis = lrange(len(input_shape)) if axis is None else axis
+            if not isinstance(axis, Iterable):
+                axis = (axis,)
+            axis = set(axis)
+            return tuple(s if i not in axis else 1 for i, s in enumerate(input_shape)
+                         if keepdims or i not in axis)
+
     def _call(self, a, out):
         a = astensor(a)
         if out is not None and not isinstance(out, Tensor):

--- a/mars/tensor/expressions/reshape/reshape.py
+++ b/mars/tensor/expressions/reshape/reshape.py
@@ -32,6 +32,21 @@ class TensorReshape(Reshape, TensorOperandMixin):
         super(TensorReshape, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def calc_shape(self, *inputs_shape):
+        newshape = self._newshape
+        known_shape = [s for s in newshape if s >= 0]
+        missing_dim = len(newshape) - len(known_shape)
+        if missing_dim > 1:
+            raise ValueError('can only specify one unknown dimension')
+        elif missing_dim == 1:
+            known_size = np.prod(known_shape)
+            input_size = np.prod(inputs_shape[0])
+            shape = tuple((input_size / known_size) if s < 0 and known_size > 0 else s
+                          for s in newshape)
+            return shape
+        else:
+            return newshape
+
     def __call__(self, a):
         return self.new_tensor([a], self._newshape)
 

--- a/mars/tensor/expressions/tests/test_arithmetic.py
+++ b/mars/tensor/expressions/tests/test_arithmetic.py
@@ -26,6 +26,7 @@ from mars.tensor.expressions.arithmetic import add, subtract, truediv, log, frex
 from mars.tensor.expressions.linalg import matmul
 from mars.tensor.core import build_mode, Tensor, SparseTensor
 from mars.operands import Add, AddConstant, SubConstant, Log, IscloseConstant, Isclose
+from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -38,17 +39,20 @@ class Test(unittest.TestCase):
         self.assertNotEqual(t3.key, k1)
         self.assertEqual(t3.shape, (3, 4))
         self.assertEqual(len(t3.chunks), 4)
+        self.assertEqual(calc_shape(t3), t3.shape)
         self.assertEqual(t3.chunks[0].inputs, [t1.chunks[0].data, t2.chunks[0].data])
         self.assertEqual(t3.chunks[1].inputs, [t1.chunks[1].data, t2.chunks[1].data])
         self.assertEqual(t3.chunks[2].inputs, [t1.chunks[2].data, t2.chunks[0].data])
         self.assertEqual(t3.chunks[3].inputs, [t1.chunks[3].data, t2.chunks[1].data])
         self.assertEqual(t3.op.dtype, np.dtype('f8'))
         self.assertEqual(t3.chunks[0].op.dtype, np.dtype('f8'))
+        self.assertEqual(calc_shape(t3.chunks[0]), t3.chunks[0].shape)
 
         t4 = t1 + 1
         t4.tiles()
         self.assertEqual(t4.shape, (3, 4))
         self.assertEqual(len(t3.chunks), 4)
+        self.assertEqual(calc_shape(t4), t4.shape)
         self.assertEqual(t4.chunks[0].inputs, [t1.chunks[0].data])
         self.assertEqual(t4.chunks[0].op.constant[0], 1)
         self.assertEqual(t4.chunks[1].inputs, [t1.chunks[1].data])
@@ -57,6 +61,7 @@ class Test(unittest.TestCase):
         self.assertEqual(t4.chunks[2].op.constant[0], 1)
         self.assertEqual(t4.chunks[3].inputs, [t1.chunks[3].data])
         self.assertEqual(t4.chunks[3].op.constant[0], 1)
+        self.assertEqual(calc_shape(t4.chunks[0]), t4.chunks[0].shape)
 
         # sparse tests
         t5 = add([1, 2, 3, 4], 1)
@@ -186,11 +191,13 @@ class Test(unittest.TestCase):
         self.assertEqual(t3.op.lhs.params.raw_chunk_size, 2)
         self.assertIs(t3.op.rhs, t2.data)
         self.assertNotEqual(t3.key, t3.op.lhs.key)
+        self.assertEqual(calc_shape(t3), t3.shape)
 
         t3.tiles()
 
         self.assertIsInstance(t1.chunks[0].op, Add)
         self.assertEqual(t1.chunks[0].op.out.key, t1.chunks[0].op.lhs.key)
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         with self.assertRaises(TypeError):
             add(t1, t2, out=1)
@@ -259,6 +266,7 @@ class Test(unittest.TestCase):
         self.assertEqual(t3.chunks[0].inputs[1], t2.chunks[0].data)
         self.assertEqual(t3.chunks[1].inputs[0], t1.chunks[1].data)
         self.assertEqual(t3.chunks[1].inputs[1], t2.chunks[0].data)
+        self.assertEqual(calc_shape(t3), t3.shape)
 
     def testTensordot(self):
         from mars.tensor.expressions.linalg import tensordot, dot, inner
@@ -268,10 +276,12 @@ class Test(unittest.TestCase):
         t3 = tensordot(t1, t2, axes=((0, 1), (1, 0)))
 
         self.assertEqual(t3.shape, (6, 5))
+        self.assertEqual(calc_shape(t3), t3.shape)
 
         t3.tiles()
 
         self.assertEqual(t3.shape, (6, 5))
+        self.assertEqual(calc_shape(t3.chunks[0]), t3.chunks[0].shape)
         self.assertEqual(len(t3.chunks), 9)
 
         a = ones((10000, 20000), chunk_size=5000)
@@ -284,27 +294,35 @@ class Test(unittest.TestCase):
         b = ones((10, 20), chunk_size=2)
         c = dot(a, b)
         self.assertEqual(c.shape, (20,))
+        self.assertEqual(calc_shape(c), c.shape)
         c.tiles()
+        self.assertEqual(calc_shape(c.chunks[0]), c.chunks[0].shape)
         self.assertEqual(c.shape, tuple(sum(s) for s in c.nsplits))
 
         a = ones((10, 20), chunk_size=2)
         b = ones(20, chunk_size=2)
         c = dot(a, b)
         self.assertEqual(c.shape, (10,))
+        self.assertEqual(calc_shape(c), c.shape)
         c.tiles()
+        self.assertEqual(calc_shape(c.chunks[0]), c.chunks[0].shape)
         self.assertEqual(c.shape, tuple(sum(s) for s in c.nsplits))
 
         v = ones((100, 100), chunk_size=10)
         tv = v.dot(v)
         self.assertEqual(tv.shape, (100, 100))
+        self.assertEqual(calc_shape(tv), tv.shape)
         tv.tiles()
+        self.assertEqual(calc_shape(tv.chunks[0]), tv.chunks[0].shape)
         self.assertEqual(tv.shape, tuple(sum(s) for s in tv.nsplits))
 
         a = ones((10, 20), chunk_size=2)
         b = ones((30, 20), chunk_size=2)
         c = inner(a, b)
         self.assertEqual(c.shape, (10, 30))
+        self.assertEqual(calc_shape(c), c.shape)
         c.tiles()
+        self.assertEqual(calc_shape(c.chunks[0]), c.chunks[0].shape)
         self.assertEqual(c.shape, tuple(sum(s) for s in c.nsplits))
 
     def testDot(self):
@@ -315,6 +333,7 @@ class Test(unittest.TestCase):
         self.assertIs(type(t1.dot(t2)), SparseTensor)
         self.assertFalse(t1.dot(t2, sparse=False).issparse())
         self.assertIs(type(t1.dot(t2, sparse=False)), Tensor)
+        self.assertEqual(calc_shape(t1.dot(t2)), (t1.dot(t2)).shape)
 
     def testFrexp(self):
         t1 = ones((3, 4, 5), chunk_size=2)
@@ -324,6 +343,8 @@ class Test(unittest.TestCase):
 
         self.assertIs(o1.op, o2.op)
         self.assertNotEqual(o1.dtype, o2.dtype)
+        self.assertEqual(calc_shape(o1), (o1.shape, o2.shape))
+        self.assertEqual(calc_shape(o2), (o1.shape, o2.shape))
 
         o1, o2 = frexp(t1, t1)
 
@@ -331,6 +352,8 @@ class Test(unittest.TestCase):
         self.assertIsNot(o1.inputs[0], t1)
         self.assertIsInstance(o1.inputs[0].op, op_type)
         self.assertIsNot(o2.inputs[0], t1)
+        self.assertEqual(calc_shape(o1), (o1.shape, o2.shape))
+        self.assertEqual(calc_shape(o2), (o1.shape, o2.shape))
 
     def testDtype(self):
         t1 = ones((2, 3), dtype='f4', chunk_size=2)
@@ -348,9 +371,11 @@ class Test(unittest.TestCase):
         t = negative(t1)
         self.assertTrue(t.issparse())
         self.assertIs(type(t), SparseTensor)
+        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertTrue(t.chunks[0].op.sparse)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
     def testCos(self):
         t1 = tensor([[0, 1, 0], [1, 0, 0]], chunk_size=2).tosparse()
@@ -358,6 +383,7 @@ class Test(unittest.TestCase):
         t = cos(t1)
         self.assertFalse(t.issparse())
         self.assertIs(type(t), Tensor)
+        self.assertEqual(calc_shape(t), t.shape)
 
     def testAround(self):
         t1 = ones((2, 3), dtype='f4', chunk_size=2)
@@ -365,10 +391,12 @@ class Test(unittest.TestCase):
         t = around(t1, decimals=3)
 
         self.assertEqual(t.op.decimals, 3)
+        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
 
         self.assertEqual(t.chunks[0].op.decimals, 3)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
     def testIsclose(self):
         t1 = ones((2, 3), dtype='f4', chunk_size=2)
@@ -383,6 +411,7 @@ class Test(unittest.TestCase):
         self.assertEqual(t.op.atol, atol)
         self.assertEqual(t.op.rtol, rtol)
         self.assertEqual(t.op.equal_nan, equal_nan)
+        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
 
@@ -390,6 +419,7 @@ class Test(unittest.TestCase):
         self.assertEqual(t.chunks[0].op.atol, atol)
         self.assertEqual(t.chunks[0].op.rtol, rtol)
         self.assertEqual(t.chunks[0].op.equal_nan, equal_nan)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t1 = ones((2, 3), dtype='f4', chunk_size=2)
         t2 = ones((2, 3), dtype='f4', chunk_size=2)
@@ -404,6 +434,7 @@ class Test(unittest.TestCase):
         self.assertEqual(t.op.atol, atol)
         self.assertEqual(t.op.rtol, rtol)
         self.assertEqual(t.op.equal_nan, equal_nan)
+        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
 
@@ -411,6 +442,7 @@ class Test(unittest.TestCase):
         self.assertEqual(t.chunks[0].op.atol, atol)
         self.assertEqual(t.chunks[0].op.rtol, rtol)
         self.assertEqual(t.chunks[0].op.equal_nan, equal_nan)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
     def testMatmul(self):
         a_data = [[1, 0], [0, 1]]
@@ -422,8 +454,10 @@ class Test(unittest.TestCase):
         t = matmul(a, b)
 
         self.assertEqual(t.shape, (2, 2))
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.shape, tuple(sum(s) for s in t.nsplits))
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         b_data = [1, 2]
         b = tensor(b_data, chunk_size=1)
@@ -431,14 +465,18 @@ class Test(unittest.TestCase):
         t = matmul(a, b)
 
         self.assertEqual(t.shape, (2,))
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.shape, tuple(sum(s) for s in t.nsplits))
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = matmul(b, a)
 
         self.assertEqual(t.shape, (2,))
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.shape, tuple(sum(s) for s in t.nsplits))
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         a_data = np.arange(2 * 2 * 4).reshape((2, 2, 4))
         b_data = np.arange(2 * 2 * 4).reshape((2, 4, 2))
@@ -449,14 +487,18 @@ class Test(unittest.TestCase):
         t = matmul(a, b)
 
         self.assertEqual(t.shape, (2, 2, 2))
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.shape, tuple(sum(s) for s in t.nsplits))
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = matmul(tensor([2j, 3j], chunk_size=1), tensor([2j, 3j], chunk_size=1))
 
         self.assertEqual(t.shape, ())
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.shape, tuple(sum(s) for s in t.nsplits))
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         with self.assertRaises(ValueError):
             matmul([1, 2], 3)
@@ -471,8 +513,10 @@ class Test(unittest.TestCase):
         v = ones((100, 100), chunk_size=10)
         tv = matmul(v, v)
         self.assertEqual(tv.shape, (100, 100))
+        self.assertEqual(calc_shape(tv), tv.shape)
         tv.tiles()
         self.assertEqual(tv.shape, tuple(sum(s) for s in tv.nsplits))
+        self.assertEqual(calc_shape(tv.chunks[0]), tv.chunks[0].shape)
 
     def testGetSetReal(self):
         a_data = np.array([1+2j, 3+4j, 5+6j])

--- a/mars/tensor/expressions/tests/test_base.py
+++ b/mars/tensor/expressions/tests/test_base.py
@@ -200,6 +200,7 @@ class Test(unittest.TestCase):
 
         self.assertTrue(np.isnan(indices.shape[0]))
         self.assertEqual(indices.shape[1], 2)
+        self.assertEqual(indices.rough_nbytes, 4 * 2 * 8)
 
         indices.tiles()
 

--- a/mars/tensor/expressions/tests/test_base.py
+++ b/mars/tensor/expressions/tests/test_base.py
@@ -370,6 +370,10 @@ class Test(unittest.TestCase):
         self.assertEqual(t.shape, (2, 15))
         self.assertEqual(calc_shape(t), t.shape)
 
+        t = repeat(a, [3], axis=1)
+        self.assertEqual(t.shape, (2, 15))
+        self.assertEqual(calc_shape(t), t.shape)
+
         t = repeat(a, [3, 4], axis=0)
         self.assertEqual(t.shape, (7, 5))
         self.assertEqual(calc_shape(t), t.shape)

--- a/mars/tensor/expressions/tests/test_base.py
+++ b/mars/tensor/expressions/tests/test_base.py
@@ -22,6 +22,7 @@ from mars.tensor.expressions.datasource import ones, tensor, arange, array, asar
 from mars.tensor.expressions.base import transpose, broadcast_to, where, argwhere, array_split, \
     split, squeeze, digitize, result_type, repeat, copyto, isin
 from mars.operands.base import CopyTo
+from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -48,11 +49,13 @@ class Test(unittest.TestCase):
         self.assertIsInstance(a.op, CopyTo)
         self.assertIs(a.inputs[0], b.data)
         self.assertIsInstance(a.inputs[1].op, tp)
+        self.assertEqual(calc_shape(a), a.shape)
 
         a.tiles()
 
         self.assertIsInstance(a.chunks[0].op, CopyTo)
         self.assertEqual(len(a.chunks[0].inputs), 2)
+        self.assertEqual(calc_shape(a.chunks[0]), a.chunks[0].shape)
 
         a = ones((10, 20), chunk_size=3, dtype='i4')
         b = ones(20, chunk_size=4, dtype='f8')
@@ -61,14 +64,16 @@ class Test(unittest.TestCase):
             copyto(a, b)
 
         b = ones(20, chunk_size=4, dtype='i4')
-        copyto(a, b, where=b>0)
+        copyto(a, b, where=b > 0)
 
         self.assertIsNotNone(a.op.where)
+        self.assertEqual(calc_shape(a), a.shape)
 
         a.tiles()
 
         self.assertIsInstance(a.chunks[0].op, CopyTo)
         self.assertEqual(len(a.chunks[0].inputs), 3)
+        self.assertEqual(calc_shape(a.chunks[0]), a.chunks[0].shape)
 
         with self.assertRaises(ValueError):
             copyto(a, a, where=np.ones(30, dtype='?'))
@@ -80,8 +85,10 @@ class Test(unittest.TestCase):
         arr2.tiles()
 
         self.assertEqual(arr2.shape, (10, 20, 30))
+        self.assertEqual(calc_shape(arr2), arr2.shape)
         self.assertTrue(np.issubdtype(arr2.dtype, np.int32))
         self.assertEqual(arr2.op.casting, 'unsafe')
+        self.assertEqual(calc_shape(arr2.chunks[0]), arr2.chunks[0].shape)
 
         with self.assertRaises(TypeError):
             arr.astype(np.int32, casting='safe')
@@ -93,9 +100,12 @@ class Test(unittest.TestCase):
         arr2.tiles()
 
         self.assertEqual(arr2.shape, (30, 20, 10))
+        self.assertEqual(calc_shape(arr2), arr2.shape)
         self.assertEqual(len(arr2.chunks), 126)
         self.assertEqual(arr2.chunks[0].shape, (5, 3, 4))
         self.assertEqual(arr2.chunks[-1].shape, (5, 2, 2))
+        self.assertEqual(calc_shape(arr2.chunks[0]), arr2.chunks[0].shape)
+        self.assertEqual(calc_shape(arr2.chunks[-1]), arr2.chunks[-1].shape)
 
         with self.assertRaises(ValueError):
             transpose(arr, axes=(1, 0))
@@ -104,25 +114,34 @@ class Test(unittest.TestCase):
         arr3.tiles()
 
         self.assertEqual(arr3.shape, (20, 30, 10))
+        self.assertEqual(calc_shape(arr3), arr3.shape)
         self.assertEqual(len(arr3.chunks), 126)
         self.assertEqual(arr3.chunks[0].shape, (3, 5, 4))
         self.assertEqual(arr3.chunks[-1].shape, (2, 5, 2))
+        self.assertEqual(calc_shape(arr3.chunks[0]), arr3.chunks[0].shape)
+        self.assertEqual(calc_shape(arr3.chunks[-1]), arr3.chunks[-1].shape)
 
         arr4 = arr.transpose(-2, 2, 0)
         arr4.tiles()
 
         self.assertEqual(arr4.shape, (20, 30, 10))
+        self.assertEqual(calc_shape(arr4), arr4.shape)
         self.assertEqual(len(arr4.chunks), 126)
         self.assertEqual(arr4.chunks[0].shape, (3, 5, 4))
         self.assertEqual(arr4.chunks[-1].shape, (2, 5, 2))
+        self.assertEqual(calc_shape(arr4.chunks[0]), arr4.chunks[0].shape)
+        self.assertEqual(calc_shape(arr4.chunks[-1]), arr4.chunks[-1].shape)
 
         arr5 = arr.T
         arr5.tiles()
 
         self.assertEqual(arr5.shape, (30, 20, 10))
+        self.assertEqual(calc_shape(arr5), arr5.shape)
         self.assertEqual(len(arr5.chunks), 126)
         self.assertEqual(arr5.chunks[0].shape, (5, 3, 4))
         self.assertEqual(arr5.chunks[-1].shape, (5, 2, 2))
+        self.assertEqual(calc_shape(arr5.chunks[0]), arr5.chunks[0].shape)
+        self.assertEqual(calc_shape(arr5.chunks[-1]), arr5.chunks[-1].shape)
 
     def testSwapaxes(self):
         arr = ones((10, 20, 30), chunk_size=[4, 3, 5])
@@ -130,7 +149,9 @@ class Test(unittest.TestCase):
         arr2.tiles()
 
         self.assertEqual(arr2.shape, (20, 10, 30))
+        self.assertEqual(calc_shape(arr2), arr2.shape)
         self.assertEqual(len(arr.chunks), len(arr2.chunks))
+        self.assertEqual(calc_shape(arr2.chunks[-1]), arr2.chunks[-1].shape)
 
     def testBroadcastTo(self):
         arr = ones((10, 5), chunk_size=2)
@@ -138,25 +159,31 @@ class Test(unittest.TestCase):
         arr2.tiles()
 
         self.assertEqual(arr2.shape, (20, 10, 5))
+        self.assertEqual(calc_shape(arr2), arr2.shape)
         self.assertEqual(len(arr2.chunks), len(arr.chunks))
         self.assertEqual(arr2.chunks[0].shape, (20, 2, 2))
+        self.assertEqual(calc_shape(arr2.chunks[-1]), arr2.chunks[-1].shape)
 
         arr = ones((10, 5, 1), chunk_size=2)
         arr3 = broadcast_to(arr, (5, 10, 5, 6))
         arr3.tiles()
 
         self.assertEqual(arr3.shape, (5, 10, 5, 6))
+        self.assertEqual(calc_shape(arr3), arr3.shape)
         self.assertEqual(len(arr3.chunks), len(arr.chunks))
         self.assertEqual(arr3.nsplits, ((5,), (2, 2, 2, 2, 2), (2, 2, 1), (6,)))
         self.assertEqual(arr3.chunks[0].shape, (5, 2, 2, 6))
+        self.assertEqual(calc_shape(arr3.chunks[-1]), arr3.chunks[-1].shape)
 
         arr = ones((10, 1), chunk_size=2)
         arr4 = broadcast_to(arr, (20, 10, 5))
         arr4.tiles()
 
         self.assertEqual(arr4.shape, (20, 10, 5))
+        self.assertEqual(calc_shape(arr4), arr4.shape)
         self.assertEqual(len(arr4.chunks), len(arr.chunks))
         self.assertEqual(arr4.chunks[0].shape, (20, 2, 5))
+        self.assertEqual(calc_shape(arr4.chunks[-1]), arr4.chunks[-1].shape)
 
         with self.assertRaises(ValueError):
             broadcast_to(arr, (10,))
@@ -173,6 +200,7 @@ class Test(unittest.TestCase):
         arr.tiles()
 
         self.assertEqual(len(arr.chunks), 4)
+        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertTrue(np.array_equal(arr.chunks[0].inputs[0].op.data, [[True]]))
         self.assertTrue(np.array_equal(arr.chunks[0].inputs[1].op.data, [1]))
         self.assertTrue(np.array_equal(arr.chunks[0].inputs[2].op.data, [3]))
@@ -185,6 +213,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(arr.chunks[3].inputs[0].op.data, [[True]]))
         self.assertTrue(np.array_equal(arr.chunks[3].inputs[1].op.data, [2]))
         self.assertTrue(np.array_equal(arr.chunks[3].inputs[2].op.data, [4]))
+        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
 
         with self.assertRaises(ValueError):
             where(cond, x)
@@ -200,11 +229,18 @@ class Test(unittest.TestCase):
 
         self.assertTrue(np.isnan(indices.shape[0]))
         self.assertEqual(indices.shape[1], 2)
-        self.assertEqual(indices.rough_nbytes, 4 * 2 * 8)
+        self.assertEqual(calc_shape(indices), indices.shape)
+        self.assertEqual(indices.op.calc_rough_shape(tuple(t.rough_shape for t in indices.inputs)), (4, 2))
+        self.assertEqual(indices.rough_nbytes, 4 * 2 * indices.dtype.itemsize)
 
         indices.tiles()
 
         self.assertEqual(indices.nsplits[1], (1, 1))
+
+        chunk = indices.chunks[0]
+        self.assertTrue(np.isnan(calc_shape(chunk)[0]))
+        self.assertEqual(calc_shape(chunk)[1], chunk.shape[1])
+        self.assertEqual(chunk.rough_shape, (2, 1))
 
     def testArraySplit(self):
         a = arange(8, chunk_size=2)
@@ -212,22 +248,30 @@ class Test(unittest.TestCase):
         splits = array_split(a, 3)
         self.assertEqual(len(splits), 3)
         self.assertEqual([s.shape[0] for s in splits], [3, 3, 2])
+        self.assertTrue(all(calc_shape(s) == ((3,), (3,), (2,)) for s in splits))
 
         splits[0].tiles()
         self.assertEqual(splits[0].nsplits, ((2, 1),))
         self.assertEqual(splits[1].nsplits, ((1, 2),))
         self.assertEqual(splits[2].nsplits, ((2,),))
+        self.assertEqual(calc_shape(splits[0].chunks[0]), splits[0].chunks[0].shape)
+        self.assertEqual(calc_shape(splits[1].chunks[0]), splits[1].chunks[0].shape)
+        self.assertEqual(calc_shape(splits[2].chunks[0]), splits[2].chunks[0].shape)
 
         a = arange(7, chunk_size=2)
 
         splits = array_split(a, 3)
         self.assertEqual(len(splits), 3)
         self.assertEqual([s.shape[0] for s in splits], [3, 2, 2])
+        self.assertTrue(all(calc_shape(s) == ((3,), (2,), (2,)) for s in splits))
 
         splits[0].tiles()
         self.assertEqual(splits[0].nsplits, ((2, 1),))
         self.assertEqual(splits[1].nsplits, ((1, 1),))
         self.assertEqual(splits[2].nsplits, ((1, 1),))
+        self.assertEqual(calc_shape(splits[0].chunks[0]), splits[0].chunks[0].shape)
+        self.assertEqual(calc_shape(splits[1].chunks[0]), splits[1].chunks[0].shape)
+        self.assertEqual(calc_shape(splits[2].chunks[0]), splits[2].chunks[0].shape)
 
     def testSplit(self):
         a = arange(9, chunk_size=2)
@@ -235,11 +279,15 @@ class Test(unittest.TestCase):
         splits = split(a, 3)
         self.assertEqual(len(splits), 3)
         self.assertTrue(all(s.shape == (3,) for s in splits))
+        self.assertTrue(all(calc_shape(s) == ((3,), (3,), (3,)) for s in splits))
 
         splits[0].tiles()
         self.assertEqual(splits[0].nsplits, ((2, 1),))
         self.assertEqual(splits[1].nsplits, ((1, 2),))
         self.assertEqual(splits[2].nsplits, ((2, 1),))
+        self.assertEqual(calc_shape(splits[0].chunks[0]), splits[0].chunks[0].shape)
+        self.assertEqual(calc_shape(splits[1].chunks[0]), splits[1].chunks[0].shape)
+        self.assertEqual(calc_shape(splits[2].chunks[0]), splits[2].chunks[0].shape)
 
         a = arange(8, chunk_size=2)
 
@@ -250,6 +298,7 @@ class Test(unittest.TestCase):
         self.assertEqual(splits[2].shape, (1,))
         self.assertEqual(splits[3].shape, (2,))
         self.assertEqual(splits[4].shape, (0,))
+        self.assertTrue(all(calc_shape(s) == ((3,), (2,), (1,), (2,), (0,)) for s in splits))
 
         splits[0].tiles()
         self.assertEqual(splits[0].nsplits, ((2, 1),))
@@ -257,6 +306,11 @@ class Test(unittest.TestCase):
         self.assertEqual(splits[2].nsplits, ((1,),))
         self.assertEqual(splits[3].nsplits, ((2,),))
         self.assertEqual(splits[4].nsplits, ((0,),))
+        self.assertEqual(calc_shape(splits[0].chunks[0]), splits[0].chunks[0].shape)
+        self.assertEqual(calc_shape(splits[1].chunks[0]), splits[1].chunks[0].shape)
+        self.assertEqual(calc_shape(splits[2].chunks[0]), splits[2].chunks[0].shape)
+        self.assertEqual(calc_shape(splits[3].chunks[0]), splits[3].chunks[0].shape)
+        self.assertEqual(calc_shape(splits[4].chunks[0]), splits[4].chunks[0].shape)
 
     def testSqueeze(self):
         data = np.array([[[0], [1], [2]]])
@@ -265,26 +319,32 @@ class Test(unittest.TestCase):
         t = squeeze(x)
         self.assertEqual(t.shape, (3,))
         self.assertIsNotNone(t.dtype)
+        self.assertEqual(calc_shape(t), t.shape)
 
         t = squeeze(x, axis=0)
         self.assertEqual(t.shape, (3, 1))
+        self.assertEqual(calc_shape(t), t.shape)
 
         with self.assertRaises(ValueError):
             squeeze(x, axis=1)
 
         t = squeeze(x, axis=2)
         self.assertEqual(t.shape, (1, 3))
+        self.assertEqual(calc_shape(t), t.shape)
 
     def testDigitize(self):
         x = tensor(np.array([0.2, 6.4, 3.0, 1.6]), chunk_size=2)
         bins = np.array([0.0, 1.0, 2.5, 4.0, 10.0])
         inds = digitize(x, bins)
+
         self.assertEqual(inds.shape, (4,))
         self.assertIsNotNone(inds.dtype)
+        self.assertEqual(calc_shape(inds), inds.shape)
 
         inds.tiles()
 
         self.assertEqual(len(inds.chunks), 2)
+        self.assertEqual(calc_shape(inds.chunks[0]), inds.chunks[0].shape)
 
     def testResultType(self):
         x = tensor([2, 3], dtype='i4')
@@ -300,15 +360,19 @@ class Test(unittest.TestCase):
 
         t = repeat(a, 3)
         self.assertEqual(t.shape, (30,))
+        self.assertEqual(calc_shape(t), t.shape)
 
         t = repeat(a, 3, axis=0)
         self.assertEqual(t.shape, (6, 5))
+        self.assertEqual(calc_shape(t), t.shape)
 
         t = repeat(a, 3, axis=1)
         self.assertEqual(t.shape, (2, 15))
+        self.assertEqual(calc_shape(t), t.shape)
 
         t = repeat(a, [3, 4], axis=0)
         self.assertEqual(t.shape, (7, 5))
+        self.assertEqual(calc_shape(t), t.shape)
 
         with self.assertRaises(ValueError):
             repeat(a, [3, 4], axis=1)
@@ -318,12 +382,26 @@ class Test(unittest.TestCase):
         t = repeat(a, 3)
         t.tiles()
         self.assertEqual(sum(t.nsplits[0]), 30)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         a = tensor(np.random.randn(100), chunk_size=10)
 
         t = repeat(a, 3)
         t.tiles()
         self.assertEqual(sum(t.nsplits[0]), 300)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
+
+        a = tensor(np.random.randn(4))
+        b = tensor((4,))
+
+        t = repeat(a, b)
+        self.assertEqual(calc_shape(t), t.shape)
+        self.assertEqual(t.rough_shape, (4,))
+
+        t.tiles()
+        self.assertTrue(np.isnan(t.nsplits[0]))
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
+        self.assertEqual(t.chunks[0].rough_shape, (4,))
 
     def testIsIn(self):
         element = 2 * arange(4, chunk_size=1).reshape(2, 2)
@@ -332,12 +410,14 @@ class Test(unittest.TestCase):
         mask = isin(element, test_elements)
         self.assertEqual(mask.shape, (2, 2))
         self.assertEqual(mask.dtype, np.bool_)
+        self.assertEqual(calc_shape(mask), mask.shape)
 
         mask.tiles()
 
         self.assertEqual(len(mask.chunks), len(element.chunks))
         self.assertEqual(len(mask.op.test_elements.chunks), 1)
         self.assertIs(mask.chunks[0].inputs[0], element.chunks[0].data)
+        self.assertEqual(calc_shape(mask.chunks[0]), mask.chunks[0].shape)
 
         element = 2 * arange(4, chunk_size=1).reshape(2, 2)
         test_elements = tensor([1, 2, 4, 8], chunk_size=2)
@@ -345,6 +425,7 @@ class Test(unittest.TestCase):
         mask = isin(element, test_elements, invert=True)
         self.assertEqual(mask.shape, (2, 2))
         self.assertEqual(mask.dtype, np.bool_)
+        self.assertEqual(calc_shape(mask), mask.shape)
 
         mask.tiles()
 
@@ -352,3 +433,4 @@ class Test(unittest.TestCase):
         self.assertEqual(len(mask.op.test_elements.chunks), 1)
         self.assertIs(mask.chunks[0].inputs[0], element.chunks[0].data)
         self.assertTrue(mask.chunks[0].op.invert)
+        self.assertEqual(calc_shape(mask.chunks[0]), mask.chunks[0].shape)

--- a/mars/tensor/expressions/tests/test_core.py
+++ b/mars/tensor/expressions/tests/test_core.py
@@ -31,7 +31,7 @@ from mars.tensor.expressions.fuse.core import TensorFuseChunk
 from mars.tensor.core import Tensor, SparseTensor, build_mode
 from mars.graph import DAG
 from mars.serialize.protos.operand_pb2 import OperandDef
-from mars.tests.core import TestBase
+from mars.tests.core import TestBase, calc_shape
 
 
 class Test(TestBase):
@@ -181,14 +181,18 @@ class Test(TestBase):
         tensor = ones((10, 10, 8), chunk_size=(3, 3, 5))
         tensor.tiles()
         self.assertEqual(tensor.shape, (10, 10, 8))
+        self.assertEqual(calc_shape(tensor), tensor.shape)
         self.assertEqual(len(tensor.chunks), 32)
+        self.assertEqual(calc_shape(tensor.chunks[0]), tensor.chunks[0].shape)
 
         tensor = ones((10, 3), chunk_size=(4, 2))
         tensor.tiles()
         self.assertEqual(tensor.shape, (10, 3))
+        self.assertEqual(calc_shape(tensor), tensor.shape)
 
         chunk = tensor.cix[1, 1]
         self.assertEqual(tensor.get_chunk_slices(chunk.index), (slice(4, 8), slice(2, 3)))
+        self.assertEqual(calc_shape(chunk), chunk.shape)
 
         tensor = ones((10, 5), chunk_size=(2, 3), gpu=True)
         tensor.tiles()
@@ -322,14 +326,17 @@ class Test(TestBase):
         t.tiles()
 
         self.assertEqual(t.shape, (10,))
+        self.assertEqual(calc_shape(t), t.shape)
         self.assertEqual(t.nsplits, ((3, 3, 3, 1),))
         self.assertEqual(t.chunks[1].op.start, 3)
         self.assertEqual(t.chunks[1].op.stop, 6)
+        self.assertEqual(calc_shape(t.chunks[1]), t.chunks[1].shape)
 
         t = arange(0, 10, 3, chunk_size=2)
         t.tiles()
 
         self.assertEqual(t.shape, (4,))
+        self.assertEqual(calc_shape(t), t.shape)
         self.assertEqual(t.nsplits, ((2, 2),))
         self.assertEqual(t.chunks[0].op.start, 0)
         self.assertEqual(t.chunks[0].op.stop, 6)
@@ -337,6 +344,8 @@ class Test(TestBase):
         self.assertEqual(t.chunks[1].op.start, 6)
         self.assertEqual(t.chunks[1].op.stop, 12)
         self.assertEqual(t.chunks[1].op.step, 3)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
+        self.assertEqual(calc_shape(t.chunks[1]), t.chunks[1].shape)
 
         self.assertRaises(TypeError, lambda: arange(10, start=0))
         self.assertRaises(TypeError, lambda: arange(0, 10, stop=0))
@@ -349,61 +358,78 @@ class Test(TestBase):
         t = diag(v)
 
         self.assertEqual(t.shape, (4,))
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.nsplits, ((2, 2),))
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         v = tensor(np.arange(16).reshape(4, 4), chunk_size=(2, 3))
         t = diag(v)
 
         self.assertEqual(t.shape, (4,))
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.nsplits, ((2, 1, 1),))
+        # self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         # test 1-d, k == 0
         v = tensor(np.arange(3), chunk_size=2)
         t = diag(v, sparse=True)
 
         self.assertEqual(t.shape, (3, 3))
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.nsplits, ((2, 1), (2, 1)))
         self.assertEqual(len([c for c in t.chunks
                               if c.op.__class__.__name__ == 'TensorDiag']), 2)
         self.assertTrue(t.chunks[0].op.sparse)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         # test 2-d, shape[0] != shape[1]
         v = tensor(np.arange(24).reshape(4, 6), chunk_size=2)
         t = diag(v)
 
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6)).shape)
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         v = tensor(np.arange(24).reshape(4, 6), chunk_size=2)
 
         t = diag(v, k=1)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=1).shape)
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = diag(v, k=2)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=2).shape)
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = diag(v, k=-1)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=-1).shape)
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = diag(v, k=-2)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=-2).shape)
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
     def testLinspace(self):
         a = linspace(2.0, 3.0, num=5, chunk_size=2)
 
         self.assertEqual(a.shape, (5,))
+        self.assertEqual(calc_shape(a), a.shape)
 
         a.tiles()
         self.assertEqual(a.nsplits, ((2, 2, 1),))
@@ -413,10 +439,12 @@ class Test(TestBase):
         self.assertEqual(a.chunks[1].op.stop, 2.75)
         self.assertEqual(a.chunks[2].op.start, 3.)
         self.assertEqual(a.chunks[2].op.stop, 3.)
+        self.assertEqual(calc_shape(a.chunks[0]), a.chunks[0].shape)
 
         a = linspace(2.0, 3.0, num=5, endpoint=False, chunk_size=2)
 
         self.assertEqual(a.shape, (5,))
+        self.assertEqual(calc_shape(a), a.shape)
 
         a.tiles()
         self.assertEqual(a.nsplits, ((2, 2, 1),))
@@ -426,6 +454,7 @@ class Test(TestBase):
         self.assertEqual(a.chunks[1].op.stop, 2.6)
         self.assertEqual(a.chunks[2].op.start, 2.8)
         self.assertEqual(a.chunks[2].op.stop, 2.8)
+        self.assertEqual(calc_shape(a.chunks[0]), a.chunks[0].shape)
 
         _, step = linspace(2.0, 3.0, num=5, chunk_size=2, retstep=True)
         self.assertEqual(step, .25)
@@ -435,68 +464,92 @@ class Test(TestBase):
         a = tensor(a_data, chunk_size=2)
 
         t = triu(a)
+        self.assertEqual(calc_shape(t), t.shape)
+
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorTriu)
         self.assertIsInstance(t.chunks[1].op, TensorTriu)
         self.assertIsInstance(t.chunks[2].op, TensorZeros)
         self.assertIsInstance(t.chunks[3].op, TensorTriu)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = triu(a, k=1)
+        self.assertEqual(calc_shape(t), t.shape)
+
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorTriu)
         self.assertIsInstance(t.chunks[1].op, TensorTriu)
         self.assertIsInstance(t.chunks[2].op, TensorZeros)
         self.assertIsInstance(t.chunks[3].op, TensorZeros)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = triu(a, k=2)
+        self.assertEqual(calc_shape(t), t.shape)
+
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorZeros)
         self.assertIsInstance(t.chunks[1].op, TensorTriu)
         self.assertIsInstance(t.chunks[2].op, TensorZeros)
         self.assertIsInstance(t.chunks[3].op, TensorZeros)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = triu(a, k=-1)
+        self.assertEqual(calc_shape(t), t.shape)
+
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorTriu)
         self.assertIsInstance(t.chunks[1].op, TensorTriu)
         self.assertIsInstance(t.chunks[2].op, TensorTriu)
         self.assertIsInstance(t.chunks[3].op, TensorTriu)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = tril(a)
+        self.assertEqual(calc_shape(t), t.shape)
+
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorTril)
         self.assertIsInstance(t.chunks[1].op, TensorZeros)
         self.assertIsInstance(t.chunks[2].op, TensorTril)
         self.assertIsInstance(t.chunks[3].op, TensorTril)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = tril(a, k=1)
+        self.assertEqual(calc_shape(t), t.shape)
+
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorTril)
         self.assertIsInstance(t.chunks[1].op, TensorTril)
         self.assertIsInstance(t.chunks[2].op, TensorTril)
         self.assertIsInstance(t.chunks[3].op, TensorTril)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = tril(a, k=-1)
+        self.assertEqual(calc_shape(t), t.shape)
+
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorTril)
         self.assertIsInstance(t.chunks[1].op, TensorZeros)
         self.assertIsInstance(t.chunks[2].op, TensorTril)
         self.assertIsInstance(t.chunks[3].op, TensorTril)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = tril(a, k=-2)
+        self.assertEqual(calc_shape(t), t.shape)
+
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorZeros)
         self.assertIsInstance(t.chunks[1].op, TensorZeros)
         self.assertIsInstance(t.chunks[2].op, TensorTril)
         self.assertIsInstance(t.chunks[3].op, TensorZeros)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
     def testSetTensorInputs(self):
         t1 = tensor([1, 2], chunk_size=2)
@@ -537,6 +590,7 @@ class Test(TestBase):
         self.assertIsInstance(t.op, CSRMatrixDataSource)
         self.assertTrue(t.issparse())
         self.assertFalse(t.op.gpu)
+        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(t.chunks[0].index, (0, 0))
@@ -547,6 +601,7 @@ class Test(TestBase):
         self.assertTrue(np.array_equal(t.chunks[0].op.indptr, m.indptr))
         self.assertTrue(np.array_equal(t.chunks[0].op.data, m.data))
         self.assertTrue(np.array_equal(t.chunks[0].op.shape, m.shape))
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
     def testFromDense(self):
         t = fromdense(tensor([[0, 0, 1], [1, 0, 0]], chunk_size=2))
@@ -554,10 +609,12 @@ class Test(TestBase):
         self.assertIsInstance(t, SparseTensor)
         self.assertIsInstance(t.op, DenseToSparse)
         self.assertTrue(t.issparse())
+        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(t.chunks[0].index, (0, 0))
         self.assertIsInstance(t.op, DenseToSparse)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
     def testOnesLike(self):
         t1 = tensor([[0, 0, 1], [1, 0, 0]], chunk_size=2).tosparse()
@@ -566,8 +623,10 @@ class Test(TestBase):
         self.assertIsInstance(t, SparseTensor)
         self.assertIsInstance(t.op, TensorOnesLike)
         self.assertTrue(t.issparse())
+        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(t.chunks[0].index, (0, 0))
         self.assertIsInstance(t.op, TensorOnesLike)
         self.assertTrue(t.chunks[0].issparse())
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)

--- a/mars/tensor/expressions/tests/test_fft.py
+++ b/mars/tensor/expressions/tests/test_fft.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from mars.tensor.expressions.datasource import ones
 from mars.tensor import fft
+from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -28,125 +29,177 @@ class Test(unittest.TestCase):
 
         t1 = fft.fft(t)
         self.assertEqual(t1.shape, (10, 20, 30))
+        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ifft(t)
         self.assertEqual(t1.shape, (10, 20, 30))
+        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.fft2(t, s=(23, 21))
+        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, (10, 23, 21))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ifft2(t, s=(11, 9), axes=(1, 2))
+        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, (10, 11, 9))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.fftn(t, s=(11, 9), axes=(1, 2))
+        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, (10, 11, 9))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ifftn(t, s=(11, 9), axes=(1, 2))
+        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, (10, 11, 9))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
     def testRealFFT(self):
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.rfft(t)
         self.assertEqual(t1.shape, np.fft.rfft(np.ones(t.shape)).shape)
+        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.irfft(t)
         self.assertEqual(t1.shape, np.fft.irfft(np.ones(t.shape)).shape)
+        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.rfft2(t, s=(23, 21))
         self.assertEqual(t1.shape, np.fft.rfft2(np.ones(t.shape), s=(23, 21)).shape)
+        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.irfft2(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.irfft2(np.ones(t.shape), s=(11, 9), axes=(1, 2)).shape)
+        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.rfftn(t, s=(11, 30), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.rfftn(np.ones(t.shape), s=(11, 30), axes=(1, 2)).shape)
+        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.irfftn(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.irfftn(np.ones(t.shape), s=(11, 9), axes=(1, 2)).shape)
+        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
     def testHermitianFFT(self):
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.hfft(t)
         self.assertEqual(t1.shape, np.fft.hfft(np.ones(t.shape)).shape)
+        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.hfft(t, n=100)
         self.assertEqual(t1.shape, np.fft.hfft(np.ones(t.shape), n=100).shape)
+        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ihfft(t)
+        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape)).shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ihfft(t, n=100)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape), n=100).shape)
+        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t1 = fft.ihfft(t, n=101)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape), n=101).shape)
+        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
+        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
     def testFFTShift(self):
         freqs = fft.fftfreq(9, d=1./9).reshape(3, 3)
         t = fft.ifftshift(fft.fftshift(freqs))
 
+        self.assertEqual(calc_shape(t), t.shape)
         self.assertIsNotNone(t.dtype)
         expect_dtype = np.fft.ifftshift(np.fft.fftshift(np.fft.fftfreq(9, d=1./9).reshape(3, 3))).dtype
         self.assertEqual(t.dtype, expect_dtype)
+
+    def testFFTFreq(self):
+        t = fft.fftfreq(10, .1, chunk_size=3)
+
+        self.assertEqual(t.shape, np.fft.fftfreq(10, .1).shape)
+        self.assertEqual(calc_shape(t), t.shape)
+        t.tiles()
+        self.assertEqual(t.shape, tuple(sum(ns) for ns in t.nsplits))
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
+
+        t = fft.rfftfreq(10, .1, chunk_size=3)
+
+        self.assertEqual(t.shape, np.fft.rfftfreq(10, .1).shape)
+        self.assertEqual(calc_shape(t), t.shape)
+        t.tiles()
+        self.assertEqual(t.shape, tuple(sum(ns) for ns in t.nsplits))
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)

--- a/mars/tensor/expressions/tests/test_indexing.py
+++ b/mars/tensor/expressions/tests/test_indexing.py
@@ -41,6 +41,13 @@ class Test(unittest.TestCase):
         self.assertEqual(indexed.shape[1], 300)
         self.assertEqual(indexed.rough_nbytes, t.nbytes)
 
+        t2 = ones((100, 200))
+        indexed = t[t2 < 2] + 1
+        self.assertEqual(len(indexed.shape), 2)
+        self.assertTrue(np.isnan(indexed.shape[0]))
+        self.assertEqual(indexed.shape[1], 300)
+        self.assertEqual(indexed.rough_nbytes, t.nbytes)
+
         t3 = ones((101, 200))
         with self.assertRaises(IndexError) as cm:
             _ = t[t3 < 2]  # noqa: F841

--- a/mars/tensor/expressions/tests/test_indexing.py
+++ b/mars/tensor/expressions/tests/test_indexing.py
@@ -32,12 +32,14 @@ class Test(unittest.TestCase):
         indexed = t[t < 2]
         self.assertEqual(len(indexed.shape), 1)
         self.assertTrue(np.isnan(indexed.shape[0]))
+        self.assertEqual(indexed.rough_nbytes, t.nbytes)
 
         t2 = ones((100, 200))
         indexed = t[t2 < 2]
         self.assertEqual(len(indexed.shape), 2)
         self.assertTrue(np.isnan(indexed.shape[0]))
         self.assertEqual(indexed.shape[1], 300)
+        self.assertEqual(indexed.rough_nbytes, t.nbytes)
 
         t3 = ones((101, 200))
         with self.assertRaises(IndexError) as cm:
@@ -96,6 +98,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(t2.shape), 3)
         self.assertTrue(np.isnan(t2.shape[0]))
         self.assertEqual(t2.shape[1:], (200, 3))
+        self.assertEqual(t2.rough_nbytes, 100 * 200 * 3 * t.dtype.itemsize)
 
     def testBoolIndexingTiles(self):
         t = ones((100, 200, 300), chunk_size=30)
@@ -118,6 +121,7 @@ class Test(unittest.TestCase):
         self.assertEqual(indexed2.chunks[0].shape[1], 30)
         self.assertEqual(indexed2.chunks[20].inputs[0], t.cix[(0, 2, 0)].data)
         self.assertEqual(indexed2.chunks[20].inputs[1], indexed2.op.indexes[0].cix[0, 2].data)
+        self.assertEqual(indexed2.rough_nbytes, t.nbytes)
 
     def testSliceTiles(self):
         t = ones((100, 200, 300), chunk_size=30)
@@ -157,6 +161,7 @@ class Test(unittest.TestCase):
 
         self.assertEqual(t2.shape[:-1], (27, 300, 1))
         self.assertTrue(np.isnan(t2.shape[-1]))
+        self.assertEqual(t2.rough_nbytes, 27 * 300 * 400 * t.dtype.itemsize)
         self.assertEqual(t2.chunk_shape, (4, 13, 1, 17))
         self.assertEqual(t2.chunks[0].op.indexes, [slice(10, 24, 3), 5, slice(None), None, cmp.cix[0,].data])
 

--- a/mars/tensor/expressions/tests/test_indexing.py
+++ b/mars/tensor/expressions/tests/test_indexing.py
@@ -24,6 +24,7 @@ from mars.tensor.expressions.indexing import choose, unravel_index, nonzero
 from mars.tensor.expressions.indexing.setitem import TensorIndexSetValue
 from mars.tensor.expressions.merge.concatenate import TensorConcatenate
 from mars.config import option_context
+from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -32,6 +33,7 @@ class Test(unittest.TestCase):
         indexed = t[t < 2]
         self.assertEqual(len(indexed.shape), 1)
         self.assertTrue(np.isnan(indexed.shape[0]))
+        self.assertTrue(np.isnan(calc_shape(indexed)[0]))
         self.assertEqual(indexed.rough_nbytes, t.nbytes)
 
         t2 = ones((100, 200))
@@ -39,6 +41,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(indexed.shape), 2)
         self.assertTrue(np.isnan(indexed.shape[0]))
         self.assertEqual(indexed.shape[1], 300)
+        self.assertTrue(np.isnan(calc_shape(indexed)[0]))
         self.assertEqual(indexed.rough_nbytes, t.nbytes)
 
         t2 = ones((100, 200))
@@ -46,6 +49,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(indexed.shape), 2)
         self.assertTrue(np.isnan(indexed.shape[0]))
         self.assertEqual(indexed.shape[1], 300)
+        self.assertTrue(np.isnan(calc_shape(indexed)[0]))
         self.assertEqual(indexed.rough_nbytes, t.nbytes)
 
         t3 = ones((101, 200))
@@ -66,19 +70,23 @@ class Test(unittest.TestCase):
         t = ones((100, 200, 300))
         t2 = t[10: 30, 199:, -30: 303]
         self.assertEqual(t2.shape, (20, 1, 30))
+        self.assertEqual(calc_shape(t2), t2.shape)
 
         t3 = t[10:90:4, 20:80:5]
         s1 = len(list(range(100))[10:90:4])
         s2 = len(list(range(200))[20:80:5])
         self.assertEqual(t3.shape, (s1, s2, 300))
+        self.assertEqual(calc_shape(t2), t2.shape)
 
     def testFancyIndexing(self):
         t = ones((100, 200, 300))
         t2 = t[[0, 1], [2, 3]]
         self.assertEqual(t2.shape, (2, 300))
+        self.assertEqual(calc_shape(t2), t2.shape)
 
         t3 = t[[[0, 1], [2, 3]], [4, 5]]
         self.assertEqual(t3.shape, (2, 2, 300))
+        self.assertEqual(calc_shape(t3), t3.shape)
 
         with self.assertRaises(IndexError) as cm:
             _ = t[[1, 2], [3, 4, 5]]  # noqa: F841
@@ -90,10 +98,14 @@ class Test(unittest.TestCase):
         t4 = t[:10, -10:, [13, 244, 151, 242, 34]].tiles()
         self.assertEqual(t4.shape, (10, 10, 5))
         self.assertEqual(t4.chunk_shape, (1, 1, 1))
+        self.assertEqual(calc_shape(t4), t4.shape)
+        self.assertEqual(calc_shape(t4.chunks[0]), t4.chunks[0].shape)
 
         t5 = t[:10, -10:, [1, 10, 20, 33, 34, 200]].tiles()
         self.assertEqual(t5.shape, (10, 10, 6))
         self.assertEqual(t5.chunk_shape, (1, 1, 5))
+        self.assertEqual(calc_shape(t5), t5.shape)
+        self.assertEqual(calc_shape(t5.chunks[0]), t5.chunks[0].shape)
 
     def testMixedIndexing(self):
         t = ones((100, 200, 300, 400))
@@ -104,7 +116,7 @@ class Test(unittest.TestCase):
         t2 = t[ones(100) < 2, ..., 20::101, 2]
         self.assertEqual(len(t2.shape), 3)
         self.assertTrue(np.isnan(t2.shape[0]))
-        self.assertEqual(t2.shape[1:], (200, 3))
+        self.assertEqual(calc_shape(t2), t2.shape)
         self.assertEqual(t2.rough_nbytes, 100 * 200 * 3 * t.dtype.itemsize)
 
     def testBoolIndexingTiles(self):
@@ -117,6 +129,10 @@ class Test(unittest.TestCase):
         self.assertEqual(indexed.chunks[20].index, (20,))
         self.assertIs(indexed.chunks[20].inputs[0], t.cix[(0, 2, 0)].data)
         self.assertIs(indexed.chunks[20].inputs[1], indexed.op.indexes[0].cix[0, 2, 0].data)
+        self.assertEqual(calc_shape(indexed.chunks[0]), indexed.chunks[0].shape)
+        self.assertEqual(calc_shape(indexed.chunks[20]), indexed.chunks[20].shape)
+        self.assertEqual(indexed.chunks[0].rough_nbytes, t.chunks[0].nbytes)
+        self.assertEqual(indexed.chunks[20].rough_nbytes, t.chunks[20].nbytes)
 
         t2 = ones((100, 200), chunk_size=30)
         indexed2 = t[t2 < 2]
@@ -129,6 +145,10 @@ class Test(unittest.TestCase):
         self.assertEqual(indexed2.chunks[20].inputs[0], t.cix[(0, 2, 0)].data)
         self.assertEqual(indexed2.chunks[20].inputs[1], indexed2.op.indexes[0].cix[0, 2].data)
         self.assertEqual(indexed2.chunks[0].rough_nbytes, 30 * 30 * 30 * t2.dtype.itemsize)
+        self.assertEqual(calc_shape(indexed2.chunks[0]), indexed2.chunks[0].shape)
+        self.assertEqual(calc_shape(indexed2.chunks[20]), indexed2.chunks[20].shape)
+        self.assertEqual(indexed2.chunks[0].rough_nbytes, t.chunks[0].nbytes)
+        self.assertEqual(indexed2.chunks[20].rough_nbytes, t.chunks[20].nbytes)
 
     def testSliceTiles(self):
         t = ones((100, 200, 300), chunk_size=30)
@@ -142,6 +162,8 @@ class Test(unittest.TestCase):
         self.assertEqual(t2.chunks[1].inputs[0], t.cix[1, -1, -1].data)
         self.assertEqual(t2.chunks[1].op.indexes, [slice(0, 10, 1), slice(19, 20, 1), slice(None)])
         self.assertEqual(t2.chunks[1].index, (1, 0, 0))
+        self.assertEqual(calc_shape(t2.chunks[0]), t2.chunks[0].shape)
+        self.assertEqual(calc_shape(t2.chunks[1]), t2.chunks[1].shape)
 
     def testIndicesIndexingTiles(self):
         t = ones((10, 20, 30), chunk_size=(2, 20, 30))
@@ -151,6 +173,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(t2.chunks), 1)
         self.assertIs(t2.chunks[0].inputs[0], t.cix[1, 0, 0].data)
         self.assertEqual(t2.chunks[0].op.indexes[0], 1)
+        self.assertEqual(calc_shape(t2.chunks[0]), t2.chunks[0].shape)
 
         t3 = t[4]
         t3.tiles()
@@ -158,6 +181,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(t3.chunks), 1)
         self.assertIs(t3.chunks[0].inputs[0], t.cix[2, 0, 0].data)
         self.assertEqual(t3.chunks[0].op.indexes[0], 0)
+        self.assertEqual(calc_shape(t3.chunks[0]), t3.chunks[0].shape)
 
     def testMixedIndexingTiles(self):
         t = ones((100, 200, 300, 400), chunk_size=24)
@@ -171,6 +195,7 @@ class Test(unittest.TestCase):
         self.assertEqual(t2.rough_nbytes, 27 * 300 * 400 * t.dtype.itemsize)
         self.assertEqual(t2.chunk_shape, (4, 13, 1, 17))
         self.assertEqual(t2.chunks[0].op.indexes, [slice(10, 24, 3), 5, slice(None), None, cmp.cix[0, ].data])
+        self.assertEqual(calc_shape(t2.chunks[0]), t2.chunks[0].shape)
         self.assertEqual(t2.chunks[0].rough_nbytes, 5 * 24 * 24 * t.dtype.itemsize)
 
         # multiple tensor type as indexes
@@ -183,9 +208,11 @@ class Test(unittest.TestCase):
         self.assertEqual(t4.shape[1], 1)
         self.assertTrue(np.isnan(t4.shape[0]))
         self.assertTrue(np.isnan(t4.shape[-1]))
+        self.assertEqual(calc_shape(t4), t4.shape)
         self.assertEqual(t4.rough_nbytes, 100 * 200 * 400 * t.dtype.itemsize)
         self.assertEqual(t4.chunk_shape, (45, 1, 17))
         self.assertEqual(t4.chunks[0].op.indexes, [cmp2.cix[0, 0].data, 5, None, cmp3.cix[0, ].data])
+        self.assertEqual(calc_shape(t4.chunks[0]), t4.chunks[0].shape)
         self.assertEqual(t4.chunks[0].rough_nbytes, 24 * 24 * 24 * t3.dtype.itemsize)
 
     def testSetItem(self):
@@ -196,20 +223,25 @@ class Test(unittest.TestCase):
         self.assertIsInstance(t.op, TensorIndexSetValue)
         self.assertEqual(t.shape, shape)
         self.assertIsInstance(t.inputs[0].op.outputs[0].op, TensorOnes)
+        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertIsInstance(t.chunks[0].op, TensorOnes)
         self.assertIsInstance(t.cix[1, 1, 0, 0].op, TensorIndexSetValue)
         self.assertEqual(t.cix[1, 1, 0, 0].op.value, 2)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
+        self.assertEqual(calc_shape(t.cix[1, 1, 0, 0]), t.cix[1, 1, 0, 0].shape)
 
         t2 = ones(shape, chunk_size=5, dtype='i4')
         shape = t2[5:20:3, 5, ..., :-5].shape
         t2[5:20:3, 5, ..., :-5] = ones(shape, chunk_size=4, dtype='i4') * 2
+        self.assertEqual(calc_shape(t2), t2.shape)
 
         t2.tiles()
         self.assertIsInstance(t2.chunks[0].op, TensorOnes)
         self.assertIsInstance(t2.cix[1, 1, 0, 0].op, TensorIndexSetValue)
         self.assertIsInstance(t2.cix[1, 1, 0, 0].op.value.op, TensorConcatenate)
+        self.assertEqual(calc_shape(t2.chunks[0]), t2.chunks[0].shape)
 
         with self.assertRaises(ValueError):
             t[0, 0, 0, 0] = ones(2, chunk_size=10)
@@ -223,6 +255,8 @@ class Test(unittest.TestCase):
             a = choose([2, 3, 1, 0], choices)
 
             a.tiles()
+            self.assertEqual(calc_shape(a), a.shape)
+            self.assertEqual(calc_shape(a.chunks[0]), a.chunks[0].shape)
             self.assertEqual(len(a.chunks), 2)
             self.assertIsInstance(a.chunks[0].op, type(a.op))
             self.assertEqual(len(a.chunks[0].inputs), 5)
@@ -232,17 +266,31 @@ class Test(unittest.TestCase):
         t = unravel_index(indices, (7, 6))
 
         self.assertEqual(len(t), 2)
+        self.assertEqual(calc_shape(t[0]), t[0].shape)
+        self.assertEqual(calc_shape(t[1]), t[1].shape)
 
         [r.tiles() for r in t]
 
         self.assertEqual(len(t[0].chunks), 3)
         self.assertEqual(len(t[1].chunks), 3)
+        self.assertEqual(calc_shape(t[0].chunks[0]), t[0].chunks[0].shape)
+        self.assertEqual(calc_shape(t[1].chunks[0]), t[1].chunks[0].shape)
 
     def testNonzero(self):
         x = tensor([[1, 0, 0], [0, 2, 0], [1, 1, 0]], chunk_size=2)
         y = nonzero(x)
 
         self.assertEqual(len(y), 2)
+        self.assertEqual(calc_shape(y[0]), y[0].shape)
+        self.assertEqual(calc_shape(y[1]), y[1].shape)
+        self.assertEqual(y[0].rough_nbytes, x.size * x.dtype.itemsize)
+        self.assertEqual(y[1].rough_nbytes, x.size * x.dtype.itemsize)
+
+        y[0].tiles()
+        self.assertEqual(calc_shape(y[0].chunks[0]), y[0].chunks[0].shape)
+        self.assertEqual(calc_shape(y[1].chunks[0]), y[1].chunks[0].shape)
+        self.assertEqual(y[0].chunks[0].rough_nbytes, 3 * x.dtype.itemsize)
+        self.assertEqual(y[1].chunks[0].rough_nbytes, 3 * x.dtype.itemsize)
 
     def testOperandKey(self):
         t = ones((10, 2), chunk_size=5)

--- a/mars/tensor/expressions/tests/test_indexing.py
+++ b/mars/tensor/expressions/tests/test_indexing.py
@@ -283,14 +283,14 @@ class Test(unittest.TestCase):
         self.assertEqual(len(y), 2)
         self.assertEqual(calc_shape(y[0]), y[0].shape)
         self.assertEqual(calc_shape(y[1]), y[1].shape)
-        self.assertEqual(y[0].rough_nbytes, x.size * x.dtype.itemsize)
-        self.assertEqual(y[1].rough_nbytes, x.size * x.dtype.itemsize)
+        self.assertEqual(y[0].rough_nbytes, x.size * np.dtype(np.intp).itemsize)
+        self.assertEqual(y[1].rough_nbytes, x.size * np.dtype(np.intp).itemsize)
 
         y[0].tiles()
         self.assertEqual(calc_shape(y[0].chunks[0]), y[0].chunks[0].shape)
         self.assertEqual(calc_shape(y[1].chunks[0]), y[1].chunks[0].shape)
-        self.assertEqual(y[0].chunks[0].rough_nbytes, 3 * x.dtype.itemsize)
-        self.assertEqual(y[1].chunks[0].rough_nbytes, 3 * x.dtype.itemsize)
+        self.assertEqual(y[0].chunks[0].rough_nbytes, 3 * np.dtype(np.intp).itemsize)
+        self.assertEqual(y[1].chunks[0].rough_nbytes, 3 * np.dtype(np.intp).itemsize)
 
     def testOperandKey(self):
         t = ones((10, 2), chunk_size=5)

--- a/mars/tensor/expressions/tests/test_merge.py
+++ b/mars/tensor/expressions/tests/test_merge.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from mars.tensor.expressions.datasource import ones
 from mars.tensor.expressions.merge import concatenate, stack
+from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -29,12 +30,14 @@ class Test(unittest.TestCase):
 
         c = concatenate([a, b])
         self.assertEqual(c.shape, (30, 20, 30))
+        self.assertEqual(calc_shape(c), c.shape)
 
         a = ones((10, 20, 30), chunk_size=10)
         b = ones((10, 20, 40), chunk_size=20)
 
         c = concatenate([a, b], axis=-1)
         self.assertEqual(c.shape, (10, 20, 70))
+        self.assertEqual(calc_shape(c), c.shape)
 
         with self.assertRaises(ValueError):
             a = ones((10, 20, 30), chunk_size=10)
@@ -58,29 +61,37 @@ class Test(unittest.TestCase):
         self.assertEqual(c.nsplits, ((5, 5, 10, 10), (5,) * 4, (5,) * 6))
         self.assertEqual(c.cix[0, 0, 0].key, a.cix[0, 0, 0].key)
         self.assertEqual(c.cix[1, 0, 0].key, a.cix[1, 0, 0].key)
+        self.assertEqual(calc_shape(c.cix[0, 0, 0]), c.cix[0, 0, 0].shape)
+        self.assertEqual(calc_shape(c.cix[1, 0, 0]), c.cix[1, 0, 0].shape)
 
     def testStack(self):
         raw_arrs = [ones((3, 4), chunk_size=2) for _ in range(10)]
         arr2 = stack(raw_arrs, axis=0)
 
         self.assertEqual(arr2.shape, (10, 3, 4))
+        self.assertEqual(calc_shape(arr2), arr2.shape)
 
         arr2.tiles()
         self.assertEqual(arr2.nsplits, ((1,) * 10, (2, 1), (2, 2)))
+        self.assertEqual(calc_shape(arr2.chunks[0]), arr2.chunks[0].shape)
 
         arr3 = stack(raw_arrs, axis=1)
 
         self.assertEqual(arr3.shape, (3, 10, 4))
+        self.assertEqual(calc_shape(arr3), arr3.shape)
 
         arr3.tiles()
         self.assertEqual(arr3.nsplits, ((2, 1), (1,) * 10, (2, 2)))
+        self.assertEqual(calc_shape(arr3.chunks[0]), arr3.chunks[0].shape)
 
         arr4 = stack(raw_arrs, axis=2)
+        self.assertEqual(calc_shape(arr4), arr4.shape)
 
         self.assertEqual(arr4.shape, (3, 4, 10))
 
         arr4.tiles()
         self.assertEqual(arr4.nsplits, ((2, 1), (2, 2), (1,) * 10))
+        self.assertEqual(calc_shape(arr4.chunks[0]), arr4.chunks[0].shape)
 
         with self.assertRaises(ValueError):
             raw_arrs2 = [ones((3, 4), chunk_size=2), ones((4, 3), chunk_size=2)]

--- a/mars/tensor/expressions/tests/test_random.py
+++ b/mars/tensor/expressions/tests/test_random.py
@@ -19,6 +19,7 @@ import numpy as np
 from mars.tensor.expressions.random import RandomState, beta, rand, choice, multivariate_normal, randint, randn
 from mars.tensor.expressions.datasource import tensor as from_ndarray
 from mars.tensor.expressions.tests.test_core import TestBase
+from mars.tests.core import calc_shape
 
 
 class Test(TestBase):
@@ -44,38 +45,49 @@ class Test(TestBase):
         arr = beta(1, 2, chunk_size=2).tiles()
 
         self.assertEqual(arr.shape, ())
+        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertEqual(len(arr.chunks), 1)
         self.assertEqual(arr.chunks[0].shape, ())
+        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
         self.assertEqual(arr.chunks[0].op.dtype, np.dtype('f8'))
 
         arr = beta([1, 2], [3, 4], chunk_size=2).tiles()
 
         self.assertEqual(arr.shape, (2,))
+        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertEqual(len(arr.chunks), 1)
         self.assertEqual(arr.chunks[0].shape, (2,))
         self.assertEqual(arr.chunks[0].op.dtype, np.dtype('f8'))
+        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
 
         arr = beta([[2, 3]], from_ndarray([[4, 6], [5, 2]], chunk_size=2),
                    chunk_size=1, size=(3, 2, 2)).tiles()
 
         self.assertEqual(arr.shape, (3, 2, 2))
+        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertEqual(len(arr.chunks), 12)
         self.assertEqual(arr.chunks[0].op.dtype, np.dtype('f8'))
+        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
 
     def testChoice(self):
         t = choice(5, chunk_size=1)
         self.assertEqual(t.shape, ())
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.nsplits, ())
         self.assertEqual(len(t.chunks), 1)
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = choice(5, 3, chunk_size=1)
         self.assertEqual(t.shape, (3,))
+        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.nsplits, ((1, 1, 1),))
+        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = choice(5, 3, replace=False)
         self.assertEqual(t.shape, (3,))
+        self.assertEqual(calc_shape(t), t.shape)
 
     def testMultivariateNormal(self):
         mean = [0, 0]
@@ -84,6 +96,7 @@ class Test(TestBase):
         t = multivariate_normal(mean, cov, 5000, chunk_size=500)
         self.assertEqual(t.shape, (5000, 2))
         self.assertEqual(t.op.size, (5000,))
+        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(t.nsplits, ((500,) * 10, (2,)))
@@ -91,17 +104,20 @@ class Test(TestBase):
         c = t.chunks[0]
         self.assertEqual(c.shape, (500, 2))
         self.assertEqual(c.op.size, (500,))
+        self.assertEqual(calc_shape(c), c.shape)
 
     def testRandint(self):
         arr = randint(1, 2, size=(10, 9), dtype='f8', density=.01, chunk_size=2).tiles()
 
         self.assertEqual(arr.shape, (10, 9))
+        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertEqual(len(arr.chunks), 25)
         self.assertEqual(arr.chunks[0].shape, (2, 2))
         self.assertEqual(arr.chunks[0].op.dtype, np.float64)
         self.assertEqual(arr.chunks[0].op.low, 1)
         self.assertEqual(arr.chunks[0].op.high, 2)
         self.assertEqual(arr.chunks[0].op.density, .01)
+        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
 
     def testUnexpectedKey(self):
         with self.assertRaises(ValueError):

--- a/mars/tensor/expressions/tests/test_rechunk.py
+++ b/mars/tensor/expressions/tests/test_rechunk.py
@@ -19,6 +19,7 @@ import unittest
 from mars.tensor.expressions.datasource import ones
 from mars.tensor.expressions.indexing.slice import TensorSlice
 from mars.tensor.expressions.rechunk.rechunk import compute_rechunk
+from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -48,6 +49,8 @@ class Test(unittest.TestCase):
         new_tensor = tensor.rechunk(3)
         new_tensor.tiles()
 
+        self.assertEqual(calc_shape(new_tensor), new_tensor.shape)
+        self.assertEqual(calc_shape(new_tensor.chunks[0]), new_tensor.chunks[0].shape)
         self.assertEqual(len(new_tensor.chunks), 12)
         self.assertEqual(new_tensor.chunks[0].inputs[0], tensor.chunks[0].data)
         self.assertEqual(len(new_tensor.chunks[1].inputs), 2)

--- a/mars/tensor/expressions/tests/test_reduction.py
+++ b/mars/tensor/expressions/tests/test_reduction.py
@@ -20,6 +20,7 @@ from mars.tensor.expressions.datasource import ones, tensor
 from mars.operands import MeanCombine, MeanChunk, Mean, Concatenate, Argmax, Argmin,\
     ArgmaxChunk, ArgmaxCombine, ArgminChunk, ArgminCombine
 from mars.tensor.expressions.reduction import all
+from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -34,37 +35,48 @@ class Test(unittest.TestCase):
         for f in [sum, prod, max, min, all, any]:
             res = f(ones((8, 8), chunk_size=8))
             self.assertEqual(res.shape, ())
+            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3))
             self.assertIsNotNone(res.dtype)
             self.assertEqual(res.shape, ())
+            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), axis=0)
             self.assertEqual(res.shape, (8,))
+            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), axis=1)
             self.assertEqual(res.shape, (10,))
+            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), keepdims=True)
             self.assertEqual(res.shape, (1, 1))
+            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), axis=0, keepdims=True)
             self.assertEqual(res.shape, (1, 8))
+            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
             self.assertEqual(res.shape, (10, 1))
+            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8, 10), chunk_size=3), axis=1)
             self.assertEqual(res.shape, (10, 10))
+            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8, 10), chunk_size=3), axis=1, keepdims=True)
             self.assertEqual(res.shape, (10, 1, 10))
+            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8, 10), chunk_size=3), axis=(0, 2))
             self.assertEqual(res.shape, (8,))
+            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8, 10), chunk_size=3), axis=(0, 2), keepdims=True)
             self.assertEqual(res.shape, (1, 8, 1))
+            self.assertEqual(calc_shape(res), res.shape)
 
     def testMeanReduction(self):
         mean = lambda x, *args, **kwargs: x.mean(*args, **kwargs).tiles()
@@ -78,24 +90,31 @@ class Test(unittest.TestCase):
 
         res = mean(ones((8, 8), chunk_size=8))
         self.assertEqual(res.shape, ())
+        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), axis=0)
         self.assertEqual(res.shape, (8,))
+        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), axis=1)
         self.assertEqual(res.shape, (10,))
+        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), keepdims=True)
         self.assertEqual(res.shape, (1, 1))
+        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), axis=0, keepdims=True)
         self.assertEqual(res.shape, (1, 8))
+        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
         self.assertEqual(res.shape, (10, 1))
+        self.assertEqual(calc_shape(res), res.shape)
         self.assertIsInstance(res.chunks[0].op, Mean)
         self.assertIsInstance(res.chunks[0].inputs[0].op, Concatenate)
         self.assertIsInstance(res.chunks[0].inputs[0].inputs[0].op, MeanChunk)
+        self.assertEqual(calc_shape(res.chunks[0]), res.chunks[0].shape)
 
     def testArgReduction(self):
         argmax = lambda x, *args, **kwargs: x.argmax(*args, **kwargs).tiles()
@@ -104,25 +123,33 @@ class Test(unittest.TestCase):
         res1 = argmax(ones((10, 8, 10), chunk_size=3))
         res2 = argmin(ones((10, 8, 10), chunk_size=3))
         self.assertEqual(res1.shape, ())
+        self.assertEqual(calc_shape(res1), res1.shape)
         self.assertIsNotNone(res1.dtype)
         self.assertEqual(res2.shape, ())
+        self.assertEqual(calc_shape(res2), res2.shape)
         self.assertIsInstance(res1.chunks[0].op, Argmax)
         self.assertIsInstance(res2.chunks[0].op, Argmin)
         self.assertIsInstance(res1.chunks[0].inputs[0].op, Concatenate)
         self.assertIsInstance(res2.chunks[0].inputs[0].op, Concatenate)
         self.assertIsInstance(res1.chunks[0].inputs[0].inputs[0].op, ArgmaxCombine)
         self.assertIsInstance(res2.chunks[0].inputs[0].inputs[0].op, ArgminCombine)
+        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
+        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         res1 = argmax(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
         res2 = argmin(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
         self.assertEqual(res1.shape, (10, 1))
+        self.assertEqual(calc_shape(res1), res1.shape)
         self.assertEqual(res2.shape, (10, 1))
+        self.assertEqual(calc_shape(res2), res2.shape)
         self.assertIsInstance(res1.chunks[0].op, Argmax)
         self.assertIsInstance(res2.chunks[0].op, Argmin)
         self.assertIsInstance(res1.chunks[0].inputs[0].op, Concatenate)
         self.assertIsInstance(res2.chunks[0].inputs[0].op, Concatenate)
         self.assertIsInstance(res1.chunks[0].inputs[0].inputs[0].op, ArgmaxChunk)
         self.assertIsInstance(res2.chunks[0].inputs[0].inputs[0].op, ArgminChunk)
+        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
+        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         self.assertRaises(TypeError, lambda: argmax(ones((10, 8, 10), chunk_size=3), axis=(0, 1)))
         self.assertRaises(TypeError, lambda: argmin(ones((10, 8, 10), chunk_size=3), axis=(0, 1)))
@@ -135,13 +162,21 @@ class Test(unittest.TestCase):
         res2 = cumprod(ones((10, 8), chunk_size=3), axis=0)
         self.assertEqual(res1.shape, (10, 8))
         self.assertIsNotNone(res1.dtype)
+        self.assertEqual(calc_shape(res1), res1.shape)
+        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
         self.assertEqual(res2.shape, (10, 8))
         self.assertIsNotNone(res2.dtype)
+        self.assertEqual(calc_shape(res2), res2.shape)
+        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         res1 = cumsum(ones((10, 8, 8), chunk_size=3), axis=1)
         res2 = cumprod(ones((10, 8, 8), chunk_size=3), axis=1)
         self.assertEqual(res1.shape, (10, 8, 8))
+        self.assertEqual(calc_shape(res1), res1.shape)
+        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
         self.assertEqual(res2.shape, (10, 8, 8))
+        self.assertEqual(calc_shape(res2), res2.shape)
+        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
     def testAllReduction(self):
         o = tensor([False])
@@ -155,6 +190,10 @@ class Test(unittest.TestCase):
         res1 = var(ones((10, 8), chunk_size=3), ddof=2)
         self.assertEqual(res1.shape, ())
         self.assertEqual(res1.op.ddof, 2)
+        self.assertEqual(calc_shape(res1), res1.shape)
+        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
 
         res1 = var(ones((10, 8, 8), chunk_size=3), axis=1)
         self.assertEqual(res1.shape, (10, 8))
+        self.assertEqual(calc_shape(res1), res1.shape)
+        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)

--- a/mars/tensor/expressions/tests/test_reshape.py
+++ b/mars/tensor/expressions/tests/test_reshape.py
@@ -17,6 +17,7 @@
 import unittest
 
 from mars.tensor.expressions.datasource import ones
+from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -26,6 +27,8 @@ class Test(unittest.TestCase):
 
         b.tiles()
 
+        self.assertEqual(calc_shape(b), b.shape)
+        self.assertEqual(calc_shape(b.chunks[0]), b.chunks[0].shape)
         self.assertEqual(tuple(sum(s) for s in b.nsplits), (10, 600))
 
         a = ones((10, 600), chunk_size=5)
@@ -33,6 +36,8 @@ class Test(unittest.TestCase):
 
         b.tiles()
 
+        self.assertEqual(calc_shape(b), b.shape)
+        self.assertEqual(calc_shape(b.chunks[0]), b.chunks[0].shape)
         self.assertEqual(tuple(sum(s) for s in b.nsplits), (10, 30, 20))
 
         a = ones((10, 600), chunk_size=5)
@@ -40,4 +45,6 @@ class Test(unittest.TestCase):
 
         a.tiles()
 
+        self.assertEqual(calc_shape(b), b.shape)
+        self.assertEqual(calc_shape(b.chunks[0]), b.chunks[0].shape)
         self.assertEqual(tuple(sum(s) for s in a.nsplits), (10, 30, 20))

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -436,3 +436,17 @@ def decide_chunk_sizes(shape, chunk_size, itemsize):
             break
 
     return tuple(dim_to_normalized[i] for i in range(len(dim_to_normalized)))
+
+
+def calc_rough_shape(tensor):
+    if np.nan in tensor.shape:
+        inputs = tensor.inputs or []
+        inputs_shape = tuple(t.rough_shape for t in inputs)
+        shape = tensor.op.calc_shape(*inputs_shape)
+        if np.nan in shape:
+            return tensor.op.calc_rough_shape(*inputs_shape)
+        else:
+            return shape
+    else:
+        return tensor.shape
+

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -257,3 +257,9 @@ def patch_method(method, *args, **kwargs):
     else:
         return mock.patch('.'.join([method.im_class.__module__, method.im_class.__name__, method.__name__]),
                           *args, **kwargs)
+
+
+def calc_shape(tensor):
+    inputs = tensor.inputs or []
+    inputs_shape = tuple(t.shape for t in inputs)
+    return tensor.op.calc_shape(*inputs_shape)

--- a/mars/web/api.py
+++ b/mars/web/api.py
@@ -26,6 +26,7 @@ from ..compat import six, futures
 from ..lib.tblib import pickling_support
 from ..actors import new_client
 from .server import MarsWebAPI
+from ..utils import to_str
 
 pickling_support.install()
 _actor_client = new_client()
@@ -129,10 +130,14 @@ class GraphApiHandler(ApiRequestHandler):
 class GraphDataHandler(ApiRequestHandler):
     @gen.coroutine
     def get(self, session_id, graph_key, tensor_key):
-        data_type = self.request.arguments.get('type')
-        if data_type == 'nsplits':
-            nsplits = self.web_api.get_tensor_nsplits(session_id, graph_key, tensor_key)
-            self.write(json.dumps(nsplits))
+        type_argument = self.request.arguments.get('type')
+        if type_argument:
+            data_type = to_str(type_argument[0])
+            if data_type == 'nsplits':
+                nsplits = self.web_api.get_tensor_nsplits(session_id, graph_key, tensor_key)
+                self.write(json.dumps(nsplits))
+            else:
+                raise web.HTTPError(403, 'Unknown data type requests')
         else:
             executor = futures.ThreadPoolExecutor(1)
 

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -169,7 +169,7 @@ class Session(object):
     def _update_tensor_shape(self, tensor):
         tensor_key = tensor.key
         session_url = self._endpoint + '/api/session/' + self._session_id
-        url = session_url + '/graph/%s/data/%s/?type=nsplits' % (self._get_graph_key(tensor_key), tensor_key)
+        url = session_url + '/graph/%s/data/%s?type=nsplits' % (self._get_graph_key(tensor_key), tensor_key)
         resp = self._req_session.get(url)
         new_nsplits = json.loads(resp.text)
         tensor._update_shape(tuple(sum(nsplit) for nsplit in new_nsplits))

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -224,8 +224,8 @@ class ExecutionActor(WorkerActor):
         for chunk in graph:
             if not isinstance(chunk.op, TensorFetchChunk) and chunk.key in graph_record.targets:
                 # use estimated size as potential allocation size
-                alloc_mem_batch[chunk.key] = chunk.nbytes * 2
-                alloc_cache_batch[chunk.key] = chunk.nbytes
+                alloc_mem_batch[chunk.key] = chunk.rough_nbytes * 2
+                alloc_cache_batch[chunk.key] = chunk.rough_nbytes
             else:
                 # use actual size as potential allocation size
                 input_chunk_keys[chunk.key] = graph_record.data_sizes.get(chunk.key, chunk.nbytes)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
As some op like bool indexing or argwhere create tensor with unknown shape, scheduler will raise `ValueError ` when calculate `output_size` of operand. In this PR, `rough_nbytes` was added for `ChunkData` and `TensorData`, it will call `op._calc_rough_nbytes` if tensor shape is unknown.

Meanwhile, `GraphDataHandler` will raise `HTTPError` when the type requested does not match any pre-defined one.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
resolve #117 
resolve #123 
resolve #124 