### PR TITLE
Support replacing actor classes given registration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -22,8 +22,6 @@ omit =
 [report]
 exclude_lines =
     pragma: no cover
-    cdef public
-    cpdef public
     def __repr__
     raise AssertionError
     raise NotImplementedError

--- a/.coveragerc-tensor
+++ b/.coveragerc-tensor
@@ -25,8 +25,6 @@ omit =
 [report]
 exclude_lines =
     pragma: no cover
-    cdef public
-    cpdef public
     def __repr__
     raise AssertionError
     raise NotImplementedError

--- a/mars/actors/__init__.py
+++ b/mars/actors/__init__.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
-from .core import create_actor_pool, Actor, FunctionActor, new_client
+from .core import create_actor_pool, Actor, FunctionActor, new_client, \
+    register_actor_implementation, unregister_actor_implementation
 from .errors import ActorPoolNotStarted, ActorNotExist, ActorAlreadyExist
 from .distributor import Distributor

--- a/mars/actors/core.pxd
+++ b/mars/actors/core.pxd
@@ -37,7 +37,7 @@ cdef class Actor:
     cpdef pre_destroy(self)
 
 
-cdef class FunctionActor(Actor):
+cdef class _FunctionActor(Actor):
     cpdef on_receive(self, message)
 
 

--- a/mars/actors/pool/gevent_pool.pyx
+++ b/mars/actors/pool/gevent_pool.pyx
@@ -243,7 +243,7 @@ cdef class LocalActorPool:
         actor.post_create()
         return ActorRef(self.address, uid)
 
-    cpdef bint has_actor(self, object actor_uid):
+    cpdef bint has_actor(self, object actor_uid) except -128:
         if actor_uid not in self.actors:
             return False
         return True

--- a/mars/actors/pool/tests/test_gevent_pool.py
+++ b/mars/actors/pool/tests/test_gevent_pool.py
@@ -327,6 +327,10 @@ class Test(unittest.TestCase):
             pool.sleep(0.5)
             self.assertEqual(ref2.send(('get',)), 9)
 
+            # error needed when illegal uids are passed
+            with self.assertRaises(TypeError):
+                ref1.send(('tell', pool.actor_ref(set()), 'add', 3))
+
     def testLocalDestroyHasActor(self):
         with create_actor_pool(n_process=1, backend='gevent') as pool:
             ref1 = pool.create_actor(DummyActor, 1)
@@ -334,6 +338,12 @@ class Test(unittest.TestCase):
 
             pool.destroy_actor(ref1)
             self.assertFalse(pool.has_actor(ref1))
+
+            # error needed when illegal uids are passed
+            with self.assertRaises(TypeError):
+                pool.has_actor(pool.actor_ref(set()))
+            with self.assertRaises(TypeError):
+                pool.has_actor(pool.actor_ref(set()), wait=False).result()
 
             ref1 = pool.create_actor(DummyActor, 1)
             future = pool.destroy_actor(ref1, wait=False)
@@ -343,7 +353,7 @@ class Test(unittest.TestCase):
             ref1 = pool.create_actor(DummyActor, 1)
             ref2 = ref1.send(('create', (DummyActor, 2)))
 
-            self.assertTrue(pool.has_actor(ref2))
+            self.assertTrue(pool.has_actor(ref2, wait=False).result())
 
             ref1.send(('delete', ref2))
             self.assertFalse(ref1.send(('has', ref2)))
@@ -515,6 +525,10 @@ class Test(unittest.TestCase):
             pool.sleep(0.5)
             self.assertEqual(ref2.send(('get',)), 9)
 
+            # error needed when illegal uids are passed
+            with self.assertRaises(TypeError):
+                ref1.send(('tell', pool.actor_ref(set()), 'add', 3))
+
     def testProcessDestroyHas(self):
         with create_actor_pool(n_process=2, distributor=DummyDistributor(2),
                                backend='gevent') as pool:
@@ -522,6 +536,12 @@ class Test(unittest.TestCase):
             self.assertTrue(pool.has_actor(ref1))
             pool.destroy_actor(ref1)
             self.assertFalse(pool.has_actor(ref1))
+
+            # error needed when illegal uids are passed
+            with self.assertRaises(TypeError):
+                pool.has_actor(pool.actor_ref(set()))
+            with self.assertRaises(TypeError):
+                pool.has_actor(pool.actor_ref(set()), wait=False).result()
 
             ref1 = pool.create_actor(DummyActor, 1, uid='admin-1')
             self.assertTrue(pool.has_actor(ref1, wait=False).result())
@@ -534,7 +554,7 @@ class Test(unittest.TestCase):
             self.assertTrue(future.result())
 
             ref1.send(('delete', ref2))
-            self.assertFalse(ref1.send(('has', ref2)))
+            self.assertFalse(ref1.send(('has_async', ref2)))
 
             with self.assertRaises(ActorNotExist):
                 pool.destroy_actor(pool.actor_ref('fake_uid'))
@@ -1251,7 +1271,7 @@ class Test(unittest.TestCase):
             ref1 = client.create_actor(DummyActor, 1, address=addr)
             ref2 = ref1.send(('create', (DummyActor, 2), dict(address=addr)))
 
-            self.assertTrue(client.has_actor(ref2))
+            self.assertTrue(client.has_actor(ref2, wait=False).result())
 
             ref1.send(('delete', ref2))
             self.assertFalse(ref1.send(('has', ref2)))
@@ -1306,7 +1326,7 @@ class Test(unittest.TestCase):
             ref1 = client.create_actor(DummyActor, 1, address=addr)
             ref2 = ref1.send(('create', (DummyActor, 2), dict(address=addr)))
 
-            self.assertTrue(client.has_actor(ref2))
+            self.assertTrue(client.has_actor(ref2, wait=False).result())
 
             ref1.send(('delete', ref2))
             self.assertFalse(ref1.send(('has', ref2)))
@@ -1363,7 +1383,7 @@ class Test(unittest.TestCase):
                 ref1 = client.create_actor(DummyActor, 1, address=addr1)
                 ref2 = ref1.send(('create', (DummyActor, 2), dict(address=addr2)))
 
-                self.assertTrue(client.has_actor(ref2))
+                self.assertTrue(client.has_actor(ref2, wait=False).result())
 
                 ref1.send(('delete', ref2))
                 self.assertFalse(ref1.send(('has', ref2)))
@@ -1420,7 +1440,7 @@ class Test(unittest.TestCase):
                 ref1 = client.create_actor(DummyActor, 1, address=addr1)
                 ref2 = ref1.send(('create', (DummyActor, 2), dict(address=addr2)))
 
-                self.assertTrue(client.has_actor(ref2))
+                self.assertTrue(client.has_actor(ref2, wait=False).result())
 
                 ref1.send(('delete', ref2))
                 self.assertFalse(ref1.send(('has', ref2)))
@@ -1471,7 +1491,7 @@ class Test(unittest.TestCase):
                 ref1 = client.create_actor(DummyActor, 1, address=addr1)
                 ref2 = ref1.send(('create', (DummyActor, 2), dict(address=addr2)))
 
-                self.assertTrue(client.has_actor(ref2))
+                self.assertTrue(client.has_actor(ref2, wait=False).result())
 
                 ref1.send(('delete', ref2))
                 self.assertFalse(ref1.send(('has', ref2)))
@@ -1523,7 +1543,7 @@ class Test(unittest.TestCase):
                 ref1 = client.create_actor(DummyActor, 1, address=addr1)
                 ref2 = ref1.send(('create', (DummyActor, 2), dict(address=addr2)))
 
-                self.assertTrue(client.has_actor(ref2))
+                self.assertTrue(client.has_actor(ref2, wait=False).result())
 
                 ref1.send(('delete', ref2))
                 self.assertFalse(ref1.send(('has', ref2)))

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ cythonize_kw = dict(language_level=sys.version_info[0])
 extension_kw = dict()
 if 'CYTHON_TRACE' in os.environ:
     extension_kw['define_macros'] = [('CYTHON_TRACE_NOGIL', '1'), ('CYTHON_TRACE', '1')]
-    cythonize_kw['compiler_directives'] = {'linetrace': True, 'binding': True}
+    cythonize_kw['compiler_directives'] = {'linetrace': True}
 
 if 'MSC' in sys.version:
     extra_compile_args = ['/Ot', '/I' + os.path.join(repo_root, 'misc')]


### PR DESCRIPTION
## What do these changes do?

Add plugin mechanism for actors, now we can use ``register_actor_implementation`` to replace actor implementations in plugins.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
