### PR TITLE
Use dataserializer to serde ndarray in protobuf and json serializers instead of numpy.save and numpy.load

### DIFF
--- a/mars/serialize/jsonserializer.pyx
+++ b/mars/serialize/jsonserializer.pyx
@@ -24,10 +24,11 @@ from cpython.version cimport PY_MAJOR_VERSION
 
 from ..compat import six, OrderedDict, izip
 from ..core import BaseWithKey
-from .core cimport Provider, ValueType, ProviderType, \
-    Field, List, Tuple, Dict, Identity, Reference, OneOf, KeyPlaceholder, \
-    ReferenceField, OneOfField, ListField
 from ..utils_c cimport to_str
+from .core cimport Provider, ValueType, ProviderType, \
+    Field, List, Tuple, Dict, Identity, Reference, KeyPlaceholder, \
+    ReferenceField, OneOfField, ListField
+from .dataserializer import dumps as datadumps, loads as dataloads
 
 
 cdef dict PRIMITIVE_TYPE_TO_NAME = {
@@ -103,11 +104,9 @@ cdef class JsonSerializeProvider(Provider):
         cdef bytes bt
         cdef str res
 
-        bio = six.BytesIO()
-        np.save(bio, value)
         return {
             'type': _get_name(ValueType.arr),
-            'value': self._to_str(base64.b64encode(bio.getvalue()))
+            'value': self._to_str(base64.b64encode(datadumps(value)))
         }
 
     cdef inline np.ndarray _deserialize_arr(self, object obj, list callbacks):
@@ -118,7 +117,7 @@ cdef class JsonSerializeProvider(Provider):
         bt = self._to_bytes(base64.b64decode(value))
 
         if bt is not None:
-            return np.load(six.BytesIO(bt))
+            return dataloads(bt)
 
         return None
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Use dataserializer to serde ndarray instead of `numpy.save` and `numpy.load`.

**Note that this will break compatibility if the client is 0.1.x and server is 0.2.x, vice versa.**

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolve #160 