### PR TITLE
Typo in index.rst: "import numpy" should be "import numpy as np"

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,7 @@ Mars tensor provides a familiar interface like Numpy.
 +------------------------------------------------+----------------------------------------------------+
 |.. code-block:: python                          |.. code-block:: python                              |
 |                                                |                                                    |
-|    import numpy                                |    import mars.tensor as mt                        |
+|    import numpy as np                          |    import mars.tensor as mt                        |
 |    a = np.random.rand(1000, 2000)              |    a = mt.random.rand(1000, 2000)                  |
 |    (a + 1).sum(axis=1)                         |    (a + 1).sum(axis=1).execute()                   |
 |                                                |                                                    |


### PR DESCRIPTION
Mistake in index.rst: "import numpy" should be "import numpy as np"

<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
