### PR TITLE
Enhance tile for DataFrame's `add`

### DIFF
--- a/mars/core.py
+++ b/mars/core.py
@@ -285,7 +285,7 @@ class Chunk(Entity):
     _allow_data_type_ = (ChunkData,)
 
 
-class TilesableData(SerializableWithKey, Tilesable):
+class TileableData(SerializableWithKey, Tilesable):
     __slots__ = '__weakref__', '_siblings', '_cix'
     _no_copy_attrs_ = SerializableWithKey._no_copy_attrs_ | {'_cix'}
 
@@ -304,7 +304,7 @@ class TilesableData(SerializableWithKey, Tilesable):
         if '_nsplits' in kwargs:
             kwargs['_nsplits'] = tuple(tuple(s) for s in kwargs['_nsplits'])
 
-        super(TilesableData, self).__init__(*args, **kwargs)
+        super(TileableData, self).__init__(*args, **kwargs)
 
         if hasattr(self, '_chunks') and self._chunks:
             self._chunks = sorted(self._chunks, key=attrgetter('index'))

--- a/mars/dataframe/__init__.py
+++ b/mars/dataframe/__init__.py
@@ -13,3 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# do imports to register operands
+from .expressions import arithmetic
+from .expressions import datasource
+del arithmetic
+del datasource
+

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -230,6 +230,11 @@ class IndexValue(Serializable):
     def max_val_close(self):
         return self._index_value.max_val_close
 
+    @property
+    def min_max(self):
+        return self._index_value.min_val, self._index_value.min_val_close, \
+               self._index_value.max_val, self._index_value.max_val_close
+
     def to_pandas(self):
         return self._index_value.to_pandas()
 

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -71,6 +71,10 @@ class IndexValue(Serializable):
         def max_val_close(self):
             return self._max_val_close
 
+        @property
+        def key(self):
+            return self._key
+
         def to_pandas(self):
             kw = {field.tag_name(None): getattr(self, attr, None)
                   for attr, field in self._FIELDS.items()
@@ -87,6 +91,10 @@ class IndexValue(Serializable):
     class RangeIndex(IndexBase):
         _name = AnyField('name')
         _slice = SliceField('slice')
+
+        @property
+        def slice(self):
+            return self._slice
 
         def to_pandas(self):
             slc = self._slice
@@ -185,6 +193,10 @@ class IndexValue(Serializable):
     @property
     def value(self):
         return self._index_value
+
+    @property
+    def key(self):
+        return self._index_value.key
 
     @property
     def is_monotonic_increasing(self):

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+try:
+    import pandas as pd
+except ImportError:  # pragma: no cover
+    pass
+
 from ..core import ChunkData, Chunk, Entity, TilesableData
 from ..serialize import Serializable, ValueType, ProviderType, DataTypeField, AnyField, SeriesField, \
     BoolField, Int64Field, Int32Field, StringField, ListField, SliceField, OneOfField, ReferenceField
@@ -65,6 +71,14 @@ class IndexValue(Serializable):
         def max_val_close(self):
             return self._max_val_close
 
+        def to_pandas(self):
+            kw = {field.tag_name(None): getattr(self, attr, None)
+                  for attr, field in self._FIELDS.items()
+                  if attr not in super(type(self), self)._FIELDS}
+            if kw['data'] is None:
+                kw['data'] = []
+            return getattr(pd, type(self).__name__)(**kw)
+
     class Index(IndexBase):
         _name = AnyField('name')
         _data = ListField('data')
@@ -74,8 +88,13 @@ class IndexValue(Serializable):
         _name = AnyField('name')
         _slice = SliceField('slice')
 
+        def to_pandas(self):
+            slc = self._slice
+            return pd.RangeIndex(slc.start, slc.stop, slc.step)
+
     class CategoricalIndex(IndexBase):
         _name = AnyField('name')
+        _data = ListField('data')
         _categories = ListField('categories')
         _ordered = BoolField('ordered')
 
@@ -143,6 +162,14 @@ class IndexValue(Serializable):
         _data = ListField('data')
         _sortorder = Int32Field('sortorder')
 
+        def to_pandas(self):
+            data = getattr(self, '_data', None)
+            if data is None:
+                return pd.MultiIndex.from_arrays([[], []], sortorder=self._sortorder,
+                                                 names=self._names)
+            return pd.MultiIndex.from_tuples(np.asarray(data), sortorder=self._sortorder,
+                                             names=self._names)
+
     _index_value = OneOfField('index_value', index=Index,
                               range_index=RangeIndex, categorical_index=CategoricalIndex,
                               interval_index=IntervalIndex, datetime_index=DatetimeIndex,
@@ -190,6 +217,9 @@ class IndexValue(Serializable):
     @property
     def max_val_close(self):
         return self._index_value.max_val_close
+
+    def to_pandas(self):
+        return self._index_value.to_pandas()
 
 
 class IndexChunkData(ChunkData):

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -20,7 +20,7 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
-from ..core import ChunkData, Chunk, Entity, TilesableData
+from ..core import ChunkData, Chunk, Entity, TileableData
 from ..serialize import Serializable, ValueType, ProviderType, DataTypeField, AnyField, SeriesField, \
     BoolField, Int64Field, Int32Field, StringField, ListField, SliceField, OneOfField, ReferenceField
 
@@ -54,6 +54,10 @@ class IndexValue(Serializable):
         @property
         def should_be_monotonic(self):
             return self._should_be_monotonic
+
+        @should_be_monotonic.setter
+        def should_be_monotonic(self, val):
+            self._should_be_monotonic = val
 
         @property
         def min_val(self):
@@ -211,6 +215,10 @@ class IndexValue(Serializable):
         return self.is_monotonic_increasing or self.is_monotonic_decreasing
 
     @property
+    def should_be_monotonic(self):
+        return self._index_value.should_be_monotonic
+
+    @property
     def is_unique(self):
         return self._index_value.is_unique
 
@@ -260,7 +268,7 @@ class IndexChunk(Chunk):
     _allow_data_type_ = (IndexChunkData,)
 
 
-class IndexData(TilesableData):
+class IndexData(TileableData):
     __slots__ = ()
 
     # optional field
@@ -314,7 +322,7 @@ class SeriesChunk(Chunk):
     _allow_data_type_ = (SeriesChunkData,)
 
 
-class SeriesData(TilesableData):
+class SeriesData(TileableData):
     __slots__ = ()
 
     # optional field
@@ -372,7 +380,7 @@ class DataFrameChunk(Chunk):
     _allow_data_type_ = (DataFrameChunkData,)
 
 
-class DataFrameData(TilesableData):
+class DataFrameData(TileableData):
     __slots__ = ()
 
     # optional field

--- a/mars/dataframe/execution/arithmetic.py
+++ b/mars/dataframe/execution/arithmetic.py
@@ -14,8 +14,6 @@
 
 import operator
 import itertools
-import hashlib
-import functools
 
 try:
     import pandas as pd

--- a/mars/dataframe/execution/arithmetic.py
+++ b/mars/dataframe/execution/arithmetic.py
@@ -22,18 +22,9 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
+from ..utils import hash_index
 from ..expressions.arithmetic.core import DataFrameIndexAlignMap, DataFrameIndexAlignReduce
 from ..expressions.arithmetic import DataFrameAdd
-
-
-def _hash(index, size):
-    def func(x, size):
-        return int(hashlib.md5(bytes(x)).hexdigest(), 16) % size
-
-    f = functools.partial(func, size=size)
-    grouped = sorted(index.groupby(index.map(f)).items(),
-                     key=operator.itemgetter(0))
-    return [g[1] for g in grouped]
 
 
 def _index_align_map(ctx, chunk):
@@ -52,7 +43,7 @@ def _index_align_map(ctx, chunk):
     else:
         # shuffle on index
         shuffle_size = chunk.op.index_shuffle_size
-        filters[0].extend(_hash(df.index, shuffle_size))
+        filters[0].extend(hash_index(df.index, shuffle_size))
 
     if chunk.op.column_shuffle_size is None:
         # no shuffle on columns
@@ -64,7 +55,7 @@ def _index_align_map(ctx, chunk):
     else:
         # shuffle on columns
         shuffle_size = chunk.op.column_shuffle_size
-        filters[1].extend(_hash(df.columns, shuffle_size))
+        filters[1].extend(hash_index(df.columns, shuffle_size))
 
     if all(len(it) == 1 for it in filters):
         # no shuffle

--- a/mars/dataframe/execution/tests/test_arithmetic_execution.py
+++ b/mars/dataframe/execution/tests/test_arithmetic_execution.py
@@ -123,3 +123,126 @@ class Test(TestBase):
         result = self._concat(expected.index, expected.dtypes, results)
 
         pd.testing.assert_frame_equal(expected, result)
+
+    def testAddBothWithOneChunk(self):
+        # only 1 axis is monotonic
+        # data1 with index split into [0...4], [5...9],
+        data1 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(10),
+                             columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
+        df1 = from_pandas(data1, chunk_size=10)
+        # data2 with index split into [6...11], [2, 5],
+        data2 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(11, 1, -1),
+                             columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
+        df2 = from_pandas(data2, chunk_size=10)
+
+        df3 = add(df1, df2)
+
+        graph = df3.build_graph(tiled=True)
+        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
+
+        expected = data1 + data2
+        result = self._concat(expected.index, expected.dtypes, results)
+
+        pd.testing.assert_frame_equal(expected, result)
+
+        # only 1 axis is monotonic
+        # data1 with columns split into [0...4], [5...9],
+        data1 = pd.DataFrame(np.random.rand(10, 10), index=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7],
+                             columns=np.arange(10))
+        df1 = from_pandas(data1, chunk_size=10)
+        # data2 with columns split into [6...11], [2, 5],
+        data2 = pd.DataFrame(np.random.rand(10, 10), index=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2],
+                             columns=np.arange(11, 1, -1))
+        df2 = from_pandas(data2, chunk_size=10)
+
+        df3 = add(df1, df2)
+
+        graph = df3.build_graph(tiled=True)
+        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
+
+        expected = data1 + data2
+        result = self._concat(expected.index, expected.dtypes, results)
+
+        pd.testing.assert_frame_equal(expected, result)
+
+    def testAddWithoutShuffleAndWithOneChunk(self):
+        # only 1 axis is monotonic
+        # data1 with index split into [0...4], [5...9],
+        data1 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(10),
+                             columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
+        df1 = from_pandas(data1, chunk_size=(5, 10))
+        # data2 with index split into [6...11], [2, 5],
+        data2 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(11, 1, -1),
+                             columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
+        df2 = from_pandas(data2, chunk_size=(6, 10))
+
+        df3 = add(df1, df2)
+
+        graph = df3.build_graph(tiled=True)
+        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
+
+        expected = data1 + data2
+        result = self._concat(expected.index, expected.dtypes, results)
+
+        pd.testing.assert_frame_equal(expected, result)
+
+        # only 1 axis is monotonic
+        # data1 with columns split into [0...4], [5...9],
+        data1 = pd.DataFrame(np.random.rand(10, 10), index=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7],
+                             columns=np.arange(10))
+        df1 = from_pandas(data1, chunk_size=(10, 5))
+        # data2 with columns split into [6...11], [2, 5],
+        data2 = pd.DataFrame(np.random.rand(10, 10), index=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2],
+                             columns=np.arange(11, 1, -1))
+        df2 = from_pandas(data2, chunk_size=(10, 6))
+
+        df3 = add(df1, df2)
+
+        graph = df3.build_graph(tiled=True)
+        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
+
+        expected = data1 + data2
+        result = self._concat(expected.index, expected.dtypes, results)
+
+        pd.testing.assert_frame_equal(expected, result)
+
+    def testAddWithShuffleAndWithOneChunk(self):
+        # only 1 axis is monotonic
+        # data1 with index split into [0...4], [5...9],
+        data1 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(10),
+                             columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
+        df1 = from_pandas(data1, chunk_size=(10, 5))
+        # data2 with index split into [6...11], [2, 5],
+        data2 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(11, 1, -1),
+                             columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
+        df2 = from_pandas(data2, chunk_size=(10, 6))
+
+        df3 = add(df1, df2)
+
+        graph = df3.build_graph(tiled=True, compose=False)
+        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
+
+        expected = data1 + data2
+        result = self._concat(expected.index, expected.dtypes, results)
+
+        pd.testing.assert_frame_equal(expected, result)
+
+        # only 1 axis is monotonic
+        # data1 with columns split into [0...4], [5...9],
+        data1 = pd.DataFrame(np.random.rand(10, 10), index=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7],
+                             columns=np.arange(10))
+        df1 = from_pandas(data1, chunk_size=(5, 10))
+        # data2 with columns split into [6...11], [2, 5],
+        data2 = pd.DataFrame(np.random.rand(10, 10), index=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2],
+                             columns=np.arange(11, 1, -1))
+        df2 = from_pandas(data2, chunk_size=(6, 10))
+
+        df3 = add(df1, df2)
+
+        graph = df3.build_graph(tiled=True, compose=False)
+        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
+
+        expected = data1 + data2
+        result = self._concat(expected.index, expected.dtypes, results)
+
+        pd.testing.assert_frame_equal(expected, result)

--- a/mars/dataframe/expressions/arithmetic/add.py
+++ b/mars/dataframe/expressions/arithmetic/add.py
@@ -16,6 +16,7 @@ import operator
 
 from .... import operands
 from ....serialize import AnyField, Float64Field
+from ....utils import classproperty
 from .core import DataFrameBinOpMixin
 
 
@@ -28,7 +29,7 @@ class DataFrameAdd(operands.Add, DataFrameBinOpMixin):
         super(DataFrameAdd, self).__init__(_axis=axis, _level=level,
                                            _fill_value=fill_value, **kw)
 
-    @property
+    @classproperty
     def _operator(self):
         return operator.add
 

--- a/mars/dataframe/expressions/arithmetic/core.py
+++ b/mars/dataframe/expressions/arithmetic/core.py
@@ -23,7 +23,7 @@ from ....serialize import AnyField, BoolField, Int32Field, KeyField
 from ...core import DATAFRAME_TYPE
 from ..core import DataFrameOperandMixin, DataFrameShuffleProxy
 from ..utils import split_monotonic_index_min_max, infer_dtypes, \
-    build_split_idx_to_origin_idx
+    build_split_idx_to_origin_idx, parse_index
 
 
 class DataFrameIndexAlignMap(Operand, DataFrameOperandMixin):
@@ -434,10 +434,10 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
         raise NotImplementedError
 
     def _call(self, x1, x2):
+        dtypes = columns = index = None
         if x1.dtypes is not None and x2.dtypes is not None:
             dtypes = infer_dtypes(x1.dtypes, x2.dtypes, self._operator)
-        else:
-            dtypes = None
+            columns = parse_index(dtypes.index, store_data=True)
         return self.new_dataframe([x1, x2], shape=(np.nan, np.nan), dtypes=dtypes)
 
     def __call__(self, x1, x2):

--- a/mars/dataframe/expressions/arithmetic/core.py
+++ b/mars/dataframe/expressions/arithmetic/core.py
@@ -22,8 +22,9 @@ from .... import opcodes as OperandDef
 from ....serialize import AnyField, BoolField, Int32Field, KeyField
 from ...core import DATAFRAME_TYPE
 from ..core import DataFrameOperandMixin, DataFrameShuffleProxy
-from ..utils import split_monotonic_index_min_max, infer_dtypes, \
-    build_split_idx_to_origin_idx, parse_index
+from ..utils import parse_index, split_monotonic_index_min_max, \
+    build_split_idx_to_origin_idx
+from .utils import infer_dtypes, infer_index_value
 
 
 class DataFrameIndexAlignMap(Operand, DataFrameOperandMixin):
@@ -438,7 +439,10 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
         if x1.dtypes is not None and x2.dtypes is not None:
             dtypes = infer_dtypes(x1.dtypes, x2.dtypes, self._operator)
             columns = parse_index(dtypes.index, store_data=True)
-        return self.new_dataframe([x1, x2], shape=(np.nan, np.nan), dtypes=dtypes)
+        if x1.index_value is not None and x2.index_value is not None:
+            index = infer_index_value(x1.index_value, x2.index_value, self._operator)
+        return self.new_dataframe([x1, x2], shape=(np.nan, np.nan), dtypes=dtypes,
+                                  columns_value=columns, index_value=index)
 
     def __call__(self, x1, x2):
         return self._call(x1, x2)

--- a/mars/dataframe/expressions/arithmetic/core.py
+++ b/mars/dataframe/expressions/arithmetic/core.py
@@ -185,7 +185,7 @@ class DataFrameIndexAlignReduce(ShuffleReduce, DataFrameOperandMixin):
                 kw['columns_value'] = filter_index_value(index_align_map_chunks[0].columns,
                                                          index_align_map_chunks[0].op.column_min_max,
                                                          store_data=True)
-                kw['dtypes'] = index_align_map_chunks[0].dtypes[kw['columns_value']]
+                kw['dtypes'] = index_align_map_chunks[0].dtypes[kw['columns_value'].to_pandas()]
             else:
                 # shuffle on columns
                 all_dtypes = [c.op.column_shuffle_segments[index[1]] for c in index_align_map_chunks

--- a/mars/dataframe/expressions/arithmetic/tests/__init__.py
+++ b/mars/dataframe/expressions/arithmetic/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mars/dataframe/expressions/arithmetic/tests/test_utils.py
+++ b/mars/dataframe/expressions/arithmetic/tests/test_utils.py
@@ -58,7 +58,7 @@ class Test(unittest.TestCase):
         self.assertNotEqual(oival.key, ival1.key)
         self.assertNotEqual(oival.key, ival2.key)
 
-        # same int64 index
+        # same int64 index, all unique
         index1 = pd.Int64Index([1, 2])
         index2 = pd.Int64Index([1, 2])
 
@@ -66,8 +66,21 @@ class Test(unittest.TestCase):
         ival2 = parse_index(index2)
         oival = infer_index_value(ival1, ival2, operator.add)
 
+        self.assertIsInstance(oival.value, IndexValue.Int64Index)
         self.assertEqual(oival.key, ival1.key)
         self.assertEqual(oival.key, ival2.key)
+
+        # same int64 index, not all unique
+        index1 = pd.Int64Index([1, 2, 2])
+        index2 = pd.Int64Index([1, 2, 2])
+
+        ival1 = parse_index(index1)
+        ival2 = parse_index(index2)
+        oival = infer_index_value(ival1, ival2, operator.add)
+
+        self.assertIsInstance(oival.value, IndexValue.Int64Index)
+        self.assertNotEqual(oival.key, ival1.key)
+        self.assertNotEqual(oival.key, ival2.key)
 
         # different int64 index
         index1 = pd.Int64Index([1, 2])

--- a/mars/dataframe/expressions/arithmetic/tests/test_utils.py
+++ b/mars/dataframe/expressions/arithmetic/tests/test_utils.py
@@ -1,0 +1,94 @@
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import operator
+
+try:
+    import pandas as pd
+except ImportError:  # pragma: no cover
+    pd = None
+
+from mars.dataframe.core import IndexValue
+from mars.dataframe.expressions.utils import parse_index
+from mars.dataframe.expressions.arithmetic.utils import infer_dtypes, infer_index_value
+
+
+@unittest.skipIf(pd is None, 'pandas not installed')
+class Test(unittest.TestCase):
+    def testInferDtypes(self):
+        data1 = pd.DataFrame([[1, 'a', False]], columns=[2.0, 3.0, 4.0])
+        data2 = pd.DataFrame([[1, 3.0, 'b']], columns=[1, 2, 3])
+
+        pd.testing.assert_series_equal(infer_dtypes(data1.dtypes, data2.dtypes, operator.add),
+                                      (data1 + data2).dtypes)
+
+    def testInferIndexValue(self):
+        # same range index
+        index1 = pd.RangeIndex(1, 3)
+        index2 = pd.RangeIndex(1, 3)
+
+        ival1 = parse_index(index1)
+        ival2 = parse_index(index2)
+        oival = infer_index_value(ival1, ival2, operator.add)
+
+        self.assertEqual(oival.key, ival1.key)
+        self.assertEqual(oival.key, ival2.key)
+
+        # different range index
+        index1 = pd.RangeIndex(1, 3)
+        index2 = pd.RangeIndex(2, 4)
+
+        ival1 = parse_index(index1)
+        ival2 = parse_index(index2)
+        oival = infer_index_value(ival1, ival2, operator.add)
+
+        self.assertIsInstance(oival.value, IndexValue.Int64Index)
+        self.assertNotEqual(oival.key, ival1.key)
+        self.assertNotEqual(oival.key, ival2.key)
+
+        # same int64 index
+        index1 = pd.Int64Index([1, 2])
+        index2 = pd.Int64Index([1, 2])
+
+        ival1 = parse_index(index1)
+        ival2 = parse_index(index2)
+        oival = infer_index_value(ival1, ival2, operator.add)
+
+        self.assertEqual(oival.key, ival1.key)
+        self.assertEqual(oival.key, ival2.key)
+
+        # different int64 index
+        index1 = pd.Int64Index([1, 2])
+        index2 = pd.Int64Index([2, 3])
+
+        ival1 = parse_index(index1)
+        ival2 = parse_index(index2)
+        oival = infer_index_value(ival1, ival2, operator.add)
+
+        self.assertIsInstance(oival.value, IndexValue.Int64Index)
+        self.assertNotEqual(oival.key, ival1.key)
+        self.assertNotEqual(oival.key, ival2.key)
+
+        # different index type
+        index1 = pd.Int64Index([1, 2])
+        index2 = pd.Float64Index([2.0, 3.0])
+
+        ival1 = parse_index(index1)
+        ival2 = parse_index(index2)
+        oival = infer_index_value(ival1, ival2, operator.add)
+
+        self.assertIsInstance(oival.value, IndexValue.Float64Index)
+        self.assertNotEqual(oival.key, ival1.key)
+        self.assertNotEqual(oival.key, ival2.key)

--- a/mars/dataframe/expressions/arithmetic/utils.py
+++ b/mars/dataframe/expressions/arithmetic/utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import operator
+
 try:
     import pandas as pd
 except ImportError:  # pragma: no cover
@@ -48,3 +50,12 @@ def infer_index_value(left_index_value, right_index_value, operator):
     out_index = operator(left_index, right_index)
     key = tokenize(left_index_value.key, right_index_value.key, operator.__name__)
     return parse_index(out_index, key=key)
+
+
+def filter_dtypes(dtypes, column_min_max):
+    l_filter = operator.ge if column_min_max[1] else operator.gt
+    l = l_filter(dtypes.index, column_min_max[0])
+    r_filter = operator.le if column_min_max[3] else operator.lt
+    r = r_filter(dtypes.index, column_min_max[2])
+    f = l & r
+    return dtypes[f]

--- a/mars/dataframe/expressions/arithmetic/utils.py
+++ b/mars/dataframe/expressions/arithmetic/utils.py
@@ -40,8 +40,8 @@ def infer_index_value(left_index_value, right_index_value, operator):
     if left_index_value.key == right_index_value.key:
         return left_index_value
 
-    left = pd.DataFrame(index=left_index_value.to_pandas())
-    right = pd.DataFrame(index=right_index_value.to_pandas())
-    out_index = operator(left, right).index
+    left_index = left_index_value.to_pandas()
+    right_index = right_index_value.to_pandas()
+    out_index = operator(left_index, right_index)
     key = tokenize(left_index_value.key, right_index_value.key, operator.__name__)
     return parse_index(out_index, key=key)

--- a/mars/dataframe/expressions/arithmetic/utils.py
+++ b/mars/dataframe/expressions/arithmetic/utils.py
@@ -37,7 +37,10 @@ def infer_index_value(left_index_value, right_index_value, operator):
                        operator.__name__)
         return parse_index(pd.Int64Index([]), key=key)
 
-    if left_index_value.key == right_index_value.key:
+    # when left index and right index is identical, and both of them are elements unique,
+    # we can infer that the out index should be identical also
+    if left_index_value.is_unique and right_index_value.is_unique and \
+            left_index_value.key == right_index_value.key:
         return left_index_value
 
     left_index = left_index_value.to_pandas()

--- a/mars/dataframe/expressions/tests/test_arithmetic.py
+++ b/mars/dataframe/expressions/tests/test_arithmetic.py
@@ -445,8 +445,6 @@ class Test(TestBase):
         for c in df3.chunks:
             self.assertIsInstance(c.op, DataFrameAdd)
             self.assertEqual(len(c.inputs), 2)
-            # test shape
-            idx = c.index
             # test the left side
             self.assertIs(c.inputs[0], df1.chunks[0].data)
             # test the right side

--- a/mars/dataframe/expressions/tests/test_arithmetic.py
+++ b/mars/dataframe/expressions/tests/test_arithmetic.py
@@ -21,6 +21,7 @@ try:
 except ImportError:  # pragma: no cover
     pd = None
 
+from mars.dataframe.core import IndexValue
 from mars.dataframe.expressions.utils import split_monotonic_index_min_max, \
     build_split_idx_to_origin_idx
 from mars.dataframe.expressions.datasource.dataframe import from_pandas
@@ -46,6 +47,14 @@ class Test(TestBase):
         df2 = from_pandas(data2, chunk_size=6)
 
         df3 = add(df1, df2)
+
+        # test df3's index and columns
+        pd.testing.assert_index_equal(df3.columns.to_pandas(), (data1 + data2).columns)
+        self.assertIsInstance(df3.index_value.value, IndexValue.Int64Index)
+        pd.testing.assert_index_equal(df3.index_value.to_pandas(), pd.Int64Index([]))
+        self.assertNotEqual(df3.index_value.key, df1.index_value.key)
+        self.assertNotEqual(df3.index_value.key, df2.index_value.key)
+
         df3.tiles()
 
         data1_index_min_max = [(0, True, 4, True), (5, True, 9, True)]
@@ -111,6 +120,14 @@ class Test(TestBase):
         df2 = from_pandas(data2, chunk_size=6)
 
         df3 = add(df1, df2)
+
+        # test df3's index and columns
+        pd.testing.assert_index_equal(df3.columns.to_pandas(), (data1 + data2).columns)
+        self.assertIsInstance(df3.index_value.value, IndexValue.Int64Index)
+        pd.testing.assert_index_equal(df3.index_value.to_pandas(), pd.Int64Index([]))
+        self.assertNotEqual(df3.index_value.key, df1.index_value.key)
+        self.assertNotEqual(df3.index_value.key, df2.index_value.key)
+
         df3.tiles()
 
         data1_index_min_max = [(0, True, 4, True), (5, True, 9, True)]
@@ -180,6 +197,14 @@ class Test(TestBase):
         df2 = from_pandas(data2, chunk_size=6)
 
         df3 = add(df1, df2)
+
+        # test df3's index and columns
+        pd.testing.assert_index_equal(df3.columns.to_pandas(), (data1 + data2).columns)
+        self.assertIsInstance(df3.index_value.value, IndexValue.Int64Index)
+        pd.testing.assert_index_equal(df3.index_value.to_pandas(), pd.Int64Index([]))
+        self.assertNotEqual(df3.index_value.key, df1.index_value.key)
+        self.assertNotEqual(df3.index_value.key, df2.index_value.key)
+
         df3.tiles()
 
         self.assertEqual(df3.chunk_shape, (2, 2))

--- a/mars/dataframe/expressions/utils.py
+++ b/mars/dataframe/expressions/utils.py
@@ -91,7 +91,7 @@ def decide_chunk_sizes(shape, chunk_size, memory_usage):
     return tuple(row_chunk_size), tuple(col_chunk_size)
 
 
-def parse_index(index_value, store_data=False):
+def parse_index(index_value, store_data=False, key=None):
     import pandas as pd
 
     def _extract_property(index, ret_data):
@@ -103,7 +103,7 @@ def parse_index(index_value, store_data=False):
             '_max_val': index.max(),
             '_min_val_close': True,
             '_max_val_close': True,
-            '_key': tokenize(index),
+            '_key': key or tokenize(index),
         }
         if ret_data:
             kw['_data'] = index.values
@@ -272,15 +272,10 @@ def build_split_idx_to_origin_idx(splits, increase=True):
     return res
 
 
-def _build_empty_df(dtypes):
+def build_empty_df(dtypes):
     columns = dtypes.index
     df = pd.DataFrame(columns=columns)
     for c, d in zip(columns, dtypes):
         df[c] = pd.Series(dtype=d)
     return df
 
-
-def infer_dtypes(left_dtypes, right_dtypes, operator):
-    left = _build_empty_df(left_dtypes)
-    right = _build_empty_df(right_dtypes)
-    return operator(left, right).dtypes

--- a/mars/dataframe/expressions/utils.py
+++ b/mars/dataframe/expressions/utils.py
@@ -279,3 +279,18 @@ def build_empty_df(dtypes):
         df[c] = pd.Series(dtype=d)
     return df
 
+
+def filter_index_value(index_value, min_max):
+    min_val, min_val_close, max_val, max_val_close = min_max
+
+    pd_index = index_value.to_pandas()
+    if min_val_close:
+        pd_index = pd_index >= min_val
+    else:
+        pd_index = pd_index > min_val
+    if max_val_close:
+        pd_index = pd_index <= max_val
+    else:
+        pd_index = pd_index < max_val
+
+    return parse_index(pd_index, store_data=True)

--- a/mars/dataframe/expressions/utils.py
+++ b/mars/dataframe/expressions/utils.py
@@ -273,7 +273,7 @@ def build_split_idx_to_origin_idx(splits, increase=True):
 
 
 def _build_empty_df(dtypes):
-    columns = dtypes.index.tolist()
+    columns = dtypes.index
     df = pd.DataFrame(columns=columns)
     for c, d in zip(columns, dtypes):
         df[c] = pd.Series(dtype=d)

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -25,3 +25,8 @@ def hash_index(index, size):
     grouped = sorted(index.groupby(index.map(f)).items(),
                      key=operator.itemgetter(0))
     return [g[1] for g in grouped]
+
+
+def hash_dtypes(dtypes, size):
+    hashed_indexes = hash_index(dtypes.index, size)
+    return [dtypes[index] for index in hashed_indexes]

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -1,0 +1,27 @@
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import functools
+import operator
+
+
+def hash_index(index, size):
+    def func(x, size):
+        return int(hashlib.md5(bytes(x)).hexdigest(), 16) % size
+
+    f = functools.partial(func, size=size)
+    grouped = sorted(index.groupby(index.map(f)).items(),
+                     key=operator.itemgetter(0))
+    return [g[1] for g in grouped]

--- a/mars/graph.pyx
+++ b/mars/graph.pyx
@@ -414,9 +414,9 @@ cdef class DirectedGraph:
     def deserialize(cls, s_graph):
         cdef DirectedGraph graph = cls()
 
-        from .core import ChunkData, TilesableData
+        from .core import ChunkData, TileableData
 
-        node_type = TilesableData if s_graph.level == SerializableGraph.Level.ENTITY else ChunkData
+        node_type = TileableData if s_graph.level == SerializableGraph.Level.ENTITY else ChunkData
         for node in s_graph.nodes:
             if isinstance(node, node_type):
                 graph._add_node(node)

--- a/mars/serialize/jsonserializer.pyx
+++ b/mars/serialize/jsonserializer.pyx
@@ -27,7 +27,6 @@ except ImportError:  # pragma: no cover
     pd = None
 
 from ..compat import six, OrderedDict, izip
-from ..core import BaseWithKey
 from .._utils cimport to_str
 from .core cimport Provider, ValueType, ProviderType, \
     Field, List, Tuple, Dict, Identity, Reference, KeyPlaceholder, \
@@ -339,6 +338,8 @@ cdef class JsonSerializeProvider(Provider):
             raise TypeError('Unknown type to serialize: {0}'.format(tp))
 
     cdef inline object _serialize_untyped_value(self, value, bint weak_ref=False):
+        from ..core import BaseWithKey
+
         if not isinstance(value, (list, tuple, dict)) and weak_ref:
             # not iterable, and is weak ref
             value = value()

--- a/mars/serialize/pbserializer.pyx
+++ b/mars/serialize/pbserializer.pyx
@@ -28,7 +28,6 @@ except ImportError:  # pragma: no cover
 from cpython.version cimport PY_MAJOR_VERSION
 
 from ..compat import six, OrderedDict
-from ..core import BaseWithKey
 from .._utils cimport to_str
 from .core cimport ProviderType, ValueType, Identity, List, Tuple, Dict, \
     Reference, KeyPlaceholder, AttrWrapper, Provider, Field, \
@@ -370,6 +369,8 @@ cdef class ProtobufSerializeProvider(Provider):
             raise TypeError('Unknown type to serialize: {0}'.format(tp))
 
     cdef inline void _set_untyped_value(self, value, obj, bint weak_ref=False) except *:
+        from ..core import BaseWithKey
+
         if not isinstance(value, (list, tuple, dict)) and weak_ref:
             # not iterable, and is weak ref
             value = value()
@@ -695,6 +696,8 @@ cdef class ProtobufSerializeProvider(Provider):
             setattr(model_instance, field.attr, self._on_deserial(field, getattr(obj, tag)))
 
     def deserialize_attribute_as_dict(self, model_cls, obj, list callbacks, dict key_to_instance):
+        from ..core import BaseWithKey
+
         cdef str attr
         cdef object d_obj
         cdef object kw

--- a/mars/serialize/protos/indexvalue.proto
+++ b/mars/serialize/protos/indexvalue.proto
@@ -39,8 +39,9 @@ message IndexValue {
     }
     message CategoricalIndex {
         Value name = 1;
-        Value categories = 2;
-        bool ordered = 3;
+        Value data = 2;
+        Value categories = 3;
+        bool ordered = 4;
         // public fields
         string key = 51;
         bool is_monotonic_increasing = 52;

--- a/mars/serialize/protos/indexvalue_pb2.py
+++ b/mars/serialize/protos/indexvalue_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n&mars/serialize/protos/indexvalue.proto\x1a!mars/serialize/protos/value.proto\"\xc5\"\n\nIndexValue\x12\"\n\x05index\x18\x01 \x01(\x0b\x32\x11.IndexValue.IndexH\x00\x12-\n\x0brange_index\x18\x02 \x01(\x0b\x32\x16.IndexValue.RangeIndexH\x00\x12\x39\n\x11\x63\x61tegorical_index\x18\x03 \x01(\x0b\x32\x1c.IndexValue.CategoricalIndexH\x00\x12\x33\n\x0einterval_index\x18\x04 \x01(\x0b\x32\x19.IndexValue.IntervalIndexH\x00\x12\x33\n\x0e\x64\x61tetime_index\x18\x05 \x01(\x0b\x32\x19.IndexValue.DatetimeIndexH\x00\x12\x35\n\x0ftimedelta_index\x18\x06 \x01(\x0b\x32\x1a.IndexValue.TimedeltaIndexH\x00\x12/\n\x0cperiod_index\x18\x07 \x01(\x0b\x32\x17.IndexValue.PeriodIndexH\x00\x12-\n\x0bint64_index\x18\x08 \x01(\x0b\x32\x16.IndexValue.Int64IndexH\x00\x12/\n\x0cuint64_index\x18\t \x01(\x0b\x32\x17.IndexValue.UInt64IndexH\x00\x12\x31\n\rfloat64_index\x18\n \x01(\x0b\x32\x18.IndexValue.Float64IndexH\x00\x12-\n\x0bmulti_index\x18\x0b \x01(\x0b\x32\x16.IndexValue.MultiIndexH\x00\x1a\xa9\x02\n\x05Index\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x15\n\x05\x64type\x18\x03 \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\x98\x02\n\nRangeIndex\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x15\n\x05slice\x18\x02 \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xb4\x02\n\x10\x43\x61tegoricalIndex\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x1a\n\ncategories\x18\x02 \x01(\x0b\x32\x06.Value\x12\x0f\n\x07ordered\x18\x03 \x01(\x08\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xaa\x02\n\rIntervalIndex\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x0e\n\x06\x63losed\x18\x03 \x01(\x08\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xbe\x03\n\rDatetimeIndex\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x66req\x18\x03 \x01(\x0b\x32\x06.Value\x12\x15\n\x05start\x18\x04 \x01(\x0b\x32\x06.Value\x12\x0f\n\x07periods\x18\x05 \x01(\x03\x12\x13\n\x03\x65nd\x18\x06 \x01(\x0b\x32\x06.Value\x12\x16\n\x06\x63losed\x18\x07 \x01(\x0b\x32\x06.Value\x12\x12\n\x02tz\x18\x08 \x01(\x0b\x32\x06.Value\x12\x10\n\x08\x64\x61yfirst\x18\t \x01(\x08\x12\x11\n\tyearfirst\x18\n \x01(\x08\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\x9c\x03\n\x0eTimedeltaIndex\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x14\n\x04unit\x18\x03 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x66req\x18\x04 \x01(\x0b\x32\x06.Value\x12\x15\n\x05start\x18\x05 \x01(\x0b\x32\x06.Value\x12\x0f\n\x07periods\x18\x06 \x01(\x03\x12\x13\n\x03\x65nd\x18\x07 \x01(\x0b\x32\x06.Value\x12\x16\n\x06\x63losed\x18\x08 \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xb6\x04\n\x0bPeriodIndex\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x66req\x18\x03 \x01(\x0b\x32\x06.Value\x12\x15\n\x05start\x18\x04 \x01(\x0b\x32\x06.Value\x12\x0f\n\x07periods\x18\x05 \x01(\x03\x12\x13\n\x03\x65nd\x18\x06 \x01(\x0b\x32\x06.Value\x12\x14\n\x04year\x18\x07 \x01(\x0b\x32\x06.Value\x12\x15\n\x05month\x18\x08 \x01(\x0b\x32\x06.Value\x12\x16\n\x06quater\x18\t \x01(\x0b\x32\x06.Value\x12\x13\n\x03\x64\x61y\x18\n \x01(\x0b\x32\x06.Value\x12\x14\n\x04hour\x18\x0b \x01(\x0b\x32\x06.Value\x12\x16\n\x06minute\x18\x0c \x01(\x0b\x32\x06.Value\x12\x16\n\x06second\x18\r \x01(\x0b\x32\x06.Value\x12\x12\n\x02tz\x18\x0e \x01(\x0b\x32\x06.Value\x12\x15\n\x05\x64type\x18\x0f \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xae\x02\n\nInt64Index\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x15\n\x05\x64type\x18\x03 \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xaf\x02\n\x0bUInt64Index\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x15\n\x05\x64type\x18\x03 \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xb0\x02\n\x0c\x46loat64Index\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x15\n\x05\x64type\x18\x03 \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xab\x02\n\nMultiIndex\x12\x15\n\x05names\x18\x01 \x03(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x11\n\tsortorder\x18\x03 \x01(\x05\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x42\r\n\x0bindex_valueb\x06proto3')
+  serialized_pb=_b('\n&mars/serialize/protos/indexvalue.proto\x1a!mars/serialize/protos/value.proto\"\xdb\"\n\nIndexValue\x12\"\n\x05index\x18\x01 \x01(\x0b\x32\x11.IndexValue.IndexH\x00\x12-\n\x0brange_index\x18\x02 \x01(\x0b\x32\x16.IndexValue.RangeIndexH\x00\x12\x39\n\x11\x63\x61tegorical_index\x18\x03 \x01(\x0b\x32\x1c.IndexValue.CategoricalIndexH\x00\x12\x33\n\x0einterval_index\x18\x04 \x01(\x0b\x32\x19.IndexValue.IntervalIndexH\x00\x12\x33\n\x0e\x64\x61tetime_index\x18\x05 \x01(\x0b\x32\x19.IndexValue.DatetimeIndexH\x00\x12\x35\n\x0ftimedelta_index\x18\x06 \x01(\x0b\x32\x1a.IndexValue.TimedeltaIndexH\x00\x12/\n\x0cperiod_index\x18\x07 \x01(\x0b\x32\x17.IndexValue.PeriodIndexH\x00\x12-\n\x0bint64_index\x18\x08 \x01(\x0b\x32\x16.IndexValue.Int64IndexH\x00\x12/\n\x0cuint64_index\x18\t \x01(\x0b\x32\x17.IndexValue.UInt64IndexH\x00\x12\x31\n\rfloat64_index\x18\n \x01(\x0b\x32\x18.IndexValue.Float64IndexH\x00\x12-\n\x0bmulti_index\x18\x0b \x01(\x0b\x32\x16.IndexValue.MultiIndexH\x00\x1a\xa9\x02\n\x05Index\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x15\n\x05\x64type\x18\x03 \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\x98\x02\n\nRangeIndex\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x15\n\x05slice\x18\x02 \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xca\x02\n\x10\x43\x61tegoricalIndex\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x1a\n\ncategories\x18\x03 \x01(\x0b\x32\x06.Value\x12\x0f\n\x07ordered\x18\x04 \x01(\x08\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xaa\x02\n\rIntervalIndex\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x0e\n\x06\x63losed\x18\x03 \x01(\x08\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xbe\x03\n\rDatetimeIndex\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x66req\x18\x03 \x01(\x0b\x32\x06.Value\x12\x15\n\x05start\x18\x04 \x01(\x0b\x32\x06.Value\x12\x0f\n\x07periods\x18\x05 \x01(\x03\x12\x13\n\x03\x65nd\x18\x06 \x01(\x0b\x32\x06.Value\x12\x16\n\x06\x63losed\x18\x07 \x01(\x0b\x32\x06.Value\x12\x12\n\x02tz\x18\x08 \x01(\x0b\x32\x06.Value\x12\x10\n\x08\x64\x61yfirst\x18\t \x01(\x08\x12\x11\n\tyearfirst\x18\n \x01(\x08\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\x9c\x03\n\x0eTimedeltaIndex\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x14\n\x04unit\x18\x03 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x66req\x18\x04 \x01(\x0b\x32\x06.Value\x12\x15\n\x05start\x18\x05 \x01(\x0b\x32\x06.Value\x12\x0f\n\x07periods\x18\x06 \x01(\x03\x12\x13\n\x03\x65nd\x18\x07 \x01(\x0b\x32\x06.Value\x12\x16\n\x06\x63losed\x18\x08 \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xb6\x04\n\x0bPeriodIndex\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x66req\x18\x03 \x01(\x0b\x32\x06.Value\x12\x15\n\x05start\x18\x04 \x01(\x0b\x32\x06.Value\x12\x0f\n\x07periods\x18\x05 \x01(\x03\x12\x13\n\x03\x65nd\x18\x06 \x01(\x0b\x32\x06.Value\x12\x14\n\x04year\x18\x07 \x01(\x0b\x32\x06.Value\x12\x15\n\x05month\x18\x08 \x01(\x0b\x32\x06.Value\x12\x16\n\x06quater\x18\t \x01(\x0b\x32\x06.Value\x12\x13\n\x03\x64\x61y\x18\n \x01(\x0b\x32\x06.Value\x12\x14\n\x04hour\x18\x0b \x01(\x0b\x32\x06.Value\x12\x16\n\x06minute\x18\x0c \x01(\x0b\x32\x06.Value\x12\x16\n\x06second\x18\r \x01(\x0b\x32\x06.Value\x12\x12\n\x02tz\x18\x0e \x01(\x0b\x32\x06.Value\x12\x15\n\x05\x64type\x18\x0f \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xae\x02\n\nInt64Index\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x15\n\x05\x64type\x18\x03 \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xaf\x02\n\x0bUInt64Index\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x15\n\x05\x64type\x18\x03 \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xb0\x02\n\x0c\x46loat64Index\x12\x14\n\x04name\x18\x01 \x01(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x15\n\x05\x64type\x18\x03 \x01(\x0b\x32\x06.Value\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x1a\xab\x02\n\nMultiIndex\x12\x15\n\x05names\x18\x01 \x03(\x0b\x32\x06.Value\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x06.Value\x12\x11\n\tsortorder\x18\x03 \x01(\x05\x12\x0b\n\x03key\x18\x33 \x01(\t\x12\x1f\n\x17is_monotonic_increasing\x18\x34 \x01(\x08\x12\x1f\n\x17is_monotonic_decreasing\x18\x35 \x01(\x08\x12\x11\n\tis_unique\x18\x36 \x01(\x08\x12\x1b\n\x13should_be_monotonic\x18\x37 \x01(\x08\x12\x17\n\x07max_val\x18\x38 \x01(\x0b\x32\x06.Value\x12\x17\n\x07min_val\x18\x39 \x01(\x0b\x32\x06.Value\x12\x15\n\rmax_val_close\x18: \x01(\x08\x12\x15\n\rmin_val_close\x18; \x01(\x08\x42\r\n\x0bindex_valueb\x06proto3')
   ,
   dependencies=[mars_dot_serialize_dot_protos_dot_value__pb2.DESCRIPTOR,])
 
@@ -249,77 +249,84 @@ _INDEXVALUE_CATEGORICALINDEX = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='categories', full_name='IndexValue.CategoricalIndex.categories', index=1,
+      name='data', full_name='IndexValue.CategoricalIndex.data', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='ordered', full_name='IndexValue.CategoricalIndex.ordered', index=2,
-      number=3, type=8, cpp_type=7, label=1,
+      name='categories', full_name='IndexValue.CategoricalIndex.categories', index=2,
+      number=3, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='ordered', full_name='IndexValue.CategoricalIndex.ordered', index=3,
+      number=4, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='key', full_name='IndexValue.CategoricalIndex.key', index=3,
+      name='key', full_name='IndexValue.CategoricalIndex.key', index=4,
       number=51, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='is_monotonic_increasing', full_name='IndexValue.CategoricalIndex.is_monotonic_increasing', index=4,
+      name='is_monotonic_increasing', full_name='IndexValue.CategoricalIndex.is_monotonic_increasing', index=5,
       number=52, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='is_monotonic_decreasing', full_name='IndexValue.CategoricalIndex.is_monotonic_decreasing', index=5,
+      name='is_monotonic_decreasing', full_name='IndexValue.CategoricalIndex.is_monotonic_decreasing', index=6,
       number=53, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='is_unique', full_name='IndexValue.CategoricalIndex.is_unique', index=6,
+      name='is_unique', full_name='IndexValue.CategoricalIndex.is_unique', index=7,
       number=54, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='should_be_monotonic', full_name='IndexValue.CategoricalIndex.should_be_monotonic', index=7,
+      name='should_be_monotonic', full_name='IndexValue.CategoricalIndex.should_be_monotonic', index=8,
       number=55, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='max_val', full_name='IndexValue.CategoricalIndex.max_val', index=8,
+      name='max_val', full_name='IndexValue.CategoricalIndex.max_val', index=9,
       number=56, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='min_val', full_name='IndexValue.CategoricalIndex.min_val', index=9,
+      name='min_val', full_name='IndexValue.CategoricalIndex.min_val', index=10,
       number=57, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='max_val_close', full_name='IndexValue.CategoricalIndex.max_val_close', index=10,
+      name='max_val_close', full_name='IndexValue.CategoricalIndex.max_val_close', index=11,
       number=58, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='min_val_close', full_name='IndexValue.CategoricalIndex.min_val_close', index=11,
+      name='min_val_close', full_name='IndexValue.CategoricalIndex.min_val_close', index=12,
       number=59, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
@@ -338,7 +345,7 @@ _INDEXVALUE_CATEGORICALINDEX = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1222,
-  serialized_end=1530,
+  serialized_end=1552,
 )
 
 _INDEXVALUE_INTERVALINDEX = _descriptor.Descriptor(
@@ -444,8 +451,8 @@ _INDEXVALUE_INTERVALINDEX = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1533,
-  serialized_end=1831,
+  serialized_start=1555,
+  serialized_end=1853,
 )
 
 _INDEXVALUE_DATETIMEINDEX = _descriptor.Descriptor(
@@ -600,8 +607,8 @@ _INDEXVALUE_DATETIMEINDEX = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1834,
-  serialized_end=2280,
+  serialized_start=1856,
+  serialized_end=2302,
 )
 
 _INDEXVALUE_TIMEDELTAINDEX = _descriptor.Descriptor(
@@ -742,8 +749,8 @@ _INDEXVALUE_TIMEDELTAINDEX = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2283,
-  serialized_end=2695,
+  serialized_start=2305,
+  serialized_end=2717,
 )
 
 _INDEXVALUE_PERIODINDEX = _descriptor.Descriptor(
@@ -933,8 +940,8 @@ _INDEXVALUE_PERIODINDEX = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2698,
-  serialized_end=3264,
+  serialized_start=2720,
+  serialized_end=3286,
 )
 
 _INDEXVALUE_INT64INDEX = _descriptor.Descriptor(
@@ -1040,8 +1047,8 @@ _INDEXVALUE_INT64INDEX = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3267,
-  serialized_end=3569,
+  serialized_start=3289,
+  serialized_end=3591,
 )
 
 _INDEXVALUE_UINT64INDEX = _descriptor.Descriptor(
@@ -1147,8 +1154,8 @@ _INDEXVALUE_UINT64INDEX = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3572,
-  serialized_end=3875,
+  serialized_start=3594,
+  serialized_end=3897,
 )
 
 _INDEXVALUE_FLOAT64INDEX = _descriptor.Descriptor(
@@ -1254,8 +1261,8 @@ _INDEXVALUE_FLOAT64INDEX = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3878,
-  serialized_end=4182,
+  serialized_start=3900,
+  serialized_end=4204,
 )
 
 _INDEXVALUE_MULTIINDEX = _descriptor.Descriptor(
@@ -1361,8 +1368,8 @@ _INDEXVALUE_MULTIINDEX = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4185,
-  serialized_end=4484,
+  serialized_start=4207,
+  serialized_end=4506,
 )
 
 _INDEXVALUE = _descriptor.Descriptor(
@@ -1465,7 +1472,7 @@ _INDEXVALUE = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=78,
-  serialized_end=4499,
+  serialized_end=4521,
 )
 
 _INDEXVALUE_INDEX.fields_by_name['name'].message_type = mars_dot_serialize_dot_protos_dot_value__pb2._VALUE
@@ -1480,6 +1487,7 @@ _INDEXVALUE_RANGEINDEX.fields_by_name['max_val'].message_type = mars_dot_seriali
 _INDEXVALUE_RANGEINDEX.fields_by_name['min_val'].message_type = mars_dot_serialize_dot_protos_dot_value__pb2._VALUE
 _INDEXVALUE_RANGEINDEX.containing_type = _INDEXVALUE
 _INDEXVALUE_CATEGORICALINDEX.fields_by_name['name'].message_type = mars_dot_serialize_dot_protos_dot_value__pb2._VALUE
+_INDEXVALUE_CATEGORICALINDEX.fields_by_name['data'].message_type = mars_dot_serialize_dot_protos_dot_value__pb2._VALUE
 _INDEXVALUE_CATEGORICALINDEX.fields_by_name['categories'].message_type = mars_dot_serialize_dot_protos_dot_value__pb2._VALUE
 _INDEXVALUE_CATEGORICALINDEX.fields_by_name['max_val'].message_type = mars_dot_serialize_dot_protos_dot_value__pb2._VALUE
 _INDEXVALUE_CATEGORICALINDEX.fields_by_name['min_val'].message_type = mars_dot_serialize_dot_protos_dot_value__pb2._VALUE

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -20,7 +20,7 @@ from collections import Iterable
 
 import numpy as np
 
-from ..core import Entity, ChunkData, Chunk, TilesableData, enter_build_mode, is_eager_mode
+from ..core import Entity, ChunkData, Chunk, TileableData, enter_build_mode, is_eager_mode
 from ..tiles import handler
 from ..serialize import ProviderType, ValueType, DataTypeField, ListField
 from .expressions.utils import get_chunk_slices
@@ -47,7 +47,7 @@ class TensorChunk(Chunk):
     _allow_data_type_ = (TensorChunkData,)
 
 
-class TensorData(TilesableData):
+class TensorData(TileableData):
     __slots__ = ()
 
     # required fields


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR aims to enhance the tile of DataFrame's `add` including:

1. If some axis of both side of inputs have only 1 chunk, avoid shuffle despite they are not monotonic. This is useful because real data may have small size of columns(1 chunk on `columns`), we could avoid shuffle even if the columns are not ordered.
2. Generate `index_value` and `columns` for all chunks generated during the tile of arithmetic.
3. Prevent generating `DataFrameIndexAlignMap` as far as possible, for example, if both side of inputs have the same chunked index and columns.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #364 
