### PR TITLE
Remove handle_params and calc_shape in operand class

### DIFF
--- a/mars/dataframe/expressions/arithmetic/core.py
+++ b/mars/dataframe/expressions/arithmetic/core.py
@@ -159,9 +159,6 @@ class DataFrameIndexAlignReduce(DataFrameShuffleReduce, DataFrameOperandMixin):
         super(DataFrameIndexAlignReduce, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        return self.outputs[0].shape
-
     def _create_chunk(self, output_idx, index, **kw):
         inputs = self.inputs
         if kw.get('index_value', None) is None and inputs[0].inputs[0].index_value is not None:

--- a/mars/dataframe/expressions/core.py
+++ b/mars/dataframe/expressions/core.py
@@ -72,9 +72,6 @@ class DataFrameShuffleProxy(ShuffleProxy, DataFrameOperandMixin):
     def __init__(self, **kwargs):
         super(DataFrameShuffleProxy, self).__init__(**kwargs)
 
-    def calc_shape(self, *inputs_shape):
-        return ()
-
 
 class DataFrameShuffleMap(ShuffleMap):
     pass

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -18,7 +18,7 @@ import weakref
 from .compat import six
 from .serialize import SerializableMetaclass, ValueType, ProviderType, \
     IdentityField, ListField, DictField, Int32Field, BoolField, StringField
-from .core import Entity, AttributeAsDictKey
+from .core import Entity, Base, AttributeAsDictKey
 from .utils import AttributeDict, to_str
 from . import opcodes as OperandDef
 
@@ -151,7 +151,7 @@ class Operand(six.with_metaclass(OperandMetaclass, AttributeAsDictKey)):
 
     @classmethod
     def _get_inputs_data(cls, inputs):
-        return [cls._get_entity_data(inp) for inp in inputs]
+        return [cls._get_entity_data(inp) for inp in inputs if isinstance(inp, (Base, Entity))]
 
     def _set_inputs(self, inputs):
         if inputs is not None:

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -18,7 +18,7 @@ import weakref
 from .compat import six
 from .serialize import SerializableMetaclass, ValueType, ProviderType, \
     IdentityField, ListField, DictField, Int32Field, BoolField, StringField
-from .core import Entity, Base, AttributeAsDictKey
+from .core import Entity, AttributeAsDictKey
 from .utils import AttributeDict, to_str
 from . import opcodes as OperandDef
 
@@ -151,7 +151,7 @@ class Operand(six.with_metaclass(OperandMetaclass, AttributeAsDictKey)):
 
     @classmethod
     def _get_inputs_data(cls, inputs):
-        return [cls._get_entity_data(inp) for inp in inputs if isinstance(inp, (Base, Entity))]
+        return [cls._get_entity_data(inp) for inp in inputs]
 
     def _set_inputs(self, inputs):
         if inputs is not None:

--- a/mars/tensor/execution/optimizes/tests/test_compose.py
+++ b/mars/tensor/execution/optimizes/tests/test_compose.py
@@ -109,7 +109,7 @@ class Test(unittest.TestCase):
         compose stopped at S, because numexpr don't support Slice op
         """
         chunks = [TensorTreeAdd(_key=str(n)).new_chunk(None, None) for n in range(6)]
-        chunk_slice = TensorSlice().new_chunk([None], None)
+        chunk_slice = TensorSlice().new_chunk([chunks[0]], None)
         graph = DirectedGraph()
         lmap(graph.add_node, chunks[:6])
         graph.add_node(chunk_slice)

--- a/mars/tensor/execution/optimizes/tests/test_compose.py
+++ b/mars/tensor/execution/optimizes/tests/test_compose.py
@@ -109,7 +109,7 @@ class Test(unittest.TestCase):
         compose stopped at S, because numexpr don't support Slice op
         """
         chunks = [TensorTreeAdd(_key=str(n)).new_chunk(None, None) for n in range(6)]
-        chunk_slice = TensorSlice().new_chunk([chunks[0]], None)
+        chunk_slice = TensorSlice().new_chunk([None], None)
         graph = DirectedGraph()
         lmap(graph.add_node, chunks[:6])
         graph.add_node(chunk_slice)

--- a/mars/tensor/execution/tests/test_arithmetic_execute.py
+++ b/mars/tensor/execution/tests/test_arithmetic_execute.py
@@ -346,6 +346,17 @@ class Test(unittest.TestCase):
         expected = np.clip(a_data, 3, 6)
         self.assertTrue(np.array_equal(res, expected))
 
+        a = tensor(a_data.copy(), chunk_size=3)
+        a_min_data = np.random.randint(1, 10, size=(10,))
+        a_max_data = np.random.randint(1, 10, size=(10,))
+        a_min = tensor(a_min_data)
+        a_max = tensor(a_max_data)
+        clip(a, a_min, a_max, out=a)
+
+        res = self.executor.execute_tensor(a, concat=True)[0]
+        expected = np.clip(a_data, a_min_data, a_max_data)
+        self.assertTrue(np.array_equal(res, expected))
+
         with option_context() as options:
             options.tensor.chunk_size = 3
 

--- a/mars/tensor/expressions/arithmetic/add.py
+++ b/mars/tensor/expressions/arithmetic/add.py
@@ -17,7 +17,7 @@
 import numpy as np
 
 from .... import opcodes as OperandDef
-from ..utils import infer_dtype, broadcast_shape
+from ..utils import infer_dtype
 from ..core import TensorOperand
 from .core import TensorBinOp, TensorConstant, TensorElementWise
 from .utils import arithmetic_operand

--- a/mars/tensor/expressions/arithmetic/add.py
+++ b/mars/tensor/expressions/arithmetic/add.py
@@ -96,6 +96,3 @@ class TensorTreeAdd(TensorOperand, TensorElementWise):
 
     def __init__(self, dtype=None, sparse=False, **kw):
         super(TensorTreeAdd, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
-
-    def calc_shape(self, *inputs_shape):
-        return broadcast_shape(*inputs_shape)

--- a/mars/tensor/expressions/arithmetic/clip.py
+++ b/mars/tensor/expressions/arithmetic/clip.py
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 from numbers import Number
 
 import numpy as np
 
 from .... import opcodes as OperandDef
 from ....serialize import KeyField, AnyField
-from ...core import TENSOR_TYPE, CHUNK_TYPE, Tensor
+from ....core import Base, Entity
+from ...core import Tensor
 from ..utils import broadcast_shape
 from ..datasource import tensor as astensor
 from .core import TensorOperand, TensorElementWise
@@ -51,80 +51,26 @@ class TensorClip(TensorOperand, TensorElementWise):
     def out(self):
         return getattr(self, '_out', None)
 
-    @contextlib.contextmanager
-    def _handle_params(self, inputs):
-        inps = inputs[:1]
-        inputs_iter = iter(inputs[1:])
+    def _set_inputs(self, inputs):
+        super(TensorClip, self)._set_inputs(inputs)
+        inputs_iter = iter(self._inputs)
 
         if getattr(self, '_a', None) is None:
             # create clip op from beginning
-
-            # a_min
-            has_a_min = False
-            a_min = next(inputs_iter)
-            if a_min is not None and isinstance(a_min, TENSOR_TYPE + CHUNK_TYPE):
-                has_a_min = True
-                inps.append(a_min)
-            else:
-                setattr(self, '_a_min', a_min)
-
-            # a_max
-            has_a_max = False
-            a_max = next(inputs_iter)
-            if a_max is not None and isinstance(a_max, TENSOR_TYPE + CHUNK_TYPE):
-                has_a_max = True
-                inps.append(a_max)
-            else:
-                setattr(self, '_a_max', a_max)
-
-            # out
-            has_out = False
-            out = next(inputs_iter)
-            if out is not None:
-                has_out = True
-                inps.append(out)
+            self._a = next(inputs_iter)
+            self._a_min = next(inputs_iter) if isinstance(inputs[1], (Base, Entity)) else inputs[1]
+            self._a_max = next(inputs_iter) if isinstance(inputs[2], (Base, Entity)) else inputs[2]
+            if inputs[3] is not None:
+                self._out = next(inputs_iter)
         else:
             # create clip op from existence
-
-            # a_min
-            raw_a_min = getattr(self, '_a_min', None)
-            has_a_min = raw_a_min is not None and isinstance(raw_a_min, TENSOR_TYPE + CHUNK_TYPE)
-            if has_a_min:
-                a_min = next(inputs_iter)
-                inps.append(a_min)
-
-            # a_max
-            raw_a_max = getattr(self, '_a_max', None)
-            has_a_max = raw_a_max is not None and isinstance(raw_a_max, TENSOR_TYPE + CHUNK_TYPE)
-            if has_a_max:
-                a_max = next(inputs_iter)
-                inps.append(a_max)
-
-            # out
-            has_out = getattr(self, '_out', None) is not None
-            if has_out:
-                out = next(inputs_iter)
-                inps.append(out)
-
-        yield inps
-
-        inputs = getattr(self, '_inputs')
-        inputs_iter = iter(inputs)
-        setattr(self, '_a', next(inputs_iter))
-        if has_a_min:
-            setattr(self, '_a_min', next(inputs_iter))
-        if has_a_max:
-            setattr(self, '_a_max', next(inputs_iter))
-        if has_out:
-            setattr(self, '_out', next(inputs_iter))
-
-    def _new_tileables(self, inputs, kws=None, **kw):
-        with self._handle_params(inputs) as inputs:
-            return super(TensorClip, self)._new_tileables(inputs, kws=kws, **kw)
-
-    def _new_chunks(self, inputs, kws=None, **kw):
-        with self._handle_params(inputs) as inputs:
-            return super(TensorClip, self)._new_chunks(inputs, kws=kws, **kw)
+            self._a = next(inputs_iter)
+            if isinstance(self._a_min, (Base, Entity)):
+                self._a_min = next(inputs_iter)
+            if isinstance(self._a_max, (Base, Entity)):
+                self._a_max = next(inputs_iter)
+            if getattr(self, '_out', None) is not None:
+                self._out = next(inputs_iter)
 
     def __call__(self, a, a_min, a_max, out=None):
         a = astensor(a)

--- a/mars/tensor/expressions/arithmetic/core.py
+++ b/mars/tensor/expressions/arithmetic/core.py
@@ -158,6 +158,9 @@ class TensorBinOp(TensorOperand, TensorBinOpMixin):
     _casting = StringField('casting')
     _err = DictField('err', ValueType.string, ValueType.string)
 
+    def __init__(self, lhs=None, rhs=None, out=None, where=None, **kwargs):
+        super(TensorBinOp, self).__init__(_lhs=lhs, _rhs=rhs, _out=out, _where=where, **kwargs)
+
     @property
     def lhs(self):
         return self._lhs
@@ -335,6 +338,9 @@ class TensorUnaryOp(TensorOperand, TensorUnaryOpMixin):
     _casting = StringField('casting')
     _err = DictField('err', ValueType.string, ValueType.string)
 
+    def __init__(self, out=None, where=None, **kwargs):
+        super(TensorUnaryOp, self).__init__(_out=out, _where=where, **kwargs)
+
     @property
     def input(self):
         return self._input
@@ -469,6 +475,9 @@ class TensorOutBinOp(TensorOperand):
     _out2 = KeyField('out2')
     _where = KeyField('where')
     _casting = StringField('casting')
+
+    def __init__(self, out1=None, out2=None, where=None, **kwargs):
+        super(TensorOutBinOp, self).__init__(_out1=out1, _out2=out2, _where=where, **kwargs)
 
     @property
     def output_limit(self):

--- a/mars/tensor/expressions/arithmetic/core.py
+++ b/mars/tensor/expressions/arithmetic/core.py
@@ -153,9 +153,6 @@ class TensorBinOpMixin(TensorElementWiseWithInputs):
         if has_where:
             setattr(self, '_where', next(inputs_iter))
 
-    def calc_shape(self, *inputs_shape):
-        return broadcast_shape(*inputs_shape)
-
     def _call(self, x1, x2, out=None, where=None):
         # if x1 or x2 is scalar, and out is none, to constant
         if (np.isscalar(x1) or np.isscalar(x2)) and not out and not where:
@@ -265,12 +262,6 @@ class TensorConstantMixin(TensorElementWiseWithInputs):
             setattr(self, '_lhs', next(inputs_iter))
         if not rhs_scalar:
             setattr(self, '_rhs', next(inputs_iter))
-
-    def calc_shape(self, *inputs_shape):
-        if not inputs_shape:
-            return ()
-        else:
-            return inputs_shape[0]
 
     def _call(self, x1, x2):
         x1_scalar = np.isscalar(x1)
@@ -389,9 +380,6 @@ class TensorUnaryOpMixin(TensorElementWiseWithInputs):
             setattr(self, '_out', next(inputs_iter))
         if has_where:
             setattr(self, '_where', next(inputs_iter))
-
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
 
     def _call(self, x, out=None, where=None):
         x, out, where = self._process_inputs(x, out, where)
@@ -543,21 +531,6 @@ class TensorOutBinOpMixin(TensorElementWiseWithInputs):
     @property
     def _fun(self):
         raise NotImplementedError
-
-    def calc_shape(self, *inputs_shape):
-        if len(inputs_shape) == 1:
-            return (inputs_shape[0],) * 2
-        shape_iter = iter(inputs_shape[1:])
-        shapes = []
-        if getattr(self, '_out1', None):
-            shapes.append(next(shape_iter))
-        else:
-            shapes.append(inputs_shape[0])
-        if getattr(self, '_out2', None):
-            shapes.append(next(shape_iter))
-        else:
-            shapes.append(inputs_shape[0])
-        return tuple(shapes)
 
     def _call(self, x, out1=None, out2=None, out=None, where=None):
         dtype = [r.dtype for r in self._fun(np.empty(1, dtype=x.dtype))]

--- a/mars/tensor/expressions/arithmetic/frexp.py
+++ b/mars/tensor/expressions/arithmetic/frexp.py
@@ -17,47 +17,15 @@
 import numpy as np
 
 from .... import opcodes as OperandDef
-from ....serialize import KeyField, StringField
-from ..core import TensorOperand
-from .core import TensorOutBinOpMixin
+from .core import TensorOutBinOpMixin, TensorOutBinOp
 
 
-class TensorFrexp(TensorOperand, TensorOutBinOpMixin):
+class TensorFrexp(TensorOutBinOp, TensorOutBinOpMixin):
     _op_type_ = OperandDef.FREXP
-
-    _input = KeyField('input')
-    _out1 = KeyField('out1')
-    _out2 = KeyField('out2')
-    _where = KeyField('where')
-    _casting = StringField('casting')
 
     def __init__(self, casting='same_kind', dtype=None, sparse=False, **kw):
         super(TensorFrexp, self).__init__(_casting=casting,
                                           _dtype=dtype, _sparse=sparse, **kw)
-
-    @property
-    def output_limit(self):
-        return 2
-
-    @property
-    def input(self):
-        return self._input
-
-    @property
-    def out1(self):
-        return getattr(self, '_out1', None)
-
-    @property
-    def out2(self):
-        return getattr(self, '_out2', None)
-
-    @property
-    def where(self):
-        return getattr(self, '_where', None)
-
-    @property
-    def casting(self):
-        return getattr(self, '_casting', None)
 
     @property
     def _fun(self):

--- a/mars/tensor/expressions/arithmetic/modf.py
+++ b/mars/tensor/expressions/arithmetic/modf.py
@@ -17,47 +17,15 @@
 import numpy as np
 
 from .... import opcodes as OperandDef
-from ....serialize import KeyField, StringField
-from ..core import TensorOperand
-from .core import TensorOutBinOpMixin
+from .core import TensorOutBinOpMixin, TensorOutBinOp
 
 
-class TensorModf(TensorOperand, TensorOutBinOpMixin):
+class TensorModf(TensorOutBinOp, TensorOutBinOpMixin):
     _op_type_ = OperandDef.MODF
-
-    _input = KeyField('input')
-    _out1 = KeyField('out1')
-    _out2 = KeyField('out2')
-    _where = KeyField('where')
-    _casting = StringField('casting')
 
     def __init__(self, casting='same_kind', dtype=None, sparse=False, **kw):
         super(TensorModf, self).__init__(_casting=casting, _dtype=dtype,
                                          _sparse=sparse, **kw)
-
-    @property
-    def output_limit(self):
-        return 2
-
-    @property
-    def input(self):
-        return self._input
-
-    @property
-    def out1(self):
-        return getattr(self, '_out1', None)
-
-    @property
-    def out2(self):
-        return getattr(self, '_out2', None)
-
-    @property
-    def where(self):
-        return getattr(self, '_where', None)
-
-    @property
-    def casting(self):
-        return getattr(self, '_casting', None)
 
     @property
     def _fun(self):

--- a/mars/tensor/expressions/base/argwhere.py
+++ b/mars/tensor/expressions/base/argwhere.py
@@ -34,10 +34,6 @@ class TensorArgwhere(TensorHasInput, TensorOperandMixin):
     def __init__(self, dtype=None, **kw):
         super(TensorArgwhere, self).__init__(_dtype=dtype, **kw)
 
-    def calc_shape(self, *inputs_shape):
-        shape = (np.nan, len(inputs_shape[0]))
-        return shape
-
     def _set_inputs(self, inputs):
         super(TensorArgwhere, self)._set_inputs(inputs)
         self._input = self._inputs[0]

--- a/mars/tensor/expressions/base/astype.py
+++ b/mars/tensor/expressions/base/astype.py
@@ -45,9 +45,6 @@ class TensorAstype(TensorHasInput, TensorOperandMixin):
         super(TensorAstype, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, tensor, copy=True):
         t = self.new_tensor([tensor], tensor.shape)
         if copy:

--- a/mars/tensor/expressions/base/broadcast_to.py
+++ b/mars/tensor/expressions/base/broadcast_to.py
@@ -34,9 +34,6 @@ class TensorBroadcastTo(TensorHasInput, TensorOperandMixin):
     def shape(self):
         return self._shape
 
-    def calc_shape(self, *inputs_shape):
-        return self.outputs[0].shape
-
     def __call__(self, tensor, shape):
         return self.new_tensor([tensor], shape)
 

--- a/mars/tensor/expressions/base/copyto.py
+++ b/mars/tensor/expressions/base/copyto.py
@@ -80,9 +80,6 @@ class TensorCopyTo(TensorOperand, TensorOperandMixin):
 
         return src, dst, where
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[1]
-
     def __call__(self, *inputs):
         from ..core import Tensor
 

--- a/mars/tensor/expressions/base/digitize.py
+++ b/mars/tensor/expressions/base/digitize.py
@@ -47,10 +47,6 @@ class TensorDigitize(TensorHasInput, TensorOperandMixin):
         if len(inputs) > 1:
             self._bins = self._inputs[1]
 
-    @classmethod
-    def calc_shape(cls, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, x, bins):
         x = astensor(x)
         inputs = [x]

--- a/mars/tensor/expressions/base/isin.py
+++ b/mars/tensor/expressions/base/isin.py
@@ -57,9 +57,6 @@ class TensorIsIn(TensorOperand, TensorOperandMixin):
         self._element = self._inputs[0]
         self._test_elements = self._inputs[1]
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, element, test_elements):
         element, test_elements = astensor(element), ravel(astensor(test_elements))
 

--- a/mars/tensor/expressions/base/repeat.py
+++ b/mars/tensor/expressions/base/repeat.py
@@ -52,19 +52,6 @@ class TensorRepeat(TensorHasInput, TensorOperandMixin):
         if len(inputs) > 1:
             self._repeats = self._inputs[1]
 
-    def calc_shape(self, *inputs_shape):
-        ax = self._axis or 0
-        input_shape = (np.prod(inputs_shape[0]),) if self._axis is None else inputs_shape[0]
-        if len(inputs_shape) == 1:
-            repeats = self._repeats
-            if isinstance(repeats, np.ndarray):
-                size = repeats.sum()
-            else:
-                size = input_shape[ax] * repeats
-            return input_shape[:ax] + (size,) + input_shape[ax + 1:]
-        else:
-            return input_shape[:ax] + (np.nan,) + input_shape[ax + 1:]
-
     def __call__(self, a, repeats):
         axis = self._axis
         a = astensor(a)

--- a/mars/tensor/expressions/base/split.py
+++ b/mars/tensor/expressions/base/split.py
@@ -53,9 +53,6 @@ class TensorSplit(TensorHasInput, TensorOperandMixin):
         if len(self._inputs) > 1:
             self._indices_or_sections = self._inputs[1]
 
-    def calc_shape(self, *inputs_shape):
-        return tuple(out.shape for out in self.outputs)
-
     def __call__(self, a, indices_or_sections, is_split=False):
         axis = self._axis
         size = a.shape[axis]

--- a/mars/tensor/expressions/base/squeeze.py
+++ b/mars/tensor/expressions/base/squeeze.py
@@ -54,9 +54,6 @@ class TensorSqueeze(TensorHasInput, TensorOperandMixin):
     def axis(self):
         return self._axis
 
-    def calc_shape(self, *inputs_shape):
-        return _get_squeeze_shape(inputs_shape[0], self.axis)[0]
-
     def __call__(self, a, shape):
         return self.new_tensor([a], shape)
 

--- a/mars/tensor/expressions/base/swapaxes.py
+++ b/mars/tensor/expressions/base/swapaxes.py
@@ -46,9 +46,6 @@ class TensorSwapAxes(TensorHasInput, TensorOperandMixin):
     def axis2(self):
         return self._axis2
 
-    def calc_shape(self, *inputs_shape):
-        return _swap(inputs_shape[0], self.axis1, self.axis2)
-
     def __call__(self, a):
         shape = _swap(a.shape, self.axis1, self.axis2)
         return self.new_tensor([a], shape)

--- a/mars/tensor/expressions/base/transpose.py
+++ b/mars/tensor/expressions/base/transpose.py
@@ -42,9 +42,6 @@ class TensorTranspose(TensorHasInput, TensorOperandMixin):
     def axes(self):
         return getattr(self, '_axes', None)
 
-    def calc_shape(self, *inputs_shape):
-        return _reorder(inputs_shape[0], self._axes)
-
     def __call__(self, a):
         shape = _reorder(a.shape, self._axes)
         return self.new_tensor([a], shape)

--- a/mars/tensor/expressions/base/where.py
+++ b/mars/tensor/expressions/base/where.py
@@ -56,9 +56,6 @@ class TensorWhere(TensorOperand, TensorOperandMixin):
         self._x = self._inputs[1]
         self._y = self._inputs[2]
 
-    def calc_shape(self, *inputs_shape):
-        return broadcast_shape(inputs_shape[1], inputs_shape[2])
-
     def __call__(self, condition, x, y, shape=None):
         shape = shape or broadcast_shape(x.shape, y.shape)
         return self.new_tensor([condition, x, y], shape)

--- a/mars/tensor/expressions/core.py
+++ b/mars/tensor/expressions/core.py
@@ -60,9 +60,6 @@ class TensorOperandMixin(TileableOperandMixin):
 
         return self.new_tensors(inputs, shape=shape, dtype=dtype, **kw)[0]
 
-    def calc_shape(self, *inputs_shape):
-        raise NotImplementedError
-
 
 class TensorOperand(Operand):
     _dtype = DataTypeField('dtype')
@@ -90,9 +87,6 @@ class TensorShuffleProxy(ShuffleProxy, TensorOperandMixin):
     @property
     def dtype(self):
         return getattr(self, '_dtype', None)
-
-    def calc_shape(self, *inputs_shape):
-        return ()
 
 
 class TensorShuffleMap(ShuffleMap):

--- a/mars/tensor/expressions/datasource/core.py
+++ b/mars/tensor/expressions/datasource/core.py
@@ -67,9 +67,6 @@ class TensorNoInput(TensorDataSource):
         if inputs and len(inputs) > 0:
             raise ValueError("Tensor data source has no inputs")
 
-    def calc_shape(self, *inputs_shape):
-        return self.outputs[0].shape
-
     def _new_chunks(self, inputs, kws=None, **kw):
         shape = kw.get('shape', None)
         self.extra_params['shape'] = shape  # set shape to make the operand key different
@@ -113,9 +110,6 @@ class TensorHasInput(TensorDataSource):
         new_op = op.copy()
         return new_op.new_tensors(op.inputs, op.outputs[0].shape, chunks=out_chunks,
                                   nsplits=op.input.nsplits)
-
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
 
     def __call__(self, a):
         return self.new_tensor([a], a.shape)

--- a/mars/tensor/expressions/datasource/diag.py
+++ b/mars/tensor/expressions/datasource/diag.py
@@ -130,14 +130,6 @@ class TensorDiag(TensorDiagBase, TensorHasInput):
         op = TensorDiag(k=chunk_k, dtype=op.dtype, gpu=op.gpu, sparse=op.sparse)
         return op.new_chunk([input_chunk], shape=chunk_shape, index=chunk_idx)
 
-    def calc_shape(self, *inputs_shape):
-        input_shape = inputs_shape[0]
-        k = self._k
-        if len(input_shape) == 1:
-            return (input_shape[0] + abs(k),) * 2
-        else:
-            return _get_diag_shape(input_shape, k)
-
     def __call__(self, v, shape, chunk_size=None):
         return self.new_tensor([v], shape, raw_chunk_size=chunk_size)
 

--- a/mars/tensor/expressions/datastore/core.py
+++ b/mars/tensor/expressions/datastore/core.py
@@ -24,9 +24,6 @@ class TensorDataStore(TensorHasInput, TensorOperandMixin):
         shape = (0,) * a.ndim
         return self.new_tensor([a], shape)
 
-    def calc_shape(self, *inputs_shape):
-        return self.outputs[0].shape
-
     @classmethod
     def _get_out_chunk(cls, op, in_chunk):
         chunk_op = op.copy().reset_key()

--- a/mars/tensor/expressions/fetch/core.py
+++ b/mars/tensor/expressions/fetch/core.py
@@ -23,9 +23,6 @@ class TensorFetchMixin(TensorOperandMixin):
         if inputs and len(inputs) > 0:
             raise ValueError("%s has no inputs" % type(self).__name__)
 
-    def calc_shape(self, *inputs_shape):
-        return self.outputs[0].shape
-
     @classmethod
     def tile(cls, op):
         raise NotImplementedError('Fetch tile cannot be handled by operand itself')

--- a/mars/tensor/expressions/fft/core.py
+++ b/mars/tensor/expressions/fft/core.py
@@ -26,9 +26,6 @@ from ..core import TensorHasInput, TensorOperandMixin
 class TensorFFTBaseMixin(TensorOperandMixin):
     __slots__ = ()
 
-    def calc_shape(self, *inputs_shape):
-        return self._get_shape(self, inputs_shape[0])
-
     @classmethod
     def _get_shape(cls, op, shape):
         raise NotImplementedError
@@ -141,9 +138,6 @@ def validate_fftn(tensor, s=None, axes=None, norm=None):
 
 class TensorFFTShiftMixin(TensorOperandMixin):
     __slots__ = ()
-
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
 
     @classmethod
     def _is_inverse(cls):

--- a/mars/tensor/expressions/fft/fftfreq.py
+++ b/mars/tensor/expressions/fft/fftfreq.py
@@ -44,9 +44,6 @@ class TensorFFTFreq(TensorOperand, TensorOperandMixin):
         shape = (self.n,)
         return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
 
-    def calc_shape(self, *inputs_shape):
-        return self.n,
-
     @classmethod
     def tile(cls, op):
         tensor = op.outputs[0]
@@ -82,9 +79,6 @@ class TensorFFTFreqChunk(TensorHasInput, TensorOperandMixin):
     @property
     def d(self):
         return self._d
-
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
 
     def _set_inputs(self, inputs):
         super(TensorFFTFreqChunk, self)._set_inputs(inputs)

--- a/mars/tensor/expressions/fft/rfftfreq.py
+++ b/mars/tensor/expressions/fft/rfftfreq.py
@@ -43,9 +43,6 @@ class TensorRFFTFreq(TensorOperand, TensorOperandMixin):
         shape = (self.n // 2 + 1,)
         return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
 
-    def calc_shape(self, *inputs_shape):
-        return self.n // 2 + 1,
-
     @classmethod
     def tile(cls, op):
         tensor = op.outputs[0]

--- a/mars/tensor/expressions/fuse/core.py
+++ b/mars/tensor/expressions/fuse/core.py
@@ -42,16 +42,6 @@ class TensorFuseChunk(TensorFuse, TensorFuseChunkMixin):
     def __init__(self, dtype=None, sparse=False, **kw):
         super(TensorFuseChunk, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
 
-    def calc_shape(self, *inputs_shape):
-        in_shapes = inputs_shape
-        out_shape = None
-
-        # TODO: the logic will be changed when fusion is not only straight line
-        for c in self.outputs[0].composed:
-            out_shape = c.op.calc_shape(*in_shapes)
-            in_shapes = [out_shape]
-        return out_shape
-
     @classmethod
     def tile(cls, op):
         raise NotSupportTile('TensorFuseChunk is a chunk operand which does not support tile')

--- a/mars/tensor/expressions/indexing/choose.py
+++ b/mars/tensor/expressions/indexing/choose.py
@@ -56,9 +56,6 @@ class TensorChoose(TensorOperand, TensorOperandMixin):
         self._a = self._inputs[0]
         self._choices = self._inputs[1:]
 
-    def calc_shape(self, *inputs_shape):
-        return broadcast_shape(inputs_shape[0], *inputs_shape[1:])
-
     def __call__(self, a, choices):
         inputs = [a] + choices
         shape = broadcast_shape(a.shape, *[c.shape for c in choices])

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -45,9 +45,6 @@ class TensorIndex(TensorHasInput, TensorOperandMixin):
     def indexes(self):
         return self._indexes
 
-    def calc_shape(self, *inputs_shape):
-        return tuple(get_index_and_shape(inputs_shape[0], self._indexes)[1])
-
     @contextlib.contextmanager
     def _handle_params(self, inputs, indexes):
         """

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -17,7 +17,6 @@
 from numbers import Integral
 import operator
 import itertools
-import contextlib
 
 import numpy as np
 
@@ -45,37 +44,25 @@ class TensorIndex(TensorHasInput, TensorOperandMixin):
     def indexes(self):
         return self._indexes
 
-    @contextlib.contextmanager
-    def _handle_params(self, inputs, indexes):
-        """
-        Index operator is special, it has additional parameter `indexes` which may also be tensor type,
-        normally, this indexes is provided when called by `tile` or `TensorIndex.__call__`, however, calls
-        in `GraphActor.get_executable_operand_dag` only provide inputs, in such situation, we need get `indexes`
-        from operand itself and replace tensor-liked indexes by new one in `inputs`.
-        """
-        if indexes is not None:
-            self._indexes = indexes
-            indexes_inputs = [ind for ind in indexes if isinstance(ind, (Base, Entity))]
-            inputs = inputs + indexes_inputs
-        yield inputs
-
+    def _set_inputs(self, inputs):
+        super(TensorIndex, self)._set_inputs(inputs)
         inputs_iter = iter(self._inputs[1:])
-        new_indexes = [next(inputs_iter) if isinstance(index, (Base, Entity)) else index
-                       for index in self._indexes]
-        self._indexes = new_indexes
-
-    def _new_tileables(self, inputs, kws=None, **kw):
-        indexes = kw.pop('indexes', None)
-        with self._handle_params(inputs, indexes) as mix_inputs:
-            return super(TensorIndex, self)._new_tileables(mix_inputs, kws=kws, **kw)
-
-    def _new_chunks(self, inputs, kws=None, **kw):
-        indexes = kw.pop('indexes', None)
-        with self._handle_params(inputs, indexes) as mix_inputs:
-            return super(TensorIndex, self)._new_chunks(mix_inputs, kws=kws, **kw)
+        if getattr(self, '_indexes', None) is None:
+            # if create operand from beginning, inputs must have two parts: input, indexes.
+            # The first element in inputs is the input tensor, the rest are all indexes,
+            # they are mars tensors or numpy arrays.
+            indexes = inputs[1:]
+            self._indexes = [next(inputs_iter) if isinstance(index, (Base, Entity)) else index
+                             for index in indexes]
+        else:
+            # if created by existing operand, inputs are all mars tensors,
+            # we should check the self.indexes and replace tensor-liked indexes by new one in `inputs`.
+            new_indexes = [next(inputs_iter) if isinstance(index, (Base, Entity)) else index
+                           for index in self._indexes]
+            self._indexes = new_indexes
 
     def __call__(self, a, index, shape):
-        return self.new_tensor([a], shape, indexes=index)
+        return self.new_tensor([a] + list(index), shape)
 
     @classmethod
     def tile(cls, op):
@@ -185,16 +172,15 @@ class TensorIndex(TensorHasInput, TensorOperandMixin):
                     output_axis += 1
 
             chunk_input = in_tensor.cix[tuple(chunk_idx)]
-            chunk_op = op.copy().reset_key()
-            chunk = chunk_op.new_chunk([chunk_input], shape=tuple(chunk_shape),
-                                       indexes=chunk_index, index=output_idx)
+            chunk_op = TensorIndex(dtype=op.dtype, sparse=op.sparse)
+            chunk = chunk_op.new_chunk([chunk_input] + chunk_index, shape=tuple(chunk_shape), index=output_idx)
             out_chunks.append(chunk)
 
         nsplits = [tuple(c.shape[i] for c in out_chunks
                          if all(idx == 0 for j, idx in enumerate(c.index) if j != i))
                    for i in range(len(out_chunks[0].shape))]
         new_op = op.copy().reset_key()
-        tensor = new_op.new_tensor([op.input], tensor.shape, indexes=op.indexes, chunks=out_chunks, nsplits=nsplits)
+        tensor = new_op.new_tensor(op.inputs, tensor.shape, chunks=out_chunks, nsplits=nsplits)
 
         if len(to_concat_axis_index) > 1:
             raise NotImplementedError
@@ -219,12 +205,11 @@ class TensorIndex(TensorHasInput, TensorOperandMixin):
                     axis=axis, dtype=chunks[0].dtype, sparse=chunks[0].op.sparse)
                 concat_chunk = concat_chunk_op.new_chunk(chunks, shape=tuple(s), index=new_idx)
                 out_chunk_op = TensorIndex(dtype=concat_chunk.dtype, sparse=concat_chunk.op.sparse)
-                out_chunk = out_chunk_op.new_chunk([concat_chunk], shape=tuple(s), indexes=indexobj, index=new_idx)
+                out_chunk = out_chunk_op.new_chunk([concat_chunk] + indexobj, shape=tuple(s), index=new_idx)
                 output_chunks.append(out_chunk)
 
             new_op = tensor.op.copy()
-            tensor = new_op.new_tensor([op.input], tuple(output_shape), indexes=op.indexes,
-                                       chunks=output_chunks, nsplits=output_nsplits)
+            tensor = new_op.new_tensor(op.inputs, tuple(output_shape), chunks=output_chunks, nsplits=output_nsplits)
 
         return [tensor]
 

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -37,8 +37,8 @@ class TensorIndex(TensorHasInput, TensorOperandMixin):
     _input = KeyField('input')
     _indexes = ListField('indexes')
 
-    def __init__(self, dtype=None, sparse=False, **kw):
-        super(TensorIndex, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
+    def __init__(self, dtype=None, sparse=False, indexes=None, **kw):
+        super(TensorIndex, self).__init__(_dtype=dtype, _sparse=sparse, _indexes=indexes, **kw)
 
     @property
     def indexes(self):
@@ -197,8 +197,8 @@ class TensorIndex(TensorHasInput, TensorOperandMixin):
                 concat_chunk_op = TensorConcatenate(
                     axis=axis, dtype=chunks[0].dtype, sparse=chunks[0].op.sparse)
                 concat_chunk = concat_chunk_op.new_chunk(chunks, shape=tuple(s), index=new_idx)
-                out_chunk_op = TensorIndex(dtype=concat_chunk.dtype, sparse=concat_chunk.op.sparse)
-                out_chunk_op._indexes = indexobj
+                out_chunk_op = TensorIndex(dtype=concat_chunk.dtype, sparse=concat_chunk.op.sparse,
+                                           indexes=indexobj)
                 out_chunk = out_chunk_op.new_chunk(filter_inputs([concat_chunk] + indexobj),
                                                    shape=tuple(s), index=new_idx)
                 output_chunks.append(out_chunk)
@@ -219,5 +219,5 @@ def _getitem(a, item):
 
     index = process_index(a, item)
     index, shape = get_index_and_shape(a.shape, index)
-    op = TensorIndex(dtype=a.dtype, sparse=a.issparse())
+    op = TensorIndex(dtype=a.dtype, sparse=a.issparse(), indexes=index)
     return op(a, index, tuple(shape))

--- a/mars/tensor/expressions/indexing/nonzero.py
+++ b/mars/tensor/expressions/indexing/nonzero.py
@@ -37,9 +37,6 @@ class TensorNonzero(TensorHasInput, TensorOperandMixin):
     def output_limit(self):
         return float('inf')
 
-    def calc_shape(self, *inputs_shape):
-        return np.nan,
-
     def __call__(self, a):
         return ExecutableTuple(self.new_tensors([a], shape=(np.nan,), output_limit=a.ndim))
 

--- a/mars/tensor/expressions/indexing/setitem.py
+++ b/mars/tensor/expressions/indexing/setitem.py
@@ -82,9 +82,6 @@ class TensorIndexSetValue(TensorHasInput, TensorOperandMixin):
         with self._handle_params(inputs, indexes, value) as mix_inputs:
             return super(TensorIndexSetValue, self)._new_chunks(mix_inputs, kws=kws, **kw)
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, a, index, value):
         return self.new_tensor([a], a.shape, indexes=index, value=value)
 

--- a/mars/tensor/expressions/indexing/slice.py
+++ b/mars/tensor/expressions/indexing/slice.py
@@ -36,22 +36,6 @@ class TensorSlice(TensorHasInput, TensorOperandMixin):
     def slices(self):
         return self._slices
 
-    def calc_shape(self, *inputs_shape):
-        input_shape = inputs_shape[0]
-        shape = []
-        idx = 0
-        for s in self._slices:
-            if s is None:
-                shape.append(1)
-            elif isinstance(s, slice):
-                if np.isnan(input_shape[idx]):
-                    shape.append(np.nan)
-                else:
-                    shape.append(calc_sliced_size(input_shape[idx], s))
-                idx += 1
-        shape.extend(list(input_shape[idx:]))
-        return tuple(shape)
-
     def _set_inputs(self, inputs):
         super(TensorSlice, self)._set_inputs(inputs)
         self._input = self._inputs[0]

--- a/mars/tensor/expressions/indexing/slice.py
+++ b/mars/tensor/expressions/indexing/slice.py
@@ -14,12 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-
 from .... import opcodes as OperandDef
 from ....serialize import KeyField, ListField
 from ..core import TensorHasInput, TensorOperandMixin
-from ..utils import calc_sliced_size
 
 
 class TensorSlice(TensorHasInput, TensorOperandMixin):

--- a/mars/tensor/expressions/indexing/unravel_index.py
+++ b/mars/tensor/expressions/indexing/unravel_index.py
@@ -46,9 +46,6 @@ class TensorUnravelIndex(TensorHasInput, TensorOperandMixin):
         super(TensorUnravelIndex, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, indices):
         kws = [{'pos': i} for i in range(len(self._dims))]
         return ExecutableTuple(self.new_tensors([indices], indices.shape, kws=kws, output_limit=len(kws)))

--- a/mars/tensor/expressions/linalg/cholesky.py
+++ b/mars/tensor/expressions/linalg/cholesky.py
@@ -30,7 +30,7 @@ def _H(chunk):
     trans_op = TensorTranspose(dtype=chunk.dtype)
     c = trans_op.new_chunk([chunk], shape=chunk.shape[::-1], index=chunk.index[::-1])
     conj_op = TensorConj(dtype=c.dtype)
-    return conj_op.new_chunk([c, None, None], shape=c.shape, index=c.index)
+    return conj_op.new_chunk([c], shape=c.shape, index=c.index)
 
 
 class TensorCholesky(TensorHasInput, TensorOperandMixin):
@@ -92,8 +92,8 @@ class TensorCholesky(TensorHasInput, TensorOperandMixin):
                         else:
                             s = tree_add(prev_chunks[0].dtype, prev_chunks,
                                          None, prev_chunks[0].shape)
-                        target = TensorSubtract(dtype=tensor.dtype).new_chunk(
-                            [target, s, None, None], shape=target.shape)
+                        target = TensorSubtract(dtype=tensor.dtype, lhs=target, rhs=s).new_chunk(
+                            [target, s], shape=target.shape)
                     lower_chunk = TensorCholesky(lower=True, dtype=tensor.dtype).new_chunk(
                         [target], shape=target.shape, index=(i, j))
                     upper_chunk = _H(lower_chunk)
@@ -113,8 +113,8 @@ class TensorCholesky(TensorHasInput, TensorOperandMixin):
                         else:
                             s = tree_add(prev_chunks[0].dtype, prev_chunks,
                                          None, prev_chunks[0].shape)
-                        target = TensorSubtract(dtype=tensor.dtype).new_chunk(
-                            [target, s, None, None], shape=target.shape)
+                        target = TensorSubtract(dtype=tensor.dtype, lhs=target, rhs=s).new_chunk(
+                            [target, s], shape=target.shape)
                     upper_chunk = TensorSolveTriangular(lower=True, dtype=tensor.dtype).new_chunk(
                         [lower_chunks[j, j], target], shape=target.shape, index=(j, i))
                     lower_chunk = _H(upper_chunk)

--- a/mars/tensor/expressions/linalg/cholesky.py
+++ b/mars/tensor/expressions/linalg/cholesky.py
@@ -50,9 +50,6 @@ class TensorCholesky(TensorHasInput, TensorOperandMixin):
         super(TensorCholesky, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, a):
         return self.new_tensor([a], a.shape)
 

--- a/mars/tensor/expressions/linalg/dot.py
+++ b/mars/tensor/expressions/linalg/dot.py
@@ -39,15 +39,6 @@ class TensorDot(TensorOperand, TensorOperandMixin):
     def b(self):
         return self._b
 
-    def calc_shape(self, *inputs_shape):
-        a_shape = inputs_shape[0]
-        b_shape = inputs_shape[1]
-        a_axes = len(a_shape) - 1
-        b_axes = len(b_shape) - 2
-        shape = tuple(s for i, s in enumerate(a_shape) if i != a_axes) + \
-            tuple(s for i, s in enumerate(b_shape) if i != b_axes)
-        return shape
-
     def _set_inputs(self, inputs):
         super(TensorDot, self)._set_inputs(inputs)
         self._a, self._b = self._inputs

--- a/mars/tensor/expressions/linalg/inv.py
+++ b/mars/tensor/expressions/linalg/inv.py
@@ -35,9 +35,6 @@ class TensorInv(TensorHasInput, TensorOperandMixin):
         a = astensor(a)
         return self.new_tensor([a], a.shape)
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     @classmethod
     def tile(cls, op):
         """

--- a/mars/tensor/expressions/linalg/lu.py
+++ b/mars/tensor/expressions/linalg/lu.py
@@ -37,9 +37,6 @@ class TensorLU(TensorHasInput, TensorOperandMixin):
     def output_limit(self):
         return 3
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, a):
         import scipy.linalg
 

--- a/mars/tensor/expressions/linalg/lu.py
+++ b/mars/tensor/expressions/linalg/lu.py
@@ -126,8 +126,8 @@ class TensorLU(TensorHasInput, TensorOperandMixin):
                         else:
                             s = tree_add(prev_chunks_u[0].dtype, prev_chunks_u,
                                          None, prev_chunks_u[0].shape, sparse=op.sparse)
-                        target = TensorSubtract(dtype=U.dtype).new_chunk(
-                            [target, s, None, None], shape=target.shape)
+                        target = TensorSubtract(dtype=U.dtype, lhs=target, rhs=s).new_chunk(
+                            [target, s], shape=target.shape)
                     upper_chunk = TensorSolveTriangular(lower=True, dtype=U.dtype, strict=False,
                                                         sparse=lower_chunks[i, i].op.sparse).new_chunk(
                         [lower_chunks[i, i], target], shape=target.shape, index=(i, j))
@@ -146,8 +146,8 @@ class TensorLU(TensorHasInput, TensorOperandMixin):
                         else:
                             s = tree_add(prev_chunks[0].dtype, prev_chunks,
                                          None, prev_chunks[0].shape, sparse=op.sparse)
-                        target = TensorSubtract(dtype=L.dtype).new_chunk(
-                            [target, s, None, None], shape=target.shape)
+                        target = TensorSubtract(dtype=L.dtype, lhs=target, rhs=s).new_chunk(
+                            [target, s], shape=target.shape)
                     new_op = TensorLU(dtype=op.dtype, sparse=target.op.sparse)
                     lu_chunks = new_op.new_chunks([target],
                                                   index=(i, j),
@@ -193,8 +193,8 @@ class TensorLU(TensorHasInput, TensorOperandMixin):
                         else:
                             s = tree_add(prev_chunks_l[0].dtype, prev_chunks_l,
                                          None, prev_chunks_l[0].shape, sparse=op.sparse)
-                        target_l = TensorSubtract(dtype=L.dtype).new_chunk(
-                            [target_l, s, None, None], shape=target_l.shape)
+                        target_l = TensorSubtract(dtype=L.dtype, lhs=target_l, rhs=s).new_chunk(
+                            [target_l, s], shape=target_l.shape)
                     u = upper_chunks[j, j]
                     a_transpose = TensorTranspose(dtype=u.dtype, sparse=op.sparse).new_chunk([u], shape=u.shape)
                     target_transpose = TensorTranspose(dtype=target_l.dtype, sparse=op.sparse).new_chunk(

--- a/mars/tensor/expressions/linalg/matmul.py
+++ b/mars/tensor/expressions/linalg/matmul.py
@@ -50,12 +50,6 @@ class TensorMatmul(TensorOperand, TensorOperandMixin):
         self._a = self._inputs[0]
         self._b = self._inputs[1]
 
-    def calc_shape(self, *inputs_shape):
-        a_shape = inputs_shape[0]
-        b_shape = inputs_shape[1]
-        shape = broadcast_shape(a_shape[:-2], b_shape[:-2]) + (a_shape[-2], b_shape[-1])
-        return shape
-
     def __call__(self, a, b, out=None):
         from ..base import broadcast_to
 

--- a/mars/tensor/expressions/linalg/norm.py
+++ b/mars/tensor/expressions/linalg/norm.py
@@ -57,11 +57,6 @@ class TensorNorm(TensorHasInput, TensorOperandMixin):
         super(TensorNorm, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        r = empty(inputs_shape[0], dtype=self.dtype)
-        shape = self._norm(r, self._ord, self._axis, self._keepdims).shape
-        return shape
-
     def __call__(self, x):
         r = x.astype(self.dtype)
         shape = self._norm(r, self._ord, self._axis, self._keepdims).shape

--- a/mars/tensor/expressions/linalg/norm.py
+++ b/mars/tensor/expressions/linalg/norm.py
@@ -24,7 +24,6 @@ from ....serialize import ValueType, KeyField, AnyField, TupleField, BoolField
 from ..utils import recursive_tile
 from ..core import TensorHasInput, TensorOperandMixin
 from ..arithmetic import sqrt
-from ..datasource import empty
 from ..datasource import tensor as astensor
 from .svd import svd
 

--- a/mars/tensor/expressions/linalg/qr.py
+++ b/mars/tensor/expressions/linalg/qr.py
@@ -46,11 +46,6 @@ class TensorQR(TensorHasInput, TensorOperandMixin):
         super(TensorQR, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        input_shape = inputs_shape[0]
-        x, y = input_shape
-        return (input_shape, (y, y)) if x > y else ((x, x), input_shape)
-
     def __call__(self, a):
         a = astensor(a)
 

--- a/mars/tensor/expressions/linalg/solve_triangular.py
+++ b/mars/tensor/expressions/linalg/solve_triangular.py
@@ -109,8 +109,8 @@ class TensorSolveTriangular(TensorOperand, TensorOperandMixin):
                     else:
                         s = tree_add(prev_chunks[0].dtype, prev_chunks,
                                      None, prev_chunks[0].shape, sparse=op.sparse)
-                    target_b = TensorSubtract(dtype=op.dtype).new_chunk(
-                        [target_b, s, None, None], shape=target_b.shape)
+                    target_b = TensorSubtract(dtype=op.dtype, lhs=target_b, rhs=s).new_chunk(
+                        [target_b, s], shape=target_b.shape)
                 out_chunk = TensorSolveTriangular(lower=lower, sparse=op.sparse, dtype=op.dtype).new_chunk(
                     [target_a, target_b], shape=_x_shape(target_a.shape, target_b.shape), index=idx)
                 out_chunks[out_chunk.index] = out_chunk

--- a/mars/tensor/expressions/linalg/solve_triangular.py
+++ b/mars/tensor/expressions/linalg/solve_triangular.py
@@ -51,11 +51,6 @@ class TensorSolveTriangular(TensorOperand, TensorOperandMixin):
         super(TensorSolveTriangular, self)._set_inputs(inputs)
         self._a, self._b = self._inputs
 
-    def calc_shape(self, *inputs_shape):
-        a_shape = inputs_shape[0]
-        b_shape = inputs_shape[1]
-        return (a_shape[1],) if len(b_shape) == 1 else (a_shape[1], b_shape[1])
-
     def __call__(self, a, b):
         shape = (a.shape[1],) if len(b.shape) == 1 else (a.shape[1], b.shape[1])
         return self.new_tensor([a, b], shape)

--- a/mars/tensor/expressions/linalg/svd.py
+++ b/mars/tensor/expressions/linalg/svd.py
@@ -50,18 +50,6 @@ class TensorSVD(TensorHasInput, TensorOperandMixin):
         super(TensorSVD, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        x, y = inputs_shape[0]
-        if x > y:
-            U_shape = (x, y)
-            s_shape = (y, )
-            V_shape = (y, y)
-        else:
-            U_shape = (x, x)
-            s_shape = (x, )
-            V_shape = (x, y)
-        return U_shape, s_shape, V_shape
-
     def __call__(self, a):
         a = astensor(a)
 

--- a/mars/tensor/expressions/linalg/tensordot.py
+++ b/mars/tensor/expressions/linalg/tensordot.py
@@ -61,13 +61,6 @@ class TensorTensorDot(TensorOperand, TensorOperandMixin):
         self._a = self._inputs[0]
         self._b = self._inputs[1]
 
-    def calc_shape(self, *inputs_shape):
-        a_shape = inputs_shape[0]
-        b_shape = inputs_shape[1]
-        shape = tuple(s for i, s in enumerate(a_shape) if i not in set(self._a_axes)) + \
-            tuple(s for i, s in enumerate(b_shape) if i not in set(self._b_axes))
-        return shape
-
     def __call__(self, a, b):
         shape = tuple(s for i, s in enumerate(a.shape) if i not in set(self._a_axes)) + \
             tuple(s for i, s in enumerate(b.shape) if i not in set(self._b_axes))

--- a/mars/tensor/expressions/merge/concatenate.py
+++ b/mars/tensor/expressions/merge/concatenate.py
@@ -38,14 +38,6 @@ class TensorConcatenate(TensorOperand, TensorOperandMixin):
     def axis(self):
         return getattr(self, '_axis', None)
 
-    def calc_shape(self, *inputs_shape):
-        inputs_shape = [s for s in inputs_shape if 0 not in s]
-        first_shape = inputs_shape[0]
-        axis = self._axis or 0
-        shape = [0 if i == axis else first_shape[i] for i in range(len(first_shape))]
-        shape[axis] = sum(s[axis] for s in inputs_shape)
-        return tuple(shape)
-
     def __call__(self, tensors):
         if len(set(t.ndim for t in tensors)) != 1:
             raise ValueError('all the input tensors must have same number of dimensions')

--- a/mars/tensor/expressions/merge/stack.py
+++ b/mars/tensor/expressions/merge/stack.py
@@ -38,11 +38,6 @@ class TensorStack(TensorOperand, TensorOperandMixin):
     def axis(self):
         return self._axis
 
-    def calc_shape(self, *inputs_shape):
-        fisrt_shape = inputs_shape[0]
-        axis = self._axis
-        return fisrt_shape[:axis] + (len(inputs_shape),) + fisrt_shape[axis:]
-
     def __call__(self, tensors):
         shape = tensors[0].shape[:self._axis] + (len(tensors),) + tensors[0].shape[self._axis:]
         return self.new_tensor(tensors, shape)

--- a/mars/tensor/expressions/random/choice.py
+++ b/mars/tensor/expressions/random/choice.py
@@ -53,9 +53,6 @@ class TensorChoice(TensorSimpleRandomData, TensorRandomOperandMixin):
     def p(self):
         return self._p
 
-    def calc_shape(self, *inputs_shape):
-        return self._size or ()
-
     def __call__(self, a, p, chunk_size=None):
         return self.new_tensor([a, p], None, raw_chunk_size=chunk_size)
 

--- a/mars/tensor/expressions/random/core.py
+++ b/mars/tensor/expressions/random/core.py
@@ -199,9 +199,6 @@ class TensorRandomOperandMixin(TensorOperandMixin):
             shapes.append(getattr(self, '_size'))
         return broadcast_shape(*shapes)
 
-    def calc_shape(self, *inputs_shape):
-        return self._get_shape(list(inputs_shape))
-
     @classmethod
     def _handle_arg(cls, arg, chunk_size):
         if isinstance(arg, (list, np.ndarray)):

--- a/mars/tensor/expressions/random/multivariate_normal.py
+++ b/mars/tensor/expressions/random/multivariate_normal.py
@@ -58,9 +58,6 @@ class TensorMultivariateNormal(TensorDistribution, TensorRandomOperandMixin):
     def tol(self):
         return self._tol
 
-    def calc_shape(self, *inputs_shape):
-        return self.outputs[0].shape
-
     def __call__(self, chunk_size=None):
         N = self._mean.size
         if self._size is None:

--- a/mars/tensor/expressions/rechunk/rechunk.py
+++ b/mars/tensor/expressions/rechunk/rechunk.py
@@ -57,9 +57,6 @@ class TensorRechunk(TensorHasInput, TensorOperandMixin):
         super(TensorRechunk, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, tensor):
         return self.new_tensor([tensor], tensor.shape)
 

--- a/mars/tensor/expressions/reduction/core.py
+++ b/mars/tensor/expressions/reduction/core.py
@@ -35,21 +35,6 @@ class TensorReductionMixin(TensorOperandMixin):
     def _is_cum(cls):
         return False
 
-    def calc_shape(self, *inputs_shape):
-        input_shape = inputs_shape[0]
-        if self._is_cum():
-            return input_shape
-        else:
-            axis = getattr(self, 'axis')
-            keepdims = getattr(self, 'keepdims', None)
-
-            axis = lrange(len(input_shape)) if axis is None else axis
-            if not isinstance(axis, Iterable):
-                axis = (axis,)
-            axis = set(axis)
-            return tuple(s if i not in axis else 1 for i, s in enumerate(input_shape)
-                         if keepdims or i not in axis)
-
     def _call(self, a, out):
         a = astensor(a)
         if out is not None and not isinstance(out, Tensor):

--- a/mars/tensor/expressions/reshape/reshape.py
+++ b/mars/tensor/expressions/reshape/reshape.py
@@ -44,21 +44,6 @@ class TensorReshape(TensorHasInput, TensorOperandMixin):
         super(TensorReshape, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        newshape = self._newshape
-        known_shape = [s for s in newshape if s >= 0]
-        missing_dim = len(newshape) - len(known_shape)
-        if missing_dim > 1:
-            raise ValueError('can only specify one unknown dimension')
-        elif missing_dim == 1:
-            known_size = np.prod(known_shape)
-            input_size = np.prod(inputs_shape[0])
-            shape = tuple((input_size / known_size) if s < 0 and known_size > 0 else s
-                          for s in newshape)
-            return shape
-        else:
-            return newshape
-
     def __call__(self, a):
         return self.new_tensor([a], self._newshape)
 
@@ -259,9 +244,6 @@ class TensorReshapeMap(TensorShuffleMap, TensorOperandMixin):
     def new_chunk_size(self):
         return self._new_chunk_size
 
-    def calc_shape(self, *inputs_shape):
-        return np.nan,
-
 
 class TensorReshapeReduce(TensorShuffleReduce, TensorOperandMixin):
     _op_type_ = OperandDef.RESHAPE_REDUCE
@@ -271,9 +253,6 @@ class TensorReshapeReduce(TensorShuffleReduce, TensorOperandMixin):
     def _set_inputs(self, inputs):
         super(TensorReshapeReduce, self)._set_inputs(inputs)
         self._input = self._inputs[0]
-
-    def calc_shape(self, *inputs_shape):
-        return self.outputs[0].shape
 
 
 def reshape(a, newshape):

--- a/mars/tensor/expressions/tests/test_base.py
+++ b/mars/tensor/expressions/tests/test_base.py
@@ -21,7 +21,6 @@ import numpy as np
 from mars.tensor.expressions.datasource import ones, tensor, arange, array, asarray
 from mars.tensor.expressions.base import transpose, broadcast_to, where, argwhere, array_split, \
     split, squeeze, digitize, result_type, repeat, copyto, isin, TensorCopyTo
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -54,13 +53,11 @@ class Test(unittest.TestCase):
         self.assertIsInstance(a.op, TensorCopyTo)
         self.assertIs(a.inputs[0], b.data)
         self.assertIsInstance(a.inputs[1].op, tp)
-        self.assertEqual(calc_shape(a), a.shape)
 
         a.tiles()
 
         self.assertIsInstance(a.chunks[0].op, TensorCopyTo)
         self.assertEqual(len(a.chunks[0].inputs), 2)
-        self.assertEqual(calc_shape(a.chunks[0]), a.chunks[0].shape)
 
         a = ones((10, 20), chunk_size=3, dtype='i4')
         b = ones(20, chunk_size=4, dtype='f8')
@@ -72,13 +69,11 @@ class Test(unittest.TestCase):
         copyto(a, b, where=b > 0)
 
         self.assertIsNotNone(a.op.where)
-        self.assertEqual(calc_shape(a), a.shape)
 
         a.tiles()
 
         self.assertIsInstance(a.chunks[0].op, TensorCopyTo)
         self.assertEqual(len(a.chunks[0].inputs), 3)
-        self.assertEqual(calc_shape(a.chunks[0]), a.chunks[0].shape)
 
         with self.assertRaises(ValueError):
             copyto(a, a, where=np.ones(30, dtype='?'))
@@ -90,10 +85,8 @@ class Test(unittest.TestCase):
         arr2.tiles()
 
         self.assertEqual(arr2.shape, (10, 20, 30))
-        self.assertEqual(calc_shape(arr2), arr2.shape)
         self.assertTrue(np.issubdtype(arr2.dtype, np.int32))
         self.assertEqual(arr2.op.casting, 'unsafe')
-        self.assertEqual(calc_shape(arr2.chunks[0]), arr2.chunks[0].shape)
 
         with self.assertRaises(TypeError):
             arr.astype(np.int32, casting='safe')
@@ -105,12 +98,9 @@ class Test(unittest.TestCase):
         arr2.tiles()
 
         self.assertEqual(arr2.shape, (30, 20, 10))
-        self.assertEqual(calc_shape(arr2), arr2.shape)
         self.assertEqual(len(arr2.chunks), 126)
         self.assertEqual(arr2.chunks[0].shape, (5, 3, 4))
         self.assertEqual(arr2.chunks[-1].shape, (5, 2, 2))
-        self.assertEqual(calc_shape(arr2.chunks[0]), arr2.chunks[0].shape)
-        self.assertEqual(calc_shape(arr2.chunks[-1]), arr2.chunks[-1].shape)
 
         with self.assertRaises(ValueError):
             transpose(arr, axes=(1, 0))
@@ -119,34 +109,25 @@ class Test(unittest.TestCase):
         arr3.tiles()
 
         self.assertEqual(arr3.shape, (20, 30, 10))
-        self.assertEqual(calc_shape(arr3), arr3.shape)
         self.assertEqual(len(arr3.chunks), 126)
         self.assertEqual(arr3.chunks[0].shape, (3, 5, 4))
         self.assertEqual(arr3.chunks[-1].shape, (2, 5, 2))
-        self.assertEqual(calc_shape(arr3.chunks[0]), arr3.chunks[0].shape)
-        self.assertEqual(calc_shape(arr3.chunks[-1]), arr3.chunks[-1].shape)
 
         arr4 = arr.transpose(-2, 2, 0)
         arr4.tiles()
 
         self.assertEqual(arr4.shape, (20, 30, 10))
-        self.assertEqual(calc_shape(arr4), arr4.shape)
         self.assertEqual(len(arr4.chunks), 126)
         self.assertEqual(arr4.chunks[0].shape, (3, 5, 4))
         self.assertEqual(arr4.chunks[-1].shape, (2, 5, 2))
-        self.assertEqual(calc_shape(arr4.chunks[0]), arr4.chunks[0].shape)
-        self.assertEqual(calc_shape(arr4.chunks[-1]), arr4.chunks[-1].shape)
 
         arr5 = arr.T
         arr5.tiles()
 
         self.assertEqual(arr5.shape, (30, 20, 10))
-        self.assertEqual(calc_shape(arr5), arr5.shape)
         self.assertEqual(len(arr5.chunks), 126)
         self.assertEqual(arr5.chunks[0].shape, (5, 3, 4))
         self.assertEqual(arr5.chunks[-1].shape, (5, 2, 2))
-        self.assertEqual(calc_shape(arr5.chunks[0]), arr5.chunks[0].shape)
-        self.assertEqual(calc_shape(arr5.chunks[-1]), arr5.chunks[-1].shape)
 
     def testSwapaxes(self):
         arr = ones((10, 20, 30), chunk_size=[4, 3, 5])
@@ -154,9 +135,7 @@ class Test(unittest.TestCase):
         arr2.tiles()
 
         self.assertEqual(arr2.shape, (20, 10, 30))
-        self.assertEqual(calc_shape(arr2), arr2.shape)
         self.assertEqual(len(arr.chunks), len(arr2.chunks))
-        self.assertEqual(calc_shape(arr2.chunks[-1]), arr2.chunks[-1].shape)
 
     def testBroadcastTo(self):
         arr = ones((10, 5), chunk_size=2)
@@ -164,31 +143,25 @@ class Test(unittest.TestCase):
         arr2.tiles()
 
         self.assertEqual(arr2.shape, (20, 10, 5))
-        self.assertEqual(calc_shape(arr2), arr2.shape)
         self.assertEqual(len(arr2.chunks), len(arr.chunks))
         self.assertEqual(arr2.chunks[0].shape, (20, 2, 2))
-        self.assertEqual(calc_shape(arr2.chunks[-1]), arr2.chunks[-1].shape)
 
         arr = ones((10, 5, 1), chunk_size=2)
         arr3 = broadcast_to(arr, (5, 10, 5, 6))
         arr3.tiles()
 
         self.assertEqual(arr3.shape, (5, 10, 5, 6))
-        self.assertEqual(calc_shape(arr3), arr3.shape)
         self.assertEqual(len(arr3.chunks), len(arr.chunks))
         self.assertEqual(arr3.nsplits, ((5,), (2, 2, 2, 2, 2), (2, 2, 1), (6,)))
         self.assertEqual(arr3.chunks[0].shape, (5, 2, 2, 6))
-        self.assertEqual(calc_shape(arr3.chunks[-1]), arr3.chunks[-1].shape)
 
         arr = ones((10, 1), chunk_size=2)
         arr4 = broadcast_to(arr, (20, 10, 5))
         arr4.tiles()
 
         self.assertEqual(arr4.shape, (20, 10, 5))
-        self.assertEqual(calc_shape(arr4), arr4.shape)
         self.assertEqual(len(arr4.chunks), len(arr.chunks))
         self.assertEqual(arr4.chunks[0].shape, (20, 2, 5))
-        self.assertEqual(calc_shape(arr4.chunks[-1]), arr4.chunks[-1].shape)
 
         with self.assertRaises(ValueError):
             broadcast_to(arr, (10,))
@@ -205,7 +178,6 @@ class Test(unittest.TestCase):
         arr.tiles()
 
         self.assertEqual(len(arr.chunks), 4)
-        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertTrue(np.array_equal(arr.chunks[0].inputs[0].op.data, [[True]]))
         self.assertTrue(np.array_equal(arr.chunks[0].inputs[1].op.data, [1]))
         self.assertTrue(np.array_equal(arr.chunks[0].inputs[2].op.data, [3]))
@@ -218,7 +190,6 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(arr.chunks[3].inputs[0].op.data, [[True]]))
         self.assertTrue(np.array_equal(arr.chunks[3].inputs[1].op.data, [2]))
         self.assertTrue(np.array_equal(arr.chunks[3].inputs[2].op.data, [4]))
-        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
 
         with self.assertRaises(ValueError):
             where(cond, x)
@@ -234,15 +205,12 @@ class Test(unittest.TestCase):
 
         self.assertTrue(np.isnan(indices.shape[0]))
         self.assertEqual(indices.shape[1], 2)
-        self.assertEqual(calc_shape(indices), indices.shape)
 
         indices.tiles()
 
         self.assertEqual(indices.nsplits[1], (1, 1))
 
         chunk = indices.chunks[0]
-        self.assertTrue(np.isnan(calc_shape(chunk)[0]))
-        self.assertEqual(calc_shape(chunk)[1], chunk.shape[1])
 
     def testArraySplit(self):
         a = arange(8, chunk_size=2)
@@ -250,30 +218,22 @@ class Test(unittest.TestCase):
         splits = array_split(a, 3)
         self.assertEqual(len(splits), 3)
         self.assertEqual([s.shape[0] for s in splits], [3, 3, 2])
-        self.assertTrue(all(calc_shape(s) == ((3,), (3,), (2,)) for s in splits))
 
         splits[0].tiles()
         self.assertEqual(splits[0].nsplits, ((2, 1),))
         self.assertEqual(splits[1].nsplits, ((1, 2),))
         self.assertEqual(splits[2].nsplits, ((2,),))
-        self.assertEqual(calc_shape(splits[0].chunks[0]), splits[0].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[1].chunks[0]), splits[1].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[2].chunks[0]), splits[2].chunks[0].shape)
 
         a = arange(7, chunk_size=2)
 
         splits = array_split(a, 3)
         self.assertEqual(len(splits), 3)
         self.assertEqual([s.shape[0] for s in splits], [3, 2, 2])
-        self.assertTrue(all(calc_shape(s) == ((3,), (2,), (2,)) for s in splits))
 
         splits[0].tiles()
         self.assertEqual(splits[0].nsplits, ((2, 1),))
         self.assertEqual(splits[1].nsplits, ((1, 1),))
         self.assertEqual(splits[2].nsplits, ((1, 1),))
-        self.assertEqual(calc_shape(splits[0].chunks[0]), splits[0].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[1].chunks[0]), splits[1].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[2].chunks[0]), splits[2].chunks[0].shape)
 
     def testSplit(self):
         a = arange(9, chunk_size=2)
@@ -281,15 +241,11 @@ class Test(unittest.TestCase):
         splits = split(a, 3)
         self.assertEqual(len(splits), 3)
         self.assertTrue(all(s.shape == (3,) for s in splits))
-        self.assertTrue(all(calc_shape(s) == ((3,), (3,), (3,)) for s in splits))
 
         splits[0].tiles()
         self.assertEqual(splits[0].nsplits, ((2, 1),))
         self.assertEqual(splits[1].nsplits, ((1, 2),))
         self.assertEqual(splits[2].nsplits, ((2, 1),))
-        self.assertEqual(calc_shape(splits[0].chunks[0]), splits[0].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[1].chunks[0]), splits[1].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[2].chunks[0]), splits[2].chunks[0].shape)
 
         a = arange(8, chunk_size=2)
 
@@ -300,7 +256,6 @@ class Test(unittest.TestCase):
         self.assertEqual(splits[2].shape, (1,))
         self.assertEqual(splits[3].shape, (2,))
         self.assertEqual(splits[4].shape, (0,))
-        self.assertTrue(all(calc_shape(s) == ((3,), (2,), (1,), (2,), (0,)) for s in splits))
 
         splits[0].tiles()
         self.assertEqual(splits[0].nsplits, ((2, 1),))
@@ -308,11 +263,6 @@ class Test(unittest.TestCase):
         self.assertEqual(splits[2].nsplits, ((1,),))
         self.assertEqual(splits[3].nsplits, ((2,),))
         self.assertEqual(splits[4].nsplits, ((0,),))
-        self.assertEqual(calc_shape(splits[0].chunks[0]), splits[0].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[1].chunks[0]), splits[1].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[2].chunks[0]), splits[2].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[3].chunks[0]), splits[3].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[4].chunks[0]), splits[4].chunks[0].shape)
 
     def testSqueeze(self):
         data = np.array([[[0], [1], [2]]])
@@ -321,18 +271,15 @@ class Test(unittest.TestCase):
         t = squeeze(x)
         self.assertEqual(t.shape, (3,))
         self.assertIsNotNone(t.dtype)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t = squeeze(x, axis=0)
         self.assertEqual(t.shape, (3, 1))
-        self.assertEqual(calc_shape(t), t.shape)
 
         with self.assertRaises(ValueError):
             squeeze(x, axis=1)
 
         t = squeeze(x, axis=2)
         self.assertEqual(t.shape, (1, 3))
-        self.assertEqual(calc_shape(t), t.shape)
 
     def testDigitize(self):
         x = tensor(np.array([0.2, 6.4, 3.0, 1.6]), chunk_size=2)
@@ -341,12 +288,10 @@ class Test(unittest.TestCase):
 
         self.assertEqual(inds.shape, (4,))
         self.assertIsNotNone(inds.dtype)
-        self.assertEqual(calc_shape(inds), inds.shape)
 
         inds.tiles()
 
         self.assertEqual(len(inds.chunks), 2)
-        self.assertEqual(calc_shape(inds.chunks[0]), inds.chunks[0].shape)
 
     def testResultType(self):
         x = tensor([2, 3], dtype='i4')
@@ -362,23 +307,18 @@ class Test(unittest.TestCase):
 
         t = repeat(a, 3)
         self.assertEqual(t.shape, (30,))
-        self.assertEqual(calc_shape(t), t.shape)
 
         t = repeat(a, 3, axis=0)
         self.assertEqual(t.shape, (6, 5))
-        self.assertEqual(calc_shape(t), t.shape)
 
         t = repeat(a, 3, axis=1)
         self.assertEqual(t.shape, (2, 15))
-        self.assertEqual(calc_shape(t), t.shape)
 
         t = repeat(a, [3], axis=1)
         self.assertEqual(t.shape, (2, 15))
-        self.assertEqual(calc_shape(t), t.shape)
 
         t = repeat(a, [3, 4], axis=0)
         self.assertEqual(t.shape, (7, 5))
-        self.assertEqual(calc_shape(t), t.shape)
 
         with self.assertRaises(ValueError):
             repeat(a, [3, 4], axis=1)
@@ -388,24 +328,20 @@ class Test(unittest.TestCase):
         t = repeat(a, 3)
         t.tiles()
         self.assertEqual(sum(t.nsplits[0]), 30)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         a = tensor(np.random.randn(100), chunk_size=10)
 
         t = repeat(a, 3)
         t.tiles()
         self.assertEqual(sum(t.nsplits[0]), 300)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         a = tensor(np.random.randn(4))
         b = tensor((4,))
 
         t = repeat(a, b)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertTrue(np.isnan(t.nsplits[0]))
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
     def testIsIn(self):
         element = 2 * arange(4, chunk_size=1).reshape(2, 2)
@@ -414,14 +350,12 @@ class Test(unittest.TestCase):
         mask = isin(element, test_elements)
         self.assertEqual(mask.shape, (2, 2))
         self.assertEqual(mask.dtype, np.bool_)
-        self.assertEqual(calc_shape(mask), mask.shape)
 
         mask.tiles()
 
         self.assertEqual(len(mask.chunks), len(element.chunks))
         self.assertEqual(len(mask.op.test_elements.chunks), 1)
         self.assertIs(mask.chunks[0].inputs[0], element.chunks[0].data)
-        self.assertEqual(calc_shape(mask.chunks[0]), mask.chunks[0].shape)
 
         element = 2 * arange(4, chunk_size=1).reshape(2, 2)
         test_elements = tensor([1, 2, 4, 8], chunk_size=2)
@@ -429,7 +363,6 @@ class Test(unittest.TestCase):
         mask = isin(element, test_elements, invert=True)
         self.assertEqual(mask.shape, (2, 2))
         self.assertEqual(mask.dtype, np.bool_)
-        self.assertEqual(calc_shape(mask), mask.shape)
 
         mask.tiles()
 
@@ -437,4 +370,3 @@ class Test(unittest.TestCase):
         self.assertEqual(len(mask.op.test_elements.chunks), 1)
         self.assertIs(mask.chunks[0].inputs[0], element.chunks[0].data)
         self.assertTrue(mask.chunks[0].op.invert)
-        self.assertEqual(calc_shape(mask.chunks[0]), mask.chunks[0].shape)

--- a/mars/tensor/expressions/tests/test_base.py
+++ b/mars/tensor/expressions/tests/test_base.py
@@ -210,8 +210,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(indices.nsplits[1], (1, 1))
 
-        chunk = indices.chunks[0]
-
     def testArraySplit(self):
         a = arange(8, chunk_size=2)
 

--- a/mars/tensor/expressions/tests/test_core.py
+++ b/mars/tensor/expressions/tests/test_core.py
@@ -32,7 +32,7 @@ from mars.tensor.core import Tensor, SparseTensor, TensorChunk
 from mars.core import build_mode
 from mars.graph import DAG
 from mars.serialize.protos.operand_pb2 import OperandDef
-from mars.tests.core import TestBase, calc_shape
+from mars.tests.core import TestBase
 
 
 class Test(TestBase):
@@ -182,18 +182,14 @@ class Test(TestBase):
         tensor = ones((10, 10, 8), chunk_size=(3, 3, 5))
         tensor.tiles()
         self.assertEqual(tensor.shape, (10, 10, 8))
-        self.assertEqual(calc_shape(tensor), tensor.shape)
         self.assertEqual(len(tensor.chunks), 32)
-        self.assertEqual(calc_shape(tensor.chunks[0]), tensor.chunks[0].shape)
 
         tensor = ones((10, 3), chunk_size=(4, 2))
         tensor.tiles()
         self.assertEqual(tensor.shape, (10, 3))
-        self.assertEqual(calc_shape(tensor), tensor.shape)
 
         chunk = tensor.cix[1, 1]
         self.assertEqual(tensor.get_chunk_slices(chunk.index), (slice(4, 8), slice(2, 3)))
-        self.assertEqual(calc_shape(chunk), chunk.shape)
 
         tensor = ones((10, 5), chunk_size=(2, 3), gpu=True)
         tensor.tiles()
@@ -398,17 +394,14 @@ class Test(TestBase):
         t.tiles()
 
         self.assertEqual(t.shape, (10,))
-        self.assertEqual(calc_shape(t), t.shape)
         self.assertEqual(t.nsplits, ((3, 3, 3, 1),))
         self.assertEqual(t.chunks[1].op.start, 3)
         self.assertEqual(t.chunks[1].op.stop, 6)
-        self.assertEqual(calc_shape(t.chunks[1]), t.chunks[1].shape)
 
         t = arange(0, 10, 3, chunk_size=2)
         t.tiles()
 
         self.assertEqual(t.shape, (4,))
-        self.assertEqual(calc_shape(t), t.shape)
         self.assertEqual(t.nsplits, ((2, 2),))
         self.assertEqual(t.chunks[0].op.start, 0)
         self.assertEqual(t.chunks[0].op.stop, 6)
@@ -416,8 +409,6 @@ class Test(TestBase):
         self.assertEqual(t.chunks[1].op.start, 6)
         self.assertEqual(t.chunks[1].op.stop, 12)
         self.assertEqual(t.chunks[1].op.step, 3)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
-        self.assertEqual(calc_shape(t.chunks[1]), t.chunks[1].shape)
 
         self.assertRaises(TypeError, lambda: arange(10, start=0))
         self.assertRaises(TypeError, lambda: arange(0, 10, stop=0))
@@ -430,72 +421,56 @@ class Test(TestBase):
         t = diag(v)
 
         self.assertEqual(t.shape, (4,))
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.nsplits, ((2, 2),))
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         v = tensor(np.arange(16).reshape(4, 4), chunk_size=(2, 3))
         t = diag(v)
 
         self.assertEqual(t.shape, (4,))
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.nsplits, ((2, 1, 1),))
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         # test 1-d, k == 0
         v = tensor(np.arange(3), chunk_size=2)
         t = diag(v, sparse=True)
 
         self.assertEqual(t.shape, (3, 3))
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.nsplits, ((2, 1), (2, 1)))
         self.assertEqual(len([c for c in t.chunks
                               if c.op.__class__.__name__ == 'TensorDiag']), 2)
         self.assertTrue(t.chunks[0].op.sparse)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         # test 2-d, shape[0] != shape[1]
         v = tensor(np.arange(24).reshape(4, 6), chunk_size=2)
         t = diag(v)
 
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6)).shape)
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         v = tensor(np.arange(24).reshape(4, 6), chunk_size=2)
 
         t = diag(v, k=1)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=1).shape)
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = diag(v, k=2)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=2).shape)
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = diag(v, k=-1)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=-1).shape)
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = diag(v, k=-2)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=-2).shape)
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         # test tiled zeros' keys
         a = arange(5, chunk_size=2)
@@ -508,7 +483,6 @@ class Test(TestBase):
         a = linspace(2.0, 3.0, num=5, chunk_size=2)
 
         self.assertEqual(a.shape, (5,))
-        self.assertEqual(calc_shape(a), a.shape)
 
         a.tiles()
         self.assertEqual(a.nsplits, ((2, 2, 1),))
@@ -518,12 +492,10 @@ class Test(TestBase):
         self.assertEqual(a.chunks[1].op.stop, 2.75)
         self.assertEqual(a.chunks[2].op.start, 3.)
         self.assertEqual(a.chunks[2].op.stop, 3.)
-        self.assertEqual(calc_shape(a.chunks[0]), a.chunks[0].shape)
 
         a = linspace(2.0, 3.0, num=5, endpoint=False, chunk_size=2)
 
         self.assertEqual(a.shape, (5,))
-        self.assertEqual(calc_shape(a), a.shape)
 
         a.tiles()
         self.assertEqual(a.nsplits, ((2, 2, 1),))
@@ -533,7 +505,6 @@ class Test(TestBase):
         self.assertEqual(a.chunks[1].op.stop, 2.6)
         self.assertEqual(a.chunks[2].op.start, 2.8)
         self.assertEqual(a.chunks[2].op.stop, 2.8)
-        self.assertEqual(calc_shape(a.chunks[0]), a.chunks[0].shape)
 
         _, step = linspace(2.0, 3.0, num=5, chunk_size=2, retstep=True)
         self.assertEqual(step, .25)
@@ -543,7 +514,6 @@ class Test(TestBase):
         a = tensor(a_data, chunk_size=2)
 
         t = triu(a)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
@@ -551,10 +521,8 @@ class Test(TestBase):
         self.assertIsInstance(t.chunks[1].op, TensorTriu)
         self.assertIsInstance(t.chunks[2].op, TensorZeros)
         self.assertIsInstance(t.chunks[3].op, TensorTriu)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = triu(a, k=1)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
@@ -562,10 +530,8 @@ class Test(TestBase):
         self.assertIsInstance(t.chunks[1].op, TensorTriu)
         self.assertIsInstance(t.chunks[2].op, TensorZeros)
         self.assertIsInstance(t.chunks[3].op, TensorZeros)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = triu(a, k=2)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
@@ -573,10 +539,8 @@ class Test(TestBase):
         self.assertIsInstance(t.chunks[1].op, TensorTriu)
         self.assertIsInstance(t.chunks[2].op, TensorZeros)
         self.assertIsInstance(t.chunks[3].op, TensorZeros)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = triu(a, k=-1)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
@@ -584,10 +548,8 @@ class Test(TestBase):
         self.assertIsInstance(t.chunks[1].op, TensorTriu)
         self.assertIsInstance(t.chunks[2].op, TensorTriu)
         self.assertIsInstance(t.chunks[3].op, TensorTriu)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = tril(a)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
@@ -595,10 +557,8 @@ class Test(TestBase):
         self.assertIsInstance(t.chunks[1].op, TensorZeros)
         self.assertIsInstance(t.chunks[2].op, TensorTril)
         self.assertIsInstance(t.chunks[3].op, TensorTril)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = tril(a, k=1)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
@@ -606,10 +566,8 @@ class Test(TestBase):
         self.assertIsInstance(t.chunks[1].op, TensorTril)
         self.assertIsInstance(t.chunks[2].op, TensorTril)
         self.assertIsInstance(t.chunks[3].op, TensorTril)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = tril(a, k=-1)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
@@ -617,10 +575,8 @@ class Test(TestBase):
         self.assertIsInstance(t.chunks[1].op, TensorZeros)
         self.assertIsInstance(t.chunks[2].op, TensorTril)
         self.assertIsInstance(t.chunks[3].op, TensorTril)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = tril(a, k=-2)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(len(t.chunks), 4)
@@ -628,7 +584,6 @@ class Test(TestBase):
         self.assertIsInstance(t.chunks[1].op, TensorZeros)
         self.assertIsInstance(t.chunks[2].op, TensorTril)
         self.assertIsInstance(t.chunks[3].op, TensorZeros)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
     def testSetTensorInputs(self):
         t1 = tensor([1, 2], chunk_size=2)
@@ -669,7 +624,6 @@ class Test(TestBase):
         self.assertIsInstance(t.op, CSRMatrixDataSource)
         self.assertTrue(t.issparse())
         self.assertFalse(t.op.gpu)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(t.chunks[0].index, (0, 0))
@@ -680,7 +634,6 @@ class Test(TestBase):
         self.assertTrue(np.array_equal(t.chunks[0].op.indptr, m.indptr))
         self.assertTrue(np.array_equal(t.chunks[0].op.data, m.data))
         self.assertTrue(np.array_equal(t.chunks[0].op.shape, m.shape))
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
     def testFromDense(self):
         t = fromdense(tensor([[0, 0, 1], [1, 0, 0]], chunk_size=2))
@@ -688,12 +641,10 @@ class Test(TestBase):
         self.assertIsInstance(t, SparseTensor)
         self.assertIsInstance(t.op, DenseToSparse)
         self.assertTrue(t.issparse())
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(t.chunks[0].index, (0, 0))
         self.assertIsInstance(t.op, DenseToSparse)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
     def testOnesLike(self):
         t1 = tensor([[0, 0, 1], [1, 0, 0]], chunk_size=2).tosparse()
@@ -702,10 +653,8 @@ class Test(TestBase):
         self.assertIsInstance(t, SparseTensor)
         self.assertIsInstance(t.op, TensorOnesLike)
         self.assertTrue(t.issparse())
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(t.chunks[0].index, (0, 0))
         self.assertIsInstance(t.op, TensorOnesLike)
         self.assertTrue(t.chunks[0].issparse())
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)

--- a/mars/tensor/expressions/tests/test_fft.py
+++ b/mars/tensor/expressions/tests/test_fft.py
@@ -20,7 +20,6 @@ import numpy as np
 
 from mars.tensor.expressions.datasource import ones
 from mars.tensor import fft
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -29,160 +28,125 @@ class Test(unittest.TestCase):
 
         t1 = fft.fft(t)
         self.assertEqual(t1.shape, (10, 20, 30))
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ifft(t)
         self.assertEqual(t1.shape, (10, 20, 30))
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.fft2(t, s=(23, 21))
-        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, (10, 23, 21))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ifft2(t, s=(11, 9), axes=(1, 2))
-        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, (10, 11, 9))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.fftn(t, s=(11, 9), axes=(1, 2))
-        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, (10, 11, 9))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ifftn(t, s=(11, 9), axes=(1, 2))
-        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, (10, 11, 9))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
     def testRealFFT(self):
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.rfft(t)
         self.assertEqual(t1.shape, np.fft.rfft(np.ones(t.shape)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.irfft(t)
         self.assertEqual(t1.shape, np.fft.irfft(np.ones(t.shape)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.rfft2(t, s=(23, 21))
         self.assertEqual(t1.shape, np.fft.rfft2(np.ones(t.shape), s=(23, 21)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.irfft2(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.irfft2(np.ones(t.shape), s=(11, 9), axes=(1, 2)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.rfftn(t, s=(11, 30), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.rfftn(np.ones(t.shape), s=(11, 30), axes=(1, 2)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.irfftn(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.irfftn(np.ones(t.shape), s=(11, 9), axes=(1, 2)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
     def testHermitianFFT(self):
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.hfft(t)
         self.assertEqual(t1.shape, np.fft.hfft(np.ones(t.shape)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.hfft(t, n=100)
         self.assertEqual(t1.shape, np.fft.hfft(np.ones(t.shape), n=100).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ihfft(t)
-        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape)).shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ihfft(t, n=100)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape), n=100).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t1 = fft.ihfft(t, n=101)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape), n=101).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
     def testFFTShift(self):
         freqs = fft.fftfreq(9, d=1./9).reshape(3, 3)
         t = fft.ifftshift(fft.fftshift(freqs))
 
-        self.assertEqual(calc_shape(t), t.shape)
         self.assertIsNotNone(t.dtype)
         expect_dtype = np.fft.ifftshift(np.fft.fftshift(np.fft.fftfreq(9, d=1./9).reshape(3, 3))).dtype
         self.assertEqual(t.dtype, expect_dtype)
@@ -191,15 +155,11 @@ class Test(unittest.TestCase):
         t = fft.fftfreq(10, .1, chunk_size=3)
 
         self.assertEqual(t.shape, np.fft.fftfreq(10, .1).shape)
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.shape, tuple(sum(ns) for ns in t.nsplits))
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = fft.rfftfreq(10, .1, chunk_size=3)
 
         self.assertEqual(t.shape, np.fft.rfftfreq(10, .1).shape)
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.shape, tuple(sum(ns) for ns in t.nsplits))
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)

--- a/mars/tensor/expressions/tests/test_linalg.py
+++ b/mars/tensor/expressions/tests/test_linalg.py
@@ -22,7 +22,6 @@ import scipy.sparse as sps
 import mars.tensor as mt
 from mars.graph import DirectedGraph
 from mars.tensor.core import SparseTensor
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -32,8 +31,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(q.shape, (9, 6))
         self.assertEqual(r.shape, (6, 6))
-        self.assertEqual(calc_shape(q), ((9, 6), (6, 6)))
-        self.assertEqual(calc_shape(r), ((9, 6), (6, 6)))
 
         q.tiles()
 
@@ -41,8 +38,6 @@ class Test(unittest.TestCase):
         self.assertEqual(len(r.chunks), 1)
         self.assertEqual(q.nsplits, ((3, 3, 3), (6,)))
         self.assertEqual(r.nsplits, ((6,), (6,)))
-        self.assertEqual(calc_shape(q.chunks[0]), q.chunks[0].shape)
-        self.assertEqual(calc_shape(r.chunks[0]), ((9, 6), (6, 6)))
 
         # for Short-and-Fat QR
         a = mt.random.rand(6, 18, chunk_size=(6, 6))
@@ -50,17 +45,12 @@ class Test(unittest.TestCase):
 
         self.assertEqual(q.shape, (6, 6))
         self.assertEqual(r.shape, (6, 18))
-        self.assertEqual(calc_shape(q), ((6, 6), (6, 18)))
-        self.assertEqual(calc_shape(r), ((6, 6), (6, 18)))
         q.tiles()
 
         self.assertEqual(len(q.chunks), 1)
         self.assertEqual(len(r.chunks), 3)
         self.assertEqual(q.nsplits, ((6,), (6,)))
         self.assertEqual(r.nsplits, ((6,), (6, 6, 6)))
-        self.assertEqual(calc_shape(q.chunks[0]), ((6, 6), (6, 6)))
-        self.assertEqual(calc_shape(r.chunks[0]), ((6, 6), (6, 6)))
-        self.assertEqual(calc_shape(r.chunks[1]), r.chunks[1].shape)
 
         # chunk width less than height
         a = mt.random.rand(6, 9, chunk_size=(6, 3))
@@ -68,8 +58,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(q.shape, (6, 6))
         self.assertEqual(r.shape, (6, 9))
-        self.assertEqual(calc_shape(q), ((6, 6), (6, 9)))
-        self.assertEqual(calc_shape(r), ((6, 6), (6, 9)))
 
         q.tiles()
 
@@ -77,17 +65,12 @@ class Test(unittest.TestCase):
         self.assertEqual(len(r.chunks), 2)
         self.assertEqual(q.nsplits, ((6,), (6,)))
         self.assertEqual(r.nsplits, ((6,), (6, 3)))
-        self.assertEqual(calc_shape(q.chunks[0]), ((6, 6), (6, 6)))
-        self.assertEqual(calc_shape(r.chunks[0]), ((6, 6), (6, 6)))
-        self.assertEqual(calc_shape(r.chunks[1]), r.chunks[1].shape)
 
         a = mt.random.rand(9, 6, chunk_size=(9, 3))
         q, r = mt.linalg.qr(a, method='sfqr')
 
         self.assertEqual(q.shape, (9, 6))
         self.assertEqual(r.shape, (6, 6))
-        self.assertEqual(calc_shape(q), ((9, 6), (6, 6)))
-        self.assertEqual(calc_shape(r), ((9, 6), (6, 6)))
 
         q.tiles()
 
@@ -95,8 +78,6 @@ class Test(unittest.TestCase):
         self.assertEqual(len(r.chunks), 1)
         self.assertEqual(q.nsplits, ((9,), (6,)))
         self.assertEqual(r.nsplits, ((6,), (6,)))
-        self.assertEqual(calc_shape(q.chunks[0]), ((9, 6), (6, 6)))
-        self.assertEqual(calc_shape(r.chunks[0]), ((9, 6), (6, 6)))
 
     def testNorm(self):
         data = np.random.rand(9, 6)
@@ -110,7 +91,6 @@ class Test(unittest.TestCase):
                         res = mt.linalg.norm(a, ord=ord, axis=axis, keepdims=keepdims)
                         expect_shape = np.linalg.norm(data, ord=ord, axis=axis, keepdims=keepdims).shape
                         self.assertEqual(res.shape, expect_shape)
-                        self.assertEqual(calc_shape(res), expect_shape)
                     except ValueError:
                         continue
 
@@ -121,9 +101,6 @@ class Test(unittest.TestCase):
         self.assertEqual(U.shape, (9, 6))
         self.assertEqual(s.shape, (6,))
         self.assertEqual(V.shape, (6, 6))
-        self.assertEqual(calc_shape(U), ((9, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(s), ((9, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(V), ((9, 6), (6,), (6, 6)))
 
         U.tiles()
         self.assertEqual(len(U.chunks), 3)
@@ -132,9 +109,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(s.ndim, 1)
         self.assertEqual(len(s.chunks[0].index), 1)
-        self.assertEqual(calc_shape(U.chunks[0]), U.chunks[0].shape)
-        self.assertEqual(calc_shape(s.chunks[0]), ((6, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(V.chunks[0]), ((6, 6), (6,), (6, 6)))
 
         a = mt.random.rand(9, 6, chunk_size=(9, 6))
         U, s, V = mt.linalg.svd(a)
@@ -142,17 +116,11 @@ class Test(unittest.TestCase):
         self.assertEqual(U.shape, (9, 6))
         self.assertEqual(s.shape, (6,))
         self.assertEqual(V.shape, (6, 6))
-        self.assertEqual(calc_shape(U), ((9, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(s), ((9, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(V), ((9, 6), (6,), (6, 6)))
 
         U.tiles()
         self.assertEqual(len(U.chunks), 1)
         self.assertEqual(len(s.chunks), 1)
         self.assertEqual(len(V.chunks), 1)
-        self.assertEqual(calc_shape(U.chunks[0]), ((9, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(s.chunks[0]), ((9, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(V.chunks[0]), ((9, 6), (6,), (6, 6)))
 
         self.assertEqual(s.ndim, 1)
         self.assertEqual(len(s.chunks[0].index), 1)
@@ -163,9 +131,6 @@ class Test(unittest.TestCase):
         self.assertEqual(U.shape, (6, 6))
         self.assertEqual(s.shape, (6,))
         self.assertEqual(V.shape, (6, 9))
-        self.assertEqual(calc_shape(U), ((6, 6), (6,), (6, 9)))
-        self.assertEqual(calc_shape(s), ((6, 6), (6,), (6, 9)))
-        self.assertEqual(calc_shape(V), ((6, 6), (6,), (6, 9)))
 
         rs = mt.random.RandomState(1)
         a = rs.rand(9, 6, chunk_size=(3, 6))
@@ -205,13 +170,6 @@ class Test(unittest.TestCase):
         self.assertEqual(l.shape, (6, 6))
         self.assertEqual(u.shape, (6, 6))
         self.assertEqual(p.shape, (6, 6))
-        self.assertEqual(calc_shape(p), p.shape)
-        self.assertEqual(calc_shape(l), l.shape)
-        self.assertEqual(calc_shape(u), u.shape)
-
-        self.assertEqual(calc_shape(p.chunks[0]), p.chunks[0].shape)
-        self.assertEqual(calc_shape(l.chunks[0]), l.chunks[0].shape)
-        self.assertEqual(calc_shape(u.chunks[0]), u.chunks[0].shape)
 
         a = mt.random.randint(1, 10, (6, 6), chunk_size=(3, 2))
         p, l, u = mt.linalg.lu(a)
@@ -281,15 +239,12 @@ class Test(unittest.TestCase):
         x = mt.linalg.solve(a, b).tiles()
 
         self.assertEqual(x.shape, (20, ))
-        self.assertEqual(calc_shape(x), x.shape)
 
         a = mt.random.randint(1, 10, (20, 20), chunk_size=5)
         b = mt.random.randint(1, 10, (20, 3), chunk_size=5)
         x = mt.linalg.solve(a, b).tiles()
 
         self.assertEqual(x.shape, (20, 3))
-        self.assertEqual(calc_shape(x), x.shape)
-        self.assertEqual(calc_shape(x.chunks[0]), x.chunks[0].shape)
 
         a = mt.random.randint(1, 10, (20, 20), chunk_size=12)
         b = mt.random.randint(1, 10, (20, 3))
@@ -304,7 +259,6 @@ class Test(unittest.TestCase):
         x = mt.linalg.solve(a, b).tiles()
 
         self.assertEqual(x.shape, (20, ))
-        self.assertEqual(calc_shape(x), x.shape)
         self.assertTrue(x.op.sparse)
         self.assertTrue(x.chunks[0].op.sparse)
 
@@ -324,8 +278,6 @@ class Test(unittest.TestCase):
         a_inv = mt.linalg.inv(a).tiles()
 
         self.assertEqual(a_inv.shape, (20, 20))
-        self.assertEqual(calc_shape(a_inv), a_inv.shape)
-        self.assertEqual(calc_shape(a_inv.chunks[0]), a_inv.chunks[0].shape)
 
         a = mt.random.randint(1, 10, (20, 20), chunk_size=11)
         a_inv = mt.linalg.inv(a).tiles()
@@ -336,8 +288,6 @@ class Test(unittest.TestCase):
         b = a.T.dot(a)
         b_inv = mt.linalg.inv(b).tiles()
         self.assertEqual(b_inv.shape, (20, 20))
-        self.assertEqual(calc_shape(b_inv), b_inv.shape)
-        self.assertEqual(calc_shape(b_inv.chunks[0]), b_inv.chunks[0].shape)
 
         # test sparse
         data = sps.csr_matrix(np.random.randint(1, 10, (20, 20)))
@@ -345,8 +295,6 @@ class Test(unittest.TestCase):
         a_inv = mt.linalg.inv(a).tiles()
 
         self.assertEqual(a_inv.shape, (20, 20))
-        self.assertEqual(calc_shape(a_inv), a_inv.shape)
-        self.assertEqual(calc_shape(a_inv.chunks[0]), a_inv.chunks[0].shape)
 
         self.assertTrue(a_inv.op.sparse)
         self.assertIsInstance(a_inv, SparseTensor)
@@ -355,8 +303,6 @@ class Test(unittest.TestCase):
         b = a.T.dot(a)
         b_inv = mt.linalg.inv(b).tiles()
         self.assertEqual(b_inv.shape, (20, 20))
-        self.assertEqual(calc_shape(b_inv), b_inv.shape)
-        self.assertEqual(calc_shape(b_inv.chunks[0]), b_inv.chunks[0].shape)
 
         self.assertTrue(b_inv.op.sparse)
         self.assertIsInstance(b_inv, SparseTensor)

--- a/mars/tensor/expressions/tests/test_merge.py
+++ b/mars/tensor/expressions/tests/test_merge.py
@@ -20,7 +20,6 @@ import numpy as np
 
 from mars.tensor.expressions.datasource import ones
 from mars.tensor.expressions.merge import concatenate, stack
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -30,14 +29,12 @@ class Test(unittest.TestCase):
 
         c = concatenate([a, b])
         self.assertEqual(c.shape, (30, 20, 30))
-        self.assertEqual(calc_shape(c), c.shape)
 
         a = ones((10, 20, 30), chunk_size=10)
         b = ones((10, 20, 40), chunk_size=20)
 
         c = concatenate([a, b], axis=-1)
         self.assertEqual(c.shape, (10, 20, 70))
-        self.assertEqual(calc_shape(c), c.shape)
 
         with self.assertRaises(ValueError):
             a = ones((10, 20, 30), chunk_size=10)
@@ -61,37 +58,29 @@ class Test(unittest.TestCase):
         self.assertEqual(c.nsplits, ((5, 5, 10, 10), (5,) * 4, (5,) * 6))
         self.assertEqual(c.cix[0, 0, 0].key, a.cix[0, 0, 0].key)
         self.assertEqual(c.cix[1, 0, 0].key, a.cix[1, 0, 0].key)
-        self.assertEqual(calc_shape(c.cix[0, 0, 0]), c.cix[0, 0, 0].shape)
-        self.assertEqual(calc_shape(c.cix[1, 0, 0]), c.cix[1, 0, 0].shape)
 
     def testStack(self):
         raw_arrs = [ones((3, 4), chunk_size=2) for _ in range(10)]
         arr2 = stack(raw_arrs, axis=0)
 
         self.assertEqual(arr2.shape, (10, 3, 4))
-        self.assertEqual(calc_shape(arr2), arr2.shape)
 
         arr2.tiles()
         self.assertEqual(arr2.nsplits, ((1,) * 10, (2, 1), (2, 2)))
-        self.assertEqual(calc_shape(arr2.chunks[0]), arr2.chunks[0].shape)
 
         arr3 = stack(raw_arrs, axis=1)
 
         self.assertEqual(arr3.shape, (3, 10, 4))
-        self.assertEqual(calc_shape(arr3), arr3.shape)
 
         arr3.tiles()
         self.assertEqual(arr3.nsplits, ((2, 1), (1,) * 10, (2, 2)))
-        self.assertEqual(calc_shape(arr3.chunks[0]), arr3.chunks[0].shape)
 
         arr4 = stack(raw_arrs, axis=2)
-        self.assertEqual(calc_shape(arr4), arr4.shape)
 
         self.assertEqual(arr4.shape, (3, 4, 10))
 
         arr4.tiles()
         self.assertEqual(arr4.nsplits, ((2, 1), (2, 2), (1,) * 10))
-        self.assertEqual(calc_shape(arr4.chunks[0]), arr4.chunks[0].shape)
 
         with self.assertRaises(ValueError):
             raw_arrs2 = [ones((3, 4), chunk_size=2), ones((4, 3), chunk_size=2)]

--- a/mars/tensor/expressions/tests/test_random.py
+++ b/mars/tensor/expressions/tests/test_random.py
@@ -19,7 +19,6 @@ import numpy as np
 from mars.tensor.expressions.random import RandomState, beta, rand, choice, multivariate_normal, randint, randn
 from mars.tensor.expressions.datasource import tensor as from_ndarray
 from mars.tensor.expressions.tests.test_core import TestBase
-from mars.tests.core import calc_shape
 
 
 class Test(TestBase):
@@ -45,49 +44,38 @@ class Test(TestBase):
         arr = beta(1, 2, chunk_size=2).tiles()
 
         self.assertEqual(arr.shape, ())
-        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertEqual(len(arr.chunks), 1)
         self.assertEqual(arr.chunks[0].shape, ())
-        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
         self.assertEqual(arr.chunks[0].op.dtype, np.dtype('f8'))
 
         arr = beta([1, 2], [3, 4], chunk_size=2).tiles()
 
         self.assertEqual(arr.shape, (2,))
-        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertEqual(len(arr.chunks), 1)
         self.assertEqual(arr.chunks[0].shape, (2,))
         self.assertEqual(arr.chunks[0].op.dtype, np.dtype('f8'))
-        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
 
         arr = beta([[2, 3]], from_ndarray([[4, 6], [5, 2]], chunk_size=2),
                    chunk_size=1, size=(3, 2, 2)).tiles()
 
         self.assertEqual(arr.shape, (3, 2, 2))
-        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertEqual(len(arr.chunks), 12)
         self.assertEqual(arr.chunks[0].op.dtype, np.dtype('f8'))
-        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
 
     def testChoice(self):
         t = choice(5, chunk_size=1)
         self.assertEqual(t.shape, ())
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.nsplits, ())
         self.assertEqual(len(t.chunks), 1)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = choice(5, 3, chunk_size=1)
         self.assertEqual(t.shape, (3,))
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.nsplits, ((1, 1, 1),))
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = choice(5, 3, replace=False)
         self.assertEqual(t.shape, (3,))
-        self.assertEqual(calc_shape(t), t.shape)
 
     def testMultivariateNormal(self):
         mean = [0, 0]
@@ -96,7 +84,6 @@ class Test(TestBase):
         t = multivariate_normal(mean, cov, 5000, chunk_size=500)
         self.assertEqual(t.shape, (5000, 2))
         self.assertEqual(t.op.size, (5000,))
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(t.nsplits, ((500,) * 10, (2,)))
@@ -104,20 +91,17 @@ class Test(TestBase):
         c = t.chunks[0]
         self.assertEqual(c.shape, (500, 2))
         self.assertEqual(c.op.size, (500,))
-        self.assertEqual(calc_shape(c), c.shape)
 
     def testRandint(self):
         arr = randint(1, 2, size=(10, 9), dtype='f8', density=.01, chunk_size=2).tiles()
 
         self.assertEqual(arr.shape, (10, 9))
-        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertEqual(len(arr.chunks), 25)
         self.assertEqual(arr.chunks[0].shape, (2, 2))
         self.assertEqual(arr.chunks[0].op.dtype, np.float64)
         self.assertEqual(arr.chunks[0].op.low, 1)
         self.assertEqual(arr.chunks[0].op.high, 2)
         self.assertEqual(arr.chunks[0].op.density, .01)
-        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
 
     def testUnexpectedKey(self):
         with self.assertRaises(ValueError):

--- a/mars/tensor/expressions/tests/test_rechunk.py
+++ b/mars/tensor/expressions/tests/test_rechunk.py
@@ -19,7 +19,6 @@ import unittest
 from mars.tensor.expressions.datasource import ones
 from mars.tensor.expressions.indexing.slice import TensorSlice
 from mars.tensor.expressions.rechunk.rechunk import compute_rechunk
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -49,8 +48,6 @@ class Test(unittest.TestCase):
         new_tensor = tensor.rechunk(3)
         new_tensor.tiles()
 
-        self.assertEqual(calc_shape(new_tensor), new_tensor.shape)
-        self.assertEqual(calc_shape(new_tensor.chunks[0]), new_tensor.chunks[0].shape)
         self.assertEqual(len(new_tensor.chunks), 12)
         self.assertEqual(new_tensor.chunks[0].inputs[0], tensor.chunks[0].data)
         self.assertEqual(len(new_tensor.chunks[1].inputs), 2)

--- a/mars/tensor/expressions/tests/test_reduction.py
+++ b/mars/tensor/expressions/tests/test_reduction.py
@@ -22,7 +22,6 @@ from mars.tensor.expressions.datasource import ones, tensor
 from mars.tensor.expressions.merge import TensorConcatenate
 from mars.tensor.expressions.reduction import all, TensorMean, TensorMeanChunk, TensorMeanCombine, \
     TensorArgmax, TensorArgmaxChunk, TensorArgmaxCombine, TensorArgmin, TensorArgminChunk, TensorArgminCombine
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -37,58 +36,46 @@ class Test(unittest.TestCase):
         for f in [sum, prod, max, min, all, any]:
             res = f(ones((8, 8), chunk_size=8))
             self.assertEqual(res.shape, ())
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3))
             self.assertIsNotNone(res.dtype)
             self.assertEqual(res.shape, ())
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), axis=0)
             self.assertEqual(res.shape, (8,))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), axis=1)
             self.assertEqual(res.shape, (10,))
-            self.assertEqual(calc_shape(res), res.shape)
 
             with self.assertRaises(np.AxisError):
                 f(ones((10, 8), chunk_size=3), axis=2)
 
             res = f(ones((10, 8), chunk_size=3), axis=-1)
             self.assertEqual(res.shape, (10,))
-            self.assertEqual(calc_shape(res), res.shape)
 
             with self.assertRaises(np.AxisError):
                 f(ones((10, 8), chunk_size=3), axis=-3)
 
             res = f(ones((10, 8), chunk_size=3), keepdims=True)
             self.assertEqual(res.shape, (1, 1))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), axis=0, keepdims=True)
             self.assertEqual(res.shape, (1, 8))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
             self.assertEqual(res.shape, (10, 1))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8, 10), chunk_size=3), axis=1)
             self.assertEqual(res.shape, (10, 10))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8, 10), chunk_size=3), axis=1, keepdims=True)
             self.assertEqual(res.shape, (10, 1, 10))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8, 10), chunk_size=3), axis=(0, 2))
             self.assertEqual(res.shape, (8,))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8, 10), chunk_size=3), axis=(0, 2), keepdims=True)
             self.assertEqual(res.shape, (1, 8, 1))
-            self.assertEqual(calc_shape(res), res.shape)
 
     def testMeanReduction(self):
         mean = lambda x, *args, **kwargs: x.mean(*args, **kwargs).tiles()
@@ -102,41 +89,33 @@ class Test(unittest.TestCase):
 
         res = mean(ones((8, 8), chunk_size=8))
         self.assertEqual(res.shape, ())
-        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), axis=0)
         self.assertEqual(res.shape, (8,))
-        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), axis=1)
         self.assertEqual(res.shape, (10,))
-        self.assertEqual(calc_shape(res), res.shape)
 
         with self.assertRaises(np.AxisError):
             mean(ones((10, 8), chunk_size=3), axis=2)
 
         res = mean(ones((10, 8), chunk_size=3), axis=-1)
         self.assertEqual(res.shape, (10,))
-        self.assertEqual(calc_shape(res), res.shape)
 
         with self.assertRaises(np.AxisError):
             mean(ones((10, 8), chunk_size=3), axis=-3)
 
         res = mean(ones((10, 8), chunk_size=3), keepdims=True)
         self.assertEqual(res.shape, (1, 1))
-        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), axis=0, keepdims=True)
         self.assertEqual(res.shape, (1, 8))
-        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
         self.assertEqual(res.shape, (10, 1))
-        self.assertEqual(calc_shape(res), res.shape)
         self.assertIsInstance(res.chunks[0].op, TensorMean)
         self.assertIsInstance(res.chunks[0].inputs[0].op, TensorConcatenate)
         self.assertIsInstance(res.chunks[0].inputs[0].inputs[0].op, TensorMeanChunk)
-        self.assertEqual(calc_shape(res.chunks[0]), res.chunks[0].shape)
 
     def testArgReduction(self):
         argmax = lambda x, *args, **kwargs: x.argmax(*args, **kwargs).tiles()
@@ -145,33 +124,25 @@ class Test(unittest.TestCase):
         res1 = argmax(ones((10, 8, 10), chunk_size=3))
         res2 = argmin(ones((10, 8, 10), chunk_size=3))
         self.assertEqual(res1.shape, ())
-        self.assertEqual(calc_shape(res1), res1.shape)
         self.assertIsNotNone(res1.dtype)
         self.assertEqual(res2.shape, ())
-        self.assertEqual(calc_shape(res2), res2.shape)
         self.assertIsInstance(res1.chunks[0].op, TensorArgmax)
         self.assertIsInstance(res2.chunks[0].op, TensorArgmin)
         self.assertIsInstance(res1.chunks[0].inputs[0].op, TensorConcatenate)
         self.assertIsInstance(res2.chunks[0].inputs[0].op, TensorConcatenate)
         self.assertIsInstance(res1.chunks[0].inputs[0].inputs[0].op, TensorArgmaxCombine)
         self.assertIsInstance(res2.chunks[0].inputs[0].inputs[0].op, TensorArgminCombine)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
-        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         res1 = argmax(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
         res2 = argmin(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
         self.assertEqual(res1.shape, (10, 1))
-        self.assertEqual(calc_shape(res1), res1.shape)
         self.assertEqual(res2.shape, (10, 1))
-        self.assertEqual(calc_shape(res2), res2.shape)
         self.assertIsInstance(res1.chunks[0].op, TensorArgmax)
         self.assertIsInstance(res2.chunks[0].op, TensorArgmin)
         self.assertIsInstance(res1.chunks[0].inputs[0].op, TensorConcatenate)
         self.assertIsInstance(res2.chunks[0].inputs[0].op, TensorConcatenate)
         self.assertIsInstance(res1.chunks[0].inputs[0].inputs[0].op, TensorArgmaxChunk)
         self.assertIsInstance(res2.chunks[0].inputs[0].inputs[0].op, TensorArgminChunk)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
-        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         self.assertRaises(TypeError, lambda: argmax(ones((10, 8, 10), chunk_size=3), axis=(0, 1)))
         self.assertRaises(TypeError, lambda: argmin(ones((10, 8, 10), chunk_size=3), axis=(0, 1)))
@@ -186,30 +157,18 @@ class Test(unittest.TestCase):
         res2 = cumprod(ones((10, 8), chunk_size=3), axis=0)
         self.assertEqual(res1.shape, (10, 8))
         self.assertIsNotNone(res1.dtype)
-        self.assertEqual(calc_shape(res1), res1.shape)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
         self.assertEqual(res2.shape, (10, 8))
         self.assertIsNotNone(res2.dtype)
-        self.assertEqual(calc_shape(res2), res2.shape)
-        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         res1 = cumsum(ones((10, 8, 8), chunk_size=3), axis=1)
         res2 = cumprod(ones((10, 8, 8), chunk_size=3), axis=1)
         self.assertEqual(res1.shape, (10, 8, 8))
-        self.assertEqual(calc_shape(res1), res1.shape)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
         self.assertEqual(res2.shape, (10, 8, 8))
-        self.assertEqual(calc_shape(res2), res2.shape)
-        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         res1 = cumsum(ones((10, 8, 8), chunk_size=3), axis=-2)
         res2 = cumprod(ones((10, 8, 8), chunk_size=3), axis=-2)
         self.assertEqual(res1.shape, (10, 8, 8))
-        self.assertEqual(calc_shape(res1), res1.shape)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
         self.assertEqual(res2.shape, (10, 8, 8))
-        self.assertEqual(calc_shape(res2), res2.shape)
-        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         with self.assertRaises(np.AxisError):
             cumsum(ones((10, 8), chunk_size=3), axis=2)
@@ -228,10 +187,6 @@ class Test(unittest.TestCase):
         res1 = var(ones((10, 8), chunk_size=3), ddof=2)
         self.assertEqual(res1.shape, ())
         self.assertEqual(res1.op.ddof, 2)
-        self.assertEqual(calc_shape(res1), res1.shape)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
 
         res1 = var(ones((10, 8, 8), chunk_size=3), axis=1)
         self.assertEqual(res1.shape, (10, 8))
-        self.assertEqual(calc_shape(res1), res1.shape)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)

--- a/mars/tensor/expressions/tests/test_reshape.py
+++ b/mars/tensor/expressions/tests/test_reshape.py
@@ -17,7 +17,6 @@
 import unittest
 
 from mars.tensor.expressions.datasource import ones
-from mars.tests.core import calc_shape
 from mars.tensor.expressions.reshape.reshape import TensorReshapeMap, TensorReshapeReduce
 
 
@@ -28,8 +27,6 @@ class Test(unittest.TestCase):
 
         b.tiles()
 
-        self.assertEqual(calc_shape(b), b.shape)
-        self.assertEqual(calc_shape(b.chunks[0]), b.chunks[0].shape)
         self.assertEqual(tuple(sum(s) for s in b.nsplits), (10, 600))
 
         a = ones((10, 600), chunk_size=5)
@@ -37,8 +34,6 @@ class Test(unittest.TestCase):
 
         b.tiles()
 
-        self.assertEqual(calc_shape(b), b.shape)
-        self.assertEqual(calc_shape(b.chunks[0]), b.chunks[0].shape)
         self.assertEqual(tuple(sum(s) for s in b.nsplits), (10, 30, 20))
 
         a = ones((10, 600), chunk_size=5)
@@ -46,8 +41,6 @@ class Test(unittest.TestCase):
 
         a.tiles()
 
-        self.assertEqual(calc_shape(b), b.shape)
-        self.assertEqual(calc_shape(b.chunks[0]), b.chunks[0].shape)
         self.assertEqual(tuple(sum(s) for s in a.nsplits), (10, 30, 20))
 
     def testShuffleReshape(self):
@@ -59,7 +52,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(tuple(sum(s) for s in b.nsplits), (27, 31))
         self.assertIsInstance(b.chunks[0].op, TensorReshapeReduce)
-        self.assertEqual(calc_shape(b.chunks[0]), b.chunks[0].shape)
 
         shuffle_map_sample = b.chunks[0].inputs[0].inputs[0]
         self.assertIsInstance(shuffle_map_sample.op, TensorReshapeMap)

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -484,3 +484,9 @@ def get_fuse_op_cls():
     from .fuse import TensorFuseChunk
 
     return TensorFuseChunk
+
+
+def filter_inputs(inputs):
+    from ...core import Base, Entity
+
+    return [inp for inp in inputs if isinstance(inp, (Base, Entity))]

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -261,9 +261,3 @@ def patch_method(method, *args, **kwargs):
                           *args, **kwargs)
     else:
         return mock.patch(method.__module__ + '.' + method.__name__, *args, **kwargs)
-
-
-def calc_shape(tensor):
-    inputs = tensor.inputs or []
-    inputs_shape = tuple(t.shape for t in inputs)
-    return tensor.op.calc_shape(*inputs_shape)


### PR DESCRIPTION
## What do these changes do?

The `calc_shape` method was introduced in #128 to calculate `rough_nbytes` for unknown shape tensors, however `rough_nbytes` was removed in #266 , the `calc_shape` is not used by any module, so they are totally removed now. 

Also removed the `handle_params` method in some special operands and move the logic to `set_inputs` to simplified the operand class.

This PR has two commits, the first one just do some deletions, the second one may need detailed review.

## Related issue number

resolve #438 