### PR TITLE
Add support for detecting NVIDIA GPU resources

### DIFF
--- a/mars/actors/pool/gevent_pool.pyx
+++ b/mars/actors/pool/gevent_pool.pyx
@@ -1652,5 +1652,9 @@ cdef class ActorClient:
         gevent.sleep(seconds)
 
     @staticmethod
+    def popen(*args, **kwargs):
+        return gevent.subprocess.Popen(*args, **kwargs)
+
+    @staticmethod
     def threadpool(num_threads):
         return ThreadPool(num_threads)

--- a/mars/node_info.py
+++ b/mars/node_info.py
@@ -21,7 +21,6 @@ import time
 
 from . import resource
 from .actors import FunctionActor
-from .compat import six
 from .utils import git_info
 
 try:
@@ -33,14 +32,22 @@ try:
 except ImportError:  # pragma: no cover
     scipy = None
 try:
+    import pandas
+except ImportError:  # pragma: no cover
+    pandas = None
+try:
     import cupy as cp
 except ImportError:  # pragma: no cover
     cp = None
+try:
+    import cudf
+except ImportError:  # pragma: no cover
+    cudf = None
 
 logger = logging.getLogger(__name__)
 
 
-def gather_node_info():
+def gather_node_info(async_ctx=None):
     from .lib.mkl_interface import mkl_get_version
     mem_stats = resource.virtual_memory()
 
@@ -56,20 +63,29 @@ def gather_node_info():
         'update_time': time.time(),
     }
 
-    if np is None:
-        node_info['numpy_info'] = 'Not installed'
-    else:
-        sio = six.StringIO()
-        sio.write('Version: %s\n' % np.__version__)
+    cuda_info = resource.cuda_info(async_ctx=async_ctx)
+    if cuda_info:
+        node_info['cuda_info'] = 'Driver: %s\nCUDA: %s\nProducts: %s\n' % \
+                                 (cuda_info.driver_version, cuda_info.cuda_version,
+                                  ', '.join(cuda_info.products))
+
+    package_lines = []
+    if np is not None:
+        ver_str = 'numpy==' + np.__version__
         if hasattr(np, '__mkl_version__') and mkl_get_version:
             mkl_version = mkl_get_version()
-            sio.write('MKL Version: %d.%d.%d\n' % (mkl_version.major, mkl_version.minor, mkl_version.update))
-        node_info['numpy_info'] = sio.getvalue().strip()
+            ver_str += ' (mkl: %d.%d.%d)' % (mkl_version.major, mkl_version.minor, mkl_version.update)
+        package_lines.append(ver_str)
+    if scipy is not None:
+        package_lines.append('scipy==%s' % scipy.__version__)
+    if pandas is not None:
+        package_lines.append('pandas==%s' % pandas.__version__)
+    if cp is not None:
+        package_lines.append('cupy==%s' % cp.__version__)
+    if cudf is not None:
+        package_lines.append('cudf==%s' % cudf.__version__)
 
-    if scipy is None:
-        node_info['scipy_info'] = 'Not installed'
-    else:
-        node_info['scipy_info'] = 'Version: %s' % scipy.__version__
+    node_info['package_info'] = '\n'.join(package_lines)
 
     git = git_info()
     if git:
@@ -95,7 +111,7 @@ class NodeInfoActor(FunctionActor):
         self.ref().gather_info()
 
     def gather_info(self):
-        self._node_info = gather_node_info()
+        self._node_info = gather_node_info(self.ctx)
         self.ref().gather_info(_tell=True, _delay=1)
 
     def get_info(self):

--- a/mars/resource.py
+++ b/mars/resource.py
@@ -166,8 +166,10 @@ def disk_io_usage():
     if sys.platform == 'win32' and not _win_diskperf_called:  # pragma: no cover
         CREATE_NO_WINDOW = 0x08000000
         try:
-            subprocess.run(['diskperf', '-y'], shell=False, creationflags=CREATE_NO_WINDOW)  # nosec
-        except subprocess.CalledProcessError:
+            proc = subprocess.Popen(['diskperf', '-y'], shell=False,
+                                    creationflags=CREATE_NO_WINDOW)  # nosec
+            proc.wait()
+        except (subprocess.CalledProcessError, OSError):
             pass
         _win_diskperf_called = True
 
@@ -211,3 +213,65 @@ def net_io_usage():
 
     _last_net_io_meta = (send_bytes, recv_bytes, tst)
     return recv_speed, send_speed
+
+
+_last_nvml_output = None
+_last_nvml_output_time = None
+
+
+def _get_nvml_output(async_ctx=None):
+    from xml.etree import ElementTree
+    global _last_nvml_output, _last_nvml_output_time
+
+    popen = getattr(async_ctx, 'popen', subprocess.Popen)
+    if _last_nvml_output_time is None or _last_nvml_output_time < time.time() - 1:
+        try:
+            proc = popen(['nvidia-smi', '-q', '-x'], shell=False, stdout=subprocess.PIPE)
+            proc.wait()
+
+            _last_nvml_output = ElementTree.fromstring(proc.stdout.read())
+            _last_nvml_output_time = time.time()
+            proc.stdout.close()
+        except (subprocess.CalledProcessError, OSError):
+            pass
+    return _last_nvml_output
+
+
+_cuda_info = namedtuple('cuda_info', 'driver_version cuda_version products gpu_count')
+_cuda_card_stat = namedtuple('cuda_card_stat', 'product_name gpu_usage temperature fb_mem_info')
+
+
+def cuda_info(async_ctx=None):
+    nvml_output = _get_nvml_output(async_ctx)
+    if nvml_output is None:
+        return None
+    return _cuda_info(
+        driver_version=nvml_output.find('driver_version').text,
+        cuda_version=nvml_output.find('cuda_version').text,
+        products=[e.find('product_name').text for e in nvml_output.findall('gpu')],
+        gpu_count=int(nvml_output.find('attached_gpus').text),
+    )
+
+
+def cuda_card_stats(async_ctx=None):
+    from .utils import parse_readable_size
+
+    nvml_output = _get_nvml_output(async_ctx)
+    if nvml_output is None:
+        return None
+    infos = []
+    for gpu_element in nvml_output.findall('gpu'):
+        fb_total_mem = parse_readable_size(gpu_element.find('fb_memory_usage/total').text)[0]
+        fb_used_mem = parse_readable_size(gpu_element.find('fb_memory_usage/used').text)[0]
+        fb_free_mem = parse_readable_size(gpu_element.find('fb_memory_usage/free').text)[0]
+
+        infos.append(_cuda_card_stat(
+            product_name=gpu_element.find('product_name').text,
+            gpu_usage=parse_readable_size(gpu_element.find('utilization/gpu_util').text)[0],
+            temperature=float(gpu_element.find('temperature/gpu_temp').text.split()[0]),
+            fb_mem_info=_virt_memory_stat(
+                total=fb_total_mem, used=fb_used_mem, free=fb_free_mem, available=fb_free_mem,
+                percent=fb_used_mem / fb_total_mem,
+            )
+        ))
+    return infos

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -79,20 +79,26 @@ def on_deserialize_shape(shape):
     return shape
 
 
-def parse_memory_limit(value):
+_memory_size_indices = {'': 0, 'k': 1, 'm': 2, 'g': 3, 't': 4}
+
+
+def parse_readable_size(value):
     if isinstance(value, numbers.Number):
         return float(value), False
-    elif value.endswith('%'):
-        return float(value[:-1]) / 100, True
-    elif value.lower().endswith('t'):
-        return float(value[:-1]) * (1024 ** 4), False
-    elif value.lower().endswith('g'):
-        return float(value[:-1]) * (1024 ** 3), False
-    elif value.lower().endswith('m'):
-        return float(value[:-1]) * (1024 ** 2), False
-    elif value.lower().endswith('k'):
-        return float(value[:-1]) * 1024, False
-    else:
+
+    value = value.strip().lower()
+    num_pos = 0
+    while num_pos < len(value) and value[num_pos] in '0123456789.-':
+        num_pos += 1
+
+    value, suffix = value[:num_pos], value[num_pos:]
+    suffix = suffix.strip()
+    if suffix.endswith('%'):
+        return float(value) / 100, True
+
+    try:
+        return float(value) * (1024 ** _memory_size_indices[suffix[:1]]), False
+    except (ValueError, KeyError):
         raise ValueError('Unknown limitation value: {0}'.format(value))
 
 

--- a/mars/web/templates/worker_detail.html
+++ b/mars/web/templates/worker_detail.html
@@ -29,12 +29,18 @@
             </tr>
             {% endif %}
             <tr>
-                <td>Git Branch</td>
-                <td><pre class="plain-pre">{{ worker_details['git_info'] }}</pre></td>
-            </tr>
-            <tr>
                 <td>Platform</td>
                 <td><pre class="plain-pre">{{ worker_details['platform'] }}</pre></td>
+            </tr>
+            {% if worker_details['cuda_info'] is defined %}
+                <tr>
+                    <td>CUDA</td>
+                    <td><pre class="plain-pre">{{ worker_details['cuda_info'] }}</pre></td>
+                </tr>
+            {% endif %}
+            <tr>
+                <td>Git Branch</td>
+                <td><pre class="plain-pre">{{ worker_details['git_info'] }}</pre></td>
             </tr>
             <tr>
                 <td>Command</td>
@@ -45,12 +51,8 @@
                 <td><pre class="plain-pre">{{ worker_details['sys_version'] }}</pre></td>
             </tr>
             <tr>
-                <td>Numpy</td>
-                <td><pre class="plain-pre">{{ worker_details['numpy_info'] }}</pre></td>
-            </tr>
-            <tr>
-                <td>Scipy</td>
-                <td><pre class="plain-pre">{{ worker_details['scipy_info'] }}</pre></td>
+                <td>Packages</td>
+                <td><pre class="plain-pre">{{ worker_details['package_info'] }}</pre></td>
             </tr>
             </tbody>
         </table>
@@ -192,6 +194,28 @@ Total: {{ worker_metrics['hardware']['disk_total'] | readable_size }}</pre></td>
             {% endfor %}
             </tbody>
         </table>
+        {% if worker_metrics['hardware']['cuda_stats'] is defined %}
+        <div><h3>GPU Details</h3></div>
+        <table class="table">
+            <thead>
+            <tr>
+                <th>Item</th>
+                <th>Value</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for item in worker_metrics['hardware']['cuda_stats'] %}
+                <tr>
+                    <td>{{ item['product_name'] }}</td>
+                    <td><pre class="plain-pre">GPU Usage: {{ '%0.2f' % item['gpu_usage'] }}
+Memory Usage: {{ item['fb_memory_used'] | readable_size }}
+Memory Total: {{ item['fb_memory_total'] | readable_size }}
+Temperature: {{ item['temperature'] }} C</pre></td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
         {% if worker_metrics['hardware']['disk_stats'] is defined %}
         <div><h3>Disk Details</h3></div>
         <table class="table">

--- a/mars/worker/chunkholder.py
+++ b/mars/worker/chunkholder.py
@@ -18,7 +18,7 @@ from functools import partial
 from .. import promise
 from ..compat import OrderedDict3, six, functools32
 from ..config import options
-from ..utils import parse_memory_limit, log_unhandled, readable_size
+from ..utils import parse_readable_size, log_unhandled, readable_size
 from ..errors import *
 from .utils import WorkerActor
 
@@ -86,9 +86,9 @@ class ChunkHolderActor(WorkerActor):
         self._plasma_limit = self._chunk_store.get_actual_capacity(self._plasma_limit)
         logger.info('Detected actual plasma store size: %s', readable_size(self._plasma_limit))
         self._total_size = self._plasma_limit
-        parse_num, is_percent = parse_memory_limit(options.worker.min_spill_size)
+        parse_num, is_percent = parse_readable_size(options.worker.min_spill_size)
         self._min_spill_size = int(self._plasma_limit * parse_num if is_percent else parse_num)
-        parse_num, is_percent = parse_memory_limit(options.worker.max_spill_size)
+        parse_num, is_percent = parse_readable_size(options.worker.max_spill_size)
         self._max_spill_size = int(self._plasma_limit * parse_num if is_percent else parse_num)
 
         self._status_ref = self.ctx.actor_ref(StatusActor.default_name())

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -23,7 +23,7 @@ except ImportError:  # pragma: no cover
 
 from ..config import options
 from .. import resource
-from ..utils import parse_memory_limit, readable_size
+from ..utils import parse_readable_size, readable_size
 from ..compat import six
 from ..cluster_info import ClusterInfoActor
 from .status import StatusActor
@@ -100,7 +100,7 @@ class WorkerService(object):
                 return None
             if isinstance(limit_str, int):
                 return limit_str
-            mem_limit, is_percent = parse_memory_limit(limit_str)
+            mem_limit, is_percent = parse_readable_size(limit_str)
             if is_percent:
                 return int(total_size * mem_limit)
             else:

--- a/mars/worker/status.py
+++ b/mars/worker/status.py
@@ -54,47 +54,47 @@ class StatusReporterActor(WorkerActor):
             net_io = resource.net_io_usage()
             if cpu_percent is None or disk_io is None or net_io is None:
                 return
-            metrics = dict()
-            metrics['cpu'] = max(0.0, resource.cpu_count() - cpu_percent / 100.0)
-            metrics['cpu_used'] = cpu_percent / 100.0
-            metrics['cpu_total'] = resource.cpu_count()
+            hw_metrics = dict()
+            hw_metrics['cpu'] = max(0.0, resource.cpu_count() - cpu_percent / 100.0)
+            hw_metrics['cpu_used'] = cpu_percent / 100.0
+            hw_metrics['cpu_total'] = resource.cpu_count()
 
-            metrics['disk_read'] = disk_io[0]
-            metrics['disk_write'] = disk_io[1]
-            metrics['net_receive'] = net_io[0]
-            metrics['net_send'] = net_io[1]
+            hw_metrics['disk_read'] = disk_io[0]
+            hw_metrics['disk_write'] = disk_io[1]
+            hw_metrics['net_receive'] = net_io[0]
+            hw_metrics['net_send'] = net_io[1]
 
             iowait = resource.iowait()
             if iowait is not None:
-                metrics['iowait'] = iowait
+                hw_metrics['iowait'] = iowait
 
             mem_stats = resource.virtual_memory()
-            metrics['memory'] = int(mem_stats.available)
+            hw_metrics['memory'] = int(mem_stats.available)
 
-            metrics['memory_used'] = int(mem_stats.used)
-            metrics['memory_total'] = int(mem_stats.total)
+            hw_metrics['memory_used'] = int(mem_stats.used)
+            hw_metrics['memory_total'] = int(mem_stats.total)
 
             cache_allocations = self._status_ref.get_cache_allocations()
             cache_total = cache_allocations.get('total', 0)
-            metrics['cached_total'] = int(cache_total)
-            metrics['cached_hold'] = int(cache_allocations.get('hold', 0))
+            hw_metrics['cached_total'] = int(cache_total)
+            hw_metrics['cached_hold'] = int(cache_allocations.get('hold', 0))
 
             mem_quota_allocations = self._status_ref.get_mem_quota_allocations()
             mem_quota_total = mem_quota_allocations.get('total', 0)
             mem_quota_allocated = mem_quota_allocations.get('allocated', 0)
-            metrics['mem_quota'] = int(mem_quota_total - mem_quota_allocated)
-            metrics['mem_quota_used'] = int(mem_quota_allocated)
-            metrics['mem_quota_total'] = int(mem_quota_total)
-            metrics['mem_quota_hold'] = int(mem_quota_allocations.get('hold', 0))
+            hw_metrics['mem_quota'] = int(mem_quota_total - mem_quota_allocated)
+            hw_metrics['mem_quota_used'] = int(mem_quota_allocated)
+            hw_metrics['mem_quota_total'] = int(mem_quota_total)
+            hw_metrics['mem_quota_hold'] = int(mem_quota_allocations.get('hold', 0))
 
             if options.worker.spill_directory:
                 if isinstance(options.worker.spill_directory, six.string_types):
                     spill_dirs = options.worker.spill_directory.split(':')
                 else:
                     spill_dirs = options.worker.spill_directory
-                if spill_dirs and 'disk_stats' not in metrics:
-                    metrics['disk_stats'] = dict()
-                disk_stats = metrics['disk_stats']
+                if spill_dirs and 'disk_stats' not in hw_metrics:
+                    hw_metrics['disk_stats'] = dict()
+                disk_stats = hw_metrics['disk_stats']
 
                 agg_disk_used = 0.0
                 agg_disk_total = 0.0
@@ -109,11 +109,21 @@ class StatusReporterActor(WorkerActor):
                     agg_disk_total += disk_usage.total
                     disk_stats[spill_dir]['disk_used'] = disk_usage.used
                     agg_disk_used += disk_usage.used
-                metrics['disk_used'] = agg_disk_used
-                metrics['disk_total'] = agg_disk_total
+                hw_metrics['disk_used'] = agg_disk_used
+                hw_metrics['disk_total'] = agg_disk_total
+
+            cuda_card_stats = resource.cuda_card_stats(async_ctx=self.ctx)
+            if cuda_card_stats:
+                hw_metrics['cuda_stats'] = [dict(
+                    product_name=stat.product_name,
+                    gpu_usage=stat.gpu_usage,
+                    temperature=stat.temperature,
+                    fb_memory_total=stat.fb_mem_info.total,
+                    fb_memory_used=stat.fb_mem_info.used,
+                ) for stat in cuda_card_stats]
 
             meta_dict = dict()
-            meta_dict['hardware'] = metrics
+            meta_dict['hardware'] = hw_metrics
             meta_dict['update_time'] = time.time()
             meta_dict['stats'] = dict()
             meta_dict['slots'] = dict()
@@ -127,7 +137,7 @@ class StatusReporterActor(WorkerActor):
                 meta_dict['slots'][k] = v
 
             meta_dict['progress'] = self._status_ref.get_progress()
-            meta_dict['details'] = gather_node_info()
+            meta_dict['details'] = gather_node_info(self.ctx)
 
             self._resource_ref.set_worker_meta(self._endpoint, meta_dict)
         except Exception as ex:


### PR DESCRIPTION
## What do these changes do?

Add support for detecting NVIDIA GPU resources by grabbing outputs from ``nvidia-smi -q -x``. We do not need to call it very frequently to daemon resource usage as we did for host memory.

## Related issue number

Fixes #316 
