### PR TITLE
Use Enum instead of numbers to specify compression types

### DIFF
--- a/mars/api.py
+++ b/mars/api.py
@@ -99,7 +99,7 @@ class MarsAPI(object):
         graph_address = self.cluster_info.get_scheduler(graph_uid)
         result_ref = self.actor_client.actor_ref(ResultReceiverActor.default_name(), address=graph_address)
 
-        compressions = set(compressions or []) | {dataserializer.COMPRESS_FLAG_NONE}
+        compressions = set(compressions or []) | {dataserializer.CompressType.NONE}
         return result_ref.fetch_tileable(session_id, graph_key, tileable_key, compressions, _wait=wait)
 
     def delete_data(self, session_id, graph_key, tileable_key):

--- a/mars/config.py
+++ b/mars/config.py
@@ -292,7 +292,6 @@ def is_in(vals):
 default_options = Config()
 default_options.register_option('tcp_timeout', 30, validator=is_integer)
 default_options.register_option('verbose', False, validator=is_bool)
-default_options.register_option('persist_compression', 1, validator=(is_null, is_integer), serialize=True)
 default_options.register_option('kv_store', ':inproc:', validator=is_string)
 
 # Tensor
@@ -321,10 +320,12 @@ default_options.register_option('scheduler.worker_blacklist_time', 3600, validat
 
 # Worker
 default_options.register_option('worker.spill_directory', None, validator=(is_null, is_string, is_list))
+default_options.register_option('worker.disk_compression', 'lz4', validator=is_string, serialize=True)
 default_options.register_option('worker.min_spill_size', '5%', validator=(is_string, is_integer))
 default_options.register_option('worker.max_spill_size', '95%', validator=(is_string, is_integer))
 default_options.register_option('worker.callback_preserve_time', 3600 * 24, validator=is_integer)
 default_options.register_option('worker.transfer_block_size', 4 * 1024 * 1024, validator=is_integer)
+default_options.register_option('worker.transfer_compression', 'lz4', validator=is_string, serialize=True)
 default_options.register_option('worker.prepare_data_timeout', 600, validator=is_integer)
 default_options.register_option('worker.peer_blacklist_time', 3600, validator=is_numeric, serialize=True)
 

--- a/mars/scheduler/tests/test_kvstore.py
+++ b/mars/scheduler/tests/test_kvstore.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 import unittest
 
@@ -29,6 +30,8 @@ class Test(unittest.TestCase):
         options.kv_store = ':inproc:'
 
     @unittest.skipIf(sys.platform == 'win32', 'does not run in windows')
+    @unittest.skipIf('CI' not in os.environ and not EtcdProcessHelper().is_installed(),
+                     'does not run without etcd')
     def testKVStoreActor(self):
         etcd_port = get_next_port()
         proc_helper = EtcdProcessHelper(port_range_start=etcd_port)

--- a/mars/scheduler/tests/test_main.py
+++ b/mars/scheduler/tests/test_main.py
@@ -275,6 +275,8 @@ class Test(unittest.TestCase):
         result = session_ref.fetch_result(graph_key, b.key)
         assert_allclose(loads(result), np.ones((27, 31)))
 
+    @unittest.skipIf('CI' not in os.environ and not EtcdProcessHelper().is_installed(),
+                     'does not run without etcd')
     def testMainTensorWithEtcd(self):
         self.start_processes(etcd=True)
 

--- a/mars/serialize/dataserializer.py
+++ b/mars/serialize/dataserializer.py
@@ -19,7 +19,7 @@ import sys
 import zlib
 from collections import namedtuple
 
-from ..compat import BytesIO
+from ..compat import BytesIO, Enum
 
 try:
     import numpy as np
@@ -90,32 +90,56 @@ else:
 
 SERIAL_VERSION = 0
 
-COMPRESS_FLAG_NONE = 0
-COMPRESS_FLAG_LZ4 = 1
-COMPRESS_FLAG_GZIP = 2
 
+class CompressType(Enum):
+    NONE = 'none'
+    LZ4 = 'lz4'
+    GZIP = 'gzip'
+
+    @property
+    def tag(self):
+        return _compress_tags[self]
+
+    @classmethod
+    def from_tag(cls, tag):
+        return _tag_to_compress[tag]
+
+    def __gt__(self, other):
+        return _compress_tags[self] > _compress_tags[other]
+
+
+_compress_tags = {
+    CompressType.NONE: 0,
+    CompressType.LZ4: 1,
+    CompressType.GZIP: 2,
+}
+_tag_to_compress = {
+    0: CompressType.NONE,
+    1: CompressType.LZ4,
+    2: CompressType.GZIP,
+}
 
 compressors = {
-    COMPRESS_FLAG_LZ4: lz4_compress,
-    COMPRESS_FLAG_GZIP: gz_compress,
+    CompressType.LZ4: lz4_compress,
+    CompressType.GZIP: gz_compress,
 }
 compressobjs = {
-    COMPRESS_FLAG_NONE: DummyCompress,
-    COMPRESS_FLAG_LZ4: lz4_compressobj,
-    COMPRESS_FLAG_GZIP: gz_compressobj,
+    CompressType.NONE: DummyCompress,
+    CompressType.LZ4: lz4_compressobj,
+    CompressType.GZIP: gz_compressobj,
 }
 decompressors = {
-    COMPRESS_FLAG_LZ4: lz4_decompress,
-    COMPRESS_FLAG_GZIP: gz_decompress,
+    CompressType.LZ4: lz4_decompress,
+    CompressType.GZIP: gz_decompress,
 }
 decompressobjs = {
-    COMPRESS_FLAG_NONE: DummyCompress,
-    COMPRESS_FLAG_LZ4: lz4_decompressobj,
-    COMPRESS_FLAG_GZIP: gz_decompressobj,
+    CompressType.NONE: DummyCompress,
+    CompressType.LZ4: lz4_decompressobj,
+    CompressType.GZIP: gz_decompressobj,
 }
 compress_openers = {
-    COMPRESS_FLAG_LZ4: lz4_open,
-    COMPRESS_FLAG_GZIP: gz_open,
+    CompressType.LZ4: lz4_open,
+    CompressType.GZIP: gz_open,
 }
 
 
@@ -132,13 +156,13 @@ def get_decompressobj(compress):
 
 
 def open_compression_file(file, compress):
-    if compress != COMPRESS_FLAG_NONE:
+    if compress != CompressType.NONE:
         file = compress_openers[compress](file, 'wb')
     return file
 
 
 def open_decompression_file(file, compress):
-    if compress != COMPRESS_FLAG_NONE:
+    if compress != CompressType.NONE:
         file = compress_openers[compress](file, 'rb')
     return file
 
@@ -155,13 +179,13 @@ def read_file_header(file):
     version, = struct.unpack('<H', header_bytes[:2])
     nbytes, = struct.unpack('<Q', header_bytes[2:10])
     compress, = struct.unpack('<H', header_bytes[10:12])
-    return file_header(version, nbytes, compress)
+    return file_header(version, nbytes, CompressType.from_tag(compress))
 
 
 def write_file_header(file, header):
     file.write(struct.pack('<H', header.version))
     file.write(struct.pack('<Q', header.nbytes))
-    file.write(struct.pack('<H', header.compress))
+    file.write(struct.pack('<H', header.compress.tag))
 
 
 def load(file, raw=False):
@@ -171,7 +195,7 @@ def load(file, raw=False):
     try:
         buf = file.read()
     finally:
-        if header.compress != COMPRESS_FLAG_NONE:
+        if header.compress != CompressType.NONE:
             file.close()
 
     if raw:
@@ -202,9 +226,8 @@ class CompressBufferReader(object):
             return b''
         bio = BytesIO()
         if self._pos == 0:
-            bio.write(struct.pack('<H', SERIAL_VERSION)
-                      + struct.pack('<Q', self._total_bytes)
-                      + struct.pack('<H', self._compress_method))
+            header = file_header(SERIAL_VERSION, self._total_bytes, self._compress_method)
+            write_file_header(bio, header)
             if hasattr(self._compressor, 'begin'):
                 bio.write(self._compressor.begin())
         while self._pos < self._total_bytes and bio.tell() < byte_num:
@@ -244,8 +267,8 @@ class DecompressBufferWriter(object):
         else:
             if len(data) < 12:
                 raise IOError('Block size too small')
-            compress = struct.unpack('<H', mv[10:12])[0]
-            self._decompressor = decompressobjs[compress]()
+            header = read_file_header(mv)
+            self._decompressor = decompressobjs[header.compress]()
             if len(data) > 12:
                 self._writer.write(self._decompressor.decompress(mv[12:]))
 
@@ -262,7 +285,7 @@ def loads(buf, raw=False):
     header = read_file_header(mv)
     compress = header.compress
 
-    if compress == COMPRESS_FLAG_NONE:
+    if compress == CompressType.NONE:
         data = buf[HEADER_LENGTH:]
     else:
         data = decompressors[compress](mv[HEADER_LENGTH:])
@@ -272,7 +295,7 @@ def loads(buf, raw=False):
         return pyarrow.deserialize(memoryview(data), mars_serialize_context())
 
 
-def dump(obj, file, compress=COMPRESS_FLAG_NONE, raw=False):
+def dump(obj, file, compress=CompressType.NONE, raw=False):
     if raw:
         serialized = obj
         data_size = len(serialized)
@@ -288,12 +311,12 @@ def dump(obj, file, compress=COMPRESS_FLAG_NONE, raw=False):
         else:
             serialized.write_to(file)
     finally:
-        if compress != COMPRESS_FLAG_NONE:
+        if compress != CompressType.NONE:
             file.close()
     return
 
 
-def dumps(obj, compress=COMPRESS_FLAG_NONE, raw=False):
+def dumps(obj, compress=CompressType.NONE, raw=False):
     sio = BytesIO()
     dump(obj, sio, compress=compress, raw=raw)
     return sio.getvalue()
@@ -301,8 +324,7 @@ def dumps(obj, compress=COMPRESS_FLAG_NONE, raw=False):
 
 def peek_serialized_size(file):
     try:
-        file.seek(2)
-        return struct.unpack('<Q', file.read(8))[0]
+        return read_file_header(file).nbytes
     finally:
         file.seek(0)
 

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -429,34 +429,34 @@ class Test(unittest.TestCase):
             array = np.random.rand(1000, 100)
             assert_array_equal(array, dataserializer.loads(dataserializer.dumps(array)))
             assert_array_equal(array, dataserializer.loads(dataserializer.dumps(
-                array, compress=dataserializer.COMPRESS_FLAG_LZ4)))
+                array, compress=dataserializer.CompressType.LZ4)))
             if not six.PY2:
                 assert_array_equal(array, dataserializer.loads(dataserializer.dumps(
-                    array, compress=dataserializer.COMPRESS_FLAG_GZIP)))
+                    array, compress=dataserializer.CompressType.GZIP)))
 
             array = np.random.rand(1000, 100)
             assert_array_equal(array, dataserializer.load(BytesIO(dataserializer.dumps(array))))
             assert_array_equal(array, dataserializer.load(BytesIO(dataserializer.dumps(
-                array, compress=dataserializer.COMPRESS_FLAG_LZ4))))
+                array, compress=dataserializer.CompressType.LZ4))))
             if not six.PY2:
                 assert_array_equal(array, dataserializer.load(BytesIO(dataserializer.dumps(
-                    array, compress=dataserializer.COMPRESS_FLAG_GZIP))))
+                    array, compress=dataserializer.CompressType.GZIP))))
 
             array = np.random.rand(1000, 100).T  # test non c-contiguous
             assert_array_equal(array, dataserializer.loads(dataserializer.dumps(array)))
             assert_array_equal(array, dataserializer.loads(dataserializer.dumps(
-                array, compress=dataserializer.COMPRESS_FLAG_LZ4)))
+                array, compress=dataserializer.CompressType.LZ4)))
             if not six.PY2:
                 assert_array_equal(array, dataserializer.loads(dataserializer.dumps(
-                    array, compress=dataserializer.COMPRESS_FLAG_GZIP)))
+                    array, compress=dataserializer.CompressType.GZIP)))
 
             array = np.float64(0.2345)
             assert_array_equal(array, dataserializer.loads(dataserializer.dumps(array)))
             assert_array_equal(array, dataserializer.loads(dataserializer.dumps(
-                array, compress=dataserializer.COMPRESS_FLAG_LZ4)))
+                array, compress=dataserializer.CompressType.LZ4)))
             if not six.PY2:
                 assert_array_equal(array, dataserializer.loads(dataserializer.dumps(
-                    array, compress=dataserializer.COMPRESS_FLAG_GZIP)))
+                    array, compress=dataserializer.CompressType.GZIP)))
 
             fn = os.path.join(tempfile.gettempdir(), 'test_dump_file_%d.bin' % id(self))
             try:
@@ -468,14 +468,14 @@ class Test(unittest.TestCase):
 
                 with open(fn, 'wb') as dump_file:
                     dataserializer.dump(array, dump_file,
-                                        compress=dataserializer.COMPRESS_FLAG_LZ4)
+                                        compress=dataserializer.CompressType.LZ4)
                 with open(fn, 'rb') as dump_file:
                     assert_array_equal(array, dataserializer.load(dump_file))
 
                 if not six.PY2:
                     with open(fn, 'wb') as dump_file:
                         dataserializer.dump(array, dump_file,
-                                            compress=dataserializer.COMPRESS_FLAG_GZIP)
+                                            compress=dataserializer.CompressType.GZIP)
                     with open(fn, 'rb') as dump_file:
                         assert_array_equal(array, dataserializer.load(dump_file))
             finally:
@@ -488,12 +488,12 @@ class Test(unittest.TestCase):
             self.assertTrue((mat.spmatrix != des_mat.spmatrix).nnz == 0)
 
             des_mat = dataserializer.loads(dataserializer.dumps(
-                mat, compress=dataserializer.COMPRESS_FLAG_LZ4))
+                mat, compress=dataserializer.CompressType.LZ4))
             self.assertTrue((mat.spmatrix != des_mat.spmatrix).nnz == 0)
 
             if not six.PY2:
                 des_mat = dataserializer.loads(dataserializer.dumps(
-                    mat, compress=dataserializer.COMPRESS_FLAG_GZIP))
+                    mat, compress=dataserializer.CompressType.GZIP))
                 self.assertTrue((mat.spmatrix != des_mat.spmatrix).nnz == 0)
 
             vector = sparse.SparseVector(sps.csr_matrix(np.random.rand(2)), shape=(2,))
@@ -501,12 +501,12 @@ class Test(unittest.TestCase):
             self.assertTrue((vector.spmatrix != des_vector.spmatrix).nnz == 0)
 
             des_vector = dataserializer.loads(dataserializer.dumps(
-                vector, compress=dataserializer.COMPRESS_FLAG_LZ4))
+                vector, compress=dataserializer.CompressType.LZ4))
             self.assertTrue((vector.spmatrix != des_vector.spmatrix).nnz == 0)
 
             if not six.PY2:
                 des_vector = dataserializer.loads(dataserializer.dumps(
-                    vector, compress=dataserializer.COMPRESS_FLAG_GZIP))
+                    vector, compress=dataserializer.CompressType.GZIP))
                 self.assertTrue((vector.spmatrix != des_vector.spmatrix).nnz == 0)
 
     @unittest.skipIf(pyarrow is None, 'PyArrow is not installed.')
@@ -549,7 +549,7 @@ class Test(unittest.TestCase):
         import pyarrow
         from numpy.testing import assert_array_equal
 
-        for compress in [dataserializer.COMPRESS_FLAG_LZ4, dataserializer.COMPRESS_FLAG_GZIP]:
+        for compress in [dataserializer.CompressType.LZ4, dataserializer.CompressType.GZIP]:
             if compress not in dataserializer.get_supported_compressions():
                 continue
 

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -174,6 +174,9 @@ class EtcdProcessHelper(object):
         if tls:
             self.schema = 'https://'
 
+    def is_installed(self):
+        return os.path.exists(os.path.join(self.base_directory, self.proc_name))
+
     def __enter__(self):
         return self
 

--- a/mars/tests/test_kvstore.py
+++ b/mars/tests/test_kvstore.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 import unittest
 
@@ -86,6 +87,8 @@ class Test(unittest.TestCase):
         self.assertEqual(repr(res), repr(expected))
 
     @unittest.skipIf(sys.platform == 'win32', 'does not run in windows')
+    @unittest.skipIf('CI' not in os.environ and not EtcdProcessHelper().is_installed(),
+                     'does not run without etcd')
     def testEtcdPathStore(self):
         with EtcdProcessHelper(port_range_start=51342).run():
             kvstore = get(u'etcd://localhost:51342')
@@ -196,6 +199,8 @@ class Test(unittest.TestCase):
         kvstore.delete('/node', dir=True, recursive=True)
 
     @unittest.skipIf(sys.platform == 'win32', 'does not run in windows')
+    @unittest.skipIf('CI' not in os.environ and not EtcdProcessHelper().is_installed(),
+                     'does not run without etcd')
     def testEtcdWatch(self):
         with EtcdProcessHelper(port_range_start=51342).run():
             kvstore = get('etcd://localhost:51342')

--- a/mars/web/api.py
+++ b/mars/web/api.py
@@ -21,12 +21,12 @@ import logging
 
 from tornado import gen, concurrent, web, ioloop
 
-from .server import register_api_handler
+from ..actors import new_client
 from ..compat import six, futures
 from ..lib.tblib import pickling_support
-from ..actors import new_client
-from .server import MarsWebAPI
+from ..serialize.dataserializer import CompressType
 from ..utils import to_str
+from .server import MarsWebAPI, register_api_handler
 
 pickling_support.install()
 _actor_client = new_client()
@@ -136,7 +136,7 @@ class GraphDataHandler(ApiRequestHandler):
         try:
             compressions_arg = self.request.arguments.get('compressions')
             if compressions_arg:
-                compressions_arg = [int(s) for s in to_str(compressions_arg[0]).split(',') if s]
+                compressions_arg = [CompressType(s) for s in to_str(compressions_arg[0]).split(',') if s]
         except (TypeError, ValueError):
             raise web.HTTPError(403, 'Malformed encodings')
         if type_arg:

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -173,7 +173,7 @@ class Session(object):
                 raise ValueError('Cannot fetch the unexecuted tileable')
 
             session_url = self._endpoint + '/api/session/' + self._session_id
-            compression_str = ','.join(str(v) for v in dataserializer.get_supported_compressions())
+            compression_str = ','.join(v.value for v in dataserializer.get_supported_compressions())
             data_url = session_url + '/graph/%s/data/%s?compressions=%s' \
                 % (self._get_tileable_graph_key(key), key, compression_str)
             resp = self._req_session.get(data_url, timeout=timeout)

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -176,15 +176,15 @@ class Test(unittest.TestCase):
                 value = sess.run(c, timeout=timeout)
                 assert_array_equal(value, np.ones((10, 10)) * 10)
 
-                dataserializer.decompressors[dataserializer.COMPRESS_FLAG_LZ4] = None
-                dataserializer.decompressobjs[dataserializer.COMPRESS_FLAG_LZ4] = None
-                dataserializer.compress_openers[dataserializer.COMPRESS_FLAG_LZ4] = None
+                dataserializer.decompressors[dataserializer.CompressType.LZ4] = None
+                dataserializer.decompressobjs[dataserializer.CompressType.LZ4] = None
+                dataserializer.compress_openers[dataserializer.CompressType.LZ4] = None
 
                 assert_array_equal(sess.fetch(c), np.ones((10, 10)) * 10)
             finally:
-                dataserializer.decompressors[dataserializer.COMPRESS_FLAG_LZ4] = dataserializer.lz4_decompress
-                dataserializer.decompressobjs[dataserializer.COMPRESS_FLAG_LZ4] = dataserializer.lz4_decompressobj
-                dataserializer.compress_openers[dataserializer.COMPRESS_FLAG_LZ4] = dataserializer.lz4_open
+                dataserializer.decompressors[dataserializer.CompressType.LZ4] = dataserializer.lz4_decompress
+                dataserializer.decompressobjs[dataserializer.CompressType.LZ4] = dataserializer.lz4_decompressobj
+                dataserializer.compress_openers[dataserializer.CompressType.LZ4] = dataserializer.lz4_open
 
             va = np.random.randint(0, 10000, (100, 100))
             vb = np.random.randint(0, 10000, (100, 100))

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -77,6 +77,11 @@ class WorkerService(object):
         else:
             self._spill_dirs = options.worker.spill_directory = []
 
+        options.worker.disk_compression = kwargs.pop('disk_compression', None) or \
+            options.worker.disk_compression
+        options.worker.transfer_compression = kwargs.pop('transfer_compression', None) or \
+            options.worker.transfer_compression
+
         self._total_mem = kwargs.pop('total_mem', None)
         self._cache_mem_limit = kwargs.pop('cache_mem_limit', None)
         self._soft_mem_limit = kwargs.pop('soft_mem_limit', None) or '80%'

--- a/mars/worker/spill.py
+++ b/mars/worker/spill.py
@@ -99,8 +99,9 @@ def write_spill_file(data_key, data):
     if not src_file_name:
         raise SpillNotConfigured('Spill not configured')
     if not os.path.exists(dest_file_name):
+        compression_type = dataserializer.CompressType(options.worker.disk_compression)
         with open(src_file_name, 'wb') as file_obj:
-            dataserializer.dump(data, file_obj, dataserializer.COMPRESS_FLAG_LZ4)
+            dataserializer.dump(data, file_obj, compression_type)
         shutil.move(src_file_name, dest_file_name)
 
 

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -218,6 +218,7 @@ class SenderActor(WorkerActor):
         # start compress and send data into targets
         logger.debug('Data writer for chunk %s allocated at targets, start transmission', chunk_key)
         min_chunk_size = options.worker.transfer_block_size
+        transfer_compression = dataserializer.CompressType(options.worker.transfer_compression)
         reader = None
 
         # filter out endpoints we need to send to
@@ -231,7 +232,7 @@ class SenderActor(WorkerActor):
             try:
                 buf = self._chunk_store.get_buffer(session_id, chunk_key)
                 # create a stream compressor from shared buffer
-                reader = dataserializer.CompressBufferReader(buf, dataserializer.COMPRESS_FLAG_LZ4)
+                reader = dataserializer.CompressBufferReader(buf, transfer_compression)
             except KeyError:
                 pass
             finally:
@@ -675,8 +676,9 @@ class ResultSenderActor(WorkerActor):
         try:
             if self._chunk_store.contains(session_id, chunk_key):
                 buf = self._chunk_store.get_buffer(session_id, chunk_key)
+                compression_type = dataserializer.CompressType(options.worker.transfer_compression)
                 compressed = self._serialize_pool.submit(
-                    dataserializer.dumps, buf, dataserializer.COMPRESS_FLAG_LZ4, raw=True).result()
+                    dataserializer.dumps, buf, compression_type, raw=True).result()
             else:
                 file_name = build_spill_file_name(chunk_key)
                 if not file_name:


### PR DESCRIPTION
## What do these changes do?

1. Use Enum instead of numbers to specify compression types.
2. Use options.worker.disk_compression and options.worker.transfer_compression to specify type of compression.

## Related issue number

Closes #423 