### PR TITLE
[BACKPORT] Fix solve_triangular operand's sparse attributes & use parallel build for coveralls (#257, #261)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -22,3 +22,4 @@ exclude_lines =
     def __repr__
     raise AssertionError
     raise NotImplementedError
+    return NotImplemented

--- a/.coveragerc-tensor
+++ b/.coveragerc-tensor
@@ -25,3 +25,4 @@ exclude_lines =
     def __repr__
     raise AssertionError
     raise NotImplementedError
+    return NotImplemented

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: python
-
+env:
+  global:
+    - COVERALLS_PARALLEL=true
+notifications:
+  webhooks:
+    - https://coveralls.io/webhook
 matrix:
   include:
     - os: linux
@@ -79,5 +84,3 @@ script:
 after_success:
   - coveralls
   - ./bin/travis-upload.sh
-# Add env var to detect it during build
-env: TRAVIS=True

--- a/mars/lib/sparse/__init__.py
+++ b/mars/lib/sparse/__init__.py
@@ -743,7 +743,7 @@ def lu(m):
     return lu_sparse_matrix(m)
 
 
-def solve_triangular(a, b, lower=False):
+def solve_triangular(a, b, lower=False, sparse=True):
     from .matrix import solve_triangular_sparse_matrix
 
-    return solve_triangular_sparse_matrix(a, b, lower=lower)
+    return solve_triangular_sparse_matrix(a, b, lower=lower, sparse=sparse)

--- a/mars/lib/sparse/tests/test_sparse.py
+++ b/mars/lib/sparse/tests/test_sparse.py
@@ -78,6 +78,12 @@ class Test(TestBase):
         self.assertArrayEqual(s1 + 1, self.s1.toarray() + 1)
         self.assertArrayEqual(1 + s1, self.s1.toarray() + 1)
 
+        # test sparse vector
+        v = SparseNDArray(self.v1, shape=(3,))
+        self.assertArrayEqual(v + v, self.v1_data + self.v1_data)
+        self.assertArrayEqual(v + self.d1, self.v1_data + self.d1)
+        self.assertArrayEqual(self.d1 + v, self.d1 + self.v1_data)
+
     def testSparseSubtract(self):
         s1 = SparseNDArray(self.s1)
         s2 = SparseNDArray(self.s2)
@@ -87,6 +93,12 @@ class Test(TestBase):
         self.assertArrayEqual(self.d1 - s1, self.d1 - self.s1)
         self.assertArrayEqual(s1 - 1, self.s1.toarray() - 1)
         self.assertArrayEqual(1 - s1, 1 - self.s1.toarray())
+
+        # test sparse vector
+        v = SparseNDArray(self.v1, shape=(3,))
+        self.assertArrayEqual(v - v, self.v1_data - self.v1_data)
+        self.assertArrayEqual(v - self.d1, self.v1_data - self.d1)
+        self.assertArrayEqual(self.d1 - v, self.d1 - self.v1_data)
 
     def testSparseMultiply(self):
         s1 = SparseNDArray(self.s1)

--- a/mars/lib/sparse/vector.py
+++ b/mars/lib/sparse/vector.py
@@ -29,6 +29,54 @@ class SparseVector(SparseNDArray):
         else:
             self.spmatrix = spvector.tocsr()
 
+    def __add__(self, other):
+        try:
+            other = naked(other)
+        except TypeError:
+            return NotImplemented
+        if issparse(other):
+            x = self.spmatrix + other.reshape(self.spmatrix.shape)
+        else:
+            x = self.toarray() + other
+        if issparse(x):
+            return SparseVector(x, shape=self.shape)
+        return get_array_module(x).asarray(x)
+
+    def __radd__(self, other):
+        try:
+            other = naked(other)
+        except TypeError:
+            return NotImplemented
+
+        x = other + self.toarray()
+        if issparse(x):
+            return SparseVector(x, shape=self.shape)
+        return get_array_module(x).asarray(x)
+
+    def __sub__(self, other):
+        try:
+            other = naked(other)
+        except TypeError:
+            return NotImplemented
+        if issparse(other):
+            x = self.spmatrix - other.reshape(self.spmatrix.shape)
+        else:
+            x = self.toarray() - other
+        if issparse(x):
+            return SparseVector(x, shape=self.shape)
+        return get_array_module(x).asarray(x)
+
+    def __rsub__(self, other):
+        try:
+            other = naked(other)
+        except TypeError:
+            return NotImplemented
+
+        x = other - self.toarray()
+        if issparse(x):
+            return SparseVector(x, shape=self.shape)
+        return get_array_module(x).asarray(x)
+
     @property
     def ndim(self):
         return 1

--- a/mars/tensor/execution/linalg.py
+++ b/mars/tensor/execution/linalg.py
@@ -77,7 +77,7 @@ def _solve_triangular(ctx, chunk):
 
             ctx[chunk.key] = cupyx.scipy.linalg.solve_triangular(a, b, lower=chunk.op.lower)
         else:
-            ctx[chunk.key] = xp.solve_triangular(a, b, lower=chunk.op.lower)
+            ctx[chunk.key] = xp.solve_triangular(a, b, lower=chunk.op.lower, sparse=chunk.op.sparse)
 
 
 def _lu(ctx, chunk):

--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -24,7 +24,7 @@ from mars.tensor.expressions.datasource import tensor, diag, ones, arange
 from mars.tensor.expressions.linalg import qr, svd, cholesky, norm, lu, \
     solve_triangular, solve, inv, tensordot, dot, inner, vdot, matmul
 from mars.tensor.expressions.random import uniform
-from mars.lib.sparse.core import issparse
+from mars.lib.sparse import issparse, SparseNDArray
 
 
 class Test(unittest.TestCase):
@@ -198,6 +198,8 @@ class Test(unittest.TestCase):
         # check lower and upper triangular matrix
         np.testing.assert_allclose(np.tril(result_l), result_l)
         np.testing.assert_allclose(np.triu(result_u), result_u)
+        self.assertIsInstance(result_l, SparseNDArray)
+        self.assertIsInstance(result_u, SparseNDArray)
 
         t = P.dot(L).dot(U)
         res = self.executor.execute_tensor(t, concat=True)[0]
@@ -211,6 +213,8 @@ class Test(unittest.TestCase):
         # check lower and upper triangular matrix
         np.testing.assert_allclose(np.tril(result_l), result_l)
         np.testing.assert_allclose(np.triu(result_u), result_u)
+        self.assertIsInstance(result_l, SparseNDArray)
+        self.assertIsInstance(result_u, SparseNDArray)
 
         t = P.dot(L).dot(U)
         res = self.executor.execute_tensor(t, concat=True)[0]
@@ -224,6 +228,8 @@ class Test(unittest.TestCase):
         # check lower and upper triangular matrix
         np.testing.assert_allclose(np.tril(result_l), result_l)
         np.testing.assert_allclose(np.triu(result_u), result_u)
+        self.assertIsInstance(result_l, SparseNDArray)
+        self.assertIsInstance(result_u, SparseNDArray)
 
         t = P.dot(L).dot(U)
         res = self.executor.execute_tensor(t, concat=True)[0]
@@ -311,6 +317,7 @@ class Test(unittest.TestCase):
         result_x = self.executor.execute_tensor(x, concat=True)[0]
         result_b = data1.dot(result_x)
 
+        self.assertIsInstance(result_x, SparseNDArray)
         np.testing.assert_allclose(result_b, data2)
 
         data1 = sps.csr_matrix(np.triu(np.random.randint(1, 10, (10, 10))))
@@ -324,6 +331,7 @@ class Test(unittest.TestCase):
         result_x = self.executor.execute_tensor(x, concat=True)[0]
         result_b = data1.dot(result_x)
 
+        self.assertIsInstance(result_x, SparseNDArray)
         np.testing.assert_allclose(result_b, data2)
 
     def testSolve(self):
@@ -377,6 +385,7 @@ class Test(unittest.TestCase):
         x = solve(A, b)
 
         res = self.executor.execute_tensor(x, concat=True)[0]
+        self.assertIsInstance(res, SparseNDArray)
         np.testing.assert_allclose(data1.dot(res), data2)
 
         data2 = np.random.randint(1, 10, (20, 5))
@@ -386,7 +395,8 @@ class Test(unittest.TestCase):
 
         x = solve(A, b)
 
-        res = self.executor.execute_tensor(A.dot(x, sparse=False), concat=True)[0]
+        res = self.executor.execute_tensor(A.dot(x), concat=True)[0]
+        self.assertIsInstance(res, SparseNDArray)
         np.testing.assert_allclose(res, data2)
 
         data2 = np.random.randint(1, 10, (20, 20))
@@ -396,7 +406,8 @@ class Test(unittest.TestCase):
 
         x = solve(A, b)
 
-        res = self.executor.execute_tensor(A.dot(x, sparse=False), concat=True)[0]
+        res = self.executor.execute_tensor(A.dot(x), concat=True)[0]
+        self.assertIsInstance(res, SparseNDArray)
         np.testing.assert_allclose(res, data2)
 
     def testSolveSymPos(self):
@@ -455,6 +466,7 @@ class Test(unittest.TestCase):
         inv_A = inv(A)
 
         res = self.executor.execute_tensor(inv_A, concat=True)[0]
+        self.assertIsInstance(res, SparseNDArray)
         self.assertTrue(np.allclose(res, scipy.linalg.inv(data)))
         res = self.executor.execute_tensor(A.dot(inv_A), concat=True)[0]
         self.assertTrue(np.allclose(res, np.eye(data.shape[0], dtype=float)))

--- a/mars/tensor/expressions/linalg/solve.py
+++ b/mars/tensor/expressions/linalg/solve.py
@@ -20,7 +20,7 @@ from .lu import lu
 from .solve_triangular import solve_triangular
 
 
-def solve(a, b, sym_pos=False):
+def solve(a, b, sym_pos=False, sparse=None):
     """
     Solve the equation ``a x = b`` for ``x``.
     Parameters
@@ -32,6 +32,8 @@ def solve(a, b, sym_pos=False):
     sym_pos : bool
     Assume `a` is symmetric and positive definite. If ``True``, use Cholesky
     decomposition.
+    sparse: bool, optional
+        Return sparse value or not.
 
     Returns
     -------
@@ -64,5 +66,6 @@ def solve(a, b, sym_pos=False):
     else:
         p, l, u = lu(a)
         b = p.T.dot(b)
-    uy = solve_triangular(l, b, lower=True)
-    return solve_triangular(u, uy)
+    sparse = sparse if sparse is not None else a.issparse()
+    uy = solve_triangular(l, b, lower=True, sparse=sparse)
+    return solve_triangular(u, uy, sparse=sparse)

--- a/mars/tensor/expressions/linalg/solve_triangular.py
+++ b/mars/tensor/expressions/linalg/solve_triangular.py
@@ -81,7 +81,7 @@ class TensorSolveTriangular(operands.SolveTriangular, TensorOperandMixin):
                         k_range = range(i + 1, a.chunk_shape[0])
                     for k in k_range:
                         a_chunk, b_chunk = a.cix[i, k], out_chunks[(k, j) if b_multi_dim else (k,)]
-                        prev_chunk = TensorDot(dtype=op.dtype, sparse=op.sparse).new_chunk(
+                        prev_chunk = TensorDot(dtype=op.dtype, sparse=a_chunk.issparse()).new_chunk(
                             [a_chunk, b_chunk], _dot_shape(a_chunk.shape, b_chunk.shape))
                         prev_chunks.append(prev_chunk)
                     if len(prev_chunks) == 1:
@@ -91,7 +91,7 @@ class TensorSolveTriangular(operands.SolveTriangular, TensorOperandMixin):
                                      None, prev_chunks[0].shape, sparse=op.sparse)
                     target_b = TensorSubtract(dtype=op.dtype).new_chunk(
                         [target_b, s, None, None], target_b.shape)
-                out_chunk = TensorSolveTriangular(lower=lower, sparse=target_a.op.sparse, dtype=op.dtype).new_chunk(
+                out_chunk = TensorSolveTriangular(lower=lower, sparse=op.sparse, dtype=op.dtype).new_chunk(
                     [target_a, target_b], _x_shape(target_a.shape, target_b.shape), index=idx)
                 out_chunks[out_chunk.index] = out_chunk
 
@@ -100,7 +100,7 @@ class TensorSolveTriangular(operands.SolveTriangular, TensorOperandMixin):
         return new_op.new_tensors(op.inputs, op.outputs[0].shape, chunks=list(out_chunks.values()), nsplits=nsplits)
 
 
-def solve_triangular(a, b, lower=False):
+def solve_triangular(a, b, lower=False, sparse=None):
     """
     Solve the equation `a x = b` for `x`, assuming a is a triangular matrix.
     Parameters
@@ -112,6 +112,8 @@ def solve_triangular(a, b, lower=False):
     lower : bool, optional
         Use only data contained in the lower triangle of `a`.
         Default is to use upper triangle.
+    sparse: bool, optional
+        Return sparse value or not.
 
     Returns
     -------
@@ -149,5 +151,6 @@ def solve_triangular(a, b, lower=False):
 
     tiny_x = scipy.linalg.solve_triangular(np.array([[2, 0], [2, 1]], dtype=a.dtype),
                                            np.array([[2], [3]], dtype=b.dtype))
-    op = TensorSolveTriangular(lower=lower, dtype=tiny_x.dtype, sparse=a.is_sparse())
+    sparse = sparse if sparse is not None else a.issparse()
+    op = TensorSolveTriangular(lower=lower, dtype=tiny_x.dtype, sparse=sparse)
     return op(a, b)

--- a/mars/tensor/expressions/tests/test_linalg.py
+++ b/mars/tensor/expressions/tests/test_linalg.py
@@ -243,7 +243,7 @@ class Test(unittest.TestCase):
         self.assertEqual(calc_shape(x), x.shape)
         self.assertEqual(calc_shape(x.chunks[0]), x.chunks[0].shape)
 
-        # test solve
+        # test sparse
         a = sps.csr_matrix(np.random.randint(1, 10, (20, 20)))
         b = mt.random.randint(1, 10, (20, ), chunk_size=3)
         x = mt.linalg.solve(a, b).tiles()
@@ -252,6 +252,10 @@ class Test(unittest.TestCase):
         self.assertEqual(calc_shape(x), x.shape)
         self.assertTrue(x.op.sparse)
         self.assertTrue(x.chunks[0].op.sparse)
+
+        x = mt.linalg.solve(a, b, sparse=False).tiles()
+        self.assertFalse(x.op.sparse)
+        self.assertFalse(x.chunks[0].op.sparse)
 
     def testInv(self):
         a = mt.random.randint(1, 10, (20, 20), chunk_size=4)
@@ -290,3 +294,6 @@ class Test(unittest.TestCase):
         self.assertIsInstance(b_inv, SparseTensor)
         self.assertTrue(all(c.is_sparse() for c in b_inv.chunks))
 
+        b_inv = mt.linalg.inv(b, sparse=False).tiles()
+        self.assertFalse(b_inv.op.sparse)
+        self.assertTrue(not all(c.is_sparse() for c in b_inv.chunks))


### PR DESCRIPTION
## What do these changes do?

Backport of #257 and #261

## Related issue number

NA