### PR TITLE
Remove DataTuple in v0.1

### DIFF
--- a/mars/serialize/dataserializer.py
+++ b/mars/serialize/dataserializer.py
@@ -91,9 +91,6 @@ else:
 SERIAL_VERSION = 0
 
 
-DATA_FLAG_DENSE = 0
-DATA_FLAG_CSR = 1
-
 COMPRESS_FLAG_NONE = 0
 COMPRESS_FLAG_LZ4 = 1
 COMPRESS_FLAG_GZIP = 2
@@ -311,10 +308,6 @@ def peek_serialized_size(file):
         file.seek(0)
 
 
-class DataTuple(tuple):
-    pass
-
-
 def _serialize_numpy_array_list(obj):
     if obj.dtype.str != '|O':
         # Make the array c_contiguous if necessary so that we can call change
@@ -366,37 +359,6 @@ def _deserialize_sparse_csr_list(data):
     return SparseNDArray(target_csr, shape=shape)
 
 
-def _serialize_data_tuple(obj):
-    data_meta = []
-    outputs = [None]
-    for item in obj:
-        if isinstance(item, np.ndarray):
-            serialized_items = _serialize_numpy_array_list(item)
-            outputs.extend(serialized_items)
-            data_meta.append(DATA_FLAG_DENSE)
-            data_meta.append(len(serialized_items))
-        else:
-            serialized_items = _serialize_sparse_csr_list(item)
-            outputs.extend(serialized_items)
-            data_meta.append(DATA_FLAG_CSR)
-            data_meta.append(len(serialized_items))
-    outputs[0] = struct.pack('<' + 'B' * len(data_meta), *data_meta)
-    return tuple(outputs)
-
-
-def _deserialize_data_tuple(data):
-    data_meta = struct.unpack('<' + 'B' * len(data[0]), data[0])
-    pos = 1
-    data_parts = []
-    for flag, size in zip(data_meta[0::2], data_meta[1::2]):
-        if flag == DATA_FLAG_DENSE:
-            data_parts.append(_deserialize_numpy_array_list(data[pos:pos + size]))
-        elif flag == DATA_FLAG_CSR:
-            data_parts.append(_deserialize_sparse_csr_list(data[pos:pos + size]))
-        pos += size
-    return DataTuple(data_parts)
-
-
 _serialize_context = None
 
 
@@ -407,8 +369,5 @@ def mars_serialize_context():
         ctx.register_type(SparseNDArray, 'mars.SparseNDArray',
                           custom_serializer=_serialize_sparse_csr_list,
                           custom_deserializer=_deserialize_sparse_csr_list)
-        ctx.register_type(DataTuple, 'mars.DataTuple',
-                          custom_serializer=_serialize_data_tuple,
-                          custom_deserializer=_deserialize_data_tuple)
         _serialize_context = ctx
     return _serialize_context

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -363,7 +363,7 @@ class Test(unittest.TestCase):
         except ImportError:
             sps = None
 
-        from mars.serialize.dataserializer import DataTuple, mars_serialize_context
+        from mars.serialize.dataserializer import mars_serialize_context
         context = mars_serialize_context()
 
         if np:
@@ -378,7 +378,7 @@ class Test(unittest.TestCase):
         if np and sps:
             array = np.random.rand(1000, 100)
             mat = sparse.SparseMatrix(sps.random(100, 100, 0.1, format='csr'))
-            tp = DataTuple((array, mat))
+            tp = (array, mat)
             des_tp = pyarrow.deserialize(pyarrow.serialize(tp, context).to_buffer(), context)
             assert_array_equal(tp[0], des_tp[0])
             self.assertTrue((tp[1].spmatrix != des_tp[1].spmatrix).nnz == 0)


### PR DESCRIPTION
## What do these changes do?

Removes DataTuple in v0.1 as standard tuples can also be serialized with pyarrow without copy.

## Related issue number

Fixes #370 