### PR TITLE
Fix --phy-mem arg error and BrokenPipeErrors under Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ install:
   - pip install -r requirements-dev.txt
   - pip install -r requirements-extra.txt
   - pip install virtualenv coveralls flake8 etcd-gevent
-  - bash bin/fix-gevent-cov.sh  # temporary fix on cython coverage problem
   - virtualenv venv && source venv/bin/activate
   - pip install -r requirements.txt
   - pip install pytest pytest-timeout

--- a/bin/fix-gevent-cov.sh
+++ b/bin/fix-gevent-cov.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-GEVENT_DIR=`python -c 'import gevent; print(gevent.__file__)'`
-GEVENT_DIR=`dirname $GEVENT_DIR`
-if [ ! -z $GEVENT_DIR ]; then
-    find $GEVENT_DIR -name *.c -delete
-fi

--- a/mars/compat/__init__.py
+++ b/mars/compat/__init__.py
@@ -17,6 +17,7 @@ import logging.config
 import itertools
 import platform
 import os
+import socket
 from unicodedata import east_asian_width
 
 from ..lib import six
@@ -177,9 +178,9 @@ else:
         return np.getbuffer(n)
 
     TimeoutError = type('TimeoutError', (Exception, ), {})
-    BrokenPipeError = type('BrokenPipeError', (Exception, ), {})
-    ConnectionRefusedError = type('ConnectionRefusedError', (Exception, ), {})
-    ConnectionResetError = type('ConnectionResetError', (Exception,), {})
+    BrokenPipeError = type('BrokenPipeError', (socket.error, ), {})
+    ConnectionRefusedError = type('ConnectionRefusedError', (socket.error, ), {})
+    ConnectionResetError = type('ConnectionResetError', (socket.error,), {})
 
 
     def accumulate(iterable, func=lambda a, b: a + b):

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -72,16 +72,17 @@ class WorkerService(object):
         options.worker.plasma_socket, _ = self._plasma_store.__enter__()
 
     @classmethod
-    def _calc_soft_memory_limit(cls):
+    def _calc_soft_memory_limit(cls, total_mem=None):
         """
         Calc memory limit for MemQuotaActor given configured percentage. Cache size and memory
         already been used will be excluded from calculated size.
         """
         mem_status = resource.virtual_memory()
+        total_mem = total_mem or mem_status.total
 
         phy_soft_limit = options.worker.physical_memory_limit_soft
         cache_limit = options.worker.cache_memory_limit
-        actual_used = mem_status.total - mem_status.available
+        actual_used = total_mem - mem_status.available
         quota_soft_limit = phy_soft_limit - cache_limit - actual_used
 
         if quota_soft_limit < 512 * 1024 ** 2:
@@ -91,7 +92,7 @@ class WorkerService(object):
         cls.service_logger.info('Setting soft limit to %s.', readable_size(quota_soft_limit))
         return quota_soft_limit
 
-    def start(self, endpoint, schedulers, pool, ignore_avail_mem=False):
+    def start(self, endpoint, schedulers, pool, total_mem=None, ignore_avail_mem=False):
         if schedulers:
             if isinstance(schedulers, six.string_types):
                 schedulers = [schedulers]
@@ -120,7 +121,7 @@ class WorkerService(object):
                 QuotaActor, options.worker.physical_memory_limit_soft, uid=MemQuotaActor.default_name())
         else:
             self._mem_quota_ref = pool.create_actor(
-                MemQuotaActor, self._calc_soft_memory_limit(),
+                MemQuotaActor, self._calc_soft_memory_limit(total_mem),
                 options.worker.physical_memory_limit_hard, uid=MemQuotaActor.default_name())
 
         # create ChunkHolderActor


### PR DESCRIPTION
## What do these changes do?

Fix BrokenPipeErrors caused by ``--phy-mem`` arg and during the running procedure under Python 2.7.

## Related issue number

Fixes #158 
