### PR TITLE
Use MurmurHash3 instead of hashlib when calculating hash

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -270,3 +270,9 @@ SIL OFL 1.1 license
 
 - font-awesome:4.7.0 (Font) (http://fortawesome.github.io/Font-Awesome/) - Created by Dave Gandy
     -> fonts in "mars/web/static/fonts"
+
+
+CC0 1.0 Universal (CC0 1.0)
+---------------------------
+
+- mmh3:2.5.1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ global-include *.pyx
 global-include *.pxd
 global-exclude *.c*
 include mars/.git-branch
+include mars/lib/mmh3_src/*
 recursive-include mars/web/static *
 recursive-include mars/web/templates *
 global-exclude .DS_Store

--- a/mars/actors/distributor.pyx
+++ b/mars/actors/distributor.pyx
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
+from mars.lib.mmh3 import hash as mmh_hash
 
 
 cdef class Distributor(object):
@@ -25,4 +25,4 @@ cdef class Distributor(object):
         if not isinstance(uid, bytes):
             uid = str(uid).encode('utf-8')
 
-        return int(hashlib.md5(uid).hexdigest(), 16) % self.n_process
+        return mmh_hash(uid) % self.n_process

--- a/mars/actors/pool/tests/test_gevent_pool.py
+++ b/mars/actors/pool/tests/test_gevent_pool.py
@@ -16,7 +16,6 @@
 
 import pickle
 import itertools
-import hashlib
 import uuid
 import time
 import unittest
@@ -29,6 +28,7 @@ from mars.actors import create_actor_pool as new_actor_pool, Actor, FunctionActo
     ActorPoolNotStarted, ActorAlreadyExist, ActorNotExist, Distributor, new_client, \
     register_actor_implementation, unregister_actor_implementation
 from mars.actors.pool.gevent_pool import Dispatcher, Connections
+from mars.lib.mmh3 import hash as mmh_hash
 from mars.utils import to_binary
 
 
@@ -190,7 +190,7 @@ class AdminDistributor(Distributor):
         if isinstance(uid, uuid.UUID):
             return uid.int % (self.n_process - 1) + 1
 
-        return int(hashlib.sha1(to_binary(uid)).hexdigest(), 16) % (self.n_process - 1) + 1
+        return mmh_hash(to_binary(uid)) % (self.n_process - 1) + 1
 
 
 @unittest.skipIf(sys.platform == 'win32', 'does not run in windows')

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
 import functools
 import operator
+
+from mars.lib.mmh3 import hash as mmh_hash
 
 
 def hash_index(index, size):
     def func(x, size):
-        return int(hashlib.md5(bytes(x)).hexdigest(), 16) % size
+        return mmh_hash(bytes(x)) % size
 
     f = functools.partial(func, size=size)
     grouped = sorted(index.groupby(index.map(f)).items(),

--- a/mars/lib/mmh3_src/MurmurHash3.cpp
+++ b/mars/lib/mmh3_src/MurmurHash3.cpp
@@ -1,0 +1,340 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - The x86 and x64 versions do _not_ produce the same results, as the
+// algorithms are optimized for their respective platforms. You can still
+// compile and run any of them on any platform, but your performance with the
+// non-native version will be less than optimal.
+
+#include "MurmurHash3.h"
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER)
+
+#define FORCE_INLINE	__forceinline
+
+#include <stdlib.h>
+
+#define ROTL32(x,y)	_rotl(x,y)
+#define ROTL64(x,y)	_rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x)
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#if defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && GNUC_MINOR >= 4))
+/* gcc version >= 4.4 4.1 = RHEL 5, 4.4 = RHEL 6. Don't inline for RHEL 5 gcc which is 4.1*/
+#define FORCE_INLINE inline __attribute__((always_inline))
+#else
+#define FORCE_INLINE 
+#endif
+
+inline uint32_t rotl32 ( uint32_t x, int8_t r )
+{
+  return (x << r) | (x >> (32 - r));
+}
+
+inline uint64_t rotl64 ( uint64_t x, int8_t r )
+{
+  return (x << r) | (x >> (64 - r));
+}
+
+#define	ROTL32(x,y)	rotl32(x,y)
+#define ROTL64(x,y)	rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
+
+FORCE_INLINE uint32_t getblock ( const uint32_t * p, int i )
+{
+  return p[i];
+}
+
+FORCE_INLINE uint64_t getblock ( const uint64_t * p, int i )
+{
+  return p[i];
+}
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+FORCE_INLINE uint32_t fmix ( uint32_t h )
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+//----------
+
+FORCE_INLINE uint64_t fmix ( uint64_t k )
+{
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+  k ^= k >> 33;
+
+  return k;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32 ( const void * key, Py_ssize_t len,
+                          uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const Py_ssize_t nblocks = len / 4;
+
+  uint32_t h1 = seed;
+
+  const uint32_t c1 = 0xcc9e2d51;
+  const uint32_t c2 = 0x1b873593;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*4);
+
+  for(Py_ssize_t i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock(blocks,i);
+
+    k1 *= c1;
+    k1 = ROTL32(k1,15);
+    k1 *= c2;
+    
+    h1 ^= k1;
+    h1 = ROTL32(h1,13); 
+    h1 = h1*5+0xe6546b64;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*4);
+
+  uint32_t k1 = 0;
+
+  switch(len & 3)
+  {
+  case 3: k1 ^= tail[2] << 16;
+  case 2: k1 ^= tail[1] << 8;
+  case 1: k1 ^= tail[0];
+          k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len;
+
+  h1 = fmix(h1);
+
+  *(uint32_t*)out = h1;
+} 
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_128 ( const void * key, const Py_ssize_t len,
+                           uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const Py_ssize_t nblocks = len / 16;
+
+  uint32_t h1 = seed;
+  uint32_t h2 = seed;
+  uint32_t h3 = seed;
+  uint32_t h4 = seed;
+
+  const uint32_t c1 = 0x239b961b; 
+  const uint32_t c2 = 0xab0e9789;
+  const uint32_t c3 = 0x38b34ae5; 
+  const uint32_t c4 = 0xa1e38b93;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
+
+  for(Py_ssize_t i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock(blocks,i*4+0);
+    uint32_t k2 = getblock(blocks,i*4+1);
+    uint32_t k3 = getblock(blocks,i*4+2);
+    uint32_t k4 = getblock(blocks,i*4+3);
+
+    k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL32(h1,19); h1 += h2; h1 = h1*5+0x561ccd1b;
+
+    k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+    h2 = ROTL32(h2,17); h2 += h3; h2 = h2*5+0x0bcaa747;
+
+    k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+    h3 = ROTL32(h3,15); h3 += h4; h3 = h3*5+0x96cd1c35;
+
+    k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+    h4 = ROTL32(h4,13); h4 += h1; h4 = h4*5+0x32ac3b17;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint32_t k1 = 0;
+  uint32_t k2 = 0;
+  uint32_t k3 = 0;
+  uint32_t k4 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k4 ^= tail[14] << 16;
+  case 14: k4 ^= tail[13] << 8;
+  case 13: k4 ^= tail[12] << 0;
+           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+  case 12: k3 ^= tail[11] << 24;
+  case 11: k3 ^= tail[10] << 16;
+  case 10: k3 ^= tail[ 9] << 8;
+  case  9: k3 ^= tail[ 8] << 0;
+           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+  case  8: k2 ^= tail[ 7] << 24;
+  case  7: k2 ^= tail[ 6] << 16;
+  case  6: k2 ^= tail[ 5] << 8;
+  case  5: k2 ^= tail[ 4] << 0;
+           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+  case  4: k1 ^= tail[ 3] << 24;
+  case  3: k1 ^= tail[ 2] << 16;
+  case  2: k1 ^= tail[ 1] << 8;
+  case  1: k1 ^= tail[ 0] << 0;
+           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len;
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  h1 = fmix(h1);
+  h2 = fmix(h2);
+  h3 = fmix(h3);
+  h4 = fmix(h4);
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  ((uint32_t*)out)[0] = h1;
+  ((uint32_t*)out)[1] = h2;
+  ((uint32_t*)out)[2] = h3;
+  ((uint32_t*)out)[3] = h4;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x64_128 ( const void * key, const Py_ssize_t len,
+                           const uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const Py_ssize_t nblocks = len / 16;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  const uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+  const uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+  //----------
+  // body
+
+  const uint64_t * blocks = (const uint64_t *)(data);
+
+  for(Py_ssize_t i = 0; i < nblocks; i++)
+  {
+    uint64_t k1 = getblock(blocks,i*2+0);
+    uint64_t k2 = getblock(blocks,i*2+1);
+
+    k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL64(h1,27); h1 += h2; h1 = h1*5+0x52dce729;
+
+    k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+    h2 = ROTL64(h2,31); h2 += h1; h2 = h2*5+0x38495ab5;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k2 ^= uint64_t(tail[14]) << 48;
+  case 14: k2 ^= uint64_t(tail[13]) << 40;
+  case 13: k2 ^= uint64_t(tail[12]) << 32;
+  case 12: k2 ^= uint64_t(tail[11]) << 24;
+  case 11: k2 ^= uint64_t(tail[10]) << 16;
+  case 10: k2 ^= uint64_t(tail[ 9]) << 8;
+  case  9: k2 ^= uint64_t(tail[ 8]) << 0;
+           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+  case  8: k1 ^= uint64_t(tail[ 7]) << 56;
+  case  7: k1 ^= uint64_t(tail[ 6]) << 48;
+  case  6: k1 ^= uint64_t(tail[ 5]) << 40;
+  case  5: k1 ^= uint64_t(tail[ 4]) << 32;
+  case  4: k1 ^= uint64_t(tail[ 3]) << 24;
+  case  3: k1 ^= uint64_t(tail[ 2]) << 16;
+  case  2: k1 ^= uint64_t(tail[ 1]) << 8;
+  case  1: k1 ^= uint64_t(tail[ 0]) << 0;
+           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix(h1);
+  h2 = fmix(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  ((uint64_t*)out)[0] = h1;
+  ((uint64_t*)out)[1] = h2;
+}
+
+//-----------------------------------------------------------------------------
+

--- a/mars/lib/mmh3_src/MurmurHash3.h
+++ b/mars/lib/mmh3_src/MurmurHash3.h
@@ -1,0 +1,43 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+#ifndef _MURMURHASH3_H_
+#define _MURMURHASH3_H_
+
+
+// To handle 64-bit data; see https://docs.python.org/2.7/c-api/arg.html
+#ifndef PY_SSIZE_T_CLEAN
+#define PY_SSIZE_T_CLEAN
+#endif
+#include <Python.h>
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER)
+typedef unsigned __int8 uint8_t;
+typedef unsigned __int32 uint32_t;
+typedef unsigned __int64 uint64_t;
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#include <stdint.h>
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32  ( const void * key, Py_ssize_t len, uint32_t seed, void * out );
+
+void MurmurHash3_x86_128 ( const void * key, Py_ssize_t len, uint32_t seed, void * out );
+
+void MurmurHash3_x64_128 ( const void * key, Py_ssize_t len, uint32_t seed, void * out );
+
+//-----------------------------------------------------------------------------
+
+#endif // _MURMURHASH3_H_

--- a/mars/lib/mmh3_src/mmh3module.cpp
+++ b/mars/lib/mmh3_src/mmh3module.cpp
@@ -1,0 +1,387 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. mmh3 Python module was written by Hajime Senuma,
+// and is also placed in the public domain.
+// The authors hereby disclaim copyright to these source codes.
+
+// To handle 64-bit data; see https://docs.python.org/2.7/c-api/arg.html
+#ifndef PY_SSIZE_T_CLEAN
+#define PY_SSIZE_T_CLEAN
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <Python.h>
+#include "MurmurHash3.h"
+
+#if defined(_MSC_VER)
+typedef signed __int8 int8_t;
+typedef signed __int32 int32_t;
+typedef signed __int64 int64_t;
+typedef unsigned __int8 uint8_t;
+typedef unsigned __int32 uint32_t;
+typedef unsigned __int64 uint64_t;
+// Other compilers
+#else    // defined(_MSC_VER)
+#include <stdint.h>
+#endif // !defined(_MSC_VER)
+
+static int
+_GetMemoryViewDataAndSize(PyObject *mview, const char **target_str,
+                         Py_ssize_t *target_str_len) {
+    Py_buffer *mview_buffer = NULL;
+
+    if (!PyMemoryView_Check(mview)) {
+        PyErr_Format(PyExc_TypeError, "key must be byte-like object "
+                     "or memoryview, not '%.200s'",
+                     mview->ob_type->tp_name);
+        return 0;
+    }
+
+    mview_buffer = PyMemoryView_GET_BUFFER(mview);
+    *target_str = (const char *)mview_buffer->buf;
+    *target_str_len = mview_buffer->len;
+    return 1;
+}
+
+static PyObject *
+mmh3_hash(PyObject *self, PyObject *args, PyObject *keywds)
+{
+    const char *target_str;
+    Py_ssize_t target_str_len;
+    PyObject *target_mview = NULL;
+    uint32_t seed = 0;
+    int32_t result[1];
+    long long_result = 0;
+    int is_signed = 1;
+
+    static char *kwlist[] = {(char *)"key", (char *)"seed",
+      (char *)"signed", NULL};
+
+#ifndef _MSC_VER
+  static uint64_t mask[] = {0x0ffffffff, 0xffffffffffffffff};
+#endif
+
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s#|IB", kwlist,
+        &target_str, &target_str_len, &seed, &is_signed)) {
+        if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|IB", kwlist,
+            &target_mview, &seed, &is_signed)) {
+            return NULL;
+        }
+        PyErr_Clear();
+        Py_INCREF(target_mview);
+
+        if (!_GetMemoryViewDataAndSize(target_mview, &target_str, &target_str_len)) {
+            Py_DECREF(target_mview);
+            return NULL;
+        }
+    }
+
+    MurmurHash3_x86_32(target_str, target_str_len, seed, result);
+
+    if (target_mview) {
+        Py_DECREF(target_mview);
+    }
+
+#if defined(_MSC_VER)
+  /* for Windows envs */
+  long_result = result[0];
+  if (is_signed == 1) {
+    return PyLong_FromLong(long_result);
+  } else {
+    return PyLong_FromUnsignedLong(long_result);
+  }
+#else
+  /* for standard envs */
+  long_result = result[0] & mask[is_signed];
+  return PyLong_FromLong(long_result);
+#endif
+}
+
+static PyObject *
+mmh3_hash_from_buffer(PyObject *self, PyObject *args, PyObject *keywds)
+{
+    Py_buffer target_buf;
+    Py_buffer *target_buf_ptr;
+    PyObject *target_mview = NULL;
+    uint32_t seed = 0;
+    int32_t result[1];
+    long long_result = 0;
+    int is_signed = 1;
+
+    static char *kwlist[] = {(char *)"key", (char *)"seed",
+      (char *)"signed", NULL};
+
+#ifndef _MSC_VER
+    static uint64_t mask[] = {0x0ffffffff, 0xffffffffffffffff};
+#endif
+
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s*|IB", kwlist,
+                                     &target_buf, &seed, &is_signed)) {
+        if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|IB", kwlist,
+            &target_mview, &seed, &is_signed)) {
+            return NULL;
+        }
+        PyErr_Clear();
+        Py_INCREF(target_mview);
+
+        if (!PyMemoryView_Check(target_mview)) {
+            PyErr_Format(PyExc_TypeError, "key must be byte-like object "
+                         "or memoryview, not '%.200s'",
+                         target_mview->ob_type->tp_name);
+            Py_DECREF(target_mview);
+            return NULL;
+        }
+
+        target_buf_ptr = PyMemoryView_GET_BUFFER(target_mview);
+    } else {
+      target_buf_ptr = &target_buf;
+    }
+
+    MurmurHash3_x86_32(target_buf_ptr->buf, target_buf_ptr->len, seed, result);
+
+    if (target_mview) {
+        Py_DECREF(target_mview);
+    }
+
+#if defined(_MSC_VER)
+    /* for Windows envs */
+    long_result = result[0];
+    if (is_signed == 1) {
+      return PyLong_FromLong(long_result);
+    } else {
+      return PyLong_FromUnsignedLong(long_result);
+    }
+#else
+    /* for standard envs */
+    long_result = result[0] & mask[is_signed];
+    return PyLong_FromLong(long_result);
+#endif
+}
+
+static PyObject *
+mmh3_hash64(PyObject *self, PyObject *args, PyObject *keywds)
+{
+    const char *target_str;
+    Py_ssize_t target_str_len;
+    PyObject *target_mview = NULL;
+    uint32_t seed = 0;
+    uint64_t result[2];
+    char x64arch = 1;
+    int is_signed = 1;
+
+    static char *kwlist[] = {(char *)"key", (char *)"seed",
+      (char *)"x64arch", (char *)"signed", NULL};
+
+    static char *valflag[] = {(char *) "KK", (char *) "LL"};
+
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s#|IBB", kwlist,
+        &target_str, &target_str_len, &seed, &x64arch, &is_signed)) {
+        if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|IBB", kwlist,
+            &target_mview, &seed, &x64arch, &is_signed)) {
+            return NULL;
+        }
+        PyErr_Clear();
+        Py_INCREF(target_mview);
+
+        if (!_GetMemoryViewDataAndSize(target_mview, &target_str, &target_str_len)) {
+            Py_DECREF(target_mview);
+            return NULL;
+        }
+    }
+
+    if (x64arch == 1) {
+      MurmurHash3_x64_128(target_str, target_str_len, seed, result);
+    } else {
+      MurmurHash3_x86_128(target_str, target_str_len, seed, result);
+    }
+
+    if (target_mview) {
+        Py_DECREF(target_mview);
+    }
+
+    PyObject *retval = Py_BuildValue(valflag[is_signed], result[0], result[1]);
+    return retval;
+}
+
+static PyObject *
+mmh3_hash128(PyObject *self, PyObject *args, PyObject *keywds)
+{
+    const char *target_str;
+    Py_ssize_t target_str_len;
+    PyObject *target_mview = NULL;
+    uint32_t seed = 0;
+    uint64_t result[2];
+    char x64arch = 1;
+    char is_signed = 0;
+
+    static char *kwlist[] = {(char *)"key", (char *)"seed",
+      (char *)"x64arch", (char *)"signed", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s#|IBB", kwlist,
+        &target_str, &target_str_len, &seed, &x64arch, &is_signed)) {
+        if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|IBB", kwlist,
+            &target_mview, &seed, &x64arch, &is_signed)) {
+            return NULL;
+        }
+        PyErr_Clear();
+        Py_INCREF(target_mview);
+
+        if (!_GetMemoryViewDataAndSize(target_mview, &target_str, &target_str_len)) {
+            Py_DECREF(target_mview);
+            return NULL;
+        }
+    }
+
+    if (x64arch == 1) {
+      MurmurHash3_x64_128(target_str, target_str_len, seed, result);
+    } else {
+      MurmurHash3_x86_128(target_str, target_str_len, seed, result);
+    }
+
+    if (target_mview) {
+        Py_DECREF(target_mview);
+    }
+
+    /**
+     * _PyLong_FromByteArray is not a part of official Python/C API
+     * and can be displaced (although it is practically stable). cf.
+     * https://mail.python.org/pipermail/python-list/2006-August/372368.html
+     */
+    PyObject *retval = _PyLong_FromByteArray((unsigned char *)result, 16, 1, is_signed);
+
+    return retval;
+}
+
+static PyObject *
+mmh3_hash_bytes(PyObject *self, PyObject *args, PyObject *keywds)
+{
+    const char *target_str = NULL;
+    Py_ssize_t target_str_len;
+    PyObject *target_mview = NULL;
+    uint32_t seed = 0;
+    uint32_t result[4];
+    char x64arch = 1;
+
+    static char *kwlist[] = {(char *)"key", (char *)"seed",
+      (char *)"x64arch", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s#|IB", kwlist,
+        &target_str, &target_str_len, &seed, &x64arch)) {
+        if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|IB", kwlist,
+            &target_mview, &seed, &x64arch)) {
+            return NULL;
+        }
+        PyErr_Clear();
+        Py_INCREF(target_mview);
+
+        if (!_GetMemoryViewDataAndSize(target_mview, &target_str, &target_str_len)) {
+            Py_DECREF(target_mview);
+            return NULL;
+        }
+    }
+
+    if (x64arch == 1) {
+      MurmurHash3_x64_128(target_str, target_str_len, seed, result);
+    } else {
+      MurmurHash3_x86_128(target_str, target_str_len, seed, result);
+    }
+
+    if (target_mview) {
+        Py_DECREF(target_mview);
+    }
+
+    char bytes[16];
+    memcpy(bytes, result, 16);
+    return PyBytes_FromStringAndSize(bytes, 16);
+}
+
+struct module_state {
+  PyObject *error;
+};
+
+#if PY_MAJOR_VERSION >= 3
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+#else
+#define GETSTATE(m) (&_state)
+static struct module_state _state;
+#endif
+
+static PyMethodDef Mmh3Methods[] = {
+    {"hash", (PyCFunction)mmh3_hash, METH_VARARGS | METH_KEYWORDS,
+        "hash(key[, seed=0, signed=True]) -> hash value\n Return a 32 bit integer."},
+    {"hash_from_buffer", (PyCFunction)mmh3_hash_from_buffer, METH_VARARGS | METH_KEYWORDS,
+     "hash_from_buffer(key[, seed=0, signed=True]) -> hash value from a memory buffer\n Return a 32 bit integer. Designed for large memory-views such as numpy arrays."},
+    {"hash64", (PyCFunction)mmh3_hash64, METH_VARARGS | METH_KEYWORDS,
+        "hash64(key[, seed=0, x64arch=True, signed=True]) -> (hash value 1, hash value 2)\n Return a tuple of two 64 bit integers for a string. Optimized for the x64 bit architecture when x64arch=True, otherwise for x86."},
+    {"hash128", (PyCFunction)mmh3_hash128, METH_VARARGS | METH_KEYWORDS,
+        "hash128(key[, seed=0, x64arch=True, signed=False]]) -> hash value\n Return a 128 bit long integer. Optimized for the x64 bit architecture when x64arch=True, otherwise for x86."},
+    {"hash_bytes", (PyCFunction)mmh3_hash_bytes,
+      METH_VARARGS | METH_KEYWORDS,
+        "hash_bytes(key[, seed=0, x64arch=True]) -> bytes\n Return a 128 bit hash value as bytes for a string. Optimized for the x64 bit architecture when x64arch=True, otherwise for the x86."},
+    {NULL, NULL, 0, NULL}
+};
+
+#if PY_MAJOR_VERSION >= 3
+
+static int mmh3_traverse(PyObject *m, visitproc visit, void *arg) {
+    Py_VISIT(GETSTATE(m)->error);
+    return 0;
+}
+
+static int mmh3_clear(PyObject *m) {
+    Py_CLEAR(GETSTATE(m)->error);
+    return 0;
+}
+
+static struct PyModuleDef mmh3module = {
+    PyModuleDef_HEAD_INIT,
+    "mmh3",
+    "mmh3 is a Python front-end to MurmurHash3, a fast and robust hash library created by Austin Appleby (http://code.google.com/p/smhasher/).\n Ported by Hajime Senuma <hajime.senuma@gmail.com>\n Try hash('foobar') or hash('foobar', 1984).\n If you find any bugs, please submit an issue via https://github.com/hajimes/mmh3",
+    sizeof(struct module_state),
+    Mmh3Methods,
+    NULL,
+    mmh3_traverse,
+    mmh3_clear,
+    NULL
+};
+
+#define INITERROR return NULL
+
+extern "C" {
+PyMODINIT_FUNC
+PyInit_mmh3(void)
+
+#else // PY_MAJOR_VERSION >= 3
+#define INITERROR return
+
+extern "C" {
+void
+initmmh3(void)
+#endif // PY_MAJOR_VERSION >= 3
+
+{
+#if PY_MAJOR_VERSION >= 3
+    PyObject *module = PyModule_Create(&mmh3module);
+#else
+    PyObject *module = Py_InitModule("mmh3", Mmh3Methods);
+#endif
+
+    if (module == NULL)
+        INITERROR;
+
+    PyModule_AddStringConstant(module, "__version__", "2.5.1");
+
+    struct module_state *st = GETSTATE(module);
+
+    st->error = PyErr_NewException((char *) "mmh3.Error", NULL, NULL);
+    if (st->error == NULL) {
+        Py_DECREF(module);
+        INITERROR;
+    }
+
+#if PY_MAJOR_VERSION >= 3
+    return module;
+#endif
+}
+} // extern "C"

--- a/mars/scheduler/distributor.py
+++ b/mars/scheduler/distributor.py
@@ -15,14 +15,10 @@
 # limitations under the License.
 
 
-import hashlib
-import logging
-
-from ..compat import six, functools32
-from ..utils import to_binary
 from ..actors import Distributor
-
-logger = logging.getLogger(__name__)
+from ..compat import six, functools32
+from ..lib.mmh3 import hash as mmh_hash
+from ..utils import to_binary
 
 
 class SchedulerDistributor(Distributor):
@@ -33,7 +29,7 @@ class SchedulerDistributor(Distributor):
         id_parts = uid.split(':')
         if id_parts[0] == 's':
             # get process id by hashing uid
-            allocate_id = int(hashlib.md5(to_binary(uid)).hexdigest(), 16) % (self.n_process - 1) + 1
+            allocate_id = mmh_hash(to_binary(uid)) % (self.n_process - 1) + 1
             return allocate_id
         else:
             return 0

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -32,7 +32,7 @@ import threading
 import numpy as np
 
 from .compat import irange, functools32, getargspec
-from ._utils import to_binary, to_str, to_text, tokenize
+from ._utils import to_binary, to_str, to_text, tokenize, tokenize_int
 from .config import options
 
 logger = logging.getLogger(__name__)
@@ -197,7 +197,7 @@ def get_next_port(typ=None):
 
 @functools32.lru_cache(200)
 def mod_hash(val, modulus):
-    return int(tokenize(val), 16) % modulus
+    return tokenize_int(val) % modulus
 
 
 class classproperty(object):

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,30 @@
 # limitations under the License.
 
 import os
+import platform
 import sys
+from distutils.sysconfig import get_config_var
+from distutils.version import LooseVersion
 from setuptools import setup, find_packages, Extension
 
 import numpy as np
 from Cython.Build import cythonize
 from Cython.Distutils import build_ext
+
+
+# From https://github.com/pandas-dev/pandas/pull/24274:
+# For mac, ensure extensions are built for macos 10.9 when compiling on a
+# 10.9 system or above, overriding distuitls behaviour which is to target
+# the version that python was built for. This may be overridden by setting
+# MACOSX_DEPLOYMENT_TARGET before calling setup.py
+if sys.platform == 'darwin':
+    if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
+        current_system = LooseVersion(platform.mac_ver()[0])
+        python_target = LooseVersion(
+            get_config_var('MACOSX_DEPLOYMENT_TARGET'))
+        if python_target < '10.9' and current_system >= '10.9':
+            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
+
 
 repo_root = os.path.dirname(os.path.abspath(__file__))
 
@@ -58,34 +76,37 @@ if os.path.exists(os.path.join(repo_root, '.git')):
             git_file.write('%s %s' % git_info)
 
 cythonize_kw = dict(language_level=sys.version_info[0])
-extension_kw = dict()
+cy_extension_kw = dict()
 if 'CYTHON_TRACE' in os.environ:
-    extension_kw['define_macros'] = [('CYTHON_TRACE_NOGIL', '1'), ('CYTHON_TRACE', '1')]
+    cy_extension_kw['define_macros'] = [('CYTHON_TRACE_NOGIL', '1'), ('CYTHON_TRACE', '1')]
     cythonize_kw['compiler_directives'] = {'linetrace': True}
 
 if 'MSC' in sys.version:
     extra_compile_args = ['/Ot', '/I' + os.path.join(repo_root, 'misc')]
-    extension_kw['extra_compile_args'] = extra_compile_args
+    cy_extension_kw['extra_compile_args'] = extra_compile_args
 else:
     extra_compile_args = ['-O3']
-    extension_kw['extra_compile_args'] = extra_compile_args
+    cy_extension_kw['extra_compile_args'] = extra_compile_args
 
-extension_kw['include_dirs'] = [np.get_include()]
-extensions = [
-    Extension('mars.graph', ['mars/graph.pyx'], **extension_kw),
-    Extension('mars.fuse', ['mars/fuse.pyx'], **extension_kw),
-    Extension('mars._utils', ['mars/_utils.pyx'], **extension_kw),
-    Extension('mars.lib.gipc', ['mars/lib/gipc.pyx'], **extension_kw),
-    Extension('mars.actors.core', ['mars/actors/core.pyx'], **extension_kw),
-    Extension('mars.actors.distributor', ['mars/actors/distributor.pyx'], **extension_kw),
-    Extension('mars.actors.cluster', ['mars/actors/cluster.pyx'], **extension_kw),
-    Extension('mars.actors.pool.messages', ['mars/actors/pool/messages.pyx'], **extension_kw),
-    Extension('mars.actors.pool.utils', ['mars/actors/pool/utils.pyx'], **extension_kw),
-    Extension('mars.actors.pool.gevent_pool', ['mars/actors/pool/gevent_pool.pyx'], **extension_kw),
-    Extension('mars.serialize.core', ['mars/serialize/core.pyx'], **extension_kw),
-    Extension('mars.serialize.pbserializer', ['mars/serialize/pbserializer.pyx'], **extension_kw),
-    Extension('mars.serialize.jsonserializer', ['mars/serialize/jsonserializer.pyx'], **extension_kw),
+cy_extension_kw['include_dirs'] = [np.get_include()]
+cy_extensions = [
+    Extension('mars.graph', ['mars/graph.pyx'], **cy_extension_kw),
+    Extension('mars.fuse', ['mars/fuse.pyx'], **cy_extension_kw),
+    Extension('mars._utils', ['mars/_utils.pyx'], **cy_extension_kw),
+    Extension('mars.lib.gipc', ['mars/lib/gipc.pyx'], **cy_extension_kw),
+    Extension('mars.actors.core', ['mars/actors/core.pyx'], **cy_extension_kw),
+    Extension('mars.actors.distributor', ['mars/actors/distributor.pyx'], **cy_extension_kw),
+    Extension('mars.actors.cluster', ['mars/actors/cluster.pyx'], **cy_extension_kw),
+    Extension('mars.actors.pool.messages', ['mars/actors/pool/messages.pyx'], **cy_extension_kw),
+    Extension('mars.actors.pool.utils', ['mars/actors/pool/utils.pyx'], **cy_extension_kw),
+    Extension('mars.actors.pool.gevent_pool', ['mars/actors/pool/gevent_pool.pyx'], **cy_extension_kw),
+    Extension('mars.serialize.core', ['mars/serialize/core.pyx'], **cy_extension_kw),
+    Extension('mars.serialize.pbserializer', ['mars/serialize/pbserializer.pyx'], **cy_extension_kw),
+    Extension('mars.serialize.jsonserializer', ['mars/serialize/jsonserializer.pyx'], **cy_extension_kw),
 ]
+
+extensions = cythonize(cy_extensions, **cythonize_kw) + \
+    [Extension('mars.lib.mmh3', ['mars/lib/mmh3_src/mmh3module.cpp', 'mars/lib/mmh3_src/MurmurHash3.cpp'])]
 
 
 setup_options = dict(
@@ -120,7 +141,7 @@ setup_options = dict(
     ]},
     install_requires=requirements,
     cmdclass={'build_ext': build_ext},
-    ext_modules=cythonize(extensions, **cythonize_kw),
+    ext_modules=extensions,
     extras_require={
         'distributed': extra_requirements,
         'dev': extra_requirements + dev_requirements,


### PR DESCRIPTION
## What do these changes do?

Use MurmurHash (https://github.com/hajimes/mmh3) to replace hashlib.md5 when calculating hash, both for tokenize and hash_index.

## Related issue number

Fixes #369 
