### PR TITLE
Fix memory size estimation for Fuse nodes in v0.1

### DIFF
--- a/mars/resource.py
+++ b/mars/resource.py
@@ -42,7 +42,7 @@ else:
 _virt_memory_stat = namedtuple('virtual_memory', 'total available percent used free')
 
 _shm_path = [pt.mountpoint for pt in psutil.disk_partitions(all=True)
-             if pt.mountpoint in ('/tmp', '/dev/shm') and pt.device == 'tmpfs']
+             if pt.mountpoint in ('/tmp', '/dev/shm') and pt.fstype == 'tmpfs']
 if not _shm_path:
     _shm_path = None
 else:

--- a/mars/scheduler/assigner.py
+++ b/mars/scheduler/assigner.py
@@ -202,7 +202,7 @@ class AssignEvaluationActor(SchedulerActor):
     """
     @classmethod
     def gen_uid(cls, session_id):
-        return 's:h1:%s$%s' % (cls.__name__, session_id)
+        return 's:0:%s$%s' % (cls.__name__, session_id)
 
     def __init__(self, assigner_ref):
         super(AssignEvaluationActor, self).__init__()

--- a/mars/tensor/execution/core.py
+++ b/mars/tensor/execution/core.py
@@ -82,13 +82,24 @@ class Executor(object):
             return cls._get_op_runner(chunk, cls._op_size_estimators)(results, chunk)
 
     def execute_graph(self, graph, keys, n_parallel=None, n_thread=None, show_progress=False,
-                      compose=True, mock=False, update_local=False):
+                      compose=True, mock=False, no_intermediate=False):
+        """
+        :param graph: graph to execute
+        :param keys: result keys
+        :param n_parallel: num of max parallelism
+        :param n_thread: num of threads to execute
+        :param show_progress:
+        :param compose: if True. fuse nodes when possible
+        :param mock: if True, only estimate data sizes without execution
+        :param no_intermediate: exclude intermediate data sizes when estimating memory size
+        :return: execution result
+        """
         with build_mode():
             optimized_graph = self._preprocess(graph, keys) if compose else graph
 
         res = execute_graph(optimized_graph, keys, self, n_parallel=n_parallel or n_thread,
                             show_progress=show_progress, prefetch=self._prefetch, retval=True,
-                            mock=mock, update_local=update_local)
+                            mock=mock, no_intermediate=no_intermediate)
         if mock:
             self._mock_max_memory = max(self._mock_max_memory, self._chunk_result.get('_mock_max_memory', 0))
             self._chunk_result.clear()
@@ -223,7 +234,7 @@ def execute_chunk(chunk, executor=None,
                   finishes=None, visited=None, q=None,
                   lock=None, semaphore=None, has_error=None,
                   preds=None, succs=None, fetch_keys=None,
-                  mock=False, update_local=False):
+                  mock=False, no_intermediate=False):
     try:
         with lock:
             if (chunk.key, chunk.id) in visited:
@@ -243,7 +254,7 @@ def execute_chunk(chunk, executor=None,
 
                     cur_memory = sum(chunk_result[op_output.key][1] for op_output in chunk.op.outputs
                                      if chunk_result.get(op_output.key) is not None)
-                    if not update_local:
+                    if not no_intermediate:
                         cur_memory += sum(tp[0] for key, tp in chunk_result.items()
                                           if key not in fetch_keys and key not in output_keys
                                           and isinstance(tp, tuple))
@@ -303,7 +314,7 @@ def _order_starts(graph):
 
 
 def execute_graph(graph, keys, executor, n_parallel=None, show_progress=False,
-                  mock=False, update_local=False, prefetch=False, retval=True):
+                  mock=False, no_intermediate=False, prefetch=False, retval=True):
     pool_executor = futures.ThreadPoolExecutor(n_parallel or 1)
     prefetch_executor = futures.ThreadPoolExecutor(n_parallel or 1) if prefetch else None
     chunk_result = executor.chunk_result
@@ -321,11 +332,15 @@ def execute_graph(graph, keys, executor, n_parallel=None, show_progress=False,
         dict(((t.key, t.id), v) for t, v in graph.iter_successor_items())
     )
 
-    fetch_keys = set(v.key for v in graph if isinstance(v.op, TensorFetchChunk))
-    for c in graph:
-        if graph.count_predecessors(c) != 0:
-            continue
-        fetch_keys.update(inp.key for inp in c.inputs or ())
+    if not mock:
+        # fetch_keys only useful when calculating sizes
+        fetch_keys = set()
+    else:
+        fetch_keys = set(v.key for v in graph if isinstance(v.op, TensorFetchChunk))
+        for c in graph:
+            if graph.count_predecessors(c) != 0:
+                continue
+            fetch_keys.update(inp.key for inp in c.inputs or ())
 
     starts = list(_order_starts(graph)) if len(graph) > 0 else list()
     assert len(starts) == sum(1 for _ in graph.iter_indep())
@@ -374,7 +389,7 @@ def execute_graph(graph, keys, executor, n_parallel=None, show_progress=False,
                                       finishes=finishes, visited=visited, q=q,
                                       lock=lock, semaphore=semaphore, has_error=has_error,
                                       preds=preds, succs=succs, fetch_keys=fetch_keys,
-                                      mock=mock, update_local=update_local)
+                                      mock=mock, no_intermediate=no_intermediate)
         fs[chunk.key] = future
 
     while len(node_keys_set - set(finishes.keys())) > 0:

--- a/mars/tensor/execution/core.py
+++ b/mars/tensor/execution/core.py
@@ -23,7 +23,7 @@ from collections import deque, defaultdict
 
 import numpy as np
 
-from ...operands import Fetch
+from ...tensor.expressions.datasource import TensorFetchChunk
 from ...graph import DirectedGraph
 from ...compat import futures, OrderedDict
 from ..core import build_mode
@@ -50,6 +50,10 @@ class Executor(object):
     @property
     def chunk_result(self):
         return self._chunk_result
+
+    @property
+    def mock_max_memory(self):
+        return self._mock_max_memory
 
     def _preprocess(self, graph, keys):
         from .optimizes.core import Optimizer
@@ -78,13 +82,13 @@ class Executor(object):
             return cls._get_op_runner(chunk, cls._op_size_estimators)(results, chunk)
 
     def execute_graph(self, graph, keys, n_parallel=None, n_thread=None, show_progress=False,
-                      mock=False):
+                      compose=True, fetch_keys=None, mock=False):
         with build_mode():
-            optimized_graph = self._preprocess(graph, keys)
+            optimized_graph = self._preprocess(graph, keys) if compose else graph
 
         res = execute_graph(optimized_graph, keys, self, n_parallel=n_parallel or n_thread,
-                            show_progress=show_progress, mock=mock, prefetch=self._prefetch,
-                            mock_max_memory=self._mock_max_memory, retval=True)
+                            show_progress=show_progress, prefetch=self._prefetch, retval=True,
+                            fetch_keys=fetch_keys, mock=mock)
         if mock:
             self._mock_max_memory = max(self._mock_max_memory, self._chunk_result.get('_mock_max_memory', 0))
             self._chunk_result.clear()
@@ -218,7 +222,7 @@ def execute_chunk(chunk, executor=None,
                   ref_counts=None, chunk_result=None,
                   finishes=None, visited=None, q=None,
                   lock=None, semaphore=None, has_error=None,
-                  preds=None, succs=None, mock=False):
+                  preds=None, succs=None, fetch_keys=None, mock=False):
     try:
         with lock:
             if (chunk.key, chunk.id) in visited:
@@ -232,10 +236,16 @@ def execute_chunk(chunk, executor=None,
 
                 # update maximal memory usage during execution
                 if mock:
-                    chunk_result['_mock_max_memory'] = max(
-                        chunk_result.get('_mock_max_memory', 0),
-                        sum(chunk_result[op_output.key][1] for op_output in chunk.op.outputs
-                            if chunk_result.get(op_output.key) is not None))
+                    # we ignore sizes of Fetch inputs as they are not part of memory needed
+                    fetch_keys = fetch_keys or set()
+                    output_keys = set(o.key for o in chunk.op.outputs or ())
+
+                    cur_memory = sum(chunk_result[op_output.key][1] for op_output in chunk.op.outputs
+                                     if chunk_result.get(op_output.key) is not None) + \
+                                 sum(tp[0] for key, tp in chunk_result.items()
+                                     if key not in fetch_keys and key not in output_keys
+                                     and isinstance(tp, tuple))
+                    chunk_result['_mock_max_memory'] = max(cur_memory, chunk_result.get('_mock_max_memory', 0))
 
             with lock:
                 for output in chunk.op.outputs:
@@ -291,7 +301,7 @@ def _order_starts(graph):
 
 
 def execute_graph(graph, keys, executor, n_parallel=None, show_progress=False,
-                  mock=False, prefetch=False, mock_max_memory=0, retval=True):
+                  mock=False, fetch_keys=None, prefetch=False, retval=True):
     pool_executor = futures.ThreadPoolExecutor(n_parallel or 1)
     prefetch_executor = futures.ThreadPoolExecutor(n_parallel or 1) if prefetch else None
     chunk_result = executor.chunk_result
@@ -308,6 +318,7 @@ def execute_graph(graph, keys, executor, n_parallel=None, show_progress=False,
     succs.update(
         dict(((t.key, t.id), v) for t, v in graph.iter_successor_items())
     )
+    fetch_keys = set(fetch_keys or ()) | set(v.key for v in graph if isinstance(v.op, TensorFetchChunk))
 
     starts = list(_order_starts(graph)) if len(graph) > 0 else list()
     assert len(starts) == sum(1 for _ in graph.iter_indep())
@@ -340,7 +351,8 @@ def execute_graph(graph, keys, executor, n_parallel=None, show_progress=False,
         if show_progress:
             c = next(count)
             if c % 30 == 0 or c >= len(graph):
-                print('[{0}] {1:.2f}% percent of graph has been submitted'.format(str(datetime.datetime.now()), float(c) * 100 / len(graph)))
+                print('[{0}] {1:.2f}% percent of graph has been submitted'.format(
+                    str(datetime.datetime.now()), float(c) * 100 / len(graph)))
 
         with lock:
             if len(q) == 0:
@@ -354,7 +366,7 @@ def execute_graph(graph, keys, executor, n_parallel=None, show_progress=False,
                                       ref_counts=ref_counts, chunk_result=chunk_result,
                                       finishes=finishes, visited=visited, q=q,
                                       lock=lock, semaphore=semaphore, has_error=has_error,
-                                      preds=preds, succs=succs,
+                                      preds=preds, succs=succs, fetch_keys=fetch_keys,
                                       mock=mock)
         fs[chunk.key] = future
 
@@ -365,21 +377,19 @@ def execute_graph(graph, keys, executor, n_parallel=None, show_progress=False,
         submit_to_execute()
 
     [f.result() for f in fs.values()]
-
-    # update with the maximal memory cost during the whole execution
-    if mock:
-        mock_max_memory = max(mock_max_memory, chunk_result.get('_mock_max_memory', 0))
-        avg_max_mem = mock_max_memory // len(keys)
-        for key in keys:
-            r = chunk_result[key]
-            chunk_result[key] = (r[0], max(r[1], avg_max_mem))
-
     if retval:
         return [chunk_result[key] for key in keys]
 
 
 def default_size_estimator(ctx, chunk, multiplier=1):
     exec_size = 0
+    outputs = chunk.op.outputs
+
+    if all(not c.is_sparse() and not np.isnan(c.nbytes) for c in outputs):
+        for c in outputs:
+            ctx[c.key] = (c.nbytes, c.nbytes * multiplier)
+        return
+
     for inp in chunk.inputs or ():
         if chunk.is_sparse() or np.isnan(inp.nbytes):
             exec_size += ctx[inp.key][0]
@@ -389,7 +399,6 @@ def default_size_estimator(ctx, chunk, multiplier=1):
 
     total_out_size = 0
     chunk_sizes = dict()
-    outputs = chunk.op.outputs
     for out in outputs:
         try:
             chunk_size = out.nbytes if not out.is_sparse() else exec_size
@@ -426,7 +435,7 @@ def size_estimator_wrapper(ctx, chunk, original_estimator=None):
 
 def ignore(*_):
     pass
-Executor._op_runners[Fetch] = ignore
+Executor._op_runners[TensorFetchChunk] = ignore
 
 
 def register(op, handler, size_estimator=None, size_multiplier=1):

--- a/mars/tensor/execution/tests/test_core_execute.py
+++ b/mars/tensor/execution/tests/test_core_execute.py
@@ -44,6 +44,45 @@ class Test(unittest.TestCase):
         self.assertEqual(len(self.executor.chunk_result), 0)
 
     def testMockExecuteSize(self):
+        import mars.tensor as mt
+        from mars.graph import DAG
+        from mars.tensor.expressions.datasource import TensorFetchChunk
+        from mars.tensor.expressions.arithmetic import TensorTreeAdd
+
+        graph_add = DAG()
+        input_chunks = []
+        for _ in range(2):
+            fetch_op = TensorFetchChunk(dtype=np.dtype('int64'))
+            inp_chunk = fetch_op.new_chunk(None, shape=(100, 100)).data
+            input_chunks.append(inp_chunk)
+
+        add_op = TensorTreeAdd(dtype=np.dtype('int64'))
+        add_chunk = add_op.new_chunk(input_chunks, shape=(100, 100), dtype=np.dtype('int64')).data
+        graph_add.add_node(add_chunk)
+        for inp_chunk in input_chunks:
+            graph_add.add_node(inp_chunk)
+            graph_add.add_edge(inp_chunk, add_chunk)
+
+        executor = Executor()
+
+        res = executor.execute_graph(graph_add, [add_chunk.key], compose=False, mock=True)[0]
+        self.assertEqual(res, (80000, 80000))
+        self.assertEqual(executor.mock_max_memory, 80000)
+
+        for _ in range(3):
+            new_add_op = TensorTreeAdd(dtype=np.dtype('int64'))
+            new_add_chunk = new_add_op.new_chunk([add_chunk], shape=(100, 100), dtype=np.dtype('int64')).data
+            graph_add.add_node(new_add_chunk)
+            graph_add.add_edge(add_chunk, new_add_chunk)
+
+            add_chunk = new_add_chunk
+
+        executor = Executor()
+
+        res = executor.execute_graph(graph_add, [add_chunk.key], compose=False, mock=True)[0]
+        self.assertEqual(res, (80000, 80000))
+        self.assertEqual(executor.mock_max_memory, 160000)
+
         a = mt.random.rand(10, 10, chunk_size=10)
         b = a[:, mt.newaxis, :] - a
         r = mt.triu(mt.sqrt(b ** 2).sum(axis=2))
@@ -53,7 +92,7 @@ class Test(unittest.TestCase):
         res = executor.execute_tensor(r, concat=False, mock=True)
         # larger than maximal memory size in calc procedure
         self.assertGreaterEqual(res[0][0], 800)
-        self.assertGreaterEqual(res[0][1], 8000)
+        self.assertGreaterEqual(executor.mock_max_memory, 8000)
 
     def testArrayFunction(self):
         a = mt.ones((10, 20), chunk_size=5)

--- a/mars/tensor/execution/utils.py
+++ b/mars/tensor/execution/utils.py
@@ -40,16 +40,25 @@ def estimate_fuse_size(ctx, chunk):
     from .core import Executor
 
     dag = DAG()
+    size_ctx = dict()
     keys = set(c.key for c in chunk.composed)
     for c in chunk.composed:
         dag.add_node(c)
         for inp in c.inputs:
             if inp.key not in keys:
-                continue
+                size_ctx[inp.key] = ctx[inp.key]
             if inp not in dag:
                 dag.add_node(inp)
             dag.add_edge(inp, c)
 
-    size_ctx = ctx.copy()
     executor = Executor(storage=size_ctx)
-    ctx[chunk.key] = executor.execute_graph(dag, [chunk.key], mock=True)[0]
+    output_keys = [o.key for o in chunk.op.outputs]
+    results = executor.execute_graph(dag, output_keys, mock=True, fetch_keys=set(size_ctx.keys()))
+    ctx.update(zip(output_keys, results))
+
+    # update with the maximal memory cost during the whole execution
+    total_mem = sum(ctx[key][1] for key in output_keys)
+    if total_mem:
+        for key in output_keys:
+            r = ctx[key]
+            ctx[key] = (r[0], max(r[1], r[1] * executor.mock_max_memory // total_mem))

--- a/mars/tensor/execution/utils.py
+++ b/mars/tensor/execution/utils.py
@@ -53,7 +53,7 @@ def estimate_fuse_size(ctx, chunk):
 
     executor = Executor(storage=size_ctx)
     output_keys = [o.key for o in chunk.op.outputs]
-    results = executor.execute_graph(dag, output_keys, mock=True, update_local=True)
+    results = executor.execute_graph(dag, output_keys, mock=True, no_intermediate=True)
     ctx.update(zip(output_keys, results))
 
     # update with the maximal memory cost during the whole execution

--- a/mars/tensor/execution/utils.py
+++ b/mars/tensor/execution/utils.py
@@ -53,7 +53,7 @@ def estimate_fuse_size(ctx, chunk):
 
     executor = Executor(storage=size_ctx)
     output_keys = [o.key for o in chunk.op.outputs]
-    results = executor.execute_graph(dag, output_keys, mock=True, fetch_keys=set(size_ctx.keys()))
+    results = executor.execute_graph(dag, output_keys, mock=True, update_local=True)
     ctx.update(zip(output_keys, results))
 
     # update with the maximal memory cost during the whole execution

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -104,7 +104,14 @@ class ExecutionActor(WorkerActor):
         size_ctx = dict((k, (v, v)) for k, v in data_sizes.items())
         executor = Executor(storage=size_ctx)
         res = executor.execute_graph(graph, targets, mock=True)
-        return dict(zip(targets, res))
+        target_sizes = dict(zip(targets, res))
+
+        total_mem = sum(target_sizes[key][1] for key in targets)
+        if total_mem:
+            for key in targets:
+                r = target_sizes[key]
+                target_sizes[key] = (r[0], max(r[1], r[1] * executor.mock_max_memory // total_mem))
+        return target_sizes
 
     @staticmethod
     def _build_load_key(graph_key, chunk_key):


### PR DESCRIPTION
## What do these changes do?

Fix execution memory size estimation for fused dags sent to workers. The value is now total stored size in chunk_result minus total size of Fetch nodes.

Note that we assume that Numexpr and Cupy will automatically reuse allocated buffers if the size is sufficient, we does not calculate memory size of inputs when estimating sizes for CpFuse and NeFuse. The arg ``update_local`` indicates the behavior we use when calculating sizes.

## Related issue number

#434 (fix for v0.1)
