### PR TITLE
Fix CI failure under python 2.7 in osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,23 +6,23 @@ matrix:
       python: "2.7"
       services:
         - docker
-      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp27-cp27mu
+      env: PYTHON=2.7 DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp27-cp27mu
     - os: linux
       python: "3.5"
       services:
         - docker
-      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp35-cp35m CYTHON_TRACE=1
+      env: PYTHON=3.5 DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp35-cp35m CYTHON_TRACE=1
     - os: linux
       python: "3.6"
       services:
         - docker
-      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp36-cp36m
+      env: PYTHON=3.6 DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp36-cp36m
     - os: linux
       python: "3.7"
       dist: xenial
       services:
         - docker
-      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp37-cp37m
+      env: PYTHON=3.7 DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp37-cp37m
     - os: osx
       language: generic
       env: PYTHON=2.7
@@ -38,7 +38,11 @@ matrix:
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then source ./bin/travis-prepare-osx.sh; fi
-  - pip install --upgrade pip setuptools wheel coverage
+  - if [[ "$PYTHON" =~ "2" ]]; then
+      pip install --upgrade pip\<19 setuptools\<40.7 wheel coverage;
+    else
+      pip install --upgrade pip setuptools wheel coverage;
+    fi
 
 # command to install dependencies
 install:


### PR DESCRIPTION
## What do these changes do?

Fix CI failure under python 2.7 in osx, caused by newly-released setuptools 40.7.0.

Related error log:

```
Collecting scandir; python_version < "3.5" (from pathlib2>=2.2.0; python_version < "3.6"->pytest>=3.5.0->-r requirements-dev.txt (line 6))
  Downloading https://files.pythonhosted.org/packages/16/2a/557af1181e6b4e30254d5a6163b18f5053791ca66e251e77ab08887e8fe3/scandir-1.9.0.tar.gz
    Complete output from command python setup.py egg_info:
    /usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/extension.py:133: UserWarning: Unknown Extension options: 'optional'
      warnings.warn(msg)
    running egg_info
    creating pip-egg-info/scandir.egg-info
    writing pip-egg-info/scandir.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/scandir.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/scandir.egg-info/dependency_links.txt
    writing manifest file 'pip-egg-info/scandir.egg-info/SOURCES.txt'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/pip-install-NLcGAU/scandir/setup.py", line 79, in <module>
        ], cmdclass={'build_ext': BuildExt},
      File "/usr/local/lib/python2.7/site-packages/setuptools/__init__.py", line 145, in setup
        return distutils.core.setup(**attrs)
      File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 151, in setup
        dist.run_commands()
      File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/usr/local/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 296, in run
        self.find_sources()
      File "/usr/local/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 303, in find_sources
        mm.run()
      File "/usr/local/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 534, in run
        self.add_defaults()
      File "/usr/local/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 570, in add_defaults
        sdist.add_defaults(self)
      File "/usr/local/lib/python2.7/site-packages/setuptools/command/py36compat.py", line 36, in add_defaults
        self._add_defaults_ext()
      File "/usr/local/lib/python2.7/site-packages/setuptools/command/py36compat.py", line 119, in _add_defaults_ext
        build_ext = self.get_finalized_command('build_ext')
      File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/cmd.py", line 312, in get_finalized_command
        cmd_obj.ensure_finalized()
      File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/cmd.py", line 109, in ensure_finalized
        self.finalize_options()
      File "/usr/local/lib/python2.7/site-packages/setuptools/command/build_ext.py", line 133, in finalize_options
        _build_ext.finalize_options(self)
      File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/command/build_ext.py", line 159, in finalize_options
        self.include_dirs.append(py_include)
    AttributeError: 'unicode' object has no attribute 'append'
```

## Related issue number

NA
