### PR TITLE
Use fixed versions of dependencies to build wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   - pip install -r requirements-dev.txt &&
     pip install -r requirements-extra.txt &&
     pip install virtualenv coveralls flake8 etcd-gevent
-  - virtualenv venv && source venv/bin/activate
+  - virtualenv testenv && source testenv/bin/activate
   - pip install -r requirements.txt && pip install pytest pytest-timeout
   - if [ -z "$DEFAULT_VENV" ]; then deactivate; else source $DEFAULT_VENV/bin/activate; fi
   - python setup.py build_ext --force --inplace
@@ -77,7 +77,7 @@ script:
   mv .coverage build/.coverage.main.file &&
   coverage combine build/ && coverage report --fail-under=85 &&
   export DEFAULT_VENV=$VIRTUAL_ENV &&
-  source venv/bin/activate &&
+  source testenv/bin/activate &&
   pytest --timeout=1500 mars/tests/test_session.py &&
   if [ -z "$DEFAULT_VENV" ]; then deactivate; else source $DEFAULT_VENV/bin/activate; fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ after_test:
   - echo index-servers =                             >> %USERPROFILE%\\.pypirc
   - echo     pypi                                    >> %USERPROFILE%\\.pypirc
   - echo [pypi]                                      >> %USERPROFILE%\\.pypirc
-  - echo repository=https://test.pypi.org/legacy/    >> %USERPROFILE%\\.pypirc
+  - echo repository=https://upload.pypi.org/legacy/  >> %USERPROFILE%\\.pypirc
   - echo username=pyodps                             >> %USERPROFILE%\\.pypirc
   - echo password=%SECUREPSD%                        >> %USERPROFILE%\\.pypirc
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
   - "python -m pip install --disable-pip-version-check --user --upgrade pip"
 
   # Install the build dependencies of the project.
-  - "pip install --upgrade wheel twine setuptools coveralls"
+  - "pip install --upgrade wheel twine setuptools virtualenv coveralls"
   - "pip install -r requirements-dev.txt"
   - "pip install -r requirements-extra.txt"
 
@@ -51,7 +51,7 @@ after_test:
   - echo index-servers =                             >> %USERPROFILE%\\.pypirc
   - echo     pypi                                    >> %USERPROFILE%\\.pypirc
   - echo [pypi]                                      >> %USERPROFILE%\\.pypirc
-  - echo repository=https://upload.pypi.org/legacy/  >> %USERPROFILE%\\.pypirc
+  - echo repository=https://test.pypi.org/legacy/    >> %USERPROFILE%\\.pypirc
   - echo username=pyodps                             >> %USERPROFILE%\\.pypirc
   - echo password=%SECUREPSD%                        >> %USERPROFILE%\\.pypirc
 
@@ -59,15 +59,20 @@ on_success:
   - echo %APPVEYOR_REPO_TAG%
   - echo %APPVEYOR_REPO_TAG_NAME%
   - echo %APPVEYOR_REPO_BRANCH%
+  - git clean -f -x
   - ps: >-
-      If ($env:APPVEYOR_REPO_TAG -eq "true"){
+      If ($env:APPVEYOR_REPO_TAG -eq "true") {
+          Invoke-Expression "virtualenv wheelenv"
+          Invoke-Expression "wheelenv\Scripts\activate"
+          Invoke-Expression "pip install -r requirements-wheel.txt"
           Invoke-Expression "python setup.py bdist_wheel"
           if ($env:PYTHON_VERSION -eq "3.6.x" -and $env:PYTHON_ARCH -eq "64")
           {
               Invoke-Expression "python setup.py sdist --formats=gztar"
           }
+          Invoke-Expression "deactivate"
 
           Invoke-Expression "twine upload --skip-existing dist/*"
-      }Else {
+      } Else {
           write-output "Not on a tag commit, won't deploy to pypi"
       }

--- a/bin/travis-build-wheels.sh
+++ b/bin/travis-build-wheels.sh
@@ -6,8 +6,7 @@ yum install -y atlas-devel
 
 # Compile wheels
 PYBIN=/opt/python/${PYVER}/bin
-"${PYBIN}/pip" install -r /io/requirements-dev.txt
-"${PYBIN}/pip" install -r /io/requirements-extra.txt
+"${PYBIN}/pip" install -r /io/requirements-wheel.txt
 
 cd /io
 "${PYBIN}/python" setup.py bdist_wheel

--- a/bin/travis-upload.sh
+++ b/bin/travis-upload.sh
@@ -34,7 +34,7 @@ else
   echo "index-servers ="                             >> ~/.pypirc
   echo "    pypi"                                    >> ~/.pypirc
   echo "[pypi]"                                      >> ~/.pypirc
-  echo "repository=https://test.pypi.org/legacy/"    >> ~/.pypirc
+  echo "repository=https://upload.pypi.org/legacy/"  >> ~/.pypirc
   echo "username=pyodps"                             >> ~/.pypirc
   echo "password=$PASSWD"                            >> ~/.pypirc
 

--- a/bin/travis-upload.sh
+++ b/bin/travis-upload.sh
@@ -1,13 +1,27 @@
 #!/bin/bash
 set -e -x
 
-if [ "$TRAVIS_TAG" ]; then
+if [ -z "$TRAVIS_TAG" ]; then
+  echo "Not on a tag, won't deploy to pypi"
+else
+  git clean -f -x
+
   if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     sudo chmod 777 bin/*
     docker pull $DOCKER_IMAGE
     docker run --rm -e "PYVER=$PYVER" -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/bin/travis-build-wheels.sh
   else
+    virtualenv wheelenv
+    source wheelenv/bin/activate
+
+    pip install -r requirements-wheel.txt
     pip wheel --no-deps .
+
+    if [ -z "$DEFAULT_VENV" ]; then
+      deactivate
+    else
+      source $DEFAULT_VENV/bin/activate
+    fi
     mkdir dist
     cp *.whl dist/
     pip install delocate
@@ -20,12 +34,10 @@ if [ "$TRAVIS_TAG" ]; then
   echo "index-servers ="                             >> ~/.pypirc
   echo "    pypi"                                    >> ~/.pypirc
   echo "[pypi]"                                      >> ~/.pypirc
-  echo "repository=https://upload.pypi.org/legacy/"  >> ~/.pypirc
+  echo "repository=https://test.pypi.org/legacy/"    >> ~/.pypirc
   echo "username=pyodps"                             >> ~/.pypirc
   echo "password=$PASSWD"                            >> ~/.pypirc
 
   python -m pip install twine
-  python -m twine upload -r pypi --skip-existing dist/*.whl;
-else
-  echo "Not on a tag, won't deploy to pypi";
+  python -m twine upload -r pypi --skip-existing dist/*.whl
 fi

--- a/mars/_version.py
+++ b/mars/_version.py
@@ -16,7 +16,7 @@ import subprocess
 import os
 import sys
 
-version_info = (0, 2, 0, 'a3')
+version_info = (0, 2, 0, 'a1')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/_version.py
+++ b/mars/_version.py
@@ -16,7 +16,7 @@ import subprocess
 import os
 import sys
 
-version_info = (0, 2, 0, 'a1')
+version_info = (0, 2, 0, 'a3')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/requirements-wheel.txt
+++ b/requirements-wheel.txt
@@ -1,0 +1,4 @@
+numpy==1.14.5
+cython==0.29.3
+requests>=2.4.0
+pyarrow>=0.11.0


### PR DESCRIPTION
## What do these changes do?

Use fixed versions of dependencies to build wheels to reduce potential errors caused by upgraded versions of dependencies.

Tag build see https://travis-ci.org/wjsi/mars/builds/486882560, test packages at testpypi.

## Related issue number

Fixes #197 
