### PR TITLE
Fix TensorInv tile when input tensor has only one chunk

### DIFF
--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -433,6 +433,14 @@ class Test(unittest.TestCase):
 
         data = np.random.randint(1, 10, (20, 20))
 
+        A = tensor(data)
+        inv_A = inv(A)
+
+        res = self.executor.execute_tensor(inv_A, concat=True)[0]
+        self.assertTrue(np.allclose(res, scipy.linalg.inv(data)))
+        res = self.executor.execute_tensor(A.dot(inv_A), concat=True)[0]
+        self.assertTrue(np.allclose(res, np.eye(data.shape[0], dtype=float)))
+
         A = tensor(data, chunk_size=5)
         inv_A = inv(A)
 

--- a/mars/tensor/expressions/linalg/inv.py
+++ b/mars/tensor/expressions/linalg/inv.py
@@ -51,7 +51,7 @@ class TensorInv(operands.Inv, TensorOperandMixin):
         from .solve_triangular import solve_triangular
         in_tensor = op.input
 
-        b_eye = eye(in_tensor.shape[0], chunk_size=in_tensor.chunks[0].shape)
+        b_eye = eye(in_tensor.shape[0], chunk_size=in_tensor.nsplits)
         b_eye.single_tiles()
 
         p, l, u = lu(in_tensor)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Use input tensor's `nsplits` to set `eye`'s chunk size instead of first chunk's shape in `TensorInv`'s tile.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
resolve #250 