### PR TITLE
Use random object id in plasma store to avoid potential collision

### DIFF
--- a/mars/scheduler/tests/test_kvstore.py
+++ b/mars/scheduler/tests/test_kvstore.py
@@ -24,6 +24,10 @@ from mars.utils import get_next_port
 
 
 class Test(unittest.TestCase):
+    def tearDown(self):
+        super(Test, self).tearDown()
+        options.kv_store = ':inproc:'
+
     @unittest.skipIf(sys.platform == 'win32', 'does not run in windows')
     def testKVStoreActor(self):
         etcd_port = get_next_port()

--- a/mars/scheduler/tests/test_main.py
+++ b/mars/scheduler/tests/test_main.py
@@ -78,6 +78,7 @@ class Test(unittest.TestCase):
 
         if self.etcd_helper:
             self.etcd_helper.stop()
+        options.kv_store = ':inproc:'
 
     def start_processes(self, n_schedulers=1, n_workers=2, etcd=False, modules=None):
         old_not_errors = gevent.hub.Hub.NOT_ERROR

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -374,9 +374,7 @@ class Tensor(Entity):
         return self._data.reshape(shape, *shapes)
 
     def totiledb(self, uri, ctx=None, key=None, timestamp=None):
-        from .expressions.datastore import totiledb
-
-        return totiledb(uri, self, ctx=ctx, key=key, timestamp=timestamp)
+        return self._data.totiledb(uri, ctx=ctx, key=key, timestamp=timestamp)
 
     def execute(self, session=None, **kw):
         return self._data.execute(session, **kw)

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -202,6 +202,13 @@ class Tensor(Entity):
     __slots__ = ()
     _allow_data_type_ = (TensorData,)
 
+    def __dir__(self):
+        from ..lib.lib_utils import dir2
+        obj_dir = dir2(self)
+        if self._data is not None:
+            obj_dir = sorted(set(dir(self._data) + obj_dir))
+        return obj_dir
+
     def __str__(self):
         return self._data.__str__()
 
@@ -370,6 +377,9 @@ class Tensor(Entity):
         from .expressions.datastore import totiledb
 
         return totiledb(uri, self, ctx=ctx, key=key, timestamp=timestamp)
+
+    def execute(self, session=None, **kw):
+        return self._data.execute(session, **kw)
 
 
 class SparseTensor(Tensor):

--- a/mars/tensor/expressions/tests/test_base.py
+++ b/mars/tensor/expressions/tests/test_base.py
@@ -35,6 +35,12 @@ class Test(unittest.TestCase):
         c = asarray(a)
         self.assertIs(a, c)
 
+    def testDir(self):
+        a = tensor([0, 1, 2], chunk_size=2)
+        tensor_dir = dir(a)
+        for attr in dir(a.data):
+            self.assertIn(attr, tensor_dir)
+
     def testCopyto(self):
         a = ones((10, 20), chunk_size=3)
         b = ones(10, chunk_size=4)

--- a/mars/worker/chunkstore.py
+++ b/mars/worker/chunkstore.py
@@ -33,7 +33,7 @@ class PlasmaKeyMapActor(FunctionActor):
     def put(self, session_id, chunk_key, obj_id):
         session_chunk_key = (session_id, chunk_key)
         if session_chunk_key in self._mapping:
-            raise StoreKeyExists
+            raise StoreKeyExists(session_chunk_key)
         self._mapping[session_chunk_key] = obj_id
 
     def get(self, session_id, chunk_key):
@@ -98,7 +98,7 @@ class PlasmaChunkStore(object):
     def _get_object_id(self, session_id, chunk_key):
         obj_id = self._mapper_ref.get(session_id, chunk_key)
         if obj_id is None:
-            raise KeyError
+            raise KeyError((session_id, chunk_key))
         return obj_id
 
     def create(self, session_id, chunk_key, size):

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -147,6 +147,10 @@ class WorkerService(object):
             schedulers = None
             service_discover_addr = options.kv_store
 
+        # create plasma key mapper
+        from .chunkstore import PlasmaKeyMapActor
+        pool.create_actor(PlasmaKeyMapActor, uid=PlasmaKeyMapActor.default_name())
+
         if distributed:
             # create ClusterInfoActor
             self._cluster_info_ref = pool.create_actor(

--- a/mars/worker/tests/test_execution.py
+++ b/mars/worker/tests/test_execution.py
@@ -34,6 +34,7 @@ from mars.scheduler import ChunkMetaActor
 from mars.tests.core import patch_method
 from mars.worker.tests.base import WorkerCase
 from mars.worker import *
+from mars.worker.chunkstore import PlasmaKeyMapActor
 from mars.worker.distributor import WorkerDistributor
 from mars.worker.prochelper import ProcessHelperActor
 from mars.worker.utils import WorkerActor
@@ -157,6 +158,7 @@ class Test(WorkerCase):
     def create_standard_actors(cls, pool, address, quota_size=None, with_daemon=True,
                                with_status=True):
         quota_size = quota_size or (1024 * 1024)
+        pool.create_actor(PlasmaKeyMapActor, uid=PlasmaKeyMapActor.default_name())
         pool.create_actor(ClusterInfoActor, schedulers=[address],
                           uid=ClusterInfoActor.default_name())
 

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -582,6 +582,7 @@ class ReceiverActor(WorkerActor):
                 self._chunk_store.seal(session_id, chunk_key)
             except KeyError:
                 pass
+            self._chunk_store.delete(session_id, chunk_key)
         else:
             src_dir = build_spill_file_name(chunk_key, writing=True)
             if os.path.exists(src_dir):

--- a/mars/worker/utils.py
+++ b/mars/worker/utils.py
@@ -46,9 +46,11 @@ class WorkerActor(HasClusterInfoActor, PromiseActor):
 
     def _init_chunk_store(self):
         import pyarrow.plasma as plasma
-        from .chunkstore import PlasmaChunkStore
+        from .chunkstore import PlasmaChunkStore, PlasmaKeyMapActor
+
+        mapper_ref = self.ctx.actor_ref(uid=PlasmaKeyMapActor.default_name())
         self._plasma_client = plasma.connect(options.worker.plasma_socket, '', 0)
-        self._chunk_store = PlasmaChunkStore(self._plasma_client)
+        self._chunk_store = PlasmaChunkStore(self._plasma_client, mapper_ref)
 
     def get_meta_ref(self, session_id, chunk_key, local=True):
         from ..scheduler.chunkmeta import ChunkMetaActor, LocalChunkMetaActor


### PR DESCRIPTION
## What do these changes do?

Use random object id in plasma store to avoid potential collision. A worker-wide kv store maintains mappings between chunk keys and plasma object ids.

## Related issue number

Fixes #224 #233 