### PR TITLE
Support concatenating DataFrame chunks into one

### DIFF
--- a/mars/dataframe/execution/arithmetic.py
+++ b/mars/dataframe/execution/arithmetic.py
@@ -47,7 +47,7 @@ def _index_align_map(ctx, chunk):
         # no shuffle on columns
         op = operator.ge if chunk.op.column_min_close else operator.gt
         columns_cond = op(df.columns, chunk.op.column_min)
-        op = operator.le if chunk.op.column_max_close else operator.ge
+        op = operator.le if chunk.op.column_max_close else operator.lt
         columns_cond = columns_cond & op(df.columns, chunk.op.column_max)
         filters[1].append(columns_cond)
     else:

--- a/mars/dataframe/execution/core.py
+++ b/mars/dataframe/execution/core.py
@@ -15,6 +15,7 @@
 from ..expressions.core import DataFrameShuffleProxy
 from .datasource import register_data_source_handler
 from .arithmetic import register_arithmetic_handler
+from .merge import register_merge_handler
 
 
 def register_dataframe_execution_handler():
@@ -23,3 +24,4 @@ def register_dataframe_execution_handler():
 
     register_data_source_handler()
     register_arithmetic_handler()
+    register_merge_handler()

--- a/mars/dataframe/execution/merge.py
+++ b/mars/dataframe/execution/merge.py
@@ -1,0 +1,58 @@
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import pandas as pd
+except ImportError:  # pragma: no cover
+    pass
+
+
+def _concat(ctx, chunk):
+    inputs = [ctx[input.key] for input in chunk.inputs]
+
+    if isinstance(inputs[0], tuple):
+        ctx[chunk.key] = tuple(_base_concat(chunk, [input[i] for input in inputs])
+                               for i in range(len(inputs[0])))
+    else:
+        ctx[chunk.key] = _base_concat(chunk, inputs)
+
+
+def _base_concat(chunk, inputs):
+    if chunk.op.axis is not None:
+        # TODO: remove this when we support concat on dataframe
+        raise NotImplementedError
+    else:
+        # auto generated concat when executing a dataframe
+        n_rows = max(inp.index[0] for inp in chunk.inputs) + 1
+        n_cols = int(len(inputs) // n_rows)
+        assert n_rows * n_cols == len(inputs)
+
+        concats = []
+        for i in range(n_rows):
+            concat = pd.concat([inputs[i * n_cols + j] for j in range(n_cols)], axis='columns')
+            concats.append(concat)
+
+        ret = pd.concat(concats)
+        if chunk.index_value.should_be_monotonic:
+            ret.sort_index(inplace=True)
+        if chunk.columns.should_be_monotonic:
+            ret.sort_index(axis=1, inplace=True)
+        return ret
+
+
+def register_merge_handler():
+    from ..expressions.merge import DataFrameConcat
+    from ...executor import register
+
+    register(DataFrameConcat, _concat)

--- a/mars/dataframe/execution/merge.py
+++ b/mars/dataframe/execution/merge.py
@@ -44,9 +44,9 @@ def _base_concat(chunk, inputs):
             concats.append(concat)
 
         ret = pd.concat(concats)
-        if chunk.index_value.should_be_monotonic:
+        if getattr(chunk.index_value, 'should_be_monotonic', False):
             ret.sort_index(inplace=True)
-        if chunk.columns.should_be_monotonic:
+        if getattr(chunk.columns, 'should_be_monotonic', False):
             ret.sort_index(axis=1, inplace=True)
         return ret
 

--- a/mars/dataframe/execution/tests/test_arithmetic_execution.py
+++ b/mars/dataframe/execution/tests/test_arithmetic_execution.py
@@ -32,15 +32,6 @@ class Test(TestBase):
         super(Test, self).setUp()
         self.executor = Executor()
 
-    @staticmethod
-    def _concat(index, dtypes, results):
-        empty = pd.DataFrame(index=index)
-        for c, d in zip(dtypes.index, dtypes):
-            empty[c] = pd.Series(dtype=d)
-        for df in results:
-            empty.loc[df.index, df.columns] = df
-        return empty
-
     def testAddWithoutShuffleExecution(self):
         # all the axes are monotonic
         # data1 with index split into [0...4], [5...9],
@@ -56,11 +47,8 @@ class Test(TestBase):
 
         df3 = add(df1, df2)
 
-        graph = df3.build_graph(tiled=True)
-        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
-
         expected = data1 + data2
-        result = self._concat(expected.index, expected.dtypes, results)
+        result = self.executor.execute_dataframe(df3, concat=True)[0]
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -77,11 +65,8 @@ class Test(TestBase):
 
         df3 = add(df1, df2)
 
-        graph = df3.build_graph(tiled=True)
-        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
-
         expected = data1 + data2
-        result = self._concat(expected.index, expected.dtypes, results)
+        result = self.executor.execute_dataframe(df3, concat=True)[0]
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -97,11 +82,8 @@ class Test(TestBase):
 
         df3 = add(df1, df2)
 
-        graph = df3.build_graph(tiled=True)
-        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
-
         expected = data1 + data2
-        result = self._concat(expected.index, expected.dtypes, results)
+        result = self.executor.execute_dataframe(df3, concat=True)[0]
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -116,11 +98,8 @@ class Test(TestBase):
 
         df3 = add(df1, df2)
 
-        graph = df3.build_graph(tiled=True, compose=False)
-        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
-
         expected = data1 + data2
-        result = self._concat(expected.index, expected.dtypes, results)
+        result = self.executor.execute_dataframe(df3, concat=True, compose=False)[0]
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -137,11 +116,8 @@ class Test(TestBase):
 
         df3 = add(df1, df2)
 
-        graph = df3.build_graph(tiled=True)
-        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
-
         expected = data1 + data2
-        result = self._concat(expected.index, expected.dtypes, results)
+        result = self.executor.execute_dataframe(df3, concat=True)[0]
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -157,11 +133,8 @@ class Test(TestBase):
 
         df3 = add(df1, df2)
 
-        graph = df3.build_graph(tiled=True)
-        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
-
         expected = data1 + data2
-        result = self._concat(expected.index, expected.dtypes, results)
+        result = self.executor.execute_dataframe(df3, concat=True)[0]
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -178,11 +151,8 @@ class Test(TestBase):
 
         df3 = add(df1, df2)
 
-        graph = df3.build_graph(tiled=True)
-        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
-
         expected = data1 + data2
-        result = self._concat(expected.index, expected.dtypes, results)
+        result = self.executor.execute_dataframe(df3, concat=True)[0]
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -198,11 +168,8 @@ class Test(TestBase):
 
         df3 = add(df1, df2)
 
-        graph = df3.build_graph(tiled=True)
-        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
-
         expected = data1 + data2
-        result = self._concat(expected.index, expected.dtypes, results)
+        result = self.executor.execute_dataframe(df3, concat=True)[0]
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -219,11 +186,8 @@ class Test(TestBase):
 
         df3 = add(df1, df2)
 
-        graph = df3.build_graph(tiled=True, compose=False)
-        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
-
         expected = data1 + data2
-        result = self._concat(expected.index, expected.dtypes, results)
+        result = self.executor.execute_dataframe(df3, concat=True, compose=False)[0]
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -239,10 +203,7 @@ class Test(TestBase):
 
         df3 = add(df1, df2)
 
-        graph = df3.build_graph(tiled=True, compose=False)
-        results = self.executor.execute_graph(graph, keys=[c.key for c in df3.chunks])
-
         expected = data1 + data2
-        result = self._concat(expected.index, expected.dtypes, results)
+        result = self.executor.execute_dataframe(df3, concat=True, compose=False)[0]
 
         pd.testing.assert_frame_equal(expected, result)

--- a/mars/dataframe/execution/tests/test_datasource_execution.py
+++ b/mars/dataframe/execution/tests/test_datasource_execution.py
@@ -33,13 +33,7 @@ class Test(TestBase):
 
     def testPandasExecution(self):
         pdf = pd.DataFrame(np.random.rand(20, 30), index=[np.arange(20), np.arange(20, 0, -1)])
-        df = from_pandas(pdf, chunk_size = (13, 21))
+        df = from_pandas(pdf, chunk_size=(13, 21))
 
-        graph = df.build_graph(tiled=True)
-        results = self.executor.execute_graph(graph, keys=[c.key for c in df.chunks])
-
-        self.assertEqual(len(results), 4)
-        pd.testing.assert_frame_equal(pdf.iloc[:13, :21], results[0])
-        pd.testing.assert_frame_equal(pdf.iloc[:13, 21:], results[1])
-        pd.testing.assert_frame_equal(pdf.iloc[13:, :21], results[2])
-        pd.testing.assert_frame_equal(pdf.iloc[13:, 21:], results[3])
+        result = self.executor.execute_dataframe(df, concat=True)[0]
+        pd.testing.assert_frame_equal(pdf, result)

--- a/mars/dataframe/expressions/__init__.py
+++ b/mars/dataframe/expressions/__init__.py
@@ -11,3 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
+from .utils import concat_tileable_chunks

--- a/mars/dataframe/expressions/arithmetic/core.py
+++ b/mars/dataframe/expressions/arithmetic/core.py
@@ -472,6 +472,7 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
     def _tile_both_dataframes(cls, op):
         # if both of the inputs are DataFrames, axis is just ignored
         left, right = op.inputs
+        df = op.outputs[0]
         nsplits = [[], []]
         splits = _MinMaxSplitInfo()
 
@@ -515,9 +516,10 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
             out_chunks = cls._gen_out_chunks_with_all_shuffle(op, out_shape, left, right)
 
         new_op = op.copy()
-        return new_op.new_dataframes(op.inputs, op.outputs[0].shape,
+        return new_op.new_dataframes(op.inputs, df.shape,
                                      nsplits=tuple(tuple(ns) for ns in nsplits),
-                                     chunks=out_chunks)
+                                     chunks=out_chunks, dtypes=df.dtypes,
+                                     index_value=df.index_value, columns_value=df.columns)
 
     @classmethod
     def tile(cls, op):

--- a/mars/dataframe/expressions/merge/__init__.py
+++ b/mars/dataframe/expressions/merge/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright 1999-2018 Alibaba Group Holding Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from . import rechunk
-from . import fuse
-from . import ufunc
-from .utils import concat_tileable_chunks

--- a/mars/dataframe/expressions/merge/__init__.py
+++ b/mars/dataframe/expressions/merge/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .concat import DataFrameConcat

--- a/mars/dataframe/expressions/merge/concat.py
+++ b/mars/dataframe/expressions/merge/concat.py
@@ -1,0 +1,82 @@
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ....serialize import ValueType, ListField, StringField, BoolField, AnyField
+from .... import opcodes as OperandDef
+from ..core import DataFrameOperand, DataFrameOperandMixin
+
+
+class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = OperandDef.CONCATENATE
+
+    _axis = AnyField('axis')
+    _join = StringField('join')
+    _join_axes = ListField('join_axes', ValueType.key)
+    _ignore_index = BoolField('ignore_index')
+    _keys = ListField('keys')
+    _levels = ListField('levels')
+    _names = ListField('names')
+    _verify_integrity = BoolField('verify_integrity')
+    _sort = BoolField('sort')
+    _copy = BoolField('copy')
+
+    def __init__(self, axis=None, join=None, join_axes=None, ignore_index=None,
+                 keys=None, levels=None, names=None, verify_integrity=None,
+                 sort=None, copy=None, sparse=None, **kw):
+        super(DataFrameConcat, self).__init__(
+            _axis=axis, _join=join, _join_axes=join_axes, _ignore_index=ignore_index,
+            _keys=keys, _levels=levels, _names=names,
+            _verify_integrity=verify_integrity, _sort=sort, _copy=copy,
+            _sparse=sparse, **kw)
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @property
+    def join(self):
+        return self._join
+
+    @property
+    def join_axes(self):
+        return self._join_axes
+
+    @property
+    def ignore_index(self):
+        return self._ignore_index
+
+    @property
+    def keys(self):
+        return self._keys
+
+    @property
+    def level(self):
+        return self._levels
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def verify_integrity(self):
+        return self._verify_integrity
+
+    @property
+    def sort(self):
+        return self._sort
+
+    @property
+    def copy_(self):
+        return self._copy
+

--- a/mars/dataframe/expressions/tests/test_arithmetic.py
+++ b/mars/dataframe/expressions/tests/test_arithmetic.py
@@ -61,6 +61,16 @@ class Test(TestBase):
 
         df3.tiles()
 
+        # test df3's index and columns after tiling
+        pd.testing.assert_index_equal(df3.columns.to_pandas(), (data1 + data2).columns)
+        self.assertTrue(df3.columns.should_be_monotonic)
+        self.assertIsInstance(df3.index_value.value, IndexValue.Int64Index)
+        self.assertTrue(df3.index_value.should_be_monotonic)
+        pd.testing.assert_index_equal(df3.index_value.to_pandas(), pd.Int64Index([]))
+        self.assertNotEqual(df3.index_value.key, df1.index_value.key)
+        self.assertNotEqual(df3.index_value.key, df2.index_value.key)
+        self.assertEqual(df3.shape[1], 11)  # columns is recorded, so we can get it
+
         data1_index_min_max = [(0, True, 4, True), (5, True, 9, True)]
         data1_columns_min_max = [[3, True, 7, True], [8, True, 12, True]]
         data2_index_min_max = [(2, True, 5, True), (6, True, 11, True)]

--- a/mars/dataframe/expressions/utils.py
+++ b/mars/dataframe/expressions/utils.py
@@ -325,3 +325,17 @@ def filter_index_value(index_value, min_max, store_data=False):
         f = f & (pd_index < max_val)
 
     return parse_index(pd_index[f], store_data=store_data)
+
+
+def concat_tileable_chunks(df):
+    from .merge.concat import DataFrameConcat
+
+    assert not df.is_coarse()
+
+    op = DataFrameConcat()
+    chunk = DataFrameConcat().new_chunk(df.chunks, shape=df.shape, dtypes=df.dtypes,
+                                        index_value=df.index_value,
+                                        columns_value=df.columns)
+    return op.new_dataframe([df], shape=df.shape, chunks=[chunk],
+                            nsplits=tuple((s,) for s in df.shape), dtypes=df.dtypes,
+                            index_value=df.index_value, columns_value=df.columns)

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -30,7 +30,7 @@ except ImportError:  # pragma: no cover
 from .operands import Fetch
 from .graph import DirectedGraph
 from .compat import six, futures, OrderedDict, enum
-from .utils import kernel_mode
+from .utils import kernel_mode, concat_tileable_chunks
 
 logger = logging.getLogger(__name__)
 
@@ -470,63 +470,57 @@ class Executor(object):
         return res
 
     @kernel_mode
-    def execute_tensor(self, tensor, n_parallel=None, n_thread=None, concat=False,
-                       print_progress=False, mock=False):
+    def execute_tileable(self, tileable, n_parallel=None, n_thread=None, concat=False,
+                         print_progress=False, mock=False, compose=True):
         if concat:
             # only for tests
-            tensor.tiles()
-            if len(tensor.chunks) > 1:
-                from .tensor.expressions.merge.concatenate import TensorConcatenate
+            tileable.tiles()
+            if len(tileable.chunks) > 1:
+                tileable = concat_tileable_chunks(tileable)
 
-                op = TensorConcatenate(dtype=tensor.op.dtype)
-                chunk = TensorConcatenate(dtype=op.dtype).new_chunk(tensor.chunks, shape=tensor.shape)
-                tensor = op.new_tensor([tensor], tensor.shape, chunks=[chunk],
-                                       nsplits=[(s,) for s in tensor.shape])
+        graph = tileable.build_graph(cls=DirectedGraph, tiled=True, compose=compose)
 
-        graph = tensor.build_graph(cls=DirectedGraph, tiled=True)
-
-        return self.execute_graph(graph, [c.key for c in tensor.chunks],
+        return self.execute_graph(graph, [c.key for c in tileable.chunks],
                                   n_parallel=n_parallel or n_thread,
                                   print_progress=print_progress, mock=mock)
 
+    execute_tensor = execute_tileable
+    execute_dataframe = execute_tileable
+
     @kernel_mode
-    def execute_tensors(self, tensors, fetch=True, n_parallel=None, n_thread=None,
-                        print_progress=False, mock=False, compose=True):
+    def execute_tileables(self, tileables, fetch=True, n_parallel=None, n_thread=None,
+                          print_progress=False, mock=False, compose=True):
         graph = DirectedGraph()
 
         result_keys = []
         to_release_keys = []
         concat_keys = []
-        for tensor in tensors:
-            tensor.tiles()
-            chunk_keys = [c.key for c in tensor.chunks]
+        for tileable in tileables:
+            tileable.tiles()
+            chunk_keys = [c.key for c in tileable.chunks]
             result_keys.extend(chunk_keys)
 
-            if tensor.key in self.stored_tileables:
-                self.stored_tileables[tensor.key][0].add(tensor.id)
+            if tileable.key in self.stored_tileables:
+                self.stored_tileables[tileable.key][0].add(tileable.id)
             else:
-                self.stored_tileables[tensor.key] = tuple([{tensor.id}, set(chunk_keys)])
+                self.stored_tileables[tileable.key] = tuple([{tileable.id}, set(chunk_keys)])
             if not fetch:
                 # no need to generate concat keys
                 pass
-            elif len(tensor.chunks) > 1:
-                from .tensor.expressions.merge.concatenate import TensorConcatenate
-
+            elif len(tileable.chunks) > 1:
                 # if need to fetch data and chunks more than 1, we concatenate them into 1
-                op = TensorConcatenate(dtype=tensor.op.dtype)
-                chunk = TensorConcatenate(dtype=op.dtype).new_chunk(tensor.chunks, shape=tensor.shape)
+                tileable = concat_tileable_chunks(tileable)
+                chunk = tileable.chunks[0]
                 result_keys.append(chunk.key)
                 # the concatenated key
                 concat_keys.append(chunk.key)
                 # after return the data to user, we release the reference
                 to_release_keys.append(chunk.key)
-                tensor = op.new_tensor([tensor], tensor.shape, chunks=[chunk],
-                                       nsplits=[(s,) for s in tensor.shape])
             else:
-                concat_keys.append(tensor.chunks[0].key)
+                concat_keys.append(tileable.chunks[0].key)
 
-            tensor.build_graph(graph=graph, tiled=True, compose=compose,
-                               executed_keys=list(self._chunk_result.keys()))
+            tileable.build_graph(graph=graph, tiled=True, compose=compose,
+                                 executed_keys=list(self._chunk_result.keys()))
 
         self.execute_graph(graph, result_keys, n_parallel=n_parallel or n_thread,
                            print_progress=print_progress, mock=mock)
@@ -540,6 +534,9 @@ class Executor(object):
         finally:
             for k in to_release_keys:
                 del results[k]
+
+    execute_tensors = execute_tileables
+    execute_dataframes = execute_tileables
 
     @kernel_mode
     def fetch_tensors(self, tensors, **kw):

--- a/mars/session.py
+++ b/mars/session.py
@@ -39,7 +39,7 @@ class LocalSession(object):
 
     @property
     def executed_tensors(self):
-        return self._executor.stored_tensors.keys()
+        return self._executor.stored_tileables.keys()
 
     @endpoint.setter
     def endpoint(self, endpoint):

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -472,3 +472,15 @@ def convert_to_fetch(entity):
         return new_op.new_tensor(None, entity.shape, _key=entity.key, _id=entity.id)
     else:
         raise ValueError('Now only support tensor or chunk type.')
+
+
+def concat_tileable_chunks(tensor):
+    from .merge.concatenate import TensorConcatenate
+
+    assert not tensor.is_coarse()
+
+    op = TensorConcatenate(dtype=tensor.op.dtype)
+    chunk = TensorConcatenate(dtype=op.dtype).new_chunk(
+        tensor.chunks, shape=tensor.shape)
+    return op.new_tensor([tensor], tensor.shape, chunks=[chunk],
+                         nsplits=tuple((s,) for s in tensor.shape))

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -401,3 +401,11 @@ class BlacklistSet(object):
                 rmv_list.append(k)
         for k in rmv_list:
             del self._key_time[k]
+
+
+def concat_tileable_chunks(tileable):
+    module_name = tileable.op._op_module_
+    # tensor.expressions and dataframe.expressions have method concat_tileable_chunks
+    expr_module_name = '{0}.expressions'.format(module_name)
+    expr_module = __import__(expr_module_name, dict(), dict(), list())
+    return expr_module.concat_tileable_chunks(tileable)

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -28,6 +28,7 @@ import sys
 import time
 import zlib
 import threading
+import importlib
 
 import numpy as np
 
@@ -406,6 +407,6 @@ class BlacklistSet(object):
 def concat_tileable_chunks(tileable):
     module_name = tileable.op._op_module_
     # tensor.expressions and dataframe.expressions have method concat_tileable_chunks
-    expr_module_name = '{0}.expressions'.format(module_name)
-    expr_module = __import__(expr_module_name, dict(), dict(), list())
+    expr_module_name = 'mars.{0}.expressions'.format(module_name)
+    expr_module = importlib.import_module(expr_module_name)
     return expr_module.concat_tileable_chunks(tileable)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Support `execute_dataframe` for `mars.executor.Executor` that the DataFrame chunks can be concatenated into one chunk.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #234 
