### PR TITLE
Support execute graph without fusion

### DIFF
--- a/mars/api.py
+++ b/mars/api.py
@@ -56,10 +56,10 @@ class MarsAPI(object):
     def delete_session(self, session_id):
         self.session_manager.delete_session(session_id)
 
-    def submit_graph(self, session_id, serialized_graph, graph_key, target):
+    def submit_graph(self, session_id, serialized_graph, graph_key, target, compose=True):
         session_uid = SessionActor.gen_name(session_id)
         session_ref = self.get_actor_ref(session_uid)
-        session_ref.submit_tensor_graph(serialized_graph, graph_key, target, _tell=True)
+        session_ref.submit_tensor_graph(serialized_graph, graph_key, target, compose=compose, _tell=True)
 
     def delete_graph(self, session_id, graph_key):
         graph_uid = GraphActor.gen_name(session_id, graph_key)

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -67,6 +67,7 @@ class LocalClusterSession(object):
     def run(self, *tensors, **kw):
         timeout = kw.pop('timeout', -1)
         fetch = kw.pop('fetch', True)
+        compose = kw.pop('compose', True)
         if kw:
             raise TypeError('run got unexpected key arguments {0}'.format(', '.join(kw.keys())))
 
@@ -79,7 +80,7 @@ class LocalClusterSession(object):
 
         # submit graph to local cluster
         self._api.submit_graph(self._session_id, json.dumps(graph.to_json()),
-                               graph_key, targets)
+                               graph_key, targets, compose=compose)
 
         exec_start_time = time.time()
         while timeout <= 0 or time.time() - exec_start_time <= timeout:

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -443,7 +443,7 @@ class Test(unittest.TestCase):
         import scipy.sparse as sps
 
         with new_cluster(scheduler_n_process=2, worker_n_process=2,
-                         shared_memory='20M', web=True) as cluster:
+                         shared_memory='20M', web=False) as cluster:
             session = cluster.session
 
             # calculate sparse with no element in matrix
@@ -452,3 +452,14 @@ class Test(unittest.TestCase):
             t1 = mt.tensor(a)
             t2 = mt.tensor(b)
             session.run(t1 * t2)
+
+    def testRunWithoutCompose(self):
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M', web=False) as cluster:
+            session = cluster.session
+
+            arr1 = (mt.ones((10, 10), chunk_size=3) + 1) * 2
+            r1 = session.run(arr1)
+            arr2 = (mt.ones((10, 10), chunk_size=4) + 1) * 2
+            r2 = session.run(arr2, compose=False)
+            np.testing.assert_array_equal(r1, r2)

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -474,7 +474,7 @@ class Executor(object):
 
     @kernel_mode
     def execute_tensors(self, tensors, fetch=True, n_parallel=None, n_thread=None,
-                        print_progress=False, mock=False, sparse_mock_percent=1.0):
+                        print_progress=False, mock=False, compose=True, sparse_mock_percent=1.0):
         graph = DirectedGraph()
 
         result_keys = []
@@ -508,7 +508,8 @@ class Executor(object):
             else:
                 concat_keys.append(tensor.chunks[0].key)
 
-            tensor.build_graph(graph=graph, tiled=True, executed_keys=list(self._chunk_result.keys()))
+            tensor.build_graph(graph=graph, tiled=True, compose=compose,
+                               executed_keys=list(self._chunk_result.keys()))
 
         self.execute_graph(graph, result_keys, n_parallel=n_parallel or n_thread,
                            print_progress=print_progress, mock=mock,

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -246,7 +246,7 @@ class GraphActor(SchedulerActor):
         self._graph_meta_ref.set_final_state(value, _tell=True)
 
     @log_unhandled
-    def execute_graph(self):
+    def execute_graph(self, compose=True):
         """
         Start graph execution
         """
@@ -264,7 +264,7 @@ class GraphActor(SchedulerActor):
         self.state = GraphState.PREPARING
 
         try:
-            self.prepare_graph()
+            self.prepare_graph(compose=compose)
             _detect_cancel()
 
             with self._open_dump_file('graph') as outf:  # pragma: no cover

--- a/mars/scheduler/session.py
+++ b/mars/scheduler/session.py
@@ -58,14 +58,14 @@ class SessionActor(SchedulerActor):
             self.ctx.destroy_actor(graph_ref)
 
     @log_unhandled
-    def submit_tensor_graph(self, serialized_graph, graph_key, target_tensors=None):
+    def submit_tensor_graph(self, serialized_graph, graph_key, target_tensors=None, compose=True):
         from .graph import GraphActor
 
         graph_uid = GraphActor.gen_name(self._session_id, graph_key)
         graph_ref = self.ctx.create_actor(GraphActor, self._session_id, graph_key,
                                           serialized_graph, target_tensors=target_tensors,
                                           uid=graph_uid, address=self.get_scheduler(graph_uid))
-        graph_ref.execute_graph(_tell=True)
+        graph_ref.execute_graph(_tell=True, compose=compose)
         self._graph_refs[graph_key] = graph_ref
         for tensor_key in target_tensors or ():
             if tensor_key not in self._tensor_to_graph:

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -263,3 +263,12 @@ class Test(unittest.TestCase):
         self.assertEqual(len(executor.chunk_result), 4)
         del arr2
         self.assertEqual(len(executor.chunk_result), 0)
+
+    def testWithoutCompose(self):
+        sess = new_session()
+
+        arr1 = (mt.ones((10, 10), chunk_size=3) + 1) * 2
+        r1 = sess.run(arr1)
+        arr2 = (mt.ones((10, 10), chunk_size=4) + 1) * 2
+        r2 = sess.run(arr2, compose=False)
+        np.testing.assert_array_equal(r1, r2)

--- a/mars/web/api.py
+++ b/mars/web/api.py
@@ -50,6 +50,7 @@ if six.PY2:  # pragma: no cover
 
 class ApiRequestHandler(web.RequestHandler):
     def initialize(self, scheduler_ip):
+        self.set_header("Content-Type", "text/plain")
         self._scheduler = scheduler_ip
         self.web_api = MarsWebAPI(scheduler_ip)
 
@@ -92,13 +93,14 @@ class GraphsApiHandler(ApiRequestHandler):
         try:
             graph = self.get_argument('graph')
             target = self.get_argument('target').split(',')
+            compose = self.get_argument('compose', True)
         except web.MissingArgumentError as ex:
             self.write(json.dumps(dict(msg=str(ex))))
             raise web.HTTPError(400, 'Argument missing')
 
         try:
             graph_key = str(uuid.uuid4())
-            self.web_api.submit_graph(session_id, graph, graph_key, target)
+            self.web_api.submit_graph(session_id, graph, graph_key, target, compose)
             self.write(json.dumps(dict(graph_key=graph_key)))
         except:  # noqa: E722
             self._dump_exception(sys.exc_info())


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Users can submit tensors with specify `compose=False` to run without fusion, including distributed mode and local mode.

## Related issue number
resolve #290 
<!-- Are there any issues opened that will be resolved by merging this change? -->
