### PR TITLE
Check reference type in serialization

### DIFF
--- a/mars/serialize/core.pxd
+++ b/mars/serialize/core.pxd
@@ -212,7 +212,7 @@ cdef class DictField(Field):
 
 
 cdef class ReferenceField(Field):
-    cdef object _model
+    cdef public object _model
 
 
 cdef class OneOfField(Field):

--- a/mars/serialize/core.pxd
+++ b/mars/serialize/core.pxd
@@ -78,14 +78,18 @@ cdef class ValueType:
     pass
 
 
+cdef class SelfReferenceOverwritten(Exception):
+    pass
+
+
 cdef class Field:
     cdef object tag
     cdef object default_val
     cdef str _tag_name
     cdef object _type
+    cdef object _model_cls
 
     cdef public bint weak_ref
-    cdef public object model
     cdef public str attr
     cdef public object on_serialize
     cdef public object on_deserialize
@@ -196,7 +200,7 @@ cdef class DataFrameField(Field):
 
 
 cdef class ListField(Field):
-    cdef object _nest_ref
+    cdef public object _nest_ref
 
 
 cdef class TupleField(Field):

--- a/mars/serialize/core.pyx
+++ b/mars/serialize/core.pyx
@@ -458,7 +458,8 @@ cdef class ReferenceField(Field):
 
     @model.setter
     def model(self, new_model_cls):
-        if getattr(self, '_model', None) == 'self' and self._model_cls is not None:
+        if getattr(self, '_model', None) == 'self' and \
+                self._model_cls is not None and new_model_cls is not None:
             raise SelfReferenceOverwritten('self reference is overwritten')
         self._model_cls = new_model_cls
 

--- a/mars/serialize/jsonserializer.pyx
+++ b/mars/serialize/jsonserializer.pyx
@@ -410,6 +410,9 @@ cdef class JsonSerializeProvider(Provider):
                 if field.weak_ref:
                     field_val = field_val()
                 if field_val is not None:
+                    if not isinstance(field_val, field.type.model):
+                        raise TypeError('Does not match type for reference field {0}: '
+                                        'expect {1}, got {2}'.format(tag, field.type.model, type(field_val)))
                     value = self._on_serial(field, field_val)
                     value.serialize(self, new_obj)
         elif isinstance(field, OneOfField):
@@ -443,7 +446,11 @@ cdef class JsonSerializeProvider(Provider):
                 if field.weak_ref:
                     val = val()
                 if val is not None:
-                    new_obj.append(val.serialize(self, dict()))
+                    if isinstance(val, field.type.type.model):
+                        new_obj.append(val.serialize(self, dict()))
+                    else:
+                        raise TypeError('Does not match type for reference in list field {0}: '
+                                        'expect {1}, got {2}'.format(tag, field.type.type.model, type(val)))
                 else:
                     new_obj.append(None)
         else:

--- a/mars/serialize/pbserializer.pyx
+++ b/mars/serialize/pbserializer.pyx
@@ -523,11 +523,34 @@ cdef class ProtobufSerializeProvider(Provider):
                 value = getattr(model_instance, name, None)
                 if value is None:
                     continue
+                tag = field.tag_name(self)
 
                 k = d_obj.dict.keys.value.add()
                 self._set_value(field.tag_name(self), k, tp=ValueType.string)
                 v = d_obj.dict.values.value.add()
-                self._set_value(value, v, tp=field.type, weak_ref=field.weak_ref)
+                if isinstance(field, ReferenceField):
+                    if field.weak_ref:
+                        value = value()
+                    if isinstance(value, field.type.model):
+                        value.serialize(self, obj=v)
+                    else:
+                        raise TypeError('Does not match type for reference field {0}: '
+                                        'expect {1}, got {2}'.format(tag, field.type.model, type(value)))
+                elif isinstance(field, ListField) and type(field.type.type) == Reference:
+                    for val in value:
+                        if field.weak_ref:
+                            val = val()
+                        it_obj = v.list.value.add()
+                        if val is not None:
+                            if isinstance(val, field.type.type.model):
+                                val.serialize(self, obj=it_obj)
+                            else:
+                                raise TypeError('Does not match type for reference in list field {0}: '
+                                                'expect {1}, got {2}'.format(tag, field.type.type.model, type(val)))
+                        elif isinstance(it_obj, Value):
+                            it_obj.is_null = True
+                else:
+                    self._set_value(value, v, tp=field.type, weak_ref=field.weak_ref)
         else:
             fields = model_instance._FIELDS
             for name, field in fields.items():
@@ -763,8 +786,19 @@ cdef class ProtobufSerializeProvider(Provider):
             for k, v in zip(d_obj.dict.keys.value, d_obj.dict.values.value):
                 tag = self._get_value(k, ValueType.string, callbacks, False)
                 it_field = tag_to_fields[tag]
-                setattr(model_instance, it_field.attr,
-                        self._get_value(v, it_field.type, callbacks, it_field.weak_ref))
+                if isinstance(it_field, ReferenceField):
+                    setattr(model_instance, it_field.attr,
+                        self._on_deserial(
+                            it_field, it_field.type.model.deserialize(self, v, callbacks, key_to_instance)))
+                elif isinstance(it_field, ListField) and type(it_field.type.type) == Reference:
+                    setattr(model_instance, it_field.attr,
+                            self._on_deserial(
+                                it_field,
+                                [it_field.type.type.model.deserialize(self, it_obj, callbacks, key_to_instance)
+                                 for it_obj in v.list.value]))
+                else:
+                    setattr(model_instance, it_field.attr,
+                            self._get_value(v, it_field.type, callbacks, it_field.weak_ref))
         else:
             for o_tag in d_obj:
                 it_field = tag_to_fields[o_tag]

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -115,6 +115,8 @@ class Node5(AttributeAsDict):
 class Node6(AttributeAsDict):
     nid = IdentityField('id', ValueType.int64)
     b = Int32Field('b')
+    r = ReferenceField('r', 'self')
+    rl = ListField('rl', ValueType.reference('self'))
 
     def __new__(cls, *args, **kwargs):
         if 'nid' in kwargs and kwargs['nid'] != 0:
@@ -320,6 +322,28 @@ class Test(unittest.TestCase):
             node42 = Node4(j=Node6())
             node42.serialize(pbs)
 
+        with self.assertRaises(TypeError):
+            node6 = Node6(nid=0)
+            node7 = Node7(nid=1, r=node6)
+            node7.serialize(pbs)
+
+        with self.assertRaises(TypeError):
+            node6 = Node6(nid=0)
+            node7 = Node7(nid=1, rl=[node6])
+            node7.serialize(pbs)
+
+        node61 = Node6(nid=0)
+        node62 = Node6(nid=0, r=node61)
+        serial = node62.serialize(pbs)
+        d_node62 = Node6.deserialize(pbs, serial)
+        self.assertIsInstance(d_node62.r, Node6)
+
+        node61 = Node6(nid=0)
+        node62 = Node6(nid=0, rl=[node61])
+        serial = node62.serialize(pbs)
+        d_node62 = Node6.deserialize(pbs, serial)
+        self.assertIsInstance(d_node62.rl[0], Node6)
+
         jss = JsonSerializeProvider()
 
         serial = node4.serialize(jss)
@@ -353,6 +377,28 @@ class Test(unittest.TestCase):
         with self.assertRaises(TypeError):
             node42 = Node4(j=Node6())
             node42.serialize(jss)
+
+        with self.assertRaises(TypeError):
+            node6 = Node6()
+            node7 = Node7(r=node6)
+            node7.serialize(jss)
+
+        with self.assertRaises(TypeError):
+            node6 = Node6(nid=0)
+            node7 = Node7(nid=1, rl=[node6])
+            node7.serialize(jss)
+
+        node61 = Node6()
+        node62 = Node6(r=node61)
+        serial = node62.serialize(jss)
+        d_node62 = Node6.deserialize(jss, serial)
+        self.assertIsInstance(d_node62.r, Node6)
+
+        node61 = Node6(nid=0)
+        node62 = Node6(nid=0, rl=[node61])
+        serial = node62.serialize(jss)
+        d_node62 = Node6.deserialize(jss, serial)
+        self.assertIsInstance(d_node62.rl[0], Node6)
 
     def testException(self):
         node1 = Node1(h=[object()])

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -316,6 +316,10 @@ class Test(unittest.TestCase):
             pd.testing.assert_series_equal(node4.p[2], d_node4.p[2])
             pd.testing.assert_frame_equal(node4.p[3], d_node4.p[3])
 
+        with self.assertRaises(TypeError):
+            node42 = Node4(j=Node6())
+            node42.serialize(pbs)
+
         jss = JsonSerializeProvider()
 
         serial = node4.serialize(jss)
@@ -345,6 +349,10 @@ class Test(unittest.TestCase):
             pd.testing.assert_index_equal(node4.p[1], d_node4.p[1])
             pd.testing.assert_series_equal(node4.p[2], d_node4.p[2])
             pd.testing.assert_frame_equal(node4.p[3], d_node4.p[3])
+
+        with self.assertRaises(TypeError):
+            node42 = Node4(j=Node6())
+            node42.serialize(jss)
 
     def testException(self):
         node1 = Node1(h=[object()])

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -169,7 +169,7 @@ class Test(unittest.TestCase):
                       f=node2,
                       g=Node2(a=[['1', '2'], ['3', '4']]),
                       h=[[2, 3], node2, True, {1: node2}, np.datetime64('1066-10-13'), np.timedelta64(1, 'D')],
-                      i=[Node1(b1=111), Node1(b1=222)])
+                      i=[Node8(b1=111), Node8(b1=222)])
         node3 = Node3(value=node1)
 
         serials = serializes(provider, [node2, node3])
@@ -204,7 +204,7 @@ class Test(unittest.TestCase):
         self.assertIs(d_node3.value.h[1], d_node3.value.f)
         self.assertEqual(node3.value.h[2], True)
         self.assertEqual([n.b1 for n in node3.value.i], [n.b1 for n in d_node3.value.i])
-        self.assertNotIsInstance(node3.value.i[0], Node8)
+        self.assertIsInstance(d_node3.value.i[0], Node8)
 
         with self.assertRaises(ValueError):
             serializes(provider, [Node3(value='sth else')])
@@ -221,7 +221,7 @@ class Test(unittest.TestCase):
                       f=node2,
                       g=Node2(a=[['1', '2'], ['3', '4']]),
                       h=[[2, 3], node2, True, {1: node2}, np.datetime64('1066-10-13'), np.timedelta64(1, 'D')],
-                      i=[Node1(b1=111), Node1(b1=222)])
+                      i=[Node8(b1=111), Node8(b1=222)])
         node3 = Node3(value=node1)
 
         serials = serializes(provider, [node2, node3])
@@ -257,7 +257,7 @@ class Test(unittest.TestCase):
         self.assertIs(d_node3.value.h[1], d_node3.value.f)
         self.assertEqual(node3.value.h[2], True)
         self.assertEqual([n.b1 for n in node3.value.i], [n.b1 for n in d_node3.value.i])
-        self.assertNotIsInstance(node3.value.i[0], Node8)
+        self.assertIsInstance(d_node3.value.i[0], Node8)
 
         with self.assertRaises(ValueError):
             serializes(provider, [Node3(value='sth else')])


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Reference type in `ReferenceField` or `ListField` with reference should be checked.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #413 