### PR TITLE
[BACKPORT] Remove handle_params and calc_shape in operand class (#443)

### DIFF
--- a/mars/operands/arithmetic.py
+++ b/mars/operands/arithmetic.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from .core import Operand
 from ..core import BaseWithKey
 from .. import opcodes as OperandDef
@@ -59,6 +61,15 @@ class Constant(ElementWise):
     def err(self):
         return getattr(self, '_err', dict())
 
+    def _set_inputs(self, inputs):
+        super(Constant, self)._set_inputs(inputs)
+        inputs_iter = iter(self._inputs)
+
+        if not np.isscalar(self._lhs):
+            self._lhs = next(inputs_iter)
+        if not np.isscalar(self._rhs):
+            self._rhs = next(inputs_iter)
+
 
 class BinOp(ElementWise):
     _lhs = KeyField('lhs')
@@ -92,6 +103,17 @@ class BinOp(ElementWise):
     def err(self):
         return getattr(self, '_err', dict())
 
+    def _set_inputs(self, inputs):
+        super(BinOp, self)._set_inputs(inputs)
+        inputs_iter = iter(self._inputs)
+
+        self._lhs = next(inputs_iter)
+        self._rhs = next(inputs_iter)
+        if getattr(self, '_out', None) is not None:
+            self._out = next(inputs_iter)
+        if getattr(self, '_where', None) is not None:
+            self._where = next(inputs_iter)
+
 
 class UnaryOp(ElementWise):
     _input = KeyField('input')
@@ -119,6 +141,16 @@ class UnaryOp(ElementWise):
     @property
     def err(self):
         return getattr(self, '_err', dict())
+
+    def _set_inputs(self, inputs):
+        super(UnaryOp, self)._set_inputs(inputs)
+        inputs_iter = iter(self._inputs)
+
+        self._input = next(inputs_iter)
+        if getattr(self, '_out', None) is not None:
+            self._out = next(inputs_iter)
+        if getattr(self, '_where', None) is not None:
+            self._where = next(inputs_iter)
 
 
 class Add(BinOp):
@@ -656,6 +688,19 @@ class Modf(ElementWise):
     def casting(self):
         return getattr(self, '_casting', None)
 
+    def _set_inputs(self, inputs):
+        super(Modf, self)._set_inputs(inputs)
+        inputs_iter = iter(self._inputs)
+
+        self._input = next(inputs_iter)
+        if getattr(self, '_out1', None) is not None:
+            self._out1 = next(inputs_iter)
+        if getattr(self, '_out2', None) is not None:
+            self._out2 = next(inputs_iter)
+        if getattr(self, '_where', None) is not None:
+            self._where = next(inputs_iter)
+
+
 
 class Ldexp(BinOp):
     _op_type_ = OperandDef.LDEXP
@@ -697,6 +742,18 @@ class Frexp(ElementWise):
     @property
     def casting(self):
         return getattr(self, '_casting', None)
+
+    def _set_inputs(self, inputs):
+        super(Frexp, self)._set_inputs(inputs)
+        inputs_iter = iter(self._inputs)
+
+        self._input = next(inputs_iter)
+        if getattr(self, '_out1', None) is not None:
+            self._out1 = next(inputs_iter)
+        if getattr(self, '_out2', None) is not None:
+            self._out2 = next(inputs_iter)
+        if getattr(self, '_where', None) is not None:
+            self._where = next(inputs_iter)
 
 
 class Clip(ElementWise):

--- a/mars/tensor/execution/tests/test_arithmetic_execute.py
+++ b/mars/tensor/execution/tests/test_arithmetic_execute.py
@@ -346,6 +346,17 @@ class Test(unittest.TestCase):
         expected = np.clip(a_data, 3, 6)
         self.assertTrue(np.array_equal(res, expected))
 
+        a = tensor(a_data.copy(), chunk_size=3)
+        a_min_data = np.random.randint(1, 10, size=(10,))
+        a_max_data = np.random.randint(1, 10, size=(10,))
+        a_min = tensor(a_min_data)
+        a_max = tensor(a_max_data)
+        clip(a, a_min, a_max, out=a)
+
+        res = self.executor.execute_tensor(a, concat=True)[0]
+        expected = np.clip(a_data, a_min_data, a_max_data)
+        self.assertTrue(np.array_equal(res, expected))
+
         with option_context() as options:
             options.tensor.chunk_size = 3
 

--- a/mars/tensor/expressions/arithmetic/add.py
+++ b/mars/tensor/expressions/arithmetic/add.py
@@ -17,7 +17,7 @@
 import numpy as np
 
 from .... import operands
-from ..utils import infer_dtype, broadcast_shape
+from ..utils import infer_dtype
 from .core import TensorBinOp, TensorConstant, TensorElementWise
 from .utils import arithmetic_operand
 
@@ -91,6 +91,3 @@ def radd(x1, x2, **kwargs):
 class TensorTreeAdd(operands.TreeAdd, TensorElementWise):
     def __init__(self, dtype=None, sparse=False, **kw):
         super(TensorTreeAdd, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
-
-    def calc_shape(self, *inputs_shape):
-        return broadcast_shape(*inputs_shape)

--- a/mars/tensor/expressions/arithmetic/clip.py
+++ b/mars/tensor/expressions/arithmetic/clip.py
@@ -14,93 +14,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 from numbers import Number
 
 import numpy as np
 
 from .... import operands
-from ...core import TENSOR_TYPE, CHUNK_TYPE, Tensor
+from ....core import Base, Entity
+from ...core import Tensor
 from ..utils import broadcast_shape
 from ..datasource import tensor as astensor
-from .core import TensorElementWise
+from .core import TensorElementWise, filter_inputs
 
 
 class TensorClip(operands.Clip, TensorElementWise):
-    @contextlib.contextmanager
-    def _handle_params(self, inputs):
-        inps = inputs[:1]
-        inputs_iter = iter(inputs[1:])
-
-        if getattr(self, '_a', None) is None:
-            # create clip op from beginning
-
-            # a_min
-            has_a_min = False
-            a_min = next(inputs_iter)
-            if a_min is not None and isinstance(a_min, TENSOR_TYPE + CHUNK_TYPE):
-                has_a_min = True
-                inps.append(a_min)
-            else:
-                setattr(self, '_a_min', a_min)
-
-            # a_max
-            has_a_max = False
-            a_max = next(inputs_iter)
-            if a_max is not None and isinstance(a_max, TENSOR_TYPE + CHUNK_TYPE):
-                has_a_max = True
-                inps.append(a_max)
-            else:
-                setattr(self, '_a_max', a_max)
-
-            # out
-            has_out = False
-            out = next(inputs_iter)
-            if out is not None:
-                has_out = True
-                inps.append(out)
-        else:
-            # create clip op from existence
-
-            # a_min
-            raw_a_min = getattr(self, '_a_min', None)
-            has_a_min = raw_a_min is not None and isinstance(raw_a_min, TENSOR_TYPE + CHUNK_TYPE)
-            if has_a_min:
-                a_min = next(inputs_iter)
-                inps.append(a_min)
-
-            # a_max
-            raw_a_max = getattr(self, '_a_max', None)
-            has_a_max = raw_a_max is not None and isinstance(raw_a_max, TENSOR_TYPE + CHUNK_TYPE)
-            if has_a_max:
-                a_max = next(inputs_iter)
-                inps.append(a_max)
-
-            # out
-            has_out = getattr(self, '_out', None) is not None
-            if has_out:
-                out = next(inputs_iter)
-                inps.append(out)
-
-        yield inps
-
-        inputs = getattr(self, '_inputs')
-        inputs_iter = iter(inputs)
-        setattr(self, '_a', next(inputs_iter))
-        if has_a_min:
-            setattr(self, '_a_min', next(inputs_iter))
-        if has_a_max:
-            setattr(self, '_a_max', next(inputs_iter))
-        if has_out:
-            setattr(self, '_out', next(inputs_iter))
-
-    def new_tensors(self, inputs, shape,**kw):
-        with self._handle_params(inputs) as inputs:
-            return super(TensorClip, self).new_tensors(inputs, shape, **kw)
-
-    def new_chunks(self, inputs, shape, **kw):
-        with self._handle_params(inputs) as inputs:
-            return super(TensorClip, self).new_chunks(inputs, shape, **kw)
+    def _set_inputs(self, inputs):
+        super(TensorClip, self)._set_inputs(inputs)
+        inputs_iter = iter(self._inputs)
+        self._a = next(inputs_iter)
+        if isinstance(self._a_min, (Base, Entity)):
+            self._a_min = next(inputs_iter)
+        if isinstance(self._a_max, (Base, Entity)):
+            self._a_max = next(inputs_iter)
+        if getattr(self, '_out', None) is not None:
+            self._out = next(inputs_iter)
 
     def __call__(self, a, a_min, a_max, out=None):
         a = astensor(a)
@@ -117,6 +53,7 @@ class TensorClip(operands.Clip, TensorElementWise):
             if not a_min.issparse():
                 sparse = False
             a_min_dtype = a_min.dtype
+        self._a_min = a_min
 
         if isinstance(a_max, Number):
             if a_max < 0:
@@ -128,25 +65,31 @@ class TensorClip(operands.Clip, TensorElementWise):
             if not a_max.issparse():
                 sparse = False
             a_max_dtype = a_max.dtype
+        self._a_max = a_max
+
+        if out is not None:
+            if isinstance(out, Tensor):
+                self._out = out
+            else:
+                raise TypeError('out should be Tensor object, got {0} instead'.format(type(out)))
 
         dtype = np.result_type(a.dtype, a_min_dtype, a_max_dtype)
         # check broadcast
         shape = broadcast_shape(*[t.shape for t in tensors])
 
         setattr(self, '_sparse', sparse)
-        t = self.new_tensor([a, a_min, a_max, out], shape)
+        inputs = filter_inputs([a, a_min, a_max, out])
+        t = self.new_tensor(inputs, shape)
 
         if out is None:
             setattr(self, '_dtype', dtype)
             return t
 
-        if not isinstance(out, Tensor):
-            raise TypeError('out should be Tensor object, got {0} instead'.format(type(out)))
+        # if `out` is specified, use out's dtype and shape
         out_shape, out_dtype = out.shape, out.dtype
 
-        # if `out` is specified, use out's dtype and shape
         if t.shape != out_shape:
-            t = self.new_tensor([a, a_min, a_max, out], out_shape)
+            t = self.new_tensor(inputs, out_shape)
         setattr(self, '_dtype', out_dtype)
 
         out.data = t.data

--- a/mars/tensor/expressions/base/argwhere.py
+++ b/mars/tensor/expressions/base/argwhere.py
@@ -29,10 +29,6 @@ class TensorArgwhere(Argwhere, TensorOperandMixin):
     def __init__(self, dtype=None, **kw):
         super(TensorArgwhere, self).__init__(_dtype=dtype, **kw)
 
-    def calc_shape(self, *inputs_shape):
-        shape = (np.nan, len(inputs_shape[0]))
-        return shape
-
     def _set_inputs(self, inputs):
         super(TensorArgwhere, self)._set_inputs(inputs)
         self._input = self._inputs[0]

--- a/mars/tensor/expressions/base/astype.py
+++ b/mars/tensor/expressions/base/astype.py
@@ -30,9 +30,6 @@ class TensorAstype(Astype, TensorOperandMixin):
         super(TensorAstype, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, tensor, copy=True):
         t = self.new_tensor([tensor], tensor.shape)
         if copy:

--- a/mars/tensor/expressions/base/broadcast_to.py
+++ b/mars/tensor/expressions/base/broadcast_to.py
@@ -28,9 +28,6 @@ class TensorBroadcastTo(BroadcastTo, TensorOperandMixin):
         super(TensorBroadcastTo, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        return self.outputs[0].shape
-
     def __call__(self, tensor, shape):
         return self.new_tensor([tensor], shape)
 

--- a/mars/tensor/expressions/base/copyto.py
+++ b/mars/tensor/expressions/base/copyto.py
@@ -56,9 +56,6 @@ class TensorCopyTo(CopyTo, TensorOperandMixin):
 
         return src, dst, where
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[1]
-
     def __call__(self, *inputs):
         from ..core import Tensor
 

--- a/mars/tensor/expressions/base/digitize.py
+++ b/mars/tensor/expressions/base/digitize.py
@@ -32,10 +32,6 @@ class TensorDigitize(Digitize, TensorOperandMixin):
         if len(inputs) > 1:
             self._bins = self._inputs[1]
 
-    @classmethod
-    def calc_shape(cls, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, x, bins):
         x = astensor(x)
         inputs = [x]

--- a/mars/tensor/expressions/base/isin.py
+++ b/mars/tensor/expressions/base/isin.py
@@ -33,9 +33,6 @@ class TensorIsIn(IsIn, TensorOperandMixin):
         self._element = self._inputs[0]
         self._test_elements = self._inputs[1]
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, element, test_elements):
         element, test_elements = astensor(element), ravel(astensor(test_elements))
 

--- a/mars/tensor/expressions/base/repeat.py
+++ b/mars/tensor/expressions/base/repeat.py
@@ -37,19 +37,6 @@ class TensorRepeat(Repeat, TensorOperandMixin):
         if len(inputs) > 1:
             self._repeats = self._inputs[1]
 
-    def calc_shape(self, *inputs_shape):
-        ax = self._axis or 0
-        input_shape = (np.prod(inputs_shape[0]),) if self._axis is None else inputs_shape[0]
-        if len(inputs_shape) == 1:
-            repeats = self._repeats
-            if isinstance(repeats, np.ndarray):
-                size = repeats.sum()
-            else:
-                size = input_shape[ax] * repeats
-            return input_shape[:ax] + (size,) + input_shape[ax + 1:]
-        else:
-            return input_shape[:ax] + (np.nan,) + input_shape[ax + 1:]
-
     def __call__(self, a, repeats):
         axis = self._axis
         a = astensor(a)

--- a/mars/tensor/expressions/base/split.py
+++ b/mars/tensor/expressions/base/split.py
@@ -33,9 +33,6 @@ class TensorSplit(Split, TensorOperandMixin):
         if len(self._inputs) > 1:
             self._indices_or_sections = self._inputs[1]
 
-    def calc_shape(self, *inputs_shape):
-        return tuple(out.shape for out in self.outputs)
-
     def __call__(self, a, indices_or_sections, is_split=False):
         axis = self._axis
         size = a.shape[axis]

--- a/mars/tensor/expressions/base/squeeze.py
+++ b/mars/tensor/expressions/base/squeeze.py
@@ -48,9 +48,6 @@ class TensorSqueeze(Squeeze, TensorOperandMixin):
         super(TensorSqueeze, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        return _get_squeeze_shape(inputs_shape[0], self.axis)[0]
-
     def __call__(self, a, shape):
         return self.new_tensor([a], shape)
 

--- a/mars/tensor/expressions/base/swapaxes.py
+++ b/mars/tensor/expressions/base/swapaxes.py
@@ -31,9 +31,6 @@ class TensorSwapAxes(SwapAxes, TensorOperandMixin):
         super(TensorSwapAxes, self).__init__(_axis1=axis1, _axis2=axis2, _dtype=dtype,
                                              _sparse=sparse, **kw)
 
-    def calc_shape(self, *inputs_shape):
-        return _swap(inputs_shape[0], self.axis1, self.axis2)
-
     def __call__(self, a):
         shape = _swap(a.shape, self.axis1, self.axis2)
         return self.new_tensor([a], shape)

--- a/mars/tensor/expressions/base/transpose.py
+++ b/mars/tensor/expressions/base/transpose.py
@@ -32,9 +32,6 @@ class TensorTranspose(Transpose, TensorOperandMixin):
         super(TensorTranspose, self).__init__(_axes=axes, _dtype=dtype,
                                               _sparse=sparse, **kw)
 
-    def calc_shape(self, *inputs_shape):
-        return _reorder(inputs_shape[0], self._axes)
-
     def __call__(self, a):
         shape = _reorder(a.shape, self._axes)
         return self.new_tensor([a], shape)

--- a/mars/tensor/expressions/base/where.py
+++ b/mars/tensor/expressions/base/where.py
@@ -37,9 +37,6 @@ class TensorWhere(Where, TensorOperandMixin):
         self._x = self._inputs[1]
         self._y = self._inputs[2]
 
-    def calc_shape(self, *inputs_shape):
-        return broadcast_shape(inputs_shape[1], inputs_shape[2])
-
     def __call__(self, condition, x, y, shape=None):
         shape = shape or broadcast_shape(x.shape, y.shape)
         return self.new_tensor([condition, x, y], shape)

--- a/mars/tensor/expressions/core.py
+++ b/mars/tensor/expressions/core.py
@@ -122,6 +122,3 @@ class TensorOperandMixin(object):
             raise TypeError('cannot new chunk with more than 1 outputs')
 
         return self.new_tensors(inputs, shape, dtype=dtype, **kw)[0]
-
-    def calc_shape(self, *inputs_shape):
-        raise NotImplementedError

--- a/mars/tensor/expressions/datasource/core.py
+++ b/mars/tensor/expressions/datasource/core.py
@@ -71,9 +71,6 @@ class TensorNoInput(TensorDataSource):
         if inputs and len(inputs) > 0:
             raise ValueError("Tensor data source has no inputs")
 
-    def calc_shape(self, *inputs_shape):
-        return self.outputs[0].shape
-
     def new_chunks(self, inputs, shape, index=None, output_limit=None,
                    kws=None, dtype=None, **kw):
         self.params['shape'] = shape  # set shape to make the operand key different
@@ -121,9 +118,6 @@ class TensorHasInput(TensorDataSource):
         new_op = op.copy()
         return new_op.new_tensors(op.inputs, op.outputs[0].shape, chunks=out_chunks,
                                   nsplits=op.input.nsplits)
-
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
 
     def __call__(self, a):
         return self.new_tensor([a], a.shape)

--- a/mars/tensor/expressions/datasource/diag.py
+++ b/mars/tensor/expressions/datasource/diag.py
@@ -130,14 +130,6 @@ class TensorDiag(TensorDiagBase, TensorHasInput):
         op = TensorDiag(k=chunk_k, dtype=op.dtype, gpu=op.gpu, sparse=op.sparse)
         return op.new_chunk([input_chunk], chunk_shape, index=chunk_idx)
 
-    def calc_shape(self, *inputs_shape):
-        input_shape = inputs_shape[0]
-        k = self._k
-        if len(input_shape) == 1:
-            return (input_shape[0] + abs(k),) * 2
-        else:
-            return _get_diag_shape(input_shape, k)
-
     def __call__(self, v, shape, chunk_size=None):
         return self.new_tensor([v], shape, raw_chunk_size=chunk_size)
 

--- a/mars/tensor/expressions/datastore/core.py
+++ b/mars/tensor/expressions/datastore/core.py
@@ -25,9 +25,6 @@ class TensorDataStore(DataStore, TensorOperandMixin):
         shape = (0,) * a.ndim
         return self.new_tensor([a], shape)
 
-    def calc_shape(self, *inputs_shape):
-        return self.outputs[0].shape
-
     @classmethod
     def _get_out_chunk(cls, op, in_chunk):
         chunk_op = op.copy().reset_key()

--- a/mars/tensor/expressions/fft/core.py
+++ b/mars/tensor/expressions/fft/core.py
@@ -24,9 +24,6 @@ from ..core import TensorOperandMixin
 class TensorFFTBaseMixin(TensorOperandMixin):
     __slots__ = ()
 
-    def calc_shape(self, *inputs_shape):
-        return self._get_shape(self, inputs_shape[0])
-
     @classmethod
     def _get_shape(cls, op, shape):
         raise NotImplementedError
@@ -141,9 +138,6 @@ def validate_fftn(tensor, s=None, axes=None, norm=None):
 
 class TensorFFTShiftMixin(TensorOperandMixin):
     __slots__ = ()
-
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
 
     @classmethod
     def _is_inverse(cls):

--- a/mars/tensor/expressions/fft/fftfreq.py
+++ b/mars/tensor/expressions/fft/fftfreq.py
@@ -30,9 +30,6 @@ class TensorFFTFreq(fftop.FFTFreq, TensorOperandMixin):
         shape = (self.n,)
         return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
 
-    def calc_shape(self, *inputs_shape):
-        return self.n,
-
     @classmethod
     def tile(cls, op):
         tensor = op.outputs[0]
@@ -54,9 +51,6 @@ class TensorFFTFreq(fftop.FFTFreq, TensorOperandMixin):
 class TensorFFTFreqChunk(fftop.FFTFreqChunk, TensorOperandMixin):
     def __init__(self, n=None, d=None, dtype=None, **kw):
         super(TensorFFTFreqChunk, self).__init__(_n=n, _d=d, _dtype=dtype, **kw)
-
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
 
     def _set_inputs(self, inputs):
         super(TensorFFTFreqChunk, self)._set_inputs(inputs)

--- a/mars/tensor/expressions/fft/rfftfreq.py
+++ b/mars/tensor/expressions/fft/rfftfreq.py
@@ -29,9 +29,6 @@ class TensorRFFTFreq(fftop.RFFTFreq, TensorOperandMixin):
         shape = (self.n // 2 + 1,)
         return self.new_tensor(None, shape, raw_chunk_size=chunk_size)
 
-    def calc_shape(self, *inputs_shape):
-        return self.n // 2 + 1,
-
     @classmethod
     def tile(cls, op):
         tensor = op.outputs[0]

--- a/mars/tensor/expressions/fuse/core.py
+++ b/mars/tensor/expressions/fuse/core.py
@@ -23,16 +23,6 @@ class TensorFuseChunk(operands.Fuse, TensorOperandMixin):
     def __init__(self, dtype=None, sparse=False, **kw):
         super(TensorFuseChunk, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
 
-    def calc_shape(self, *inputs_shape):
-        in_shapes = inputs_shape
-        out_shape = None
-
-        # TODO: the logic will be changed when fusion is not only straight line
-        for c in self.outputs[0].composed:
-            out_shape = c.op.calc_shape(*in_shapes)
-            in_shapes = [out_shape]
-        return out_shape
-
     @classmethod
     def tile(cls, op):
         raise NotSupportTile('TensorFuseChunk is a chunk operand which does not support tile')

--- a/mars/tensor/expressions/indexing/choose.py
+++ b/mars/tensor/expressions/indexing/choose.py
@@ -31,9 +31,6 @@ class TensorChoose(Choose, TensorOperandMixin):
         self._a = self._inputs[0]
         self._choices = self._inputs[1:]
 
-    def calc_shape(self, *inputs_shape):
-        return broadcast_shape(inputs_shape[0], *inputs_shape[1:])
-
     def __call__(self, a, choices):
         inputs = [a] + choices
         shape = broadcast_shape(a.shape, *[c.shape for c in choices])

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -17,58 +17,33 @@
 from numbers import Integral
 import operator
 import itertools
-import contextlib
 
 import numpy as np
 
 from ....operands import Index
-from ....core import BaseWithKey, Entity
+from ....core import Entity, Base
 from ....compat import reduce, irange, izip
 from ...core import TENSOR_TYPE
 from ..utils import unify_chunks, split_index_into_chunks, is_asc_sorted, \
-    slice_split, calc_sliced_size
+    slice_split, calc_sliced_size, filter_inputs
 from ..core import TensorOperandMixin
 from .core import process_index, get_index_and_shape
 
 
 class TensorIndex(Index, TensorOperandMixin):
-    def __init__(self, dtype=None, sparse=False, **kw):
-        super(TensorIndex, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
+    def __init__(self, dtype=None, sparse=False, indexes=None, **kw):
+        super(TensorIndex, self).__init__(_dtype=dtype, _sparse=sparse, _indexes=indexes, **kw)
 
-    def calc_shape(self, *inputs_shape):
-        return tuple(get_index_and_shape(inputs_shape[0], self._indexes)[1])
-
-    @contextlib.contextmanager
-    def _handle_params(self, inputs, indexes):
-        """
-        Index operator is special, it has additional parameter `indexes` which may also be tensor type,
-        normally, this indexes is provided when called by `tile` or `TensorIndex.__call__`, however, calls
-        in `GraphActor.get_executable_operand_dag` only provide inputs, in such situation, we need get `indexes`
-        from operand itself and replace tensor-liked indexes by new one in `inputs`.
-        """
-        if indexes is not None:
-            self._indexes = indexes
-            indexes_inputs = [ind for ind in indexes if isinstance(ind, (BaseWithKey, Entity))]
-            inputs = inputs + indexes_inputs
-        yield inputs
-
+    def _set_inputs(self, inputs):
+        super(TensorIndex, self)._set_inputs(inputs)
         inputs_iter = iter(self._inputs[1:])
-        new_indexes = [next(inputs_iter) if isinstance(index, (BaseWithKey, Entity)) else index
+        new_indexes = [next(inputs_iter) if isinstance(index, (Base, Entity)) else index
                        for index in self._indexes]
         self._indexes = new_indexes
 
-    def new_tensors(self, inputs, shape, **kw):
-        indexes = kw.pop('indexes', None)
-        with self._handle_params(inputs, indexes) as mix_inputs:
-            return super(TensorIndex, self).new_tensors(mix_inputs, shape, **kw)
-
-    def new_chunks(self, inputs, shape, **kw):
-        indexes = kw.pop('indexes', None)
-        with self._handle_params(inputs, indexes) as mix_inputs:
-            return super(TensorIndex, self).new_chunks(mix_inputs, shape, **kw)
-
     def __call__(self, a, index, shape):
-        return self.new_tensor([a], shape, indexes=index)
+        self._indexes = index
+        return self.new_tensor(filter_inputs([a] + list(index)), shape)
 
     @classmethod
     def tile(cls, op):
@@ -179,14 +154,16 @@ class TensorIndex(Index, TensorOperandMixin):
 
             chunk_input = in_tensor.cix[tuple(chunk_idx)]
             chunk_op = op.copy().reset_key()
-            chunk = chunk_op.new_chunk([chunk_input], tuple(chunk_shape), indexes=chunk_index, index=output_idx)
+            chunk_op._indexes = chunk_index
+            chunk = chunk_op.new_chunk(filter_inputs([chunk_input] + chunk_index),
+                                       shape=tuple(chunk_shape), index=output_idx)
             out_chunks.append(chunk)
 
         nsplits = [tuple(c.shape[i] for c in out_chunks
                          if all(idx == 0 for j, idx in enumerate(c.index) if j != i))
                    for i in range(len(out_chunks[0].shape))]
         new_op = op.copy().reset_key()
-        tensor = new_op.new_tensor([op.input], tensor.shape, indexes=op.indexes, chunks=out_chunks, nsplits=nsplits)
+        tensor = new_op.new_tensor(op.inputs, tensor.shape, chunks=out_chunks, nsplits=nsplits)
 
         if len(to_concat_axis_index) > 1:
             raise NotImplementedError
@@ -209,14 +186,15 @@ class TensorIndex(Index, TensorOperandMixin):
                 s[axis] = len(output_index)
                 concat_chunk_op = TensorConcatenate(
                     axis=axis, dtype=chunks[0].dtype, sparse=chunks[0].op.sparse)
-                concat_chunk = concat_chunk_op.new_chunk(chunks, tuple(s), index=new_idx)
-                out_chunk_op = TensorIndex(dtype=concat_chunk.dtype, sparse=concat_chunk.op.sparse)
-                out_chunk = out_chunk_op.new_chunk([concat_chunk], tuple(s), indexes=indexobj, index=new_idx)
+                concat_chunk = concat_chunk_op.new_chunk(chunks, shape=tuple(s), index=new_idx)
+                out_chunk_op = TensorIndex(dtype=concat_chunk.dtype, sparse=concat_chunk.op.sparse,
+                                           indexes=indexobj)
+                out_chunk = out_chunk_op.new_chunk(filter_inputs([concat_chunk] + indexobj),
+                                                   shape=tuple(s), index=new_idx)
                 output_chunks.append(out_chunk)
 
             new_op = tensor.op.copy()
-            tensor = new_op.new_tensor([op.input], tuple(output_shape), indexes=op.indexes,
-                                       chunks=output_chunks, nsplits=output_nsplits)
+            tensor = new_op.new_tensor(op.inputs, tuple(output_shape), chunks=output_chunks, nsplits=output_nsplits)
 
         return [tensor]
 
@@ -231,5 +209,5 @@ def _getitem(a, item):
 
     index = process_index(a, item)
     index, shape = get_index_and_shape(a.shape, index)
-    op = TensorIndex(dtype=a.dtype, sparse=a.issparse())
+    op = TensorIndex(dtype=a.dtype, sparse=a.issparse(), indexes=index)
     return op(a, index, tuple(shape))

--- a/mars/tensor/expressions/indexing/nonzero.py
+++ b/mars/tensor/expressions/indexing/nonzero.py
@@ -32,9 +32,6 @@ class TensorNonzero(Nonzero, TensorOperandMixin):
         super(TensorNonzero, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        return np.nan,
-
     def __call__(self, a):
         return ExecutableTuple(self.new_tensors([a], shape=(np.nan,), output_limit=a.ndim))
 

--- a/mars/tensor/expressions/indexing/setitem.py
+++ b/mars/tensor/expressions/indexing/setitem.py
@@ -15,63 +15,36 @@
 # limitations under the License.
 
 from numbers import Integral
-import contextlib
 
 import numpy as np
 
 from ....operands import IndexSetValue
-from ....core import BaseWithKey, Entity
-from ...core import TENSOR_TYPE, CHUNK_TYPE
+from ....core import Base, Entity
+from ...core import TENSOR_TYPE
 from ..core import TensorOperandMixin
+from ..utils import filter_inputs
 from .core import process_index, get_index_and_shape
 from .getitem import TensorIndex
 
 
 class TensorIndexSetValue(IndexSetValue, TensorOperandMixin):
-    def __init__(self, dtype=None, sparse=False, **kw):
-        super(TensorIndexSetValue, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
+    def __init__(self, dtype=None, sparse=False, indexes=None, value=None, **kw):
+        super(TensorIndexSetValue, self).__init__(_dtype=dtype, _sparse=sparse,
+                                                  _indexes=indexes, _value=value, **kw)
 
-    @contextlib.contextmanager
-    def _handle_params(self, inputs, indexes, value):
-        """
-        TensorIndexSetValue operator is like Index operand, it has additional parameter `indexes` and `value`, all of
-        them may be tensor type. As explained in TensorIndex, when indexes and value are not provided, we should get
-        from operand itself and replace tensor-liked objects by iterating over inputs.
-        """
-        if indexes is not None and value is not None:
-            self._indexes = indexes
-            self._value = value
-
-            indexes_inputs = [ind for ind in indexes if isinstance(ind, TENSOR_TYPE + CHUNK_TYPE)]
-            inputs += indexes_inputs
-            if isinstance(value, TENSOR_TYPE + CHUNK_TYPE):
-                inputs += [value]
-        yield inputs
-
+    def _set_inputs(self, inputs):
+        super(TensorIndexSetValue, self)._set_inputs(inputs)
         inputs_iter = iter(self._inputs[1:])
-        new_indexes = [next(inputs_iter) if isinstance(index, (BaseWithKey, Entity)) else index
+        new_indexes = [next(inputs_iter) if isinstance(index, (Base, Entity)) else index
                        for index in self._indexes]
         self._indexes = new_indexes
-        if isinstance(self._value, (BaseWithKey, Entity)):
-            self._value = next(inputs_iter)
-
-    def new_tensors(self, inputs, shape, **kw):
-        indexes = kw.pop('indexes', None)
-        value = kw.pop('value', None)
-        with self._handle_params(inputs, indexes, value) as mix_inputs:
-            return super(TensorIndexSetValue, self).new_tensors(mix_inputs, shape, **kw)
-
-    def new_chunks(self, inputs, shape, **kw):
-        indexes = kw.pop('indexes', None)
-        value = kw.pop('value', None)
-        with self._handle_params(inputs, indexes, value) as mix_inputs:
-            return super(TensorIndexSetValue, self).new_chunks(mix_inputs, shape, **kw)
-
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
+        self._value = next(inputs_iter) if isinstance(self._value, (Base, Entity)) else self._value
 
     def __call__(self, a, index, value):
-        return self.new_tensor([a], a.shape, indexes=index, value=value)
+        inputs = filter_inputs([a] + list(index) + [value])
+        self._indexes = index
+        self._value = value
+        return self.new_tensor(inputs, a.shape)
 
     @classmethod
     def tile(cls, op):
@@ -79,8 +52,9 @@ class TensorIndexSetValue(IndexSetValue, TensorOperandMixin):
         value = op.value
         is_value_tensor = isinstance(value, TENSOR_TYPE)
 
-        index_tensor_op = TensorIndex(dtype=tensor.dtype, sparse=op.sparse)
-        index_tensor = index_tensor_op.new_tensor([op.input], tensor.shape, indexes=op.indexes).single_tiles()
+        index_tensor_op = TensorIndex(dtype=tensor.dtype, sparse=op.sparse, indexes=op.indexes)
+        index_tensor_inputs = filter_inputs([op.input] + op.indexes)
+        index_tensor = index_tensor_op.new_tensor(index_tensor_inputs, tensor.shape).single_tiles()
 
         nsplits = index_tensor.nsplits
         if any(any(np.isnan(ns) for ns in nsplit) for nsplit in nsplits):
@@ -98,14 +72,14 @@ class TensorIndexSetValue(IndexSetValue, TensorOperandMixin):
                 continue
 
             value_chunk = value.cix[index_chunk.index] if is_value_tensor else value
-            chunk_op = op.copy().reset_key()
-            out_chunk = chunk_op.new_chunk([chunk], chunk.shape, indexes=index_chunk.op.indexes,
-                                           value=value_chunk, index=chunk.index)
+            chunk_op = TensorIndexSetValue(dtype=op.dtype, sparse=op.sparse,
+                                           indexes=index_chunk.op.indexes, value=value_chunk)
+            chunk_inputs = filter_inputs([chunk] + index_chunk.op.indexes + [value_chunk])
+            out_chunk = chunk_op.new_chunk(chunk_inputs, shape=chunk.shape, index=chunk.index)
             out_chunks.append(out_chunk)
 
         new_op = op.copy()
-        return new_op.new_tensors([op.input], tensor.shape, indexes=op.indexes, value=op.value,
-                                  chunks=out_chunks, nsplits=op.input.nsplits)
+        return new_op.new_tensors(op.inputs, tensor.shape, chunks=out_chunks, nsplits=op.input.nsplits)
 
 
 def _setitem(a, item, value):
@@ -123,6 +97,6 @@ def _setitem(a, item, value):
     else:
         value = broadcast_to(value, shape).astype(a.dtype)
 
-    op = TensorIndexSetValue(dtype=a.dtype, sparse=a.issparse())
+    op = TensorIndexSetValue(dtype=a.dtype, sparse=a.issparse(), indexes=index, value=value)
     ret = op(a, index, value)
     a.data = ret.data

--- a/mars/tensor/expressions/indexing/slice.py
+++ b/mars/tensor/expressions/indexing/slice.py
@@ -14,33 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-
 from ....operands import Slice
 from ..core import TensorOperandMixin
-from ..utils import calc_sliced_size
 
 
 class TensorSlice(Slice, TensorOperandMixin):
     def __init__(self, slices=None, dtype=None, sparse=False, **kw):
         super(TensorSlice, self).__init__(_slices=slices, _dtype=dtype,
                                           _sparse=sparse, **kw)
-
-    def calc_shape(self, *inputs_shape):
-        input_shape = inputs_shape[0]
-        shape = []
-        idx = 0
-        for s in self._slices:
-            if s is None:
-                shape.append(1)
-            elif isinstance(s, slice):
-                if np.isnan(input_shape[idx]):
-                    shape.append(np.nan)
-                else:
-                    shape.append(calc_sliced_size(input_shape[idx], s))
-                idx += 1
-        shape.extend(list(input_shape[idx:]))
-        return tuple(shape)
 
     def _set_inputs(self, inputs):
         super(TensorSlice, self)._set_inputs(inputs)

--- a/mars/tensor/expressions/indexing/unravel_index.py
+++ b/mars/tensor/expressions/indexing/unravel_index.py
@@ -32,9 +32,6 @@ class TensorUnravelIndex(UnravelIndex, TensorOperandMixin):
         super(TensorUnravelIndex, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, indices):
         kws = [{'pos': i} for i in range(len(self._dims))]
         return ExecutableTuple(self.new_tensors([indices], indices.shape, kws=kws, output_limit=len(kws)))

--- a/mars/tensor/expressions/linalg/cholesky.py
+++ b/mars/tensor/expressions/linalg/cholesky.py
@@ -29,7 +29,7 @@ def _H(chunk):
     trans_op = TensorTranspose(dtype=chunk.dtype)
     c = trans_op.new_chunk([chunk], chunk.shape[::-1], index=chunk.index[::-1])
     conj_op = TensorConj(dtype=c.dtype)
-    return conj_op.new_chunk([c, None, None], c.shape, index=c.index)
+    return conj_op.new_chunk([c], c.shape, index=c.index)
 
 
 class TensorCholesky(operands.Cholesky, TensorOperandMixin):
@@ -39,9 +39,6 @@ class TensorCholesky(operands.Cholesky, TensorOperandMixin):
     def _set_inputs(self, inputs):
         super(TensorCholesky, self)._set_inputs(inputs)
         self._input = self._inputs[0]
-
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
 
     def __call__(self, a):
         return self.new_tensor([a], a.shape)
@@ -85,8 +82,8 @@ class TensorCholesky(operands.Cholesky, TensorOperandMixin):
                         else:
                             s = tree_add(prev_chunks[0].dtype, prev_chunks,
                                          None, prev_chunks[0].shape)
-                        target = TensorSubtract(dtype=tensor.dtype).new_chunk(
-                            [target, s, None, None], target.shape)
+                        target = TensorSubtract(dtype=tensor.dtype, lhs=target, rhs=s).new_chunk(
+                            [target, s], shape=target.shape)
                     lower_chunk = TensorCholesky(lower=True, dtype=tensor.dtype).new_chunk(
                         [target], target.shape, index=(i, j))
                     upper_chunk = _H(lower_chunk)
@@ -106,8 +103,8 @@ class TensorCholesky(operands.Cholesky, TensorOperandMixin):
                         else:
                             s = tree_add(prev_chunks[0].dtype, prev_chunks,
                                          None, prev_chunks[0].shape)
-                        target = TensorSubtract(dtype=tensor.dtype).new_chunk(
-                            [target, s, None, None], target.shape)
+                        target = TensorSubtract(dtype=tensor.dtype, lhs=target, rhs=s).new_chunk(
+                            [target, s], shape=target.shape)
                     upper_chunk = TensorSolveTriangular(lower=True, dtype=tensor.dtype).new_chunk(
                         [lower_chunks[j, j], target], target.shape, index=(j, i))
                     lower_chunk = _H(upper_chunk)

--- a/mars/tensor/expressions/linalg/dot.py
+++ b/mars/tensor/expressions/linalg/dot.py
@@ -25,15 +25,6 @@ class TensorDot(operands.Dot, TensorOperandMixin):
     def __init__(self, dtype=None, sparse=False, **kw):
         super(TensorDot, self).__init__(_dtype=dtype, _sparse=sparse, **kw)
 
-    def calc_shape(self, *inputs_shape):
-        a_shape = inputs_shape[0]
-        b_shape = inputs_shape[1]
-        a_axes = len(a_shape) - 1
-        b_axes = len(b_shape) - 2
-        shape = tuple(s for i, s in enumerate(a_shape) if i != a_axes) + \
-            tuple(s for i, s in enumerate(b_shape) if i != b_axes)
-        return shape
-
     def _set_inputs(self, inputs):
         super(TensorDot, self)._set_inputs(inputs)
         self._a, self._b = self._inputs

--- a/mars/tensor/expressions/linalg/inv.py
+++ b/mars/tensor/expressions/linalg/inv.py
@@ -30,9 +30,6 @@ class TensorInv(operands.Inv, TensorOperandMixin):
         a = astensor(a)
         return self.new_tensor([a], a.shape)
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     @classmethod
     def tile(cls, op):
         """

--- a/mars/tensor/expressions/linalg/lu.py
+++ b/mars/tensor/expressions/linalg/lu.py
@@ -32,9 +32,6 @@ class TensorLU(operands.LU, TensorOperandMixin):
         super(TensorLU, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, a):
         import scipy.linalg
 
@@ -124,8 +121,8 @@ class TensorLU(operands.LU, TensorOperandMixin):
                         else:
                             s = tree_add(prev_chunks_u[0].dtype, prev_chunks_u,
                                          None, prev_chunks_u[0].shape, sparse=op.sparse)
-                        target = TensorSubtract(dtype=U.dtype).new_chunk(
-                            [target, s, None, None], target.shape)
+                        target = TensorSubtract(dtype=U.dtype, lhs=target, rhs=s).new_chunk(
+                            [target, s], shape=target.shape)
                     upper_chunk = TensorSolveTriangular(lower=True, dtype=U.dtype, strict=False,
                                                         sparse=lower_chunks[i, i].op.sparse).new_chunk(
                         [lower_chunks[i, i], target], target.shape, index=(i, j))
@@ -144,8 +141,8 @@ class TensorLU(operands.LU, TensorOperandMixin):
                         else:
                             s = tree_add(prev_chunks[0].dtype, prev_chunks,
                                          None, prev_chunks[0].shape, sparse=op.sparse)
-                        target = TensorSubtract(dtype=L.dtype).new_chunk(
-                            [target, s, None, None], target.shape)
+                        target = TensorSubtract(dtype=L.dtype, lhs=target, rhs=s).new_chunk(
+                            [target, s], shape=target.shape)
                     new_op = TensorLU(dtype=op.dtype, sparse=target.op.sparse)
                     lu_chunks = new_op.new_chunks([target], (target.shape, target.shape, target.shape),
                                                   index=(i, j),
@@ -191,8 +188,8 @@ class TensorLU(operands.LU, TensorOperandMixin):
                         else:
                             s = tree_add(prev_chunks_l[0].dtype, prev_chunks_l,
                                          None, prev_chunks_l[0].shape, sparse=op.sparse)
-                        target_l = TensorSubtract(dtype=L.dtype).new_chunk(
-                            [target_l, s, None, None], target_l.shape)
+                        target_l = TensorSubtract(dtype=L.dtype, lhs=target_l, rhs=s).new_chunk(
+                            [target_l, s], shape=target_l.shape)
                     u = upper_chunks[j, j]
                     a_transpose = TensorTranspose(dtype=u.dtype, sparse=op.sparse).new_chunk([u], u.shape)
                     target_transpose = TensorTranspose(dtype=target_l.dtype, sparse=op.sparse).new_chunk(

--- a/mars/tensor/expressions/linalg/matmul.py
+++ b/mars/tensor/expressions/linalg/matmul.py
@@ -36,12 +36,6 @@ class TensorMatmul(operands.Matmul, TensorOperandMixin):
         self._a = self._inputs[0]
         self._b = self._inputs[1]
 
-    def calc_shape(self, *inputs_shape):
-        a_shape = inputs_shape[0]
-        b_shape = inputs_shape[1]
-        shape = broadcast_shape(a_shape[:-2], b_shape[:-2]) + (a_shape[-2], b_shape[-1])
-        return shape
-
     def __call__(self, a, b, out=None):
         from ..base import broadcast_to
 

--- a/mars/tensor/expressions/linalg/norm.py
+++ b/mars/tensor/expressions/linalg/norm.py
@@ -23,7 +23,6 @@ from .... import operands
 from ..utils import recursive_tile
 from ..core import TensorOperandMixin
 from ..arithmetic import sqrt
-from ..datasource import empty
 from ..datasource import tensor as astensor
 from .svd import svd
 
@@ -36,11 +35,6 @@ class TensorNorm(operands.Norm, TensorOperandMixin):
     def _set_inputs(self, inputs):
         super(TensorNorm, self)._set_inputs(inputs)
         self._input = self._inputs[0]
-
-    def calc_shape(self, *inputs_shape):
-        r = empty(inputs_shape[0], dtype=self.dtype)
-        shape = self._norm(r, self._ord, self._axis, self._keepdims).shape
-        return shape
 
     def __call__(self, x):
         r = x.astype(self.dtype)

--- a/mars/tensor/expressions/linalg/qr.py
+++ b/mars/tensor/expressions/linalg/qr.py
@@ -32,11 +32,6 @@ class TensorQR(operands.QR, TensorOperandMixin):
         super(TensorQR, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        input_shape = inputs_shape[0]
-        x, y = input_shape
-        return (input_shape, (y, y)) if x > y else ((x, x), input_shape)
-
     def __call__(self, a):
         a = astensor(a)
 

--- a/mars/tensor/expressions/linalg/solve_triangular.py
+++ b/mars/tensor/expressions/linalg/solve_triangular.py
@@ -34,11 +34,6 @@ class TensorSolveTriangular(operands.SolveTriangular, TensorOperandMixin):
         super(TensorSolveTriangular, self)._set_inputs(inputs)
         self._a, self._b = self._inputs
 
-    def calc_shape(self, *inputs_shape):
-        a_shape = inputs_shape[0]
-        b_shape = inputs_shape[1]
-        return (a_shape[1],) if len(b_shape) == 1 else (a_shape[1], b_shape[1])
-
     def __call__(self, a, b):
         shape = (a.shape[1],) if len(b.shape) == 1 else (a.shape[1], b.shape[1])
         return self.new_tensor([a, b], shape)
@@ -97,8 +92,8 @@ class TensorSolveTriangular(operands.SolveTriangular, TensorOperandMixin):
                     else:
                         s = tree_add(prev_chunks[0].dtype, prev_chunks,
                                      None, prev_chunks[0].shape, sparse=op.sparse)
-                    target_b = TensorSubtract(dtype=op.dtype).new_chunk(
-                        [target_b, s, None, None], target_b.shape)
+                    target_b = TensorSubtract(dtype=op.dtype, lhs=target_b, rhs=s).new_chunk(
+                        [target_b, s], shape=target_b.shape)
                 out_chunk = TensorSolveTriangular(lower=lower, sparse=op.sparse, dtype=op.dtype).new_chunk(
                     [target_a, target_b], _x_shape(target_a.shape, target_b.shape), index=idx)
                 out_chunks[out_chunk.index] = out_chunk

--- a/mars/tensor/expressions/linalg/svd.py
+++ b/mars/tensor/expressions/linalg/svd.py
@@ -36,18 +36,6 @@ class TensorSVD(operands.SVD, TensorOperandMixin):
         super(TensorSVD, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        x, y = inputs_shape[0]
-        if x > y:
-            U_shape = (x, y)
-            s_shape = (y, )
-            V_shape = (y, y)
-        else:
-            U_shape = (x, x)
-            s_shape = (x, )
-            V_shape = (x, y)
-        return U_shape, s_shape, V_shape
-
     def __call__(self, a):
         a = astensor(a)
 

--- a/mars/tensor/expressions/linalg/tensordot.py
+++ b/mars/tensor/expressions/linalg/tensordot.py
@@ -37,13 +37,6 @@ class TensorTensorDot(operands.TensorDot, TensorOperandMixin):
         self._a = self._inputs[0]
         self._b = self._inputs[1]
 
-    def calc_shape(self, *inputs_shape):
-        a_shape = inputs_shape[0]
-        b_shape = inputs_shape[1]
-        shape = tuple(s for i, s in enumerate(a_shape) if i not in set(self._a_axes)) + \
-            tuple(s for i, s in enumerate(b_shape) if i not in set(self._b_axes))
-        return shape
-
     def __call__(self, a, b):
         shape = tuple(s for i, s in enumerate(a.shape) if i not in set(self._a_axes)) + \
             tuple(s for i, s in enumerate(b.shape) if i not in set(self._b_axes))

--- a/mars/tensor/expressions/merge/concatenate.py
+++ b/mars/tensor/expressions/merge/concatenate.py
@@ -29,14 +29,6 @@ class TensorConcatenate(Concatenate, TensorOperandMixin):
         super(TensorConcatenate, self).__init__(_axis=axis, _dtype=dtype,
                                                 _sparse=sparse, **kw)
 
-    def calc_shape(self, *inputs_shape):
-        inputs_shape = [s for s in inputs_shape if 0 not in s]
-        first_shape = inputs_shape[0]
-        axis = self._axis or 0
-        shape = [0 if i == axis else first_shape[i] for i in range(len(first_shape))]
-        shape[axis] = sum(s[axis] for s in inputs_shape)
-        return tuple(shape)
-
     def __call__(self, tensors):
         if len(set(t.ndim for t in tensors)) != 1:
             raise ValueError('all the input tensors must have same number of dimensions')

--- a/mars/tensor/expressions/merge/stack.py
+++ b/mars/tensor/expressions/merge/stack.py
@@ -29,10 +29,9 @@ class TensorStack(Stack, TensorOperandMixin):
         super(TensorStack, self).__init__(_axis=axis, _dtype=dtype,
                                           _sparse=sparse, **kw)
 
-    def calc_shape(self, *inputs_shape):
-        fisrt_shape = inputs_shape[0]
-        axis = self._axis
-        return fisrt_shape[:axis] + (len(inputs_shape),) + fisrt_shape[axis:]
+    @property
+    def axis(self):
+        return self._axis
 
     def __call__(self, tensors):
         shape = tensors[0].shape[:self._axis] + (len(tensors),) + tensors[0].shape[self._axis:]

--- a/mars/tensor/expressions/random/choice.py
+++ b/mars/tensor/expressions/random/choice.py
@@ -35,10 +35,7 @@ class TensorChoice(operands.Choice, TensorRandomOperandMixin):
         dtype = np.dtype(dtype) if dtype is not None else dtype
         super(TensorChoice, self).__init__(_state=state, _size=size,
                                            _replace=replace, _dtype=dtype, _gpu=gpu, **kw)
-
-    def calc_shape(self, *inputs_shape):
-        return self._size or ()
-
+        
     def __call__(self, a, p, chunk_size=None):
         return self.new_tensor([a, p], None, raw_chunk_size=chunk_size)
 

--- a/mars/tensor/expressions/random/choice.py
+++ b/mars/tensor/expressions/random/choice.py
@@ -35,7 +35,7 @@ class TensorChoice(operands.Choice, TensorRandomOperandMixin):
         dtype = np.dtype(dtype) if dtype is not None else dtype
         super(TensorChoice, self).__init__(_state=state, _size=size,
                                            _replace=replace, _dtype=dtype, _gpu=gpu, **kw)
-        
+
     def __call__(self, a, p, chunk_size=None):
         return self.new_tensor([a, p], None, raw_chunk_size=chunk_size)
 

--- a/mars/tensor/expressions/random/core.py
+++ b/mars/tensor/expressions/random/core.py
@@ -156,9 +156,6 @@ class TensorRandomOperandMixin(TensorOperandMixin):
             shapes.append(getattr(self, '_size'))
         return broadcast_shape(*shapes)
 
-    def calc_shape(self, *inputs_shape):
-        return self._get_shape(list(inputs_shape))
-
     @classmethod
     def _handle_arg(cls, arg, chunk_size):
         if isinstance(arg, (list, np.ndarray)):

--- a/mars/tensor/expressions/random/multivariate_normal.py
+++ b/mars/tensor/expressions/random/multivariate_normal.py
@@ -36,9 +36,6 @@ class TensorMultivariateNormal(operands.MultivariateNormal, TensorRandomOperandM
                                                        _check_valid=check_valid, _tol=tol,
                                                        _state=state, _dtype=dtype, _gpu=gpu, **kw)
 
-    def calc_shape(self, *inputs_shape):
-        return self.outputs[0].shape
-
     def __call__(self, chunk_size=None):
         N = self._mean.size
         if self._size is None:

--- a/mars/tensor/expressions/rechunk/rechunk.py
+++ b/mars/tensor/expressions/rechunk/rechunk.py
@@ -37,9 +37,6 @@ class TensorRechunk(Rechunk, TensorOperandMixin):
         super(TensorRechunk, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        return inputs_shape[0]
-
     def __call__(self, tensor):
         return self.new_tensor([tensor], tensor.shape)
 

--- a/mars/tensor/expressions/reduction/core.py
+++ b/mars/tensor/expressions/reduction/core.py
@@ -34,21 +34,6 @@ class TensorReduction(TensorOperandMixin):
     def _is_cum(cls):
         return False
 
-    def calc_shape(self, *inputs_shape):
-        input_shape = inputs_shape[0]
-        if self._is_cum():
-            return input_shape
-        else:
-            axis = getattr(self, 'axis')
-            keepdims = getattr(self, 'keepdims', None)
-
-            axis = lrange(len(input_shape)) if axis is None else axis
-            if not isinstance(axis, Iterable):
-                axis = (axis,)
-            axis = set(axis)
-            return tuple(s if i not in axis else 1 for i, s in enumerate(input_shape)
-                         if keepdims or i not in axis)
-
     def _call(self, a, out):
         a = astensor(a)
         if out is not None and not isinstance(out, Tensor):

--- a/mars/tensor/expressions/reshape/reshape.py
+++ b/mars/tensor/expressions/reshape/reshape.py
@@ -32,21 +32,6 @@ class TensorReshape(Reshape, TensorOperandMixin):
         super(TensorReshape, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def calc_shape(self, *inputs_shape):
-        newshape = self._newshape
-        known_shape = [s for s in newshape if s >= 0]
-        missing_dim = len(newshape) - len(known_shape)
-        if missing_dim > 1:
-            raise ValueError('can only specify one unknown dimension')
-        elif missing_dim == 1:
-            known_size = np.prod(known_shape)
-            input_size = np.prod(inputs_shape[0])
-            shape = tuple((input_size / known_size) if s < 0 and known_size > 0 else s
-                          for s in newshape)
-            return shape
-        else:
-            return newshape
-
     def __call__(self, a):
         return self.new_tensor([a], self._newshape)
 

--- a/mars/tensor/expressions/tests/test_base.py
+++ b/mars/tensor/expressions/tests/test_base.py
@@ -22,7 +22,6 @@ from mars.tensor.expressions.datasource import ones, tensor, arange, array, asar
 from mars.tensor.expressions.base import transpose, broadcast_to, where, argwhere, array_split, \
     split, squeeze, digitize, result_type, repeat, copyto, isin
 from mars.operands.base import CopyTo
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -55,13 +54,11 @@ class Test(unittest.TestCase):
         self.assertIsInstance(a.op, CopyTo)
         self.assertIs(a.inputs[0], b.data)
         self.assertIsInstance(a.inputs[1].op, tp)
-        self.assertEqual(calc_shape(a), a.shape)
 
         a.tiles()
 
         self.assertIsInstance(a.chunks[0].op, CopyTo)
         self.assertEqual(len(a.chunks[0].inputs), 2)
-        self.assertEqual(calc_shape(a.chunks[0]), a.chunks[0].shape)
 
         a = ones((10, 20), chunk_size=3, dtype='i4')
         b = ones(20, chunk_size=4, dtype='f8')
@@ -73,13 +70,11 @@ class Test(unittest.TestCase):
         copyto(a, b, where=b > 0)
 
         self.assertIsNotNone(a.op.where)
-        self.assertEqual(calc_shape(a), a.shape)
 
         a.tiles()
 
         self.assertIsInstance(a.chunks[0].op, CopyTo)
         self.assertEqual(len(a.chunks[0].inputs), 3)
-        self.assertEqual(calc_shape(a.chunks[0]), a.chunks[0].shape)
 
         with self.assertRaises(ValueError):
             copyto(a, a, where=np.ones(30, dtype='?'))
@@ -91,10 +86,8 @@ class Test(unittest.TestCase):
         arr2.tiles()
 
         self.assertEqual(arr2.shape, (10, 20, 30))
-        self.assertEqual(calc_shape(arr2), arr2.shape)
         self.assertTrue(np.issubdtype(arr2.dtype, np.int32))
         self.assertEqual(arr2.op.casting, 'unsafe')
-        self.assertEqual(calc_shape(arr2.chunks[0]), arr2.chunks[0].shape)
 
         with self.assertRaises(TypeError):
             arr.astype(np.int32, casting='safe')
@@ -106,12 +99,9 @@ class Test(unittest.TestCase):
         arr2.tiles()
 
         self.assertEqual(arr2.shape, (30, 20, 10))
-        self.assertEqual(calc_shape(arr2), arr2.shape)
         self.assertEqual(len(arr2.chunks), 126)
         self.assertEqual(arr2.chunks[0].shape, (5, 3, 4))
         self.assertEqual(arr2.chunks[-1].shape, (5, 2, 2))
-        self.assertEqual(calc_shape(arr2.chunks[0]), arr2.chunks[0].shape)
-        self.assertEqual(calc_shape(arr2.chunks[-1]), arr2.chunks[-1].shape)
 
         with self.assertRaises(ValueError):
             transpose(arr, axes=(1, 0))
@@ -120,34 +110,25 @@ class Test(unittest.TestCase):
         arr3.tiles()
 
         self.assertEqual(arr3.shape, (20, 30, 10))
-        self.assertEqual(calc_shape(arr3), arr3.shape)
         self.assertEqual(len(arr3.chunks), 126)
         self.assertEqual(arr3.chunks[0].shape, (3, 5, 4))
         self.assertEqual(arr3.chunks[-1].shape, (2, 5, 2))
-        self.assertEqual(calc_shape(arr3.chunks[0]), arr3.chunks[0].shape)
-        self.assertEqual(calc_shape(arr3.chunks[-1]), arr3.chunks[-1].shape)
 
         arr4 = arr.transpose(-2, 2, 0)
         arr4.tiles()
 
         self.assertEqual(arr4.shape, (20, 30, 10))
-        self.assertEqual(calc_shape(arr4), arr4.shape)
         self.assertEqual(len(arr4.chunks), 126)
         self.assertEqual(arr4.chunks[0].shape, (3, 5, 4))
         self.assertEqual(arr4.chunks[-1].shape, (2, 5, 2))
-        self.assertEqual(calc_shape(arr4.chunks[0]), arr4.chunks[0].shape)
-        self.assertEqual(calc_shape(arr4.chunks[-1]), arr4.chunks[-1].shape)
 
         arr5 = arr.T
         arr5.tiles()
 
         self.assertEqual(arr5.shape, (30, 20, 10))
-        self.assertEqual(calc_shape(arr5), arr5.shape)
         self.assertEqual(len(arr5.chunks), 126)
         self.assertEqual(arr5.chunks[0].shape, (5, 3, 4))
         self.assertEqual(arr5.chunks[-1].shape, (5, 2, 2))
-        self.assertEqual(calc_shape(arr5.chunks[0]), arr5.chunks[0].shape)
-        self.assertEqual(calc_shape(arr5.chunks[-1]), arr5.chunks[-1].shape)
 
     def testSwapaxes(self):
         arr = ones((10, 20, 30), chunk_size=[4, 3, 5])
@@ -155,9 +136,7 @@ class Test(unittest.TestCase):
         arr2.tiles()
 
         self.assertEqual(arr2.shape, (20, 10, 30))
-        self.assertEqual(calc_shape(arr2), arr2.shape)
         self.assertEqual(len(arr.chunks), len(arr2.chunks))
-        self.assertEqual(calc_shape(arr2.chunks[-1]), arr2.chunks[-1].shape)
 
     def testBroadcastTo(self):
         arr = ones((10, 5), chunk_size=2)
@@ -165,31 +144,25 @@ class Test(unittest.TestCase):
         arr2.tiles()
 
         self.assertEqual(arr2.shape, (20, 10, 5))
-        self.assertEqual(calc_shape(arr2), arr2.shape)
         self.assertEqual(len(arr2.chunks), len(arr.chunks))
         self.assertEqual(arr2.chunks[0].shape, (20, 2, 2))
-        self.assertEqual(calc_shape(arr2.chunks[-1]), arr2.chunks[-1].shape)
 
         arr = ones((10, 5, 1), chunk_size=2)
         arr3 = broadcast_to(arr, (5, 10, 5, 6))
         arr3.tiles()
 
         self.assertEqual(arr3.shape, (5, 10, 5, 6))
-        self.assertEqual(calc_shape(arr3), arr3.shape)
         self.assertEqual(len(arr3.chunks), len(arr.chunks))
         self.assertEqual(arr3.nsplits, ((5,), (2, 2, 2, 2, 2), (2, 2, 1), (6,)))
         self.assertEqual(arr3.chunks[0].shape, (5, 2, 2, 6))
-        self.assertEqual(calc_shape(arr3.chunks[-1]), arr3.chunks[-1].shape)
 
         arr = ones((10, 1), chunk_size=2)
         arr4 = broadcast_to(arr, (20, 10, 5))
         arr4.tiles()
 
         self.assertEqual(arr4.shape, (20, 10, 5))
-        self.assertEqual(calc_shape(arr4), arr4.shape)
         self.assertEqual(len(arr4.chunks), len(arr.chunks))
         self.assertEqual(arr4.chunks[0].shape, (20, 2, 5))
-        self.assertEqual(calc_shape(arr4.chunks[-1]), arr4.chunks[-1].shape)
 
         with self.assertRaises(ValueError):
             broadcast_to(arr, (10,))
@@ -206,7 +179,6 @@ class Test(unittest.TestCase):
         arr.tiles()
 
         self.assertEqual(len(arr.chunks), 4)
-        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertTrue(np.array_equal(arr.chunks[0].inputs[0].op.data, [[True]]))
         self.assertTrue(np.array_equal(arr.chunks[0].inputs[1].op.data, [1]))
         self.assertTrue(np.array_equal(arr.chunks[0].inputs[2].op.data, [3]))
@@ -219,7 +191,6 @@ class Test(unittest.TestCase):
         self.assertTrue(np.array_equal(arr.chunks[3].inputs[0].op.data, [[True]]))
         self.assertTrue(np.array_equal(arr.chunks[3].inputs[1].op.data, [2]))
         self.assertTrue(np.array_equal(arr.chunks[3].inputs[2].op.data, [4]))
-        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
 
         with self.assertRaises(ValueError):
             where(cond, x)
@@ -235,15 +206,10 @@ class Test(unittest.TestCase):
 
         self.assertTrue(np.isnan(indices.shape[0]))
         self.assertEqual(indices.shape[1], 2)
-        self.assertEqual(calc_shape(indices), indices.shape)
 
         indices.tiles()
 
         self.assertEqual(indices.nsplits[1], (1, 1))
-
-        chunk = indices.chunks[0]
-        self.assertTrue(np.isnan(calc_shape(chunk)[0]))
-        self.assertEqual(calc_shape(chunk)[1], chunk.shape[1])
 
     def testArraySplit(self):
         a = arange(8, chunk_size=2)
@@ -251,30 +217,22 @@ class Test(unittest.TestCase):
         splits = array_split(a, 3)
         self.assertEqual(len(splits), 3)
         self.assertEqual([s.shape[0] for s in splits], [3, 3, 2])
-        self.assertTrue(all(calc_shape(s) == ((3,), (3,), (2,)) for s in splits))
 
         splits[0].tiles()
         self.assertEqual(splits[0].nsplits, ((2, 1),))
         self.assertEqual(splits[1].nsplits, ((1, 2),))
         self.assertEqual(splits[2].nsplits, ((2,),))
-        self.assertEqual(calc_shape(splits[0].chunks[0]), splits[0].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[1].chunks[0]), splits[1].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[2].chunks[0]), splits[2].chunks[0].shape)
 
         a = arange(7, chunk_size=2)
 
         splits = array_split(a, 3)
         self.assertEqual(len(splits), 3)
         self.assertEqual([s.shape[0] for s in splits], [3, 2, 2])
-        self.assertTrue(all(calc_shape(s) == ((3,), (2,), (2,)) for s in splits))
 
         splits[0].tiles()
         self.assertEqual(splits[0].nsplits, ((2, 1),))
         self.assertEqual(splits[1].nsplits, ((1, 1),))
         self.assertEqual(splits[2].nsplits, ((1, 1),))
-        self.assertEqual(calc_shape(splits[0].chunks[0]), splits[0].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[1].chunks[0]), splits[1].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[2].chunks[0]), splits[2].chunks[0].shape)
 
     def testSplit(self):
         a = arange(9, chunk_size=2)
@@ -282,15 +240,11 @@ class Test(unittest.TestCase):
         splits = split(a, 3)
         self.assertEqual(len(splits), 3)
         self.assertTrue(all(s.shape == (3,) for s in splits))
-        self.assertTrue(all(calc_shape(s) == ((3,), (3,), (3,)) for s in splits))
 
         splits[0].tiles()
         self.assertEqual(splits[0].nsplits, ((2, 1),))
         self.assertEqual(splits[1].nsplits, ((1, 2),))
         self.assertEqual(splits[2].nsplits, ((2, 1),))
-        self.assertEqual(calc_shape(splits[0].chunks[0]), splits[0].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[1].chunks[0]), splits[1].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[2].chunks[0]), splits[2].chunks[0].shape)
 
         a = arange(8, chunk_size=2)
 
@@ -301,7 +255,6 @@ class Test(unittest.TestCase):
         self.assertEqual(splits[2].shape, (1,))
         self.assertEqual(splits[3].shape, (2,))
         self.assertEqual(splits[4].shape, (0,))
-        self.assertTrue(all(calc_shape(s) == ((3,), (2,), (1,), (2,), (0,)) for s in splits))
 
         splits[0].tiles()
         self.assertEqual(splits[0].nsplits, ((2, 1),))
@@ -309,11 +262,6 @@ class Test(unittest.TestCase):
         self.assertEqual(splits[2].nsplits, ((1,),))
         self.assertEqual(splits[3].nsplits, ((2,),))
         self.assertEqual(splits[4].nsplits, ((0,),))
-        self.assertEqual(calc_shape(splits[0].chunks[0]), splits[0].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[1].chunks[0]), splits[1].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[2].chunks[0]), splits[2].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[3].chunks[0]), splits[3].chunks[0].shape)
-        self.assertEqual(calc_shape(splits[4].chunks[0]), splits[4].chunks[0].shape)
 
     def testSqueeze(self):
         data = np.array([[[0], [1], [2]]])
@@ -322,18 +270,15 @@ class Test(unittest.TestCase):
         t = squeeze(x)
         self.assertEqual(t.shape, (3,))
         self.assertIsNotNone(t.dtype)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t = squeeze(x, axis=0)
         self.assertEqual(t.shape, (3, 1))
-        self.assertEqual(calc_shape(t), t.shape)
 
         with self.assertRaises(ValueError):
             squeeze(x, axis=1)
 
         t = squeeze(x, axis=2)
         self.assertEqual(t.shape, (1, 3))
-        self.assertEqual(calc_shape(t), t.shape)
 
     def testDigitize(self):
         x = tensor(np.array([0.2, 6.4, 3.0, 1.6]), chunk_size=2)
@@ -342,12 +287,10 @@ class Test(unittest.TestCase):
 
         self.assertEqual(inds.shape, (4,))
         self.assertIsNotNone(inds.dtype)
-        self.assertEqual(calc_shape(inds), inds.shape)
 
         inds.tiles()
 
         self.assertEqual(len(inds.chunks), 2)
-        self.assertEqual(calc_shape(inds.chunks[0]), inds.chunks[0].shape)
 
     def testResultType(self):
         x = tensor([2, 3], dtype='i4')
@@ -363,23 +306,18 @@ class Test(unittest.TestCase):
 
         t = repeat(a, 3)
         self.assertEqual(t.shape, (30,))
-        self.assertEqual(calc_shape(t), t.shape)
 
         t = repeat(a, 3, axis=0)
         self.assertEqual(t.shape, (6, 5))
-        self.assertEqual(calc_shape(t), t.shape)
 
         t = repeat(a, 3, axis=1)
         self.assertEqual(t.shape, (2, 15))
-        self.assertEqual(calc_shape(t), t.shape)
 
         t = repeat(a, [3], axis=1)
         self.assertEqual(t.shape, (2, 15))
-        self.assertEqual(calc_shape(t), t.shape)
 
         t = repeat(a, [3, 4], axis=0)
         self.assertEqual(t.shape, (7, 5))
-        self.assertEqual(calc_shape(t), t.shape)
 
         with self.assertRaises(ValueError):
             repeat(a, [3, 4], axis=1)
@@ -389,24 +327,20 @@ class Test(unittest.TestCase):
         t = repeat(a, 3)
         t.tiles()
         self.assertEqual(sum(t.nsplits[0]), 30)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         a = tensor(np.random.randn(100), chunk_size=10)
 
         t = repeat(a, 3)
         t.tiles()
         self.assertEqual(sum(t.nsplits[0]), 300)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         a = tensor(np.random.randn(4))
         b = tensor((4,))
 
         t = repeat(a, b)
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertTrue(np.isnan(t.nsplits[0]))
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
     def testIsIn(self):
         element = 2 * arange(4, chunk_size=1).reshape(2, 2)
@@ -415,14 +349,12 @@ class Test(unittest.TestCase):
         mask = isin(element, test_elements)
         self.assertEqual(mask.shape, (2, 2))
         self.assertEqual(mask.dtype, np.bool_)
-        self.assertEqual(calc_shape(mask), mask.shape)
 
         mask.tiles()
 
         self.assertEqual(len(mask.chunks), len(element.chunks))
         self.assertEqual(len(mask.op.test_elements.chunks), 1)
         self.assertIs(mask.chunks[0].inputs[0], element.chunks[0].data)
-        self.assertEqual(calc_shape(mask.chunks[0]), mask.chunks[0].shape)
 
         element = 2 * arange(4, chunk_size=1).reshape(2, 2)
         test_elements = tensor([1, 2, 4, 8], chunk_size=2)
@@ -430,7 +362,6 @@ class Test(unittest.TestCase):
         mask = isin(element, test_elements, invert=True)
         self.assertEqual(mask.shape, (2, 2))
         self.assertEqual(mask.dtype, np.bool_)
-        self.assertEqual(calc_shape(mask), mask.shape)
 
         mask.tiles()
 
@@ -438,4 +369,3 @@ class Test(unittest.TestCase):
         self.assertEqual(len(mask.op.test_elements.chunks), 1)
         self.assertIs(mask.chunks[0].inputs[0], element.chunks[0].data)
         self.assertTrue(mask.chunks[0].op.invert)
-        self.assertEqual(calc_shape(mask.chunks[0]), mask.chunks[0].shape)

--- a/mars/tensor/expressions/tests/test_fft.py
+++ b/mars/tensor/expressions/tests/test_fft.py
@@ -20,7 +20,6 @@ import numpy as np
 
 from mars.tensor.expressions.datasource import ones
 from mars.tensor import fft
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -29,160 +28,125 @@ class Test(unittest.TestCase):
 
         t1 = fft.fft(t)
         self.assertEqual(t1.shape, (10, 20, 30))
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ifft(t)
         self.assertEqual(t1.shape, (10, 20, 30))
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.fft2(t, s=(23, 21))
-        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, (10, 23, 21))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ifft2(t, s=(11, 9), axes=(1, 2))
-        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, (10, 11, 9))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.fftn(t, s=(11, 9), axes=(1, 2))
-        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, (10, 11, 9))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ifftn(t, s=(11, 9), axes=(1, 2))
-        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, (10, 11, 9))
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
     def testRealFFT(self):
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.rfft(t)
         self.assertEqual(t1.shape, np.fft.rfft(np.ones(t.shape)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.irfft(t)
         self.assertEqual(t1.shape, np.fft.irfft(np.ones(t.shape)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.rfft2(t, s=(23, 21))
         self.assertEqual(t1.shape, np.fft.rfft2(np.ones(t.shape), s=(23, 21)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.irfft2(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.irfft2(np.ones(t.shape), s=(11, 9), axes=(1, 2)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.rfftn(t, s=(11, 30), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.rfftn(np.ones(t.shape), s=(11, 30), axes=(1, 2)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.irfftn(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.irfftn(np.ones(t.shape), s=(11, 9), axes=(1, 2)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
     def testHermitianFFT(self):
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.hfft(t)
         self.assertEqual(t1.shape, np.fft.hfft(np.ones(t.shape)).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.hfft(t, n=100)
         self.assertEqual(t1.shape, np.fft.hfft(np.ones(t.shape), n=100).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ihfft(t)
-        self.assertEqual(calc_shape(t1), t1.shape)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape)).shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft.ihfft(t, n=100)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape), n=100).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
         t1 = fft.ihfft(t, n=101)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape), n=101).shape)
-        self.assertEqual(calc_shape(t1), t1.shape)
         t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
-        self.assertEqual(calc_shape(t1.chunks[0]), t1.chunks[0].shape)
 
     def testFFTShift(self):
         freqs = fft.fftfreq(9, d=1./9).reshape(3, 3)
         t = fft.ifftshift(fft.fftshift(freqs))
 
-        self.assertEqual(calc_shape(t), t.shape)
         self.assertIsNotNone(t.dtype)
         expect_dtype = np.fft.ifftshift(np.fft.fftshift(np.fft.fftfreq(9, d=1./9).reshape(3, 3))).dtype
         self.assertEqual(t.dtype, expect_dtype)
@@ -191,15 +155,11 @@ class Test(unittest.TestCase):
         t = fft.fftfreq(10, .1, chunk_size=3)
 
         self.assertEqual(t.shape, np.fft.fftfreq(10, .1).shape)
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.shape, tuple(sum(ns) for ns in t.nsplits))
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = fft.rfftfreq(10, .1, chunk_size=3)
 
         self.assertEqual(t.shape, np.fft.rfftfreq(10, .1).shape)
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.shape, tuple(sum(ns) for ns in t.nsplits))
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)

--- a/mars/tensor/expressions/tests/test_linalg.py
+++ b/mars/tensor/expressions/tests/test_linalg.py
@@ -22,7 +22,6 @@ import scipy.sparse as sps
 import mars.tensor as mt
 from mars.graph import DirectedGraph
 from mars.tensor.core import SparseTensor
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -32,8 +31,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(q.shape, (9, 6))
         self.assertEqual(r.shape, (6, 6))
-        self.assertEqual(calc_shape(q), ((9, 6), (6, 6)))
-        self.assertEqual(calc_shape(r), ((9, 6), (6, 6)))
 
         q.tiles()
 
@@ -41,8 +38,6 @@ class Test(unittest.TestCase):
         self.assertEqual(len(r.chunks), 1)
         self.assertEqual(q.nsplits, ((3, 3, 3), (6,)))
         self.assertEqual(r.nsplits, ((6,), (6,)))
-        self.assertEqual(calc_shape(q.chunks[0]), q.chunks[0].shape)
-        self.assertEqual(calc_shape(r.chunks[0]), ((9, 6), (6, 6)))
 
         # for Short-and-Fat QR
         a = mt.random.rand(6, 18, chunk_size=(6, 6))
@@ -50,17 +45,12 @@ class Test(unittest.TestCase):
 
         self.assertEqual(q.shape, (6, 6))
         self.assertEqual(r.shape, (6, 18))
-        self.assertEqual(calc_shape(q), ((6, 6), (6, 18)))
-        self.assertEqual(calc_shape(r), ((6, 6), (6, 18)))
         q.tiles()
 
         self.assertEqual(len(q.chunks), 1)
         self.assertEqual(len(r.chunks), 3)
         self.assertEqual(q.nsplits, ((6,), (6,)))
         self.assertEqual(r.nsplits, ((6,), (6, 6, 6)))
-        self.assertEqual(calc_shape(q.chunks[0]), ((6, 6), (6, 6)))
-        self.assertEqual(calc_shape(r.chunks[0]), ((6, 6), (6, 6)))
-        self.assertEqual(calc_shape(r.chunks[1]), r.chunks[1].shape)
 
         # chunk width less than height
         a = mt.random.rand(6, 9, chunk_size=(6, 3))
@@ -68,8 +58,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(q.shape, (6, 6))
         self.assertEqual(r.shape, (6, 9))
-        self.assertEqual(calc_shape(q), ((6, 6), (6, 9)))
-        self.assertEqual(calc_shape(r), ((6, 6), (6, 9)))
 
         q.tiles()
 
@@ -77,17 +65,12 @@ class Test(unittest.TestCase):
         self.assertEqual(len(r.chunks), 2)
         self.assertEqual(q.nsplits, ((6,), (6,)))
         self.assertEqual(r.nsplits, ((6,), (6, 3)))
-        self.assertEqual(calc_shape(q.chunks[0]), ((6, 6), (6, 6)))
-        self.assertEqual(calc_shape(r.chunks[0]), ((6, 6), (6, 6)))
-        self.assertEqual(calc_shape(r.chunks[1]), r.chunks[1].shape)
 
         a = mt.random.rand(9, 6, chunk_size=(9, 3))
         q, r = mt.linalg.qr(a, method='sfqr')
 
         self.assertEqual(q.shape, (9, 6))
         self.assertEqual(r.shape, (6, 6))
-        self.assertEqual(calc_shape(q), ((9, 6), (6, 6)))
-        self.assertEqual(calc_shape(r), ((9, 6), (6, 6)))
 
         q.tiles()
 
@@ -95,8 +78,6 @@ class Test(unittest.TestCase):
         self.assertEqual(len(r.chunks), 1)
         self.assertEqual(q.nsplits, ((9,), (6,)))
         self.assertEqual(r.nsplits, ((6,), (6,)))
-        self.assertEqual(calc_shape(q.chunks[0]), ((9, 6), (6, 6)))
-        self.assertEqual(calc_shape(r.chunks[0]), ((9, 6), (6, 6)))
 
     def testNorm(self):
         data = np.random.rand(9, 6)
@@ -110,7 +91,6 @@ class Test(unittest.TestCase):
                         res = mt.linalg.norm(a, ord=ord, axis=axis, keepdims=keepdims)
                         expect_shape = np.linalg.norm(data, ord=ord, axis=axis, keepdims=keepdims).shape
                         self.assertEqual(res.shape, expect_shape)
-                        self.assertEqual(calc_shape(res), expect_shape)
                     except ValueError:
                         continue
 
@@ -121,9 +101,6 @@ class Test(unittest.TestCase):
         self.assertEqual(U.shape, (9, 6))
         self.assertEqual(s.shape, (6,))
         self.assertEqual(V.shape, (6, 6))
-        self.assertEqual(calc_shape(U), ((9, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(s), ((9, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(V), ((9, 6), (6,), (6, 6)))
 
         U.tiles()
         self.assertEqual(len(U.chunks), 3)
@@ -132,9 +109,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(s.ndim, 1)
         self.assertEqual(len(s.chunks[0].index), 1)
-        self.assertEqual(calc_shape(U.chunks[0]), U.chunks[0].shape)
-        self.assertEqual(calc_shape(s.chunks[0]), ((6, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(V.chunks[0]), ((6, 6), (6,), (6, 6)))
 
         a = mt.random.rand(9, 6, chunk_size=(9, 6))
         U, s, V = mt.linalg.svd(a)
@@ -142,17 +116,11 @@ class Test(unittest.TestCase):
         self.assertEqual(U.shape, (9, 6))
         self.assertEqual(s.shape, (6,))
         self.assertEqual(V.shape, (6, 6))
-        self.assertEqual(calc_shape(U), ((9, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(s), ((9, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(V), ((9, 6), (6,), (6, 6)))
 
         U.tiles()
         self.assertEqual(len(U.chunks), 1)
         self.assertEqual(len(s.chunks), 1)
         self.assertEqual(len(V.chunks), 1)
-        self.assertEqual(calc_shape(U.chunks[0]), ((9, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(s.chunks[0]), ((9, 6), (6,), (6, 6)))
-        self.assertEqual(calc_shape(V.chunks[0]), ((9, 6), (6,), (6, 6)))
 
         self.assertEqual(s.ndim, 1)
         self.assertEqual(len(s.chunks[0].index), 1)
@@ -163,9 +131,6 @@ class Test(unittest.TestCase):
         self.assertEqual(U.shape, (6, 6))
         self.assertEqual(s.shape, (6,))
         self.assertEqual(V.shape, (6, 9))
-        self.assertEqual(calc_shape(U), ((6, 6), (6,), (6, 9)))
-        self.assertEqual(calc_shape(s), ((6, 6), (6,), (6, 9)))
-        self.assertEqual(calc_shape(V), ((6, 6), (6,), (6, 9)))
 
         rs = mt.random.RandomState(1)
         a = rs.rand(9, 6, chunk_size=(3, 6))
@@ -205,13 +170,6 @@ class Test(unittest.TestCase):
         self.assertEqual(l.shape, (6, 6))
         self.assertEqual(u.shape, (6, 6))
         self.assertEqual(p.shape, (6, 6))
-        self.assertEqual(calc_shape(p), p.shape)
-        self.assertEqual(calc_shape(l), l.shape)
-        self.assertEqual(calc_shape(u), u.shape)
-
-        self.assertEqual(calc_shape(p.chunks[0]), p.chunks[0].shape)
-        self.assertEqual(calc_shape(l.chunks[0]), l.chunks[0].shape)
-        self.assertEqual(calc_shape(u.chunks[0]), u.chunks[0].shape)
 
         a = mt.random.randint(1, 10, (6, 6), chunk_size=(3, 2))
         p, l, u = mt.linalg.lu(a)
@@ -281,15 +239,12 @@ class Test(unittest.TestCase):
         x = mt.linalg.solve(a, b).tiles()
 
         self.assertEqual(x.shape, (20, ))
-        self.assertEqual(calc_shape(x), x.shape)
 
         a = mt.random.randint(1, 10, (20, 20), chunk_size=5)
         b = mt.random.randint(1, 10, (20, 3), chunk_size=5)
         x = mt.linalg.solve(a, b).tiles()
 
         self.assertEqual(x.shape, (20, 3))
-        self.assertEqual(calc_shape(x), x.shape)
-        self.assertEqual(calc_shape(x.chunks[0]), x.chunks[0].shape)
 
         a = mt.random.randint(1, 10, (20, 20), chunk_size=12)
         b = mt.random.randint(1, 10, (20, 3))
@@ -304,7 +259,6 @@ class Test(unittest.TestCase):
         x = mt.linalg.solve(a, b).tiles()
 
         self.assertEqual(x.shape, (20, ))
-        self.assertEqual(calc_shape(x), x.shape)
         self.assertTrue(x.op.sparse)
         self.assertTrue(x.chunks[0].op.sparse)
 
@@ -324,8 +278,6 @@ class Test(unittest.TestCase):
         a_inv = mt.linalg.inv(a).tiles()
 
         self.assertEqual(a_inv.shape, (20, 20))
-        self.assertEqual(calc_shape(a_inv), a_inv.shape)
-        self.assertEqual(calc_shape(a_inv.chunks[0]), a_inv.chunks[0].shape)
 
         a = mt.random.randint(1, 10, (20, 20), chunk_size=11)
         a_inv = mt.linalg.inv(a).tiles()
@@ -336,8 +288,6 @@ class Test(unittest.TestCase):
         b = a.T.dot(a)
         b_inv = mt.linalg.inv(b).tiles()
         self.assertEqual(b_inv.shape, (20, 20))
-        self.assertEqual(calc_shape(b_inv), b_inv.shape)
-        self.assertEqual(calc_shape(b_inv.chunks[0]), b_inv.chunks[0].shape)
 
         # test sparse
         data = sps.csr_matrix(np.random.randint(1, 10, (20, 20)))
@@ -345,8 +295,6 @@ class Test(unittest.TestCase):
         a_inv = mt.linalg.inv(a).tiles()
 
         self.assertEqual(a_inv.shape, (20, 20))
-        self.assertEqual(calc_shape(a_inv), a_inv.shape)
-        self.assertEqual(calc_shape(a_inv.chunks[0]), a_inv.chunks[0].shape)
 
         self.assertTrue(a_inv.op.sparse)
         self.assertIsInstance(a_inv, SparseTensor)
@@ -355,8 +303,6 @@ class Test(unittest.TestCase):
         b = a.T.dot(a)
         b_inv = mt.linalg.inv(b).tiles()
         self.assertEqual(b_inv.shape, (20, 20))
-        self.assertEqual(calc_shape(b_inv), b_inv.shape)
-        self.assertEqual(calc_shape(b_inv.chunks[0]), b_inv.chunks[0].shape)
 
         self.assertTrue(b_inv.op.sparse)
         self.assertIsInstance(b_inv, SparseTensor)

--- a/mars/tensor/expressions/tests/test_merge.py
+++ b/mars/tensor/expressions/tests/test_merge.py
@@ -20,7 +20,6 @@ import numpy as np
 
 from mars.tensor.expressions.datasource import ones
 from mars.tensor.expressions.merge import concatenate, stack
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -30,14 +29,12 @@ class Test(unittest.TestCase):
 
         c = concatenate([a, b])
         self.assertEqual(c.shape, (30, 20, 30))
-        self.assertEqual(calc_shape(c), c.shape)
 
         a = ones((10, 20, 30), chunk_size=10)
         b = ones((10, 20, 40), chunk_size=20)
 
         c = concatenate([a, b], axis=-1)
         self.assertEqual(c.shape, (10, 20, 70))
-        self.assertEqual(calc_shape(c), c.shape)
 
         with self.assertRaises(ValueError):
             a = ones((10, 20, 30), chunk_size=10)
@@ -61,37 +58,29 @@ class Test(unittest.TestCase):
         self.assertEqual(c.nsplits, ((5, 5, 10, 10), (5,) * 4, (5,) * 6))
         self.assertEqual(c.cix[0, 0, 0].key, a.cix[0, 0, 0].key)
         self.assertEqual(c.cix[1, 0, 0].key, a.cix[1, 0, 0].key)
-        self.assertEqual(calc_shape(c.cix[0, 0, 0]), c.cix[0, 0, 0].shape)
-        self.assertEqual(calc_shape(c.cix[1, 0, 0]), c.cix[1, 0, 0].shape)
 
     def testStack(self):
         raw_arrs = [ones((3, 4), chunk_size=2) for _ in range(10)]
         arr2 = stack(raw_arrs, axis=0)
 
         self.assertEqual(arr2.shape, (10, 3, 4))
-        self.assertEqual(calc_shape(arr2), arr2.shape)
 
         arr2.tiles()
         self.assertEqual(arr2.nsplits, ((1,) * 10, (2, 1), (2, 2)))
-        self.assertEqual(calc_shape(arr2.chunks[0]), arr2.chunks[0].shape)
 
         arr3 = stack(raw_arrs, axis=1)
 
         self.assertEqual(arr3.shape, (3, 10, 4))
-        self.assertEqual(calc_shape(arr3), arr3.shape)
 
         arr3.tiles()
         self.assertEqual(arr3.nsplits, ((2, 1), (1,) * 10, (2, 2)))
-        self.assertEqual(calc_shape(arr3.chunks[0]), arr3.chunks[0].shape)
 
         arr4 = stack(raw_arrs, axis=2)
-        self.assertEqual(calc_shape(arr4), arr4.shape)
 
         self.assertEqual(arr4.shape, (3, 4, 10))
 
         arr4.tiles()
         self.assertEqual(arr4.nsplits, ((2, 1), (2, 2), (1,) * 10))
-        self.assertEqual(calc_shape(arr4.chunks[0]), arr4.chunks[0].shape)
 
         with self.assertRaises(ValueError):
             raw_arrs2 = [ones((3, 4), chunk_size=2), ones((4, 3), chunk_size=2)]

--- a/mars/tensor/expressions/tests/test_random.py
+++ b/mars/tensor/expressions/tests/test_random.py
@@ -19,7 +19,6 @@ import numpy as np
 from mars.tensor.expressions.random import RandomState, beta, rand, choice, multivariate_normal, randint, randn
 from mars.tensor.expressions.datasource import tensor as from_ndarray
 from mars.tensor.expressions.tests.test_core import TestBase
-from mars.tests.core import calc_shape
 
 
 class Test(TestBase):
@@ -45,49 +44,38 @@ class Test(TestBase):
         arr = beta(1, 2, chunk_size=2).tiles()
 
         self.assertEqual(arr.shape, ())
-        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertEqual(len(arr.chunks), 1)
         self.assertEqual(arr.chunks[0].shape, ())
-        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
         self.assertEqual(arr.chunks[0].op.dtype, np.dtype('f8'))
 
         arr = beta([1, 2], [3, 4], chunk_size=2).tiles()
 
         self.assertEqual(arr.shape, (2,))
-        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertEqual(len(arr.chunks), 1)
         self.assertEqual(arr.chunks[0].shape, (2,))
         self.assertEqual(arr.chunks[0].op.dtype, np.dtype('f8'))
-        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
 
         arr = beta([[2, 3]], from_ndarray([[4, 6], [5, 2]], chunk_size=2),
                    chunk_size=1, size=(3, 2, 2)).tiles()
 
         self.assertEqual(arr.shape, (3, 2, 2))
-        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertEqual(len(arr.chunks), 12)
         self.assertEqual(arr.chunks[0].op.dtype, np.dtype('f8'))
-        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
 
     def testChoice(self):
         t = choice(5, chunk_size=1)
         self.assertEqual(t.shape, ())
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.nsplits, ())
         self.assertEqual(len(t.chunks), 1)
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = choice(5, 3, chunk_size=1)
         self.assertEqual(t.shape, (3,))
-        self.assertEqual(calc_shape(t), t.shape)
         t.tiles()
         self.assertEqual(t.nsplits, ((1, 1, 1),))
-        self.assertEqual(calc_shape(t.chunks[0]), t.chunks[0].shape)
 
         t = choice(5, 3, replace=False)
         self.assertEqual(t.shape, (3,))
-        self.assertEqual(calc_shape(t), t.shape)
 
     def testMultivariateNormal(self):
         mean = [0, 0]
@@ -96,7 +84,6 @@ class Test(TestBase):
         t = multivariate_normal(mean, cov, 5000, chunk_size=500)
         self.assertEqual(t.shape, (5000, 2))
         self.assertEqual(t.op.size, (5000,))
-        self.assertEqual(calc_shape(t), t.shape)
 
         t.tiles()
         self.assertEqual(t.nsplits, ((500,) * 10, (2,)))
@@ -104,20 +91,17 @@ class Test(TestBase):
         c = t.chunks[0]
         self.assertEqual(c.shape, (500, 2))
         self.assertEqual(c.op.size, (500,))
-        self.assertEqual(calc_shape(c), c.shape)
 
     def testRandint(self):
         arr = randint(1, 2, size=(10, 9), dtype='f8', density=.01, chunk_size=2).tiles()
 
         self.assertEqual(arr.shape, (10, 9))
-        self.assertEqual(calc_shape(arr), arr.shape)
         self.assertEqual(len(arr.chunks), 25)
         self.assertEqual(arr.chunks[0].shape, (2, 2))
         self.assertEqual(arr.chunks[0].op.dtype, np.float64)
         self.assertEqual(arr.chunks[0].op.low, 1)
         self.assertEqual(arr.chunks[0].op.high, 2)
         self.assertEqual(arr.chunks[0].op.density, .01)
-        self.assertEqual(calc_shape(arr.chunks[0]), arr.chunks[0].shape)
 
     def testUnexpectedKey(self):
         with self.assertRaises(ValueError):

--- a/mars/tensor/expressions/tests/test_rechunk.py
+++ b/mars/tensor/expressions/tests/test_rechunk.py
@@ -19,7 +19,6 @@ import unittest
 from mars.tensor.expressions.datasource import ones
 from mars.tensor.expressions.indexing.slice import TensorSlice
 from mars.tensor.expressions.rechunk.rechunk import compute_rechunk
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -49,8 +48,6 @@ class Test(unittest.TestCase):
         new_tensor = tensor.rechunk(3)
         new_tensor.tiles()
 
-        self.assertEqual(calc_shape(new_tensor), new_tensor.shape)
-        self.assertEqual(calc_shape(new_tensor.chunks[0]), new_tensor.chunks[0].shape)
         self.assertEqual(len(new_tensor.chunks), 12)
         self.assertEqual(new_tensor.chunks[0].inputs[0], tensor.chunks[0].data)
         self.assertEqual(len(new_tensor.chunks[1].inputs), 2)

--- a/mars/tensor/expressions/tests/test_reduction.py
+++ b/mars/tensor/expressions/tests/test_reduction.py
@@ -22,7 +22,6 @@ from mars.tensor.expressions.datasource import ones, tensor
 from mars.operands import MeanCombine, MeanChunk, Mean, Concatenate, Argmax, Argmin,\
     ArgmaxChunk, ArgmaxCombine, ArgminChunk, ArgminCombine
 from mars.tensor.expressions.reduction import all
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -37,58 +36,46 @@ class Test(unittest.TestCase):
         for f in [sum, prod, max, min, all, any]:
             res = f(ones((8, 8), chunk_size=8))
             self.assertEqual(res.shape, ())
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3))
             self.assertIsNotNone(res.dtype)
             self.assertEqual(res.shape, ())
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), axis=0)
             self.assertEqual(res.shape, (8,))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), axis=1)
             self.assertEqual(res.shape, (10,))
-            self.assertEqual(calc_shape(res), res.shape)
 
             with self.assertRaises(np.AxisError):
                 f(ones((10, 8), chunk_size=3), axis=2)
 
             res = f(ones((10, 8), chunk_size=3), axis=-1)
             self.assertEqual(res.shape, (10,))
-            self.assertEqual(calc_shape(res), res.shape)
 
             with self.assertRaises(np.AxisError):
                 f(ones((10, 8), chunk_size=3), axis=-3)
 
             res = f(ones((10, 8), chunk_size=3), keepdims=True)
             self.assertEqual(res.shape, (1, 1))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), axis=0, keepdims=True)
             self.assertEqual(res.shape, (1, 8))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
             self.assertEqual(res.shape, (10, 1))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8, 10), chunk_size=3), axis=1)
             self.assertEqual(res.shape, (10, 10))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8, 10), chunk_size=3), axis=1, keepdims=True)
             self.assertEqual(res.shape, (10, 1, 10))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8, 10), chunk_size=3), axis=(0, 2))
             self.assertEqual(res.shape, (8,))
-            self.assertEqual(calc_shape(res), res.shape)
 
             res = f(ones((10, 8, 10), chunk_size=3), axis=(0, 2), keepdims=True)
             self.assertEqual(res.shape, (1, 8, 1))
-            self.assertEqual(calc_shape(res), res.shape)
 
     def testMeanReduction(self):
         mean = lambda x, *args, **kwargs: x.mean(*args, **kwargs).tiles()
@@ -102,41 +89,33 @@ class Test(unittest.TestCase):
 
         res = mean(ones((8, 8), chunk_size=8))
         self.assertEqual(res.shape, ())
-        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), axis=0)
         self.assertEqual(res.shape, (8,))
-        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), axis=1)
         self.assertEqual(res.shape, (10,))
-        self.assertEqual(calc_shape(res), res.shape)
 
         with self.assertRaises(np.AxisError):
             mean(ones((10, 8), chunk_size=3), axis=2)
 
         res = mean(ones((10, 8), chunk_size=3), axis=-1)
         self.assertEqual(res.shape, (10,))
-        self.assertEqual(calc_shape(res), res.shape)
 
         with self.assertRaises(np.AxisError):
             mean(ones((10, 8), chunk_size=3), axis=-3)
 
         res = mean(ones((10, 8), chunk_size=3), keepdims=True)
         self.assertEqual(res.shape, (1, 1))
-        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), axis=0, keepdims=True)
         self.assertEqual(res.shape, (1, 8))
-        self.assertEqual(calc_shape(res), res.shape)
 
         res = mean(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
         self.assertEqual(res.shape, (10, 1))
-        self.assertEqual(calc_shape(res), res.shape)
         self.assertIsInstance(res.chunks[0].op, Mean)
         self.assertIsInstance(res.chunks[0].inputs[0].op, Concatenate)
         self.assertIsInstance(res.chunks[0].inputs[0].inputs[0].op, MeanChunk)
-        self.assertEqual(calc_shape(res.chunks[0]), res.chunks[0].shape)
 
     def testArgReduction(self):
         argmax = lambda x, *args, **kwargs: x.argmax(*args, **kwargs).tiles()
@@ -145,33 +124,25 @@ class Test(unittest.TestCase):
         res1 = argmax(ones((10, 8, 10), chunk_size=3))
         res2 = argmin(ones((10, 8, 10), chunk_size=3))
         self.assertEqual(res1.shape, ())
-        self.assertEqual(calc_shape(res1), res1.shape)
         self.assertIsNotNone(res1.dtype)
         self.assertEqual(res2.shape, ())
-        self.assertEqual(calc_shape(res2), res2.shape)
         self.assertIsInstance(res1.chunks[0].op, Argmax)
         self.assertIsInstance(res2.chunks[0].op, Argmin)
         self.assertIsInstance(res1.chunks[0].inputs[0].op, Concatenate)
         self.assertIsInstance(res2.chunks[0].inputs[0].op, Concatenate)
         self.assertIsInstance(res1.chunks[0].inputs[0].inputs[0].op, ArgmaxCombine)
         self.assertIsInstance(res2.chunks[0].inputs[0].inputs[0].op, ArgminCombine)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
-        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         res1 = argmax(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
         res2 = argmin(ones((10, 8), chunk_size=3), axis=1, keepdims=True)
         self.assertEqual(res1.shape, (10, 1))
-        self.assertEqual(calc_shape(res1), res1.shape)
         self.assertEqual(res2.shape, (10, 1))
-        self.assertEqual(calc_shape(res2), res2.shape)
         self.assertIsInstance(res1.chunks[0].op, Argmax)
         self.assertIsInstance(res2.chunks[0].op, Argmin)
         self.assertIsInstance(res1.chunks[0].inputs[0].op, Concatenate)
         self.assertIsInstance(res2.chunks[0].inputs[0].op, Concatenate)
         self.assertIsInstance(res1.chunks[0].inputs[0].inputs[0].op, ArgmaxChunk)
         self.assertIsInstance(res2.chunks[0].inputs[0].inputs[0].op, ArgminChunk)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
-        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         self.assertRaises(TypeError, lambda: argmax(ones((10, 8, 10), chunk_size=3), axis=(0, 1)))
         self.assertRaises(TypeError, lambda: argmin(ones((10, 8, 10), chunk_size=3), axis=(0, 1)))
@@ -186,30 +157,18 @@ class Test(unittest.TestCase):
         res2 = cumprod(ones((10, 8), chunk_size=3), axis=0)
         self.assertEqual(res1.shape, (10, 8))
         self.assertIsNotNone(res1.dtype)
-        self.assertEqual(calc_shape(res1), res1.shape)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
         self.assertEqual(res2.shape, (10, 8))
         self.assertIsNotNone(res2.dtype)
-        self.assertEqual(calc_shape(res2), res2.shape)
-        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         res1 = cumsum(ones((10, 8, 8), chunk_size=3), axis=1)
         res2 = cumprod(ones((10, 8, 8), chunk_size=3), axis=1)
         self.assertEqual(res1.shape, (10, 8, 8))
-        self.assertEqual(calc_shape(res1), res1.shape)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
         self.assertEqual(res2.shape, (10, 8, 8))
-        self.assertEqual(calc_shape(res2), res2.shape)
-        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         res1 = cumsum(ones((10, 8, 8), chunk_size=3), axis=-2)
         res2 = cumprod(ones((10, 8, 8), chunk_size=3), axis=-2)
         self.assertEqual(res1.shape, (10, 8, 8))
-        self.assertEqual(calc_shape(res1), res1.shape)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
         self.assertEqual(res2.shape, (10, 8, 8))
-        self.assertEqual(calc_shape(res2), res2.shape)
-        self.assertEqual(calc_shape(res2.chunks[0]), res2.chunks[0].shape)
 
         with self.assertRaises(np.AxisError):
             cumsum(ones((10, 8), chunk_size=3), axis=2)
@@ -228,10 +187,6 @@ class Test(unittest.TestCase):
         res1 = var(ones((10, 8), chunk_size=3), ddof=2)
         self.assertEqual(res1.shape, ())
         self.assertEqual(res1.op.ddof, 2)
-        self.assertEqual(calc_shape(res1), res1.shape)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)
 
         res1 = var(ones((10, 8, 8), chunk_size=3), axis=1)
         self.assertEqual(res1.shape, (10, 8))
-        self.assertEqual(calc_shape(res1), res1.shape)
-        self.assertEqual(calc_shape(res1.chunks[0]), res1.chunks[0].shape)

--- a/mars/tensor/expressions/tests/test_reshape.py
+++ b/mars/tensor/expressions/tests/test_reshape.py
@@ -17,7 +17,6 @@
 import unittest
 
 from mars.tensor.expressions.datasource import ones
-from mars.tests.core import calc_shape
 
 
 class Test(unittest.TestCase):
@@ -27,8 +26,6 @@ class Test(unittest.TestCase):
 
         b.tiles()
 
-        self.assertEqual(calc_shape(b), b.shape)
-        self.assertEqual(calc_shape(b.chunks[0]), b.chunks[0].shape)
         self.assertEqual(tuple(sum(s) for s in b.nsplits), (10, 600))
 
         a = ones((10, 600), chunk_size=5)
@@ -36,8 +33,6 @@ class Test(unittest.TestCase):
 
         b.tiles()
 
-        self.assertEqual(calc_shape(b), b.shape)
-        self.assertEqual(calc_shape(b.chunks[0]), b.chunks[0].shape)
         self.assertEqual(tuple(sum(s) for s in b.nsplits), (10, 30, 20))
 
         a = ones((10, 600), chunk_size=5)
@@ -45,6 +40,4 @@ class Test(unittest.TestCase):
 
         a.tiles()
 
-        self.assertEqual(calc_shape(b), b.shape)
-        self.assertEqual(calc_shape(b.chunks[0]), b.chunks[0].shape)
         self.assertEqual(tuple(sum(s) for s in a.nsplits), (10, 30, 20))

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -435,3 +435,9 @@ def decide_chunk_sizes(shape, chunk_size, itemsize):
             break
 
     return tuple(dim_to_normalized[i] for i in range(len(dim_to_normalized)))
+
+
+def filter_inputs(inputs):
+    from ...core import Base, Entity
+
+    return [inp for inp in inputs if isinstance(inp, (Base, Entity))]

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -260,9 +260,3 @@ def patch_method(method, *args, **kwargs):
     else:
         return mock.patch('.'.join([method.im_class.__module__, method.im_class.__name__, method.__name__]),
                           *args, **kwargs)
-
-
-def calc_shape(tensor):
-    inputs = tensor.inputs or []
-    inputs_shape = tuple(t.shape for t in inputs)
-    return tensor.op.calc_shape(*inputs_shape)


### PR DESCRIPTION
Backport of #443 , most of the code is merged manually, especially in file `mars/tensor/expressions/arithmetic/core.py`, review is needed.