### PR TITLE
Fix kernel_mode decorator when an exception occurred in wrapped function 

### DIFF
--- a/mars/tests/test_eager_mode.py
+++ b/mars/tests/test_eager_mode.py
@@ -172,3 +172,23 @@ class Test(unittest.TestCase):
 
         self.assertNotIn(repr(np.ones((10, 10))), repr(a))
         self.assertNotIn(str(np.ones((10, 10))), str(a))
+
+    def testRuntimeError(self):
+        from mars.utils import kernel_mode
+
+        @kernel_mode
+        def raise_error(*_):
+            raise ValueError
+
+        with option_context({'eager_mode': True}):
+            a = mt.zeros((10, 10))
+            with self.assertRaises(ValueError):
+                raise_error(a)
+
+            r = a + 1
+            self.assertIn(repr(np.zeros((10, 10)) + 1), repr(r))
+            np.testing.assert_array_equal(r.fetch(), np.zeros((10, 10)) + 1)
+
+        a = mt.zeros((10, 10))
+        with self.assertRaises(ValueError):
+            a.fetch()

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -350,9 +350,11 @@ def kernel_mode(func):
     """
 
     def _wrapped(*args, **kwargs):
-        _kernel_mode.eager = False
-        return_value = func(*args, **kwargs)
-        _kernel_mode.eager = None
+        try:
+            _kernel_mode.eager = False
+            return_value = func(*args, **kwargs)
+        finally:
+            _kernel_mode.eager = None
         return return_value
 
     return _wrapped

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -352,9 +352,8 @@ def kernel_mode(func):
     def _wrapped(*args, **kwargs):
         try:
             _kernel_mode.eager = False
-            return_value = func(*args, **kwargs)
+            return func(*args, **kwargs)
         finally:
             _kernel_mode.eager = None
-        return return_value
 
     return _wrapped


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Use `finally` statement to make sure `_kernel_mode.eager` set to `None`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
resolve #268 