### PR TITLE
Use miniconda to test on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       python: "3.5"
       services:
         - docker
-      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp35-cp35m CI_MODE=1
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp35-cp35m CYTHON_TRACE=1
     - os: linux
       python: "3.6"
       services:
@@ -43,12 +43,16 @@ before_install:
 # command to install dependencies
 install:
   - export DEFAULT_VENV=$VIRTUAL_ENV
+  - if [ -z "$CYTHON_TRACE" ]; then
+      for cf in `ls .coveragerc*`; do
+        sed -i.bak "s/plugins *= *Cython\.Coverage//g" $cf;
+      done
+    fi
   - pip install -r requirements-dev.txt
   - pip install -r requirements-extra.txt
   - pip install virtualenv coveralls flake8 etcd-gevent
   - virtualenv venv && source venv/bin/activate
-  - pip install -r requirements.txt
-  - pip install pytest pytest-timeout
+  - pip install -r requirements.txt && pip install pytest pytest-timeout
   - if [ -z "$DEFAULT_VENV" ]; then deactivate; else source $DEFAULT_VENV/bin/activate; fi
   - python setup.py build_ext --force --inplace
   - source bin/download-etcd.sh
@@ -60,13 +64,11 @@ before_script:
 # command to run tests
 script:
   mkdir -p build &&
-  pytest --cov-report= --cov-config .coveragerc-tensor --cov=mars --timeout=1500 -W ignore::PendingDeprecationWarning
-    mars/tensor mars/web &&
-  mv .coverage build/.coverage.tensor.file &&
-  pytest --cov-report= --cov-config .coveragerc --cov=mars --timeout=1500 --forked -W ignore::PendingDeprecationWarning
-    $(find mars -maxdepth 1 -mindepth 1 -type d -not -path "mars/tensor" -not -path "*__pycache__*") &&
-  mv .coverage build/.coverage.main.file &&
-  coverage combine build/ && coverage report --fail-under=80 &&
+  pytest --cov-report= --cov-config .coveragerc-tensor --cov=mars --timeout=1500
+    -W ignore::PendingDeprecationWarning mars/tensor mars/web &&
+  pytest --cov-report= --cov-config .coveragerc --cov=mars --cov-append --timeout=1500
+    -W ignore::PendingDeprecationWarning --forked --ignore=mars/tensor mars &&
+  coverage report --fail-under=85 &&
   export DEFAULT_VENV=$VIRTUAL_ENV &&
   source venv/bin/activate &&
   pytest --timeout=1500 mars/tests/test_session.py &&

--- a/bin/travis-prepare-osx.sh
+++ b/bin/travis-prepare-osx.sh
@@ -4,19 +4,16 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 
     ulimit -n 1024
 
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv
-    PYENV_ROOT="$HOME/.pyenv"
-    PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init -)"
-
     function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
 
     if version_gt "3.0" "$PYTHON" ; then
         curl -O https://bootstrap.pypa.io/get-pip.py
         python get-pip.py --user
     else
-        pyenv install $PYTHON
-        pyenv global $PYTHON
+        curl -s -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+        bash miniconda.sh -b -p $HOME/miniconda && rm miniconda.sh
+        $HOME/miniconda/bin/conda create --quiet --yes -n test python=$PYTHON virtualenv gevent psutil nomkl
+        export PATH="$HOME/miniconda/envs/test/bin:$PATH"
     fi
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if os.path.exists(os.path.join(repo_root, '.git')):
 
 cythonize_kw = dict(language_level=sys.version_info[0])
 extension_kw = dict()
-if 'CI_MODE' in os.environ:
+if 'CYTHON_TRACE' in os.environ:
     extension_kw['define_macros'] = [('CYTHON_TRACE_NOGIL', '1'), ('CYTHON_TRACE', '1')]
     cythonize_kw['compiler_directives'] = {'linetrace': True, 'binding': True}
 


### PR DESCRIPTION
## What do these changes do?

1. Use Miniconda instead of pyenv to run ci on MacOS to save run time.
2. Remove Cython.Coverage when not needs. This reduces fluctuation of coverage when running tests with and without CYTHON_TRACE.

## Related issue number

NA