### PR TITLE
Add IndexField, SeriesField, DataFrameField for protobuf and json serializer, remove DataTuple for dataserializer

### DIFF
--- a/mars/serialize/core.pxd
+++ b/mars/serialize/core.pxd
@@ -39,6 +39,9 @@ cpdef enum ExtendType:
     key = 18
     datetime64 = 19
     timedelta64 = 20
+    index = 21
+    series = 22
+    dataframe = 23
 
 
 cdef class Identity:
@@ -177,6 +180,18 @@ cdef class Timedelta64Field(Field):
 
 
 cdef class DataTypeField(Field):
+    pass
+
+
+cdef class IndexField(Field):
+    pass
+
+
+cdef class SeriesField(Field):
+    pass
+
+
+cdef class DataFrameField(Field):
     pass
 
 

--- a/mars/serialize/core.pyx
+++ b/mars/serialize/core.pyx
@@ -106,6 +106,9 @@ cdef class ValueType:
     key = ExtendType.key
     datetime64 = ExtendType.datetime64
     timedelta64 = ExtendType.timedelta64
+    index = ExtendType.index
+    series = ExtendType.series
+    dataframe = ExtendType.dataframe
 
     identity = Identity()
 
@@ -332,6 +335,30 @@ cdef class DataTypeField(Field):
             tag, default=default, weak_ref=weak_ref,
             on_serialize=on_serialize, on_deserialize=on_deserialize)
         self._type = ValueType.dtype
+
+
+cdef class IndexField(Field):
+    def __init__(self, tag, default=None, bint weak_ref=False, on_serialize=None, on_deserialize=None):
+        super(IndexField, self).__init__(
+            tag, default=default, weak_ref=weak_ref,
+            on_serialize=on_serialize, on_deserialize=on_deserialize)
+        self._type = ValueType.index
+
+
+cdef class SeriesField(Field):
+    def __init__(self, tag, default=None, bint weak_ref=False, on_serialize=None, on_deserialize=None):
+        super(SeriesField, self).__init__(
+            tag, default=default, weak_ref=weak_ref,
+            on_serialize=on_serialize, on_deserialize=on_deserialize)
+        self._type = ValueType.series
+
+
+cdef class DataFrameField(Field):
+    def __init__(self, tag, default=None, bint weak_ref=False, on_serialize=None, on_deserialize=None):
+        super(DataFrameField, self).__init__(
+            tag, default=default, weak_ref=weak_ref,
+            on_serialize=on_serialize, on_deserialize=on_deserialize)
+        self._type = ValueType.dataframe
 
 
 cdef inline _handle_nest_reference(field, ref):

--- a/mars/serialize/dataserializer.py
+++ b/mars/serialize/dataserializer.py
@@ -252,10 +252,6 @@ def peek_serialized_size(file):
         file.seek(0)
 
 
-class DataTuple(tuple):
-    pass
-
-
 def _serialize_numpy_array_list(obj):
     if obj.dtype.str != '|O':
         # Make the array c_contiguous if necessary so that we can call change
@@ -303,37 +299,6 @@ def _deserialize_sparse_csr_list(data):
     return SparseNDArray(target_csr)
 
 
-def _serialize_data_tuple(obj):
-    data_meta = []
-    outputs = [None]
-    for item in obj:
-        if isinstance(item, np.ndarray):
-            serialized_items = _serialize_numpy_array_list(item)
-            outputs.extend(serialized_items)
-            data_meta.append(DATA_FLAG_DENSE)
-            data_meta.append(len(serialized_items))
-        else:
-            serialized_items = _serialize_sparse_csr_list(item)
-            outputs.extend(serialized_items)
-            data_meta.append(DATA_FLAG_CSR)
-            data_meta.append(len(serialized_items))
-    outputs[0] = struct.pack('<' + 'B' * len(data_meta), *data_meta)
-    return tuple(outputs)
-
-
-def _deserialize_data_tuple(data):
-    data_meta = struct.unpack('<' + 'B' * len(data[0]), data[0])
-    pos = 1
-    data_parts = []
-    for flag, size in zip(data_meta[0::2], data_meta[1::2]):
-        if flag == DATA_FLAG_DENSE:
-            data_parts.append(_deserialize_numpy_array_list(data[pos:pos + size]))
-        elif flag == DATA_FLAG_CSR:
-            data_parts.append(_deserialize_sparse_csr_list(data[pos:pos + size]))
-        pos += size
-    return DataTuple(data_parts)
-
-
 _serialize_context = None
 
 
@@ -344,8 +309,5 @@ def mars_serialize_context():
         ctx.register_type(SparseNDArray, 'mars.SparseNDArray',
                           custom_serializer=_serialize_sparse_csr_list,
                           custom_deserializer=_deserialize_sparse_csr_list)
-        ctx.register_type(DataTuple, 'mars.DataTuple',
-                          custom_serializer=_serialize_data_tuple,
-                          custom_deserializer=_deserialize_data_tuple)
         _serialize_context = ctx
     return _serialize_context

--- a/mars/serialize/jsonserializer.pyx
+++ b/mars/serialize/jsonserializer.pyx
@@ -23,7 +23,7 @@ cimport numpy as np
 from cpython.version cimport PY_MAJOR_VERSION
 try:
     import pandas as pd
-except ImportError:
+except ImportError:  # pragma: no cover
     pd = None
 
 from ..compat import six, OrderedDict, izip
@@ -364,11 +364,11 @@ cdef class JsonSerializeProvider(Provider):
             return self._serialize_arr(value)
         elif isinstance(value, np.dtype):
             return self._serialize_dtype(value)
-        elif pd and isinstance(value, pd.Index):
+        elif pd is not None and isinstance(value, pd.Index):
             return self._serialize_index(value)
-        elif pd and isinstance(value, pd.Series):
+        elif pd is not None and isinstance(value, pd.Series):
             return self._serialize_series(value)
-        elif pd and isinstance(value, pd.DataFrame):
+        elif pd is not None and isinstance(value, pd.DataFrame):
             return self._serialize_dataframe(value)
         elif isinstance(value, BaseWithKey):
             return self._serialize_key(value)

--- a/mars/serialize/jsonserializer.pyx
+++ b/mars/serialize/jsonserializer.pyx
@@ -21,6 +21,10 @@ import weakref
 import numpy as np
 cimport numpy as np
 from cpython.version cimport PY_MAJOR_VERSION
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
 
 from ..compat import six, OrderedDict, izip
 from ..core import BaseWithKey
@@ -52,6 +56,9 @@ cdef dict EXTEND_TYPE_TO_NAME = {
     ValueType.slice: 'slice',
     ValueType.arr: 'arr',
     ValueType.dtype: 'dtype',
+    ValueType.index: 'index',
+    ValueType.series: 'series',
+    ValueType.dataframe: 'dataframe',
     ValueType.key: 'key',
     ValueType.datetime64: 'datetime64',
     ValueType.timedelta64: 'timedelta64',
@@ -101,9 +108,6 @@ cdef class JsonSerializeProvider(Provider):
         return slice(value['start'], value['stop'], value['step'])
 
     cdef inline dict _serialize_arr(self, np.ndarray value):
-        cdef bytes bt
-        cdef str res
-
         return {
             'type': _get_name(ValueType.arr),
             'value': self._to_str(base64.b64encode(datadumps(value)))
@@ -139,6 +143,36 @@ cdef class JsonSerializeProvider(Provider):
         except TypeError:
             val = value['value']
             return np.dtype(pickle.loads(base64.b64decode(val)))
+
+    cdef inline dict _serialize_index(self, value):
+        return {
+            'type': _get_name(ValueType.index),
+            'value': self._to_str(base64.b64encode(datadumps(value)))
+        }
+
+    cdef inline object _deserialize_pd_entity(self, object obj, list callbacks):
+        cdef bytes bt
+
+        value = obj['value']
+
+        bt = self._to_bytes(base64.b64decode(value))
+
+        if bt is not None:
+            return dataloads(bt)
+
+        return None
+
+    cdef inline dict _serialize_series(self, value):
+        return {
+            'type': _get_name(ValueType.series),
+            'value': self._to_str(base64.b64encode(datadumps(value)))
+        }
+
+    cdef inline dict _serialize_dataframe(self, value):
+        return {
+            'type': _get_name(ValueType.dataframe),
+            'value': self._to_str(base64.b64encode(datadumps(value)))
+        }
 
     cdef inline dict _serialize_key(self, value):
         return {
@@ -281,6 +315,12 @@ cdef class JsonSerializeProvider(Provider):
             return self._serialize_arr(value)
         elif tp is ValueType.dtype:
             return self._serialize_dtype(value)
+        elif tp is ValueType.index:
+            return self._serialize_index(value)
+        elif tp is ValueType.series:
+            return self._serialize_series(value)
+        elif tp is ValueType.dataframe:
+            return self._serialize_dataframe(value)
         elif tp is ValueType.key:
             return self._serialize_key(value)
         elif tp == ValueType.datetime64:
@@ -324,6 +364,12 @@ cdef class JsonSerializeProvider(Provider):
             return self._serialize_arr(value)
         elif isinstance(value, np.dtype):
             return self._serialize_dtype(value)
+        elif pd and isinstance(value, pd.Index):
+            return self._serialize_index(value)
+        elif pd and isinstance(value, pd.Series):
+            return self._serialize_series(value)
+        elif pd and isinstance(value, pd.DataFrame):
+            return self._serialize_dataframe(value)
         elif isinstance(value, BaseWithKey):
             return self._serialize_key(value)
         elif isinstance(value, list):
@@ -422,6 +468,8 @@ cdef class JsonSerializeProvider(Provider):
             return ref(self._deserialize_arr(obj, callbacks))
         elif tp is ValueType.dtype:
             return ref(self._deserialize_dtype(obj, callbacks))
+        elif tp in (ValueType.index, ValueType.series, ValueType.dataframe):
+            return ref(self._deserialize_pd_entity(obj, callbacks))
         elif tp is ValueType.key:
             return self._deserialize_key(obj, callbacks)  # the weakref will do in the callback, so skip
         elif tp is ValueType.datetime64:

--- a/mars/serialize/pbserializer.pyx
+++ b/mars/serialize/pbserializer.pyx
@@ -22,7 +22,7 @@ cimport numpy as np
 cimport cython
 try:
     import pandas as pd
-except ImportError:
+except ImportError:  # pragma: no cover
     pd = None
 
 from cpython.version cimport PY_MAJOR_VERSION
@@ -396,11 +396,11 @@ cdef class ProtobufSerializeProvider(Provider):
             self._set_arr(value, obj)
         elif isinstance(value, np.dtype):
             self._set_dtype(value, obj)
-        elif pd and isinstance(value, pd.Index):
+        elif pd is not None and isinstance(value, pd.Index):
             self._set_index(value, obj)
-        elif pd and isinstance(value, pd.Series):
+        elif pd is not None and isinstance(value, pd.Series):
             self._set_series(value, obj)
-        elif pd and isinstance(value, pd.DataFrame):
+        elif pd is not None and isinstance(value, pd.DataFrame):
             self._set_dataframe(value, obj)
         elif isinstance(value, BaseWithKey):
             self._set_key(value, obj)

--- a/mars/serialize/pbserializer.pyx
+++ b/mars/serialize/pbserializer.pyx
@@ -20,6 +20,10 @@ import weakref
 import numpy as np
 cimport numpy as np
 cimport cython
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
 
 from cpython.version cimport PY_MAJOR_VERSION
 
@@ -76,8 +80,6 @@ cdef class ProtobufSerializeProvider(Provider):
         return slice(start, stop, step)
 
     cdef inline void _set_arr(self, np.ndarray value, obj, tp=None):
-        cdef object bio
-
         obj.arr = datadumps(value)
 
     cdef inline np.ndarray _get_arr(self, obj):
@@ -102,6 +104,27 @@ cdef class ProtobufSerializeProvider(Provider):
             return np.dtype(obj.dtype)
         except TypeError:
             return np.dtype(pickle.loads(obj.dtype))
+
+    cdef inline void _set_index(self, value, obj, tp=None) except *:
+        obj.index = datadumps(value)
+
+    cdef inline _get_index(self, obj):
+        x = obj.index
+        return dataloads(x) if x is not None and len(x) > 0 else None
+
+    cdef inline void _set_series(self, value, obj, tp=None) except *:
+        obj.series = datadumps(value)
+
+    cdef inline _get_series(self, obj):
+        x = obj.series
+        return dataloads(x) if x is not None and len(x) > 0 else None
+
+    cdef inline void _set_dataframe(self, value, obj, tp=None) except *:
+        obj.dataframe = datadumps(value)
+
+    cdef inline object _get_dataframe(self, obj):
+        x = obj.dataframe
+        return dataloads(x) if x is not None and len(x) > 0 else None
 
     cdef inline void _set_key(self, object value, obj, tp=None) except *:
         obj.key.key = value.key
@@ -319,6 +342,12 @@ cdef class ProtobufSerializeProvider(Provider):
             self._set_arr(<np.ndarray>value, obj, tp)
         elif tp is ValueType.dtype:
             self._set_dtype(<np.dtype>value, obj, tp)
+        elif tp is ValueType.index:
+            self._set_index(value, obj, tp)
+        elif tp is ValueType.series:
+            self._set_series(value, obj, tp)
+        elif tp is ValueType.dataframe:
+            self._set_dataframe(value, obj, tp)
         elif tp is ValueType.key:
             self._set_key(value, obj, tp)
         elif tp is ValueType.datetime64:
@@ -367,6 +396,12 @@ cdef class ProtobufSerializeProvider(Provider):
             self._set_arr(value, obj)
         elif isinstance(value, np.dtype):
             self._set_dtype(value, obj)
+        elif pd and isinstance(value, pd.Index):
+            self._set_index(value, obj)
+        elif pd and isinstance(value, pd.Series):
+            self._set_series(value, obj)
+        elif pd and isinstance(value, pd.DataFrame):
+            self._set_dataframe(value, obj)
         elif isinstance(value, BaseWithKey):
             self._set_key(value, obj)
         elif isinstance(value, list):
@@ -509,6 +544,12 @@ cdef class ProtobufSerializeProvider(Provider):
             return ref(self._get_arr(obj))
         elif tp is ValueType.dtype:
             return ref(self._get_dtype(obj))
+        elif tp is ValueType.index:
+            return ref(self._get_index(obj))
+        elif tp is ValueType.series:
+            return ref(self._get_series(obj))
+        elif tp is ValueType.dataframe:
+            return ref(self._get_dataframe(obj))
         elif tp is ValueType.key:
             return self._get_key(obj)
         elif tp is ValueType.datetime64:
@@ -571,6 +612,12 @@ cdef class ProtobufSerializeProvider(Provider):
             return ref(self._get_arr(obj))
         elif field == 'dtype':
             return ref(self._get_dtype(obj))
+        elif field == 'index':
+            return ref(self._get_index(obj))
+        elif field == 'series':
+            return ref(self._get_series(obj))
+        elif field == 'dataframe':
+            return ref(self._get_dataframe(obj))
         elif field == 'key':
             return self._get_key(obj)
         elif field == 'datetime64':

--- a/mars/serialize/protos/value.proto
+++ b/mars/serialize/protos/value.proto
@@ -39,6 +39,9 @@ message Value {
         Key key = 12;  // BaseWithKey object, only save `key`
         bytes datetime64 = 13; // numpy datetime64
         bytes timedelta64 = 14; // numpy timedelta64
+        bytes index = 15; // pandas Index
+        bytes series = 16;  // pandas Series
+        bytes dataframe = 17;  // pandas DataFrame
     }
 
 }

--- a/mars/serialize/protos/value_pb2.py
+++ b/mars/serialize/protos/value_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n!mars/serialize/protos/value.proto\"\xa6\x04\n\x05Value\x12\x11\n\x07is_null\x18\x01 \x01(\x08H\x00\x12\x0b\n\x01\x62\x18\x02 \x01(\x08H\x00\x12\x0b\n\x01i\x18\x03 \x01(\x03H\x00\x12\x0b\n\x01\x66\x18\x04 \x01(\x02H\x00\x12\x0b\n\x01s\x18\x05 \x01(\x0cH\x00\x12\x0b\n\x01u\x18\x06 \x01(\tH\x00\x12\x1b\n\x04list\x18\x07 \x01(\x0b\x32\x0b.Value.ListH\x00\x12\x1b\n\x04\x64ict\x18\x08 \x01(\x0b\x32\x0b.Value.DictH\x00\x12\x1d\n\x05slice\x18\t \x01(\x0b\x32\x0c.Value.SliceH\x00\x12\r\n\x03\x61rr\x18\n \x01(\x0cH\x00\x12\x0f\n\x05\x64type\x18\x0b \x01(\x0cH\x00\x12\x19\n\x03key\x18\x0c \x01(\x0b\x32\n.Value.KeyH\x00\x12\x14\n\ndatetime64\x18\r \x01(\x0cH\x00\x12\x15\n\x0btimedelta64\x18\x0e \x01(\x0cH\x00\x1a/\n\x04List\x12\x10\n\x08is_tuple\x18\x01 \x01(\x08\x12\x15\n\x05value\x18\x02 \x03(\x0b\x32\x06.Value\x1an\n\x05Slice\x12\x0f\n\x07is_null\x18\x04 \x01(\x08\x12\x13\n\tstart_val\x18\x01 \x01(\x03H\x00\x12\x12\n\x08stop_val\x18\x02 \x01(\x03H\x01\x12\x12\n\x08step_val\x18\x03 \x01(\x03H\x02\x42\x07\n\x05startB\x06\n\x04stopB\x06\n\x04step\x1a>\n\x04\x44ict\x12\x19\n\x04keys\x18\x01 \x01(\x0b\x32\x0b.Value.List\x12\x1b\n\x06values\x18\x02 \x01(\x0b\x32\x0b.Value.List\x1a\x1e\n\x03Key\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\tB\x07\n\x05valueb\x06proto3')
+  serialized_pb=_b('\n!mars/serialize/protos/value.proto\"\xde\x04\n\x05Value\x12\x11\n\x07is_null\x18\x01 \x01(\x08H\x00\x12\x0b\n\x01\x62\x18\x02 \x01(\x08H\x00\x12\x0b\n\x01i\x18\x03 \x01(\x03H\x00\x12\x0b\n\x01\x66\x18\x04 \x01(\x02H\x00\x12\x0b\n\x01s\x18\x05 \x01(\x0cH\x00\x12\x0b\n\x01u\x18\x06 \x01(\tH\x00\x12\x1b\n\x04list\x18\x07 \x01(\x0b\x32\x0b.Value.ListH\x00\x12\x1b\n\x04\x64ict\x18\x08 \x01(\x0b\x32\x0b.Value.DictH\x00\x12\x1d\n\x05slice\x18\t \x01(\x0b\x32\x0c.Value.SliceH\x00\x12\r\n\x03\x61rr\x18\n \x01(\x0cH\x00\x12\x0f\n\x05\x64type\x18\x0b \x01(\x0cH\x00\x12\x19\n\x03key\x18\x0c \x01(\x0b\x32\n.Value.KeyH\x00\x12\x14\n\ndatetime64\x18\r \x01(\x0cH\x00\x12\x15\n\x0btimedelta64\x18\x0e \x01(\x0cH\x00\x12\x0f\n\x05index\x18\x0f \x01(\x0cH\x00\x12\x10\n\x06series\x18\x10 \x01(\x0cH\x00\x12\x13\n\tdataframe\x18\x11 \x01(\x0cH\x00\x1a/\n\x04List\x12\x10\n\x08is_tuple\x18\x01 \x01(\x08\x12\x15\n\x05value\x18\x02 \x03(\x0b\x32\x06.Value\x1an\n\x05Slice\x12\x0f\n\x07is_null\x18\x04 \x01(\x08\x12\x13\n\tstart_val\x18\x01 \x01(\x03H\x00\x12\x12\n\x08stop_val\x18\x02 \x01(\x03H\x01\x12\x12\n\x08step_val\x18\x03 \x01(\x03H\x02\x42\x07\n\x05startB\x06\n\x04stopB\x06\n\x04step\x1a>\n\x04\x44ict\x12\x19\n\x04keys\x18\x01 \x01(\x0b\x32\x0b.Value.List\x12\x1b\n\x06values\x18\x02 \x01(\x0b\x32\x0b.Value.List\x1a\x1e\n\x03Key\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\tB\x07\n\x05valueb\x06proto3')
 )
 
 
@@ -58,8 +58,8 @@ _VALUE_LIST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=324,
-  serialized_end=371,
+  serialized_start=380,
+  serialized_end=427,
 )
 
 _VALUE_SLICE = _descriptor.Descriptor(
@@ -118,8 +118,8 @@ _VALUE_SLICE = _descriptor.Descriptor(
       name='step', full_name='Value.Slice.step',
       index=2, containing_type=None, fields=[]),
   ],
-  serialized_start=373,
-  serialized_end=483,
+  serialized_start=429,
+  serialized_end=539,
 )
 
 _VALUE_DICT = _descriptor.Descriptor(
@@ -155,8 +155,8 @@ _VALUE_DICT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=485,
-  serialized_end=547,
+  serialized_start=541,
+  serialized_end=603,
 )
 
 _VALUE_KEY = _descriptor.Descriptor(
@@ -192,8 +192,8 @@ _VALUE_KEY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=549,
-  serialized_end=579,
+  serialized_start=605,
+  serialized_end=635,
 )
 
 _VALUE = _descriptor.Descriptor(
@@ -301,6 +301,27 @@ _VALUE = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='index', full_name='Value.index', index=14,
+      number=15, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='series', full_name='Value.series', index=15,
+      number=16, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='dataframe', full_name='Value.dataframe', index=16,
+      number=17, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -317,7 +338,7 @@ _VALUE = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=38,
-  serialized_end=588,
+  serialized_end=644,
 )
 
 _VALUE_LIST.fields_by_name['value'].message_type = _VALUE
@@ -382,6 +403,15 @@ _VALUE.fields_by_name['datetime64'].containing_oneof = _VALUE.oneofs_by_name['va
 _VALUE.oneofs_by_name['value'].fields.append(
   _VALUE.fields_by_name['timedelta64'])
 _VALUE.fields_by_name['timedelta64'].containing_oneof = _VALUE.oneofs_by_name['value']
+_VALUE.oneofs_by_name['value'].fields.append(
+  _VALUE.fields_by_name['index'])
+_VALUE.fields_by_name['index'].containing_oneof = _VALUE.oneofs_by_name['value']
+_VALUE.oneofs_by_name['value'].fields.append(
+  _VALUE.fields_by_name['series'])
+_VALUE.fields_by_name['series'].containing_oneof = _VALUE.oneofs_by_name['value']
+_VALUE.oneofs_by_name['value'].fields.append(
+  _VALUE.fields_by_name['dataframe'])
+_VALUE.fields_by_name['dataframe'].containing_oneof = _VALUE.oneofs_by_name['value']
 DESCRIPTOR.message_types_by_name['Value'] = _VALUE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -141,10 +141,10 @@ class Node4(AttributeAsDict):
     j = ReferenceField('k', Node5)
     k = ListField('l', ValueType.reference('Node5'))
     l = OneOfField('m', n5=Node5, n6=Node6)
-    m = IndexField('k')
-    mm = IndexField('mj')
-    n = SeriesField('l')
-    o = DataFrameField('m')
+    m = IndexField('n')
+    mm = IndexField('mn')
+    n = SeriesField('o')
+    o = DataFrameField('p')
 
     @classmethod
     def cls(cls, provider):
@@ -259,10 +259,10 @@ class Test(unittest.TestCase):
         if pd:
             df = pd.DataFrame({'a': [1, 2, 3], 'b': ['测试', '属性', 'c']},
                               index=[[0, 0, 1], ['测试', '属性', '测试']])
-            other_data['j'] = df.columns
-            other_data['mj'] = df.index
-            other_data['k'] = df['b']
-            other_data['l'] = df
+            other_data['m'] = df.columns
+            other_data['mm'] = df.index
+            other_data['n'] = df['b']
+            other_data['o'] = df
         node4 = Node4(a=to_binary('中文'),
                       b=np.random.randint(4, size=(3, 4)),
                       c=np.datetime64(datetime.datetime.now()),

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -145,6 +145,7 @@ class Node4(AttributeAsDict):
     mm = IndexField('mn')
     n = SeriesField('o')
     o = DataFrameField('p')
+    p = ListField('q')
 
     @classmethod
     def cls(cls, provider):
@@ -257,12 +258,13 @@ class Test(unittest.TestCase):
     def testAttributeAsDict(self):
         other_data = {}
         if pd:
-            df = pd.DataFrame({'a': [1, 2, 3], 'b': ['测试', '属性', 'c']},
+            df = pd.DataFrame({'a': [1, 2, 3], 'b': [to_text('测试'), to_binary('属性'), 'c']},
                               index=[[0, 0, 1], ['测试', '属性', '测试']])
             other_data['m'] = df.columns
             other_data['mm'] = df.index
             other_data['n'] = df['b']
             other_data['o'] = df
+            other_data['p'] = [df.columns, df.index, df['a'], df]
         node4 = Node4(a=to_binary('中文'),
                       b=np.random.randint(4, size=(3, 4)),
                       c=np.datetime64(datetime.datetime.now()),
@@ -300,6 +302,10 @@ class Test(unittest.TestCase):
             pd.testing.assert_index_equal(node4.mm, d_node4.mm)
             pd.testing.assert_series_equal(node4.n, d_node4.n)
             pd.testing.assert_frame_equal(node4.o, d_node4.o)
+            pd.testing.assert_index_equal(node4.p[0], d_node4.p[0])
+            pd.testing.assert_index_equal(node4.p[1], d_node4.p[1])
+            pd.testing.assert_series_equal(node4.p[2], d_node4.p[2])
+            pd.testing.assert_frame_equal(node4.p[3], d_node4.p[3])
 
         jss = JsonSerializeProvider()
 
@@ -326,6 +332,10 @@ class Test(unittest.TestCase):
             pd.testing.assert_index_equal(node4.mm, d_node4.mm)
             pd.testing.assert_series_equal(node4.n, d_node4.n)
             pd.testing.assert_frame_equal(node4.o, d_node4.o)
+            pd.testing.assert_index_equal(node4.p[0], d_node4.p[0])
+            pd.testing.assert_index_equal(node4.p[1], d_node4.p[1])
+            pd.testing.assert_series_equal(node4.p[2], d_node4.p[2])
+            pd.testing.assert_frame_equal(node4.p[3], d_node4.p[3])
 
     def testException(self):
         node1 = Node1(h=[object()])

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -386,7 +386,7 @@ class Test(unittest.TestCase):
         except ImportError:
             sps = None
 
-        from mars.serialize.dataserializer import DataTuple, mars_serialize_context
+        from mars.serialize.dataserializer import mars_serialize_context
         context = mars_serialize_context()
 
         if np:
@@ -401,7 +401,7 @@ class Test(unittest.TestCase):
         if np and sps:
             array = np.random.rand(1000, 100)
             mat = sparse.SparseMatrix(sps.random(100, 100, 0.1, format='csr'))
-            tp = DataTuple((array, mat))
+            tp = (array, mat)
             des_tp = pyarrow.deserialize(pyarrow.serialize(tp, context).to_buffer(), context)
             assert_array_equal(tp[0], des_tp[0])
             self.assertTrue((tp[1].spmatrix != des_tp[1].spmatrix).nnz == 0)

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -21,11 +21,14 @@ import tempfile
 import unittest
 
 import numpy as np
-
 try:
     import pyarrow
 except ImportError:
     pyarrow = None
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
 
 from mars.compat import six, OrderedDict, BytesIO
 from mars.lib import sparse
@@ -34,7 +37,7 @@ from mars.serialize.core import Serializable, IdentityField, StringField, Unicod
     UInt32Field, UInt64Field, Float16Field, Float32Field, Float64Field, BoolField, \
     Datetime64Field, Timedelta64Field, DataTypeField, KeyField, ReferenceField, OneOfField, \
     ListField, NDArrayField, DictField, TupleField, ValueType, serializes, deserializes, \
-    ProviderType, AttributeAsDict
+    IndexField, SeriesField, DataFrameField, ProviderType, AttributeAsDict
 from mars.serialize import dataserializer
 from mars.serialize.pbserializer import ProtobufSerializeProvider
 from mars.serialize.jsonserializer import JsonSerializeProvider
@@ -138,6 +141,10 @@ class Node4(AttributeAsDict):
     j = ReferenceField('k', Node5)
     k = ListField('l', ValueType.reference('Node5'))
     l = OneOfField('m', n5=Node5, n6=Node6)
+    m = IndexField('k')
+    mm = IndexField('mj')
+    n = SeriesField('l')
+    o = DataFrameField('m')
 
     @classmethod
     def cls(cls, provider):
@@ -248,6 +255,14 @@ class Test(unittest.TestCase):
         self.assertNotIsInstance(node3.value.i[0], Node8)
 
     def testAttributeAsDict(self):
+        other_data = {}
+        if pd:
+            df = pd.DataFrame({'a': [1, 2, 3], 'b': ['测试', '属性', 'c']},
+                              index=[[0, 0, 1], ['测试', '属性', '测试']])
+            other_data['j'] = df.columns
+            other_data['mj'] = df.index
+            other_data['k'] = df['b']
+            other_data['l'] = df
         node4 = Node4(a=to_binary('中文'),
                       b=np.random.randint(4, size=(3, 4)),
                       c=np.datetime64(datetime.datetime.now()),
@@ -259,7 +274,7 @@ class Test(unittest.TestCase):
                       i=(slice(10), slice(0, 2), None, slice(2, 0, -1)),
                       j=Node5(a='aa'),
                       k=[Node5(a='bb'), None],
-                      l=Node6(b=3, nid=1))
+                      l=Node6(b=3, nid=1), **other_data)
 
         pbs = ProtobufSerializeProvider()
 
@@ -267,7 +282,7 @@ class Test(unittest.TestCase):
         d_node4 = Node4.deserialize(pbs, serial)
 
         self.assertEqual(node4.a, d_node4.a)
-        self.assertTrue(np.array_equal(node4.b, d_node4.b))
+        np.testing.assert_array_equal(node4.b, d_node4.b)
         self.assertEqual(node4.c, d_node4.c)
         self.assertEqual(node4.d, d_node4.d)
         self.assertEqual(node4.e, d_node4.e)
@@ -280,6 +295,11 @@ class Test(unittest.TestCase):
         self.assertIsNone(d_node4.k[1])
         self.assertIsInstance(d_node4.l, Node7)
         self.assertEqual(d_node4.l.b, 3)
+        if pd:
+            pd.testing.assert_index_equal(node4.m, d_node4.m)
+            pd.testing.assert_index_equal(node4.mm, d_node4.mm)
+            pd.testing.assert_series_equal(node4.n, d_node4.n)
+            pd.testing.assert_frame_equal(node4.o, d_node4.o)
 
         jss = JsonSerializeProvider()
 
@@ -288,7 +308,7 @@ class Test(unittest.TestCase):
         d_node4 = Node4.deserialize(jss, serial)
 
         self.assertEqual(node4.a, d_node4.a)
-        self.assertTrue(np.array_equal(node4.b, d_node4.b))
+        np.testing.assert_array_equal(node4.b, d_node4.b)
         self.assertEqual(node4.c, d_node4.c)
         self.assertEqual(node4.d, d_node4.d)
         self.assertEqual(node4.e, d_node4.e)
@@ -301,6 +321,11 @@ class Test(unittest.TestCase):
         self.assertIsNone(d_node4.k[1])
         self.assertIsInstance(d_node4.l, Node7)
         self.assertEqual(d_node4.l.b, 3)
+        if pd:
+            pd.testing.assert_index_equal(node4.m, d_node4.m)
+            pd.testing.assert_index_equal(node4.mm, d_node4.mm)
+            pd.testing.assert_series_equal(node4.n, d_node4.n)
+            pd.testing.assert_frame_equal(node4.o, d_node4.o)
 
     def testException(self):
         node1 = Node1(h=[object()])

--- a/mars/worker/chunkstore.py
+++ b/mars/worker/chunkstore.py
@@ -150,11 +150,8 @@ class PlasmaChunkStore(object):
         """
         import pyarrow
         from pyarrow.lib import PlasmaStoreFull, PlasmaObjectExists
-        from ..serialize.dataserializer import DataTuple
 
         data_size = calc_data_size(value)
-        if isinstance(value, tuple):
-            value = DataTuple(*value)
 
         obj_id = self._calc_object_id(session_id, chunk_key)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Add IndexField, SeriesField, DataFrameField for protobuf and json serializer, remove DataTuple for dataserializer which is not needed any more.

Note that this PR will break compatibility between 0.1.x and 0.2.x.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolve #161 
