### PR TITLE
Assign initials given existing data in eager mode

### DIFF
--- a/mars/graph.pyx
+++ b/mars/graph.pyx
@@ -279,6 +279,17 @@ cdef class DirectedGraph:
                 queue.append(node)
                 queue.extend(n for n in preds if n not in visited)
 
+    def copy(self):
+        cdef DirectedGraph graph = type(self)()
+        for n in self:
+            if n not in graph._nodes:
+                graph._add_node(n)
+            for succ in self.iter_successors(n):
+                if succ not in graph._nodes:
+                    graph._add_node(succ)
+                graph._add_edge(n, succ)
+        return graph
+
     def build_undirected(self):
         cdef DirectedGraph graph = DirectedGraph()
         for n in self:

--- a/mars/scheduler/tests/test_graph.py
+++ b/mars/scheduler/tests/test_graph.py
@@ -193,7 +193,7 @@ class Test(unittest.TestCase):
             graph_ref = pool.create_actor(GraphActor, session_id, graph_key, serialized_graph,
                                           uid=GraphActor.gen_name(session_id, graph_key))
 
-            def _mock_raises(*_):
+            def _mock_raises(*_, **__):
                 raise RuntimeError
 
             with patch_method(GraphActor.create_operand_actors, new=_mock_raises):
@@ -207,7 +207,7 @@ class Test(unittest.TestCase):
             graph_ref = pool.create_actor(GraphActor, session_id, graph_key, serialized_graph,
                                           uid=GraphActor.gen_name(session_id, graph_key))
 
-            def _mock_cancels(*_):
+            def _mock_cancels(*_, **__):
                 graph_meta_ref = pool.actor_ref(GraphMetaActor.gen_name(session_id, graph_key))
                 graph_meta_ref.set_state(GraphState.CANCELLING)
 
@@ -220,7 +220,7 @@ class Test(unittest.TestCase):
             graph_ref = pool.create_actor(GraphActor, session_id, graph_key, serialized_graph,
                                           uid=GraphActor.gen_name(session_id, graph_key))
 
-            def _mock_cancels(*_):
+            def _mock_cancels(*_, **__):
                 graph_meta_ref = pool.actor_ref(GraphMetaActor.gen_name(session_id, graph_key))
                 graph_meta_ref.set_state(GraphState.CANCELLING)
                 return dict()

--- a/mars/tensor/execution/tests/test_datasource_execute.py
+++ b/mars/tensor/execution/tests/test_datasource_execute.py
@@ -89,12 +89,12 @@ class Test(TestBase):
         res = self.executor.execute_tensor(t, concat=True)
         self.assertEqual(res[0].shape, (20, 30))
         self.assertEqual(res[0].dtype, np.int64)
-        self.assertFalse(np.array_equal(res, np.zeros((20, 30))))
 
         t = empty((20, 30), chunk_size=5)
 
         res = self.executor.execute_tensor(t, concat=True)
-        self.assertFalse(np.allclose(res, np.zeros((20, 30))))
+        self.assertEqual(res[0].shape, (20, 30))
+        self.assertEqual(res[0].dtype, np.float64)
 
         t2 = empty_like(t)
         res = self.executor.execute_tensor(t2, concat=True)

--- a/mars/tests/test_graph.py
+++ b/mars/tests/test_graph.py
@@ -43,7 +43,7 @@ class Test(unittest.TestCase):
         with self.assertRaises(KeyError):
             dag.add_edge(10, 1)
 
-        self.assertEqual(set(dag[2]), set([5, 6]))
+        self.assertEqual(set(dag[2]), {5, 6})
         self.assertEqual(list(dag.topological_iter()), [3, 2, 5, 6, 1, 4])
 
         self.assertEqual(list(dag.dfs()), [3, 2, 5, 6, 1, 4])
@@ -80,6 +80,12 @@ class Test(unittest.TestCase):
                                 for pred in dag.predecessors(n)))
             self.assertTrue(all(undigraph.has_successor(n, pred)
                                 for pred in dag.predecessors(n)))
+
+        dag_copy = dag.copy()
+        for n in dag:
+            self.assertIn(n, dag_copy)
+            self.assertTrue(all(dag_copy.has_successor(pred, n)
+                                for pred in dag_copy.predecessors(n)))
 
     def testToDot(self):
         import mars.tensor as mt


### PR DESCRIPTION
## What do these changes do?

Assign initial chunks to dominant workers for eager mode to reduce data transfer caused by random allocation. The main changes are in ```calc_initial_assignments```, where an ```input_chunk_metas``` argument is added to provide information on data distribution. Allocations are done in ```_iter_assignments_by_transfer_sizes```.

## Related issue number

Fixes #195 
