### PR TITLE
 Fix missing import in install.rst

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -46,6 +46,7 @@ Then start a local cluster by run
 
     from mars.deploy.local import new_cluster
     import mars.tensor as mt
+    from mars.session import new_session
     
     cluster = new_cluster()
 


### PR DESCRIPTION


<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Fix missing import in install.rst: add "from mars.session import new_session"  in local cluster example.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
