### PR TITLE
Fix stuck web interface when tiling a graph

### DIFF
--- a/mars/api.py
+++ b/mars/api.py
@@ -36,6 +36,12 @@ class MarsAPI(object):
         actor_address = self.cluster_info.get_scheduler(uid)
         return self.actor_client.actor_ref(uid, address=actor_address)
 
+    def get_graph_meta_ref(self, session_id, graph_key):
+        graph_uid = GraphActor.gen_uid(session_id, graph_key)
+        graph_meta_uid = GraphMetaActor.gen_uid(session_id, graph_key)
+        graph_addr = self.cluster_info.get_scheduler(graph_uid)
+        return self.actor_client.actor_ref(graph_meta_uid, address=graph_addr)
+
     def get_schedulers_info(self):
         schedulers = self.cluster_info.get_schedulers()
         infos = dict()
@@ -69,8 +75,8 @@ class MarsAPI(object):
 
     def stop_graph(self, session_id, graph_key):
         from .scheduler import GraphState
-        graph_meta_uid = GraphMetaActor.gen_uid(session_id, graph_key)
-        self.get_actor_ref(graph_meta_uid).set_state(GraphState.CANCELLING)
+        graph_meta_ref = self.get_graph_meta_ref(session_id, graph_key)
+        graph_meta_ref.set_state(GraphState.CANCELLING)
 
         graph_uid = GraphActor.gen_uid(session_id, graph_key)
         graph_ref = self.get_actor_ref(graph_uid)
@@ -79,8 +85,7 @@ class MarsAPI(object):
     def get_graph_state(self, session_id, graph_key):
         from .scheduler import GraphState
 
-        graph_meta_uid = GraphMetaActor.gen_uid(session_id, graph_key)
-        graph_meta_ref = self.get_actor_ref(graph_meta_uid)
+        graph_meta_ref = self.get_graph_meta_ref(session_id, graph_key)
         if self.actor_client.has_actor(graph_meta_ref):
             state_obj = graph_meta_ref.get_state()
             state = state_obj.value if state_obj else 'preparing'

--- a/mars/scheduler/operands/base.py
+++ b/mars/scheduler/operands/base.py
@@ -102,7 +102,7 @@ class BaseOperandActor(SchedulerActor):
         self._info['state'] = value.name
         futures = []
         for graph_ref in self._graph_refs:
-            futures.append(graph_ref.set_operand_state(self._op_key, value.value, _tell=True, _wait=False))
+            futures.append(graph_ref.set_operand_state(self._op_key, value, _tell=True, _wait=False))
         if self._kv_store_ref is not None:
             futures.append(self._kv_store_ref.write(
                 '%s/state' % self._op_path, value.name, _tell=True, _wait=False))

--- a/mars/tests/test_distributor.py
+++ b/mars/tests/test_distributor.py
@@ -37,9 +37,12 @@ class Test(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             distributor.distribute('Actor')
+        with self.assertRaises(ValueError):
+            distributor.distribute('w:x:Actor')
 
         distributor = MarsDistributor(3, 'w:2:')
         self.assertEqual(distributor.distribute('Actor'), 2)
+        self.assertEqual(distributor.distribute('w:x:Actor'), 2)
 
         distributor = MarsDistributor(3)
         ref_uid = 'w:h1:Actor2'

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -328,11 +328,10 @@ def build_graph(tensors, graph=None, executed_keys=None, tiled=False, compose=Tr
 
 
 _kernel_mode = threading.local()
-_kernel_mode.eager = None
 
 
 def is_eager_mode():
-    if _kernel_mode.eager is None:
+    if getattr(_kernel_mode, 'eager', None) is None:
         return options.eager_mode
     return _kernel_mode.eager
 

--- a/mars/web/server.py
+++ b/mars/web/server.py
@@ -29,7 +29,7 @@ from .. import kvstore
 from ..compat import six
 from ..utils import get_next_port
 from ..config import options
-from ..scheduler import GraphActor, ResourceActor
+from ..scheduler import ResourceActor
 from ..api import MarsAPI
 
 logger = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ class MarsWebAPI(MarsAPI):
             session_desc['name'] = session_id
             session_desc['tasks'] = dict()
             session_ref = self.actor_client.actor_ref(session_ref)
-            for graph_key, graph_ref in six.iteritems(session_ref.get_graph_refs()):
+            for graph_key, graph_meta_ref in six.iteritems(session_ref.get_graph_meta_refs()):
                 task_desc = dict()
 
                 state = self.get_graph_state(session_id, graph_key)
@@ -95,10 +95,10 @@ class MarsWebAPI(MarsAPI):
                     session_desc['tasks'][graph_key] = task_desc
                     continue
 
-                graph_ref = self.actor_client.actor_ref(graph_ref)
+                graph_meta_ref = self.actor_client.actor_ref(graph_meta_ref)
                 task_desc['id'] = graph_key
-                task_desc['state'] = graph_ref.get_state().value
-                start_time, end_time, graph_size = graph_ref.get_graph_info()
+                task_desc['state'] = graph_meta_ref.get_state().value
+                start_time, end_time, graph_size = graph_meta_ref.get_graph_info()
                 task_desc['start_time'] = start_time
                 task_desc['end_time'] = end_time
                 task_desc['graph_size'] = graph_size
@@ -107,9 +107,8 @@ class MarsWebAPI(MarsAPI):
         return sessions
 
     def get_task_detail(self, session_id, task_id):
-        graph_uid = GraphActor.gen_uid(session_id, task_id)
-        graph_ref = self.get_actor_ref(graph_uid)
-        return graph_ref.calc_stats()
+        graph_meta_ref = self.get_graph_meta_ref(session_id, task_id)
+        return graph_meta_ref.calc_stats()
 
     def get_workers_meta(self):
         resource_uid = ResourceActor.default_name()

--- a/mars/worker/tests/test_quota.py
+++ b/mars/worker/tests/test_quota.py
@@ -146,7 +146,7 @@ class Test(WorkerCase):
         mock_mem_stat = AttributeDict(dict(total=300, available=50, used=0, free=50))
         local_pool_addr = 'localhost:%d' % get_next_port()
         with create_actor_pool(n_process=1, backend='gevent', address=local_pool_addr) as pool, \
-                patch_method(resource.virtual_memory, new=lambda: mock_mem_stat) as _:
+                patch_method(resource.virtual_memory, new=lambda: mock_mem_stat):
             pool.create_actor(WorkerClusterInfoActor, schedulers=[local_pool_addr],
                               uid=WorkerClusterInfoActor.default_name())
             pool.create_actor(StatusActor, local_pool_addr, uid=StatusActor.default_name())


### PR DESCRIPTION
## What do these changes do?

Submit tiling of tensors into a thread pool and then gevent can switch to other lines. What's more, the function of GraphMetaActor is enhanced to hold state of every operand.

## Related issue number

Fixes #389 
