### PR TITLE
Add size estimator for sparse randint

### DIFF
--- a/mars/tensor/execution/random.py
+++ b/mars/tensor/execution/random.py
@@ -241,6 +241,14 @@ def _randint(ctx, chunk):
     return _rand(ctx, chunk)
 
 
+def _random_estimate_size(ctx, chunk):
+    if not chunk.is_sparse() or not getattr(chunk.op, '_density', None):
+        raise NotImplementedError
+    # use density to estimate real memory usage
+    nbytes = int(chunk.nbytes * getattr(chunk.op, '_density'))
+    ctx[chunk.key] = (nbytes, nbytes)
+
+
 def register_random_handler():
     from ...executor import register
     from ...operands import random as random_op
@@ -248,4 +256,4 @@ def register_random_handler():
     register(random_op.SimpleRandomData, _rand)
     register(random_op.Distribution, _distribution)
     register(random.TensorMultivariateNormal, _multivariate_normal)
-    register(random.TensorRandint, _randint)
+    register(random.TensorRandint, _randint, _random_estimate_size)

--- a/mars/tensor/execution/tests/test_random_execute.py
+++ b/mars/tensor/execution/tests/test_random_execute.py
@@ -49,7 +49,12 @@ class Test(unittest.TestCase):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).randn(5, 5)))
 
     def testRandintExecution(self):
+        size_executor = Executor(sync_provider_type=Executor.SyncProviderType.MOCK)
+
         arr = tensor.random.randint(0, 2, size=(10, 30), chunk_size=3)
+        size_res = size_executor.execute_tensor(arr, mock=True)
+        self.assertEqual(arr.nbytes, sum(tp[0] for tp in size_res))
+
         res = self.executor.execute_tensor(arr, concat=True)[0]
         self.assertEqual(res.shape, (10, 30))
         self.assertTrue(np.all(res >= 0))
@@ -158,7 +163,12 @@ class Test(unittest.TestCase):
                                                                     p=[.2, .5, .3])))
 
     def testSparseRandintExecution(self):
+        size_executor = Executor(sync_provider_type=Executor.SyncProviderType.MOCK)
+
         arr = tensor.random.randint(1, 2, size=(30, 50), density=.1, chunk_size=10, dtype='f4')
+        size_res = size_executor.execute_tensor(arr, mock=True)
+        self.assertAlmostEqual(arr.nbytes * 0.1, sum(tp[0] for tp in size_res))
+
         res = self.executor.execute_tensor(arr, concat=True)[0]
         self.assertTrue(issparse(res))
         self.assertEqual(res.shape, (30, 50))


### PR DESCRIPTION
## What do these changes do?

Estimate result size of sparse ``TensorRandInt`` by multiplying its ``nbytes`` with density.

## Related issue number

Fixes #354 
