### PR TITLE
Allow renaming allocation keys in QuotaActor

### DIFF
--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -99,10 +99,8 @@ cdef inline list h_iterative(object ob):
 
 
 cdef inline object h_non_iterative(object ob):
-    if isinstance(ob, (int, float, str, unicode, bytes,
+    if isinstance(ob, (int, long, float, str, unicode, bytes, complex,
                        type(None), type, slice, date, datetime, timedelta)):
-        return ob
-    if isinstance(ob, (int, long, complex)):
         return ob
     if hasattr(ob, 'key'):
         return ob.key

--- a/mars/promise.py
+++ b/mars/promise.py
@@ -34,7 +34,8 @@ class Promise(object):
     """
     Object representing a promised result
     """
-    def __init__(self, resolve=None, reject=None, done=False, failed=False):
+    def __init__(self, resolve=None, reject=None, done=False, failed=False,
+                 args=None, kwargs=None):
         # use random promise id
         self._id = struct.pack('<Q', id(self)) + np.random.bytes(32)
         # register in global pool to reject gc collection
@@ -61,8 +62,8 @@ class Promise(object):
             self._accepted = False
         else:
             self._accepted = None
-        self._args = ()
-        self._kwargs = {}
+        self._args = args or ()
+        self._kwargs = kwargs or {}
 
         self.post_create()
 
@@ -472,3 +473,18 @@ def all_(promises):
     else:
         new_promise.step_next()
         return new_promise
+
+
+def finished(*args, **kwargs):
+    """
+    Create a promise already finished
+    :return: Promise object if _promise is True, otherwise args[0] will be returned
+    """
+    promise = kwargs.pop('_promise', True)
+    accept = kwargs.pop('_accept', True)
+    if not promise:
+        return args[0] if args else None
+    if accept:
+        return Promise(done=True, args=args, kwargs=kwargs)
+    else:
+        return Promise(failed=True, args=args, kwargs=kwargs)

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -253,9 +253,11 @@ class EtcdProcessHelper(object):
 def patch_method(method, *args, **kwargs):
     if hasattr(method, '__qualname__'):
         return mock.patch(method.__module__ + '.' + method.__qualname__, *args, **kwargs)
-    else:
+    elif hasattr(method, 'im_class'):
         return mock.patch('.'.join([method.im_class.__module__, method.im_class.__name__, method.__name__]),
                           *args, **kwargs)
+    else:
+        return mock.patch(method.__module__ + '.' + method.__name__, *args, **kwargs)
 
 
 def calc_shape(tensor):

--- a/mars/tests/test_promise.py
+++ b/mars/tests/test_promise.py
@@ -220,7 +220,7 @@ class Test(unittest.TestCase):
 
             # immediate error
             value_list = []
-            p = promise.Promise(done=True) \
+            p = promise.finished() \
                 .then(lambda *_: 5 / 0)
             p.catch(lambda *_: gen_promise(0)) \
                 .wait()
@@ -231,7 +231,7 @@ class Test(unittest.TestCase):
 
             # chained errors
             value_list = []
-            p = promise.Promise(failed=True) \
+            p = promise.finished(_accept=False) \
                 .catch(lambda *_: 1 / 0) \
                 .catch(lambda *_: 2 / 0) \
                 .catch(lambda *_: gen_promise(0)) \

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -313,7 +313,7 @@ class CpuCalcActor(WorkerActor):
                     apply_alloc_sizes[get_chunk_key(k)] += data_size
 
             for k, v in apply_alloc_sizes.items():
-                self._mem_quota_ref.apply_allocation(k, v)
+                self._mem_quota_ref.alter_allocation(k, v)
 
             if self._status_ref:
                 self._status_ref.update_mean_stats(

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -139,7 +139,7 @@ class InProcessCacheActor(WorkerActor):
             data_shape = value[0].shape if isinstance(value, tuple) else value.shape
             del value
             promises.append(
-                promise.Promise(done=True).then(partial(_try_put_chunk, k, data_size, data_shape))
+                promise.finished().then(partial(_try_put_chunk, k, data_size, data_shape))
             )
         promise.all_(promises).then(_finish_store) \
             .catch(lambda *exc: self.tell_promise(callback, *exc, **dict(_accept=False)))

--- a/mars/worker/chunkholder.py
+++ b/mars/worker/chunkholder.py
@@ -35,7 +35,7 @@ def ensure_chunk(promise_actor, session_id, chunk_key, move_to_end=False):
         logger.debug('No need to load key %s from spill.', chunk_key)
         if move_to_end:
             chunk_holder_ref.move_to_end(chunk_key)
-        return promise.Promise(done=True)
+        return promise.finished()
 
     logger.debug('Try starting loading data %s from spill.', chunk_key)
 

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -449,7 +449,7 @@ class ExecutionActor(WorkerActor):
             except:  # noqa: E722
                 _handle_network_error(*sys.exc_info())
 
-        return promise.Promise(done=True) \
+        return promise.finished() \
             .then(lambda *_: remote_disp_ref.get_free_slot('sender', _promise=True, _timeout=timeout)) \
             .then(_fetch_step) \
             .catch(_handle_network_error)
@@ -588,7 +588,7 @@ class ExecutionActor(WorkerActor):
             self._result_cache[(session_id, graph_key)] = GraphResultRecord(save_sizes)
             _handle_success()
         else:
-            promise.Promise(done=True) \
+            promise.finished() \
                 .then(lambda: self._prepare_graph_inputs(session_id, graph_key)) \
                 .then(_wait_free_slot) \
                 .then(lambda uid: self._send_calc_request(session_id, graph_key, uid)) \
@@ -671,7 +671,7 @@ class ExecutionActor(WorkerActor):
 
             # fetch data from other workers, if one fails, try another
             sorted_workers = sorted(worker_priorities, key=lambda pr: pr[1])
-            p = promise.Promise(failed=True)
+            p = promise.finished(_accept=False)
             for wp in sorted_workers:
                 p = p.catch(functools.partial(self._fetch_remote_data, session_id, graph_key, input_key, wp[0],
                                               ensure_cached=input_key in shared_input_chunks))
@@ -761,7 +761,7 @@ class ExecutionActor(WorkerActor):
 
         promises = []
         for key, targets in data_to_addresses.items():
-            promises.append(promise.Promise(done=True)
+            promises.append(promise.finished()
                             .then(lambda: self._dispatch_ref.get_free_slot('sender', _promise=True))
                             .then(functools.partial(_send_chunk, data_key=key, target_addrs=targets))
                             .catch(lambda *_: None))

--- a/mars/worker/quota.py
+++ b/mars/worker/quota.py
@@ -128,6 +128,9 @@ class QuotaActor(WorkerActor):
         :param make_first: whether to move request keys to the highest priority
         :return: if request is returned immediately, return True, otherwise False
         """
+        if delta > self._total_size:
+            raise ValueError('Cannot allocate size larger than the total capacity.')
+
         if not multiple and self._allocations.get(keys, 0) >= quota_sizes:
             # already allocated, inform and quit
             if callback is not None:

--- a/mars/worker/tests/base.py
+++ b/mars/worker/tests/base.py
@@ -47,14 +47,9 @@ class WorkerTestActor(WorkerActor):
             kw['_tell'] = True
             self.ref().run_later(fun, *args, **kw)
 
-    def set_result(self, result, accept=True, destroy=True):
+    def set_result(self, result, accept=True):
         self.test_obj._result_store = (result, accept)
         self.test_obj._result_event.set()
-        try:
-            if destroy:
-                self.ctx.destroy_actor(self.ref())
-        except:
-            pass
 
 
 class WorkerCase(unittest.TestCase):

--- a/mars/worker/tests/base.py
+++ b/mars/worker/tests/base.py
@@ -38,6 +38,15 @@ class WorkerTestActor(WorkerActor):
         v = yield
         del v
 
+    def run_later(self, fun, *args, **kw):
+        delay = kw.get('_delay')
+        if not delay:
+            kw.pop('_delay', None)
+            return fun(*args, **kw)
+        else:
+            kw['_tell'] = True
+            self.ref().run_later(fun, *args, **kw)
+
     def set_result(self, result, accept=True, destroy=True):
         self.test_obj._result_store = (result, accept)
         self.test_obj._result_event.set()

--- a/mars/worker/tests/test_chunkholder.py
+++ b/mars/worker/tests/test_chunkholder.py
@@ -66,7 +66,7 @@ class CacheTestActor(WorkerActor):
 
         data_promises = []
         for data_id, data in data_list:
-            data_promises.append(promise.Promise(done=True) \
+            data_promises.append(promise.finished()
                                  .then(partial(_put_chunk, data_id, data)))
 
         def assert_true(v):

--- a/mars/worker/tests/test_dispatcher.py
+++ b/mars/worker/tests/test_dispatcher.py
@@ -17,6 +17,7 @@ from functools import partial
 
 import gevent
 
+from mars import promise
 from mars.tests.core import patch_method
 from mars.utils import get_next_port
 from mars.actors import create_actor_pool
@@ -72,8 +73,7 @@ class Test(WorkerCase):
             # while the last one will be delayed due to lack of slots
 
             with self.run_actor_test(pool) as test_actor:
-                from mars.promise import Promise
-                p = Promise(done=True)
+                p = promise.finished()
                 _dispatch_ref = test_actor.promise_ref(DispatchActor.default_name())
 
                 def _call_on_dispatched(uid, key=None):

--- a/mars/worker/tests/test_execution.py
+++ b/mars/worker/tests/test_execution.py
@@ -338,7 +338,7 @@ class Test(WorkerCase):
                     dict(chunks=[input_chunks[0].key]), None,
                     succ_keys=[new_add_chunk.op.key], _promise=True) \
                     .then(lambda *_: execution_ref.start_execution(session_id, graph_input_op_keys[0], _promise=True)) \
-                    .then(lambda *_: test_actor.set_result(None, destroy=False)) \
+                    .then(lambda *_: test_actor.set_result(None)) \
                     .catch(lambda *exc: test_actor.set_result(exc, False))
                 self.get_result()
 

--- a/mars/worker/tests/test_quota.py
+++ b/mars/worker/tests/test_quota.py
@@ -32,6 +32,9 @@ class Test(WorkerCase):
             quota_ref.hold_quota('non_exist')
             quota_ref.release_quota('non_exist')
 
+            with self.assertRaises(ValueError):
+                quota_ref.request_quota('ERROR', 1000)
+
             self.assertTrue(quota_ref.request_quota('0', 100))
             self.assertTrue(quota_ref.request_quota('0', 50))
             self.assertTrue(quota_ref.request_quota('0', 200))

--- a/mars/worker/tests/test_quota.py
+++ b/mars/worker/tests/test_quota.py
@@ -16,8 +16,9 @@ import functools
 import time
 
 from mars.actors import create_actor_pool
-from mars.utils import get_next_port
-from mars.worker import QuotaActor
+from mars.tests.core import patch_method
+from mars.utils import get_next_port, build_exc_info
+from mars.worker import QuotaActor, MemQuotaActor, DispatchActor, ProcessHelperActor
 from mars.worker.tests.base import WorkerCase
 
 
@@ -27,28 +28,79 @@ class Test(WorkerCase):
         with create_actor_pool(n_process=1, backend='gevent', address=local_pool_addr) as pool:
             quota_ref = pool.create_actor(QuotaActor, 300, uid=QuotaActor.default_name())
 
-            end_time = []
-            for idx in range(4):
-                x = str(idx)
-                with self.run_actor_test(pool) as test_actor:
-                    ref = test_actor.promise_ref(QuotaActor.default_name())
+            quota_ref.process_quota('non_exist')
+            quota_ref.hold_quota('non_exist')
+            quota_ref.release_quota('non_exist')
 
-                    def actual_exec(x):
-                        test_actor.ctx.sleep(1)
-                        ref.release_quota(x)
-                        end_time.append(time.time())
+            self.assertTrue(quota_ref.request_quota('0', 100))
+            self.assertTrue(quota_ref.request_quota('0', 50))
+            self.assertTrue(quota_ref.request_quota('0', 200))
+
+            quota_ref.process_quota('0')
+            self.assertIn('0', quota_ref.dump_data().proc_sizes)
+            quota_ref.apply_allocation('0', 190, new_key=('0', 0))
+            self.assertEqual(quota_ref.dump_data().allocations[('0', 0)], 190)
+
+            quota_ref.hold_quota(('0', 0))
+            self.assertIn(('0', 0), quota_ref.dump_data().hold_sizes)
+            quota_ref.apply_allocation(('0', 0), 180, new_key=('0', 1))
+            self.assertEqual(quota_ref.dump_data().allocations[('0', 1)], 180)
+
+            with self.run_actor_test(pool) as test_actor:
+                ref = test_actor.promise_ref(QuotaActor.default_name())
+
+                ref.request_quota('1', 150, _promise=True) \
+                    .catch(lambda *exc: test_actor.set_result(exc, accept=False))
+
+                self.assertFalse(quota_ref.request_quota('2', 50))
+                self.assertFalse(quota_ref.request_quota('3', 200))
+
+                self.assertFalse(quota_ref.request_quota('3', 180))
+
+                self.assertNotIn('2', quota_ref.dump_data().allocations)
+
+                ref.cancel_requests(('1',), reject_exc=build_exc_info(ValueError))
+                with self.assertRaises(ValueError):
+                    self.get_result(5)
+
+            self.assertNotIn('1', quota_ref.dump_data().requests)
+            self.assertIn('2', quota_ref.dump_data().allocations)
+            self.assertNotIn('3', quota_ref.dump_data().allocations)
+
+            quota_ref.release_quotas([('0', 1)])
+            self.assertIn('3', quota_ref.dump_data().allocations)
+
+    def testQuotaAllocation(self):
+        local_pool_addr = 'localhost:%d' % get_next_port()
+        with create_actor_pool(n_process=1, backend='gevent', address=local_pool_addr) as pool:
+            quota_ref = pool.create_actor(QuotaActor, 300, uid=QuotaActor.default_name())
+
+            end_time = []
+            finished = set()
+            with self.run_actor_test(pool) as test_actor:
+                ref = test_actor.promise_ref(QuotaActor.default_name())
+
+                def actual_exec(x):
+                    ref.release_quota(x)
+                    end_time.append(time.time())
+                    finished.add(x)
+                    if len(finished) == 5:
                         test_actor.set_result(None)
 
-                    ref.request_quota(x, 100, _promise=True) \
-                        .then(functools.partial(actual_exec, x))
+                for idx in range(5):
+                    x = str(idx)
 
-            pool.sleep(2.5)
+                    ref.request_quota(x, 100, _promise=True) \
+                        .then(functools.partial(test_actor.run_later, actual_exec, x, _delay=0.5))
+                self.get_result(10)
+
             self.assertLess(abs(end_time[0] - end_time[1]), 0.1)
             self.assertLess(abs(end_time[0] - end_time[2]), 0.1)
-            self.assertGreater(abs(end_time[0] - end_time[3]), 0.9)
+            self.assertGreater(abs(end_time[0] - end_time[3]), 0.4)
+            self.assertLess(abs(end_time[3] - end_time[4]), 0.1)
             self.assertEqual(quota_ref.get_allocated_size(), 0)
 
-    def testBatchQuota(self):
+    def testBatchQuotaAllocation(self):
         local_pool_addr = 'localhost:%d' % get_next_port()
         with create_actor_pool(n_process=1, backend='gevent', address=local_pool_addr) as pool:
             quota_ref = pool.create_actor(QuotaActor, 300, uid=QuotaActor.default_name())
@@ -60,7 +112,6 @@ class Test(WorkerCase):
                     ref = test_actor.promise_ref(QuotaActor.default_name())
 
                     def actual_exec(keys):
-                        test_actor.ctx.sleep(1)
                         for k in keys:
                             ref.release_quota(k)
                         end_time.append(time.time())
@@ -69,8 +120,42 @@ class Test(WorkerCase):
                     keys = [x + '_0', x + '_1']
                     batch = dict((k, 100) for k in keys)
                     ref.request_batch_quota(batch, _promise=True) \
-                        .then(functools.partial(actual_exec, keys))
+                        .then(functools.partial(test_actor.run_later, actual_exec, keys, _delay=0.5))
+                    self.get_result(10)
 
-            pool.sleep(2.5)
-            self.assertGreater(abs(end_time[0] - end_time[1]), 0.9)
+            self.assertGreater(abs(end_time[0] - end_time[1]), 0.4)
             self.assertEqual(quota_ref.get_allocated_size(), 0)
+
+    def testMemQuotaAllocation(self):
+        from mars import resource
+        from mars.utils import AttributeDict
+
+        mock_mem_stat = AttributeDict(dict(total=300, available=50, used=0, free=50))
+        local_pool_addr = 'localhost:%d' % get_next_port()
+        with create_actor_pool(n_process=1, backend='gevent', address=local_pool_addr) as pool, \
+                patch_method(resource.virtual_memory, new=lambda: mock_mem_stat) as _:
+            pool.create_actor(DispatchActor, uid=DispatchActor.default_name())
+            pool.create_actor(ProcessHelperActor, uid=ProcessHelperActor.default_name())
+            quota_ref = pool.create_actor(MemQuotaActor, 300, refresh_time=0.1,
+                                          uid=MemQuotaActor.default_name())
+
+            time_recs = []
+            with self.run_actor_test(pool) as test_actor:
+                ref = test_actor.promise_ref(quota_ref)
+                time_recs.append(time.time())
+
+                def actual_exec(x):
+                    ref.release_quota(x)
+                    time_recs.append(time.time())
+                    test_actor.set_result(None)
+
+                ref.request_quota('req', 100, _promise=True) \
+                    .then(functools.partial(actual_exec, 'req'))
+
+                pool.sleep(0.5)
+                mock_mem_stat['available'] = 150
+                mock_mem_stat['free'] = 150
+
+                self.get_result(2)
+
+            self.assertGreater(abs(time_recs[0] - time_recs[1]), 0.4)

--- a/mars/worker/tests/test_utils.py
+++ b/mars/worker/tests/test_utils.py
@@ -49,12 +49,12 @@ class Test(unittest.TestCase):
         cache['v1'] = 1
         cache['v2'] = 2
 
-        time.sleep(0.2)
+        time.sleep(0.3)
         cache['v2'] = 2
         self.assertIn('v1', cache)
         self.assertIn('v2', cache)
 
-        time.sleep(0.4)
+        time.sleep(0.3)
         cache['v3'] = 3
         self.assertNotIn('v1', cache)
         self.assertIn('v2', cache)

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -177,14 +177,14 @@ class SenderActor(WorkerActor):
                 )
                 # register finish listeners
                 finish_promises.append(
-                    promise.Promise(done=True)
+                    promise.finished()
                     .then(functools.partial(ref.register_finish_callback, session_id, chunk_key,
                                             _timeout=timeout, _promise=True))
                 )
             # register wait-only listeners
             for ref in wait_refs:
                 finish_promises.append(
-                    promise.Promise(done=True)
+                    promise.finished()
                     .then(functools.partial(ref.register_finish_callback, session_id, chunk_key,
                                             _timeout=timeout, _promise=True))
                 )
@@ -430,7 +430,7 @@ class ReceiverActor(WorkerActor):
             if callback:
                 self.tell_promise(callback, *exc, **dict(_accept=False))
 
-        promise.Promise(done=True) \
+        promise.finished() \
             .then(lambda *_: self._create_writer(session_id, chunk_key, ensure_cached=ensure_cached)) \
             .then(_handle_accept, _handle_reject)
 


### PR DESCRIPTION
## What do these changes do?

1. Add capability for renaming allocation keys
2. Add test cases to refine coverage for QuotaActor

## Related issue number

Fixes #335 