### PR TITLE
[BACKPORT] Fix `nsplits` of tensors generated in the tile of QR decomposition (#387)

### DIFF
--- a/mars/tensor/expressions/linalg/core.py
+++ b/mars/tensor/expressions/linalg/core.py
@@ -120,7 +120,8 @@ class TSQR(object):
         concat_op = TensorConcatenate(axis=0, dtype=stage1_r_chunks[0].dtype)
         concat_r_chunk = concat_op.new_chunk(stage1_r_chunks, shape, index=(0, 0))
         qr_op = TensorQR()
-        qr_shapes = concat_r_chunk.shape, (concat_r_chunk.shape[1],) * 2
+        qr_shapes = (concat_r_chunk.shape[0], min(concat_r_chunk.shape)), \
+                    (min(concat_r_chunk.shape), concat_r_chunk.shape[1])
         qr_chunks = qr_op.new_chunks([concat_r_chunk], qr_shapes, index=concat_r_chunk.index,
                                      kws=[{'side': 'q', 'dtype': q_dtype},
                                           {'side': 'r', 'dtype': r_dtype}])

--- a/mars/tensor/expressions/linalg/core.py
+++ b/mars/tensor/expressions/linalg/core.py
@@ -72,7 +72,7 @@ class SFQR(object):
         q, r = op.outputs
         new_op = op.copy()
         q_nsplits = ((q_chunk.shape[0],), (q_chunk.shape[1],))
-        r_nsplits = ((1,), (c.shape[1] for c in r_chunks))
+        r_nsplits = ((r_chunks[0].shape[0],), tuple(c.shape[1] for c in r_chunks))
         kws = [
             {'chunks': [q_chunk], 'nsplits': q_nsplits, 'dtype': q.dtype},
             {'chunks': r_chunks, 'nsplits': r_nsplits, 'dtype': r.dtype}
@@ -134,7 +134,8 @@ class TSQR(object):
         stage2_q_chunks = []
         for c, s in zip(stage1_q_chunks, q_slices):
             slice_op = TensorSlice(slices=[s], dtype=c.dtype)
-            stage2_q_chunks.append(slice_op.new_chunk([stage2_q_chunk], c.shape, index=c.index))
+            stage2_q_chunks.append(slice_op.new_chunk([stage2_q_chunk],
+                                                      (c.shape[0], stage2_q_chunk.shape[1]), index=c.index))
         stage3_q_chunks = []
         for c1, c2 in izip(stage1_q_chunks, stage2_q_chunks):
             dot_op = TensorDot(dtype=q_dtype)
@@ -144,8 +145,7 @@ class TSQR(object):
         if not calc_svd:
             q, r = op.outputs
             new_op = op.copy()
-            # unify_nsplits will get nsplits by chunk shape if it was set to (1,)
-            q_nsplits = ((c.shape[0] for c in stage3_q_chunks), (1,))
+            q_nsplits = (tuple(c.shape[0] for c in stage3_q_chunks), (stage3_q_chunks[0].shape[1],))
             r_nsplits = ((stage2_r_chunk.shape[0],), (stage2_r_chunk.shape[1],))
             kws = [
                 # Q
@@ -182,7 +182,7 @@ class TSQR(object):
                                                             index=c1.index))
 
             new_op = op.copy()
-            u_nsplits = ((c.shape[0] for c in stage4_u_chunks), (1,))
+            u_nsplits = (tuple(c.shape[0] for c in stage4_u_chunks), (stage4_u_chunks[0].shape[1],))
             s_nsplits = ((stage2_s_chunk.shape[0],),)
             v_nsplits = ((stage2_v_chunk.shape[0],), (stage2_v_chunk.shape[1],))
             kws = [

--- a/mars/tensor/expressions/linalg/qr.py
+++ b/mars/tensor/expressions/linalg/qr.py
@@ -68,8 +68,8 @@ class TensorQR(operands.QR, TensorOperandMixin):
 
             new_op = op.copy()
             kws = [
-                {'chunks': [q_chunk], 'nsplits': ((1,), (1,)), 'dtype': q_dtype},
-                {'chunks': [r_chunk], 'nsplits': ((1,), (1,)), 'dtype': r_dtype}
+                {'chunks': [q_chunk], 'nsplits': ((q_shape[0],), (q_shape[1],)), 'dtype': q_dtype},
+                {'chunks': [r_chunk], 'nsplits': ((r_shape[0],), (r_shape[1],)), 'dtype': r_dtype}
             ]
             return new_op.new_tensors(op.inputs, [q_shape, r_shape], kws=kws)
         elif op.method == 'tsqr':

--- a/mars/tensor/expressions/tests/test_linalg.py
+++ b/mars/tensor/expressions/tests/test_linalg.py
@@ -39,6 +39,8 @@ class Test(unittest.TestCase):
 
         self.assertEqual(len(q.chunks), 3)
         self.assertEqual(len(r.chunks), 1)
+        self.assertEqual(q.nsplits, ((3, 3, 3), (6,)))
+        self.assertEqual(r.nsplits, ((6,), (6,)))
         self.assertEqual(calc_shape(q.chunks[0]), q.chunks[0].shape)
         self.assertEqual(calc_shape(r.chunks[0]), ((9, 6), (6, 6)))
 
@@ -54,6 +56,8 @@ class Test(unittest.TestCase):
 
         self.assertEqual(len(q.chunks), 1)
         self.assertEqual(len(r.chunks), 3)
+        self.assertEqual(q.nsplits, ((6,), (6,)))
+        self.assertEqual(r.nsplits, ((6,), (6, 6, 6)))
         self.assertEqual(calc_shape(q.chunks[0]), ((6, 6), (6, 6)))
         self.assertEqual(calc_shape(r.chunks[0]), ((6, 6), (6, 6)))
         self.assertEqual(calc_shape(r.chunks[1]), r.chunks[1].shape)
@@ -71,6 +75,8 @@ class Test(unittest.TestCase):
 
         self.assertEqual(len(q.chunks), 1)
         self.assertEqual(len(r.chunks), 2)
+        self.assertEqual(q.nsplits, ((6,), (6,)))
+        self.assertEqual(r.nsplits, ((6,), (6, 3)))
         self.assertEqual(calc_shape(q.chunks[0]), ((6, 6), (6, 6)))
         self.assertEqual(calc_shape(r.chunks[0]), ((6, 6), (6, 6)))
         self.assertEqual(calc_shape(r.chunks[1]), r.chunks[1].shape)
@@ -87,6 +93,8 @@ class Test(unittest.TestCase):
 
         self.assertEqual(len(q.chunks), 1)
         self.assertEqual(len(r.chunks), 1)
+        self.assertEqual(q.nsplits, ((9,), (6,)))
+        self.assertEqual(r.nsplits, ((6,), (6,)))
         self.assertEqual(calc_shape(q.chunks[0]), ((9, 6), (6, 6)))
         self.assertEqual(calc_shape(r.chunks[0]), ((9, 6), (6, 6)))
 


### PR DESCRIPTION
Backport of #387 