### PR TITLE
Fix starting with multiple schedulers with --schedulers

### DIFF
--- a/mars/cluster_info.py
+++ b/mars/cluster_info.py
@@ -21,6 +21,7 @@ from . import kvstore
 from .actors import FunctionActor
 from .promise import PromiseActor
 from .lib.uhashring import HashRing
+from .utils import to_str
 
 
 SCHEDULER_PATH = '/schedulers'
@@ -49,7 +50,7 @@ class _ClusterInfoWatchActor(FunctionActor):
     def _get_schedulers(self):
         schedulers = [s.key.rsplit('/', 1)[1] for s in self._client.read(SCHEDULER_PATH).children]
         logger.debug('Schedulers obtained. Results: %r', schedulers)
-        return schedulers
+        return [to_str(s) for s in schedulers]
 
     def get_schedulers(self):
         try:
@@ -60,7 +61,7 @@ class _ClusterInfoWatchActor(FunctionActor):
 
     def watch(self):
         for new_schedulers in self._client.eternal_watch(SCHEDULER_PATH):
-            self._cluster_info_ref.set_schedulers(new_schedulers)
+            self._cluster_info_ref.set_schedulers([to_str(s) for s in new_schedulers])
 
 
 class ClusterInfoActor(FunctionActor):

--- a/mars/core.py
+++ b/mars/core.py
@@ -27,8 +27,6 @@ from .serialize import ValueType, ProviderType, Serializable, AttributeAsDict, \
 from .tiles import Tilesable, handler
 from .graph import DAG
 
-_sorted_slots = dict()
-
 
 class Base(object):
     __slots__ = ()
@@ -43,10 +41,13 @@ class Base(object):
 
     @property
     def _keys_(self):
+        cls = type(self)
+        member = '__keys_' + cls.__name__
         try:
-            return _sorted_slots[type(self)]
-        except KeyError:
-            slots = _sorted_slots[type(self)] = sorted(self.__slots__)
+            return getattr(cls, member)
+        except AttributeError:
+            slots = sorted(self.__slots__)
+            setattr(cls, member, slots)
             return slots
 
     @property

--- a/mars/lib/gipc.pyx
+++ b/mars/lib/gipc.pyx
@@ -1156,4 +1156,8 @@ else:
         exec("""exec _code_ in _globs_, _locs_""")
 
     __exec("""def _reraise(tp, value, tb=None):
-    raise tp, value, tb""")
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
+""")

--- a/mars/operands/random.py
+++ b/mars/operands/random.py
@@ -45,7 +45,7 @@ class RandomOperand(Operand):
                 if slot not in set(RandomOperand.__slots__)]
 
     def update_key(self):
-        args = tuple(getattr(self, k, None) for k in self.__slots__)
+        args = tuple(getattr(self, k, None) for k in self._keys_)
         if self.state is None:
             args += (np.random.random(),)
         self._key = tokenize(type(self), *args)

--- a/mars/scheduler/service.py
+++ b/mars/scheduler/service.py
@@ -18,6 +18,7 @@ import json
 import logging
 
 from .. import kvstore
+from ..compat import six
 from ..config import options
 from ..cluster_info import ClusterInfoActor
 from .assigner import AssignerActor
@@ -65,6 +66,8 @@ class SchedulerService(object):
             logger.info('Mars Scheduler started in standalone mode.')
             service_discover_addr = None
             all_schedulers = {endpoint}
+            if isinstance(schedulers, six.string_types):
+                schedulers = schedulers.split(',')
             if schedulers:
                 all_schedulers.update(schedulers)
             all_schedulers = list(all_schedulers)

--- a/mars/scheduler/tests/test_kvstore.py
+++ b/mars/scheduler/tests/test_kvstore.py
@@ -17,14 +17,18 @@ import sys
 import unittest
 
 from mars.actors import create_actor_pool
+from mars.config import options
 from mars.scheduler.kvstore import KVStoreActor
 from mars.tests.core import EtcdProcessHelper
+from mars.utils import get_next_port
 
 
 class Test(unittest.TestCase):
     @unittest.skipIf(sys.platform == 'win32', 'does not run in windows')
     def testKVStoreActor(self):
-        proc_helper = EtcdProcessHelper(port_range_start=54131)
+        etcd_port = get_next_port()
+        proc_helper = EtcdProcessHelper(port_range_start=etcd_port)
+        options.kv_store = 'etcd://127.0.0.1:%s' % etcd_port
         with proc_helper.run(), create_actor_pool(n_process=1, backend='gevent') as pool:
             store_ref = pool.create_actor(KVStoreActor, uid=KVStoreActor.default_name())
 

--- a/mars/scheduler/tests/test_main.py
+++ b/mars/scheduler/tests/test_main.py
@@ -24,6 +24,7 @@ import uuid
 
 import numpy as np
 from numpy.testing import assert_array_equal
+import gevent
 
 from mars import tensor as mt
 from mars.cluster_info import ClusterInfoActor
@@ -79,6 +80,9 @@ class Test(unittest.TestCase):
             self.etcd_helper.stop()
 
     def start_processes(self, n_schedulers=1, n_workers=2, etcd=False, modules=None):
+        old_not_errors = gevent.hub.Hub.NOT_ERROR
+        gevent.hub.Hub.NOT_ERROR = (Exception,)
+
         scheduler_ports = [str(get_next_port()) for _ in range(n_schedulers)]
         self.scheduler_endpoints = ['127.0.0.1:' + p for p in scheduler_ports]
 
@@ -142,6 +146,8 @@ class Test(unittest.TestCase):
                 if time.time() - check_time > 20:
                     raise
                 time.sleep(0.1)
+
+        gevent.hub.Hub.NOT_ERROR = old_not_errors
 
     def check_process_statuses(self):
         for scheduler_proc in self.proc_schedulers:

--- a/mars/scheduler/tests/test_main.py
+++ b/mars/scheduler/tests/test_main.py
@@ -24,15 +24,16 @@ import uuid
 
 import numpy as np
 from numpy.testing import assert_array_equal
-import gevent
 
 from mars import tensor as mt
+from mars.cluster_info import ClusterInfoActor
 from mars.compat import reduce
 from mars.serialize.dataserializer import loads
 from mars.config import options
+from mars.tests.core import EtcdProcessHelper
 from mars.utils import get_next_port
 from mars.actors.core import new_client
-from mars.scheduler import SessionActor, ResourceActor
+from mars.scheduler import SessionManagerActor, ResourceActor
 from mars.scheduler.graph import GraphState
 
 
@@ -54,61 +55,13 @@ class Test(unittest.TestCase):
             shutil.rmtree(options.worker.spill_directory)
 
     def setUp(self):
-        scheduler_port = str(get_next_port())
-        proc_worker1 = subprocess.Popen([sys.executable, '-m', 'mars.worker',
-                                         '-a', '127.0.0.1',
-                                         '--cpu-procs', '2',
-                                         '--level', 'debug',
-                                         '--cache-mem', '16m',
-                                         '--schedulers', '127.0.0.1:' + scheduler_port,
-                                         '--ignore-avail-mem'])
-        proc_worker2 = subprocess.Popen([sys.executable, '-m', 'mars.worker',
-                                         '-a', '127.0.0.1',
-                                         '--cpu-procs', '2',
-                                         '--level', 'debug',
-                                         '--cache-mem', '16m',
-                                         '--schedulers', '127.0.0.1:' + scheduler_port,
-                                         '--ignore-avail-mem'])
-        proc_scheduler = subprocess.Popen([sys.executable, '-m', 'mars.scheduler',
-                                           '-H', '127.0.0.1',
-                                           '--level', 'debug',
-                                           '-p', scheduler_port,
-                                           '--format', '%(asctime)-15s %(message)s'])
-
-        self.scheduler_port = scheduler_port
-        self.proc_workers = [proc_worker1, proc_worker2]
-        self.proc_scheduler = proc_scheduler
-
-        time.sleep(2)
-        actor_client = new_client()
-        check_time = time.time()
-        while True:
-            try:
-                resource_ref = actor_client.actor_ref(ResourceActor.default_name(), address='127.0.0.1:' + scheduler_port)
-                if actor_client.has_actor(resource_ref):
-                    break
-                else:
-                    raise SystemError('Check meta_timestamp timeout')
-            except:
-                if time.time() - check_time > 10:
-                    raise
-                time.sleep(1)
-
-        check_time = time.time()
-        while True:
-            if resource_ref.get_worker_count() < 2:
-                time.sleep(0.5)
-                self.check_process_statuses()
-                if time.time() - check_time > 20:
-                    raise SystemError('Check meta_timestamp timeout')
-            else:
-                break
-
-        self.exceptions = gevent.hub.Hub.NOT_ERROR
-        gevent.hub.Hub.NOT_ERROR = (Exception,)
+        self.scheduler_endpoints = []
+        self.proc_schedulers = []
+        self.proc_workers = []
+        self.etcd_helper = None
 
     def tearDown(self):
-        procs = (self.proc_scheduler,) + tuple(self.proc_workers)
+        procs = tuple(self.proc_workers) + tuple(self.proc_schedulers)
         for p in procs:
             p.send_signal(signal.SIGINT)
 
@@ -122,11 +75,78 @@ class Test(unittest.TestCase):
             if p.poll() is None:
                 p.kill()
 
-        gevent.hub.Hub.NOT_ERROR = self.exceptions
+        if self.etcd_helper:
+            self.etcd_helper.stop()
+
+    def start_processes(self, n_schedulers=1, n_workers=2, etcd=False, modules=None):
+        scheduler_ports = [str(get_next_port()) for _ in range(n_schedulers)]
+        self.scheduler_endpoints = ['127.0.0.1:' + p for p in scheduler_ports]
+
+        append_args = []
+        if modules:
+            append_args.extend(['--load-modules', ','.join(modules)])
+
+        if etcd:
+            etcd_port = get_next_port()
+            self.etcd_helper = EtcdProcessHelper(port_range_start=etcd_port)
+            self.etcd_helper.run()
+            options.kv_store = 'etcd://127.0.0.1:%s' % etcd_port
+            append_args.extend(['--kv-store', options.kv_store])
+        else:
+            append_args.extend(['--schedulers', ','.join(self.scheduler_endpoints)])
+
+        self.proc_schedulers = [
+            subprocess.Popen([sys.executable, '-m', 'mars.scheduler',
+                              '-H', '127.0.0.1',
+                              '--level', 'debug',
+                              '-p', p,
+                              '--format', '%(asctime)-15s %(message)s']
+                             + append_args)
+            for p in scheduler_ports]
+        self.proc_workers = [
+            subprocess.Popen([sys.executable, '-m', 'mars.worker',
+                              '-a', '127.0.0.1',
+                              '--cpu-procs', '1',
+                              '--level', 'debug',
+                              '--cache-mem', '16m',
+                              '--ignore-avail-mem']
+                             + append_args)
+            for _ in range(n_workers)
+        ]
+
+        actor_client = new_client()
+        self.cluster_info = actor_client.actor_ref(
+            ClusterInfoActor.default_name(), address=self.scheduler_endpoints[0])
+
+        check_time = time.time()
+        while True:
+            try:
+                started_schedulers = self.cluster_info.get_schedulers()
+                if len(started_schedulers) < n_schedulers:
+                    raise RuntimeError('Schedulers does not met requirement: %d < %d.' % (
+                        len(started_schedulers), n_schedulers
+                    ))
+                actor_address = self.cluster_info.get_scheduler(SessionManagerActor.default_name())
+                self.session_manager_ref = actor_client.actor_ref(
+                    SessionManagerActor.default_name(), address=actor_address)
+
+                actor_address = self.cluster_info.get_scheduler(ResourceActor.default_name())
+                resource_ref = actor_client.actor_ref(ResourceActor.default_name(), address=actor_address)
+
+                if resource_ref.get_worker_count() < n_workers:
+                    raise RuntimeError('Workers does not met requirement: %d < %d.' % (
+                        resource_ref.get_worker_count(), n_workers
+                    ))
+                break
+            except:
+                if time.time() - check_time > 20:
+                    raise
+                time.sleep(0.1)
 
     def check_process_statuses(self):
-        if self.proc_scheduler.poll() is not None:
-            raise SystemError('Scheduler not started. exit code %s' % self.proc_scheduler.poll())
+        for scheduler_proc in self.proc_schedulers:
+            if scheduler_proc.poll() is not None:
+                raise SystemError('Scheduler not started. exit code %s' % self.proc_scheduler.poll())
         for worker_proc in self.proc_workers:
             if worker_proc.poll() is not None:
                 raise SystemError('Worker not started. exit code %s' % worker_proc.poll())
@@ -141,14 +161,14 @@ class Test(unittest.TestCase):
             if session_ref.graph_state(graph_key) in GraphState.TERMINATED_STATES:
                 return session_ref.graph_state(graph_key)
 
-    def testMain(self):
+    def testMainWithoutEtcd(self):
+        self.start_processes(n_schedulers=2)
+
         session_id = uuid.uuid1()
-        scheduler_address = '127.0.0.1:' + self.scheduler_port
         actor_client = new_client()
-        session_ref = actor_client.create_actor(SessionActor,
-                                                uid=SessionActor.gen_name(session_id),
-                                                address=scheduler_address,
-                                                session_id=session_id)
+
+        session_ref = actor_client.actor_ref(self.session_manager_ref.create_session(session_id))
+
         a = mt.ones((100, 100), chunk_size=30) * 2 * 1 + 1
         b = mt.ones((100, 100), chunk_size=30) * 2 * 1 + 1
         c = (a * b * 2 + 1).sum()
@@ -202,3 +222,27 @@ class Test(unittest.TestCase):
         expected = reduce(operator.add, [base_arr[:10, :10] for _ in range(10)])
         result = session_ref.fetch_result(graph_key, sumv.key)
         assert_array_equal(loads(result), expected)
+
+    def testMainWithEtcd(self):
+        self.start_processes(n_schedulers=2, etcd=True)
+
+        session_id = uuid.uuid1()
+        actor_client = new_client()
+
+        session_ref = actor_client.actor_ref(self.session_manager_ref.create_session(session_id))
+
+        a = mt.ones((100, 100), chunk_size=30) * 2 * 1 + 1
+        b = mt.ones((100, 100), chunk_size=30) * 2 * 1 + 1
+        c = (a * b * 2 + 1).sum()
+        graph = c.build_graph()
+        targets = [c.key]
+        graph_key = uuid.uuid1()
+        session_ref.submit_tensor_graph(json.dumps(graph.to_json()),
+                                        graph_key, target_tensors=targets)
+
+        state = self.wait_for_termination(session_ref, graph_key)
+        self.assertEqual(state, GraphState.SUCCEEDED)
+
+        result = session_ref.fetch_result(graph_key, c.key)
+        expected = (np.ones(a.shape) * 2 * 1 + 1) ** 2 * 2 + 1
+        assert_array_equal(loads(result), expected.sum())

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -25,7 +25,7 @@ from ..compat import Enum
 from ..config import options
 from ..errors import PinChunkFailed, WorkerProcessStopped, ExecutionInterrupted, DependencyMissing
 from ..tensor.expressions.datasource import TensorFetch
-from ..utils import deserialize_graph, log_unhandled
+from ..utils import deserialize_graph, log_unhandled, to_str
 from .chunkholder import ensure_chunk
 from .spill import spill_exists
 from .utils import WorkerActor, ExpiringCache, concat_operand_keys
@@ -558,10 +558,11 @@ class ExecutionActor(WorkerActor):
                 continue
 
             # load data from another worker
-            chunk_meta = self.get_meta_ref(session_id, chunk.key) \
-                .get_chunk_meta(session_id, chunk.key)
+            chunk_key = to_str(chunk.key)
+            chunk_meta = self.get_meta_ref(session_id, chunk_key) \
+                .get_chunk_meta(session_id, chunk_key)
             if chunk_meta is None:
-                raise DependencyMissing('Dependency %s not met on sending.' % chunk.key)
+                raise DependencyMissing('Dependency %s not met on sending.' % chunk_key)
             worker_results = chunk_meta.workers
 
             worker_priorities = []

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -141,7 +141,7 @@ class WorkerService(object):
     def start(self, endpoint, pool, distributed=True, schedulers=None, process_start_index=0):
         if schedulers:
             if isinstance(schedulers, six.string_types):
-                schedulers = [schedulers]
+                schedulers = schedulers.split(',')
             service_discover_addr = None
         else:
             schedulers = None


### PR DESCRIPTION
## What do these changes do?

Fix starting with multiple schedulers with ``--schedulers`` arg, also add cases for multiple schedulers with and without etcd. Remove profile in ``base_app`` as it is useless under multiple process scenarios. 

## Related issue number

Fixes #201 
