### PR TITLE
Fix missing import in install.rst

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -45,7 +45,8 @@ Then start a local cluster by run
 .. code-block:: python
 
     from mars.deploy.local import new_cluster
-
+    import mars.tensor as mt
+    
     cluster = new_cluster()
 
     # new cluster will start a session and set it as default one


### PR DESCRIPTION


<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Mistake in  install.rst:  "import mars.tensor as mt" should be added in local cluster example.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
