### PR TITLE
Resolve use_one_memory_mapped_file argument issue when starting plasma_store

### DIFF
--- a/mars/config.py
+++ b/mars/config.py
@@ -333,7 +333,6 @@ default_options.register_option('worker.transfer_block_size', 4 * 1024 * 1024, v
 default_options.register_option('worker.prepare_data_timeout', 600, validator=is_integer)
 
 default_options.register_option('worker.plasma_socket', '/tmp/plasma', validator=is_string)
-default_options.register_option('worker.plasma_one_mapped_file', False, validator=is_bool)
 default_options.register_option('worker.advertise_addr', '127.0.0.1', validator=is_string)
 
 # optimization

--- a/mars/worker/__main__.py
+++ b/mars/worker/__main__.py
@@ -89,7 +89,7 @@ class WorkerApplication(BaseApplication, WorkerService):
 
         # start plasma
         self.start_plasma(self.calc_cache_memory_limit(),
-                          one_mapped_file=options.worker.plasma_one_mapped_file or False)
+                          one_mapped_file=self.args.plasma_one_mapped_file or False)
 
         kwargs['distributor'] = WorkerDistributor(self.n_process)
         return super(WorkerApplication, self).create_pool(*args, **kwargs)

--- a/mars/worker/chunkholder.py
+++ b/mars/worker/chunkholder.py
@@ -155,13 +155,11 @@ class ChunkHolderActor(WorkerActor):
                     return
 
                 logger.debug('Removing reference of chunk %s from %s when spilling', key, self.uid)
-                chunk_size = 0
                 if key in self._chunk_holder:
-                    chunk_size = len(self._chunk_holder[key])
-                    self._total_hold -= chunk_size
+                    self._total_hold -= len(self._chunk_holder[key])
                     del self._chunk_holder[key]
-
-                self._plasma_client.evict(chunk_size)
+                    session_id = self._cache_chunk_sessions[key]
+                    self._chunk_store.delete(session_id, key)
 
             @log_unhandled
             def _handle_spill_reject(*exc, **kwargs):
@@ -221,8 +219,6 @@ class ChunkHolderActor(WorkerActor):
 
     @log_unhandled
     def unregister_chunk(self, session_id, chunk_key):
-        _ = session_id  # noqa: F841
-
         spill_ref = self._get_spill_actor_ref(chunk_key)
         if spill_ref:
             spill_ref.delete(chunk_key, _tell=True)
@@ -233,6 +229,7 @@ class ChunkHolderActor(WorkerActor):
         if chunk_key in self._chunk_holder:
             self._total_hold -= self._chunk_holder[chunk_key].size
             del self._chunk_holder[chunk_key]
+            self._chunk_store.delete(session_id, chunk_key)
 
         logger.debug('Chunk %s unregistered in %s. total_hold=%d', chunk_key, self.uid, self._total_hold)
 

--- a/mars/worker/chunkstore.py
+++ b/mars/worker/chunkstore.py
@@ -13,26 +13,51 @@
 # limitations under the License.
 
 import logging
-import hashlib
 
-from ..utils import to_binary, calc_data_size
-from ..compat import functools32
+from ..actors import FunctionActor
 from ..errors import StoreFull, StoreKeyExists
-
+from ..utils import calc_data_size
 
 logger = logging.getLogger(__name__)
+
+
+class PlasmaKeyMapActor(FunctionActor):
+    @classmethod
+    def default_name(cls):
+        return 'w:' + cls.__name__
+
+    def __init__(self):
+        super(PlasmaKeyMapActor, self).__init__()
+        self._mapping = dict()
+
+    def put(self, session_id, chunk_key, obj_id):
+        session_chunk_key = (session_id, chunk_key)
+        if session_chunk_key in self._mapping:
+            raise StoreKeyExists(session_chunk_key)
+        self._mapping[session_chunk_key] = obj_id
+
+    def get(self, session_id, chunk_key):
+        return self._mapping.get((session_id, chunk_key))
+
+    def delete(self, session_id, chunk_key):
+        try:
+            del self._mapping[(session_id, chunk_key)]
+        except KeyError:
+            pass
 
 
 class PlasmaChunkStore(object):
     """
     Wrapper of plasma client for Mars objects
     """
-    def __init__(self, plasma_client):
+    def __init__(self, plasma_client, mapper_ref):
         from ..serialize.dataserializer import mars_serialize_context
 
         self._plasma_client = plasma_client
         self._actual_size = None
         self._serialize_context = mars_serialize_context()
+
+        self._mapper_ref = mapper_ref
 
     def get_actual_capacity(self, store_limit):
         """
@@ -67,21 +92,28 @@ class PlasmaChunkStore(object):
             self._actual_size = total_size
         return self._actual_size
 
-    @staticmethod
-    @functools32.lru_cache(100)
-    def _calc_object_id(session_id, chunk_key):
+    def _new_object_id(self, session_id, chunk_key):
         """
         Calc unique object id for chunks
         """
         from pyarrow.plasma import ObjectID
-        key = '%s#%s' % (session_id, chunk_key)
-        digest = hashlib.md5(to_binary(key)).digest()
-        return ObjectID(digest + digest[:4])
+        while True:
+            new_id = ObjectID.from_random()
+            if not self._plasma_client.contains(new_id):
+                break
+        self._mapper_ref.put(session_id, chunk_key, new_id)
+        return new_id
+
+    def _get_object_id(self, session_id, chunk_key):
+        obj_id = self._mapper_ref.get(session_id, chunk_key)
+        if obj_id is None:
+            raise KeyError((session_id, chunk_key))
+        return obj_id
 
     def create(self, session_id, chunk_key, size):
-        from pyarrow.lib import PlasmaStoreFull, PlasmaObjectExists
+        from pyarrow.lib import PlasmaStoreFull
+        obj_id = self._new_object_id(session_id, chunk_key)
 
-        obj_id = self._calc_object_id(session_id, chunk_key)
         try:
             buffer = self._plasma_client.create(obj_id, size)
             return buffer
@@ -89,18 +121,13 @@ class PlasmaChunkStore(object):
             exc_type = PlasmaStoreFull
             logger.warning('Chunk %s(%d) failed to store to plasma due to StoreFullError',
                            chunk_key, size)
-        except PlasmaObjectExists:
-            exc_type = PlasmaObjectExists
-            logger.warning('Chunk %s(%d) already exists in plasma store', chunk_key, size)
 
         if exc_type is PlasmaStoreFull:
             raise StoreFull
-        elif exc_type is PlasmaObjectExists:
-            raise StoreKeyExists
 
     def seal(self, session_id, chunk_key):
         from pyarrow.lib import PlasmaObjectNonexistent
-        obj_id = self._calc_object_id(session_id, chunk_key)
+        obj_id = self._get_object_id(session_id, chunk_key)
         try:
             self._plasma_client.seal(obj_id)
         except PlasmaObjectNonexistent:
@@ -112,7 +139,7 @@ class PlasmaChunkStore(object):
         """
         from pyarrow.plasma import ObjectNotAvailable
 
-        obj_id = self._calc_object_id(session_id, chunk_key)
+        obj_id = self._get_object_id(session_id, chunk_key)
         obj = self._plasma_client.get(obj_id, serialization_context=self._serialize_context, timeout_ms=10)
         if obj is ObjectNotAvailable:
             raise KeyError('(%r, %r)' % (session_id, chunk_key))
@@ -122,7 +149,7 @@ class PlasmaChunkStore(object):
         """
         Get raw buffer from plasma store
         """
-        obj_id = self._calc_object_id(session_id, chunk_key)
+        obj_id = self._get_object_id(session_id, chunk_key)
         [buf] = self._plasma_client.get_buffers([obj_id], timeout_ms=10)
         if buf is None:
             raise KeyError('(%r, %r)' % (session_id, chunk_key))
@@ -134,7 +161,7 @@ class PlasmaChunkStore(object):
         """
         buf = None
         try:
-            obj_id = self._calc_object_id(session_id, chunk_key)
+            obj_id = self._get_object_id(session_id, chunk_key)
             [buf] = self._plasma_client.get_buffers([obj_id], timeout_ms=10)
             size = buf.size
         finally:
@@ -149,14 +176,19 @@ class PlasmaChunkStore(object):
         :param value: Mars object to be put
         """
         import pyarrow
-        from pyarrow.lib import PlasmaStoreFull, PlasmaObjectExists
+        from pyarrow.lib import PlasmaStoreFull
         from ..serialize.dataserializer import DataTuple
 
         data_size = calc_data_size(value)
         if isinstance(value, tuple):
             value = DataTuple(*value)
 
-        obj_id = self._calc_object_id(session_id, chunk_key)
+        try:
+            obj_id = self._new_object_id(session_id, chunk_key)
+        except StoreKeyExists:
+            obj_id = self._get_object_id(session_id, chunk_key)
+            [buffer] = self._plasma_client.get_buffers([obj_id])
+            return buffer
 
         try:
             serialized = pyarrow.serialize(value, self._serialize_context)
@@ -166,12 +198,11 @@ class PlasmaChunkStore(object):
                 stream.set_memcopy_threads(6)
                 serialized.write_to(stream)
                 self._plasma_client.seal(obj_id)
-            except PlasmaObjectExists:
-                [buffer] = self._plasma_client.get_buffers([obj_id])
             finally:
                 del serialized
             return buffer
         except PlasmaStoreFull:
+            self._mapper_ref.delete(session_id, chunk_key)
             logger.warning('Chunk %s(%d) failed to store to plasma due to StoreFullError',
                            chunk_key, data_size)
             exc = PlasmaStoreFull
@@ -184,7 +215,10 @@ class PlasmaChunkStore(object):
         Check if given chunk key exists in current plasma store
         """
         try:
-            obj_id = self._calc_object_id(session_id, chunk_key)
+            obj_id = self._get_object_id(session_id, chunk_key)
             return self._plasma_client.contains(obj_id)
         except KeyError:
             return False
+
+    def delete(self, session_id, chunk_key):
+        self._mapper_ref.delete(session_id, chunk_key)

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -99,6 +99,10 @@ class WorkerService(object):
             schedulers = None
             service_discover_addr = options.kv_store
 
+        # create plasma key mapper
+        from .chunkstore import PlasmaKeyMapActor
+        pool.create_actor(PlasmaKeyMapActor, uid=PlasmaKeyMapActor.default_name())
+
         # create ClusterInfoActor
         self._cluster_info_ref = pool.create_actor(ClusterInfoActor, schedulers=schedulers,
                                                    service_discover_addr=service_discover_addr,
@@ -207,6 +211,10 @@ class WorkerService(object):
             spill_directory = parse_spill_dirs(spill_dir)
         else:
             spill_directory = None
+
+        # create plasma key mapper
+        from .chunkstore import PlasmaKeyMapActor
+        pool.create_actor(PlasmaKeyMapActor, uid=PlasmaKeyMapActor.default_name())
 
         # create StatusActor
         self._status_ref = pool.create_actor(

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -64,9 +64,12 @@ class WorkerService(object):
         self._result_sender_ref = None
 
     def start_plasma(self, mem_limit, one_mapped_file=False):
-        self._plasma_store = plasma.start_plasma_store(
-            int(mem_limit), use_one_memory_mapped_file=one_mapped_file
-        )
+        try:
+            self._plasma_store = plasma.start_plasma_store(
+                int(mem_limit), use_one_memory_mapped_file=one_mapped_file
+            )
+        except TypeError:
+            self._plasma_store = plasma.start_plasma_store(int(mem_limit))
         options.worker.plasma_socket, _ = self._plasma_store.__enter__()
 
     @classmethod

--- a/mars/worker/tests/test_chunkholder.py
+++ b/mars/worker/tests/test_chunkholder.py
@@ -16,8 +16,6 @@ import uuid
 import numpy as np
 from functools import partial
 
-import gevent
-
 from mars.actors import create_actor_pool
 from mars.compat import six
 from mars.config import options
@@ -29,6 +27,7 @@ from mars.scheduler.kvstore import KVStoreActor
 from mars.tests.core import mock
 from mars.worker.tests.base import WorkerCase
 from mars.worker import *
+from mars.worker.chunkstore import PlasmaKeyMapActor
 from mars.worker.utils import WorkerActor
 
 
@@ -59,7 +58,7 @@ class CacheTestActor(WorkerActor):
             try:
                 ref = chunk_store.put(session_id, data_key, data)
                 chunk_holder_ref.register_chunk(session_id, data_key)
-                gevent.sleep(0.5)
+                self.ctx.sleep(0.5)
                 del ref
             except StoreFull:
                 return chunk_holder_ref.spill_size(calc_data_size(data) * 2, _promise=True) \
@@ -119,6 +118,7 @@ class Test(WorkerCase):
     def testHolder(self):
         pool_address = '127.0.0.1:%d' % get_next_port()
         with create_actor_pool(n_process=1, backend='gevent', address=pool_address) as pool:
+            pool.create_actor(PlasmaKeyMapActor, uid=PlasmaKeyMapActor.default_name())
             pool.create_actor(ClusterInfoActor, schedulers=[pool_address],
                               uid=ClusterInfoActor.default_name())
             pool.create_actor(KVStoreActor, uid=KVStoreActor.default_name())
@@ -132,7 +132,7 @@ class Test(WorkerCase):
                 test_ref = pool.create_actor(CacheTestActor)
                 test_ref.run_test_cache()
                 while not test_ref.get_exc_info()[0]:
-                    gevent.sleep(0.1)
+                    pool.sleep(0.1)
                 exc_info = test_ref.get_exc_info()[1]
                 if exc_info:
                     six.reraise(*exc_info)
@@ -145,6 +145,7 @@ class Test(WorkerCase):
 
         pool_address = '127.0.0.1:%d' % get_next_port()
         with create_actor_pool(n_process=1, backend='gevent', address=pool_address) as pool:
+            pool.create_actor(PlasmaKeyMapActor, uid=PlasmaKeyMapActor.default_name())
             pool.create_actor(ClusterInfoActor, schedulers=[pool_address],
                               uid=ClusterInfoActor.default_name())
             pool.create_actor(KVStoreActor, uid=KVStoreActor.default_name())
@@ -159,7 +160,7 @@ class Test(WorkerCase):
                 test_ref = pool.create_actor(CacheTestActor)
                 test_ref.run_test_ensure_timeout()
                 while not test_ref.get_exc_info()[0]:
-                    gevent.sleep(0.1)
+                    pool.sleep(0.1)
                 exc_info = test_ref.get_exc_info()[1]
                 self.assertIsNotNone(exc_info)
                 self.assertIsInstance(exc_info[1], PromiseTimeout)

--- a/mars/worker/tests/test_execution.py
+++ b/mars/worker/tests/test_execution.py
@@ -26,6 +26,7 @@ from mars.cluster_info import ClusterInfoActor
 from mars.scheduler import ChunkMetaActor
 from mars.worker.tests.base import WorkerCase
 from mars.worker import *
+from mars.worker.chunkstore import PlasmaKeyMapActor
 from mars.worker.utils import WorkerActor
 
 
@@ -81,6 +82,7 @@ class Test(WorkerCase):
     def testExecute(self):
         pool_address = '127.0.0.1:%d' % get_next_port()
         with create_actor_pool(n_process=1, backend='gevent', address=pool_address) as pool:
+            pool.create_actor(PlasmaKeyMapActor, uid=PlasmaKeyMapActor.default_name())
             pool.create_actor(ClusterInfoActor, schedulers=[pool_address],
                               uid=ClusterInfoActor.default_name())
             cache_ref = pool.create_actor(ChunkHolderActor, self.plasma_storage_size,

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -541,6 +541,7 @@ class ReceiverActor(WorkerActor):
                 self._chunk_store.seal(session_id, chunk_key)
             except KeyError:
                 pass
+            self._chunk_store.delete(session_id, chunk_key)
         else:
             src_dir = build_spill_file_name(chunk_key, writing=True)
             if os.path.exists(src_dir):

--- a/mars/worker/utils.py
+++ b/mars/worker/utils.py
@@ -46,9 +46,11 @@ class WorkerActor(HasClusterInfoActor, PromiseActor):
 
     def _init_chunk_store(self):
         import pyarrow.plasma as plasma
-        from .chunkstore import PlasmaChunkStore
+        from .chunkstore import PlasmaChunkStore, PlasmaKeyMapActor
+
+        mapper_ref = self.ctx.actor_ref(uid=PlasmaKeyMapActor.default_name())
         self._plasma_client = plasma.connect(options.worker.plasma_socket, '', 0)
-        self._chunk_store = PlasmaChunkStore(self._plasma_client)
+        self._chunk_store = PlasmaChunkStore(self._plasma_client, mapper_ref)
 
     def get_meta_ref(self, session_id, chunk_key):
         from ..scheduler.chunkmeta import LocalChunkMetaActor


### PR DESCRIPTION
## What do these changes do?

Try the old calling routine before removing the argument and retry for compatibility. Note that this is related to but NOT a straightforward backport of #318 and review is needed.

This also includes a back-port for #226 to solve error in testHolder.

## Related issue number

NA
