### PR TITLE
Fix defunct compose option in web session

### DIFF
--- a/mars/web/api.py
+++ b/mars/web/api.py
@@ -93,7 +93,7 @@ class GraphsApiHandler(ApiRequestHandler):
         try:
             graph = self.get_argument('graph')
             target = self.get_argument('target').split(',')
-            compose = self.get_argument('compose', True)
+            compose = bool(int(self.get_argument('compose', '1')))
         except web.MissingArgumentError as ex:
             self.write(json.dumps(dict(msg=str(ex))))
             raise web.HTTPError(400, 'Argument missing')

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -221,7 +221,7 @@ class Session(object):
         resp = self._req_session.post(session_url + '/graph', dict(
             graph=json.dumps(graph_json),
             target=targets,
-            compose=compose
+            compose='1' if compose else '0'
         ))
         if resp.status_code >= 400:
             resp_json = json.loads(resp.text)


### PR DESCRIPTION
## What do these changes do?

Pass string 0 or 1 instead of boolean string in web sessions to fix mismatch compose arg.

## Related issue number
Fixes #394 