### PR TITLE
Pass sparse parameter when create fetch operand

### DIFF
--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -438,3 +438,17 @@ class Test(unittest.TestCase):
 
                 r = a.dot(a)
                 np.testing.assert_array_equal(r.execute(), np.ones((10, 10)) * 10)
+
+    def testSparse(self):
+        import scipy.sparse as sps
+
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M', web=True) as cluster:
+            session = cluster.session
+
+            # calculate sparse with no element in matrix
+            a = sps.csr_matrix((10000, 10000))
+            b = sps.csr_matrix((10000, 1))
+            t1 = mt.tensor(a)
+            t2 = mt.tensor(b)
+            session.run(t1 * t2)

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -545,11 +545,11 @@ class Executor(object):
             # generate TensorFetch op for each chunk
             chunks = []
             for c in tensor.chunks:
-                op = TensorFetch(dtype=c.dtype)
+                op = TensorFetch(dtype=c.dtype, sparse=c.op.sparse)
                 chunk = op.new_chunk(None, c.shape, index=c.index, _key=c.key)
                 chunks.append(chunk)
 
-            new_op = TensorFetch(dtype=tensor.dtype)
+            new_op = TensorFetch(dtype=tensor.dtype, sparse=tensor.op.sparse)
             # copy key and id to ensure that fetch tensor won't add the count of executed tensor
             tensor = new_op.new_tensor(None, tensor.shape, chunks=chunks,
                                        nsplits=tensor.nsplits, _key=tensor.key, _id=tensor.id)
@@ -619,6 +619,8 @@ def default_size_estimator(ctx, chunk, multiplier=1):
             pass
     exec_size = max(exec_size, total_out_size)
     for out in outputs:
+        if out.key in ctx:
+            continue
         if out.key in chunk_sizes:
             store_size = chunk_sizes[out.key]
         else:

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -543,7 +543,7 @@ class GraphActor(SchedulerActor):
         inputs_to_copied = dict()
         for c in self._op_key_to_chunk[op_key]:
             for inp in set(c.inputs or ()):
-                op = TensorFetch(dtype=inp.dtype)
+                op = TensorFetch(dtype=inp.dtype, sparse=inp.op.sparse)
                 inp_chunk = op.new_chunk(None, inp.shape, _key=inp.key).data
                 inputs_to_copied[inp] = inp_chunk
                 graph.add_node(inp_chunk)
@@ -799,13 +799,13 @@ class GraphActor(SchedulerActor):
         if len(tiled_tensor.chunks) == 1:
             # only one chunk, just trigger fetch
             c = tiled_tensor.chunks[0]
-            op = TensorFetch(dtype=c.dtype)
+            op = TensorFetch(dtype=c.dtype, sparse=c.op.sparse)
             fetch_chunk = op.new_chunk(None, c.shape, index=c.index, _key=c.key).data
             graph.add_node(fetch_chunk)
         else:
             fetch_chunks = []
             for c in tiled_tensor.chunks:
-                op = TensorFetch(dtype=c.dtype)
+                op = TensorFetch(dtype=c.dtype, sparse=c.op.sparse)
                 fetch_chunk = op.new_chunk(None, c.shape, index=c.index, _key=c.key).data
                 graph.add_node(fetch_chunk)
                 fetch_chunks.append(fetch_chunk)
@@ -826,11 +826,11 @@ class GraphActor(SchedulerActor):
 
         chunks = []
         for c in tiled_tensor.chunks:
-            fetch_op = TensorFetch(dtype=c.dtype)
+            fetch_op = TensorFetch(dtype=c.dtype, sparse=c.op.sparse)
             fetch_chunk = fetch_op.new_chunk(None, c.shape, c.index, _key=c.key)
             chunks.append(fetch_chunk)
 
-        new_op = TensorFetch(dtype=tiled_tensor.dtype)
+        new_op = TensorFetch(dtype=tiled_tensor.dtype, sparse=tiled_tensor.op.sparse)
         new_tensor = new_op.new_tensor(None, tiled_tensor.shape, chunks=chunks,
                                        nsplits=tiled_tensor.nsplits, _key=tiled_tensor.key)
         graph.add_node(new_tensor)

--- a/mars/tensor/expressions/fetch/core.py
+++ b/mars/tensor/expressions/fetch/core.py
@@ -31,9 +31,9 @@ class TensorFetchMixin(TensorOperandMixin):
 
 
 class TensorFetch(Fetch, TensorFetchMixin):
-    def __init__(self, dtype=None, to_fetch_key=None, **kw):
+    def __init__(self, dtype=None, to_fetch_key=None, sparse=False, **kw):
         super(TensorFetch, self).__init__(
-            _dtype=dtype, _to_fetch_key=to_fetch_key, **kw)
+            _dtype=dtype, _to_fetch_key=to_fetch_key, _sparse=sparse, **kw)
 
     def _new_chunks(self, inputs, shape, index=None, output_limit=None, kws=None, **kw):
         if '_key' in kw and self._to_fetch_key is None:

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -465,11 +465,11 @@ def convert_to_fetch(entity):
     from .fetch import TensorFetch
 
     if isinstance(entity, CHUNK_TYPE):
-        new_op = TensorFetch(dtype=entity.dtype)
+        new_op = TensorFetch(dtype=entity.dtype, sparse=entity.op.sparse)
         return new_op.new_chunk(None, entity.shape, index=entity.index,
                                 _key=entity.key, _id=entity.id)
     elif isinstance(entity, TENSOR_TYPE):
-        new_op = TensorFetch(dtype=entity.dtype)
+        new_op = TensorFetch(dtype=entity.dtype, sparse=entity.op.sparse)
         return new_op.new_tensor(None, entity.shape, _key=entity.key, _id=entity.id)
     else:
         raise ValueError('Now only support tensor or chunk type.')

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -245,11 +245,11 @@ def merge_tensor_chunks(input_tensor, ctx):
 
     chunks = []
     for c in input_tensor.chunks:
-        op = TensorFetch(dtype=c.dtype)
+        op = TensorFetch(dtype=c.dtype, sparse=c.op.sparse)
         chunk = op.new_chunk(None, c.shape, index=c.index, _key=c.key)
         chunks.append(chunk)
 
-    new_op = TensorFetch(dtype=input_tensor.dtype)
+    new_op = TensorFetch(dtype=input_tensor.dtype, sparse=input_tensor.op.sparse)
     tensor = new_op.new_tensor(None, input_tensor.shape, chunks=chunks,
                                nsplits=input_tensor.nsplits)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Pass sparse parameter when create fetch operand and skip the fetch chunk when estimate the needed memory size.

<!-- Please give a short brief about these changes. -->

## Related issue number
fixes #276 

<!-- Are there any issues opened that will be resolved by merging this change? -->
