### PR TITLE
Support arithmetic operators on only nonzero elements in a sparse matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,8 @@ install:
     fi
   - pip install -r requirements-dev.txt &&
     pip install -r requirements-extra.txt &&
-    pip install virtualenv coveralls flake8 etcd-gevent tiledb
+    pip install virtualenv coveralls flake8 etcd-gevent
+  - PYTHONHTTPSVERIFY=0 pip install tiledb  # workaround for tiledb ssl error
   - virtualenv testenv && source testenv/bin/activate
   - pip install -r requirements.txt && pip install pytest pytest-timeout
   - if [ -z "$DEFAULT_VENV" ]; then deactivate; else source $DEFAULT_VENV/bin/activate; fi

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,8 @@ Mars
 
 Mars is a tensor-based unified framework for large-scale data computation.
 
+See documentation for more information: https://docs.mars-project.io
+
 Installation
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,7 @@ Mars
 
 |PyPI version| |Docs| |Build| |Coverage| |Quality| |License|
 
-Mars is a tensor-based unified framework for large-scale data computation.
-
-See documentation for more information: https://docs.mars-project.io
+Mars is a tensor-based unified framework for large-scale data computation. `Documentation`_.
 
 Installation
 ------------
@@ -231,9 +229,10 @@ Thank you in advance for your contributions!
 .. |PyPI version| image:: https://img.shields.io/pypi/v/pymars.svg?style=flat-square
    :target: https://pypi.python.org/pypi/pymars
 .. |Docs| image:: https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat-square
-   :target: http://mars-project.readthedocs.org/
+   :target: `Documentation`_
 .. |License| image:: https://img.shields.io/pypi/l/pymars.svg?style=flat-square
    :target: https://github.com/mars-project/mars/blob/master/LICENSE
 .. _`mars-dev@googlegroups.com`: https://groups.google.com/forum/#!forum/mars-dev
 .. _`GitHub issue`: https://github.com/mars-project/mars/issues
 .. _`pull requests`: https://github.com/mars-project/mars/pulls
+.. _`Documentation`: https://docs.mars-project.io

--- a/mars/lib/sparse/__init__.py
+++ b/mars/lib/sparse/__init__.py
@@ -461,10 +461,6 @@ def matmul(a, b, sparse=True, **_):
 
 
 def concatenate(tensors, axis=0):
-    has_sparse = any(issparse(t) for t in tensors)
-    if has_sparse:
-        tensors = [asarray(get_sparse_module(t).csr_matrix(t), t.shape) for t in tensors]
-
     return reduce(lambda a, b: _call_bin('concatenate', a, b, axis=axis), tensors)
 
 

--- a/mars/lib/sparse/__init__.py
+++ b/mars/lib/sparse/__init__.py
@@ -109,9 +109,12 @@ def mod(a, b, **_):
 
 def _call_bin(method, a, b, **kwargs):
     from .core import get_array_module, cp, issparse
+    from .array import call_sparse_binary_scalar
 
     if hasattr(a, method):
         res = getattr(a, method)(b, **kwargs)
+    elif get_array_module(a).isscalar(a):
+        res = call_sparse_binary_scalar(method, a, b, **kwargs)
     else:
         assert get_array_module(a) == get_array_module(b)
         xp = get_array_module(a)

--- a/mars/lib/sparse/array.py
+++ b/mars/lib/sparse/array.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .core import issparse
+from .core import issparse, get_array_module, get_sparse_module
 
 
 class SparseNDArray(object):
@@ -40,3 +40,29 @@ class SparseNDArray(object):
     @property
     def raw(self):
         raise NotImplementedError
+
+
+def call_sparse_binary_scalar(method, left, right, **kwargs):
+    if isinstance(left, SparseNDArray):
+        spmatrix = left.spmatrix
+        xp = get_array_module(spmatrix)
+        new_data = getattr(xp, method)(spmatrix.data, right, **kwargs)
+        shape = left.shape
+    else:
+        spmatrix = right.spmatrix
+        xp = get_array_module(spmatrix)
+        new_data = getattr(xp, method)(left, spmatrix.data, **kwargs)
+        shape = right.shape
+    new_spmatrix = get_sparse_module(spmatrix).csr_matrix(
+        (new_data, spmatrix.indices, spmatrix.indptr), spmatrix.shape)
+    return SparseNDArray(new_spmatrix, shape=shape)
+
+
+def call_sparse_unary(method, matrix, *args, **kwargs):
+    spmatrix = matrix.spmatrix
+    xp = get_array_module(spmatrix)
+    new_data = getattr(xp, method)(spmatrix.data, *args, **kwargs)
+    new_spmatrix = get_sparse_module(spmatrix).csr_matrix(
+        (new_data, spmatrix.indices, spmatrix.indptr), spmatrix.shape)
+    return SparseNDArray(new_spmatrix, shape=matrix.shape)
+

--- a/mars/lib/sparse/array.py
+++ b/mars/lib/sparse/array.py
@@ -65,4 +65,3 @@ def call_sparse_unary(method, matrix, *args, **kwargs):
     new_spmatrix = get_sparse_module(spmatrix).csr_matrix(
         (new_data, spmatrix.indices, spmatrix.indptr), spmatrix.shape)
     return SparseNDArray(new_spmatrix, shape=matrix.shape)
-

--- a/mars/lib/sparse/tests/test_sparse.py
+++ b/mars/lib/sparse/tests/test_sparse.py
@@ -184,7 +184,8 @@ class Test(TestBase):
                        'sign', 'conj', 'exp', 'exp2', 'log', 'log2', 'log10',
                        'expm1', 'log1p', 'sqrt', 'square', 'cbrt', 'reciprocal',
                        'sin', 'cos', 'tan', 'arcsin', 'arccos', 'arctan',
-                       'arcsinh', 'arccosh', 'arctanh', 'deg2rad', 'rad2deg', 'angle'):
+                       'arcsinh', 'arccosh', 'arctanh', 'deg2rad', 'rad2deg',
+                       'angle', 'isnan', 'isinf', 'signbit', 'sinc', 'isreal', 'isfinite'):
             lm, rm = getattr(mls, method), getattr(np, method)
             r = sps.csr_matrix((rm(self.s1.data), self.s1.indices, self.s1.indptr), self.s1.shape)
             self.assertArrayEqual(lm(s1), r)

--- a/mars/lib/sparse/tests/test_sparse.py
+++ b/mars/lib/sparse/tests/test_sparse.py
@@ -75,14 +75,20 @@ class Test(TestBase):
         self.assertArrayEqual(s1 + s2, self.s1 + self.s2)
         self.assertArrayEqual(s1 + self.d1, self.s1 + self.d1)
         self.assertArrayEqual(self.d1 + s1, self.d1 + self.s1)
-        self.assertArrayEqual(s1 + 1, self.s1.toarray() + 1)
-        self.assertArrayEqual(1 + s1, self.s1.toarray() + 1)
+        r = sps.csr_matrix(((self.s1.data + 1), self.s1.indices, self.s1.indptr), self.s1.shape)
+        self.assertArrayEqual(s1 + 1, r)
+        r = sps.csr_matrix(((1 + self.s1.data), self.s1.indices, self.s1.indptr), self.s1.shape)
+        self.assertArrayEqual(1 + s1, r)
 
         # test sparse vector
         v = SparseNDArray(self.v1, shape=(3,))
         self.assertArrayEqual(v + v, self.v1_data + self.v1_data)
         self.assertArrayEqual(v + self.d1, self.v1_data + self.d1)
         self.assertArrayEqual(self.d1 + v, self.d1 + self.v1_data)
+        r = sps.csr_matrix(((self.v1.data + 1), self.v1.indices, self.v1.indptr), self.v1.shape)
+        self.assertArrayEqual(v + 1, r.toarray().reshape(3))
+        r = sps.csr_matrix(((1 + self.v1.data), self.v1.indices, self.v1.indptr), self.v1.shape)
+        self.assertArrayEqual(1 + v, r.toarray().reshape(3))
 
     def testSparseSubtract(self):
         s1 = SparseNDArray(self.s1)
@@ -91,14 +97,20 @@ class Test(TestBase):
         self.assertArrayEqual(s1 - s2, self.s1 - self.s2)
         self.assertArrayEqual(s1 - self.d1, self.s1 - self.d1)
         self.assertArrayEqual(self.d1 - s1, self.d1 - self.s1)
-        self.assertArrayEqual(s1 - 1, self.s1.toarray() - 1)
-        self.assertArrayEqual(1 - s1, 1 - self.s1.toarray())
+        r = sps.csr_matrix(((self.s1.data - 1), self.s1.indices, self.s1.indptr), self.s1.shape)
+        self.assertArrayEqual(s1 - 1, r)
+        r = sps.csr_matrix(((1 - self.s1.data), self.s1.indices, self.s1.indptr), self.s1.shape)
+        self.assertArrayEqual(1 - s1, r)
 
         # test sparse vector
         v = SparseNDArray(self.v1, shape=(3,))
         self.assertArrayEqual(v - v, self.v1_data - self.v1_data)
         self.assertArrayEqual(v - self.d1, self.v1_data - self.d1)
         self.assertArrayEqual(self.d1 - v, self.d1 - self.v1_data)
+        r = sps.csr_matrix(((self.v1.data - 1), self.v1.indices, self.v1.indptr), self.v1.shape)
+        self.assertArrayEqual(v - 1, r.toarray().reshape(3))
+        r = sps.csr_matrix(((1 - self.v1.data), self.v1.indices, self.v1.indptr), self.v1.shape)
+        self.assertArrayEqual(1 - v, r.toarray().reshape(3))
 
     def testSparseMultiply(self):
         s1 = SparseNDArray(self.s1)
@@ -155,13 +167,15 @@ class Test(TestBase):
         s2 = SparseNDArray(self.s2)
 
         for method in ('fmod', 'logaddexp', 'logaddexp2', 'equal', 'not_equal',
-                       'less', 'less_equal', 'greater', 'greater_equal', 'hypot'):
+                       'less', 'less_equal', 'greater', 'greater_equal', 'hypot', 'arctan2'):
             lm, rm = getattr(mls, method), getattr(np, method)
             self.assertArrayEqual(lm(s1, s2), rm(self.s1.toarray(), self.s2.toarray()))
             self.assertArrayEqual(lm(s1, self.d1), rm(self.s1.toarray(), self.d1))
             self.assertArrayEqual(lm(self.d1, s1), rm(self.d1, self.s1.toarray()))
-            self.assertArrayEqual(lm(s1, 2), rm(self.s1.toarray(), 2))
-            self.assertArrayEqual(lm(2, s1), rm(2, self.s1.toarray()))
+            r1 = sps.csr_matrix((rm(self.s1.data, 2), self.s1.indices, self.s1.indptr), self.s1.shape)
+            self.assertArrayEqual(lm(s1, 2), r1)
+            r2 = sps.csr_matrix((rm(2, self.s1.data), self.s1.indices, self.s1.indptr), self.s1.shape)
+            self.assertArrayEqual(lm(2, s1), r2)
 
     def testSparseUnary(self):
         s1 = SparseNDArray(self.s1)
@@ -170,9 +184,10 @@ class Test(TestBase):
                        'sign', 'conj', 'exp', 'exp2', 'log', 'log2', 'log10',
                        'expm1', 'log1p', 'sqrt', 'square', 'cbrt', 'reciprocal',
                        'sin', 'cos', 'tan', 'arcsin', 'arccos', 'arctan',
-                       'arcsinh', 'arccosh', 'arctanh', 'deg2rad', 'rad2deg'):
+                       'arcsinh', 'arccosh', 'arctanh', 'deg2rad', 'rad2deg', 'angle'):
             lm, rm = getattr(mls, method), getattr(np, method)
-            self.assertArrayEqual(lm(s1), rm(self.s1.toarray()))
+            r = sps.csr_matrix((rm(self.s1.data), self.s1.indices, self.s1.indptr), self.s1.shape)
+            self.assertArrayEqual(lm(s1), r)
 
     def testSparseDot(self):
         s1 = SparseNDArray(self.s1)
@@ -202,6 +217,7 @@ class Test(TestBase):
         s1 = SparseNDArray(self.s1)
         self.assertEqual(s1.sum(), self.s1.sum())
         np.testing.assert_array_equal(s1.sum(axis=1), np.asarray(self.s1.sum(axis=1)).reshape(2))
+        np.testing.assert_array_equal(s1.sum(axis=0), np.asarray(self.s1.sum(axis=0)).reshape(3))
 
     @unittest.skip
     def testSparseGetitem(self):

--- a/mars/lib/sparse/vector.py
+++ b/mars/lib/sparse/vector.py
@@ -180,6 +180,9 @@ class SparseVector(SparseNDArray):
         return get_array_module(x).asarray(x)
 
     def concatenate(self, other, axis=0):
+        if other.ndim != 1:
+            raise ValueError('all the input arrays must have same number of dimensions')
+
         try:
             other = naked(other)
         except TypeError:
@@ -189,7 +192,8 @@ class SparseVector(SparseNDArray):
             xps = get_sparse_module(self.spmatrix)
             if axis != 0:
                 raise ValueError('axis can only be 0')
-            x = xps.hstack((self.spmatrix, other))
+            other = other.reshape(1, other.shape[0]) if other.shape[0] != 1 else other
+            x = xps.hstack((self.spmatrix.reshape(1, self.shape[0]), other))
         else:
             xp = get_array_module(self.spmatrix)
             x = xp.concatenate((self.spmatrix.toarray().reshape(self.shape), other), axis=axis)

--- a/mars/lib/sparse/vector.py
+++ b/mars/lib/sparse/vector.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .array import SparseNDArray
+from .array import SparseNDArray, call_sparse_binary_scalar
 from .core import get_array_module, get_sparse_module, cp, cps, naked, issparse
 
 
@@ -34,6 +34,8 @@ class SparseVector(SparseNDArray):
             other = naked(other)
         except TypeError:
             return NotImplemented
+        if get_array_module(other).isscalar(other):
+            return call_sparse_binary_scalar('add', self, other)
         if issparse(other):
             x = self.spmatrix + other.reshape(self.spmatrix.shape)
         else:
@@ -48,6 +50,8 @@ class SparseVector(SparseNDArray):
         except TypeError:
             return NotImplemented
 
+        if get_array_module(other).isscalar(other):
+            return call_sparse_binary_scalar('add', other, self)
         x = other + self.toarray()
         if issparse(x):
             return SparseVector(x, shape=self.shape)
@@ -58,6 +62,9 @@ class SparseVector(SparseNDArray):
             other = naked(other)
         except TypeError:
             return NotImplemented
+
+        if get_array_module(other).isscalar(other):
+            return call_sparse_binary_scalar('subtract', self, other)
         if issparse(other):
             x = self.spmatrix - other.reshape(self.spmatrix.shape)
         else:
@@ -72,6 +79,8 @@ class SparseVector(SparseNDArray):
         except TypeError:
             return NotImplemented
 
+        if get_array_module(other).isscalar(other):
+            return call_sparse_binary_scalar('subtract', other, self)
         x = other - self.toarray()
         if issparse(x):
             return SparseVector(x, shape=self.shape)

--- a/mars/tensor/execution/reduction.py
+++ b/mars/tensor/execution/reduction.py
@@ -16,6 +16,7 @@
 
 from functools import wraps
 from math import factorial
+import operator
 try:
     from collections.abc import Container, Iterable, Sequence
 except ImportError:  # pragma: no cover
@@ -23,7 +24,7 @@ except ImportError:  # pragma: no cover
 
 import numpy as np
 
-from ...compat import getargspec, numpy_compat
+from ...compat import getargspec, numpy_compat, reduce
 from ...operands import Mean
 from .array import get_array_module, as_same_device, device, cp
 
@@ -282,8 +283,9 @@ def _numel(x, **kwargs):
 
 
 def _nannumel(x, **kwargs):
+    x_size = reduce(operator.mul, x.shape)
     xp = get_array_module(x)
-    return sum(~xp.isnan(x), **kwargs)
+    return x_size - sum(xp.isnan(x), **kwargs)
 
 
 def _nanargmin(x, **kwargs):

--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -674,6 +674,8 @@ class Test(unittest.TestCase):
         np.testing.assert_array_equal(res, np.ones((100, 100)) * 100)
 
     def testSparseDotExecution(self):
+        size_executor = Executor(sync_provider_type=Executor.SyncProviderType.MOCK)
+
         a_data = sps.random(5, 9, density=.1)
         b_data = sps.random(9, 10, density=.2)
         a = tensor(a_data, chunk_size=2)
@@ -681,7 +683,9 @@ class Test(unittest.TestCase):
 
         c = dot(a, b)
 
+        size_res = size_executor.execute_tensor(c, mock=True)
         res = self.executor.execute_tensor(c, concat=True)[0]
+        self.assertEqual(sum(s[0] for s in size_res), 0)
         self.assertTrue(issparse(res))
         np.testing.assert_allclose(res.toarray(), a_data.dot(b_data).toarray())
 

--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -674,8 +674,6 @@ class Test(unittest.TestCase):
         np.testing.assert_array_equal(res, np.ones((100, 100)) * 100)
 
     def testSparseDotExecution(self):
-        size_executor = Executor(sync_provider_type=Executor.SyncProviderType.MOCK)
-
         a_data = sps.random(5, 9, density=.1)
         b_data = sps.random(9, 10, density=.2)
         a = tensor(a_data, chunk_size=2)
@@ -683,9 +681,7 @@ class Test(unittest.TestCase):
 
         c = dot(a, b)
 
-        size_res = size_executor.execute_tensor(c, mock=True)
         res = self.executor.execute_tensor(c, concat=True)[0]
-        self.assertGreater(sum(s[0] for s in size_res), 0)
         self.assertTrue(issparse(res))
         np.testing.assert_allclose(res.toarray(), a_data.dot(b_data).toarray())
 

--- a/mars/tensor/expressions/arithmetic/add.py
+++ b/mars/tensor/expressions/arithmetic/add.py
@@ -29,7 +29,7 @@ class TensorAdd(operands.Add, TensorBinOp):
         return TensorAddConstant
 
 
-@arithmetic_operand(sparse_mode='binary_and_const')
+@arithmetic_operand(sparse_mode='binary_or_const')
 class TensorAddConstant(operands.AddConstant, TensorConstant):
     pass
 

--- a/mars/tensor/expressions/arithmetic/arccos.py
+++ b/mars/tensor/expressions/arithmetic/arccos.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorArccos(operands.Arccos, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/arccosh.py
+++ b/mars/tensor/expressions/arithmetic/arccosh.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorArccosh(operands.Arccosh, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/copysign.py
+++ b/mars/tensor/expressions/arithmetic/copysign.py
@@ -29,7 +29,7 @@ class TensorCopysign(operands.Copysign, TensorBinOp):
         return TensorCopysignConstant
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='binary_or_const')
 class TensorCopysignConstant(operands.CopysignConstant, TensorConstant):
     pass
 

--- a/mars/tensor/expressions/arithmetic/cos.py
+++ b/mars/tensor/expressions/arithmetic/cos.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorCos(operands.Cos, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/cosh.py
+++ b/mars/tensor/expressions/arithmetic/cosh.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorCosh(operands.Cosh, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/exp.py
+++ b/mars/tensor/expressions/arithmetic/exp.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorExp(operands.Exp, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/exp2.py
+++ b/mars/tensor/expressions/arithmetic/exp2.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorExp2(operands.Exp2, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/expm1.py
+++ b/mars/tensor/expressions/arithmetic/expm1.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorExpm1(operands.Expm1, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/floordiv.py
+++ b/mars/tensor/expressions/arithmetic/floordiv.py
@@ -29,7 +29,7 @@ class TensorFloorDiv(operands.FloorDiv, TensorBinOp):
         return TensorFDivConstant
 
 
-@arithmetic_operand
+@arithmetic_operand(sparse_mode='binary_or_const')
 class TensorFDivConstant(operands.FDivConstant, TensorConstant):
     @classmethod
     def _is_sparse(cls, x1, x2):

--- a/mars/tensor/expressions/arithmetic/hypot.py
+++ b/mars/tensor/expressions/arithmetic/hypot.py
@@ -29,7 +29,7 @@ class TensorHypot(operands.Hypot, TensorBinOp):
         return TensorHypotConstant
 
 
-@arithmetic_operand(sparse_mode='binary_and_const')
+@arithmetic_operand(sparse_mode='binary_or_const')
 class TensorHypotConstant(operands.HypotConstant, TensorConstant):
     pass
 

--- a/mars/tensor/expressions/arithmetic/invert.py
+++ b/mars/tensor/expressions/arithmetic/invert.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorInvert(operands.Invert, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/isfinite.py
+++ b/mars/tensor/expressions/arithmetic/isfinite.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorIsFinite(operands.IsFinite, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/isreal.py
+++ b/mars/tensor/expressions/arithmetic/isreal.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorIsReal(operands.IsReal, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/log.py
+++ b/mars/tensor/expressions/arithmetic/log.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorLog(operands.Log, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/log10.py
+++ b/mars/tensor/expressions/arithmetic/log10.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorLog10(operands.Log10, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/log2.py
+++ b/mars/tensor/expressions/arithmetic/log2.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorLog2(operands.Log2, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/logaddexp.py
+++ b/mars/tensor/expressions/arithmetic/logaddexp.py
@@ -29,7 +29,7 @@ class TensorLogAddExp(operands.LogAddExp, TensorBinOp):
         return TensorLAEConstant
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='binary_or_const')
 class TensorLAEConstant(operands.LAEConstant, TensorConstant):
     pass
 

--- a/mars/tensor/expressions/arithmetic/logaddexp2.py
+++ b/mars/tensor/expressions/arithmetic/logaddexp2.py
@@ -29,7 +29,7 @@ class TensorLogAddExp2(operands.LogAddExp2, TensorBinOp):
         return TensorLAE2Constant
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='binary_or_const')
 class TensorLAE2Constant(operands.LAE2Constant, TensorConstant):
     pass
 

--- a/mars/tensor/expressions/arithmetic/logical_not.py
+++ b/mars/tensor/expressions/arithmetic/logical_not.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorNot(operands.Not, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/logical_or.py
+++ b/mars/tensor/expressions/arithmetic/logical_or.py
@@ -29,7 +29,7 @@ class TensorOr(operands.Or, TensorBinOp):
         return TensorOrConstant
 
 
-@arithmetic_operand(sparse_mode='binary_and_const')
+@arithmetic_operand(sparse_mode='binary_or_const')
 class TensorOrConstant(operands.OrConstant, TensorConstant):
     pass
 

--- a/mars/tensor/expressions/arithmetic/logical_xor.py
+++ b/mars/tensor/expressions/arithmetic/logical_xor.py
@@ -29,7 +29,7 @@ class TensorXor(operands.Xor, TensorBinOp):
         return TensorXorConstant
 
 
-@arithmetic_operand(sparse_mode='binary_and_const')
+@arithmetic_operand(sparse_mode='binary_or_const')
 class TensorXorConstant(operands.XorConstant, TensorConstant):
     pass
 

--- a/mars/tensor/expressions/arithmetic/reciprocal.py
+++ b/mars/tensor/expressions/arithmetic/reciprocal.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorReciprocal(operands.Reciprocal, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/sinc.py
+++ b/mars/tensor/expressions/arithmetic/sinc.py
@@ -22,7 +22,7 @@ from .core import TensorUnaryOp
 from .utils import arithmetic_operand
 
 
-@arithmetic_operand(sparse_mode='always_false')
+@arithmetic_operand(sparse_mode='unary')
 class TensorSinc(operands.Sinc, TensorUnaryOp):
     pass
 

--- a/mars/tensor/expressions/arithmetic/subtract.py
+++ b/mars/tensor/expressions/arithmetic/subtract.py
@@ -29,7 +29,7 @@ class TensorSubtract(operands.Subtract, TensorBinOp):
         return TensorSubConstant
 
 
-@arithmetic_operand(sparse_mode='binary_and_const')
+@arithmetic_operand(sparse_mode='binary_or_const')
 class TensorSubConstant(operands.SubConstant, TensorConstant):
     pass
 

--- a/mars/tensor/expressions/arithmetic/truediv.py
+++ b/mars/tensor/expressions/arithmetic/truediv.py
@@ -29,7 +29,7 @@ class TensorTrueDiv(operands.TrueDiv, TensorBinOp):
         return TensorTDivConstant
 
 
-@arithmetic_operand
+@arithmetic_operand(sparse_mode='binary_or_const')
 class TensorTDivConstant(operands.TDivConstant, TensorConstant):
     @classmethod
     def _is_sparse(cls, x1, x2):

--- a/mars/tensor/expressions/rechunk/rechunk.py
+++ b/mars/tensor/expressions/rechunk/rechunk.py
@@ -29,9 +29,9 @@ from ..core import TensorOperandMixin
 
 
 class TensorRechunk(Rechunk, TensorOperandMixin):
-    def __init__(self, chunk_size=None, threshold=None, chunk_size_limit=None, dtype=None, **kw):
+    def __init__(self, chunk_size=None, threshold=None, chunk_size_limit=None, dtype=None, sparse=False, **kw):
         super(TensorRechunk, self).__init__(_chunk_size=chunk_size, _threshold=threshold,
-                                            _chunk_size_limit=chunk_size_limit, _dtype=dtype, **kw)
+                                            _chunk_size_limit=chunk_size_limit, _dtype=dtype, _sparse=sparse, **kw)
 
     def _set_inputs(self, inputs):
         super(TensorRechunk, self)._set_inputs(inputs)
@@ -61,7 +61,8 @@ def rechunk(tensor, chunk_size, threshold=None, chunk_size_limit=None):
     if chunk_size == tensor.nsplits:
         return tensor
 
-    op = TensorRechunk(chunk_size, threshold, chunk_size_limit, dtype=tensor.dtype)
+    op = TensorRechunk(chunk_size, threshold, chunk_size_limit,
+                       dtype=tensor.dtype, sparse=tensor.issparse())
     return op(tensor)
 
 
@@ -396,6 +397,6 @@ def compute_rechunk(tensor, chunk_size):
             out_chunk = chunk_op.new_chunk(to_merge, chunk_shape, index=idx)
             result_chunks.append(out_chunk)
 
-    op = TensorRechunk(chunk_size)
+    op = TensorRechunk(chunk_size, sparse=tensor.issparse())
     return op.new_tensor([tensor], tensor.shape, dtype=tensor.dtype,
                          nsplits=chunk_size, chunks=result_chunks)

--- a/mars/tensor/expressions/rechunk/rechunk.py
+++ b/mars/tensor/expressions/rechunk/rechunk.py
@@ -384,7 +384,7 @@ def compute_rechunk(tensor, chunk_size):
             chunk_index, chunk_slice = lzip(*index_slices)
             old_chunk = tensor.cix[chunk_index]
             merge_chunk_shape = tuple(calc_sliced_size(s, chunk_slice[0]) for s in old_chunk.shape)
-            merge_chunk_op = TensorSlice(chunk_slice, dtype=old_chunk.dtype)
+            merge_chunk_op = TensorSlice(chunk_slice, dtype=old_chunk.dtype, sparse=old_chunk.op.sparse)
             merge_chunk = merge_chunk_op.new_chunk([old_chunk], merge_chunk_shape, index=merge_idx)
             to_merge.append(merge_chunk)
         if len(to_merge) == 1:
@@ -392,7 +392,7 @@ def compute_rechunk(tensor, chunk_size):
             out_chunk = chunk_op.new_chunk(to_merge[0].op.inputs, chunk_shape, index=idx)
             result_chunks.append(out_chunk)
         else:
-            chunk_op = TensorConcatenate(dtype=to_merge[0].dtype)
+            chunk_op = TensorConcatenate(dtype=to_merge[0].dtype, sparse=to_merge[0].op.sparse)
             out_chunk = chunk_op.new_chunk(to_merge, chunk_shape, index=idx)
             result_chunks.append(out_chunk)
 

--- a/mars/tensor/expressions/tests/test_arithmetic.py
+++ b/mars/tensor/expressions/tests/test_arithmetic.py
@@ -72,11 +72,11 @@ class Test(unittest.TestCase):
         t1 = tensor([[0, 1, 0], [1, 0, 0]], chunk_size=2).tosparse()
 
         t = t1 + 1
-        self.assertFalse(t.issparse())
-        self.assertIs(type(t), Tensor)
+        self.assertTrue(t.issparse())
+        self.assertIs(type(t), SparseTensor)
 
         t.tiles()
-        self.assertFalse(t.chunks[0].op.sparse)
+        self.assertTrue(t.chunks[0].op.sparse)
 
         t = t1 + 0
         self.assertTrue(t.issparse())
@@ -382,8 +382,8 @@ class Test(unittest.TestCase):
         t1 = tensor([[0, 1, 0], [1, 0, 0]], chunk_size=2).tosparse()
 
         t = cos(t1)
-        self.assertFalse(t.issparse())
-        self.assertIs(type(t), Tensor)
+        self.assertTrue(t.issparse())
+        self.assertIs(type(t), SparseTensor)
         self.assertEqual(calc_shape(t), t.shape)
 
     def testAround(self):

--- a/mars/tensor/expressions/tests/test_fuse.py
+++ b/mars/tensor/expressions/tests/test_fuse.py
@@ -20,7 +20,7 @@ import scipy.sparse as sps
 
 import mars.tensor as mt
 from mars.tensor.expressions.fuse.core import TensorFuseChunk
-from mars.tensor.expressions.datasource import CSRMatrixDataSource
+from mars.tensor.expressions.datasource import CSRMatrixDataSource, SparseToDense
 from mars import operands
 
 
@@ -81,8 +81,7 @@ class Test(unittest.TestCase):
         self.assertIsInstance(fuse_node.composed[2].op, (operands.TDivConstant, operands.DivConstant))
         self.assertTrue(all(c.op.sparse for c in fuse_node.composed))
 
-        # add constant will convert sparse matrix to dense matrix
-        t2 = t * 2 + 3
+        t2 = (t * 2).todense()
         g = t2.build_graph(tiled=True, compose=True)
         graph_nodes = list(g)
         self.assertTrue(all([isinstance(n.op, TensorFuseChunk) for n in graph_nodes]))
@@ -95,5 +94,5 @@ class Test(unittest.TestCase):
         self.assertIsInstance(fuse_node.composed[0].op, CSRMatrixDataSource)
         self.assertIsInstance(fuse_node.composed[1].op, operands.MulConstant)
         self.assertTrue(fuse_node.composed[1].op.sparse)
-        self.assertIsInstance(fuse_node.composed[2].op, operands.AddConstant)
+        self.assertIsInstance(fuse_node.composed[2].op, SparseToDense)
         self.assertFalse(fuse_node.composed[2].op.sparse)

--- a/mars/tensor/expressions/tests/test_rechunk.py
+++ b/mars/tensor/expressions/tests/test_rechunk.py
@@ -63,3 +63,11 @@ class Test(unittest.TestCase):
                          (slice(1, None, None), slice(2, None, None)))
         self.assertEqual(new_tensor.chunks[-1].inputs[1].op.slices,
                          (slice(1, None, None), slice(None, None, None)))
+
+    def testSparse(self):
+        tensor = ones((7, 12), chunk_size=4).tosparse()
+        new_tensor = tensor.rechunk(5)
+        new_tensor.tiles()
+
+        self.assertTrue(new_tensor.issparse())
+        self.assertTrue(all(c.issparse() for c in new_tensor.chunks))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Support arithmetic operators on only nonzero elements in a sparse matrix.

- For unary function like `cos`, it will only operate on the nonzero elements if input matrix is sparse:
``` Python
In [1]: import mars.tensor as mt                                                                              

In [2]: import scipy.sparse as sps                                                                            

In [3]: a = sps.rand(5, 5, density=0.2)                                                                       

In [4]: r = mt.cos(mt.tensor(a)).execute()                                                                    

In [5]: r                                                                                                     
Out[5]: <mars.lib.sparse.matrix.SparseMatrix at 0xc222dd6a0>

In [6]: r.todense()                                                                                           
Out[6]: 
array([[0.        , 0.        , 0.        , 0.        , 0.        ],
       [0.97912032, 0.        , 0.        , 0.88517772, 0.        ],
       [0.        , 0.        , 0.99379958, 0.        , 0.        ],
       [0.        , 0.        , 0.        , 0.        , 0.66819625],
       [0.        , 0.86675006, 0.        , 0.        , 0.        ]])

In [7]: a.A                                                                                                   
Out[7]: 
array([[0.        , 0.        , 0.        , 0.        , 0.        ],
       [0.20470834, 0.        , 0.        , 0.48392046, 0.        ],
       [0.        , 0.        , 0.11141665, 0.        , 0.        ],
       [0.        , 0.        , 0.        , 0.        , 0.83901463],
       [0.        , 0.52214764, 0.        , 0.        , 0.        ]])
```

- For binary operators like `add`, the output will be sparse if one input is a sparse matrix and the other input is a scalar, do add on those nonzero elements.
``` Python
In [9]: r = (mt.tensor(a) + 1).execute()                                                                      

In [10]: r.todense()                                                                                          
Out[10]: 
array([[0.        , 0.        , 0.        , 0.        , 0.        ],
       [1.20470834, 0.        , 0.        , 1.48392046, 0.        ],
       [0.        , 0.        , 1.11141665, 0.        , 0.        ],
       [0.        , 0.        , 0.        , 0.        , 1.83901463],
       [0.        , 1.52214764, 0.        , 0.        , 0.        ]])
```


## Related issue number
resolve #298 
fixes #264 
fixes #283 
<!-- Are there any issues opened that will be resolved by merging this change? -->
