### PR TITLE
Support **kwargs in new_session

### DIFF
--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -27,7 +27,7 @@ from ...utils import build_graph
 
 
 class LocalClusterSession(object):
-    def __init__(self, endpoint):
+    def __init__(self, endpoint, **kwargs):
         self._session_id = uuid.uuid4()
         self._endpoint = endpoint
         # dict structure: {tensor_key -> graph_key, tensor_ids}
@@ -37,6 +37,10 @@ class LocalClusterSession(object):
 
         # create session on the cluster side
         self._api.create_session(self._session_id)
+
+        if kwargs:
+            unexpected_keys = ', '.join(list(kwargs.keys()))
+            raise TypeError('Local cluster session got unexpected arguments: %s' % unexpected_keys)
 
     @property
     def endpoint(self):

--- a/mars/session.py
+++ b/mars/session.py
@@ -23,11 +23,15 @@ except ImportError:  # pragma: no cover
 
 
 class LocalSession(object):
-    def __init__(self):
+    def __init__(self, **kwargs):
         from .executor import Executor
 
         self._executor = Executor()
         self._endpoint = None
+
+        if kwargs:
+            unexpected_keys = ', '.join(list(kwargs.keys()))
+            raise TypeError('Local session got unexpected arguments: %s' % unexpected_keys)
 
     @property
     def endpoint(self):
@@ -90,9 +94,9 @@ class Session(object):
                 # connect to local cluster
                 from .deploy.local.session import LocalClusterSession
 
-                self._sess = LocalClusterSession(endpoint)
+                self._sess = LocalClusterSession(endpoint, **kwargs)
         else:
-            self._sess = LocalSession()
+            self._sess = LocalSession(**kwargs)
 
     def run(self, *tensors, **kw):
         from . import tensor as mt

--- a/mars/session.py
+++ b/mars/session.py
@@ -79,13 +79,13 @@ class LocalSession(object):
 class Session(object):
     _default_session = None
 
-    def __init__(self, endpoint=None):
+    def __init__(self, endpoint=None, **kwargs):
         if endpoint is not None:
             if 'http' in endpoint:
                 # connect to web
                 from .web.session import Session as WebSession
 
-                self._sess = WebSession(endpoint)
+                self._sess = WebSession(endpoint, **kwargs)
             else:
                 # connect to local cluster
                 from .deploy.local.session import LocalClusterSession
@@ -185,5 +185,5 @@ class Session(object):
         return cls._default_session
 
 
-def new_session(scheduler=None):
-    return Session(scheduler)
+def new_session(scheduler=None, **kwargs):
+    return Session(scheduler, **kwargs)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

As introduced in #294 , `WebSession` support passing arguments like `req_session`, `new_session` should support passing `**kwargs` when creating web session.
