### PR TITLE
Fix serialization of DataFrame's index_value or columns_value if its type is int64

### DIFF
--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -20,7 +20,7 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
-from ..utils import on_serialize_shape, on_deserialize_shape
+from ..utils import on_serialize_shape, on_deserialize_shape, on_serialize_numpy_type
 from ..core import ChunkData, Chunk, Entity, TileableData
 from ..serialize import Serializable, ValueType, ProviderType, DataTypeField, AnyField, \
     SeriesField, BoolField, Int64Field, Int32Field, StringField, ListField, SliceField, \
@@ -36,9 +36,9 @@ class IndexValue(Serializable):
         _is_monotonic_decreasing = BoolField('is_monotonic_decreasing')
         _is_unique = BoolField('is_unique')
         _should_be_monotonic = BoolField('should_be_monotonic')
-        _max_val = AnyField('max_val')
+        _max_val = AnyField('max_val', on_serialize=on_serialize_numpy_type)
         _max_val_close = BoolField('max_val_close')
-        _min_val = AnyField('min_val')
+        _min_val = AnyField('min_val', on_serialize=on_serialize_numpy_type)
         _min_val_close = BoolField('min_val_close')
 
         @property

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -188,7 +188,7 @@ class IndexValue(Serializable):
                               range_index=RangeIndex, categorical_index=CategoricalIndex,
                               interval_index=IntervalIndex, datetime_index=DatetimeIndex,
                               timedelta_index=TimedeltaIndex, period_index=PeriodIndex,
-                              int64_index=Int64Field, uint64_index=UInt64Index,
+                              int64_index=Int64Index, uint64_index=UInt64Index,
                               float64_index=Float64Index, multi_index=MultiIndex)
 
     def __mars_tokenize__(self):

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -339,6 +339,13 @@ class SeriesData(TileableData):
                         on_serialize=lambda x: [it.data for it in x] if x is not None else x,
                         on_deserialize=lambda x: [SeriesChunk(it) for it in x] if x is not None else x)
 
+    @classmethod
+    def cls(cls, provider):
+        if provider.type == ProviderType.protobuf:
+            from ..serialize.protos.dataframe_pb2 import SeriesDef
+            return SeriesDef
+        return super(SeriesData, cls).cls(provider)
+
     @property
     def dtype(self):
         return getattr(self, '_dtype', None) or self.op.dtype
@@ -418,6 +425,13 @@ class DataFrameData(TileableData):
     _chunks = ListField('chunks', ValueType.reference(DataFrameChunkData),
                         on_serialize=lambda x: [it.data for it in x] if x is not None else x,
                         on_deserialize=lambda x: [DataFrameChunk(it) for it in x] if x is not None else x)
+
+    @classmethod
+    def cls(cls, provider):
+        if provider.type == ProviderType.protobuf:
+            from ..serialize.protos.dataframe_pb2 import DataFrameDef
+            return DataFrameDef
+        return super(DataFrameData, cls).cls(provider)
 
     @property
     def params(self):

--- a/mars/dataframe/expressions/fetch/core.py
+++ b/mars/dataframe/expressions/fetch/core.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ....serialize.core import TupleField, SeriesField, ReferenceField, ValueType
+from ....serialize.core import TupleField, SeriesField, ValueType
 from ....operands import Fetch, FetchShuffle
 from ....utils import on_serialize_shape, on_deserialize_shape
 from ..core import DataFrameOperandMixin

--- a/mars/dataframe/expressions/fetch/core.py
+++ b/mars/dataframe/expressions/fetch/core.py
@@ -37,8 +37,6 @@ class DataFrameFetch(Fetch, DataFrameFetchMixin):
                         on_serialize=on_serialize_shape, on_deserialize=on_deserialize_shape)
     # optional fields
     _dtypes = SeriesField('dtypes')
-    _index_value = ReferenceField('index_value', IndexValue)
-    _columns_value = ReferenceField('columns_value', IndexValue)
 
     def __init__(self, dtypes=None, to_fetch_key=None, sparse=False, **kw):
         super(DataFrameFetch, self).__init__(
@@ -65,8 +63,6 @@ class DataFrameFetchShuffle(FetchShuffle, DataFrameFetchMixin):
                         on_serialize=on_serialize_shape, on_deserialize=on_deserialize_shape)
     # optional fields
     _dtypes = SeriesField('dtypes')
-    _index_value = ReferenceField('index_value', IndexValue)
-    _columns_value = ReferenceField('columns_value', IndexValue)
 
     def __init__(self, dtypes=None, to_fetch_keys=None, **kw):
         super(DataFrameFetchShuffle, self).__init__(

--- a/mars/dataframe/expressions/fetch/core.py
+++ b/mars/dataframe/expressions/fetch/core.py
@@ -15,7 +15,6 @@
 from ....serialize.core import TupleField, SeriesField, ReferenceField, ValueType
 from ....operands import Fetch, FetchShuffle
 from ....utils import on_serialize_shape, on_deserialize_shape
-from ...core import IndexValue
 from ..core import DataFrameOperandMixin
 
 

--- a/mars/dataframe/expressions/tests/test_datasource.py
+++ b/mars/dataframe/expressions/tests/test_datasource.py
@@ -31,7 +31,8 @@ from mars.tests.core import TestBase
 @unittest.skipIf(pd is None, 'pandas not installed')
 class Test(TestBase):
     def testChunkSerialize(self):
-        data = pd.DataFrame(np.random.rand(10, 10), index=np.random.randint(-100, 100, size=(10,)))
+        data = pd.DataFrame(np.random.rand(10, 10), index=np.random.randint(-100, 100, size=(10,)),
+                            columns=[np.random.bytes(10) for _ in range(10)])
         df = from_pandas(data).tiles()
 
         # pb
@@ -49,6 +50,9 @@ class Test(TestBase):
         self.assertEqual(chunk.index, chunk2.index)
         self.assertEqual(chunk.key, chunk2.key)
         self.assertEqual(chunk.shape, chunk2.shape)
+        self.assertEqual(chunk.op.dtype, chunk2.op.dtype)
+        pd.testing.assert_index_equal(chunk2.index_value.to_pandas(), chunk.index_value.to_pandas())
+        pd.testing.assert_index_equal(chunk2.columns.to_pandas(), chunk.columns.to_pandas())
 
         # json
         chunk = df.chunks[0]
@@ -59,9 +63,13 @@ class Test(TestBase):
         self.assertEqual(chunk.index, chunk2.index)
         self.assertEqual(chunk.key, chunk2.key)
         self.assertEqual(chunk.shape, chunk2.shape)
+        self.assertEqual(chunk.op.dtype, chunk2.op.dtype)
+        pd.testing.assert_index_equal(chunk2.index_value.to_pandas(), chunk.index_value.to_pandas())
+        pd.testing.assert_index_equal(chunk2.columns.to_pandas(), chunk.columns.to_pandas())
 
     def testDataFrameGraphSerialize(self):
-        df = from_pandas(pd.DataFrame(np.random.rand(10, 10)))
+        df = from_pandas(pd.DataFrame(np.random.rand(10, 10),
+                                      columns=[np.random.bytes(10) for _ in range(10)]))
         graph = df.build_graph(tiled=False)
 
         pb = graph.to_pb()
@@ -73,6 +81,8 @@ class Test(TestBase):
         self.assertBaseEqual(t.op, t2.op)
         self.assertEqual(t.shape, t2.shape)
         self.assertEqual(sorted(i.key for i in t.inputs), sorted(i.key for i in t2.inputs))
+        pd.testing.assert_index_equal(t2.index_value.to_pandas(), t.index_value.to_pandas())
+        pd.testing.assert_index_equal(t2.columns.to_pandas(), t.columns.to_pandas())
 
         jsn = graph.to_json()
         graph2 = DAG.from_json(jsn)
@@ -83,6 +93,8 @@ class Test(TestBase):
         self.assertBaseEqual(t.op, t2.op)
         self.assertEqual(t.shape, t2.shape)
         self.assertEqual(sorted(i.key for i in t.inputs), sorted(i.key for i in t2.inputs))
+        pd.testing.assert_index_equal(t2.index_value.to_pandas(), t.index_value.to_pandas())
+        pd.testing.assert_index_equal(t2.columns.to_pandas(), t.columns.to_pandas())
 
         # test graph with tiled DataFrame
         t2 = from_pandas(pd.DataFrame(np.random.rand(10, 10)), chunk_size=(5, 4)).tiles()
@@ -97,6 +109,8 @@ class Test(TestBase):
         self.assertIsInstance(chunks[0], DataFrameChunk)
         self.assertEqual(chunks[0].index, t2.chunks[0].index)
         self.assertBaseEqual(chunks[0].op, t2.chunks[0].op)
+        pd.testing.assert_index_equal(chunks[0].index_value.to_pandas(), t2.chunks[0].index_value.to_pandas())
+        pd.testing.assert_index_equal(chunks[0].columns.to_pandas(), t2.chunks[0].columns.to_pandas())
 
         jsn = graph.to_json()
         graph2 = DAG.from_json(jsn)
@@ -106,6 +120,8 @@ class Test(TestBase):
         self.assertIsInstance(chunks[0], DataFrameChunk)
         self.assertEqual(chunks[0].index, t2.chunks[0].index)
         self.assertBaseEqual(chunks[0].op, t2.chunks[0].op)
+        pd.testing.assert_index_equal(chunks[0].index_value.to_pandas(), t2.chunks[0].index_value.to_pandas())
+        pd.testing.assert_index_equal(chunks[0].columns.to_pandas(), t2.chunks[0].columns.to_pandas())
 
     def testFromPandas(self):
         data = pd.DataFrame(np.random.rand(10, 10), columns=['c' + str(i) for i in range(10)])

--- a/mars/dataframe/expressions/tests/test_datasource.py
+++ b/mars/dataframe/expressions/tests/test_datasource.py
@@ -50,7 +50,6 @@ class Test(TestBase):
         self.assertEqual(chunk.index, chunk2.index)
         self.assertEqual(chunk.key, chunk2.key)
         self.assertEqual(chunk.shape, chunk2.shape)
-        self.assertEqual(chunk.op.dtype, chunk2.op.dtype)
         pd.testing.assert_index_equal(chunk2.index_value.to_pandas(), chunk.index_value.to_pandas())
         pd.testing.assert_index_equal(chunk2.columns.to_pandas(), chunk.columns.to_pandas())
 
@@ -63,7 +62,6 @@ class Test(TestBase):
         self.assertEqual(chunk.index, chunk2.index)
         self.assertEqual(chunk.key, chunk2.key)
         self.assertEqual(chunk.shape, chunk2.shape)
-        self.assertEqual(chunk.op.dtype, chunk2.op.dtype)
         pd.testing.assert_index_equal(chunk2.index_value.to_pandas(), chunk.index_value.to_pandas())
         pd.testing.assert_index_equal(chunk2.columns.to_pandas(), chunk.columns.to_pandas())
 

--- a/mars/graph.pyx
+++ b/mars/graph.pyx
@@ -345,7 +345,7 @@ cdef class DirectedGraph:
                 if level is None:
                     level = SerializableGraph.Level.ENTITY
                 for c in (node.chunks or ()):
-                    add_obj(c)
+                    add_obj(c.data)
                 add_obj(node)
             else:
                 raise TypeError('Unknown node type to serialize: {0}'.format(type(node)))

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -632,7 +632,7 @@ class GraphActor(SchedulerActor):
         input_chunk_keys = set(input_chunk_keys) if input_chunk_keys is not None else None
         for c in self._op_key_to_chunk[op_key]:
             for inp in set(c.inputs or ()):
-                inp_chunk = build_fetch_chunk(inp, input_chunk_keys)
+                inp_chunk = build_fetch_chunk(inp, input_chunk_keys).data
                 inputs_to_copied[inp] = inp_chunk
                 graph.add_node(inp_chunk)
             inputs = [inputs_to_copied[inp] for inp in (c.inputs or ())]

--- a/mars/serialize/core.pyx
+++ b/mars/serialize/core.pyx
@@ -466,6 +466,10 @@ cdef class OneOfField(Field):
             self._type = ValueType.oneof(*[f.type for f in self.fields])
         return self._type
 
+    @property
+    def attrs(self):
+        return [f.attr for f in self.fields]
+
 
 class SerializableMetaclass(type):
     def __new__(mcs, str name, tuple bases, dict kv):

--- a/mars/serialize/core.pyx
+++ b/mars/serialize/core.pyx
@@ -540,7 +540,8 @@ class Serializable(six.with_metaclass(SerializableMetaclass)):
         if provider.type == ProviderType.json:
             return dict
 
-        raise TypeError('Unknown provider type: {0}'.format(provider.type.value))
+        raise TypeError('Unknown provider type `{0}` for class `{1}`'.format(
+            ProviderType(provider.type).name, cls.__name__))
 
     def serialize(self, Provider provider, obj=None):
         return provider.serialize_model(self, obj=obj)

--- a/mars/serialize/jsonserializer.pyx
+++ b/mars/serialize/jsonserializer.pyx
@@ -430,6 +430,9 @@ cdef class JsonSerializeProvider(Provider):
                     new_obj = obj[tag] = dict()
                     value.serialize(self, new_obj)
                     return
+            if not has_val and value is not None:
+                raise ValueError('Value {0} cannot match any type for OneOfField `{1}`'.format(
+                    value, field.tag_name(self)))
         elif isinstance(field, ListField) and type(field.type.type) == Reference:
             tag = field.tag_name(self)
             value = self._on_serial(field, getattr(model_instance, field.attr, None))
@@ -517,7 +520,8 @@ cdef class JsonSerializeProvider(Provider):
                             'Only one of attributes({0}) can be specified'.format(field.attrs))
 
                     setattr(model_instance, f.attr,
-                            self._on_deserial(field, f.type.model.deserialize(self, obj[tag], callbacks, key_to_instance)))
+                            self._on_deserial(field, f.type.model.deserialize(self, obj[tag],
+                                                                              callbacks, key_to_instance)))
         elif isinstance(field, ListField) and type(field.type.type) == Reference:
             tag = field.tag_name(self)
             if tag not in obj:

--- a/mars/serialize/jsonserializer.pyx
+++ b/mars/serialize/jsonserializer.pyx
@@ -306,8 +306,6 @@ cdef class JsonSerializeProvider(Provider):
             }
         elif tp in PRIMITIVE_TYPE_TO_NAME:
             # primitive type, we do not do any type check here
-            if isinstance(value, np.generic):
-                value = value.item()
             return value
         elif type(tp) is Identity:
             return self._serialize_typed_value(value, tp.type, weak_ref=weak_ref)
@@ -346,10 +344,6 @@ cdef class JsonSerializeProvider(Provider):
             value = value()
         if value is None:
             return
-
-        # handle numpy type
-        if isinstance(value, np.generic):
-            value = value.item()
 
         if isinstance(value, bool):
             return value

--- a/mars/serialize/jsonserializer.pyx
+++ b/mars/serialize/jsonserializer.pyx
@@ -306,6 +306,8 @@ cdef class JsonSerializeProvider(Provider):
             }
         elif tp in PRIMITIVE_TYPE_TO_NAME:
             # primitive type, we do not do any type check here
+            if isinstance(value, np.generic):
+                value = value.item()
             return value
         elif type(tp) is Identity:
             return self._serialize_typed_value(value, tp.type, weak_ref=weak_ref)
@@ -344,6 +346,10 @@ cdef class JsonSerializeProvider(Provider):
             value = value()
         if value is None:
             return
+
+        # handle numpy type
+        if isinstance(value, np.generic):
+            value = value.item()
 
         if isinstance(value, bool):
             return value

--- a/mars/serialize/pbserializer.pyx
+++ b/mars/serialize/pbserializer.pyx
@@ -435,15 +435,21 @@ cdef class ProtobufSerializeProvider(Provider):
         cdef object field_obj
         cdef object add
         cdef object it_obj
+        cdef bint matched
         cdef OneOfField oneoffield
 
         if isinstance(field, OneOfField):
             oneoffield = <OneOfField> field
             value = getattr(model_instance, oneoffield.attr, None)
+            matched = False
             for f in oneoffield.fields:
                 if isinstance(value, f.type.model):
                     f.serialize(self, model_instance, obj)
+                    matched = True
                     return
+            if not matched and value is not None:
+                raise ValueError('Value {0} cannot match any type for OneOfField `{1}`'.format(
+                    value, field.tag_name(self)))
             return
 
         value = getattr(model_instance, field.attr, field.default)

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -206,6 +206,9 @@ class Test(unittest.TestCase):
         self.assertEqual([n.b1 for n in node3.value.i], [n.b1 for n in d_node3.value.i])
         self.assertNotIsInstance(node3.value.i[0], Node8)
 
+        with self.assertRaises(ValueError):
+            serializes(provider, [Node3(value='sth else')])
+
     def testJSONSerialize(self):
         provider = JsonSerializeProvider()
 
@@ -255,6 +258,9 @@ class Test(unittest.TestCase):
         self.assertEqual(node3.value.h[2], True)
         self.assertEqual([n.b1 for n in node3.value.i], [n.b1 for n in d_node3.value.i])
         self.assertNotIsInstance(node3.value.i[0], Node8)
+
+        with self.assertRaises(ValueError):
+            serializes(provider, [Node3(value='sth else')])
 
     def testAttributeAsDict(self):
         other_data = {}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix serialization of DataFrame's `index_value` or `columns_value` if its type is int64.

This PR also optimizes serialization of OneOfField, when the value is not None, and no type in OneOfField can be matched, error will be raised.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #400 
