### PR TITLE
Fix parse error of cache_mem on v0.1

### DIFF
--- a/mars/worker/__main__.py
+++ b/mars/worker/__main__.py
@@ -72,7 +72,9 @@ class WorkerApplication(BaseApplication, WorkerService):
         options.worker.physical_memory_limit_soft = self._calc_size_limit(
             options.worker.physical_memory_limit_soft, self._total_mem
         )
-        options.worker.cache_memory_limit = self.args.cache_mem
+        options.worker.cache_memory_limit = self._calc_size_limit(
+            self.args.cache_mem, self._total_mem
+        )
         options.worker.disk_limit = self.args.disk
         if self.args.spill_dir:
             from .spill import parse_spill_dirs


### PR DESCRIPTION
## What do these changes do?

Provide a straightforward solution to fix cache_mem parse error on v0.1. Complete refactored version is in #170 which will be released with v0.2.

## Related issue number

Fixes #167.