### PR TITLE
Fix worker start fail on machines with insufficient memory (also some doc fixes)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,13 +142,13 @@ Web service can be started with the following command:
 
 .. code-block:: bash
 
-    mars-web -a <web_ip> -s <scheduler_ip> --ui-port <ui_port_exposed_to_user>
+    mars-web -a <web_ip> -s <scheduler_endpoint> --ui-port <ui_port_exposed_to_user>
 
 Workers can be started with the following command:
 
 .. code-block:: bash
 
-    mars-worker -a <worker_ip> -p <worker_port> -s <scheduler_ip>
+    mars-worker -a <worker_ip> -p <worker_port> -s <scheduler_endpoint>
 
 After all mars processes are started, users can run
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -31,8 +31,8 @@ After installation, you can simply open a Python console and run
 Local cluster
 -------------
 
-Users can start the distributed runtime of Mars on a single machine.
-First, install Mars distributed by run
+Users can start the distributed runtime of Mars on a single machine.  First,
+install Mars distributed by run
 
 .. code-block:: bash
 
@@ -65,6 +65,10 @@ Then start a local cluster by run
 
 Run on Clusters
 ===============
+
+Basic Steps
+-----------
+
 Mars can be deployed on a cluster. First, yu need to run
 
 .. code-block:: bash
@@ -84,13 +88,13 @@ Web service can be started with the following command:
 
 .. code-block:: bash
 
-    mars-web -a <web_ip> -s <scheduler_ip> -p <communicator_port> --ui-port <ui_port_exposed_to_user>
+    mars-web -a <web_ip> -s <scheduler_endpoint> -p <communicator_port> --ui-port <ui_port_exposed_to_user>
 
 Workers can be started with the following command:
 
 .. code-block:: bash
 
-    mars-worker -a <worker_ip> -p <worker_port> -s <scheduler_ip>
+    mars-worker -a <worker_ip> -p <worker_port> -s <scheduler_endpoint>
 
 After all Mars processes are started, you can open a Python console and run
 
@@ -106,3 +110,26 @@ After all Mars processes are started, you can open a Python console and run
 You can open a web browser and type ``http://<web_ip>:<ui_port>`` to open Mars
 UI to look up resource usage of workers and execution progress of the task
 submitted just now.
+
+Memory Tuning
+-------------
+Mars worker manages two different parts of memory. The first is private process
+memory and the second is shared memory between all worker processes handled by
+`plasma_store in Apache Arrow
+<https://arrow.apache.org/docs/python/plasma.html>`_. When Mars Worker starts,
+it will take 50% of free memory space by default as shared memory and the left
+as private process memory. What's more, Mars provides soft and hard memory
+limits for memory allocations, which are 75% and 90% by default. If these
+configurations does not meet your need, you can configure them when Mars Worker
+starts. You can use ``--cache-mem`` argument to configure the size of shared
+memory, ``--phy-mem`` to configure total memory size, from which the soft and
+hard limits are computed.
+
+For instance, by using
+
+.. code-block:: bash
+
+    mars-worker -a localhost -p 9012 -s localhost:9010 --cache-mem 512m --phy-mem 90%
+
+We limit the size of shared memory as 512MB and the worker can use up to 90% of
+total physical memory.

--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -96,7 +96,7 @@ class LocalDistributedCluster(object):
         self._started = True
 
         # start plasma
-        self._worker_service.start_plasma(self._worker_service.cache_memory_limit())
+        self._worker_service.start_plasma(self._worker_service.calc_cache_memory_limit())
 
         # start actor pool
         n_process = self._scheduler_n_process + self._worker_n_process

--- a/mars/scheduler/service.py
+++ b/mars/scheduler/service.py
@@ -53,14 +53,14 @@ class SchedulerService(object):
 
         if not isinstance(kv_store, kvstore.LocalKVStore):
             # set etcd as service discover
-            logger.info('Mars scheduler started with kv store %s.', options.kv_store)
+            logger.info('Mars Scheduler started with kv store %s.', options.kv_store)
             service_discover_addr = options.kv_store
             all_schedulers = None
             # create KVStoreActor when there is a distributed KV store
             self._kv_store_ref = pool.create_actor(KVStoreActor, uid=KVStoreActor.default_name())
         else:
             # single scheduler
-            logger.info('Mars scheduler started in standalone mode.')
+            logger.info('Mars Scheduler started in standalone mode.')
             service_discover_addr = None
             all_schedulers = {endpoint}
             if schedulers:

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -175,6 +175,8 @@ class WorkerService(object):
         :param total_size: total size of the container
         :return: actual size in bytes
         """
+        if limit_str is None:
+            return None
         if isinstance(limit_str, int):
             return limit_str
         mem_limit, is_percent = parse_memory_limit(limit_str)
@@ -184,8 +186,10 @@ class WorkerService(object):
             return int(mem_limit)
 
     @staticmethod
-    def cache_memory_limit():
+    def calc_cache_memory_limit():
         mem_stats = resource.virtual_memory()
+        if options.worker.cache_memory_limit is None:
+            options.worker.cache_memory_limit = mem_stats.free // 2
 
         return WorkerService._calc_size_limit(
             options.worker.cache_memory_limit, mem_stats.total
@@ -199,9 +203,6 @@ class WorkerService(object):
         )
         options.worker.physical_memory_limit_soft = self._calc_size_limit(
             options.worker.physical_memory_limit_soft, mem_stats.total
-        )
-        options.worker.cache_memory_limit = self._calc_size_limit(
-            options.worker.cache_memory_limit, mem_stats.total
         )
         if spill_dir:
             from .spill import parse_spill_dirs


### PR DESCRIPTION
## What do these changes do?

Previously Mars workers are started on machines with sufficient memory, and the default value of --cache-mem, 48%, works well. When it is started on a machine with insufficient memory, however, the worker fails when doing memory test. Now we change the strategy by using half of free memory to ensure that it can start under most of the circumstances.

What's more, we add fixes on docs to add memory tuning section and errors on endpoints.

## Related issue number

#140 (Fix not added, just for verification)
