### PR TITLE
Remove central ChunkMetaActor in schedulers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ mars/lib/*.c*
 mars/actors/*.c*
 mars/actors/pool/*.c*
 mars/serialize/*.c*
+mars/scheduler/*.c*
+mars/worker/*.c*

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,6 @@ mars/*.c*
 mars/lib/*.c*
 mars/actors/*.c*
 mars/actors/pool/*.c*
-mars/serialize/*.c*
 mars/scheduler/*.c*
+mars/serialize/*.c*
 mars/worker/*.c*

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,3 +91,7 @@ script:
 after_success:
   - coveralls
   - ./bin/travis-upload.sh
+
+after_failure:
+  # delay to make all data in stdout loaded by travis
+  - sleep 5

--- a/mars/api.py
+++ b/mars/api.py
@@ -16,7 +16,7 @@ import logging
 
 from .actors import new_client
 from .scheduler import SessionActor, GraphActor, GraphMetaActor, ResourceActor, \
-    ChunkMetaActor, SessionManagerActor
+    SessionManagerActor, ChunkMetaClient
 from .scheduler.graph import ResultReceiverActor
 from .scheduler.node_info import NodeInfoActor
 from .scheduler.utils import SchedulerClusterInfoActor
@@ -113,8 +113,9 @@ class MarsAPI(object):
         graph_ref = self.get_actor_ref(graph_uid)
         chunk_indexes = graph_ref.get_tileable_chunk_indexes(tileable_key)
 
-        chunk_meta_ref = self.get_actor_ref(ChunkMetaActor.default_name())
-        chunk_shapes = chunk_meta_ref.batch_get_chunk_shape(session_id, list(chunk_indexes.keys()))
+        chunk_meta_client = ChunkMetaClient(self.actor_client, self.cluster_info)
+        chunk_shapes = chunk_meta_client.batch_get_chunk_shape(
+            session_id, list(chunk_indexes.keys()))
 
         # for each dimension, record chunk shape whose index is zero on other dimensions
         ndim = len(chunk_shapes[0])

--- a/mars/scheduler/__init__.py
+++ b/mars/scheduler/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .chunkmeta import ChunkMetaActor
+from .chunkmeta import ChunkMetaActor, ChunkMetaClient
 from .graph import GraphActor, GraphMetaActor
 from .operands import OperandActor, OperandState
 from .assigner import AssignerActor

--- a/mars/scheduler/assigner.py
+++ b/mars/scheduler/assigner.py
@@ -20,7 +20,6 @@ from collections import defaultdict
 
 from ..errors import DependencyMissing
 from ..utils import log_unhandled
-from .chunkmeta import ChunkMetaActor
 from .resource import ResourceActor
 from .utils import SchedulerActor
 
@@ -43,7 +42,6 @@ class AssignerActor(SchedulerActor):
 
         self._cluster_info_ref = None
         self._resource_actor_ref = None
-        self._chunk_meta_ref = None
 
         self._sufficient_operands = set()
         self._operand_sufficient_time = dict()
@@ -54,7 +52,6 @@ class AssignerActor(SchedulerActor):
         self.set_cluster_info_ref()
         # the ref of the actor actually handling assignment work
         self._resource_ref = self.get_actor_ref(ResourceActor.default_name())
-        self._chunk_meta_ref = self.ctx.actor_ref(ChunkMetaActor.default_name())
 
     def _refresh_worker_metrics(self):
         t = time.time()
@@ -105,7 +102,7 @@ class AssignerActor(SchedulerActor):
         return candidate_workers
 
     def _get_chunks_meta(self, session_id, keys):
-        return dict(zip(keys, self._chunk_meta_ref.batch_get_chunk_meta(session_id, keys)))
+        return dict(zip(keys, self.chunk_meta.batch_get_chunk_meta(session_id, keys)))
 
     def _get_eps_by_worker_locality(self, input_keys, chunk_workers, input_sizes):
         locality_data = defaultdict(lambda: 0)

--- a/mars/scheduler/chunkmeta.py
+++ b/mars/scheduler/chunkmeta.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import logging
 import os
 from collections import defaultdict
@@ -65,8 +66,11 @@ class ChunkMetaStore(object):
         return self._chunk_metas[chunk_key]
 
     def __setitem__(self, chunk_key, worker_meta):
-        if chunk_key in self._chunk_metas:
-            self._del_chunk_key_from_workers(chunk_key, self._chunk_metas[chunk_key].workers)
+        try:
+            meta = self._chunk_metas[chunk_key]
+            self._del_chunk_key_from_workers(chunk_key, meta.workers)
+        except KeyError:
+            pass
 
         self._chunk_metas[chunk_key] = worker_meta
 
@@ -84,8 +88,10 @@ class ChunkMetaStore(object):
         """
         worker_to_chunk_keys = self._worker_to_chunk_keys
         for w in workers:
-            if w in worker_to_chunk_keys:
+            try:
                 worker_to_chunk_keys[w].remove(chunk_key)
+            except KeyError:
+                pass
 
     def get(self, chunk_key, default=None):
         return self._chunk_metas.get(chunk_key, default)
@@ -159,12 +165,12 @@ class ChunkMetaCache(ChunkMetaStore):
                 self._del_chunk_key_from_workers(dkey, ditem.workers)
 
 
-class LocalChunkMetaActor(SchedulerActor):
+class ChunkMetaActor(SchedulerActor):
     """
     Actor storing chunk metas and chunk cache
     """
     def __init__(self, chunk_info_uid=None):
-        super(LocalChunkMetaActor, self).__init__()
+        super(ChunkMetaActor, self).__init__()
         self._meta_store = ChunkMetaStore()
         self._meta_broadcasts = dict()
         self._meta_cache = ChunkMetaCache()
@@ -175,7 +181,7 @@ class LocalChunkMetaActor(SchedulerActor):
 
     def post_create(self):
         logger.debug('Actor %s running in process %d at %s', self.uid, os.getpid(), self.address)
-        super(LocalChunkMetaActor, self).post_create()
+        super(ChunkMetaActor, self).post_create()
 
         self._kv_store_ref = self.ctx.actor_ref(KVStoreActor.default_name())
         if not self.ctx.has_actor(self._kv_store_ref):
@@ -380,25 +386,20 @@ class LocalChunkMetaActor(SchedulerActor):
         return [k[1] for k in removed_chunks]
 
 
-class ChunkMetaActor(SchedulerActor):
+class ChunkMetaClient(object):
     """
     Actor dispatches chunk meta requests to different scheduler hosts
     """
-    def __init__(self):
-        super(ChunkMetaActor, self).__init__()
-        self._local_meta_store_ref = None
+    def __init__(self, ctx, cluster_info_ref):
+        self._cluster_info = cluster_info_ref
+        self.ctx = ctx
+        self._local_meta_store_ref = ctx.actor_ref(
+            ChunkMetaActor.default_name(), address=cluster_info_ref.address)
+        if not ctx.has_actor(self._local_meta_store_ref):
+            self._local_meta_store_ref = None
 
-    def post_create(self):
-        logger.debug('Actor %s running in process %d at %s', self.uid, os.getpid(), self.address)
-        super(ChunkMetaActor, self).post_create()
-
-        self.set_cluster_info_ref()
-        self._local_meta_store_ref = self.ctx.create_actor(
-            LocalChunkMetaActor, uid=LocalChunkMetaActor.default_name())
-
-    def pre_destroy(self):
-        super(ChunkMetaActor, self).pre_destroy()
-        self._local_meta_store_ref.destroy()
+    def get_scheduler(self, key):
+        return self._cluster_info.get_scheduler(key)
 
     def set_chunk_broadcasts(self, session_id, chunk_key, broadcast_dests):
         """
@@ -410,10 +411,11 @@ class ChunkMetaActor(SchedulerActor):
         :param broadcast_dests: destination addresses for broadcast
         """
         addr = self.get_scheduler((session_id, chunk_key))
-        self.ctx.actor_ref(LocalChunkMetaActor.default_name(), address=addr) \
+        self.ctx.actor_ref(ChunkMetaActor.default_name(), address=addr) \
             .set_chunk_broadcasts(session_id, chunk_key, broadcast_dests, _tell=True, _wait=False)
 
-    def batch_set_chunk_broadcasts(self, session_id, chunk_keys, broadcast_dests):
+    def batch_set_chunk_broadcasts(self, session_id, chunk_keys, broadcast_dests,
+                                   _tell=False, _wait=True):
         query_chunk = defaultdict(lambda: (list(), list()))
         for key, dests in zip(chunk_keys, broadcast_dests):
             addr = self.get_scheduler((session_id, key))
@@ -421,10 +423,12 @@ class ChunkMetaActor(SchedulerActor):
             query_chunk[addr][1].append(dests)
 
         for addr, (chunk_keys, dest_groups) in query_chunk.items():
-            self.ctx.actor_ref(LocalChunkMetaActor.default_name(), address=addr) \
-                .batch_set_chunk_broadcasts(session_id, chunk_keys, dest_groups)
+            self.ctx.actor_ref(ChunkMetaActor.default_name(), address=addr) \
+                .batch_set_chunk_broadcasts(session_id, chunk_keys, dest_groups,
+                                            _tell=_tell, _wait=_wait)
 
-    def set_chunk_meta(self, session_id, chunk_key, size=None, shape=None, workers=None):
+    def set_chunk_meta(self, session_id, chunk_key, size=None, shape=None, workers=None,
+                       _tell=False, _wait=True):
         """
         Update chunk metadata
         :param session_id: session id
@@ -434,8 +438,9 @@ class ChunkMetaActor(SchedulerActor):
         :param workers: workers holding the chunk
         """
         addr = self.get_scheduler((session_id, chunk_key))
-        self.ctx.actor_ref(LocalChunkMetaActor.default_name(), address=addr) \
-            .set_chunk_meta(session_id, chunk_key, size=size, shape=shape, workers=workers)
+        self.ctx.actor_ref(ChunkMetaActor.default_name(), address=addr) \
+            .set_chunk_meta(session_id, chunk_key, size=size, shape=shape, workers=workers,
+                            _tell=_tell, _wait=_wait)
 
     def set_chunk_size(self, session_id, chunk_key, size):
         self.set_chunk_meta(session_id, chunk_key, size=size)
@@ -444,15 +449,15 @@ class ChunkMetaActor(SchedulerActor):
         meta = self.get_chunk_meta(session_id, chunk_key)
         return meta.chunk_size if meta is not None else None
 
-    def set_chunk_shape(self, session_id, chunk_key, shape):
-        self.set_chunk_meta(session_id, chunk_key, shape=shape)
+    def set_chunk_shape(self, session_id, chunk_key, shape, _tell=False, _wait=True):
+        self.set_chunk_meta(session_id, chunk_key, shape=shape, _tell=_tell, _wait=_wait)
 
     def get_chunk_shape(self, session_id, chunk_key):
         meta = self.get_chunk_meta(session_id, chunk_key)
         return meta.chunk_shape if meta is not None else None
 
-    def add_worker(self, session_id, chunk_key, worker_addr):
-        self.set_chunk_meta(session_id, chunk_key, workers=(worker_addr,))
+    def add_worker(self, session_id, chunk_key, worker_addr, _tell=False, _wait=True):
+        self.set_chunk_meta(session_id, chunk_key, workers=(worker_addr,), _tell=_tell, _wait=_wait)
 
     def get_workers(self, session_id, chunk_key):
         meta = self.get_chunk_meta(session_id, chunk_key)
@@ -476,12 +481,15 @@ class ChunkMetaActor(SchedulerActor):
         :param session_id: session id
         :param chunk_key: chunk key
         """
-        local_result = self._local_meta_store_ref.get_chunk_meta(session_id, chunk_key)
+        if self._local_meta_store_ref is not None:
+            local_result = self._local_meta_store_ref.get_chunk_meta(session_id, chunk_key)
+        else:
+            local_result = None
         if local_result is not None:
             return local_result
 
         addr = self.get_scheduler((session_id, chunk_key))
-        meta = self.ctx.actor_ref(LocalChunkMetaActor.default_name(), address=addr) \
+        meta = self.ctx.actor_ref(ChunkMetaActor.default_name(), address=addr) \
             .get_chunk_meta(session_id, chunk_key)
         return meta
 
@@ -496,7 +504,10 @@ class ChunkMetaActor(SchedulerActor):
         meta_dict = dict()
 
         # try obtaining metadata from local cache
-        local_results = self._local_meta_store_ref.batch_get_chunk_meta(session_id, chunk_keys)
+        if self._local_meta_store_ref is not None:
+            local_results = self._local_meta_store_ref.batch_get_chunk_meta(session_id, chunk_keys)
+        else:
+            local_results = itertools.repeat(None)
 
         # collect dispatch destinations for non-local metadata
         for chunk_key, local_result in zip(chunk_keys, local_results):
@@ -512,7 +523,7 @@ class ChunkMetaActor(SchedulerActor):
         futures = []
         for addr, keys in query_dict.items():
             futures.append(
-                self.ctx.actor_ref(LocalChunkMetaActor.default_name(), address=addr)
+                self.ctx.actor_ref(ChunkMetaActor.default_name(), address=addr)
                     .batch_get_chunk_meta(session_id, keys, _wait=False)
             )
         # accept results and merge
@@ -521,13 +532,40 @@ class ChunkMetaActor(SchedulerActor):
             meta_dict.update(zip(keys, results))
         return [meta_dict.get(k) for k in chunk_keys]
 
-    def delete_meta(self, session_id, chunk_key):
+    def batch_set_chunk_meta(self, session_id, keys, metas, _tell=False, _wait=True):
+        """
+        Set chunk meta in batch
+
+        :param session_id: session id
+        :param keys: keys to set
+        :param metas: metas to set
+        """
+        update_dict = defaultdict(lambda: ([], []))
+
+        # collect dispatch destinations for non-local metadata
+        for chunk_key, meta in zip(keys, metas):
+            k = (session_id, chunk_key)
+            list_tuple = update_dict[self.get_scheduler(k)]
+            list_tuple[0].append(chunk_key)
+            list_tuple[1].append(meta)
+
+        # dispatch query
+        futures = []
+        for addr, (k, m) in update_dict.items():
+            futures.append(
+                self.ctx.actor_ref(ChunkMetaActor.default_name(), address=addr)
+                    .batch_set_chunk_meta(session_id, k, m, _tell=_tell, _wait=False)
+            )
+        if _wait:
+            [f.result() for f in futures]
+
+    def delete_meta(self, session_id, chunk_key, _tell=False, _wait=True):
         query_key = (session_id, chunk_key)
         addr = self.get_scheduler(query_key)
-        self.ctx.actor_ref(LocalChunkMetaActor.default_name(), address=addr) \
-            .delete_meta(session_id, chunk_key, _tell=True)
+        self.ctx.actor_ref(ChunkMetaActor.default_name(), address=addr) \
+            .delete_meta(session_id, chunk_key, _tell=_tell, _wait=_wait)
 
-    def batch_delete_meta(self, session_id, chunk_keys):
+    def batch_delete_meta(self, session_id, chunk_keys, _tell=False, _wait=True):
         """
         Delete chunk metadata in batch
         :param session_id: session id
@@ -543,7 +581,8 @@ class ChunkMetaActor(SchedulerActor):
         futures = []
         for addr, keys in query_dict.items():
             futures.append(
-                self.ctx.actor_ref(LocalChunkMetaActor.default_name(), address=addr)
-                    .batch_delete_meta(session_id, list(keys), _wait=False, _tell=True)
+                self.ctx.actor_ref(ChunkMetaActor.default_name(), address=addr)
+                    .batch_delete_meta(session_id, list(keys), _wait=False, _tell=_tell)
             )
-        [f.result() for f in futures]
+        if _wait:
+            [f.result() for f in futures]

--- a/mars/scheduler/operands/common.py
+++ b/mars/scheduler/operands/common.py
@@ -445,7 +445,7 @@ class OperandActor(BaseOperandActor):
             broadcast_ep_groups.append(broadcast_eps)
         broadcast_chunk_keys = [k for k in chunk_keys if not isinstance(k, tuple)]
         if broadcast_chunk_keys:
-            self._chunk_meta_ref.batch_set_chunk_broadcasts(
+            self.chunk_meta.batch_set_chunk_broadcasts(
                 self._session_id, broadcast_chunk_keys, broadcast_ep_groups,
                 _tell=True, _wait=False)
 
@@ -487,7 +487,7 @@ class OperandActor(BaseOperandActor):
             data_sizes = dict((k, v.chunk_size) for k, v in input_metas.items())
         except KeyError:
             input_chunks = self._input_chunks
-            chunk_sizes = self._chunk_meta_ref.batch_get_chunk_size(self._session_id, input_chunks)
+            chunk_sizes = self.chunk_meta.batch_get_chunk_size(self._session_id, input_chunks)
             if any(v is None for v in chunk_sizes):
                 logger.warning('DependencyMissing met, operand %s will be back to UNSCHEDULED.',
                                self._op_key)

--- a/mars/scheduler/session.py
+++ b/mars/scheduler/session.py
@@ -99,14 +99,14 @@ class SessionActor(SchedulerActor):
         """
         logger.debug('Worker change detected. adds: %r, removes: %r', adds, removes)
 
-        from .chunkmeta import LocalChunkMetaActor
+        from .chunkmeta import ChunkMetaActor
 
         # collect affected chunks
         futures = []
         if removes:
             lost_chunks = set()
             for scheduler in self.get_schedulers():
-                ref = self.ctx.actor_ref(LocalChunkMetaActor.default_name(), address=scheduler)
+                ref = self.ctx.actor_ref(ChunkMetaActor.default_name(), address=scheduler)
                 futures.append(ref.remove_workers_in_session(self._session_id, removes, _wait=False))
 
             for f in futures:

--- a/mars/scheduler/tests/test_assigner.py
+++ b/mars/scheduler/tests/test_assigner.py
@@ -17,7 +17,7 @@ import uuid
 
 import gevent
 
-from mars.scheduler import ResourceActor, AssignerActor, ChunkMetaActor
+from mars.scheduler import ResourceActor, AssignerActor, ChunkMetaClient, ChunkMetaActor
 from mars.scheduler.utils import SchedulerClusterInfoActor
 from mars.actors import create_actor_pool
 from mars.utils import get_next_port
@@ -28,10 +28,10 @@ class Test(unittest.TestCase):
     def testAssignerActor(self):
         mock_scheduler_addr = '127.0.0.1:%d' % get_next_port()
         with create_actor_pool(n_process=1, backend='gevent', address=mock_scheduler_addr) as pool:
-            pool.create_actor(SchedulerClusterInfoActor, [pool.cluster_info.address],
-                              uid=SchedulerClusterInfoActor.default_name())
+            cluster_info_ref = pool.create_actor(SchedulerClusterInfoActor, [pool.cluster_info.address],
+                                                 uid=SchedulerClusterInfoActor.default_name())
             resource_ref = pool.create_actor(ResourceActor, uid=ResourceActor.default_name())
-            chunk_meta_ref = pool.create_actor(ChunkMetaActor, uid=ChunkMetaActor.default_name())
+            pool.create_actor(ChunkMetaActor, uid=ChunkMetaActor.default_name())
 
             endpoint1 = 'localhost:12345'
             endpoint2 = 'localhost:23456'
@@ -63,9 +63,10 @@ class Test(unittest.TestCase):
                 }
             }
 
-            chunk_meta_ref.set_chunk_meta(session_id, chunk_key1, size=512, workers=(endpoint1,))
-            chunk_meta_ref.set_chunk_meta(session_id, chunk_key2, size=512, workers=(endpoint1,))
-            chunk_meta_ref.set_chunk_meta(session_id, chunk_key3, size=512, workers=(endpoint2,))
+            chunk_meta_client = ChunkMetaClient(pool, cluster_info_ref)
+            chunk_meta_client.set_chunk_meta(session_id, chunk_key1, size=512, workers=(endpoint1,))
+            chunk_meta_client.set_chunk_meta(session_id, chunk_key2, size=512, workers=(endpoint1,))
+            chunk_meta_client.set_chunk_meta(session_id, chunk_key3, size=512, workers=(endpoint2,))
 
             workers = assigner_ref.get_worker_assignments(session_id, op_info)
             self.assertEqual(workers[0], endpoint1)

--- a/mars/scheduler/tests/test_chunkmeta.py
+++ b/mars/scheduler/tests/test_chunkmeta.py
@@ -19,7 +19,7 @@ import uuid
 
 from mars.actors import create_actor_pool, new_client
 from mars.scheduler.chunkmeta import WorkerMeta, ChunkMetaStore, ChunkMetaCache, \
-    ChunkMetaActor, LocalChunkMetaActor
+    ChunkMetaActor, ChunkMetaClient
 from mars.scheduler.utils import SchedulerClusterInfoActor
 from mars.tests.core import patch_method
 from mars.utils import get_next_port
@@ -95,7 +95,7 @@ class Test(unittest.TestCase):
         self.assertTrue(all('c%d' % idx in dup_cache for idx in range(3, 11)))
 
     @unittest.skipIf(sys.platform == 'win32', 'Currently not support multiple pools under Windows')
-    @patch_method(ChunkMetaActor.get_scheduler)
+    @patch_method(ChunkMetaClient.get_scheduler)
     def testChunkMetaActors(self, *_):
         proc_count = 2
         endpoints = ['127.0.0.1:%d' % get_next_port() for _ in range(proc_count)]
@@ -104,7 +104,7 @@ class Test(unittest.TestCase):
         def _mock_get_scheduler(key):
             return endpoints[keys.index(key[1]) % len(endpoints)]
 
-        ChunkMetaActor.get_scheduler.side_effect = _mock_get_scheduler
+        ChunkMetaClient.get_scheduler.side_effect = _mock_get_scheduler
 
         session1 = str(uuid.uuid4())
         session2 = str(uuid.uuid4())
@@ -112,58 +112,62 @@ class Test(unittest.TestCase):
             pool1.create_actor(SchedulerClusterInfoActor, endpoints,
                                uid=SchedulerClusterInfoActor.default_name())
             pool1.create_actor(ChunkMetaActor, uid=ChunkMetaActor.default_name())
+            cluster_info1 = pool1.actor_ref(ChunkMetaActor.cluster_info_uid, address=endpoints[0])
 
             with create_actor_pool(n_process=1, backend='gevent', address=endpoints[1]) as pool2:
                 pool2.create_actor(SchedulerClusterInfoActor, endpoints,
                                    uid=SchedulerClusterInfoActor.default_name())
                 pool2.create_actor(ChunkMetaActor, uid=ChunkMetaActor.default_name())
+                cluster_info2 = pool2.actor_ref(ChunkMetaActor.cluster_info_uid, address=endpoints[1])
 
-                client = new_client()
-                ref1 = client.actor_ref(ChunkMetaActor.default_name(), address=endpoints[0])
-                ref2 = client.actor_ref(ChunkMetaActor.default_name(), address=endpoints[1])
+                actor_client = new_client()
+                client1 = ChunkMetaClient(actor_client, actor_client.actor_ref(cluster_info1))
+                client2 = ChunkMetaClient(actor_client, actor_client.actor_ref(cluster_info2))
 
-                loc_ref1 = client.actor_ref(LocalChunkMetaActor.default_name(), address=endpoints[0])
-                loc_ref2 = client.actor_ref(LocalChunkMetaActor.default_name(), address=endpoints[1])
+                loc_ref1 = actor_client.actor_ref(ChunkMetaActor.default_name(), address=endpoints[0])
+                loc_ref2 = actor_client.actor_ref(ChunkMetaActor.default_name(), address=endpoints[1])
 
                 key1 = (str(uuid.uuid4()), str(uuid.uuid4()))
                 key2 = str(uuid.uuid4())
                 key3 = str(uuid.uuid4())
                 key4 = (str(uuid.uuid4()), str(uuid.uuid4()))
-                keys = [key1, key2, key3, key4]
-                ref1.set_chunk_size(session1, key1, 512)
-                ref2.set_chunk_size(session1, key2, 1024)
-                ref2.set_chunk_size(session2, key3, 1024)
+                key5 = str(uuid.uuid4())
+                key6 = str(uuid.uuid4())
+                keys = [key1, key2, key3, key4, key5, key6]
+                client1.set_chunk_size(session1, key1, 512)
+                client2.set_chunk_size(session1, key2, 1024)
+                client2.set_chunk_size(session2, key3, 1024)
 
-                self.assertEqual(ref1.get_chunk_size(session1, key1), 512)
-                self.assertEqual(ref2.get_chunk_size(session1, key2), 1024)
-                self.assertEqual(ref1.get_chunk_size(session1, key2), 1024)
-                self.assertEqual(ref2.get_chunk_size(session1, key1), 512)
+                self.assertEqual(client1.get_chunk_size(session1, key1), 512)
+                self.assertEqual(client2.get_chunk_size(session1, key2), 1024)
+                self.assertEqual(client1.get_chunk_size(session1, key2), 1024)
+                self.assertEqual(client2.get_chunk_size(session1, key1), 512)
 
-                self.assertListEqual(ref1.batch_get_chunk_size(session1, [key1, key2]), [512, 1024])
-                self.assertListEqual(ref2.batch_get_chunk_size(session1, [key1, key2]), [512, 1024])
+                self.assertListEqual(client1.batch_get_chunk_size(session1, [key1, key2]), [512, 1024])
+                self.assertListEqual(client2.batch_get_chunk_size(session1, [key1, key2]), [512, 1024])
 
-                ref1.set_chunk_shape(session1, key1, (10,))
-                ref2.set_chunk_shape(session1, key2, (10,) * 2)
-                ref2.set_chunk_shape(session2, key3, (10,) * 2)
+                client1.set_chunk_shape(session1, key1, (10,))
+                client2.set_chunk_shape(session1, key2, (10,) * 2)
+                client2.set_chunk_shape(session2, key3, (10,) * 2)
 
-                self.assertEqual(ref1.get_chunk_shape(session1, key1), (10,))
-                self.assertEqual(ref2.get_chunk_shape(session1, key2), (10,) * 2)
-                self.assertEqual(ref1.get_chunk_shape(session1, key2), (10,) * 2)
-                self.assertEqual(ref2.get_chunk_shape(session1, key1), (10,))
+                self.assertEqual(client1.get_chunk_shape(session1, key1), (10,))
+                self.assertEqual(client2.get_chunk_shape(session1, key2), (10,) * 2)
+                self.assertEqual(client1.get_chunk_shape(session1, key2), (10,) * 2)
+                self.assertEqual(client2.get_chunk_shape(session1, key1), (10,))
 
-                self.assertListEqual(ref1.batch_get_chunk_shape(session1, [key1, key2]), [(10,), (10,) * 2])
-                self.assertListEqual(ref2.batch_get_chunk_shape(session1, [key1, key2]), [(10,), (10,) * 2])
+                self.assertListEqual(client1.batch_get_chunk_shape(session1, [key1, key2]), [(10,), (10,) * 2])
+                self.assertListEqual(client2.batch_get_chunk_shape(session1, [key1, key2]), [(10,), (10,) * 2])
 
-                ref1.add_worker(session1, key1, 'abc')
-                ref1.add_worker(session1, key1, 'def')
-                ref2.add_worker(session1, key2, 'ghi')
+                client1.add_worker(session1, key1, 'abc')
+                client1.add_worker(session1, key1, 'def')
+                client2.add_worker(session1, key2, 'ghi')
 
-                ref1.add_worker(session2, key3, 'ghi')
+                client1.add_worker(session2, key3, 'ghi')
 
-                self.assertEqual(sorted(ref1.get_workers(session1, key1)), sorted(('abc', 'def')))
-                self.assertEqual(sorted(ref2.get_workers(session1, key2)), sorted(('ghi',)))
+                self.assertEqual(sorted(client1.get_workers(session1, key1)), sorted(('abc', 'def')))
+                self.assertEqual(sorted(client2.get_workers(session1, key2)), sorted(('ghi',)))
 
-                batch_result = ref1.batch_get_workers(session1, [key1, key2])
+                batch_result = client1.batch_get_workers(session1, [key1, key2])
                 self.assertEqual(sorted(batch_result[0]), sorted(('abc', 'def')))
                 self.assertEqual(sorted(batch_result[1]), sorted(('ghi',)))
 
@@ -171,26 +175,32 @@ class Test(unittest.TestCase):
                 for loc_ref in (loc_ref1, loc_ref2):
                     affected.extend(loc_ref.remove_workers_in_session(session2, ['ghi']))
                 self.assertEqual(affected, [key3])
-                self.assertEqual(sorted(ref1.get_workers(session1, key2)), sorted(('ghi',)))
-                self.assertIsNone(ref1.get_workers(session2, key3))
+                self.assertEqual(sorted(client1.get_workers(session1, key2)), sorted(('ghi',)))
+                self.assertIsNone(client1.get_workers(session2, key3))
 
-                ref1.delete_meta(session1, key1)
-                self.assertIsNone(ref1.get_workers(session1, key1))
-                self.assertIsNone(ref1.batch_get_chunk_size(session1, [key1, key2])[0])
-                self.assertIsNone(ref1.batch_get_workers(session1, [key1, key2])[0])
+                client1.delete_meta(session1, key1)
+                self.assertIsNone(client1.get_workers(session1, key1))
+                self.assertIsNone(client1.batch_get_chunk_size(session1, [key1, key2])[0])
+                self.assertIsNone(client1.batch_get_workers(session1, [key1, key2])[0])
 
-                ref2.batch_delete_meta(session1, [key1, key2])
-                self.assertIsNone(ref1.get_workers(session1, key2))
-                self.assertIsNone(ref1.batch_get_chunk_size(session1, [key1, key2])[1])
-                self.assertIsNone(ref1.batch_get_workers(session1, [key1, key2])[1])
+                client2.batch_delete_meta(session1, [key1, key2])
+                self.assertIsNone(client1.get_workers(session1, key2))
+                self.assertIsNone(client1.batch_get_chunk_size(session1, [key1, key2])[1])
+                self.assertIsNone(client1.batch_get_workers(session1, [key1, key2])[1])
 
                 meta4 = WorkerMeta(chunk_size=512, chunk_shape=(10,) * 2, workers=(endpoints[0],))
                 loc_ref2.batch_set_chunk_meta(session1, [key4], [meta4])
                 self.assertEqual(loc_ref2.get_chunk_meta(session1, key4).chunk_size, 512)
                 self.assertEqual(loc_ref2.get_chunk_meta(session1, key4).chunk_shape, (10,) * 2)
 
+                meta5 = WorkerMeta(chunk_size=512, chunk_shape=(10,) * 2, workers=(endpoints[0],))
+                meta6 = WorkerMeta(chunk_size=512, chunk_shape=(10,) * 2, workers=(endpoints[0],))
+                client1.batch_set_chunk_meta(session1, [key5, key6], [meta5, meta6])
+                self.assertEqual(loc_ref1.get_chunk_meta(session1, key5).chunk_size, 512)
+                self.assertEqual(loc_ref2.get_chunk_meta(session1, key6).chunk_size, 512)
+
     @unittest.skipIf(sys.platform == 'win32', 'Currently not support multiple pools under Windows')
-    @patch_method(ChunkMetaActor.get_scheduler)
+    @patch_method(ChunkMetaClient.get_scheduler)
     def testChunkBroadcast(self, *_):
         proc_count = 2
         endpoints = ['127.0.0.1:%d' % get_next_port() for _ in range(proc_count)]
@@ -199,38 +209,40 @@ class Test(unittest.TestCase):
         def _mock_get_scheduler(key):
             return endpoints[keys.index(key[1]) % len(endpoints)]
 
-        ChunkMetaActor.get_scheduler.side_effect = _mock_get_scheduler
+        ChunkMetaClient.get_scheduler.side_effect = _mock_get_scheduler
 
         session_id = str(uuid.uuid4())
         with create_actor_pool(n_process=1, backend='gevent', address=endpoints[0]) as pool1:
             pool1.create_actor(SchedulerClusterInfoActor, endpoints,
                                uid=SchedulerClusterInfoActor.default_name())
             pool1.create_actor(ChunkMetaActor, uid=ChunkMetaActor.default_name())
+            cluster_info1 = pool1.actor_ref(ChunkMetaActor.cluster_info_uid, address=endpoints[0])
 
             with create_actor_pool(n_process=1, backend='gevent', address=endpoints[1]) as pool2:
                 pool2.create_actor(SchedulerClusterInfoActor, endpoints,
                                    uid=SchedulerClusterInfoActor.default_name())
                 pool2.create_actor(ChunkMetaActor, uid=ChunkMetaActor.default_name())
+                cluster_info2 = pool2.actor_ref(ChunkMetaActor.cluster_info_uid, address=endpoints[1])
 
-                client = new_client()
-                ref1 = client.actor_ref(ChunkMetaActor.default_name(), address=endpoints[0])
-                ref2 = client.actor_ref(ChunkMetaActor.default_name(), address=endpoints[0])
-                local_ref1 = client.actor_ref(LocalChunkMetaActor.default_name(), address=endpoints[0])
-                local_ref2 = client.actor_ref(LocalChunkMetaActor.default_name(), address=endpoints[1])
+                actor_client = new_client()
+                client1 = ChunkMetaClient(actor_client, actor_client.actor_ref(cluster_info1))
+                client2 = ChunkMetaClient(actor_client, actor_client.actor_ref(cluster_info2))
+                local_ref1 = actor_client.actor_ref(ChunkMetaActor.default_name(), address=endpoints[0])
+                local_ref2 = actor_client.actor_ref(ChunkMetaActor.default_name(), address=endpoints[1])
 
                 key1 = str(uuid.uuid4())
                 key2 = str(uuid.uuid4())
                 key3 = str(uuid.uuid4())
                 keys = [key1, key2, key3]
 
-                ref1.set_chunk_broadcasts(session_id, key1, [endpoints[1]])
-                ref1.set_chunk_size(session_id, key1, 512)
-                ref1.set_chunk_shape(session_id, key1, (10,) * 2)
-                ref1.add_worker(session_id, key1, 'abc')
-                ref2.set_chunk_broadcasts(session_id, key2, [endpoints[0]])
-                ref2.set_chunk_size(session_id, key2, 512)
-                ref1.set_chunk_shape(session_id, key2, (10,) * 2)
-                ref2.add_worker(session_id, key2, 'def')
+                client1.set_chunk_broadcasts(session_id, key1, [endpoints[1]])
+                client1.set_chunk_size(session_id, key1, 512)
+                client1.set_chunk_shape(session_id, key1, (10,) * 2)
+                client1.add_worker(session_id, key1, 'abc')
+                client2.set_chunk_broadcasts(session_id, key2, [endpoints[0]])
+                client2.set_chunk_size(session_id, key2, 512)
+                client1.set_chunk_shape(session_id, key2, (10,) * 2)
+                client2.add_worker(session_id, key2, 'def')
                 pool2.sleep(0.1)
 
                 self.assertEqual(local_ref1.get_chunk_meta(session_id, key1).chunk_size, 512)
@@ -240,13 +252,13 @@ class Test(unittest.TestCase):
                 self.assertEqual(local_ref2.get_chunk_meta(session_id, key1).chunk_shape, (10,) * 2)
                 self.assertEqual(local_ref2.get_chunk_broadcasts(session_id, key2), [endpoints[0]])
 
-                ref1.batch_set_chunk_broadcasts(session_id, [key3], [[endpoints[1]]])
+                client1.batch_set_chunk_broadcasts(session_id, [key3], [[endpoints[1]]])
                 meta3 = WorkerMeta(chunk_size=512, chunk_shape=(10,) * 2, workers=(endpoints[0],))
                 local_ref1.batch_set_chunk_meta(session_id, [key3], [meta3])
                 self.assertEqual(local_ref2.get_chunk_meta(session_id, key3).chunk_size, 512)
                 self.assertEqual(local_ref2.get_chunk_meta(session_id, key3).chunk_shape, (10,) * 2)
 
-                ref1.delete_meta(session_id, key1)
+                client1.delete_meta(session_id, key1)
                 pool2.sleep(0.1)
 
                 self.assertIsNone(local_ref1.get_chunk_meta(session_id, key1))

--- a/mars/scheduler/utils.py
+++ b/mars/scheduler/utils.py
@@ -44,21 +44,22 @@ class SchedulerClusterInfoActor(ClusterInfoActor):
 
 
 class SchedulerHasClusterInfoActor(HasClusterInfoActor):
-    pass
+    cluster_info_uid = SchedulerClusterInfoActor.default_name()
 
 
 class SchedulerActor(SchedulerHasClusterInfoActor, PromiseActor):
-    cluster_info_uid = SchedulerClusterInfoActor.default_name()
-
-    def __init__(self, **kwargs):
-        super(SchedulerActor, self).__init__()
-
-        if 'balancer' in kwargs:
-            self._balancer_ref = kwargs['balancer']
-
     @classmethod
     def default_name(cls):
         return 's:h1:{0}'.format(cls.__name__)
+
+    @property
+    def chunk_meta(self):
+        try:
+            return self._chunk_meta_client
+        except AttributeError:
+            from .chunkmeta import ChunkMetaClient
+            self._chunk_meta_client = ChunkMetaClient(self.ctx, self._cluster_info_ref)
+            return self._chunk_meta_client
 
 
 if six.PY3:

--- a/mars/tests/test_api.py
+++ b/mars/tests/test_api.py
@@ -20,7 +20,7 @@ from mars.compat import OrderedDict
 from mars.actors import create_actor_pool
 from mars.utils import get_next_port
 from mars.scheduler import GraphActor, ResourceActor, SessionManagerActor,\
-    GraphState, ChunkMetaActor
+    GraphState, ChunkMetaClient, ChunkMetaActor
 from mars.scheduler.utils import SchedulerClusterInfoActor
 from mars.api import MarsAPI
 from mars.tests.core import patch_method
@@ -71,7 +71,7 @@ class Test(unittest.TestCase):
         self.assertFalse(self.pool.has_actor(graph_ref))
 
     @patch_method(GraphActor.get_tileable_chunk_indexes)
-    @patch_method(ChunkMetaActor.batch_get_chunk_shape)
+    @patch_method(ChunkMetaClient.batch_get_chunk_shape)
     def testGetTensorNsplits(self, *_):
         session_id = 'mock_session_id'
         graph_key = 'mock_graph_key'
@@ -94,7 +94,7 @@ class Test(unittest.TestCase):
         ]
 
         GraphActor.get_tileable_chunk_indexes.side_effect = mock_indexes
-        ChunkMetaActor.batch_get_chunk_shape.side_effect = mock_shapes
+        ChunkMetaClient.batch_get_chunk_shape.side_effect = mock_shapes
 
         nsplits = self.api.get_tileable_nsplits(session_id, graph_key, tensor_key)
         self.assertEqual(((3, 4, 5, 6),), nsplits)

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -266,8 +266,7 @@ class ExecutionActor(WorkerActor):
             missing_keys = [c.key for c in succ_rec.graph if c.key not in succ_rec.data_sizes
                             and isinstance(c.op, Fetch)]
             if missing_keys:
-                sizes = self.get_meta_ref(session_id, graph_key, local=False) \
-                    .batch_get_chunk_size(session_id, missing_keys)
+                sizes = self.get_meta_client().batch_get_chunk_size(session_id, missing_keys)
                 succ_rec.data_sizes.update(zip(missing_keys, sizes))
             logger.debug('Worker graph %s(%s) targeting at %r from PRE_PUSHED into ALLOCATING.',
                          succ_key, succ_rec.op_string, succ_rec.chunk_targets)
@@ -656,8 +655,7 @@ class ExecutionActor(WorkerActor):
                 chunk_meta = input_metas[input_key]
                 chunk_meta.workers = tuple(w for w in chunk_meta.workers if w != self.address)
             except KeyError:
-                chunk_meta = self.get_meta_ref(session_id, input_key) \
-                    .get_chunk_meta(session_id, input_key)
+                chunk_meta = self.get_meta_client().get_chunk_meta(session_id, input_key)
 
             if chunk_meta is None or not chunk_meta.workers:
                 raise DependencyMissing('Dependency %r not met on sending.' % (input_key,))

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -543,7 +543,7 @@ class ReceiverActor(WorkerActor):
                     _tell=True, _wait=False)
 
             if not isinstance(chunk_key, tuple):
-                self.get_meta_ref(session_id, chunk_key).set_chunk_meta(
+                self.get_meta_client().set_chunk_meta(
                     session_id, chunk_key, size=data_meta.chunk_size, workers=(self.address,))
 
             if data_meta.write_shared:

--- a/mars/worker/utils.py
+++ b/mars/worker/utils.py
@@ -63,11 +63,9 @@ class WorkerActor(WorkerHasClusterInfoActor, PromiseActor):
         self._plasma_client = plasma.connect(options.worker.plasma_socket, '', 0)
         self._chunk_store = PlasmaChunkStore(self._plasma_client, mapper_ref)
 
-    def get_meta_ref(self, session_id, chunk_key, local=True):
-        from ..scheduler.chunkmeta import ChunkMetaActor, LocalChunkMetaActor
-        addr = self.get_scheduler((session_id, chunk_key))
-        actor_cls = LocalChunkMetaActor if local else ChunkMetaActor
-        return self.ctx.actor_ref(actor_cls.default_name(), address=addr)
+    def get_meta_client(self):
+        from ..scheduler.chunkmeta import ChunkMetaClient
+        return ChunkMetaClient(self.ctx, self._cluster_info_ref)
 
     def handle_actors_down(self, halt_refs):
         """


### PR DESCRIPTION
## What do these changes do?

Replace central ChunkMetaActor with a local client to reduce latency.

## Related issue number

Fixes #420 
