### PR TITLE
Allow batch rejecting peers in workers by endpoints

### DIFF
--- a/mars/base_app.py
+++ b/mars/base_app.py
@@ -150,7 +150,8 @@ class BaseApplication(object):
                 level = logging.INFO
             else:
                 level = getattr(logging, self.args.level.upper())
-            logging.basicConfig(level=level, format=self.args.format)
+            logging.getLogger('mars').setLevel(level)
+            logging.basicConfig(format=self.args.format)
 
     def validate_arguments(self):
         pass

--- a/mars/config.py
+++ b/mars/config.py
@@ -326,6 +326,7 @@ default_options.register_option('worker.max_spill_size', '95%', validator=(is_st
 default_options.register_option('worker.callback_preserve_time', 3600 * 24, validator=is_integer)
 default_options.register_option('worker.transfer_block_size', 4 * 1024 * 1024, validator=is_integer)
 default_options.register_option('worker.prepare_data_timeout', 600, validator=is_integer)
+default_options.register_option('worker.peer_blacklist_time', 3600, validator=is_numeric, serialize=True)
 
 default_options.register_option('worker.plasma_socket', '/tmp/plasma', validator=is_string)
 default_options.register_option('worker.advertise_addr', '127.0.0.1', validator=is_string)

--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -259,7 +259,10 @@ class LocalDistributedClusterClient(object):
             try:
                 import psutil
                 for subproc in psutil.Process(proc.pid).children(recursive=True):
-                    subproc.kill()
+                    try:
+                        subproc.kill()
+                    except psutil.NoSuchProcess:  # pragma: no cover
+                        pass
             except ImportError:
                 pass
             finally:

--- a/mars/promise.py
+++ b/mars/promise.py
@@ -368,15 +368,15 @@ class PromiseActor(FunctionActor):
         del self._promises[promise_id]
         del self._promise_ref_keys[promise_id]
 
-    def reject_dead_workers(self, dead_workers, *args, **kwargs):
+    def reject_dead_endpoints(self, dead_endpoints, *args, **kwargs):
         """
         Reject all promises related to given remote address
-        :param dead_workers: list of dead workers
+        :param dead_endpoints: list of dead workers
         """
         dead_refs = []
         for ref_key in self._ref_key_promises.keys():
             uid, addr = ref_key
-            if addr in dead_workers:
+            if addr in dead_endpoints:
                 dead_refs.append(self.ctx.actor_ref(uid, address=addr))
         return self.reject_promise_refs(dead_refs, *args, **kwargs)
 

--- a/mars/scheduler/assigner.py
+++ b/mars/scheduler/assigner.py
@@ -67,9 +67,10 @@ class AssignerActor(SchedulerActor):
         logger.debug('Metrics cache marked as expired.')
         self._worker_metric_time = 0
 
-    def is_worker_alive(self, worker):
-        self._refresh_worker_metrics()
-        return worker in self._worker_metrics
+    def filter_alive_workers(self, workers, refresh=False):
+        if refresh:
+            self._refresh_worker_metrics()
+        return [w for w in workers if w in self._worker_metrics] if self._worker_metrics else []
 
     @log_unhandled
     def get_worker_assignments(self, session_id, op_info):

--- a/mars/scheduler/chunkmeta.py
+++ b/mars/scheduler/chunkmeta.py
@@ -228,7 +228,10 @@ class LocalChunkMetaActor(SchedulerActor):
         :param broadcast: broadcast meta into registered destinations
         """
         query_key = (session_id, chunk_key)
-        workers = tuple(w for w in workers or () if w not in self._worker_blacklist)
+
+        workers = workers or ()
+        workers = tuple(w for w in workers if w not in self._worker_blacklist)
+
         # update input with existing value
         if query_key in self._meta_store:
             old_meta = self._meta_store[query_key]  # type: WorkerMeta

--- a/mars/scheduler/operands/tests/test_common_ut.py
+++ b/mars/scheduler/operands/tests/test_common_ut.py
@@ -63,7 +63,8 @@ class FakeExecutionActor(promise.PromiseActor):
             self._undone_preds[graph_key] = set(pred_keys) - self._finished_keys
 
     def start_execution(self, session_id, graph_key, send_addresses=None, callback=None):
-        self._finish_callbacks[graph_key].append(callback)
+        if callback:
+            self._finish_callbacks[graph_key].append(callback)
         self.ref().mock_send_all_callbacks(graph_key, _tell=True, _delay=self._exec_delay)
 
     def add_finish_callback(self, session_id, graph_key, callback):
@@ -74,6 +75,7 @@ class FakeExecutionActor(promise.PromiseActor):
 
 
 @patch_method(ResourceActor._broadcast_sessions)
+@patch_method(ResourceActor._broadcast_workers)
 class Test(unittest.TestCase):
     @contextlib.contextmanager
     def _prepare_test_graph(self, session_id, graph_key, mock_workers):

--- a/mars/tests/test_promise.py
+++ b/mars/tests/test_promise.py
@@ -148,7 +148,7 @@ class PromiseTestActor(promise.PromiseActor):
         ref.serve(0, delay=2, _promise=True) \
             .catch(_rejecter) \
             .then(lambda *_: setattr(self, '_finished', True))
-        self.reject_dead_workers([self.address], *build_exc_info(WorkerDead))
+        self.reject_dead_endpoints([self.address], *build_exc_info(WorkerDead))
 
 
 def _raise_exception(exc):

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import copy
+import time
 import unittest
 
 import numpy as np
@@ -168,3 +169,23 @@ class Test(unittest.TestCase):
         with option_context({'eager_mode': True}):
             self.assertTrue(options.eager_mode)
             self.assertFalse(wrapped())
+
+    def testBlacklistSet(self):
+        blset = utils.BlacklistSet(0.1)
+        blset.update([1, 2])
+        time.sleep(0.3)
+        blset.add(3)
+
+        with self.assertRaises(KeyError):
+            blset.remove(2)
+
+        self.assertNotIn(1, blset)
+        self.assertNotIn(2, blset)
+        self.assertIn(3, blset)
+
+        blset.add(4)
+        time.sleep(0.3)
+        blset.add(5)
+        blset.add(6)
+
+        self.assertSetEqual({5, 6}, set(blset))

--- a/mars/worker/chunkstore.py
+++ b/mars/worker/chunkstore.py
@@ -190,10 +190,15 @@ class PlasmaChunkStore(object):
         try:
             obj_id = self._new_object_id(session_id, chunk_key)
         except StoreKeyExists:
-            logger.debug('Chunk %s already exists, returning existing', chunk_key)
             obj_id = self._get_object_id(session_id, chunk_key)
-            [buffer] = self._plasma_client.get_buffers([obj_id], timeout_ms=10)
-            return buffer
+            if self._plasma_client.contains(obj_id):
+                logger.debug('Chunk %s already exists, returning existing', chunk_key)
+                [buffer] = self._plasma_client.get_buffers([obj_id], timeout_ms=10)
+                return buffer
+            else:
+                logger.warning('Chunk %s registered but no data found, reconstructed', chunk_key)
+                self.delete(session_id, chunk_key)
+                obj_id = self._new_object_id(session_id, chunk_key)
 
         try:
             serialized = pyarrow.serialize(value, self._serialize_context)

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -917,12 +917,12 @@ class ExecutionActor(WorkerActor):
             return
         self._peer_blacklist.update(removes)
 
-        handled_refs = self.reject_dead_workers(removes, *build_exc_info(DependencyMissing))
+        handled_refs = self.reject_dead_endpoints(removes, *build_exc_info(DependencyMissing))
         logger.debug('Peer worker halt received. Affected promises %r rejected.',
                      [ref.uid for ref in handled_refs])
 
         for sender_slot in self._dispatch_ref.get_slots('sender'):
-            self.ctx.actor_ref(sender_slot).reject_dead_workers(removes, _tell=True)
+            self.ctx.actor_ref(sender_slot).reject_dead_endpoints(removes, _tell=True)
         for receiver_slot in self._dispatch_ref.get_slots('receiver'):
             self.ctx.actor_ref(receiver_slot).notify_dead_senders(removes, _tell=True)
 

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -23,11 +23,11 @@ from .. import promise
 from ..compat import reduce, six, Enum, BrokenPipeError, \
     ConnectionRefusedError, TimeoutError  # pylint: disable=W0622
 from ..config import options
-from ..errors import PinChunkFailed, WorkerProcessStopped, ExecutionInterrupted, \
-    DependencyMissing
+from ..errors import PinChunkFailed, WorkerProcessStopped, WorkerDead, \
+    ExecutionInterrupted, DependencyMissing
 from ..executor import Executor
 from ..operands import Fetch, FetchShuffle
-from ..utils import deserialize_graph, log_unhandled
+from ..utils import deserialize_graph, log_unhandled, build_exc_info, BlacklistSet
 from .chunkholder import ensure_chunk
 from .spill import spill_exists, get_spill_data_size
 from .utils import WorkerActor, ExpiringCache, concat_operand_keys, build_load_key
@@ -136,6 +136,8 @@ class ExecutionActor(WorkerActor):
 
         self._graph_records = dict()  # type: dict[tuple, GraphExecutionRecord]
         self._result_cache = ExpiringCache()  # type: dict[tuple, GraphResultRecord]
+
+        self._peer_blacklist = BlacklistSet(options.worker.peer_blacklist_time)
 
     def post_create(self):
         from .chunkholder import ChunkHolderActor
@@ -391,6 +393,9 @@ class ExecutionActor(WorkerActor):
         """
         from .dispatcher import DispatchActor
 
+        if remote_addr in self._peer_blacklist:
+            raise DependencyMissing
+
         remote_disp_ref = self.promise_ref(uid=DispatchActor.default_name(),
                                            address=remote_addr)
         ensure_cached = kwargs.pop('ensure_cached', True)
@@ -418,13 +423,17 @@ class ExecutionActor(WorkerActor):
                     return
 
                 six.reraise(*exc)
-            except (BrokenPipeError, ConnectionRefusedError, TimeoutError, promise.PromiseTimeout):
+            except (BrokenPipeError, ConnectionRefusedError, TimeoutError,
+                    WorkerDead, promise.PromiseTimeout):
                 if self._resource_ref:
                     self._resource_ref.detach_dead_workers([remote_addr], _tell=True)
                 raise DependencyMissing
 
         @log_unhandled
         def _fetch_step(sender_uid):
+            if remote_addr in self._peer_blacklist:
+                raise DependencyMissing
+
             if self._graph_records[(session_id, graph_key)].stop_requested:
                 remote_disp_ref.register_free_slot(sender_uid, 'sender', _tell=True)
                 raise ExecutionInterrupted
@@ -555,10 +564,7 @@ class ExecutionActor(WorkerActor):
             if graph_record.stop_requested:
                 graph_record.stop_requested = False
                 if not isinstance(exc[1], ExecutionInterrupted):
-                    try:
-                        raise ExecutionInterrupted
-                    except ExecutionInterrupted:
-                        exc = sys.exc_info()
+                    exc = build_exc_info(ExecutionInterrupted)
 
             if isinstance(exc[1], ExecutionInterrupted):
                 logger.warning('Execution of graph %s interrupted.', graph_key)
@@ -894,15 +900,31 @@ class ExecutionActor(WorkerActor):
 
         graph_record.stop_requested = True
         if graph_record.state == ExecutionState.ALLOCATING:
-            try:
-                raise ExecutionInterrupted
-            except:  # noqa: E722
-                exc_info = sys.exc_info()
             if graph_record.mem_request:
-                self._mem_quota_ref.cancel_requests(tuple(graph_record.mem_request.keys()), exc_info, _tell=True)
+                self._mem_quota_ref.cancel_requests(
+                    tuple(graph_record.mem_request.keys()), build_exc_info(ExecutionInterrupted), _tell=True)
         elif graph_record.state == ExecutionState.CALCULATING:
             if self._daemon_ref is not None and graph_record.calc_actor_uid is not None:
                 self._daemon_ref.kill_actor_process(self.ctx.actor_ref(graph_record.calc_actor_uid), _tell=True)
+
+    @log_unhandled
+    def handle_worker_change(self, _adds, removes):
+        """
+        Handle worker dead event
+        :param removes: list of dead workers
+        """
+        if not removes:
+            return
+        self._peer_blacklist.update(removes)
+
+        handled_refs = self.reject_dead_workers(removes, *build_exc_info(DependencyMissing))
+        logger.debug('Peer worker halt received. Affected promises %r rejected.',
+                     [ref.uid for ref in handled_refs])
+
+        for sender_slot in self._dispatch_ref.get_slots('sender'):
+            self.ctx.actor_ref(sender_slot).reject_dead_workers(removes, _tell=True)
+        for receiver_slot in self._dispatch_ref.get_slots('receiver'):
+            self.ctx.actor_ref(receiver_slot).notify_dead_senders(removes, _tell=True)
 
     @log_unhandled
     def _invoke_finish_callbacks(self, session_id, graph_key):

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -237,18 +237,18 @@ class WorkerService(object):
     def stop(self):
         try:
             if self._result_sender_ref:
-                self._result_sender_ref.destroy()
+                self._result_sender_ref.destroy(wait=False)
             if self._status_ref:
-                self._status_ref.destroy()
+                self._status_ref.destroy(wait=False)
             if self._chunk_holder_ref:
-                self._chunk_holder_ref.destroy()
+                self._chunk_holder_ref.destroy(wait=False)
             if self._dispatch_ref:
-                self._dispatch_ref.destroy()
+                self._dispatch_ref.destroy(wait=False)
             if self._execution_ref:
-                self._execution_ref.destroy()
+                self._execution_ref.destroy(wait=False)
 
             for actor in (self._cpu_calc_actors + self._sender_actors
                           + self._receiver_actors + self._spill_actors + self._process_helper_actors):
-                actor.destroy()
+                actor.destroy(wait=False)
         finally:
             self._plasma_store.__exit__(None, None, None)

--- a/mars/worker/spill.py
+++ b/mars/worker/spill.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import shutil
 import sys
 import time
 
@@ -100,7 +101,7 @@ def write_spill_file(data_key, data):
     if not os.path.exists(dest_file_name):
         with open(src_file_name, 'wb') as file_obj:
             dataserializer.dump(data, file_obj, dataserializer.COMPRESS_FLAG_LZ4)
-        os.rename(src_file_name, dest_file_name)
+        shutil.move(src_file_name, dest_file_name)
 
 
 def spill_exists(data_key):

--- a/mars/worker/tests/test_daemon.py
+++ b/mars/worker/tests/test_daemon.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 import os
-import sys
 
 from mars.actors import create_actor_pool
 from mars.compat import six
 from mars.errors import WorkerProcessStopped
-from mars.utils import get_next_port
+from mars.utils import get_next_port, build_exc_info
 from mars.worker import WorkerDaemonActor, DispatchActor, ProcessHelperActor
 from mars.worker.distributor import WorkerDistributor
 from mars.worker.utils import WorkerActor
@@ -60,12 +59,7 @@ class DaemonTestActor(WorkerActor):
             return val
 
     def handle_process_down(self, halt_refs):
-        try:
-            raise WorkerProcessStopped
-        except WorkerProcessStopped:
-            exc_info = sys.exc_info()
-
-        self.reject_promise_refs(halt_refs, *exc_info)
+        self.reject_promise_refs(halt_refs, *build_exc_info(WorkerProcessStopped))
 
 
 class Test(WorkerCase):

--- a/mars/worker/tests/test_execution.py
+++ b/mars/worker/tests/test_execution.py
@@ -153,6 +153,7 @@ class Test(WorkerCase):
         super(Test, self).tearDown()
         logger = logging.getLogger(ExecutionActor.__module__)
         logger.setLevel(logging.WARNING)
+        self.rm_spill_dirs(options.worker.spill_directory)
 
     @classmethod
     def create_standard_actors(cls, pool, address, quota_size=None, with_daemon=True,
@@ -289,7 +290,7 @@ class Test(WorkerCase):
             data = test_actor._chunk_store.get(session_id, arr_add.chunks[0].key)
             assert_array_equal(data, data_inputs[0] + data_inputs[1])
 
-        options.worker.spill_directory = tempfile.mkdtemp('mars_worker_prep_spilled-')
+        options.worker.spill_directory = tempfile.mkdtemp(prefix='mars_worker_prep_spilled-')
 
         # register when all predecessors unfinished
         with create_actor_pool(n_process=1, backend='gevent', address=pool_address) as pool:
@@ -419,7 +420,7 @@ class Test(WorkerCase):
         session_id = str(uuid.uuid4())
         mock_data = np.array([1, 2, 3, 4])
 
-        options.worker.spill_directory = tempfile.mkdtemp('mars_worker_prep_spilled-')
+        options.worker.spill_directory = tempfile.mkdtemp(prefix='mars_worker_prep_spilled-')
 
         with create_actor_pool(n_process=1, backend='gevent', address=pool_address) as pool:
             self.create_standard_actors(pool, pool_address, with_daemon=False, with_status=False)

--- a/mars/worker/utils.py
+++ b/mars/worker/utils.py
@@ -15,17 +15,16 @@
 import logging
 import math
 import os
-import sys
 import time
 from collections import OrderedDict
 
 from ..actors import ActorNotExist
-from ..compat import OrderedDict3
-from ..errors import WorkerProcessStopped
-from ..config import options
-from ..promise import PromiseActor
 from ..cluster_info import HasClusterInfoActor
-
+from ..compat import OrderedDict3
+from ..config import options
+from ..errors import WorkerProcessStopped
+from ..promise import PromiseActor
+from ..utils import build_exc_info
 
 logger = logging.getLogger(__name__)
 
@@ -65,12 +64,7 @@ class WorkerActor(HasClusterInfoActor, PromiseActor):
         Handle process down event
         :param halt_refs: actor refs in halt processes
         """
-        try:
-            raise WorkerProcessStopped
-        except WorkerProcessStopped:
-            exc_info = sys.exc_info()
-
-        handled_refs = self.reject_promise_refs(halt_refs, *exc_info)
+        handled_refs = self.reject_promise_refs(halt_refs, *build_exc_info(WorkerProcessStopped))
         logger.debug('Process halt detected. Affected promises %r rejected.',
                      [ref.uid for ref in handled_refs])
 


### PR DESCRIPTION
## What do these changes do?

* Broadcast peer worker failures to workers and reject corresponding promise calls
* Fix KeyError in PlasmaChunkStore when previous transfer does not stop elegantly and stops fail-over procedure
* Fix worker start failure caused by logging in gipc under some installations

## Related issue number

Fixes #240
