### PR TITLE
add dockerfile and compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.7.1
+
+RUN pip install pymars
+
+RUN pip install 'pymars[distributed]'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3'
+
+services:
+  web:
+    build: .
+    image: mars
+    container_name: mars_web
+    hostname: mars_web
+    restart: always
+    entrypoint: mars-web -a mars_web -s mars_scheduler:5051 --ui-port 5050
+    ports:
+      - "5050:5050"
+    depends_on:
+      - scheduler
+    links:
+    #    allow web to reach scheduler as scheduler or mars_scheduler
+      - "scheduler:mars_scheduler"
+
+  scheduler:
+    build: .
+    image: mars
+    container_name: mars_scheduler
+    hostname: mars_scheduler
+    restart: always
+    entrypoint: mars-scheduler -a mars_scheduler -p 5051
+    ports:
+      - "5051:5051"
+
+  worker:
+    build: .
+    image: mars
+    container_name: mars_worker
+    hostname: mars_worker
+    restart: always
+    entrypoint: mars-worker -a mars_worker -p 5052 -s mars_scheduler:5051 --cache-mem 10m
+    ports:
+      - "5052:5052"
+    depends_on:
+      - scheduler
+    links:
+    #    allow worker to reach scheduler
+      - "scheduler:mars_scheduler"


### PR DESCRIPTION
## What do these changes do?
Simply add Dockerfile for building single service image and docker-compose.yml file to chain the services up. Note that this will just build a runnable container based on the README instruction, more features should be added in the future especially the `--cache-mem` argument.
## Related issue number
Resolve #146
