### PR TITLE
Fix arithmetic calculation with `where`

### DIFF
--- a/mars/tensor/execution/arithmetic.py
+++ b/mars/tensor/execution/arithmetic.py
@@ -149,6 +149,8 @@ def _build_elementwise(op):
                 inputs, kw['out'], kw['where'] = inputs[:-2], inputs[-2].copy(), inputs[-1]
             elif chunk.op.out:
                 inputs, kw['out'] = inputs[:-1], inputs[-1].copy()
+            elif chunk.op.where:
+                inputs, kw['where'] = inputs[:-1], inputs[-1]
 
             with np.errstate(**chunk.op.err):
                 if len(inputs) == 1:

--- a/mars/tensor/execution/tests/test_arithmetic_execute.py
+++ b/mars/tensor/execution/tests/test_arithmetic_execute.py
@@ -247,6 +247,21 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(
             res, np.true_divide(data1, data2, out=data1.copy(), where=data2 > .5)))
 
+        arr1 = tensor(data1.copy(), chunk_size=4)
+        arr2 = tensor(data2.copy(), chunk_size=4)
+
+        arr3 = add(arr1, arr2, where=arr1 > .5)
+        res = self.executor.execute_tensor(arr3, concat=True)[0]
+        expected = np.add(data1, data2, where=data1 > .5)
+        self.assertTrue(np.array_equal(res[data1 > .5], expected[data1 > .5]))
+
+        arr1 = tensor(data1.copy(), chunk_size=4)
+
+        arr3 = add(arr1, 1, where=arr1 > .5)
+        res = self.executor.execute_tensor(arr3, concat=True)[0]
+        expected = np.add(data1, 1, where=data1 > .5)
+        self.assertTrue(np.array_equal(res[data1 > .5], expected[data1 > .5]))
+
     def testFrexpExecution(self):
         data1 = np.random.random((5, 9, 4))
 

--- a/mars/tensor/expressions/arithmetic/core.py
+++ b/mars/tensor/expressions/arithmetic/core.py
@@ -159,7 +159,7 @@ class TensorBinOp(TensorElementWiseWithInputs):
 
     def _call(self, x1, x2, out=None, where=None):
         # if x1 or x2 is scalar, and out is none, to constant
-        if (np.isscalar(x1) or np.isscalar(x2)) and not out:
+        if (np.isscalar(x1) or np.isscalar(x2)) and not out and not where:
             return self.to_constant(x1, x2)
 
         x1, x2, out, where = self._process_inputs(x1, x2, out, where)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix the behavior of arithmetic operands with specified `where`.

 refer to `Numpy`'s Docs:

> where : array_like, optional
Values of True indicate to calculate the ufunc at that position, values of False indicate to leave the value in the output alone.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
fixes #306 
fixes #282 