### PR TITLE
Fix bug that chunks of ones and zeros with same shape generated different key

### DIFF
--- a/mars/scheduler/tests/test_analyzer.py
+++ b/mars/scheduler/tests/test_analyzer.py
@@ -42,8 +42,8 @@ class Test(unittest.TestCase):
                 self.assertLessEqual(2, depths[n.op.key])
 
     def testDescendantSize(self):
-        arr = mt.ones((10, 10), chunk_size=4)
-        arr2 = mt.zeros((10, 10), chunk_size=4)
+        arr = mt.random.rand(10, 10, chunk_size=4)
+        arr2 = mt.random.rand(10, 10, chunk_size=4)
         arr_dot = arr.dot(arr2)
 
         graph = arr_dot.build_graph(compose=False, tiled=True)

--- a/mars/tensor/execution/tests/test_core_execute.py
+++ b/mars/tensor/execution/tests/test_core_execute.py
@@ -35,7 +35,7 @@ class Test(unittest.TestCase):
 
         b.execute(session=self.session)
 
-        self.assertEqual(len(self.executor.chunk_result), 8)
+        self.assertEqual(len(self.executor.chunk_result), 1)
 
         del b
         # decref called

--- a/mars/tensor/expressions/datasource/core.py
+++ b/mars/tensor/expressions/datasource/core.py
@@ -37,9 +37,9 @@ class TensorDataSource(DataSource, TensorOperandMixin):
     __slots__ = ()
 
     def to_chunk_op(self, *args):
-        chunk_shape, idx, chunk_size = args
+        chunk_shape, _, chunk_size = args
         chunk_op = self.copy().reset_key()
-        chunk_op.params = {'size': chunk_shape, 'index': idx}  # to make op key different
+        chunk_op.params = {'size': chunk_shape}  # to make op key different
         return chunk_op
 
     @classmethod

--- a/mars/tensor/expressions/tests/test_core.py
+++ b/mars/tensor/expressions/tests/test_core.py
@@ -23,7 +23,7 @@ import scipy.sparse as sps
 from mars.tensor import ones, zeros, tensor, full, arange, diag, linspace, triu, tril, ones_like, dot
 from mars.tensor.expressions.datasource import fromdense
 from mars.tensor.expressions.datasource.tri import TensorTriu, TensorTril
-from mars.tensor.expressions.datasource.zeros import TensorZeros
+from mars.tensor.expressions.datasource.zeros import zeros, TensorZeros
 from mars.tensor.expressions.datasource.fromdense import DenseToSparse
 from mars.tensor.expressions.datasource.array import CSRMatrixDataSource
 from mars.tensor.expressions.datasource.ones import TensorOnes, TensorOnesLike
@@ -232,6 +232,11 @@ class Test(TestBase):
         self.assertNotEqual(chunk1.op.key, chunk2.op.key)
         self.assertNotEqual(chunk1.key, chunk2.key)
 
+        tensor = ones((100, 100), chunk_size=50)
+        tensor.tiles()
+        self.assertEqual(len({c.op.key for c in tensor.chunks}), 1)
+        self.assertEqual(len({c.key for c in tensor.chunks}), 1)
+
     def testZeros(self):
         tensor = zeros((2, 3, 4))
         self.assertEqual(len(list(tensor)), 2)
@@ -252,6 +257,11 @@ class Test(TestBase):
         chunk2 = chunk_op2.new_chunk(None, (3, 4), index=(0, 1))
         self.assertNotEqual(chunk1.op.key, chunk2.op.key)
         self.assertNotEqual(chunk1.key, chunk2.key)
+
+        tensor = zeros((100, 100), chunk_size=50)
+        tensor.tiles()
+        self.assertEqual(len({c.op.key for c in tensor.chunks}), 1)
+        self.assertEqual(len({c.key for c in tensor.chunks}), 1)
 
     def testDataSource(self):
         from mars.tensor.expressions.base.broadcast_to import TensorBroadcastTo
@@ -357,7 +367,7 @@ class Test(TestBase):
         self.assertEqual(chunk.shape, chunk2.shape)
         self.assertEqual(sorted(i.key for i in chunk.inputs), sorted(i.key for i in chunk2.inputs))
 
-        t = ones((10, 3), chunk_size=(5, 2)) + 2
+        t = ones((10, 3), chunk_size=((3, 5, 2), 2)) + 2
         graph = t.build_graph(tiled=True)
 
         pb = graph.to_pb()

--- a/mars/tests/test_eager_mode.py
+++ b/mars/tests/test_eager_mode.py
@@ -130,7 +130,7 @@ class Test(unittest.TestCase):
             arr2 = mt.ones((10, 5), chunk_size=4) - 1
             result = arr2.fetch()
             np.testing.assert_array_equal(result[:4, :4], np.ones((4, 4)))
-            np.testing.assert_array_equal(result[4:8, :4], np.zeros((4, 4)))
+            np.testing.assert_array_equal(result[8:, :4], np.zeros((2, 4)))
 
         arr3 = mt.ones((10, 5), chunk_size=4) - 1
 
@@ -139,7 +139,7 @@ class Test(unittest.TestCase):
 
         result = arr3.execute()
         np.testing.assert_array_equal(result[:4, :4], np.ones((4, 4)))
-        np.testing.assert_array_equal(result[4:8, :4], np.zeros((4, 4)))
+        np.testing.assert_array_equal(result[8:, :4], np.zeros((2, 4)))
 
     def testKernelMode(self):
         from mars.session import Session

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -249,8 +249,8 @@ class Test(unittest.TestCase):
 
         executor = sess._sess._executor
 
-        self.assertEqual(len(executor.chunk_result), 8)
+        self.assertEqual(len(executor.chunk_result), 4)  # 4 kinds of shapes
         del arr1
-        self.assertEqual(len(executor.chunk_result), 8)
+        self.assertEqual(len(executor.chunk_result), 4)
         del arr2
         self.assertEqual(len(executor.chunk_result), 0)

--- a/mars/worker/tests/test_main.py
+++ b/mars/worker/tests/test_main.py
@@ -43,8 +43,8 @@ class WorkerProcessTestActor(PromiseActor):
 
         session_id = str(uuid.uuid4())
 
-        a = mt.ones((100, 50), chunk_size=30)
-        b = mt.ones((50, 200), chunk_size=30)
+        a = mt.random.rand(100, 50, chunk_size=30)
+        b = mt.random.rand(50, 200, chunk_size=30)
         result = a.dot(b)
 
         graph = result.build_graph(tiled=True)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Fix bug that chunks of ones and zeros with same shape generated different key.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #214 
