### PR TITLE
Fix process clean up when local cluster terminates

### DIFF
--- a/mars/base_app.py
+++ b/mars/base_app.py
@@ -196,8 +196,7 @@ class BaseApplication(object):
                                 stopped.append(idx)
                         if stopped:
                             self.handle_process_down(stopped)
-                except:
-                    self._running = False
+                finally:
                     self.stop()
         finally:
             self._running = False

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 import functools
-import unittest
 import sys
+import time
+import unittest
 
 import numpy as np
 
@@ -68,8 +69,15 @@ class Test(unittest.TestCase):
             self.assertNotIn(session._session_id, api.session_manager.get_sessions())
 
     def testLocalClusterWithWeb(self):
+        import psutil
         with new_cluster(scheduler_n_process=2, worker_n_process=3,
                          shared_memory='20M', web=True) as cluster:
+            cluster_proc = psutil.Process(cluster._cluster_process.pid)
+            web_proc = psutil.Process(cluster._web_process.pid)
+            processes = [cluster_proc, web_proc] + \
+                        list(cluster_proc.children(recursive=True)) + \
+                        list(web_proc.children(recursive=True))
+
             with cluster.session as session:
                 t = mt.ones((3, 3), chunk_size=2)
                 result = session.run(t)
@@ -81,6 +89,12 @@ class Test(unittest.TestCase):
                 result = session.run(t)
 
                 np.testing.assert_array_equal(result, np.ones((3, 3)))
+
+        check_time = time.time()
+        while not all(not p.is_running() for p in processes):
+            time.sleep(0.1)
+            if check_time + 10 < time.time():
+                self.assertTrue(all(not p.is_running() for p in processes))
 
     def testNSchedulersNWorkers(self):
         calc_cpu_cnt = functools.partial(lambda: 4)

--- a/mars/lib/gipc.pyx
+++ b/mars/lib/gipc.pyx
@@ -1127,6 +1127,7 @@ def _reset_signal_handlers():
         if s < signal.NSIG:
             signal.signal(s, signal.SIG_DFL)
     cleanup_on_sigterm()
+    signal.signal(signal.SIGINT, signal.default_int_handler)
 
 
 PY3 = sys.version_info[0] == 3

--- a/mars/scheduler/chunkmeta.py
+++ b/mars/scheduler/chunkmeta.py
@@ -136,12 +136,12 @@ class ChunkMetaCache(ChunkMetaStore):
         self._chunk_metas.move_to_end(item)
         return super(ChunkMetaCache, self).__getitem__(item)
 
-    def get(self, key, default=None):
+    def get(self, chunk_key, default=None):
         try:
-            self._chunk_metas.move_to_end(key)
+            self._chunk_metas.move_to_end(chunk_key)
         except KeyError:
             pass
-        return super(ChunkMetaCache, self).get(key, default)
+        return super(ChunkMetaCache, self).get(chunk_key, default)
 
     def __setitem__(self, key, value):
         limit = self._limit

--- a/mars/tensor/expressions/base/expand_dims.py
+++ b/mars/tensor/expressions/base/expand_dims.py
@@ -78,8 +78,8 @@ def expand_dims(a, axis):
     a = astensor(a)
 
     if axis > a.ndim or axis < -a.ndim - 1:
-        raise np.AxisError('Axis must be between -%d and %d, got %d'.format(
-            a.ndim + 1, a.ndim, axis))
+        raise np.AxisError('Axis must be between -%d and %d, got %d' %
+                           (a.ndim + 1, a.ndim, axis))
 
     axis = axis if axis >= 0 else axis + a.ndim + 1
     indexes = (slice(None),) * axis + (np.newaxis,) + (slice(None),) * (a.ndim - axis)

--- a/mars/tensor/expressions/random/dirichlet.py
+++ b/mars/tensor/expressions/random/dirichlet.py
@@ -35,8 +35,8 @@ class TensorDirichlet(operands.Dirichlet, TensorRandomOperandMixin):
         super(TensorDirichlet, self).__init__(_alpha=alpha, _state=state, _size=size,
                                               _dtype=dtype, _gpu=gpu, **kw)
 
-    def _get_shape(self, inputs):
-        shape = super(TensorDirichlet, self)._get_shape(inputs)
+    def _get_shape(self, shapes):
+        shape = super(TensorDirichlet, self)._get_shape(shapes)
         return shape + (len(self._alpha),)
 
     def __call__(self, chunk_size=None):

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -233,19 +233,20 @@ class WorkerService(object):
         self._daemon_ref.handle_process_down(proc_indices, _tell=True)
 
     def stop(self):
-        if self._result_sender_ref:
-            self._result_sender_ref.destroy()
-        if self._status_ref:
-            self._status_ref.destroy()
-        if self._chunk_holder_ref:
-            self._chunk_holder_ref.destroy()
-        if self._dispatch_ref:
-            self._dispatch_ref.destroy()
-        if self._execution_ref:
-            self._execution_ref.destroy()
+        try:
+            if self._result_sender_ref:
+                self._result_sender_ref.destroy()
+            if self._status_ref:
+                self._status_ref.destroy()
+            if self._chunk_holder_ref:
+                self._chunk_holder_ref.destroy()
+            if self._dispatch_ref:
+                self._dispatch_ref.destroy()
+            if self._execution_ref:
+                self._execution_ref.destroy()
 
-        for actor in (self._cpu_calc_actors + self._sender_actors
-                      + self._receiver_actors + self._spill_actors + self._process_helper_actors):
-            actor.destroy()
-
-        self._plasma_store.__exit__(None, None, None)
+            for actor in (self._cpu_calc_actors + self._sender_actors
+                          + self._receiver_actors + self._spill_actors + self._process_helper_actors):
+                actor.destroy()
+        finally:
+            self._plasma_store.__exit__(None, None, None)


### PR DESCRIPTION
## What do these changes do?

Fix process clean up when local cluster terminates by restoring default SIGINT handler. Also fixes codacy errors.

## Related issue number

#205 
