### PR TITLE
Fix executor's behavior of result deletions

### DIFF
--- a/mars/_version.py
+++ b/mars/_version.py
@@ -16,7 +16,7 @@ import subprocess
 import os
 import sys
 
-version_info = (0, 2, 0, 'a1')
+version_info = (0, 2, 0, 'a2')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -112,6 +112,15 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(t, concat=True)[0]
         self.assertTrue(np.allclose(res, data))
 
+        # test for matrix of ones
+        data = np.ones((20, 10))
+
+        a = tensor(data, chunk_size=10)
+        s = svd(a)[1]
+        res = self.executor.execute_tensor(s, concat=True)[0]
+        expected = np.linalg.svd(a)[1]
+        np.testing.assert_array_almost_equal(res, expected)
+
     def testCholeskyExecution(self):
         data = np.array([[1, -2j], [2j, 5]])
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Add `deleted_chunk_keys` in executor to avoid duplicate deletion.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
resolve #248 