### PR TITLE
Decouple services from applications & unify worker start logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,11 +64,13 @@ before_script:
 # command to run tests
 script:
   mkdir -p build &&
-  pytest --cov-report= --cov-config .coveragerc-tensor --cov=mars --timeout=1500
-    -W ignore::PendingDeprecationWarning mars/tensor mars/web &&
-  pytest --cov-report= --cov-config .coveragerc --cov=mars --cov-append --timeout=1500
-    -W ignore::PendingDeprecationWarning --forked --ignore=mars/tensor mars &&
-  coverage report --fail-under=85 &&
+  pytest --cov-report= --cov-config .coveragerc-tensor --cov=mars --timeout=1500 -W ignore::PendingDeprecationWarning
+    mars/tensor mars/web &&
+  mv .coverage build/.coverage.tensor.file &&
+  pytest --cov-report= --cov-config .coveragerc --cov=mars --timeout=1500 --forked -W ignore::PendingDeprecationWarning
+    --ignore mars/tensor mars &&
+  mv .coverage build/.coverage.main.file &&
+  coverage combine build/ && coverage report --fail-under=85 &&
   export DEFAULT_VENV=$VIRTUAL_ENV &&
   source venv/bin/activate &&
   pytest --timeout=1500 mars/tests/test_session.py &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,16 @@ matrix:
       env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp37-cp37m
     - os: osx
       language: generic
-      env: PYTHON=2.7.12
+      env: PYTHON=2.7
     - os: osx
       language: generic
-      env: PYTHON=3.5.3
+      env: PYTHON=3.5
     - os: osx
       language: generic
-      env: PYTHON=3.6.1
+      env: PYTHON=3.6
     - os: osx
       language: generic
-      env: PYTHON=3.7.1
+      env: PYTHON=3.7
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then source ./bin/travis-prepare-osx.sh; fi

--- a/bin/travis-prepare-osx.sh
+++ b/bin/travis-prepare-osx.sh
@@ -12,7 +12,7 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     else
         curl -s -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
         bash miniconda.sh -b -p $HOME/miniconda && rm miniconda.sh
-        $HOME/miniconda/bin/conda create --quiet --yes -n test python=$PYTHON virtualenv gevent psutil nomkl
+        $HOME/miniconda/bin/conda create --quiet --yes -n test python=$PYTHON virtualenv gevent psutil pyyaml nomkl
         export PATH="$HOME/miniconda/envs/test/bin:$PATH"
     fi
 fi

--- a/mars/base_app.py
+++ b/mars/base_app.py
@@ -196,7 +196,7 @@ class BaseApplication(object):
 
             with self.pool:
                 try:
-                    self.start_service()
+                    self.start()
                     self._running = True
                     while True:
                         self.pool.join(1)
@@ -208,7 +208,7 @@ class BaseApplication(object):
                             self.handle_process_down(stopped)
                 except:
                     self._running = False
-                    self.stop_service()
+                    self.stop()
         finally:
             self._running = False
             if profile_file:
@@ -240,8 +240,8 @@ class BaseApplication(object):
     def config_args(self, parser):
         raise NotImplementedError
 
-    def start_service(self):
+    def start(self):
         raise NotImplementedError
 
-    def stop_service(self):
+    def stop(self):
         raise NotImplementedError

--- a/mars/compat/__init__.py
+++ b/mars/compat/__init__.py
@@ -423,7 +423,7 @@ except ImportError:
                     gc.enable()
 
 
-__all__ = ['PY27', 'sys', 'builtins', 'OrderedDict', 'dictconfig', 'suppress', 'reduce', 'reload_module',
+__all__ = ['PY27', 'sys', 'builtins', 'long_type', 'OrderedDict', 'dictconfig', 'suppress', 'reduce', 'reload_module',
            'Queue', 'PriorityQueue', 'Empty', 'urlretrieve', 'pickle', 'urlencode', 'urlparse', 'unquote',
            'quote', 'quote_plus', 'parse_qsl', 'Enum', 'ConfigParser', 'decimal', 'Decimal', 'DECIMAL_TYPES',
            'FixedOffset', 'utc', 'finalize', 'functools32', 'zip_longest', 'OrderedDict3', 'BrokenPipeError',

--- a/mars/config.py
+++ b/mars/config.py
@@ -319,12 +319,6 @@ default_options.register_option('scheduler.fetch_limit', 10 * 1024 ** 2, validat
 default_options.register_option('scheduler.retry_delay', 60, validator=is_integer, serialize=True)
 
 # Worker
-default_options.register_option('worker.cpu_process_count', None, validator=(is_null, is_integer))
-default_options.register_option('worker.io_process_count', None, validator=(is_null, is_integer))
-default_options.register_option('worker.physical_memory_limit_soft', '75%', validator=(is_null, is_string, is_integer))
-default_options.register_option('worker.physical_memory_limit_hard', '90%', validator=(is_null, is_string, is_integer))
-default_options.register_option('worker.cache_memory_limit', None, validator=(is_null, is_string, is_integer))
-default_options.register_option('worker.disk_limit', None, validator=(is_null, is_string))
 default_options.register_option('worker.spill_directory', None, validator=(is_null, is_string, is_list))
 default_options.register_option('worker.min_spill_size', '5%', validator=(is_string, is_integer))
 default_options.register_option('worker.max_spill_size', '95%', validator=(is_string, is_integer))
@@ -333,7 +327,6 @@ default_options.register_option('worker.transfer_block_size', 4 * 1024 * 1024, v
 default_options.register_option('worker.prepare_data_timeout', 600, validator=is_integer)
 
 default_options.register_option('worker.plasma_socket', '/tmp/plasma', validator=is_string)
-default_options.register_option('worker.plasma_one_mapped_file', False, validator=is_bool)
 default_options.register_option('worker.advertise_addr', '127.0.0.1', validator=is_string)
 
 # optimization

--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -20,7 +20,7 @@ import os
 import time
 
 from ...actors import create_actor_pool
-from ...compat import six, TimeoutError
+from ...compat import six, TimeoutError  # pylint: disable=W0622
 from ...lib import gipc
 from ...resource import cpu_count
 from ...scheduler.service import SchedulerService

--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -19,14 +19,14 @@ import signal
 import os
 import time
 
-from ...utils import get_next_port
+from ...actors import create_actor_pool
+from ...compat import six, TimeoutError
+from ...lib import gipc
 from ...resource import cpu_count
 from ...scheduler.service import SchedulerService
-from ...worker.service import WorkerService
-from ...actors import create_actor_pool
 from ...session import new_session
-from ...compat import six
-from ...lib import gipc
+from ...utils import get_next_port
+from ...worker.service import WorkerService
 from .distributor import gen_distributor
 
 
@@ -36,9 +36,8 @@ class LocalDistributedCluster(object):
     MIN_SCHEDULER_N_PROCESS = 2
     MIN_WORKER_N_PROCESS = 2
 
-    def __init__(self, endpoint, n_process=None,
-                 scheduler_n_process=None, worker_n_process=None,
-                 shared_memory=None):
+    def __init__(self, endpoint, n_process=None, scheduler_n_process=None,
+                 worker_n_process=None, ignore_avail_mem=True, shared_memory=None):
         self._endpoint = endpoint
 
         self._started = False
@@ -46,7 +45,8 @@ class LocalDistributedCluster(object):
 
         self._pool = None
         self._scheduler_service = SchedulerService()
-        self._worker_service = WorkerService(cache_mem_limit=shared_memory)
+        self._worker_service = WorkerService(ignore_avail_mem=ignore_avail_mem,
+                                             cache_mem_limit=shared_memory)
 
         self._scheduler_n_process, self._worker_n_process = \
             self._calc_scheduler_worker_n_process(n_process,

--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -17,6 +17,7 @@
 import multiprocessing
 import signal
 import os
+import time
 
 from ...utils import get_next_port
 from ...resource import cpu_count
@@ -77,12 +78,15 @@ class LocalDistributedCluster(object):
 
         return n_scheduler, n_worker
 
-    def _make_sure_scheduler_ready(self):
+    def _make_sure_scheduler_ready(self, timeout=120):
+        check_start_time = time.time()
         while True:
             workers_meta = self._scheduler_service._resource_ref.get_workers_meta()
             if not workers_meta:
                 # wait for worker to report status
                 self._pool.sleep(.5)
+                if time.time() - check_start_time > timeout:  # pragma: no cover
+                    raise TimeoutError('Check worker ready timed out.')
             else:
                 break
 

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -19,7 +19,7 @@ import json
 import time
 
 from ...api import MarsAPI
-from ...compat import TimeoutError
+from ...compat import TimeoutError  # pylint: disable=W0622
 from ...graph import DirectedGraph
 from ...scheduler.graph import GraphState
 from ...serialize import dataserializer

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -24,7 +24,6 @@ from mars import tensor as mt
 from mars.operands import Operand
 from mars.tensor.expressions.arithmetic.core import TensorElementWise
 from mars.serialize import Int64Field
-from mars.config import options
 from mars.session import new_session, Session
 from mars.deploy.local.core import new_cluster, LocalDistributedCluster, gen_endpoint
 from mars.cluster_info import ClusterInfoActor
@@ -47,16 +46,10 @@ class SerializeMustFailOperand(Operand, TensorElementWise):
 
 @unittest.skipIf(sys.platform == 'win32', 'does not run in windows')
 class Test(unittest.TestCase):
-    def setUp(self):
-        self._old_cache_memory_limit = options.worker.cache_memory_limit
-        options.worker.cache_memory_limit = '20M'
-
-    def tearDown(self):
-        options.worker.cache_memory_limit = self._old_cache_memory_limit
-
     def testLocalCluster(self):
         endpoint = gen_endpoint('0.0.0.0')
-        with LocalDistributedCluster(endpoint, scheduler_n_process=2, worker_n_process=3) as cluster:
+        with LocalDistributedCluster(endpoint, scheduler_n_process=2, worker_n_process=3,
+                                     shared_memory='20M') as cluster:
             pool = cluster.pool
 
             self.assertTrue(pool.has_actor(pool.actor_ref(ClusterInfoActor.default_name())))
@@ -74,7 +67,8 @@ class Test(unittest.TestCase):
             self.assertNotIn(session._session_id, api.session_manager.get_sessions())
 
     def testLocalClusterWithWeb(self):
-        with new_cluster(scheduler_n_process=2, worker_n_process=3, web=True) as cluster:
+        with new_cluster(scheduler_n_process=2, worker_n_process=3,
+                         shared_memory='20M', web=True) as cluster:
             with cluster.session as session:
                 t = mt.ones((3, 3), chunk_size=2)
                 result = session.run(t)
@@ -109,7 +103,8 @@ class Test(unittest.TestCase):
             5, 3, 2, calc_cpu_count=calc_cpu_cnt), (3, 2))
 
     def testSingleOutputTensorExecute(self):
-        with new_cluster(scheduler_n_process=2, worker_n_process=2) as cluster:
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M') as cluster:
             self.assertIs(cluster.session, Session.default_or_local())
 
             t = mt.random.rand(10)
@@ -126,7 +121,8 @@ class Test(unittest.TestCase):
             self.assertLess(res, 39)
 
     def testMultipleOutputTensorExecute(self):
-        with new_cluster(scheduler_n_process=2, worker_n_process=2) as cluster:
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M') as cluster:
             session = cluster.session
 
             t = mt.random.rand(20, 5, chunk_size=5)
@@ -175,7 +171,8 @@ class Test(unittest.TestCase):
                 np.testing.assert_allclose(s_result, s_expected)
 
     def testIndexTensorExecute(self):
-        with new_cluster(scheduler_n_process=2, worker_n_process=2) as cluster:
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M') as cluster:
             session = cluster.session
 
             a = mt.random.rand(10, 5)
@@ -217,7 +214,8 @@ class Test(unittest.TestCase):
                 np.testing.assert_array_equal(r[10:20], np.ones((10, 5)) * 2)
 
     def testBoolIndexingExecute(self, *_):
-        with new_cluster(scheduler_n_process=2, worker_n_process=2, web=True) as cluster:
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M', web=True) as cluster:
             a = mt.random.rand(8, 8, chunk_size=4)
             a[2:6, 2:6] = mt.ones((4, 4)) * 2
             b = a[a > 1]
@@ -252,14 +250,16 @@ class Test(unittest.TestCase):
                 np.testing.assert_array_equal(r, np.ones((16,)) * 2)
 
     def testExecutableTuple(self):
-        with new_cluster(scheduler_n_process=2, worker_n_process=2, web=True) as cluster:
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M', web=True) as cluster:
             with new_session('http://' + cluster._web_endpoint).as_default():
                 a = mt.ones((20, 10), chunk_size=10)
                 u, s, v = (mt.linalg.svd(a)).execute()
                 np.testing.assert_allclose(u.dot(np.diag(s).dot(v)), np.ones((20, 10)))
 
     def testRerunTensor(self):
-        with new_cluster(scheduler_n_process=2, worker_n_process=2) as cluster:
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M') as cluster:
             session = cluster.session
 
             a = mt.ones((10, 10)) + 1
@@ -277,7 +277,8 @@ class Test(unittest.TestCase):
                 np.testing.assert_array_equal(b_result, np.ones((10, 10)))
 
     def testRunWithoutFetch(self):
-        with new_cluster(scheduler_n_process=2, worker_n_process=2) as cluster:
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M') as cluster:
             session = cluster.session
 
             a = mt.ones((10, 20)) + 1
@@ -288,6 +289,7 @@ class Test(unittest.TestCase):
         op = SerializeMustFailOperand(f=3)
         tensor = op.new_tensor(None, (3, 3))
 
-        with new_cluster(scheduler_n_process=2, worker_n_process=2) as cluster:
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M') as cluster:
             with self.assertRaises(SystemError):
                 cluster.session.run(tensor)

--- a/mars/kvstore.py
+++ b/mars/kvstore.py
@@ -15,7 +15,7 @@
 from datetime import datetime, timedelta
 from gevent.event import Event
 
-from .compat import urlparse, TimeoutError
+from .compat import urlparse, TimeoutError  # pylint: disable=W0622
 
 
 def _normalize_path(path):

--- a/mars/lib/sparse/core.py
+++ b/mars/lib/sparse/core.py
@@ -17,15 +17,15 @@
 import numpy as np
 try:
     import cupy.sparse as cps
-except ImportError:
+except ImportError:  # pragma: no cover
     cps = None
 try:
     import scipy.sparse as sps
-except ImportError:
+except ImportError:  # pragma: no cover
     sps = None
 try:
     import cupy as cp
-except ImportError:
+except ImportError:  # pragma: no cover
     cp = None
 
 

--- a/mars/scheduler/__main__.py
+++ b/mars/scheduler/__main__.py
@@ -22,23 +22,28 @@ from .service import SchedulerService
 logger = logging.getLogger(__name__)
 
 
-class SchedulerApplication(BaseApplication, SchedulerService):
+class SchedulerApplication(BaseApplication):
     service_description = 'Mars Scheduler'
     service_logger = logger
+
+    def __init__(self):
+        super(SchedulerApplication, self).__init__()
+        self._service = None
 
     def config_args(self, parser):
         parser.add_argument('--nproc', help='number of processes')
 
     def create_pool(self, *args, **kwargs):
+        self._service = SchedulerService()
         self.n_process = int(self.args.nproc or resource.cpu_count())
         kwargs['distributor'] = SchedulerDistributor(self.n_process)
         return super(SchedulerApplication, self).create_pool(*args, **kwargs)
 
-    def start_service(self):
-        super(SchedulerApplication, self).start(self.endpoint, self.args.schedulers, self.pool)
+    def start(self):
+        self._service.start(self.endpoint, self.args.schedulers, self.pool)
 
-    def stop_service(self):
-        super(SchedulerApplication, self).stop(self.pool)
+    def stop(self):
+        self._service.stop(self.pool)
 
 
 main = SchedulerApplication()

--- a/mars/scheduler/tests/test_main.py
+++ b/mars/scheduler/tests/test_main.py
@@ -114,7 +114,7 @@ class Test(unittest.TestCase):
 
         check_time = time.time()
         while any(p.poll() is None for p in procs):
-            time.sleep(1)
+            time.sleep(0.1)
             if time.time() - check_time > 5:
                 break
 

--- a/mars/tensor/execution/array.py
+++ b/mars/tensor/execution/array.py
@@ -20,7 +20,7 @@ from contextlib import contextmanager
 import numpy as np
 try:
     import cupy as cp
-except ImportError:
+except ImportError:  # pragma: no cover
     cp = None
 
 from ...lib import sparse

--- a/mars/tensor/execution/core.py
+++ b/mars/tensor/execution/core.py
@@ -388,7 +388,7 @@ try:
     NUMEXPR_INSTALLED = True
     from .ne import register_numexpr_handler
     register_numexpr_handler()
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 CP_INSTALLED = False
@@ -397,7 +397,7 @@ try:
     CP_INSTALLED = True
     from .cp import register_cp_handler
     register_cp_handler()
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 register_data_source_handler()

--- a/mars/tensor/execution/fft.py
+++ b/mars/tensor/execution/fft.py
@@ -17,7 +17,7 @@
 import numpy as np
 try:
     import scipy.fftpack as scifft
-except ImportError:
+except ImportError:  # pragma: no cover
     scifft = None
 
 from ...operands import fft as fftop

--- a/mars/tensor/execution/linalg.py
+++ b/mars/tensor/execution/linalg.py
@@ -53,7 +53,7 @@ def _cholesky(ctx, chunk):
 
                 ctx[chunk.key] = scipy.linalg.cholesky(a, lower=chunk.op.lower)
                 return
-            except ImportError:
+            except ImportError:  # pragma: no cover
                 pass
 
         r = xp.linalg.cholesky(a)

--- a/mars/web/__main__.py
+++ b/mars/web/__main__.py
@@ -43,13 +43,13 @@ class WebApplication(BaseApplication):
 
     def main_loop(self):
         try:
-            self.start_service()
+            self.start()
             while True:
                 time.sleep(0.1)
         finally:
-            self.stop_service()
+            self.stop()
 
-    def start_service(self):
+    def start(self):
         from .server import MarsWeb
         if MarsWeb is None:
             self.mars_web = None
@@ -63,7 +63,7 @@ class WebApplication(BaseApplication):
             self.mars_web = MarsWeb(port=ui_port, scheduler_ip=scheduler_ip)
             self.mars_web.start()
 
-    def stop_service(self):
+    def stop(self):
         if self.mars_web:
             self.mars_web.stop()
 

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -19,7 +19,7 @@ import logging
 
 import requests
 
-from ..compat import six, TimeoutError
+from ..compat import six, TimeoutError  # pylint: disable=W0622
 from ..serialize import dataserializer
 from ..errors import ResponseMalformed, ExecutionInterrupted, ExecutionFailed, \
     ExecutionStateUnknown, ExecutionNotStopped

--- a/mars/worker/__main__.py
+++ b/mars/worker/__main__.py
@@ -14,8 +14,6 @@
 
 import logging
 
-from .. import resource
-from ..config import options
 from ..base_app import BaseApplication
 from ..errors import StartArgumentError
 from .distributor import WorkerDistributor
@@ -24,7 +22,7 @@ from .service import WorkerService
 logger = logging.getLogger(__name__)
 
 
-class WorkerApplication(BaseApplication, WorkerService):
+class WorkerApplication(BaseApplication):
     """
     Main function class of Mars Worker
     """
@@ -32,9 +30,8 @@ class WorkerApplication(BaseApplication, WorkerService):
     service_logger = logger
 
     def __init__(self):
-        BaseApplication.__init__(self)
-        WorkerService.__init__(self)
-        self._total_mem = None
+        super(WorkerApplication, self).__init__()
+        self._service = None
 
     def config_args(self, parser):
         parser.add_argument('--cpu-procs', help='number of processes used for cpu')
@@ -42,7 +39,6 @@ class WorkerApplication(BaseApplication, WorkerService):
         parser.add_argument('--phy-mem', help='physical memory size limit')
         parser.add_argument('--ignore-avail-mem', action='store_true', help='ignore available memory')
         parser.add_argument('--cache-mem', help='cache memory size limit')
-        parser.add_argument('--disk', help='disk size limit')
         parser.add_argument('--spill-dir', help='spill directory')
         parser.add_argument('--plasma-one-mapped-file', action='store_true',
                             help='path of Plasma UNIX socket')
@@ -56,54 +52,30 @@ class WorkerApplication(BaseApplication, WorkerService):
     def create_pool(self, *args, **kwargs):
         # here we create necessary actors on worker
         # and distribute them over processes
-        mem_stats = resource.virtual_memory()
-
-        options.worker.cpu_process_count = int(self.args.cpu_procs or resource.cpu_count())
-        options.worker.io_process_count = int(self.args.io_procs or '1')
-
-        if self.args.phy_mem:
-            self._total_mem = self._calc_size_limit(self.args.phy_mem, mem_stats.total)
-        else:
-            self._total_mem = mem_stats.total
-
-        options.worker.physical_memory_limit_hard = self._calc_size_limit(
-            options.worker.physical_memory_limit_hard, self._total_mem
+        self._service = WorkerService(
+            advertise_addr=self.args.advertise,
+            cpu_procs=self.args.cpu_procs,
+            io_procs=self.args.io_procs,
+            spill_dirs=self.args.spill_dir,
+            total_mem=self.args.phy_mem,
+            cache_mem_limit=self.args.cache_mem,
+            ignore_avail_mem=self.args.ignore_avail_mem,
         )
-        options.worker.physical_memory_limit_soft = self._calc_size_limit(
-            options.worker.physical_memory_limit_soft, self._total_mem
-        )
-        options.worker.cache_memory_limit = self.args.cache_mem
-        options.worker.disk_limit = self.args.disk
-        if self.args.spill_dir:
-            from .spill import parse_spill_dirs
-            options.worker.spill_directory = parse_spill_dirs(self.args.spill_dir)
-            spill_dir_count = 1
-        else:
-            options.worker.spill_directory = None
-            spill_dir_count = 0
-        options.worker.advertise_addr = self.args.advertise
-
-        self.n_process = 1 + options.worker.cpu_process_count + options.worker.io_process_count + spill_dir_count
-
         # start plasma
-        self.start_plasma(self.calc_cache_memory_limit(),
-                          one_mapped_file=options.worker.plasma_one_mapped_file or False)
+        self._service.start_plasma(one_mapped_file=self.args.plasma_one_mapped_file or False)
 
+        self.n_process = self._service.n_processes
         kwargs['distributor'] = WorkerDistributor(self.n_process)
         return super(WorkerApplication, self).create_pool(*args, **kwargs)
 
-    def start_service(self):
-        super(WorkerApplication, self).start(self.endpoint, self.args.schedulers, self.pool,
-                                             total_mem=self._total_mem, ignore_avail_mem=self.args.ignore_avail_mem)
+    def start(self):
+        self._service.start(self.endpoint, self.pool, schedulers=self.args.schedulers)
 
     def handle_process_down(self, proc_indices):
-        logger.debug('Process %r halt. Trying to recover.', proc_indices)
-        for pid in proc_indices:
-            self.pool.restart_process(pid)
-        self._daemon_ref.handle_process_down(proc_indices, _tell=True)
+        self._service.handle_process_down(proc_indices)
 
-    def stop_service(self):
-        super(WorkerApplication, self).stop()
+    def stop(self):
+        self._service.stop()
 
 
 main = WorkerApplication()

--- a/mars/worker/__main__.py
+++ b/mars/worker/__main__.py
@@ -54,8 +54,8 @@ class WorkerApplication(BaseApplication):
         # and distribute them over processes
         self._service = WorkerService(
             advertise_addr=self.args.advertise,
-            cpu_procs=self.args.cpu_procs,
-            io_procs=self.args.io_procs,
+            n_cpu_process=self.args.cpu_procs,
+            n_io_process=self.args.io_procs,
             spill_dirs=self.args.spill_dir,
             total_mem=self.args.phy_mem,
             cache_mem_limit=self.args.cache_mem,
@@ -64,7 +64,7 @@ class WorkerApplication(BaseApplication):
         # start plasma
         self._service.start_plasma(one_mapped_file=self.args.plasma_one_mapped_file or False)
 
-        self.n_process = self._service.n_processes
+        self.n_process = self._service.n_process
         kwargs['distributor'] = WorkerDistributor(self.n_process)
         return super(WorkerApplication, self).create_pool(*args, **kwargs)
 
@@ -72,7 +72,7 @@ class WorkerApplication(BaseApplication):
         self._service.start(self.endpoint, self.pool, schedulers=self.args.schedulers)
 
     def handle_process_down(self, proc_indices):
-        self._service.handle_process_down(proc_indices)
+        self._service.handle_process_down(self.pool, proc_indices)
 
     def stop(self):
         self._service.stop()

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -19,7 +19,7 @@ import logging
 
 try:
     from pyarrow import plasma
-except ImportError:
+except ImportError:  # pragma: no cover
     plasma = None
 
 from ..config import options
@@ -44,9 +44,8 @@ logger = logging.getLogger(__name__)
 
 
 class WorkerService(object):
-    service_logger = logger
-
-    def __init__(self):
+    def __init__(self, **kwargs):
+        self._pool = None
         self._plasma_store = None
 
         self._chunk_holder_ref = None
@@ -65,34 +64,82 @@ class WorkerService(object):
         self._process_helper_actors = []
         self._result_sender_ref = None
 
-    def start_plasma(self, mem_limit, one_mapped_file=False):
+        self._advertise_addr = kwargs.pop('advertise_addr', None)
+
+        self._n_cpu_process = int(kwargs.pop('cpu_procs', None) or resource.cpu_count())
+        self._n_io_process = int(kwargs.pop('io_procs', None) or '1')
+
+        self._spill_dirs = kwargs.pop('spill_dirs', None)
+        if self._spill_dirs:
+            from .spill import parse_spill_dirs
+            self._spill_dirs = options.worker.spill_directory = parse_spill_dirs(self._spill_dirs)
+        else:
+            self._spill_dirs = options.worker.spill_directory = []
+
+        self._total_mem = kwargs.pop('total_mem', None)
+        self._cache_mem_limit = kwargs.pop('cache_mem_limit', None)
+        self._soft_mem_limit = kwargs.pop('soft_mem_limit', '75%')
+        self._hard_mem_limit = kwargs.pop('hard_mem_limit', '90%')
+        self._ignore_avail_mem = kwargs.pop('ignore_avail_mem', False)
+
+        self._soft_quota_limit = self._soft_mem_limit
+
+        self._calc_memory_limits()
+
+        if kwargs:  # pragma: no cover
+            raise TypeError('Keyword arguments %r cannot be recognized.' % ', '.join(kwargs))
+
+    @property
+    def n_processes(self):
+        return 1 + self._n_cpu_process + self._n_io_process + (1 if self._spill_dirs else 0)
+
+    def _calc_memory_limits(self):
+        def _calc_size_limit(limit_str, total_size):
+            if limit_str is None:
+                return None
+            if isinstance(limit_str, int):
+                return limit_str
+            mem_limit, is_percent = parse_memory_limit(limit_str)
+            if is_percent:
+                return int(total_size * mem_limit)
+            else:
+                return int(mem_limit)
+
+        mem_stats = resource.virtual_memory()
+
+        if self._total_mem:
+            self._total_mem = _calc_size_limit(self._total_mem, mem_stats.total)
+        else:
+            self._total_mem = mem_stats.total
+
+        self._hard_mem_limit = _calc_size_limit(self._hard_mem_limit, self._total_mem)
+
+        self._cache_mem_limit = _calc_size_limit(self._cache_mem_limit, self._total_mem)
+        if self._cache_mem_limit is None:
+            self._cache_mem_limit = mem_stats.free // 2
+
+        self._soft_mem_limit = _calc_size_limit(self._soft_mem_limit, self._total_mem)
+        actual_used = self._total_mem - mem_stats.available
+        if self._ignore_avail_mem:
+            self._soft_quota_limit = self._soft_mem_limit
+        else:
+            self._soft_quota_limit = self._soft_mem_limit - self._cache_mem_limit - actual_used
+            if self._soft_quota_limit < 512 * 1024 ** 2:
+                raise MemoryError('Memory not enough. soft_limit=%s, cache_limit=%s, used=%s' %
+                                  tuple(readable_size(k) for k in (
+                                      self._soft_mem_limit, self._cache_mem_limit, actual_used)))
+
+        logger.info('Setting soft limit to %s.', readable_size(self._soft_quota_limit))
+
+    def start_plasma(self, one_mapped_file=False):
         self._plasma_store = plasma.start_plasma_store(
-            int(mem_limit), use_one_memory_mapped_file=one_mapped_file
+            self._cache_mem_limit, use_one_memory_mapped_file=one_mapped_file
         )
         options.worker.plasma_socket, _ = self._plasma_store.__enter__()
 
-    @classmethod
-    def _calc_soft_memory_limit(cls, total_mem=None):
-        """
-        Calc memory limit for MemQuotaActor given configured percentage. Cache size and memory
-        already been used will be excluded from calculated size.
-        """
-        mem_status = resource.virtual_memory()
-        total_mem = total_mem or mem_status.total
+    def start(self, endpoint, pool, distributed=True, schedulers=None, process_start_index=0):
+        self._pool = pool
 
-        phy_soft_limit = options.worker.physical_memory_limit_soft
-        cache_limit = options.worker.cache_memory_limit
-        actual_used = total_mem - mem_status.available
-        quota_soft_limit = phy_soft_limit - cache_limit - actual_used
-
-        if quota_soft_limit < 512 * 1024 ** 2:
-            raise MemoryError('Memory not sufficient. soft_limit=%s, cache_limit=%s, used=%s'
-                              % tuple(readable_size(k) for k in (phy_soft_limit, cache_limit, actual_used)))
-
-        cls.service_logger.info('Setting soft limit to %s.', readable_size(quota_soft_limit))
-        return quota_soft_limit
-
-    def start(self, endpoint, schedulers, pool, total_mem=None, ignore_avail_mem=False):
         if schedulers:
             if isinstance(schedulers, six.string_types):
                 schedulers = [schedulers]
@@ -101,32 +148,40 @@ class WorkerService(object):
             schedulers = None
             service_discover_addr = options.kv_store
 
-        # create ClusterInfoActor
-        self._cluster_info_ref = pool.create_actor(ClusterInfoActor, schedulers=schedulers,
-                                                   service_discover_addr=service_discover_addr,
-                                                   uid=ClusterInfoActor.default_name())
-        # create StatusActor
-        port_str = endpoint.rsplit(':', 1)[-1]
-        self._status_ref = pool.create_actor(
-            StatusActor, options.worker.advertise_addr + ':' + port_str,
-            uid=StatusActor.default_name())
+        if distributed:
+            # create ClusterInfoActor
+            self._cluster_info_ref = pool.create_actor(
+                ClusterInfoActor, schedulers=schedulers, service_discover_addr=service_discover_addr,
+                uid=ClusterInfoActor.default_name())
 
-        from .daemon import WorkerDaemonActor
-        daemon_ref = self._daemon_ref = pool.create_actor(WorkerDaemonActor, uid=WorkerDaemonActor.default_name())
+            # create process daemon
+            from .daemon import WorkerDaemonActor
+            actor_holder = self._daemon_ref = pool.create_actor(
+                WorkerDaemonActor, uid=WorkerDaemonActor.default_name())
 
-        if ignore_avail_mem:
+            # create StatusActor
+            port_str = endpoint.rsplit(':', 1)[-1]
+            self._status_ref = pool.create_actor(
+                StatusActor, self._advertise_addr + ':' + port_str, uid=StatusActor.default_name())
+        else:
+            # create StatusActor
+            self._status_ref = pool.create_actor(
+                StatusActor, endpoint, uid=StatusActor.default_name())
+
+            actor_holder = pool
+
+        if self._ignore_avail_mem:
             # start a QuotaActor instead of MemQuotaActor to avoid memory size detection
             # for debug purpose only, DON'T USE IN PRODUCTION
             self._mem_quota_ref = pool.create_actor(
-                QuotaActor, options.worker.physical_memory_limit_soft, uid=MemQuotaActor.default_name())
+                QuotaActor, self._soft_mem_limit, uid=MemQuotaActor.default_name())
         else:
             self._mem_quota_ref = pool.create_actor(
-                MemQuotaActor, self._calc_soft_memory_limit(total_mem),
-                options.worker.physical_memory_limit_hard, uid=MemQuotaActor.default_name())
+                MemQuotaActor, self._soft_quota_limit, self._hard_mem_limit, uid=MemQuotaActor.default_name())
 
         # create ChunkHolderActor
         self._chunk_holder_ref = pool.create_actor(
-            ChunkHolderActor, options.worker.cache_memory_limit, uid=ChunkHolderActor.default_name())
+            ChunkHolderActor, self._cache_mem_limit, uid=ChunkHolderActor.default_name())
         # create TaskQueueActor
         self._task_queue_ref = pool.create_actor(TaskQueueActor, uid=TaskQueueActor.default_name())
         # create DispatchActor
@@ -135,128 +190,48 @@ class WorkerService(object):
         self._execution_ref = pool.create_actor(ExecutionActor, uid=ExecutionActor.default_name())
 
         # create CpuCalcActor
-        for cpu_id in range(options.worker.cpu_process_count):
+        if not distributed:
+            self._n_cpu_process = pool.cluster_info.n_process - 1 - process_start_index
+
+        for cpu_id in range(self._n_cpu_process):
             uid = 'w:%d:mars-calc-%d-%d' % (cpu_id + 1, os.getpid(), cpu_id)
-            actor = daemon_ref.create_actor(CpuCalcActor, uid=uid)
+            actor = actor_holder.create_actor(CpuCalcActor, uid=uid)
             self._cpu_calc_actors.append(actor)
 
-        # create SenderActor and ReceiverActor
-        start_pid = 1 + options.worker.cpu_process_count
-        for sender_id in range(options.worker.io_process_count):
-            uid = 'w:%d:mars-sender-%d-%d' % (start_pid + sender_id, os.getpid(), sender_id)
-            actor = daemon_ref.create_actor(SenderActor, uid=uid)
-            self._sender_actors.append(actor)
-        for receiver_id in range(2 * options.worker.io_process_count):
-            uid = 'w:%d:mars-receiver-%d-%d' % (start_pid + receiver_id // 2, os.getpid(), receiver_id)
-            actor = daemon_ref.create_actor(ReceiverActor, uid=uid)
-            self._receiver_actors.append(actor)
+        if distributed:
+            # create SenderActor and ReceiverActor
+            start_pid = 1 + self._n_cpu_process
+            for sender_id in range(self._n_io_process):
+                uid = 'w:%d:mars-sender-%d-%d' % (start_pid + sender_id, os.getpid(), sender_id)
+                actor = actor_holder.create_actor(SenderActor, uid=uid)
+                self._sender_actors.append(actor)
+            for receiver_id in range(2 * self._n_io_process):
+                uid = 'w:%d:mars-receiver-%d-%d' % (start_pid + receiver_id // 2, os.getpid(), receiver_id)
+                actor = actor_holder.create_actor(ReceiverActor, uid=uid)
+                self._receiver_actors.append(actor)
 
         # create ProcessHelperActor
-        for proc_id in range(pool.cluster_info.n_process):
+        for proc_id in range(pool.cluster_info.n_process - process_start_index):
             uid = 'w:%d:mars-process-helper-%d-%d' % (proc_id, os.getpid(), proc_id)
-            actor = daemon_ref.create_actor(ProcessHelperActor, uid=uid)
+            actor = actor_holder.create_actor(ProcessHelperActor, uid=uid)
             self._process_helper_actors.append(actor)
 
         # create ResultSenderActor
         self._result_sender_ref = pool.create_actor(ResultSenderActor, uid=ResultSenderActor.default_name())
 
         # create SpillActor
-        start_pid = 1 + options.worker.cpu_process_count + options.worker.io_process_count
+        start_pid = pool.cluster_info.n_process - 1
         if options.worker.spill_directory:
             for spill_id in range(len(options.worker.spill_directory) * 2):
                 uid = 'w:%d:mars-spill-%d-%d' % (start_pid, os.getpid(), spill_id)
-                actor = daemon_ref.create_actor(SpillActor, uid=uid)
+                actor = actor_holder.create_actor(SpillActor, uid=uid)
                 self._spill_actors.append(actor)
 
-    @staticmethod
-    def _calc_size_limit(limit_str, total_size):
-        """
-        Calculate limitation size when it is represented in percentage or prettified format
-        :param limit_str: percentage or prettified format
-        :param total_size: total size of the container
-        :return: actual size in bytes
-        """
-        if limit_str is None:
-            return None
-        if isinstance(limit_str, int):
-            return limit_str
-        mem_limit, is_percent = parse_memory_limit(limit_str)
-        if is_percent:
-            return int(total_size * mem_limit)
-        else:
-            return int(mem_limit)
-
-    @staticmethod
-    def calc_cache_memory_limit():
-        mem_stats = resource.virtual_memory()
-        if options.worker.cache_memory_limit is None:
-            options.worker.cache_memory_limit = mem_stats.free // 2
-
-        return WorkerService._calc_size_limit(
-            options.worker.cache_memory_limit, mem_stats.total
-        )
-
-    def start_local(self, endpoint, pool, process_start_index, ignore_avail_mem=True, spill_dir=None):
-        mem_stats = resource.virtual_memory()
-
-        options.worker.physical_memory_limit_hard = self._calc_size_limit(
-            options.worker.physical_memory_limit_hard, mem_stats.total
-        )
-        options.worker.physical_memory_limit_soft = self._calc_size_limit(
-            options.worker.physical_memory_limit_soft, mem_stats.total
-        )
-        if spill_dir:
-            from .spill import parse_spill_dirs
-            spill_directory = parse_spill_dirs(spill_dir)
-        else:
-            spill_directory = None
-
-        # create StatusActor
-        self._status_ref = pool.create_actor(
-            StatusActor, endpoint, uid=StatusActor.default_name())
-
-        if ignore_avail_mem:
-            # start a QuotaActor instead of MemQuotaActor to avoid memory size detection
-            # for debug purpose only, DON'T USE IN PRODUCTION
-            self._mem_quota_ref = pool.create_actor(
-                QuotaActor, options.worker.physical_memory_limit_soft, uid=MemQuotaActor.default_name())
-        else:
-            self._mem_quota_ref = pool.create_actor(
-                MemQuotaActor, self._calc_soft_memory_limit(),
-                options.worker.physical_memory_limit_hard, uid=MemQuotaActor.default_name())
-
-        # create ChunkHolderActor
-        self._chunk_holder_ref = pool.create_actor(
-            ChunkHolderActor, options.worker.cache_memory_limit, uid=ChunkHolderActor.default_name())
-        # create TaskQueueActor
-        self._task_queue_ref = pool.create_actor(TaskQueueActor, uid=TaskQueueActor.default_name())
-        # create DispatchActor
-        self._dispatch_ref = pool.create_actor(DispatchActor, uid=DispatchActor.default_name())
-        # create ExecutionActor
-        self._execution_ref = pool.create_actor(ExecutionActor, uid=ExecutionActor.default_name())
-
-        # create CpuCalcActor
-        for cpu_id in range(pool.cluster_info.n_process - 1 - process_start_index):
-            uid = 'w:%d:mars-calc-%d-%d' % (cpu_id + 1, os.getpid(), cpu_id)
-            actor = pool.create_actor(CpuCalcActor, uid=uid)
-            self._cpu_calc_actors.append(actor)
-
-        # create ProcessHelperActor
-        for proc_id in range(pool.cluster_info.n_process - process_start_index):
-            uid = 'w:%d:mars-process-helper-%d-%d' % (proc_id, os.getpid(), proc_id)
-            actor = pool.create_actor(ProcessHelperActor, uid=uid)
-            self._process_helper_actors.append(actor)
-
-        # create ResultSenderActor
-        self._result_sender_ref = pool.create_actor(ResultSenderActor, uid=ResultSenderActor.default_name())
-
-        # create SpillActor, put it into the last process
-        start_pid = pool.cluster_info.n_process - 1
-        if spill_directory:
-            for spill_id in range(len(spill_directory) * 2):
-                uid = 'w:%d:mars-spill-%d-%d' % (start_pid, os.getpid(), spill_id)
-                actor = pool.create_actor(SpillActor, uid=uid)
-                self._spill_actors.append(actor)
+    def handle_process_down(self, proc_indices):
+        logger.debug('Process %r halt. Trying to recover.', proc_indices)
+        for pid in proc_indices:
+            self._pool.restart_process(pid)
+        self._daemon_ref.handle_process_down(proc_indices, _tell=True)
 
     def stop(self):
         if self._result_sender_ref:
@@ -275,3 +250,4 @@ class WorkerService(object):
             actor.destroy()
 
         self._plasma_store.__exit__(None, None, None)
+        self._pool = None

--- a/mars/worker/tests/test_service.py
+++ b/mars/worker/tests/test_service.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from mars.worker.service import WorkerService
+from mars.compat import long_type
+from mars.config import options
+
+
+class Test(unittest.TestCase):
+    def setUp(self):
+        self._old_spill_dirs = options.worker.spill_directory
+
+    def tearDown(self):
+        options.worker.spill_directory = self._old_spill_dirs
+
+    def testServiceArgs(self):
+        svc = WorkerService(ignore_avail_mem=True)
+        self.assertGreaterEqual(svc._cache_mem_limit, 0)
+        self.assertIsInstance(svc._soft_mem_limit, (long_type, int))
+        self.assertIsInstance(svc._hard_mem_limit, (long_type, int))
+        self.assertIsInstance(svc._cache_mem_limit, (long_type, int))
+
+        svc = WorkerService(ignore_avail_mem=True, total_mem=256 * 1024 * 1024)
+        self.assertEqual(svc._total_mem, 256 * 1024 ** 2)
+
+        svc = WorkerService(ignore_avail_mem=True, total_mem='512m')
+        self.assertEqual(svc._total_mem, 512 * 1024 ** 2)
+
+        with self.assertRaises(MemoryError):
+            WorkerService(soft_mem_limit='128m', cache_mem_limit='256m')
+
+        svc = WorkerService(ignore_avail_mem=True, spill_dirs='/tmp/a')
+        self.assertListEqual(svc._spill_dirs, ['/tmp/a'])
+
+        svc = WorkerService(ignore_avail_mem=True, n_cpu_process=4, n_io_process=2)
+        self.assertEqual(svc.n_process, 7)
+
+        svc = WorkerService(ignore_avail_mem=True, n_cpu_process=4, n_io_process=2,
+                            spill_dirs='/tmp/a')
+        self.assertEqual(svc.n_process, 8)
+
+        svc = WorkerService(ignore_avail_mem=True, n_cpu_process=4, n_io_process=2,
+                            spill_dirs=['/tmp/a', '/tmp/b'])
+        self.assertEqual(svc.n_process, 8)


### PR DESCRIPTION
## What do these changes do?

1. Decouple services from applications. Change services into attributes of applications.
2. Merge ``start_local`` into ``start`` in ``WorkerService``. A ``distributed`` arg is provided to configure start mode.
3. Add cases so that every branch of memory size calculation is covered.
4. Accelerate testing by removing ``--cov-append``.

## Compatibility break
1. In ``BaseApplication``, ``start_service`` is renamed as ``start`` and ``stop_service`` is renamed as ``stop``. Those changes may break compatibility of inherited applications.

## Related issue number

Deal with #167 (#171 will fix the bug on v0.1).