### PR TITLE
Remove rough_size from tensor & remove chunk registration when creation failed

### DIFF
--- a/mars/executor.py
+++ b/mars/executor.py
@@ -16,6 +16,7 @@ import datetime
 import threading
 import weakref
 import itertools
+import functools
 import logging
 from collections import deque, defaultdict
 
@@ -223,25 +224,19 @@ class GraphExecution(object):
         deleted_chunk_keys = set()
         try:
             ops = list(self._op_key_to_ops[op.key])
-            if not self._mock:
-                # do real execution
-                # note that currently execution is the chunk-level
-                # so we pass the first operand's first output to Executor.handle
-                first_op = ops[0]
-                Executor.handle(first_op.outputs[0], results)
-                executed_chunk_keys.update([c.key for c in first_op.outputs])
-                op_keys.add(first_op.key)
-                # handle other operands
-                for rest_op in ops[1:]:
-                    for op_output, rest_op_output in zip(first_op.outputs, rest_op.outputs):
-                        # if the op's outputs have been stored,
-                        # other same key ops' results will be the same
-                        if rest_op_output.key not in executed_chunk_keys:
-                            results[rest_op_output.key] = results[op_output.key]
-            else:
-                sparse_percent = self._sparse_mock_percent if op.sparse else 1.0
-                for output in op.outputs:
-                    results[output.key] = output.nbytes * sparse_percent
+            # note that currently execution is the chunk-level
+            # so we pass the first operand's first output to Executor.handle
+            first_op = ops[0]
+            Executor.handle(first_op.outputs[0], results, self._mock)
+            executed_chunk_keys.update([c.key for c in first_op.outputs])
+            op_keys.add(first_op.key)
+            # handle other operands
+            for rest_op in ops[1:]:
+                for op_output, rest_op_output in zip(first_op.outputs, rest_op.outputs):
+                    # if the op's outputs have been stored,
+                    # other same key ops' results will be the same
+                    if rest_op_output.key not in executed_chunk_keys:
+                        results[rest_op_output.key] = results[op_output.key]
 
             with self._lock:
                 for output in itertools.chain(*[op.outputs for op in ops]):
@@ -330,16 +325,10 @@ class GraphExecution(object):
 
     def execute(self, retval=True):
         executed_futures = []
-        maximum_usage = 0
         while len(self._submitted_op_keys) < len(self._op_key_to_ops):
             if self._has_error.is_set():
                 # something wrong happened
                 break
-            if self._mock:
-                # if mock, the value in chunk_results is the data size
-                # just adding up to get the maximum memory usage
-                curr_usage = np.sum(list(self._chunk_results.values()))
-                maximum_usage = max(maximum_usage, curr_usage)
 
             future = self._submit_operand_to_execute()
             if future is not None:
@@ -349,14 +338,13 @@ class GraphExecution(object):
         for future in executed_futures:
             future.result()
 
-        if self._mock:
-            return maximum_usage
         if retval:
             return [self._chunk_results[key] for key in self._keys]
 
 
 class Executor(object):
     _op_runners = {}
+    _op_size_estimators = {}
 
     class SyncProviderType(enum.Enum):
         THREAD = 0
@@ -394,19 +382,25 @@ class Executor(object):
         Optimizer(graph, self._engine).optimize(keys=keys)
         return graph
 
-    @classmethod
-    def handle(cls, chunk, results):
+    @staticmethod
+    def _get_op_runner(chunk, mapper):
         try:
             op_cls = type(chunk.op)
-
-            return cls._op_runners[op_cls](results, chunk)
+            return mapper[op_cls]
         except KeyError:
-            for op_cls in cls._op_runners.keys():
+            for op_cls in mapper.keys():
                 if isinstance(chunk.op, op_cls):
-                    cls._op_runners[type(chunk.op)] = cls._op_runners[op_cls]
-                    return cls._op_runners[op_cls](results, chunk)
+                    mapper[type(chunk.op)] = mapper[op_cls]
+                    return mapper[op_cls]
 
             raise KeyError('No handler found for op: %s' % chunk.op)
+
+    @classmethod
+    def handle(cls, chunk, results, mock=False):
+        if not mock:
+            return cls._get_op_runner(chunk, cls._op_runners)(results, chunk)
+        else:
+            return cls._get_op_runner(chunk, cls._op_size_estimators)(results, chunk)
 
     def execute_graph(self, graph, keys, n_parallel=None, print_progress=False,
                       mock=False, sparse_mock_percent=1.0):
@@ -418,7 +412,10 @@ class Executor(object):
                                          n_parallel=n_parallel, prefetch=self._prefetch,
                                          print_progress=print_progress, mock=mock,
                                          sparse_mock_percent=sparse_mock_percent)
-        return graph_execution.execute(True)
+        res = graph_execution.execute(True)
+        if mock:
+            self._chunk_result.clear()
+        return res
 
     @kernel_mode
     def execute_tensor(self, tensor, n_parallel=None, n_thread=None, concat=False,
@@ -571,11 +568,44 @@ def ignore(*_):
     pass
 
 
+def default_size_estimator(ctx, chunk, multiplier=1):
+    exec_size = int(sum(ctx[inp.key][0] for inp in chunk.inputs or ()) * multiplier)
+
+    total_out_size = 0
+    chunk_sizes = dict()
+    outputs = chunk.op.outputs
+    for out in outputs:
+        try:
+            chunk_size = out.nbytes if not out.is_sparse() else exec_size
+            if np.isnan(chunk_size):
+                raise TypeError
+            chunk_sizes[out.key] = chunk_size
+            total_out_size += chunk_size
+        except (AttributeError, TypeError, ValueError):
+            pass
+    exec_size = max(exec_size, total_out_size)
+    for out in outputs:
+        if out.key in chunk_sizes:
+            store_size = chunk_sizes[out.key]
+        else:
+            store_size = max(exec_size // len(outputs),
+                             total_out_size // max(len(chunk_sizes), 1))
+        try:
+            max_sparse_size = out.nbytes + np.dtype(np.int64).itemsize * np.prod(out.shape) * out.ndim
+        except TypeError:  # pragma: no cover
+            max_sparse_size = np.nan
+        if not np.isnan(max_sparse_size):
+            store_size = min(store_size, max_sparse_size)
+        ctx[out.key] = (store_size, exec_size // len(outputs))
+
+
 Executor._op_runners[Fetch] = ignore
 
 
-def register(op, handler):
+def register(op, handler, size_estimator=None, size_multiplier=1):
     Executor._op_runners[op] = handler
+    Executor._op_size_estimators[op] = size_estimator or \
+        functools.partial(default_size_estimator, multiplier=size_multiplier)
 
 
 # register tensor and dataframe execution handler

--- a/mars/scheduler/analyzer.py
+++ b/mars/scheduler/analyzer.py
@@ -132,22 +132,21 @@ class GraphAnalyzer(object):
             if not graph.count_predecessors(n):
                 continue
             pred_sizes = defaultdict(lambda: 0)
-            total_size = 0
+            total_count = 0
             worker_involved = set()
             # calculate ratios of every worker in predecessors
             for pred in graph.iter_predecessors(n):
                 op_key = pred.op.key
-                pred_bytes = pred.rough_nbytes
-                total_size += pred_bytes
+                total_count += 1
                 if op_key in worker_assigns:
-                    pred_sizes[worker_assigns[op_key]] += pred_bytes
+                    pred_sizes[worker_assigns[op_key]] += 1
                     worker_involved.add(worker_assigns[op_key])
                 else:
                     worker_involved.add(None)
             # get the worker occupying most of the data
             max_size, max_workers = self._get_workers_with_max_size(pred_sizes)
             # if there is a dominant worker, return it
-            if max_size > total_size / max(2, len(worker_involved)) and max_workers:
+            if max_size > total_count / max(2, len(worker_involved)) and max_workers:
                 max_worker = random.choice(max_workers)
                 worker_assigns[n.op.key] = max_worker
                 yield n.op.key, max_worker

--- a/mars/scheduler/assigner.py
+++ b/mars/scheduler/assigner.py
@@ -18,7 +18,6 @@ import random
 import time
 from collections import defaultdict
 
-from ..config import options
 from ..errors import DependencyMissing
 from ..utils import log_unhandled
 from .chunkmeta import ChunkMetaActor
@@ -92,17 +91,11 @@ class AssignerActor(SchedulerActor):
             raise DependencyMissing
 
         input_sizes = dict((k, meta.chunk_size) for k, meta in metas.items())
-        output_size = op_info['output_size']
 
         if target_worker is None:
-            op_name = op_info['op_name']
             chunk_workers = dict((k, meta.workers) for k, meta in metas.items())
 
             candidate_workers = self._get_eps_by_worker_locality(input_chunk_keys, chunk_workers, input_sizes)
-            if self._is_stats_sufficient(op_name):
-                ep = self._get_ep_by_worker_stats(input_chunk_keys, chunk_workers, input_sizes, output_size, op_name)
-                if ep:
-                    candidate_workers.append(ep)
         else:
             candidate_workers = [target_worker]
 
@@ -110,49 +103,6 @@ class AssignerActor(SchedulerActor):
 
     def _get_chunks_meta(self, session_id, keys):
         return dict(zip(keys, self._chunk_meta_ref.batch_get_chunk_meta(session_id, keys)))
-
-    def _get_op_metric_item(self, ep, op_name, item):
-        return self._get_metric_item(ep, 'calc_speed.' + op_name, item)
-
-    def _get_metric_item(self, ep, metric, item):
-        return self._worker_metrics[ep].get('stats', {}).get(metric, {}).get(item, 0)
-
-    def _is_stats_sufficient(self, op_name):
-        if not options.scheduler.enable_chunk_relocation:
-            return False
-        if op_name is None:
-            return False
-
-        if op_name in self._sufficient_operands:
-            return True
-
-        t = time.time()
-        if self._operand_sufficient_time.get(op_name, 0) > t - 1:
-            return False
-
-        if any(self._worker_metrics[ep].get('stats', {}).get('max_est_finish_time') is None
-               for ep in self._worker_metrics):
-            self._operand_sufficient_time[op_name] = t
-            return False
-        minimal_stats = options.optimize.min_stats_count
-        minimal_workers = len(self._worker_metrics) * options.optimize.stats_sufficient_ratio - 1e-6
-        if sum(self._get_metric_item(ep, 'net_transfer_speed', 'count') >= minimal_stats
-               for ep in self._worker_metrics) < minimal_workers:
-            if all(self._get_metric_item(ep, 'net_transfer_speed', 'count') == 0 for ep in self._worker_metrics) or \
-                    all(self._worker_metrics[ep].get('submitted_count', 0) > 0 for ep in self._worker_metrics):
-                self._operand_sufficient_time[op_name] = t
-                return False
-        if any(self._get_op_metric_item(ep, op_name, 'count') < minimal_stats for ep in self._worker_metrics):
-            self._operand_sufficient_time[op_name] = t
-            return False
-        if any(abs(self._get_op_metric_item(ep, op_name, 'mean')) < 1e-6 for ep in self._worker_metrics):
-            self._operand_sufficient_time[op_name] = t
-            return False
-
-        if op_name in self._operand_sufficient_time:
-            del self._operand_sufficient_time[op_name]
-        self._sufficient_operands.add(op_name)
-        return True
 
     def _get_eps_by_worker_locality(self, input_keys, chunk_workers, input_sizes):
         locality_data = defaultdict(lambda: 0)
@@ -171,74 +121,3 @@ class AssignerActor(SchedulerActor):
             elif locality_data[ep] == max_locality:
                 max_eps.append(ep)
         return max_eps
-
-    def _get_ep_by_worker_stats(self, input_keys, chunk_workers, input_sizes, output_size, op_name):
-        ep_net_speeds = dict()
-        if any(self._get_metric_item(ep, 'net_transfer_speed', 'count') <= options.optimize.min_stats_count
-               for ep in self._worker_metrics):
-            sum_speeds, sum_records = 0, 0
-            for ep in self._worker_metrics.keys():
-                sum_speeds += self._get_metric_item(ep, 'net_transfer_speed', 'mean')
-                sum_records += self._get_metric_item(ep, 'net_transfer_speed', 'count')
-            avg_speed = sum_speeds * 1.0 / sum_records
-        else:
-            avg_speed = 0
-        for ep in self._worker_metrics:
-            if self._get_metric_item(ep, 'net_transfer_speed', 'count') > options.optimize.min_stats_count:
-                ep_net_speeds[ep] = self._get_metric_item(ep, 'net_transfer_speed', 'mean')
-            else:
-                ep_net_speeds[ep] = avg_speed
-
-        start_time = time.time()
-        ep_transmit_times = defaultdict(list)
-        ep_calc_time = defaultdict(lambda: 0)
-        locality_data = defaultdict(lambda: 0)
-        for key in input_keys:
-            contain_eps = chunk_workers.get(key, set())
-            for ep in self._worker_metrics:
-                if ep not in contain_eps:
-                    ep_transmit_times[ep].append(input_sizes[key] * 1.0 / ep_net_speeds[ep])
-                else:
-                    locality_data[ep] += input_sizes[key]
-
-        ep_transmit_time = dict()
-        for ep in self._worker_metrics:
-            if ep_transmit_times[ep]:
-                ep_transmit_time[ep] = sum(ep_transmit_times[ep])
-            else:
-                ep_transmit_time[ep] = 0
-
-        max_eps = []
-        max_locality = 0
-        for ep, locality in locality_data.items():
-            if locality == max_locality:
-                max_eps.append(ep)
-            elif locality > max_locality:
-                max_eps = [ep]
-                max_locality = locality
-        max_eps = set(max_eps)
-
-        for ep in self._worker_metrics:
-            ep_calc_time[ep] = sum(input_sizes.values()) * 1.0 / self._get_op_metric_item(ep, op_name, 'mean')
-
-        min_locality_exec_time = 0
-        for ep in max_eps:
-            finish_time = max(start_time, self._worker_metrics[ep].get('stats', {}).get('max_est_finish_time', 0.0)) + \
-                          ep_transmit_time[ep] + ep_calc_time[ep]
-            min_locality_exec_time = max(finish_time, min_locality_exec_time)
-
-        min_finish_time = None
-        min_ep = None
-        for ep in self._worker_metrics:
-            if ep_calc_time[ep] < 2 * ep_transmit_time[ep]:
-                continue
-            finish_time = max(start_time, self._worker_metrics[ep].get('stats', {}).get('min_est_finish_time', 0.0)) + \
-                          ep_transmit_time[ep] + ep_calc_time[ep]
-            if ep not in max_eps:
-                finish_time += output_size * 1.0 / ep_net_speeds[ep]
-            if finish_time - min_locality_exec_time > 1e-6:
-                continue
-            if min_finish_time is None or min_finish_time > finish_time:
-                min_finish_time = finish_time
-                min_ep = ep
-        return min_ep

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -603,7 +603,7 @@ class GraphActor(SchedulerActor):
             successor_keys = set()
             input_chunk_keys = set()
             shared_input_chunk_keys = set()
-            chunk_key_sizes = dict()
+            chunks = set()
 
             for c in self._op_key_to_chunk[op_key]:
                 for pn in chunk_graph.iter_predecessors(c):
@@ -612,19 +612,17 @@ class GraphActor(SchedulerActor):
                     if chunk_graph.count_successors(pn) > 1:
                         shared_input_chunk_keys.add(pn.key)
                 successor_keys.update(pn.op.key for pn in chunk_graph.iter_successors(c))
-                chunk_key_sizes.update((co.key, co.rough_nbytes) for co in c.op.outputs)
+                chunks.update(co.key for co in c.op.outputs)
 
             io_meta = dict(
                 predecessors=list(predecessor_keys),
                 successors=list(successor_keys),
                 input_chunks=list(input_chunk_keys),
                 shared_input_chunks=list(shared_input_chunk_keys),
-                chunks=list(chunk_key_sizes.keys()),
+                chunks=list(chunks),
             )
             op_info['op_name'] = op_name
             op_info['io_meta'] = io_meta
-            output_size = sum(chunk_key_sizes.values())
-            op_info['output_size'] = int(output_size)
 
             if predecessor_keys:
                 state = 'UNSCHEDULED'

--- a/mars/scheduler/tests/test_assigner.py
+++ b/mars/scheduler/tests/test_assigner.py
@@ -54,7 +54,6 @@ class Test(unittest.TestCase):
             op_info = {
                 'op_name': 'test_op',
                 'io_meta': dict(input_chunks=[chunk_key1, chunk_key2, chunk_key3]),
-                'output_size': 512,
                 'retries': 0,
                 'optimize': {
                     'depth': 0,

--- a/mars/scheduler/tests/test_graph.py
+++ b/mars/scheduler/tests/test_graph.py
@@ -102,8 +102,6 @@ class Test(unittest.TestCase):
                     self.assertSetEqual(set(io_meta['input_chunks']), set(orig_io_meta['input_chunks']))
                     self.assertSetEqual(set(io_meta['chunks']), set(orig_io_meta['chunks']))
 
-                    self.assertEqual(op_infos[n.op.key]['output_size'], sum(ch.nbytes for ch in n.op.outputs))
-
             yield pool, graph_ref
 
     def testSimpleGraphPreparation(self, *_):

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -23,7 +23,7 @@ import numpy as np
 from ..core import Entity, ChunkData, Chunk, TilesableData, enter_build_mode, is_eager_mode
 from ..tiles import handler
 from ..serialize import ProviderType, ValueType, DataTypeField, ListField
-from .expressions.utils import get_chunk_slices, calc_rough_shape
+from .expressions.utils import get_chunk_slices
 
 
 class TensorChunkData(ChunkData):
@@ -40,14 +40,6 @@ class TensorChunkData(ChunkData):
     @property
     def nbytes(self):
         return np.prod(self.shape) * self.dtype.itemsize
-
-    @property
-    def rough_nbytes(self):
-        return np.prod(self.rough_shape) * self.dtype.itemsize
-
-    @property
-    def rough_shape(self):
-        return calc_rough_shape(self)
 
 
 class TensorChunk(Chunk):
@@ -104,14 +96,6 @@ class TensorData(TilesableData):
     @property
     def nbytes(self):
         return np.prod(self.shape) * self.dtype.itemsize
-
-    @property
-    def rough_nbytes(self):
-        return np.prod(self.rough_shape) * self.dtype.itemsize
-
-    @property
-    def rough_shape(self):
-        return calc_rough_shape(self)
 
     def get_chunk_slices(self, idx):
         return get_chunk_slices(self.nsplits, idx)

--- a/mars/tensor/execution/arithmetic.py
+++ b/mars/tensor/execution/arithmetic.py
@@ -389,8 +389,7 @@ def _tree_multiply(ctx, chunk):
 def _tree_op_estimate_size(ctx, chunk):
     sum_inputs = sum(ctx[inp.key][0] for inp in chunk.inputs)
     if not chunk.is_sparse():
-        calc_size = chunk.nbytes * 2
-        chunk_size = chunk.nbytes
+        calc_size = chunk_size = chunk.nbytes
         if np.isnan(calc_size):
             chunk_size = calc_size = sum_inputs
     else:

--- a/mars/tensor/execution/arithmetic.py
+++ b/mars/tensor/execution/arithmetic.py
@@ -386,6 +386,21 @@ def _tree_multiply(ctx, chunk):
         ctx[chunk.key] = reduce(xp.multiply, inputs)
 
 
+def _tree_op_estimate_size(ctx, chunk):
+    sum_inputs = sum(ctx[inp.key][0] for inp in chunk.inputs)
+    if not chunk.is_sparse():
+        calc_size = chunk.nbytes * 2
+        chunk_size = chunk.nbytes
+        if np.isnan(calc_size):
+            chunk_size = calc_size = sum_inputs
+    else:
+        calc_size = sum_inputs
+        chunk_size = min(sum_inputs, chunk.nbytes + np.dtype(np.int64).itemsize * np.prod(chunk.shape) * chunk.ndim)
+        if np.isnan(chunk_size):
+            chunk_size = sum_inputs
+    ctx[chunk.key] = (chunk_size, calc_size)
+
+
 def register_arithmetic_handler():
     from ...executor import register
 
@@ -401,8 +416,8 @@ def register_arithmetic_handler():
     register(arithmetic.TensorSetImag, _set_imag)
     register(arithmetic.TensorSetImagConstant, _set_imag)
 
-    register(arithmetic.TensorTreeAdd, _tree_add)
-    register(arithmetic.TensorTreeMultiply, _tree_multiply)
+    register(arithmetic.TensorTreeAdd, _tree_add, _tree_op_estimate_size)
+    register(arithmetic.TensorTreeMultiply, _tree_multiply, _tree_op_estimate_size)
     register(arithmetic.TensorAround, _around)
     register(arithmetic.TensorAngle, _angle)
     register(arithmetic.TensorIsclose, _isclose)

--- a/mars/tensor/execution/base.py
+++ b/mars/tensor/execution/base.py
@@ -150,7 +150,7 @@ def register_basic_handler():
     from ... import operands
     from ...executor import register
 
-    register(operands.VirtualOperand, _virtual)
+    register(operands.VirtualOperand, _virtual, _virtual)
 
     register(operands.CopyTo, _copyto)
     register(operands.Astype, _astype)

--- a/mars/tensor/execution/cp.py
+++ b/mars/tensor/execution/cp.py
@@ -16,6 +16,7 @@
 
 from string import ascii_letters
 
+from .utils import estimate_fuse_size
 from ..expressions import arithmetic
 from ..expressions.fuse import TensorCpFuseChunk
 from ...utils import tokenize
@@ -71,4 +72,4 @@ def _execute_cp(ctx, chunk):
 def register_cp_handler():
     from ...executor import register
 
-    register(TensorCpFuseChunk, _execute_cp)
+    register(TensorCpFuseChunk, _execute_cp, estimate_fuse_size)

--- a/mars/tensor/execution/indexing.py
+++ b/mars/tensor/execution/indexing.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from .array import as_same_device, device
 from ...compat import izip
 
@@ -25,19 +27,43 @@ def _slice(ctx, chunk):
 def _index(ctx, chunk):
     indexes = tuple(ctx[index.key] if hasattr(index, 'key') else index
                     for index in chunk.op.indexes)
-    input = ctx[chunk.inputs[0].key]
-    ctx[chunk.key] = input[indexes]
+    input_ = ctx[chunk.inputs[0].key]
+    ctx[chunk.key] = input_[indexes]
+
+
+def _index_estimate_size(ctx, chunk):
+    from mars.core import BaseWithKey, Entity
+
+    op = chunk.op
+    shape = op.outputs[0].shape
+    new_indexes = [index for index in op._indexes if index is not None]
+
+    new_shape = []
+    for index in new_indexes:
+        if isinstance(index, (BaseWithKey, Entity)) and index.dtype == np.bool_:
+            new_shape.append(ctx[index.key][0] // index.dtype.itemsize)
+
+    rough_shape = []
+    idx = 0
+    for s in shape:
+        if np.isnan(s):
+            rough_shape.append(new_shape[idx])
+            idx += 1
+        else:
+            rough_shape.append(s)
+    result = int(np.prod(rough_shape) * chunk.dtype.itemsize)
+    ctx[chunk.key] = (result, result)
 
 
 def _index_set_value(ctx, chunk):
     indexes = [ctx[index.key] if hasattr(index, 'key') else index
                for index in chunk.op.indexes]
-    input = ctx[chunk.inputs[0].key].copy()
+    input_ = ctx[chunk.inputs[0].key].copy()
     value = ctx[chunk.op.value.key] if hasattr(chunk.op.value, 'key') else chunk.op.value
-    if hasattr(input, 'flags') and not input.flags.writeable:
-        input.setflags(write=True)
-    input[tuple(indexes)] = value
-    ctx[chunk.key] = input
+    if hasattr(input_, 'flags') and not input_.flags.writeable:
+        input_.setflags(write=True)
+    input_[tuple(indexes)] = value
+    ctx[chunk.key] = input_
 
 
 def _choose(ctx, chunk):
@@ -65,7 +91,7 @@ def register_indexing_handler():
     from ...executor import register
 
     register(Slice, _slice)
-    register(Index, _index)
+    register(Index, _index, _index_estimate_size)
     register(IndexSetValue, _index_set_value)
     register(Choose, _choose)
     register(UnravelIndex, _unravel_index)

--- a/mars/tensor/execution/ne.py
+++ b/mars/tensor/execution/ne.py
@@ -21,6 +21,7 @@ from ...compat import six, izip
 from ..expressions import arithmetic, reduction
 from ..expressions.fuse import TensorNeFuseChunk
 from .array import as_same_device
+from .utils import estimate_fuse_size
 
 _VAR_FLAG = 'V_'
 
@@ -180,4 +181,4 @@ def evaluate(ctx, chunk):
 def register_numexpr_handler():
     from ...executor import register
 
-    register(TensorNeFuseChunk, evaluate)
+    register(TensorNeFuseChunk, evaluate, estimate_fuse_size)

--- a/mars/tensor/execution/tests/test_base_execute.py
+++ b/mars/tensor/execution/tests/test_base_execute.py
@@ -229,7 +229,9 @@ class Test(unittest.TestCase):
         y4 = x.reshape(60, 25, 40)
         y4.op.params['_reshape_with_shuffle'] = True
 
+        size_res = self.executor.execute_tensor(y4, mock=True)
         res = self.executor.execute_tensor(y4, concat=True)
+        self.assertEqual(res[0].nbytes, sum(v[0] for v in size_res))
         self.assertTrue(np.array_equal(res[0], raw_data.reshape(60, 25, 40)))
 
     def testExpandDimsExecution(self):

--- a/mars/tensor/execution/tests/test_index_execute.py
+++ b/mars/tensor/execution/tests/test_index_execute.py
@@ -42,8 +42,10 @@ class Test(unittest.TestCase):
 
         index = arr < .5
         arr2 = arr[index]
+        size_res = self.executor.execute_tensor(arr2, mock=True)
         res = self.executor.execute_tensor(arr2)
 
+        self.assertEqual(sum(s[0] for s in size_res), arr.nbytes)
         self.assertTrue(np.array_equal(np.sort(np.concatenate(res)), np.sort(raw[raw < .5])))
 
         index2 = tensor(raw[:, :, 0, 0], chunk_size=3) < .5
@@ -98,8 +100,12 @@ class Test(unittest.TestCase):
         raw_cond = raw[0, :, 0, 0] < .5
         cond = tensor(raw[0, :, 0, 0], chunk_size=3) < .5
         arr2 = arr[10::-2, cond, None, ..., :5]
+        size_res = self.executor.execute_tensor(arr2, mock=True)
         res = self.executor.execute_tensor(arr2, concat=True)
 
+        new_shape = list(arr2.shape)
+        new_shape[1] = cond.shape[0]
+        self.assertEqual(sum(s[0] for s in size_res), int(np.prod(new_shape) * arr2.dtype.itemsize))
         self.assertTrue(np.array_equal(res[0], raw[10::-2, raw_cond, None, ..., :5]))
 
         b_raw = np.random.random(8)

--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -514,6 +514,8 @@ class Test(unittest.TestCase):
         self.assertAlmostEqual(res, 3.14, delta=1)
 
     def testTensordotExecution(self):
+        size_executor = Executor()
+
         a_data = np.arange(60).reshape(3, 4, 5)
         a = tensor(a_data, chunk_size=2)
         b_data = np.arange(24).reshape(4, 3, 2)
@@ -521,8 +523,10 @@ class Test(unittest.TestCase):
 
         axes = ([1, 0], [0, 1])
         c = tensordot(a, b, axes=axes)
+        size_res = size_executor.execute_tensor(c, mock=True)
         res = self.executor.execute_tensor(c)
         expected = np.tensordot(a_data, b_data, axes=axes)
+        self.assertEqual(sum(s[0] for s in size_res), c.nbytes)
         self.assertTrue(np.array_equal(res[0], expected[:2, :]))
         self.assertTrue(np.array_equal(res[1], expected[2:4, :]))
         self.assertTrue(np.array_equal(res[2], expected[4:, :]))
@@ -575,6 +579,8 @@ class Test(unittest.TestCase):
         np.testing.assert_array_equal(res, np.ones((100, 100)) * 100)
 
     def testSparseDotExecution(self):
+        size_executor = Executor()
+
         a_data = sps.random(5, 9, density=.1)
         b_data = sps.random(9, 10, density=.2)
         a = tensor(a_data, chunk_size=2)
@@ -582,7 +588,9 @@ class Test(unittest.TestCase):
 
         c = dot(a, b)
 
+        size_res = size_executor.execute_tensor(c, mock=True)
         res = self.executor.execute_tensor(c, concat=True)[0]
+        self.assertGreater(sum(s[0] for s in size_res), 0)
         self.assertTrue(issparse(res))
         np.testing.assert_allclose(res.toarray(), a_data.dot(b_data).toarray())
 

--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -514,7 +514,7 @@ class Test(unittest.TestCase):
         self.assertAlmostEqual(res, 3.14, delta=1)
 
     def testTensordotExecution(self):
-        size_executor = Executor()
+        size_executor = Executor(sync_provider_type=Executor.SyncProviderType.MOCK)
 
         a_data = np.arange(60).reshape(3, 4, 5)
         a = tensor(a_data, chunk_size=2)
@@ -579,7 +579,7 @@ class Test(unittest.TestCase):
         np.testing.assert_array_equal(res, np.ones((100, 100)) * 100)
 
     def testSparseDotExecution(self):
-        size_executor = Executor()
+        size_executor = Executor(sync_provider_type=Executor.SyncProviderType.MOCK)
 
         a_data = sps.random(5, 9, density=.1)
         b_data = sps.random(9, 10, density=.2)

--- a/mars/tensor/execution/tests/test_numexpr_execute.py
+++ b/mars/tensor/execution/tests/test_numexpr_execute.py
@@ -45,6 +45,22 @@ class Test(unittest.TestCase):
         res5_cmp = self.executor.execute_tensor((arr1 + arr1), concat=True)
         self.assertTrue(np.array_equal(res5[0], res5_cmp[0]))
 
+    def testFuseSizeExecution(self):
+        executor_size = Executor()
+        executor_numpy = Executor()
+
+        raw1 = np.random.randint(10, size=(10, 10, 10))
+        arr1 = tensor(raw1, chunk_size=3)
+        arr2 = arr1 + 10
+        arr3 = arr2 * 3
+        arr4 = arr3 + 5
+
+        res4_size = executor_size.execute_tensor(arr4, mock=True)
+        res4 = executor_numpy.execute_tensor(arr4, concat=True)
+        res4_cmp = self.executor.execute_tensor(arr4, concat=True)
+        self.assertEqual(sum(s[0] for s in res4_size), arr4.nbytes)
+        self.assertTrue(np.array_equal(res4[0], res4_cmp[0]))
+
     def testUnaryExecution(self):
         from mars.tensor.expressions.arithmetic import UNARY_UFUNC, arccosh, invert, sin, conj
 

--- a/mars/tensor/execution/utils.py
+++ b/mars/tensor/execution/utils.py
@@ -51,5 +51,5 @@ def estimate_fuse_size(ctx, chunk):
             dag.add_edge(inp, c)
 
     size_ctx = ctx.copy()
-    executor = Executor(storage=size_ctx)
+    executor = Executor(storage=size_ctx, sync_provider_type=Executor.SyncProviderType.MOCK)
     ctx[chunk.key] = executor.execute_graph(dag, [chunk.key], mock=True)[0]

--- a/mars/tensor/expressions/base/argwhere.py
+++ b/mars/tensor/expressions/base/argwhere.py
@@ -29,10 +29,6 @@ class TensorArgwhere(Argwhere, TensorOperandMixin):
     def __init__(self, dtype=None, **kw):
         super(TensorArgwhere, self).__init__(_dtype=dtype, **kw)
 
-    def calc_rough_shape(self, *inputs_shape):
-        rough_shape = (np.prod(inputs_shape[0]), self.input.ndim)
-        return rough_shape
-
     def calc_shape(self, *inputs_shape):
         shape = (np.nan, len(inputs_shape[0]))
         return shape

--- a/mars/tensor/expressions/base/repeat.py
+++ b/mars/tensor/expressions/base/repeat.py
@@ -37,10 +37,6 @@ class TensorRepeat(Repeat, TensorOperandMixin):
         if len(inputs) > 1:
             self._repeats = self._inputs[1]
 
-    def calc_rough_shape(self, *inputs_shape):
-        input_shape = inputs_shape[0]
-        return tuple(s if not np.isnan(s) else input_shape[i] for i, s in enumerate(self.outputs[0].shape))
-
     def calc_shape(self, *inputs_shape):
         ax = self._axis or 0
         input_shape = (np.prod(inputs_shape[0]),) if self._axis is None else inputs_shape[0]

--- a/mars/tensor/expressions/fuse/core.py
+++ b/mars/tensor/expressions/fuse/core.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-
 from .... import operands
 from ....tiles import NotSupportTile
 from ..core import TensorOperandMixin
@@ -24,18 +22,6 @@ from ..core import TensorOperandMixin
 class TensorFuseChunk(operands.Fuse, TensorOperandMixin):
     def __init__(self, dtype=None, **kw):
         super(TensorFuseChunk, self).__init__(_dtype=dtype, **kw)
-
-    def calc_rough_shape(self, *inputs_shape):
-        in_shapes = inputs_shape
-        out_shape = None
-
-        # TODO: the logic will be changed when fusion is not only straight line
-        for c in self.outputs[0].composed:
-            out_shape = c.op.calc_shape(*in_shapes)
-            if np.nan in out_shape:
-                out_shape = c.op.calc_rough_shape(*in_shapes)
-            in_shapes = [out_shape]
-        return out_shape
 
     def calc_shape(self, *inputs_shape):
         in_shapes = inputs_shape

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -35,29 +35,6 @@ class TensorIndex(Index, TensorOperandMixin):
     def __init__(self, dtype=None, sparse=False, **kw):
         super(TensorIndex, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
 
-    def calc_rough_shape(self, *inputs_shape):
-        input_shape = inputs_shape[0]
-        shape = self.outputs[0].shape
-        new_indexes = [index for index in self._indexes if index is not None]
-
-        idx = 0
-        new_shape = []
-        for index in new_indexes:
-            if isinstance(index, (BaseWithKey, Entity)) and index.dtype == np.bool_:
-                new_shape.append(input_shape[idx: (idx + index.ndim)])
-                idx += index.ndim - 1
-            idx += 1
-
-        rough_shape = []
-        idx = 0
-        for s in shape:
-            if np.isnan(s):
-                rough_shape.extend(new_shape[idx])
-                idx += 1
-            else:
-                rough_shape.append(s)
-        return tuple(rough_shape)
-
     def calc_shape(self, *inputs_shape):
         return tuple(get_index_and_shape(inputs_shape[0], self._indexes)[1])
 

--- a/mars/tensor/expressions/indexing/nonzero.py
+++ b/mars/tensor/expressions/indexing/nonzero.py
@@ -32,10 +32,6 @@ class TensorNonzero(Nonzero, TensorOperandMixin):
         super(TensorNonzero, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    @staticmethod
-    def calc_rough_shape(*inputs_shape):
-        return np.prod(inputs_shape[0]),
-
     def calc_shape(self, *inputs_shape):
         return np.nan,
 

--- a/mars/tensor/expressions/reshape/reshape.py
+++ b/mars/tensor/expressions/reshape/reshape.py
@@ -253,12 +253,6 @@ class TensorReshapeMap(ShuffleMap, TensorOperandMixin):
     def calc_shape(self, *inputs_shape):
         return np.nan,
 
-    def calc_rough_shape(self, *input_shapes):
-        inp_shape = input_shapes[0]
-        indices_overhead = np.int64().itemsize * (len(inp_shape) + 2)
-        scaled_original = 1 + int(np.ceil(indices_overhead / self.dtype.itemsize))
-        return (scaled_original,) + inp_shape
-
 
 class TensorReshapeReduce(ShuffleReduce, TensorOperandMixin):
     _op_type_ = opcodes.RESHAPE_REDUCE

--- a/mars/tensor/expressions/tests/test_base.py
+++ b/mars/tensor/expressions/tests/test_base.py
@@ -236,8 +236,6 @@ class Test(unittest.TestCase):
         self.assertTrue(np.isnan(indices.shape[0]))
         self.assertEqual(indices.shape[1], 2)
         self.assertEqual(calc_shape(indices), indices.shape)
-        self.assertEqual(indices.op.calc_rough_shape(tuple(t.rough_shape for t in indices.inputs)), (4, 2))
-        self.assertEqual(indices.rough_nbytes, 4 * 2 * indices.dtype.itemsize)
 
         indices.tiles()
 
@@ -246,7 +244,6 @@ class Test(unittest.TestCase):
         chunk = indices.chunks[0]
         self.assertTrue(np.isnan(calc_shape(chunk)[0]))
         self.assertEqual(calc_shape(chunk)[1], chunk.shape[1])
-        self.assertEqual(chunk.rough_shape, (2, 1))
 
     def testArraySplit(self):
         a = arange(8, chunk_size=2)
@@ -406,12 +403,10 @@ class Test(unittest.TestCase):
 
         t = repeat(a, b)
         self.assertEqual(calc_shape(t), t.shape)
-        self.assertEqual(t.rough_shape, (4,))
 
         t.tiles()
         self.assertTrue(np.isnan(t.nsplits[0]))
         self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
-        self.assertEqual(t.chunks[0].rough_shape, (4,))
 
     def testIsIn(self):
         element = 2 * arange(4, chunk_size=1).reshape(2, 2)

--- a/mars/tensor/expressions/tests/test_indexing.py
+++ b/mars/tensor/expressions/tests/test_indexing.py
@@ -34,7 +34,6 @@ class Test(unittest.TestCase):
         self.assertEqual(len(indexed.shape), 1)
         self.assertTrue(np.isnan(indexed.shape[0]))
         self.assertTrue(np.isnan(calc_shape(indexed)[0]))
-        self.assertEqual(indexed.rough_nbytes, t.nbytes)
 
         t2 = ones((100, 200))
         indexed = t[t2 < 2]
@@ -42,7 +41,6 @@ class Test(unittest.TestCase):
         self.assertTrue(np.isnan(indexed.shape[0]))
         self.assertEqual(indexed.shape[1], 300)
         self.assertTrue(np.isnan(calc_shape(indexed)[0]))
-        self.assertEqual(indexed.rough_nbytes, t.nbytes)
 
         t2 = ones((100, 200))
         indexed = t[t2 < 2] + 1
@@ -50,7 +48,6 @@ class Test(unittest.TestCase):
         self.assertTrue(np.isnan(indexed.shape[0]))
         self.assertEqual(indexed.shape[1], 300)
         self.assertTrue(np.isnan(calc_shape(indexed)[0]))
-        self.assertEqual(indexed.rough_nbytes, t.nbytes)
 
         t3 = ones((101, 200))
         with self.assertRaises(IndexError) as cm:
@@ -117,7 +114,6 @@ class Test(unittest.TestCase):
         self.assertEqual(len(t2.shape), 3)
         self.assertTrue(np.isnan(t2.shape[0]))
         self.assertEqual(calc_shape(t2), t2.shape)
-        self.assertEqual(t2.rough_nbytes, 100 * 200 * 3 * t.dtype.itemsize)
 
     def testBoolIndexingTiles(self):
         t = ones((100, 200, 300), chunk_size=30)
@@ -131,8 +127,6 @@ class Test(unittest.TestCase):
         self.assertIs(indexed.chunks[20].inputs[1], indexed.op.indexes[0].cix[0, 2, 0].data)
         self.assertEqual(calc_shape(indexed.chunks[0]), indexed.chunks[0].shape)
         self.assertEqual(calc_shape(indexed.chunks[20]), indexed.chunks[20].shape)
-        self.assertEqual(indexed.chunks[0].rough_nbytes, t.chunks[0].nbytes)
-        self.assertEqual(indexed.chunks[20].rough_nbytes, t.chunks[20].nbytes)
 
         t2 = ones((100, 200), chunk_size=30)
         indexed2 = t[t2 < 2]
@@ -144,11 +138,8 @@ class Test(unittest.TestCase):
         self.assertEqual(indexed2.chunks[0].shape[1], 30)
         self.assertEqual(indexed2.chunks[20].inputs[0], t.cix[(0, 2, 0)].data)
         self.assertEqual(indexed2.chunks[20].inputs[1], indexed2.op.indexes[0].cix[0, 2].data)
-        self.assertEqual(indexed2.chunks[0].rough_nbytes, 30 * 30 * 30 * t2.dtype.itemsize)
         self.assertEqual(calc_shape(indexed2.chunks[0]), indexed2.chunks[0].shape)
         self.assertEqual(calc_shape(indexed2.chunks[20]), indexed2.chunks[20].shape)
-        self.assertEqual(indexed2.chunks[0].rough_nbytes, t.chunks[0].nbytes)
-        self.assertEqual(indexed2.chunks[20].rough_nbytes, t.chunks[20].nbytes)
 
     def testSliceTiles(self):
         t = ones((100, 200, 300), chunk_size=30)
@@ -192,11 +183,9 @@ class Test(unittest.TestCase):
 
         self.assertEqual(t2.shape[:-1], (27, 300, 1))
         self.assertTrue(np.isnan(t2.shape[-1]))
-        self.assertEqual(t2.rough_nbytes, 27 * 300 * 400 * t.dtype.itemsize)
         self.assertEqual(t2.chunk_shape, (4, 13, 1, 17))
         self.assertEqual(t2.chunks[0].op.indexes, [slice(10, 24, 3), 5, slice(None), None, cmp.cix[0, ].data])
         self.assertEqual(calc_shape(t2.chunks[0]), t2.chunks[0].shape)
-        self.assertEqual(t2.chunks[0].rough_nbytes, 5 * 24 * 24 * t.dtype.itemsize)
 
         # multiple tensor type as indexes
         t3 = ones((100, 200, 300, 400), chunk_size=24)
@@ -209,11 +198,9 @@ class Test(unittest.TestCase):
         self.assertTrue(np.isnan(t4.shape[0]))
         self.assertTrue(np.isnan(t4.shape[-1]))
         self.assertEqual(calc_shape(t4), t4.shape)
-        self.assertEqual(t4.rough_nbytes, 100 * 200 * 400 * t.dtype.itemsize)
         self.assertEqual(t4.chunk_shape, (45, 1, 17))
         self.assertEqual(t4.chunks[0].op.indexes, [cmp2.cix[0, 0].data, 5, None, cmp3.cix[0, ].data])
         self.assertEqual(calc_shape(t4.chunks[0]), t4.chunks[0].shape)
-        self.assertEqual(t4.chunks[0].rough_nbytes, 24 * 24 * 24 * t3.dtype.itemsize)
 
     def testSetItem(self):
         shape = (10, 20, 30, 40)
@@ -283,14 +270,10 @@ class Test(unittest.TestCase):
         self.assertEqual(len(y), 2)
         self.assertEqual(calc_shape(y[0]), y[0].shape)
         self.assertEqual(calc_shape(y[1]), y[1].shape)
-        self.assertEqual(y[0].rough_nbytes, x.size * np.dtype(np.intp).itemsize)
-        self.assertEqual(y[1].rough_nbytes, x.size * np.dtype(np.intp).itemsize)
 
         y[0].tiles()
         self.assertEqual(calc_shape(y[0].chunks[0]), y[0].chunks[0].shape)
         self.assertEqual(calc_shape(y[1].chunks[0]), y[1].chunks[0].shape)
-        self.assertEqual(y[0].chunks[0].rough_nbytes, 3 * np.dtype(np.intp).itemsize)
-        self.assertEqual(y[1].chunks[0].rough_nbytes, 3 * np.dtype(np.intp).itemsize)
 
     def testOperandKey(self):
         t = ones((10, 2), chunk_size=5)

--- a/mars/tensor/expressions/tests/test_reshape.py
+++ b/mars/tensor/expressions/tests/test_reshape.py
@@ -63,4 +63,3 @@ class Test(unittest.TestCase):
 
         shuffle_map_sample = b.chunks[0].inputs[0].inputs[0]
         self.assertIsInstance(shuffle_map_sample.op, TensorReshapeMap)
-        self.assertGreater(shuffle_map_sample.rough_nbytes, 0)

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -460,19 +460,6 @@ def decide_chunk_sizes(shape, chunk_size, itemsize):
     return tuple(dim_to_normalized[i] for i in range(len(dim_to_normalized)))
 
 
-def calc_rough_shape(tensor):
-    if np.nan in tensor.shape:
-        inputs = tensor.inputs or []
-        inputs_shape = tuple(t.rough_shape for t in inputs)
-        shape = tensor.op.calc_shape(*inputs_shape)
-        if np.nan in shape:
-            return tensor.op.calc_rough_shape(*inputs_shape)
-        else:
-            return shape
-    else:
-        return tensor.shape
-
-
 def convert_to_fetch(entity):
     from ..core import CHUNK_TYPE, TENSOR_TYPE
     from .fetch import TensorFetch

--- a/mars/worker/chunkstore.py
+++ b/mars/worker/chunkstore.py
@@ -111,8 +111,12 @@ class PlasmaChunkStore(object):
             return buffer
         except PlasmaStoreFull:
             exc_type = PlasmaStoreFull
+            self._mapper_ref.delete(session_id, chunk_key)
             logger.warning('Chunk %s(%d) failed to store to plasma due to StoreFullError',
                            chunk_key, size)
+        except:  # noqa: E722  # pragma: no cover
+            self._mapper_ref.delete(session_id, chunk_key)
+            raise
 
         if exc_type is PlasmaStoreFull:
             raise StoreFull
@@ -198,6 +202,10 @@ class PlasmaChunkStore(object):
             logger.warning('Chunk %s(%d) failed to store to plasma due to StoreFullError',
                            chunk_key, data_size)
             exc = PlasmaStoreFull
+        except:  # noqa: E722  # pragma: no cover
+            self._mapper_ref.delete(session_id, chunk_key)
+            raise
+
         if exc is PlasmaStoreFull:
             raise StoreFull
 

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -274,7 +274,7 @@ class ExecutionActor(WorkerActor):
     def _estimate_calc_memory(self, session_id, graph_key):
         graph_record = self._graph_records[(session_id, graph_key)]
         size_ctx = dict((k, (v, v)) for k, v in graph_record.data_sizes.items())
-        executor = Executor(storage=size_ctx)
+        executor = Executor(storage=size_ctx, sync_provider_type=Executor.SyncProviderType.MOCK)
         res = executor.execute_graph(graph_record.graph, graph_record.targets, mock=True)
         return dict(zip(graph_record.targets, res))
 

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -17,7 +17,6 @@ import logging
 import random
 import sys
 import time
-from functools import partial
 from collections import defaultdict
 
 from .. import promise
@@ -25,6 +24,7 @@ from ..compat import six, Enum, BrokenPipeError, ConnectionRefusedError, Timeout
 from ..config import options
 from ..errors import PinChunkFailed, WorkerProcessStopped, ExecutionInterrupted, \
     DependencyMissing
+from ..executor import Executor
 from ..operands import Fetch
 from ..utils import deserialize_graph, log_unhandled, to_str
 from .chunkholder import ensure_chunk
@@ -269,7 +269,14 @@ class ExecutionActor(WorkerActor):
             p = self._task_queue_ref.enqueue_task(
                 session_id, succ_key, succ_rec.priority_data, _promise=True)
             if enqueue_callback:
-                p.then(partial(self.tell_promise, enqueue_callback))
+                p.then(functools.partial(self.tell_promise, enqueue_callback))
+
+    def _estimate_calc_memory(self, session_id, graph_key):
+        graph_record = self._graph_records[(session_id, graph_key)]
+        size_ctx = dict((k, (v, v)) for k, v in graph_record.data_sizes.items())
+        executor = Executor(storage=size_ctx)
+        res = executor.execute_graph(graph_record.graph, graph_record.targets, mock=True)
+        return dict(zip(graph_record.targets, res))
 
     @log_unhandled
     def prepare_quota_request(self, session_id, graph_key):
@@ -292,12 +299,13 @@ class ExecutionActor(WorkerActor):
         if self._status_ref:
             self.estimate_graph_finish_time(session_id, graph_key)
 
+        memory_estimations = self._estimate_calc_memory(session_id, graph_key)
+
         # collect potential allocation sizes
         for chunk in graph:
             if not isinstance(chunk.op, Fetch) and chunk.key in graph_record.targets:
                 # use estimated size as potential allocation size
-                alloc_mem_batch[chunk.key] = chunk.rough_nbytes * 2
-                alloc_cache_batch[chunk.key] = chunk.rough_nbytes
+                alloc_cache_batch[chunk.key], alloc_mem_batch[chunk.key] = memory_estimations[chunk.key]
             else:
                 # use actual size as potential allocation size
                 input_chunk_keys[chunk.key] = graph_record.data_sizes.get(chunk.key, chunk.nbytes)
@@ -605,8 +613,8 @@ class ExecutionActor(WorkerActor):
                     # input only use in current operand, we only need to load it into process memory
                     continue
                 self._mem_quota_ref.release_quota(self._build_load_key(graph_key, chunk.key))
-                load_fun = partial(lambda gk, ck, *_: self._chunk_holder_ref.pin_chunks(gk, ck),
-                                   graph_key, chunk.key)
+                load_fun = functools.partial(lambda gk, ck, *_: self._chunk_holder_ref.pin_chunks(gk, ck),
+                                             graph_key, chunk.key)
                 unspill_keys.append(chunk.key)
                 prepare_promises.append(ensure_chunk(self, session_id, chunk.key, move_to_end=True) \
                                         .then(load_fun))
@@ -728,7 +736,7 @@ class ExecutionActor(WorkerActor):
             for key, targets in send_addresses.items():
                 promises.append(promise.Promise(done=True)
                                 .then(lambda: self._dispatch_ref.get_free_slot('sender', _promise=True))
-                                .then(partial(_send_chunk, chunk_key=key, target_addrs=targets))
+                                .then(functools.partial(_send_chunk, chunk_key=key, target_addrs=targets))
                                 .catch(lambda *_: None))
             return promise.all_(promises)
 


### PR DESCRIPTION
## What do these changes do?

Remove all rough_nbytes and rough_sizes from tensor expressions and add size estimation in execution. Also remove chunk registration when creation failed.

## Related issue number

Fixes #265
Fixes #269 