### PR TITLE
Fix tiledb error when numpy int64 in shape

### DIFF
--- a/mars/session.py
+++ b/mars/session.py
@@ -119,7 +119,7 @@ class Session(object):
             ret = []
             for r, t in zip(result, tensors):
                 if t.isscalar() and hasattr(r, 'item'):
-                    ret.append(np.asscalar(r))
+                    ret.append(r.item())
                 else:
                     ret.append(r)
             if ret_list:
@@ -139,7 +139,7 @@ class Session(object):
         ret = []
         for r, t in zip(result, tensors):
             if t.isscalar() and hasattr(r, 'item'):
-                ret.append(np.asscalar(r))
+                ret.append(r.item())
             else:
                 ret.append(r)
         if ret_list:

--- a/mars/tensor/execution/datastore.py
+++ b/mars/tensor/execution/datastore.py
@@ -38,8 +38,8 @@ def _store_tiledb(ctx, chunk):
         to_store = np.ascontiguousarray(ctx[chunk.op.input.key])
         slcs = []
         for axis in range(chunk.ndim):
-            axis_offset = axis_offsets[axis]
-            axis_length = chunk.op.input.shape[axis]
+            axis_offset = int(axis_offsets[axis])
+            axis_length = int(chunk.op.input.shape[axis])
             slcs.append(slice(axis_offset, axis_offset + axis_length))
         with tiledb.DenseArray(uri=uri, ctx=tiledb_ctx, mode='w',
                                key=key, timestamp=timestamp) as arr:

--- a/mars/tensor/execution/tests/test_datastore_execute.py
+++ b/mars/tensor/execution/tests/test_datastore_execute.py
@@ -25,7 +25,7 @@ except (ImportError, OSError):  # pragma: no cover
 
 from mars.executor import Executor
 from mars.tests.core import TestBase
-from mars.tensor import tensor, totiledb
+from mars.tensor import tensor, arange, totiledb
 
 
 class Test(TestBase):
@@ -47,6 +47,18 @@ class Test(TestBase):
 
             with tiledb.DenseArray(uri=tempdir, ctx=ctx) as arr:
                 np.testing.assert_allclose(expected, arr.read_direct())
+        finally:
+            shutil.rmtree(tempdir)
+
+        tempdir = tempfile.mkdtemp()
+        try:
+            # store tensor with 1 chunk to TileDB dense array
+            a = arange(12)
+            save = totiledb(tempdir, a, ctx=ctx)
+            self.executor.execute_tensor(save)
+
+            with tiledb.DenseArray(uri=tempdir, ctx=ctx) as arr:
+                np.testing.assert_allclose(np.arange(12), arr.read_direct())
         finally:
             shutil.rmtree(tempdir)
 

--- a/mars/tensor/expressions/datasource/scalar.py
+++ b/mars/tensor/expressions/datasource/scalar.py
@@ -49,7 +49,7 @@ class Scalar(TensorNoInput):
 def scalar(data, dtype=None, gpu=False):
     try:
         arr = np.array(data, dtype=dtype)
-        op = Scalar(np.asscalar(arr), dtype=arr.dtype, gpu=gpu)
+        op = Scalar(arr.item(), dtype=arr.dtype, gpu=gpu)
         shape = ()
         return op(shape)
     except ValueError:

--- a/mars/tensor/expressions/reduction/core.py
+++ b/mars/tensor/expressions/reduction/core.py
@@ -173,11 +173,11 @@ class TensorReduction(TensorOperandMixin):
         for combine_block_idx, combine_block in izip(itertools.product(*combine_blocks_idxes),
                                                      itertools.product(*combine_blocks)):
             chks = [tensor.cix[idx] for idx in itertools.product(*combine_block)]
-            if len(chks) == 1:
-                chunks.append(chks[0])
-                continue
-            op = TensorConcatenate(axis=axes, dtype=chks[0].dtype)
-            chk = op.new_chunk(chks, shape=cls._concatenate_shape(tensor, combine_block))
+            if len(chks) > 1:
+                op = TensorConcatenate(axis=axes, dtype=chks[0].dtype)
+                chk = op.new_chunk(chks, shape=cls._concatenate_shape(tensor, combine_block))
+            else:
+                chk = chks[0]
             shape = tuple(s if i not in combine_size else 1
                           for i, s in enumerate(chk.shape) if keepdims or i not in combine_size)
             agg_op = agg_op_type(axis=axis, dtype=dtype, keepdims=keepdims, **kw)

--- a/mars/tensor/expressions/reduction/core.py
+++ b/mars/tensor/expressions/reduction/core.py
@@ -173,6 +173,9 @@ class TensorReduction(TensorOperandMixin):
         for combine_block_idx, combine_block in izip(itertools.product(*combine_blocks_idxes),
                                                      itertools.product(*combine_blocks)):
             chks = [tensor.cix[idx] for idx in itertools.product(*combine_block)]
+            if len(chks) == 1:
+                chunks.append(chks[0])
+                continue
             op = TensorConcatenate(axis=axes, dtype=chks[0].dtype)
             chk = op.new_chunk(chks, shape=cls._concatenate_shape(tensor, combine_block))
             shape = tuple(s if i not in combine_size else 1

--- a/mars/tensor/expressions/tests/test_datastore.py
+++ b/mars/tensor/expressions/tests/test_datastore.py
@@ -79,7 +79,7 @@ class Test(TestBase):
             saved = totiledb(tempdir, t2)
             self.assertEqual(saved.shape, (0, 0))
             self.assertIsNone(saved.op.tiledb_config)
-            self.assertEquals(saved.op.tiledb_uri, tempdir)
+            self.assertEqual(saved.op.tiledb_uri, tempdir)
 
             with self.assertRaises(tiledb.TileDBError):
                 tiledb.DenseArray(ctx=ctx, uri=tempdir)

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -447,7 +447,7 @@ def decide_chunk_sizes(shape, chunk_size, itemsize):
         dim_size = np.maximum(int(np.power(max_chunk_size / nbytes_occupied, 1 / float(len(left)))), 1)
         for j, ns in six.iteritems(left.copy()):
             unsplit = left_unsplit[j]
-            ns.append(np.minimum(unsplit, dim_size))
+            ns.append(int(np.minimum(unsplit, dim_size)))
             left_unsplit[j] -= ns[-1]
             if left_unsplit[j] <= 0:
                 dim_to_normalized[j] = tuple(ns)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Fix that when setting tiledb DenseArray' data with slice within numpy int64, error will be raised. Also rename all `np.asscalar` to scalar.item() cause that `np.asscalar` is deprecated.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #334 
