### PR TITLE
Fix memory size estimation for Fuse nodes in v0.2

### DIFF
--- a/mars/executor.py
+++ b/mars/executor.py
@@ -175,7 +175,7 @@ class GraphExecution(object):
     """
     def __init__(self, chunk_results, graph, keys, executed_keys, sync_provider,
                  n_parallel=None, prefetch=False, print_progress=False,
-                 mock=False, mock_max_memory=0):
+                 mock=False, mock_max_memory=0, fetch_keys=None, update_local=False):
         self._chunk_results = chunk_results
         self._graph = graph
         self._keys = keys
@@ -185,6 +185,8 @@ class GraphExecution(object):
         self._print_progress = print_progress
         self._mock = mock
         self._mock_max_memory = mock_max_memory
+        self._update_local = update_local
+        self._fetch_keys = fetch_keys or set()
 
         # pool executor for the operand execution
         self._operand_executor = sync_provider.thread_pool_executor(self._n_parallel)
@@ -263,10 +265,15 @@ class GraphExecution(object):
 
             # update maximal memory usage during execution
             if self._mock:
-                self._mock_max_memory = max(
-                    self._mock_max_memory,
-                    sum(results[op_output.key][1] for op_output in first_op.outputs
-                        if results.get(op_output.key) is not None))
+                output_keys = set(o.key for o in first_op.outputs or ())
+
+                cur_memory = sum(results[op_output.key][1] for op_output in first_op.outputs
+                                 if results.get(op_output.key) is not None)
+                if not self._update_local:
+                    cur_memory += sum(tp[0] for key, tp in results.items()
+                                      if key not in self._fetch_keys and key not in output_keys
+                                      and isinstance(tp, tuple))
+                self._mock_max_memory = max(cur_memory, self._mock_max_memory)
 
             executed_chunk_keys.update([c.key for c in first_op.outputs])
             op_keys.add(first_op.key)
@@ -378,13 +385,6 @@ class GraphExecution(object):
         for future in executed_futures:
             future.result()
 
-        # update with the maximal memory cost during the whole execution
-        if self._mock:
-            avg_max_mem = self._mock_max_memory // len(self._keys)
-            for key in self._keys:
-                r = self._chunk_results[key]
-                self._chunk_results[key] = (r[0], max(r[1], avg_max_mem))
-
         if retval:
             return [self._chunk_results[key] for key in self._keys]
 
@@ -426,6 +426,10 @@ class Executor(object):
     def chunk_result(self):
         return self._chunk_result
 
+    @property
+    def mock_max_memory(self):
+        return self._mock_max_memory
+
     def _preprocess(self, graph, keys):
         # TODO(xuye.qin): make an universal optimzier
         from .tensor.execution.optimizes.core import Optimizer
@@ -454,15 +458,22 @@ class Executor(object):
             return cls._get_op_runner(chunk, cls._op_size_estimators)(results, chunk)
 
     def execute_graph(self, graph, keys, n_parallel=None, print_progress=False,
-                      mock=False, retval=True):
-        optimized_graph = self._preprocess(graph, keys)
+                      mock=False, update_local=False, compose=True, retval=True):
+        optimized_graph = self._preprocess(graph, keys) if compose else graph
+
+        fetch_keys = set(v.key for v in graph if isinstance(v.op, Fetch))
+        for c in graph:
+            if graph.count_predecessors(c) != 0:
+                continue
+            fetch_keys.update(inp.key for inp in c.inputs or ())
 
         executed_keys = list(itertools.chain(*[v[1] for v in self.stored_tileables.values()]))
         graph_execution = GraphExecution(self._chunk_result, optimized_graph,
                                          keys, executed_keys, self._sync_provider,
                                          n_parallel=n_parallel, prefetch=self._prefetch,
                                          print_progress=print_progress, mock=mock,
-                                         mock_max_memory=self._mock_max_memory)
+                                         mock_max_memory=self._mock_max_memory,
+                                         fetch_keys=fetch_keys, update_local=update_local)
         res = graph_execution.execute(retval)
         self._mock_max_memory = max(self._mock_max_memory, graph_execution._mock_max_memory)
         if mock:
@@ -606,6 +617,11 @@ def ignore(*_):
 
 def default_size_estimator(ctx, chunk, multiplier=1):
     exec_size = 0
+    outputs = chunk.op.outputs
+    if all(not c.is_sparse() and hasattr(c, 'nbytes') and not np.isnan(c.nbytes) for c in outputs):
+        for out in outputs:
+            ctx[out.key] = (out.nbytes, out.nbytes * multiplier)
+
     for inp in chunk.inputs or ():
         try:
             exec_size += ctx[inp.key][0]
@@ -618,7 +634,6 @@ def default_size_estimator(ctx, chunk, multiplier=1):
 
     total_out_size = 0
     chunk_sizes = dict()
-    outputs = chunk.op.outputs
     for out in outputs:
         try:
             chunk_size = calc_data_size(out) if not out.is_sparse() else exec_size

--- a/mars/resource.py
+++ b/mars/resource.py
@@ -42,7 +42,7 @@ else:
 _virt_memory_stat = namedtuple('virtual_memory', 'total available percent used free')
 
 _shm_path = [pt.mountpoint for pt in psutil.disk_partitions(all=True)
-             if pt.mountpoint in ('/tmp', '/dev/shm') and pt.device == 'tmpfs']
+             if pt.mountpoint in ('/tmp', '/dev/shm') and pt.fstype == 'tmpfs']
 if not _shm_path:
     _shm_path = None
 else:

--- a/mars/tensor/execution/utils.py
+++ b/mars/tensor/execution/utils.py
@@ -53,7 +53,7 @@ def estimate_fuse_size(ctx, chunk):
 
     executor = Executor(storage=size_ctx)
     output_keys = [o.key for o in chunk.op.outputs]
-    results = executor.execute_graph(dag, output_keys, mock=True, update_local=True)
+    results = executor.execute_graph(dag, output_keys, mock=True, no_intermediate=True)
     ctx.update(zip(output_keys, results))
 
     # update with the maximal memory cost during the whole execution

--- a/mars/tensor/execution/utils.py
+++ b/mars/tensor/execution/utils.py
@@ -40,16 +40,25 @@ def estimate_fuse_size(ctx, chunk):
     from ...executor import Executor
 
     dag = DAG()
+    size_ctx = dict()
     keys = set(c.key for c in chunk.composed)
     for c in chunk.composed:
         dag.add_node(c)
         for inp in c.inputs:
             if inp.key not in keys:
-                continue
+                size_ctx[inp.key] = ctx[inp.key]
             if inp not in dag:
                 dag.add_node(inp)
             dag.add_edge(inp, c)
 
-    size_ctx = ctx.copy()
-    executor = Executor(storage=size_ctx, sync_provider_type=Executor.SyncProviderType.MOCK)
-    ctx[chunk.key] = executor.execute_graph(dag, [chunk.key], mock=True)[0]
+    executor = Executor(storage=size_ctx)
+    output_keys = [o.key for o in chunk.op.outputs]
+    results = executor.execute_graph(dag, output_keys, mock=True, update_local=True)
+    ctx.update(zip(output_keys, results))
+
+    # update with the maximal memory cost during the whole execution
+    total_mem = sum(ctx[key][1] for key in output_keys)
+    if total_mem:
+        for key in output_keys:
+            r = ctx[key]
+            ctx[key] = (r[0], max(r[1], r[1] * executor.mock_max_memory // total_mem))

--- a/mars/tests/test_executor.py
+++ b/mars/tests/test_executor.py
@@ -82,6 +82,43 @@ class Test(unittest.TestCase):
             self.assertIsNone(actor.send(1))
 
     def testMockExecuteSize(self):
+        import mars.tensor as mt
+        from mars.graph import DAG
+        from mars.tensor.expressions.fetch import TensorFetch
+        from mars.tensor.expressions.arithmetic import TensorTreeAdd
+
+        graph_add = DAG()
+        input_chunks = []
+        for _ in range(2):
+            fetch_op = TensorFetch(dtype=np.dtype('int64'))
+            inp_chunk = fetch_op.new_chunk(None, shape=(100, 100)).data
+            input_chunks.append(inp_chunk)
+
+        add_op = TensorTreeAdd(dtype=np.dtype('int64'))
+        add_chunk = add_op.new_chunk(input_chunks, shape=(100, 100), dtype=np.dtype('int64')).data
+        graph_add.add_node(add_chunk)
+        for inp_chunk in input_chunks:
+            graph_add.add_node(inp_chunk)
+            graph_add.add_edge(inp_chunk, add_chunk)
+
+        executor = Executor()
+        res = executor.execute_graph(graph_add, [add_chunk.key], compose=False, mock=True)[0]
+        self.assertEqual(res, (80000, 80000))
+        self.assertEqual(executor.mock_max_memory, 80000)
+
+        for _ in range(3):
+            new_add_op = TensorTreeAdd(dtype=np.dtype('int64'))
+            new_add_chunk = new_add_op.new_chunk([add_chunk], shape=(100, 100), dtype=np.dtype('int64')).data
+            graph_add.add_node(new_add_chunk)
+            graph_add.add_edge(add_chunk, new_add_chunk)
+
+            add_chunk = new_add_chunk
+
+        executor = Executor()
+        res = executor.execute_graph(graph_add, [add_chunk.key], compose=False, mock=True)[0]
+        self.assertEqual(res, (80000, 80000))
+        self.assertEqual(executor.mock_max_memory, 160000)
+
         a = mt.random.rand(10, 10, chunk_size=10)
         b = a[:, mt.newaxis, :] - a
         r = mt.triu(mt.sqrt(b ** 2).sum(axis=2))
@@ -90,4 +127,4 @@ class Test(unittest.TestCase):
         res = executor.execute_tensor(r, concat=False, mock=True)
         # larger than maximal memory size in calc procedure
         self.assertGreaterEqual(res[0][0], 800)
-        self.assertGreaterEqual(res[0][1], 8000)
+        self.assertGreaterEqual(executor.mock_max_memory, 8000)


### PR DESCRIPTION
## What do these changes do?

Fix execution memory size estimation for fused dags sent to workers. The value is now total stored size in chunk_result minus total size of Fetch nodes.

Note that we assume that Numexpr and Cupy will automatically reuse allocated buffers if the size is sufficient, we does not calculate memory size of inputs when estimating sizes for CpFuse and NeFuse. The arg ``update_local`` indicates the behavior we use when calculating sizes.

## Related issue number

Fixes #434