### PR TITLE
[BACKPORT] Fix bug that TensorZeros generate same key even if their shapes are different in TensorDiag.tile (#210)

### DIFF
--- a/mars/tensor/expressions/datasource/core.py
+++ b/mars/tensor/expressions/datasource/core.py
@@ -74,13 +74,19 @@ class TensorNoInput(TensorDataSource):
     def calc_shape(self, *inputs_shape):
         return self.outputs[0].shape
 
-    def _new_chunks(self, inputs, shape, **kw):
+    def new_chunks(self, inputs, shape, index=None, output_limit=None,
+                   kws=None, dtype=None, **kw):
         self.params['shape'] = shape  # set shape to make the operand key different
-        return super(TensorNoInput, self)._new_chunks(inputs, shape, **kw)
+        return super(TensorNoInput, self).new_chunks(
+            inputs, shape, index=index, output_limit=output_limit,
+            kws=kws, dtype=dtype, **kw)
 
-    def _new_entities(self, inputs, shape, **kw):
+    def new_tensors(self, inputs, shape, dtype=None, chunks=None, nsplits=None,
+                    output_limit=None, kws=None, **kw):
         self.params['shape'] = shape  # set shape to make the operand key different
-        return super(TensorNoInput, self)._new_entities(inputs, shape, **kw)
+        return super(TensorNoInput, self).new_tensors(
+            inputs, shape, dtype=dtype, chunks=chunks, nsplits=nsplits,
+            output_limit=output_limit, kws=kws, **kw)
 
     def __call__(self, shape, chunk_size=None):
         shape = normalize_shape(shape)

--- a/mars/tensor/expressions/datasource/core.py
+++ b/mars/tensor/expressions/datasource/core.py
@@ -74,6 +74,14 @@ class TensorNoInput(TensorDataSource):
     def calc_shape(self, *inputs_shape):
         return self.outputs[0].shape
 
+    def _new_chunks(self, inputs, shape, **kw):
+        self.params['shape'] = shape  # set shape to make the operand key different
+        return super(TensorNoInput, self)._new_chunks(inputs, shape, **kw)
+
+    def _new_entities(self, inputs, shape, **kw):
+        self.params['shape'] = shape  # set shape to make the operand key different
+        return super(TensorNoInput, self)._new_entities(inputs, shape, **kw)
+
     def __call__(self, shape, chunk_size=None):
         shape = normalize_shape(shape)
         return self.new_tensor(None, shape, raw_chunk_size=chunk_size)


### PR DESCRIPTION
Backport of #210 

Note that the PR has been modified due to the reason that there is no `_new_chunks` and `_new_entities` in v0.1 branch, instead, `new_chunks` and `new_tensors` should be involved.