### PR TITLE
Use new allocation strategy to circumvent inflating granularity in arrow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -22,7 +22,6 @@ omit =
 [report]
 exclude_lines =
     pragma: no cover
-    pass
     cdef public
     cpdef public
     def __repr__

--- a/.coveragerc-tensor
+++ b/.coveragerc-tensor
@@ -25,7 +25,6 @@ omit =
 [report]
 exclude_lines =
     pragma: no cover
-    pass
     cdef public
     cpdef public
     def __repr__

--- a/mars/errors.py
+++ b/mars/errors.py
@@ -91,7 +91,7 @@ class PromiseTimeout(MarsError):
     pass
 
 
-class SpillExhausted(MarsError):
+class NoDataToSpill(MarsError):
     pass
 
 

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -603,7 +603,13 @@ def ignore(*_):
 
 
 def default_size_estimator(ctx, chunk, multiplier=1):
-    exec_size = int(sum(ctx[inp.key][0] for inp in chunk.inputs or ()) * multiplier)
+    exec_size = 0
+    for inp in chunk.inputs or ():
+        if chunk.is_sparse() or np.isnan(inp.nbytes):
+            exec_size += ctx[inp.key][0]
+        else:
+            exec_size += inp.nbytes
+    exec_size = int(exec_size * multiplier)
 
     total_out_size = 0
     chunk_sizes = dict()

--- a/mars/promise.py
+++ b/mars/promise.py
@@ -368,20 +368,24 @@ class PromiseActor(FunctionActor):
         del self._promises[promise_id]
         del self._promise_ref_keys[promise_id]
 
-    def reject_promise_ref(self, ref, *args, **kwargs):
+    def reject_promise_refs(self, refs, *args, **kwargs):
         """
         Reject all promises related to given actor ref
-        :param ref: actor ref to reject
+        :param refs: actor refs to reject
         """
         kwargs['_accept'] = False
-        ref_key = (ref.uid, ref.address)
-        if ref_key not in self._ref_key_promises:
-            return
-        for promise_id in list(self._ref_key_promises[ref_key]):
-            p = self.get_promise(promise_id)
-            if p is None:
+        handled_refs = []
+        for ref in refs:
+            ref_key = (ref.uid, ref.address)
+            if ref_key not in self._ref_key_promises:
                 continue
-            p.step_next(*args, **kwargs)
+            handled_refs.append(ref)
+            for promise_id in list(self._ref_key_promises[ref_key]):
+                p = self.get_promise(promise_id)
+                if p is None:
+                    continue
+                p.step_next(*args, **kwargs)
+        return handled_refs
 
     def tell_promise(self, callback, *args, **kwargs):
         """

--- a/mars/tensor/execution/linalg.py
+++ b/mars/tensor/execution/linalg.py
@@ -122,6 +122,13 @@ def _tensordot(ctx, chunk):
             ctx[chunk.key] = xp.tensordot(a, b, axes)
 
 
+def _tensordot_estimate_size(ctx, chunk):
+    if chunk.is_sparse():
+        raise NotImplementedError
+    # empirical value in real environments
+    ctx[chunk.key] = (chunk.nbytes, int(chunk.nbytes * 2.5))
+
+
 def _dot(ctx, chunk):
     (a, b), device_id, xp = as_same_device(
         [ctx[c.key] for c in chunk.inputs], device=chunk.device, ret_extra=True)
@@ -157,6 +164,6 @@ def register_linalg_handler():
     register(SolveTriangular, _solve_triangular)
     register(LU, _lu)
     register(Norm, _norm)
-    register(TensorDot, _tensordot)
+    register(TensorDot, _tensordot, _tensordot_estimate_size)
     register(Dot, _dot)
     register(Matmul, _matmul)

--- a/mars/tests/test_promise.py
+++ b/mars/tests/test_promise.py
@@ -138,7 +138,7 @@ class PromiseTestActor(promise.PromiseActor):
         ref.serve(0, delay=2, _promise=True) \
             .catch(_rejecter) \
             .then(lambda *_: setattr(self, '_finished', True))
-        self.reject_promise_ref(ref, *exc_info)
+        self.reject_promise_refs([ref], *exc_info)
 
 
 def _raise_exception(exc):

--- a/mars/worker/chunkholder.py
+++ b/mars/worker/chunkholder.py
@@ -82,7 +82,7 @@ class ChunkHolderActor(WorkerActor):
         super(ChunkHolderActor, self).post_create()
         self._dispatch_ref = self.promise_ref(DispatchActor.default_name())
 
-        self._plasma_limit = self._chunk_store.get_actual_capacity()
+        self._plasma_limit = self._chunk_store.get_actual_capacity(self._plasma_limit)
         logger.info('Detected actual plasma store size: %s', readable_size(self._plasma_limit))
         self._total_size = self._plasma_limit
         parse_num, is_percent = parse_memory_limit(options.worker.min_spill_size)

--- a/mars/worker/taskqueue.py
+++ b/mars/worker/taskqueue.py
@@ -256,8 +256,8 @@ class TaskQueueAllocatorActor(WorkerActor):
 
             # obtain quota sizes for operands
             quota_request = self._execution_ref.prepare_quota_request(item.session_id, item.op_key)
-            logger.debug('Quota request for %s in %s: %r', item.op_key, self.address, quota_request)
             if quota_request:
+                logger.debug('Quota request for %s in %s: %r', item.op_key, self.address, quota_request)
                 local_cb = ((self._queue_ref.uid, self._queue_ref.address),
                             TaskQueueActor.handle_allocated.__name__,
                             item.session_id, item.op_key, item.callback)

--- a/mars/worker/tests/test_chunkholder.py
+++ b/mars/worker/tests/test_chunkholder.py
@@ -21,7 +21,7 @@ from mars.compat import six
 from mars.config import options
 from mars.utils import get_next_port, calc_data_size
 from mars import promise
-from mars.errors import StoreFull, SpillExhausted
+from mars.errors import StoreFull, NoDataToSpill
 from mars.cluster_info import ClusterInfoActor
 from mars.scheduler.kvstore import KVStoreActor
 from mars.tests.core import patch_method
@@ -51,7 +51,7 @@ class CacheTestActor(WorkerActor):
 
         def _put_chunk(data_key, data, *_):
             def _handle_reject(*exc):
-                if issubclass(exc[0], SpillExhausted):
+                if issubclass(exc[0], NoDataToSpill):
                     return
                 six.reraise(*exc)
 

--- a/mars/worker/tests/test_daemon.py
+++ b/mars/worker/tests/test_daemon.py
@@ -65,8 +65,7 @@ class DaemonTestActor(WorkerActor):
         except WorkerProcessStopped:
             exc_info = sys.exc_info()
 
-        for ref in halt_refs:
-            self.reject_promise_ref(ref, *exc_info)
+        self.reject_promise_refs(halt_refs, *exc_info)
 
 
 class Test(WorkerCase):


### PR DESCRIPTION
## What do these changes do?

Given the implementation of allocating mmap in Apache Arrow, as is listed below,

https://github.com/apache/arrow/blob/7ddad36e0fd3707f0a893bbfda3e2f9149909708/cpp/src/plasma/malloc.cc#L163

the granularity when allocating mmap files are multiplied by 2 every time when data chunk is allocated. This behavior limit the total amount of memory plasma store can allocate when checked by original version of ``get_actual_capacity``, which allocates memory by 4MB block. To reduce the influence of this behavior, the new version of ``get_actual_capacity`` first tries to allocate 90% of the requested size, then allocates the rest part in an iterative manner. Test results show that the new strategy can effectively enlarge the size of allocated cache memory.

## Related issue number

Fixes #286 
