### PR TITLE
Fix execute one of the multiple output tensors

### DIFF
--- a/mars/executor.py
+++ b/mars/executor.py
@@ -239,6 +239,9 @@ class GraphExecution(object):
 
             with self._lock:
                 for output in itertools.chain(*[op.outputs for op in ops]):
+                    # the output not in the graph will be skipped
+                    if output not in self._graph:
+                        continue
                     # in case that operand has multiple outputs
                     # and some of the output not in result keys, delete them
                     if ref_counts.get(output.key) == 0:

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -55,6 +55,15 @@ class Test(unittest.TestCase):
 
         np.testing.assert_array_equal(result, expected)
 
+        # test multiple outputs, but only execute 1
+        data = np.random.randint(0, 10, (5, 5))
+        arr3 = mt.tensor(data)
+        arrs = mt.linalg.qr(arr3)
+        result = arrs[0].execute()
+        expected = np.linalg.qr(data)[0]
+
+        np.testing.assert_array_almost_equal(result, expected)
+
     def testReExecuteSame(self):
         data = np.random.random((5, 9))
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Skip the output chunks not in the graph to ensure they will not be executed.

## Related issue number

resolve #220 