### PR TITLE
Remove chunk square limitation in cholesky decomposition

### DIFF
--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -122,40 +122,68 @@ class Test(unittest.TestCase):
         np.testing.assert_array_almost_equal(res, expected)
 
     def testCholeskyExecution(self):
-        data = np.array([[1, -2j], [2j, 5]])
+        data = np.random.randint(1, 10, (10, 10))
+        symmetric_data = data.dot(data.T)
 
-        a = tensor(data, chunk_size=1)
+        a = tensor(symmetric_data, chunk_size=5)
 
-        L = cholesky(a, lower=True)
-        t = L.dot(L.T.conj())
+        U = cholesky(a)
+        t = U.T.dot(U)
+
+        res_u = self.executor.execute_tensor(U, concat=True)[0]
+        np.testing.assert_allclose(np.triu(res_u), res_u)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
-        self.assertTrue(np.allclose(res, data))
+        self.assertTrue(np.allclose(res, symmetric_data))
 
         L = cholesky(a, lower=True)
         U = cholesky(a)
         t = L.dot(U)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
-        self.assertTrue(np.allclose(res, data))
+        self.assertTrue(np.allclose(res, symmetric_data))
 
-        a = tensor(data, chunk_size=2)
-
-        L = cholesky(a, lower=True)
-        U = cholesky(a)
-        t = L.dot(U)
-
-        res = self.executor.execute_tensor(t, concat=True)[0]
-        np.testing.assert_allclose(res, data)
-
-        a = tensor(data, chunk_size=(1, 2))
+        a = tensor(symmetric_data, chunk_size=2)
 
         L = cholesky(a, lower=True)
         U = cholesky(a)
         t = L.dot(U)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
-        np.testing.assert_allclose(res, data)
+        np.testing.assert_allclose(res, symmetric_data)
+
+        a = tensor(symmetric_data, chunk_size=(1, 2))
+
+        L = cholesky(a, lower=True)
+        U = cholesky(a)
+        t = L.dot(U)
+
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        np.testing.assert_allclose(res, symmetric_data)
+
+        a = tensor(symmetric_data, chunk_size=4)
+
+        L = cholesky(a, lower=True)
+        U = cholesky(a)
+        t = L.dot(U)
+
+        res_u = self.executor.execute_tensor(U, concat=True)[0]
+        np.testing.assert_allclose(np.triu(res_u), res_u)
+
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        np.testing.assert_allclose(res, symmetric_data)
+
+        a = tensor(symmetric_data, chunk_size=3)
+
+        L = cholesky(a, lower=True)
+        U = cholesky(a)
+        t = L.dot(U)
+
+        res_u = self.executor.execute_tensor(U, concat=True)[0]
+        np.testing.assert_allclose(np.triu(res_u), res_u)
+
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        np.testing.assert_allclose(res, symmetric_data)
 
     def testLUExecution(self):
         np.random.seed(1)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Remove the limitation in cholesky decomposition that all chunks must be square.

We can use cholesky decomposition to solve pseudo-inverse matrix, for a non-square matrix `A`, `A.T.dot(A)` is always a symmetric matrix.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
fixes #326 