### PR TITLE
[BACKPORT] Fix bug that chunks of ones and zeros with same shape generated different key

### DIFF
--- a/mars/tensor/execution/tests/test_core_execute.py
+++ b/mars/tensor/execution/tests/test_core_execute.py
@@ -17,7 +17,7 @@
 import unittest
 
 from mars.tensor.execution.core import Executor
-from mars.tensor import ones
+from mars.tensor import random
 from mars.session import LocalSession, Session
 
 
@@ -30,7 +30,7 @@ class Test(unittest.TestCase):
         self.session._sess = local_session
 
     def testDecref(self):
-        a = ones((10, 20), chunk_size=5)
+        a = random.rand(10, 20, chunk_size=5)
         b = a + 1
 
         b.execute(session=self.session)

--- a/mars/tensor/expressions/datasource/core.py
+++ b/mars/tensor/expressions/datasource/core.py
@@ -37,9 +37,9 @@ class TensorDataSource(DataSource, TensorOperandMixin):
     __slots__ = ()
 
     def to_chunk_op(self, *args):
-        chunk_shape, idx, chunk_size = args
+        chunk_shape, _, chunk_size = args
         chunk_op = self.copy().reset_key()
-        chunk_op.params = {'size': chunk_shape, 'index': idx}  # to make op key different
+        chunk_op.params = {'size': chunk_shape}  # to make op key different
         return chunk_op
 
     @classmethod

--- a/mars/tensor/expressions/tests/test_core.py
+++ b/mars/tensor/expressions/tests/test_core.py
@@ -359,7 +359,7 @@ class Test(TestBase):
         self.assertEqual(chunk.shape, chunk2.shape)
         self.assertEqual(sorted(i.key for i in chunk.inputs), sorted(i.key for i in chunk2.inputs))
 
-        t = ones((10, 3), chunk_size=(5, 2)) + 2
+        t = ones((10, 3), chunk_size=((3, 5, 2), 2)) + 2
         graph = t.build_graph(tiled=True)
 
         pb = graph.to_pb()

--- a/mars/tensor/expressions/tests/test_core.py
+++ b/mars/tensor/expressions/tests/test_core.py
@@ -231,6 +231,11 @@ class Test(TestBase):
         self.assertNotEqual(chunk1.op.key, chunk2.op.key)
         self.assertNotEqual(chunk1.key, chunk2.key)
 
+        tensor = ones((100, 100), chunk_size=50)
+        tensor.tiles()
+        self.assertEqual(len({c.op.key for c in tensor.chunks}), 1)
+        self.assertEqual(len({c.key for c in tensor.chunks}), 1)
+
     def testZeros(self):
         tensor = zeros((2, 3, 4))
         self.assertEqual(len(list(tensor)), 2)
@@ -251,6 +256,11 @@ class Test(TestBase):
         chunk2 = chunk_op2.new_chunk(None, (3, 4), index=(0, 1))
         self.assertNotEqual(chunk1.op.key, chunk2.op.key)
         self.assertNotEqual(chunk1.key, chunk2.key)
+
+        tensor = zeros((100, 100), chunk_size=50)
+        tensor.tiles()
+        self.assertEqual(len({c.op.key for c in tensor.chunks}), 1)
+        self.assertEqual(len({c.key for c in tensor.chunks}), 1)
 
     def testDataSource(self):
         from mars.tensor.expressions.base.broadcast_to import TensorBroadcastTo
@@ -308,6 +318,22 @@ class Test(TestBase):
         self.assertBaseEqual(t.op, t2.op)
         self.assertEqual(t.shape, t2.shape)
         self.assertEqual(sorted(i.key for i in t.inputs), sorted(i.key for i in t2.inputs))
+
+        t = ones((10, 3), chunk_size=((3, 5, 2), 2)) + 2
+        graph = t.build_graph(tiled=True)
+
+        pb = graph.to_pb()
+        graph2 = DAG.from_pb(pb)
+        chunk = next(c for c in graph)
+        chunk2 = next(c for c in graph2 if c.key == chunk.key)
+        self.assertBaseEqual(chunk.op, chunk2.op)
+        self.assertEqual(sorted(i.key for i in chunk.composed), sorted(i.key for i in chunk2.composed))
+        jsn = graph.to_json()
+        graph2 = DAG.from_json(jsn)
+        chunk = next(c for c in graph)
+        chunk2 = next(c for c in graph2 if c.key == chunk.key)
+        self.assertBaseEqual(chunk.op, chunk2.op)
+        self.assertEqual(sorted(i.key for i in chunk.composed), sorted(i.key for i in chunk2.composed))
 
     def testTensorGraphTiledSerialize(self):
         t = ones((10, 3), chunk_size=(5, 2)) + tensor(np.random.random((10, 3)), chunk_size=(5, 2))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

Backport of #216 
