### PR TITLE
Use parallel build for coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: python
-
+env:
+  global:
+    - COVERALLS_PARALLEL=true
+notifications:
+  webhooks:
+    - https://coveralls.io/webhook
 matrix:
   include:
     - os: linux
@@ -84,5 +89,3 @@ script:
 after_success:
   - coveralls
   - ./bin/travis-upload.sh
-# Add env var to detect it during build
-env: TRAVIS=True

--- a/mars/scheduler/tests/test_main.py
+++ b/mars/scheduler/tests/test_main.py
@@ -177,7 +177,7 @@ class Test(unittest.TestCase):
     def wait_for_termination(self, actor_client, session_ref, graph_key):
         check_time = time.time()
         dump_time = time.time()
-        check_timeout = int(os.environ.get('CHECK_TIMEOUT', 60))
+        check_timeout = int(os.environ.get('CHECK_TIMEOUT', 120))
         while True:
             time.sleep(0.1)
             self.check_process_statuses()


### PR DESCRIPTION
## What do these changes do?

Enable using ``COVERALLS_PARALLEL=true`` for coveralls according to https://docs.coveralls.io/parallel-build-webhook to reduce errors.

## Related issue number

NA
