### PR TITLE
Support non-square matrix for lu decomposition

### DIFF
--- a/mars/tensor/execution/linalg.py
+++ b/mars/tensor/execution/linalg.py
@@ -71,7 +71,12 @@ def _solve_triangular(ctx, chunk):
         if xp is np:
             import scipy.linalg
 
-            ctx[chunk.key] = scipy.linalg.solve_triangular(a, b, lower=chunk.op.lower)
+            try:
+                ctx[chunk.key] = scipy.linalg.solve_triangular(a, b, lower=chunk.op.lower)
+            except np.linalg.LinAlgError:
+                if chunk.op.strict is not False:
+                    raise
+                ctx[chunk.key] = np.linalg.lstsq(a, b, rcond=-1)[0]
         elif xp is cp:
             import cupyx
 

--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -305,6 +305,64 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(t, concat=True)[0]
         np.testing.assert_allclose(res, data)
 
+        # shape[0] < shape[1]
+        data = np.random.randint(1, 10, (6, 10))
+
+        a = tensor(data)
+        P, L, U = lu(a)
+
+        # check lower and upper triangular matrix
+        result_l = self.executor.execute_tensor(L, concat=True)[0]
+        result_u = self.executor.execute_tensor(U, concat=True)[0]
+
+        np.testing.assert_allclose(np.tril(result_l), result_l)
+        np.testing.assert_allclose(np.triu(result_u), result_u)
+
+        t = P.dot(L).dot(U)
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        np.testing.assert_allclose(res, data)
+
+        a = tensor(data, chunk_size=2)
+        P, L, U = lu(a)
+
+        # check lower and upper triangular matrix
+        result_l = self.executor.execute_tensor(L, concat=True)[0]
+        result_u = self.executor.execute_tensor(U, concat=True)[0]
+
+        np.testing.assert_allclose(np.tril(result_l), result_l)
+        np.testing.assert_allclose(np.triu(result_u), result_u)
+
+        t = P.dot(L).dot(U)
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        np.testing.assert_allclose(res, data)
+
+        a = tensor(data, chunk_size=(2, 3))
+        P, L, U = lu(a)
+
+        # check lower and upper triangular matrix
+        result_l = self.executor.execute_tensor(L, concat=True)[0]
+        result_u = self.executor.execute_tensor(U, concat=True)[0]
+
+        np.testing.assert_allclose(np.tril(result_l), result_l)
+        np.testing.assert_allclose(np.triu(result_u), result_u)
+
+        t = P.dot(L).dot(U)
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        np.testing.assert_allclose(res, data)
+
+        a = tensor(data, chunk_size=4)
+        P, L, U = lu(a)
+
+        # check lower and upper triangular matrix
+        result_l, result_u = self.executor.execute_tensors([L, U])
+
+        np.testing.assert_allclose(np.tril(result_l), result_l)
+        np.testing.assert_allclose(np.triu(result_u), result_u)
+
+        t = P.dot(L).dot(U)
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        np.testing.assert_allclose(res, data)
+
         # test for sparse
         data = sps.csr_matrix([[2, 0, 0, 0, 5, 2],
                                [0, 6, 1, 0, 0, 6],

--- a/mars/tensor/execution/tests/test_linalg_execute.py
+++ b/mars/tensor/execution/tests/test_linalg_execute.py
@@ -188,6 +188,7 @@ class Test(unittest.TestCase):
     def testLUExecution(self):
         np.random.seed(1)
 
+        # square matrix
         data = np.random.randint(1, 10, (6, 6))
 
         a = tensor(data)
@@ -238,6 +239,64 @@ class Test(unittest.TestCase):
         # check lower and upper triangular matrix
         result_l = self.executor.execute_tensor(L, concat=True)[0]
         result_u = self.executor.execute_tensor(U, concat=True)[0]
+
+        np.testing.assert_allclose(np.tril(result_l), result_l)
+        np.testing.assert_allclose(np.triu(result_u), result_u)
+
+        t = P.dot(L).dot(U)
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        np.testing.assert_allclose(res, data)
+
+        # shape[0] > shape[1]
+        data = np.random.randint(1, 10, (10, 6))
+
+        a = tensor(data)
+        P, L, U = lu(a)
+
+        # check lower and upper triangular matrix
+        result_l = self.executor.execute_tensor(L, concat=True)[0]
+        result_u = self.executor.execute_tensor(U, concat=True)[0]
+
+        np.testing.assert_allclose(np.tril(result_l), result_l)
+        np.testing.assert_allclose(np.triu(result_u), result_u)
+
+        t = P.dot(L).dot(U)
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        np.testing.assert_allclose(res, data)
+
+        a = tensor(data, chunk_size=2)
+        P, L, U = lu(a)
+
+        # check lower and upper triangular matrix
+        result_l = self.executor.execute_tensor(L, concat=True)[0]
+        result_u = self.executor.execute_tensor(U, concat=True)[0]
+
+        np.testing.assert_allclose(np.tril(result_l), result_l)
+        np.testing.assert_allclose(np.triu(result_u), result_u)
+
+        t = P.dot(L).dot(U)
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        np.testing.assert_allclose(res, data)
+
+        a = tensor(data, chunk_size=(2, 3))
+        P, L, U = lu(a)
+
+        # check lower and upper triangular matrix
+        result_l = self.executor.execute_tensor(L, concat=True)[0]
+        result_u = self.executor.execute_tensor(U, concat=True)[0]
+
+        np.testing.assert_allclose(np.tril(result_l), result_l)
+        np.testing.assert_allclose(np.triu(result_u), result_u)
+
+        t = P.dot(L).dot(U)
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        np.testing.assert_allclose(res, data)
+
+        a = tensor(data, chunk_size=4)
+        P, L, U = lu(a)
+
+        # check lower and upper triangular matrix
+        result_l, result_u = self.executor.execute_tensors([L, U])
 
         np.testing.assert_allclose(np.tril(result_l), result_l)
         np.testing.assert_allclose(np.triu(result_u), result_u)

--- a/mars/tensor/expressions/linalg/lu.py
+++ b/mars/tensor/expressions/linalg/lu.py
@@ -19,6 +19,7 @@ from numpy.linalg import LinAlgError
 
 from .... import operands
 from ....core import ExecutableTuple
+from ..utils import recursive_tile
 from ..core import TensorOperandMixin
 from ..datasource import tensor as astensor
 
@@ -41,16 +42,25 @@ class TensorLU(operands.LU, TensorOperandMixin):
         if a.ndim != 2:
             raise LinAlgError('{0}-dimensional array given. '
                               'Tensor must be two-dimensional'.format(a.ndim))
-        if a.shape[0] != a.shape[1]:
-            raise LinAlgError('Input must be square')
+
+        if a.shape[0] > a.shape[1]:
+            p_shape = (a.shape[0],) * 2
+            l_shape = a.shape
+            u_shape = (a.shape[1],) * 2
+        elif a.shape[0] < a.shape[1]:
+            p_shape = (a.shape[0],) * 2
+            l_shape = (a.shape[0],) * 2
+            u_shape = a.shape
+        else:
+            p_shape, l_shape, u_shape = (a.shape,) * 3
 
         tiny_p, tiny_l, tiny_u = scipy.linalg.lu(np.array([[1, 2], [2, 5]], dtype=a.dtype))
 
         p, l, u = self.new_tensors([a],
                                    kws=[
-                                       {'side': 'p', 'dtype': tiny_p.dtype, 'shape': a.shape},
-                                       {'side': 'l', 'dtype': tiny_l.dtype, 'shape': a.shape},
-                                       {'side': 'u', 'dtype': tiny_u.dtype, 'shape': a.shape},
+                                       {'side': 'p', 'dtype': tiny_p.dtype, 'shape': p_shape},
+                                       {'side': 'l', 'dtype': tiny_l.dtype, 'shape': l_shape},
+                                       {'side': 'u', 'dtype': tiny_u.dtype, 'shape': u_shape},
                                    ])
         return ExecutableTuple([p, l, u])
 
@@ -59,12 +69,29 @@ class TensorLU(operands.LU, TensorOperandMixin):
         from ..arithmetic.subtract import TensorSubtract
         from ..arithmetic.utils import tree_add
         from ..base.transpose import TensorTranspose
-        from ..datasource.zeros import TensorZeros
+        from ..merge.vstack import vstack
+        from ..merge.hstack import hstack
+        from ..datasource.zeros import TensorZeros, zeros
         from .dot import TensorDot
         from .solve_triangular import TensorSolveTriangular
 
         P, L, U = op.outputs
-        in_tensor = op.input
+        raw_in_tensor = in_tensor = op.input
+
+        if in_tensor.shape[0] > in_tensor.shape[1]:
+            zero_tensor = zeros((in_tensor.shape[0], in_tensor.shape[0] - in_tensor.shape[1]),
+                                dtype=in_tensor.dtype, sparse=in_tensor.issparse(),
+                                gpu=in_tensor.op.gpu,
+                                chunk_size=(in_tensor.nsplits[0], max(in_tensor.nsplits[1])))
+            in_tensor = hstack([in_tensor, zero_tensor])
+            recursive_tile(in_tensor)
+        elif in_tensor.shape[0] < in_tensor.shape[1]:
+            zero_tensor = zeros((in_tensor.shape[1] - in_tensor.shape[0], in_tensor.shape[1]),
+                                dtype=in_tensor.dtype, sparse=in_tensor.issparse(),
+                                gpu=in_tensor.op.gpu,
+                                chunk_size=(max(in_tensor.nsplits[0]), in_tensor.nsplits[1]))
+            in_tensor = vstack([in_tensor, zero_tensor])
+            recursive_tile(in_tensor)
 
         if in_tensor.nsplits[0] != in_tensor.nsplits[1]:
             # all chunks on diagonal should be square
@@ -99,7 +126,7 @@ class TensorLU(operands.LU, TensorOperandMixin):
                                          None, prev_chunks_u[0].shape, sparse=op.sparse)
                         target = TensorSubtract(dtype=U.dtype).new_chunk(
                             [target, s, None, None], shape=target.shape)
-                    upper_chunk = TensorSolveTriangular(lower=True, dtype=U.dtype,
+                    upper_chunk = TensorSolveTriangular(lower=True, dtype=U.dtype, strict=False,
                                                         sparse=lower_chunks[i, i].op.sparse).new_chunk(
                         [lower_chunks[i, i], target], shape=target.shape, index=(i, j))
                     upper_chunks[upper_chunk.index] = upper_chunk
@@ -171,7 +198,7 @@ class TensorLU(operands.LU, TensorOperandMixin):
                     target_transpose = TensorTranspose(dtype=target_l.dtype, sparse=op.sparse).new_chunk(
                         [target_l], shape=target_l.shape)
                     lower_permuted_chunk = TensorSolveTriangular(
-                        lower=True, dtype=L.dtype, sparse=op.sparse).new_chunk(
+                        lower=True, dtype=L.dtype, strict=False, sparse=op.sparse).new_chunk(
                         [a_transpose, target_transpose], shape=target_l.shape, index=(i, j))
                     lower_transpose = TensorTranspose(dtype=lower_permuted_chunk.dtype, sparse=op.sparse).new_chunk(
                         [lower_permuted_chunk], shape=lower_permuted_chunk.shape, index=lower_permuted_chunk.index)
@@ -184,7 +211,23 @@ class TensorLU(operands.LU, TensorOperandMixin):
             {'chunks': list(lower_chunks.values()), 'nsplits': in_tensor.nsplits,
              'dtype': L.dtype, 'shape': L.shape},
             {'chunks': list(upper_chunks.values()), 'nsplits': in_tensor.nsplits,
-             'dtype': U.dtype, 'shape': L.shape}
+             'dtype': U.dtype, 'shape': U.shape}
+        ]
+        if raw_in_tensor.shape[0] == raw_in_tensor.shape[1]:
+            return new_op.new_tensors(op.inputs, kws=kws)
+
+        p, l, u = new_op.new_tensors(op.inputs, kws=kws)
+        if raw_in_tensor.shape[0] > raw_in_tensor.shape[1]:
+            l = l[:, :raw_in_tensor.shape[1]].single_tiles()
+            u = u[:raw_in_tensor.shape[1], :raw_in_tensor.shape[1]].single_tiles()
+        else:
+            p = p[:raw_in_tensor.shape[0], :raw_in_tensor.shape[0]].single_tiles()
+            l = l[:raw_in_tensor.shape[0], :raw_in_tensor.shape[0]].single_tiles()
+            u = u[:raw_in_tensor.shape[0], :].single_tiles()
+        kws = [
+            {'chunks': p.chunks, 'nsplits': p.nsplits, 'dtype': P.dtype, 'shape': p.shape},
+            {'chunks': l.chunks, 'nsplits': l.nsplits, 'dtype': l.dtype, 'shape': l.shape},
+            {'chunks': u.chunks, 'nsplits': u.nsplits, 'dtype': u.dtype, 'shape': u.shape}
         ]
         return new_op.new_tensors(op.inputs, kws=kws)
 

--- a/mars/tensor/expressions/linalg/solve_triangular.py
+++ b/mars/tensor/expressions/linalg/solve_triangular.py
@@ -18,13 +18,17 @@ import numpy as np
 from numpy.linalg import LinAlgError
 
 from .... import operands
+from ....serialize import BoolField
 from ..core import TensorOperandMixin
 from ..datasource import tensor as astensor
 
 
 class TensorSolveTriangular(operands.SolveTriangular, TensorOperandMixin):
-    def __init__(self, lower=None, dtype=None, sparse=False, **kw):
-        super(TensorSolveTriangular, self).__init__(_lower=lower, _dtype=dtype, _sparse=sparse, **kw)
+    _strict = BoolField('strict')
+
+    def __init__(self, lower=None, dtype=None, sparse=False, strict=None, **kw):
+        super(TensorSolveTriangular, self).__init__(_lower=lower, _dtype=dtype, _sparse=sparse,
+                                                    _strict=strict, **kw)
 
     def _set_inputs(self, inputs):
         super(TensorSolveTriangular, self)._set_inputs(inputs)
@@ -38,6 +42,10 @@ class TensorSolveTriangular(operands.SolveTriangular, TensorOperandMixin):
     def __call__(self, a, b):
         shape = (a.shape[1],) if len(b.shape) == 1 else (a.shape[1], b.shape[1])
         return self.new_tensor([a, b], shape)
+
+    @property
+    def strict(self):
+        return self._strict
 
     @classmethod
     def tile(cls, op):

--- a/mars/tensor/expressions/tests/test_linalg.py
+++ b/mars/tensor/expressions/tests/test_linalg.py
@@ -229,6 +229,22 @@ class Test(unittest.TestCase):
         self.assertEqual(l.nsplits, ((4, 3), (4, 3)))
         self.assertEqual(u.nsplits, ((4, 3), (4, 3)))
 
+        a = mt.random.randint(1, 10, (7, 5), chunk_size=4)
+        p, l, u = mt.linalg.lu(a)
+        l.tiles()
+
+        self.assertEqual(l.shape, (7, 5))
+        self.assertEqual(u.shape, (5, 5))
+        self.assertEqual(p.shape, (7, 7))
+
+        a = mt.random.randint(1, 10, (5, 7), chunk_size=4)
+        p, l, u = mt.linalg.lu(a)
+        l.tiles()
+
+        self.assertEqual(l.shape, (5, 5))
+        self.assertEqual(u.shape, (5, 7))
+        self.assertEqual(p.shape, (5, 5))
+
         # test sparse
         data = sps.csr_matrix([[2, 0, 0, 0, 5, 2],
                                [0, 6, 1, 0, 0, 6],


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Try to let `lu` decomposition support non-square matrix.

An issue is that because we append zeros on axis 0 or 1, the `SolveTriangular` op which generated in tiling of `lu` could oftenly encounter  the error: `LinAlgError: singular matrix: resolution failed at diagonal 0
` which is quite annoying. Thus I try to use `np.linalg.lstsq` to address the problem, but the effort is enabled only for the `SolveTriangular` generated by `lu`.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #380 
