### PR TITLE
Avoid shuffle for adding two dataframes whose index and columns are identical

### DIFF
--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import functools
-import operator
 
 from mars.lib.mmh3 import hash as mmh_hash
 
@@ -23,9 +22,8 @@ def hash_index(index, size):
         return mmh_hash(bytes(x)) % size
 
     f = functools.partial(func, size=size)
-    grouped = sorted(index.groupby(index.map(f)).items(),
-                     key=operator.itemgetter(0))
-    return [g[1] for g in grouped]
+    idx_to_grouped = dict(index.groupby(index.map(f)).items())
+    return [idx_to_grouped.get(i, list()) for i in range(size)]
 
 
 def hash_dtypes(dtypes, size):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

If adding two dataframes with same index and columns, shuffle can be avoided. Add more ut for shuffle case.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #428 
