### PR TITLE
Remove use_one_memory_mapped_file argument when starting plasma_store

### DIFF
--- a/mars/worker/__main__.py
+++ b/mars/worker/__main__.py
@@ -40,8 +40,6 @@ class WorkerApplication(BaseApplication):
         parser.add_argument('--ignore-avail-mem', action='store_true', help='ignore available memory')
         parser.add_argument('--cache-mem', help='cache memory size limit')
         parser.add_argument('--spill-dir', help='spill directory')
-        parser.add_argument('--plasma-one-mapped-file', action='store_true',
-                            help='path of Plasma UNIX socket')
 
     def validate_arguments(self):
         if not self.args.schedulers and not self.args.kv_store:
@@ -62,7 +60,7 @@ class WorkerApplication(BaseApplication):
             ignore_avail_mem=self.args.ignore_avail_mem,
         )
         # start plasma
-        self._service.start_plasma(one_mapped_file=self.args.plasma_one_mapped_file or False)
+        self._service.start_plasma()
 
         self.n_process = self._service.n_process
         kwargs['distributor'] = WorkerDistributor(self.n_process)

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -132,10 +132,8 @@ class WorkerService(object):
 
         logger.info('Setting soft limit to %s.', readable_size(self._soft_quota_limit))
 
-    def start_plasma(self, one_mapped_file=False):
-        self._plasma_store = plasma.start_plasma_store(
-            self._cache_mem_limit, use_one_memory_mapped_file=one_mapped_file
-        )
+    def start_plasma(self):
+        self._plasma_store = plasma.start_plasma_store(self._cache_mem_limit)
         options.worker.plasma_socket, _ = self._plasma_store.__enter__()
 
     def start(self, endpoint, pool, distributed=True, schedulers=None, process_start_index=0):


### PR DESCRIPTION
## What do these changes do?

As arrow removes ``use_one_memory_mapped_file`` in ARROW-4296, we shall remove it when starting plasma_store.

## Related issue number

NA
