### PR TITLE
Add mutable tensor support for local cluster

### DIFF
--- a/mars/api.py
+++ b/mars/api.py
@@ -83,10 +83,10 @@ class MarsAPI(object):
         session_ref.submit_tileable_graph(
             serialized_graph, graph_key, target, compose=compose, _tell=not wait)
 
-    def create_mutable_tensor(self, session_id, name, tensor_key, shape, dtype, *args, **kwargs):
+    def create_mutable_tensor(self, session_id, name, shape, dtype, *args, **kwargs):
         session_uid = SessionActor.gen_uid(session_id)
         session_ref = self.get_actor_ref(session_uid)
-        return session_ref.create_mutable_tensor(name, tensor_key, shape, dtype, *args, **kwargs)
+        return session_ref.create_mutable_tensor(name, shape, dtype, *args, **kwargs)
 
     def get_mutable_tensor(self, session_id, name):
         session_uid = SessionActor.gen_uid(session_id)

--- a/mars/api.py
+++ b/mars/api.py
@@ -100,7 +100,7 @@ class MarsAPI(object):
         session_ref = self.get_actor_ref(session_uid)
 
         chunk_records = []
-        for chunk_key, records in chunk_records_to_send:
+        for chunk_key, records in chunk_records_to_send.items():
             record_chunk_key = tokenize(chunk_key, uuid.uuid4().hex)
             ep = self.cluster_info.get_scheduler(chunk_key)
             # register quota

--- a/mars/api.py
+++ b/mars/api.py
@@ -13,8 +13,12 @@
 # limitations under the License.
 
 import logging
+import uuid
+import zlib
+import pyarrow
 
 from .actors import new_client
+from .config import options
 from .errors import GraphNotExists
 from .scheduler import SessionActor, GraphActor, GraphMetaActor, ResourceActor, \
     SessionManagerActor, ChunkMetaClient
@@ -22,6 +26,7 @@ from .scheduler.graph import ResultReceiverActor
 from .scheduler.node_info import NodeInfoActor
 from .scheduler.utils import SchedulerClusterInfoActor
 from .serialize import dataserializer
+from .utils import tokenize
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +56,13 @@ class MarsAPI(object):
             infos[scheduler] = info_ref.get_info()
         return infos
 
+    def get_receiver_ref(self, chunk_key):
+        from .worker.dispatcher import DispatchActor
+        ep = self.cluster_info.get_scheduler(chunk_key)
+        dispatch_ref = self.actor_client.actor_ref(DispatchActor.default_uid(), address=ep)
+        uid = dispatch_ref.get_hash_slot('receiver', chunk_key)
+        return self.actor_client.actor_ref(uid, address=ep)
+
     def count_workers(self):
         try:
             uid = ResourceActor.default_uid()
@@ -70,6 +82,66 @@ class MarsAPI(object):
         session_ref = self.get_actor_ref(session_uid)
         session_ref.submit_tileable_graph(
             serialized_graph, graph_key, target, compose=compose, _tell=not wait)
+
+    def create_mutable_tensor(self, session_id, name, tensor_key, shape, dtype, *args, **kwargs):
+        session_uid = SessionActor.gen_uid(session_id)
+        session_ref = self.get_actor_ref(session_uid)
+        return session_ref.create_mutable_tensor(name, tensor_key, shape, dtype, *args, **kwargs)
+
+    def get_mutable_tensor(self, session_id, name):
+        session_uid = SessionActor.gen_uid(session_id)
+        session_ref = self.get_actor_ref(session_uid)
+        return session_ref.get_mutable_tensor(name)
+
+    def send_chunk_records(self, session_id, name, chunk_records_to_send, directly=True):
+        from .worker.dataio import ArrowBufferIO
+        from .worker.quota import MemQuotaActor
+        session_uid = SessionActor.gen_uid(session_id)
+        session_ref = self.get_actor_ref(session_uid)
+
+        chunk_records = []
+        for chunk_key, records in chunk_records_to_send:
+            record_chunk_key = tokenize(chunk_key, uuid.uuid4().hex)
+            ep = self.cluster_info.get_scheduler(chunk_key)
+            # register quota
+            quota_ref = self.actor_client.actor_ref(MemQuotaActor.default_uid(), address=ep)
+            quota_ref.request_batch_quota({record_chunk_key: records.nbytes})
+            # send record chunk
+            buf = pyarrow.serialize(records).to_buffer()
+            receiver_ref = self.get_receiver_ref(chunk_key)
+            receiver_ref.create_data_writer(session_id, record_chunk_key, buf.size, None,
+                                            ensure_cached=False, use_promise=False)
+
+            block_size = options.worker.transfer_block_size
+
+            try:
+                reader = ArrowBufferIO(buf, 'r', block_size=block_size)
+                checksum = 0
+                while True:
+                    next_chunk = reader.read(block_size)
+                    if not next_chunk:
+                        reader.close()
+                        receiver_ref.finish_receive(session_id, record_chunk_key, checksum)
+                        break
+                    checksum = zlib.crc32(next_chunk, checksum)
+                    receiver_ref.receive_data_part(session_id, record_chunk_key, next_chunk, checksum)
+            except:
+                receiver_ref.cancel_receive(session_id, chunk_key)
+                raise
+            finally:
+                if reader:
+                    reader.close()
+                del reader
+
+            chunk_records.append((chunk_key, record_chunk_key))
+
+        # register the record chunk to MutableTensorActor
+        session_ref.append_chunk_records(name, chunk_records)
+
+    def seal(self, session_id, name):
+        session_uid = SessionActor.gen_uid(session_id)
+        session_ref = self.get_actor_ref(session_uid)
+        return session_ref.seal(name)
 
     def delete_graph(self, session_id, graph_key):
         graph_uid = GraphActor.gen_uid(session_id, graph_key)

--- a/mars/api.py
+++ b/mars/api.py
@@ -56,7 +56,7 @@ class MarsAPI(object):
             infos[scheduler] = info_ref.get_info()
         return infos
 
-    def get_receiver_ref(self, chunk_key):
+    def _get_receiver_ref(self, chunk_key):
         from .worker.dispatcher import DispatchActor
         ep = self.cluster_info.get_scheduler(chunk_key)
         dispatch_ref = self.actor_client.actor_ref(DispatchActor.default_uid(), address=ep)
@@ -108,7 +108,7 @@ class MarsAPI(object):
             quota_ref.request_batch_quota({record_chunk_key: records.nbytes})
             # send record chunk
             buf = pyarrow.serialize(records).to_buffer()
-            receiver_ref = self.get_receiver_ref(chunk_key)
+            receiver_ref = self._get_receiver_ref(chunk_key)
             receiver_ref.create_data_writer(session_id, record_chunk_key, buf.size, None,
                                             ensure_cached=False, use_promise=False)
 

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -68,6 +68,22 @@ class LocalClusterSession(object):
         tileable._update_shape(tuple(sum(nsplit) for nsplit in new_nsplits))
         tileable.nsplits = new_nsplits
 
+    def create_mutable_tensor(self, name, shape, dtype, *args, **kwargs):
+        tensor_key = uuid.uuid4()
+        return self._api.create_mutable_tensor(self._session_id, name, tensor_key, shape,
+                                               dtype, *args, **kwargs)
+
+    def get_mutable_tensor(self, name):
+        return self._api.get_mutable_tensor(self._session_id, name)
+
+    def send_chunk_records(self, name, chunk_records_to_send):
+        return self._api.send_chunk_records(self._session_id, name, chunk_records_to_send)
+
+    def seal(self, name):
+        graph_key, tensor_key, tensor_id, tensor_meta = self._api.seal(self._session_id, name)
+        self._executed_tileables[tensor_key] = graph_key, {tensor_id}
+        return tensor_meta
+
     def run(self, *tileables, **kw):
         timeout = kw.pop('timeout', -1)
         fetch = kw.pop('fetch', True)

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -69,8 +69,7 @@ class LocalClusterSession(object):
         tileable.nsplits = new_nsplits
 
     def create_mutable_tensor(self, name, shape, dtype, *args, **kwargs):
-        tensor_key = uuid.uuid4()
-        return self._api.create_mutable_tensor(self._session_id, name, tensor_key, shape,
+        return self._api.create_mutable_tensor(self._session_id, name, shape,
                                                dtype, *args, **kwargs)
 
     def get_mutable_tensor(self, name):

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -942,6 +942,14 @@ class GraphActor(SchedulerActor):
         return dataserializer.dumps(concat_result)
 
     @log_unhandled
+    def add_fetch_tileable(self, tileable_key, tileable_id, shape, dtype, chunk_size, chunk_keys):
+        from ..tensor.expressions.utils import create_fetch_tensor
+        tensor = create_fetch_tensor(chunk_size, shape, dtype,
+                                     tileable_key, tileable_id, chunk_keys)
+        self._tileable_key_to_opid[tileable_key] = tensor.op.id
+        self._tileable_key_opid_to_tiled[(tileable_key, tensor.op.id)].append(tensor)
+
+    @log_unhandled
     def check_operand_can_be_freed(self, succ_op_keys):
         """
         Check if the data of an operand can be freed.

--- a/mars/scheduler/mutable.py
+++ b/mars/scheduler/mutable.py
@@ -39,7 +39,7 @@ class MutableTensorActor(SchedulerActor):
         else:
             self._dtype = np.dtype(dtype)
         self._graph_key = graph_key
-        self._chunk_size = chunk_size or options.tensor.chunk_size
+        self._chunk_size = chunk_size
         self._tensor = None
         self._sealed = False
         self._chunk_map = defaultdict(lambda: [])

--- a/mars/scheduler/mutable.py
+++ b/mars/scheduler/mutable.py
@@ -16,7 +16,6 @@ from collections import defaultdict
 
 import numpy as np
 
-from ..config import options
 from ..utils import log_unhandled
 from .utils import SchedulerActor
 

--- a/mars/scheduler/mutable.py
+++ b/mars/scheduler/mutable.py
@@ -1,0 +1,104 @@
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+import logging
+
+import numpy as np
+
+from ..config import options
+from .graph import GraphActor, GraphState
+from ..utils import log_unhandled
+from ..worker.transfer import ResultSenderActor
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+class MutableTensorActor(GraphActor):
+    def __init__(self, session_id, name, shape, dtype, graph_key, chunk_size=None, *arg, **kwargs):
+        super(MutableTensorActor, self).__init__(session_id, graph_key, None,
+                                                 state=GraphState.SUCCEEDED, final_state=GraphState.SUCCEEDED)
+        self._session_id = session_id
+        self._name = name
+        self._shape = shape
+        if isinstance(dtype, np.dtype):
+            self._dtype = dtype
+        else:
+            self._dtype = np.dtype(dtype)
+        self._graph_key = graph_key
+        self._chunk_size = chunk_size or options.tensor.chunk_size
+        self._tensor = None
+        self._sealed = False
+        self._chunk_map = defaultdict(lambda: [])
+        self._record_type = np.dtype([("index", np.uint32), ("ts", np.dtype('datetime64[ns]')), ("value", self._dtype)])
+
+    @log_unhandled
+    def post_create(self):
+        from ..tensor.expressions.utils import create_fetch_tensor
+
+        super(MutableTensorActor, self).post_create()
+        self._tensor = create_fetch_tensor(self._chunk_size, self._shape, self._dtype)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def tensor(self):
+        return self._tensor
+
+    def tensor_meta(self):
+        return self._shape, self._dtype, self._chunk_size, [c.key for c in self._tensor.chunks]
+
+    def tensor_key(self):
+        return self._tensor.key
+
+    def graph_key(self):
+        return self._graph_key
+
+    def sealed(self):
+        return self._sealed
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    @log_unhandled
+    def read(self, tensor_index):
+        raise NotImplementedError
+
+    @log_unhandled
+    def append_chunk_records(self, chunk_records):
+        for chunk_key, record_chunk_key in chunk_records:
+            self._chunk_map[chunk_key].append(record_chunk_key)
+
+    @log_unhandled
+    def seal(self):
+        self._sealed = True
+        for chunk in self._tensor.chunks:
+            ep = self.get_scheduler(chunk.key)
+            chunk_sender_ref = self.ctx.actor_ref(ResultSenderActor.default_uid(),
+                                                  address=ep)
+            chunk_sender_ref.finalize_chunk(self._session_id, self._graph_key,
+                                            chunk.key, self._chunk_map[chunk.key],
+                                            chunk.shape, self._record_type, self._dtype)
+
+        # Put chunks to records of GraphActor
+        self._tileable_key_to_opid[self._tensor.key] = self._tensor.op.id
+        self._tileable_key_opid_to_tiled[(self._tensor.key, self._tensor.op.id)].append(self._tensor)
+        return self._graph_key, self._tensor.key, self._tensor.id, self.tensor_meta()

--- a/mars/scheduler/session.py
+++ b/mars/scheduler/session.py
@@ -106,21 +106,21 @@ class SessionActor(SchedulerActor):
     def get_mutable_tensor(self, name):
         tensor_ref = self._mut_tensor_refs.get(name)
         if tensor_ref is None or tensor_ref.sealed():
-            raise RuntimeError("The mutable tensor with name %s doesn't exist, or has already been sealed.", name)
+            raise RuntimeError("The mutable tensor named '%s' doesn't exist, or has already been sealed." % name)
         return tensor_ref.tensor_meta()
 
     @log_unhandled
     def read_mutable_tensor(self, name, index):
         tensor_ref = self._mut_tensor_refs.get(name)
         if tensor_ref is None or tensor_ref.sealed():
-            raise RuntimeError("The mutable tensor with name %s doesn't exist, or has already been sealed.", name)
+            raise RuntimeError("The mutable tensor named '%s' doesn't exist, or has already been sealed." % name)
         return tensor_ref.read(index)
 
     @log_unhandled
     def append_chunk_records(self, name, chunk_records):
         tensor_ref = self._mut_tensor_refs.get(name)
         if tensor_ref is None or tensor_ref.sealed():
-            raise RuntimeError("The mutable tensor with name %s doesn't exist, or has already been sealed.", name)
+            raise RuntimeError("The mutable tensor named '%s' doesn't exist, or has already been sealed." % name)
         return tensor_ref.append_chunk_records(chunk_records)
 
     @log_unhandled
@@ -129,7 +129,7 @@ class SessionActor(SchedulerActor):
 
         tensor_ref = self._mut_tensor_refs.get(name)
         if tensor_ref is None or tensor_ref.sealed():
-            raise RuntimeError("The mutable tensor with name %s doesn't exist, or has already been sealed.", name)
+            raise RuntimeError("The mutable tensor named '%s' doesn't exist, or has already been sealed." % name)
 
         graph_key, tensor_key, tensor_id, tensor_meta = tensor_ref.seal()
 

--- a/mars/session.py
+++ b/mars/session.py
@@ -198,7 +198,8 @@ class Session(object):
                 self._sess.create_mutable_tensor(name, shape, dtype, *args, **kwargs)
         # Construct MutableTensor on the fly.
         tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys)
-        return MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
+        return MutableTensor(chunk_size=chunk_size,
+                             data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
                                                     _nsplits=tensor.nsplits, _chunks=tensor.chunks))
 
     def get_mutable_tensor(self, name):
@@ -208,7 +209,8 @@ class Session(object):
         shape, dtype, chunk_size, chunk_keys = self._sess.get_mutable_tensor(name)
         # Construct MutableTensor on the fly.
         tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys)
-        return MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
+        return MutableTensor(chunk_size=chunk_size,
+                             data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
                                                     _nsplits=tensor.nsplits, _chunks=tensor.chunks))
     def write_mutable_tensor(self, tensor, index, value):
         self._ensure_local_cluster()

--- a/mars/session.py
+++ b/mars/session.py
@@ -198,8 +198,7 @@ class Session(object):
                 self._sess.create_mutable_tensor(name, shape, dtype, *args, **kwargs)
         # Construct MutableTensor on the fly.
         tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
-        return MutableTensor(chunk_size=chunk_size,
-                             data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
+        return MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
                                                     _nsplits=tensor.nsplits, _chunks=tensor.chunks))
 
     def get_mutable_tensor(self, name):
@@ -209,8 +208,7 @@ class Session(object):
         shape, dtype, chunk_size, chunk_keys = self._sess.get_mutable_tensor(name)
         # Construct MutableTensor on the fly.
         tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
-        return MutableTensor(chunk_size=chunk_size,
-                             data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
+        return MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
                                                     _nsplits=tensor.nsplits, _chunks=tensor.chunks))
     def write_mutable_tensor(self, tensor, index, value):
         self._ensure_local_cluster()
@@ -229,7 +227,7 @@ class Session(object):
     def _ensure_local_cluster(self):
         from .deploy.local.session import LocalClusterSession
         if not isinstance(self._sess, LocalClusterSession):
-            raise RuntimeError("Only local cluster session can manipulate mutable tensors")
+            raise RuntimeError("Only local cluster session can be used to manipulate mutable tensors.")
 
 def new_session(scheduler=None, **kwargs):
     return Session(scheduler, **kwargs)

--- a/mars/session.py
+++ b/mars/session.py
@@ -197,7 +197,7 @@ class Session(object):
         shape, dtype, chunk_size, chunk_keys = \
                 self._sess.create_mutable_tensor(name, shape, dtype, *args, **kwargs)
         # Construct MutableTensor on the fly.
-        tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys)
+        tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
         return MutableTensor(chunk_size=chunk_size,
                              data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
                                                     _nsplits=tensor.nsplits, _chunks=tensor.chunks))
@@ -208,7 +208,7 @@ class Session(object):
         self._ensure_local_cluster()
         shape, dtype, chunk_size, chunk_keys = self._sess.get_mutable_tensor(name)
         # Construct MutableTensor on the fly.
-        tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys)
+        tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
         return MutableTensor(chunk_size=chunk_size,
                              data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
                                                     _nsplits=tensor.nsplits, _chunks=tensor.chunks))
@@ -224,7 +224,7 @@ class Session(object):
         self._sess.send_chunk_records(tensor.name, chunk_records_to_send)
         shape, dtype, chunk_size, chunk_keys = self._sess.seal(tensor.name)
         # Construct Tensor on the fly.
-        return create_fetch_tensor(chunk_size, shape, dtype, chunk_keys)
+        return create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
 
     def _ensure_local_cluster(self):
         from .deploy.local.session import LocalClusterSession

--- a/mars/session.py
+++ b/mars/session.py
@@ -210,6 +210,7 @@ class Session(object):
         tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
         return MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
                                                     _nsplits=tensor.nsplits, _chunks=tensor.chunks))
+
     def write_mutable_tensor(self, tensor, index, value):
         self._ensure_local_cluster()
         chunk_records_to_send = tensor._do_write(index, value)

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -441,11 +441,11 @@ class MutableTensor(Entity):
     __slots__ = ("_chunk_buffers", "_record_type", "_buffer_size")
     _allow_data_type_ = (MutableTensorData,)
 
-    def __init__(self, chunk_size, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super(MutableTensor, self).__init__(*args, **kwargs)
         self._chunk_buffers = defaultdict(lambda: [])
         self._record_type = np.dtype([("index", np.uint32), ("ts", np.dtype('datetime64[ns]')), ("value", self.dtype)])
-        self._buffer_size = chunk_size * chunk_size
+        self._buffer_size = np.prod(self.chunks[0].shape)
 
     def __len__(self):
         return len(self._data)

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -29,6 +29,7 @@ from .expressions.utils import get_chunk_slices
 import logging
 logger = logging.getLogger(__name__)
 
+
 class TensorChunkData(ChunkData):
     __slots__ = ()
 
@@ -394,6 +395,7 @@ class Tensor(Entity):
     def execute(self, session=None, **kw):
         return self._data.execute(session, **kw)
 
+
 class MutableTensorData(TensorData):
     __slots__ = ()
 
@@ -433,6 +435,7 @@ class MutableTensorData(TensorData):
     @property
     def compression(self):
         return getattr(self, '_compression', None)
+
 
 class MutableTensor(Entity):
     __slots__ = ("_chunk_buffers", "_record_type", "_buffer_size")
@@ -525,6 +528,7 @@ class MutableTensor(Entity):
                 chunk_records_to_send[chunk_key] = np.array(records, dtype=self._record_type)
                 self._chunk_buffers[chunk_key] = []
         return chunk_records_to_send
+
 
 class SparseTensor(Tensor):
     __slots__ = ()

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -408,12 +408,12 @@ class MutableTensorData(TensorData):
         return super(MutableTensorData, cls).cls(provider)
 
     def __str__(self):
-        return 'MutableTensorData(op={0}, name={1}, shape={2})'.format(self.op.__class__.__name__,
+        return 'MutableTensor(op={0}, name={1}, shape={2})'.format(self.op.__class__.__name__,
                                                                    self.name,
                                                                    self.shape)
 
     def __repr__(self):
-        return 'MutableTensorData <op={0}, name={1}, shape={2}, key={3}>'.format(self.op.__class__.__name__,
+        return 'MutableTensor <op={0}, name={1}, shape={2}, key={3}>'.format(self.op.__class__.__name__,
                                                                              self.name,
                                                                              self.shape,
                                                                              self.key)

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -554,6 +554,7 @@ def create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=None):
     return fetch_op.copy().new_tensor(None, shape=shape, dtype=dtype,
                                       nsplits=chunk_size, chunks=chunks)
 
+
 def setitem_as_records(nsplits_acc, output_chunk, value, ts):
     '''
     Turns a `__setitem__`  to a list of index-value records.
@@ -603,6 +604,7 @@ def setitem_as_records(nsplits_acc, output_chunk, value, ts):
             new_value = chunk_value[value_idx]
         records.append((np.ravel_multi_index(chunk_idx, input_chunk.shape), ts, new_value))
     return records
+
 
 def get_fetch_op_cls(op):
     from ...operands import ShuffleProxy

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from collections import Iterable
+import itertools
 from math import ceil
 from numbers import Integral
 import operator
@@ -526,6 +527,82 @@ def concat_tileable_chunks(tensor):
     return op.new_tensor([tensor], tensor.shape, chunks=[chunk],
                          nsplits=tuple((s,) for s in tensor.shape))
 
+
+def create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=None):
+    from ...config import options
+    from .fetch import TensorFetch
+
+    # compute chunks
+    chunk_size = chunk_size or options.tensor.chunk_size
+    chunk_size = decide_chunk_sizes(shape, chunk_size, dtype.itemsize)
+    chunk_size_idxes = (range(len(size)) for size in chunk_size)
+
+    fetch_op = TensorFetch(dtype=dtype).reset_key()
+
+    if not isinstance(dtype, np.dtype):
+        dtype = np.dtype(dtype)
+    if chunk_keys is None:
+        chunk_keys = itertools.repeat(None)
+
+    chunks = []
+    for chunk_shape, chunk_idx, chunk_key in izip(itertools.product(*chunk_size),
+                                                  itertools.product(*chunk_size_idxes),
+                                                  chunk_keys):
+        chunk = fetch_op.copy().reset_key().new_chunk(None, shape=chunk_shape, index=chunk_idx,
+                                                      _key=chunk_key)
+        chunks.append(chunk)
+    return fetch_op.copy().new_tensor(None, shape=shape, dtype=dtype,
+                                      nsplits=chunk_size, chunks=chunks)
+
+def setitem_as_records(nsplits_acc, output_chunk, value, ts):
+    '''
+    Turns a `__setitem__`  to a list of index-value records.
+
+    Parameters:
+    :arg nsplits_acc:
+        Accumulate nsplits arrays of the output tensor chunks.
+
+    :arg output_chunk:
+        A chunk in the output of the `__setitem__` op.
+
+    :arg value:
+        The scalar or ndarray value that are set to the tensor.
+
+    :arg ts:
+        The timestamp value will be contained in the records.
+
+    :returns:
+        A list of `[index, value, timestamp]`.
+    '''
+    # prepare chunk value
+    if np.isscalar(value):
+        chunk_value = value
+    else:
+        chunk_value_slice = tuple(slice(nsplits_acc[i][output_chunk.index[i]],
+                                        nsplits_acc[i][output_chunk.index[i] + 1])
+                                    for i in range(len(output_chunk.index)))
+        chunk_value = value[chunk_value_slice]
+
+    input_chunk = output_chunk.op.input
+
+    input_indices = []  # index in the chunk of the mutable tensor
+    value_indices = []  # index in the chunk of the assigned value
+    for d, s in zip(output_chunk.op.indexes, input_chunk.shape):
+        # expand the index (slice)
+        idx = np.r_[slice(*d.indices(s)) if isinstance(d, slice) else d]
+        input_indices.append(idx)
+        if isinstance(d, slice):
+            value_indices.append(np.arange(len(idx)))
+
+    records = []
+    for chunk_idx, value_idx in zip(itertools.product(*input_indices),
+                                    itertools.product(*value_indices)):
+        if np.isscalar(chunk_value):
+            new_value = chunk_value
+        else:
+            new_value = chunk_value[value_idx]
+        records.append((np.ravel_multi_index(chunk_idx, input_chunk.shape), ts, new_value))
+    return records
 
 def get_fetch_op_cls(op):
     from ...operands import ShuffleProxy

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -592,7 +592,7 @@ def setitem_as_records(nsplits_acc, output_chunk, value, ts):
         # expand the index (slice)
         idx = np.r_[slice(*d.indices(s)) if isinstance(d, slice) else d]
         input_indices.append(idx)
-        if isinstance(d, slice):
+        if not isinstance(d, Integral):
             value_indices.append(np.arange(len(idx)))
 
     records = []

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 from collections import Iterable
-import itertools
 from math import ceil
 from numbers import Integral
 import operator

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -527,7 +527,7 @@ def concat_tileable_chunks(tensor):
                          nsplits=tuple((s,) for s in tensor.shape))
 
 
-def create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=None):
+def create_fetch_tensor(chunk_size, shape, dtype, tensor_key=None, tensor_id=None, chunk_keys=None):
     from ...config import options
     from .fetch import TensorFetch
 
@@ -550,8 +550,8 @@ def create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=None):
         chunk = fetch_op.copy().reset_key().new_chunk(None, shape=chunk_shape, index=chunk_idx,
                                                       _key=chunk_key)
         chunks.append(chunk)
-    return fetch_op.copy().new_tensor(None, shape=shape, dtype=dtype,
-                                      nsplits=chunk_size, chunks=chunks)
+    return fetch_op.copy().new_tensor(None, shape=shape, dtype=dtype, nsplits=chunk_size,
+                                      chunks=chunks, _key=tensor_key, _id=tensor_id)
 
 
 def setitem_as_records(nsplits_acc, output_chunk, value, ts):

--- a/mars/tests/test_mutable.py
+++ b/mars/tests/test_mutable.py
@@ -46,7 +46,6 @@ class Test(unittest.TestCase):
                     self.assertEqual(chunk1.dtype, chunk2.dtype)
 
     def testMutableTensorWrite(self):
-        self.maxDiff = None
         with new_cluster(scheduler_n_process=2, worker_n_process=2,
                          shared_memory='20M') as cluster:
             with new_session(cluster.endpoint) as session:

--- a/mars/tests/test_mutable.py
+++ b/mars/tests/test_mutable.py
@@ -85,7 +85,7 @@ class Test(unittest.TestCase):
                 expected = np.array([[0, 8.], [1, 9.]])
                 self.assertRecordsEqual(result, expected)
 
-                # mtensor[1], and buffer is not full.
+                # write [1], and buffer is not full.
                 chunk_records = mut._do_write(1, np.arange(5))
                 self.assertEqual(chunk_records, dict())
                 chunk_records = mut._do_flush()
@@ -96,6 +96,19 @@ class Test(unittest.TestCase):
 
                 result = chunk_records[mut.cix[(0, 1)].key]
                 expected = np.array([[2, 3.], [3, 4.]])
+                self.assertRecordsEqual(result, expected)
+
+                # write [2, [0, 2, 4]] (fancy index), and buffer is not full.
+                chunk_records = mut._do_write((2, [0, 2, 4]), np.array([11, 22, 33]))
+                self.assertEqual(chunk_records, dict())
+                chunk_records = mut._do_flush()
+
+                result = chunk_records[mut.cix[(0, 0)].key]
+                expected = np.array([[6, 11.], [8, 22.]])
+                self.assertRecordsEqual(result, expected)
+
+                result = chunk_records[mut.cix[(0, 1)].key]
+                expected = np.array([[5, 33.]])
                 self.assertRecordsEqual(result, expected)
 
                 # write [:], and the first buffer is full.

--- a/mars/tests/test_mutable.py
+++ b/mars/tests/test_mutable.py
@@ -20,23 +20,141 @@ import unittest
 import numpy as np
 
 from mars.deploy.local.core import new_cluster
+from mars.session import new_session
 
 @unittest.skipIf(sys.platform == 'win32', 'does not run in windows')
 class Test(unittest.TestCase):
-    def testMutableTensor(self):
+    def testMutableTensorCreateAndGet(self):
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M') as cluster:
+            with new_session(cluster.endpoint) as session:
+                mut1 = session.create_mutable_tensor("test", (4, 5), dtype=np.double, chunk_size=3)
+                mut2 = session.get_mutable_tensor("test")
+
+                self.assertEqual(mut1.shape, (4, 5))
+                self.assertEqual(mut1.dtype, np.double)
+                self.assertEqual(mut1.nsplits, ((3, 1), (3, 2)))
+
+                self.assertEqual(mut1.shape, mut2.shape)
+                self.assertEqual(mut1.dtype, mut2.dtype)
+                self.assertEqual(mut1.nsplits, mut2.nsplits)
+
+                for chunk1, chunk2 in zip(mut2.chunks, mut2.chunks):
+                    self.assertEqual(chunk1.key, chunk2.key)
+                    self.assertEqual(chunk1.index, chunk2.index)
+                    self.assertEqual(chunk1.shape, chunk2.shape)
+                    self.assertEqual(chunk1.dtype, chunk2.dtype)
+
+    def testMutableTensorWrite(self):
+        self.maxDiff = None
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M') as cluster:
+            with new_session(cluster.endpoint) as session:
+                mut = session.create_mutable_tensor("test", (4, 5), dtype=np.double, chunk_size=3)
+
+                # write [1:4, 2], and buffer is not full.
+                chunk_records = mut._do_write((slice(1, 4, None), 2), 8)
+                self.assertEqual(chunk_records, dict())
+                chunk_records = mut._do_flush()
+
+                result = chunk_records[mut.cix[(0, 0)].key]
+                expected = np.array([[5, 8.], [8, 8.]])
+                self.assertRecordsEqual(result, expected)
+
+                result = chunk_records[mut.cix[(1, 0)].key]
+                expected = np.array([[2, 8.]])
+                self.assertRecordsEqual(result, expected)
+
+                # write [2:4], and buffer is not full.
+                chunk_records = mut._do_write(slice(2, 4, None), np.arange(10).reshape((2, 5)))
+                self.assertEqual(chunk_records, dict())
+                chunk_records = mut._do_flush()
+
+                result = chunk_records[mut.cix[(0, 0)].key]
+                expected = np.array([[6, 0.], [7, 1.], [8, 2.]])
+                self.assertRecordsEqual(result, expected)
+
+                result = chunk_records[mut.cix[(0, 1)].key]
+                expected = np.array([[4, 3.], [5, 4.]])
+                self.assertRecordsEqual(result, expected)
+
+                result = chunk_records[mut.cix[(1, 0)].key]
+                expected = np.array([[0, 5.], [1, 6.], [2, 7.]])
+                self.assertRecordsEqual(result, expected)
+
+                result = chunk_records[mut.cix[(1, 1)].key]
+                expected = np.array([[0, 8.], [1, 9.]])
+                self.assertRecordsEqual(result, expected)
+
+                # mtensor[1], and buffer is not full.
+                chunk_records = mut._do_write(1, np.arange(5))
+                self.assertEqual(chunk_records, dict())
+                chunk_records = mut._do_flush()
+
+                result = chunk_records[mut.cix[(0, 0)].key]
+                expected = np.array([[3, 0.], [4, 1.], [5, 2.]])
+                self.assertRecordsEqual(result, expected)
+
+                result = chunk_records[mut.cix[(0, 1)].key]
+                expected = np.array([[2, 3.], [3, 4.]])
+                self.assertRecordsEqual(result, expected)
+
+                # write [:], and the first buffer is full.
+                chunk_records = mut._do_write(slice(None, None, None), 999)
+
+                result = chunk_records[mut.cix[(0, 0)].key]
+                expected = np.array([[0, 999.], [1, 999.], [2, 999.], [3, 999.], [4, 999.],
+                                     [5, 999.], [6, 999.], [7, 999.], [8, 999.]])
+                self.assertRecordsEqual(result, expected)
+
+                # check other chunks
+                chunk_records = mut._do_flush()
+
+                result = chunk_records[mut.cix[(0, 1)].key]
+                expected = np.array([[0, 999.], [1, 999.], [2, 999.], [3, 999.], [4, 999.],
+                                     [5, 999.]])
+                self.assertRecordsEqual(result, expected)
+
+                result = chunk_records[mut.cix[(1, 0)].key]
+                expected = np.array([[0, 999.], [1, 999.], [2, 999.]])
+                self.assertRecordsEqual(result, expected)
+
+                result = chunk_records[mut.cix[(1, 1)].key]
+                expected = np.array([[0, 999.], [1, 999.]])
+                self.assertRecordsEqual(result, expected)
+
+
+    def testMutableTensorSeal(self):
         with new_cluster(scheduler_n_process=2, worker_n_process=2,
                          shared_memory='20M') as cluster:
             session = cluster.session
 
-            mut = session.create_mutable_tensor("test", (4, 4), dtype=np.int32, chunk_size=3)
+            mut = session.create_mutable_tensor("test", (4, 5), dtype=np.int32, chunk_size=3)
             mut[1:4, 2] = 8
-            mut[2:4] = np.arange(8).reshape(2, 4)
-            mut[1] = np.arange(4).reshape(4)
-            result = session.fetch(mut.seal())
+            mut[2:4] = np.arange(10).reshape(2, 5)
+            mut[1] = np.arange(5)
+            arr = mut.seal()
 
-            expected = np.zeros((4, 4), dtype=np.int32)
+            expected = np.zeros((4, 5), dtype=np.int32)
             expected[1:4, 2] = 8
-            expected[2:4] = np.arange(8).reshape(2, 4)
-            expected[1] = np.arange(4).reshape(4)
+            expected[2:4] = np.arange(10).reshape(2, 5)
+            expected[1] = np.arange(5)
 
-            np.testing.assert_array_equal(result, expected)
+            # check chunk properties
+            for chunk1, chunk2 in zip(mut.chunks, arr.chunks):
+                self.assertEqual(chunk1.key, chunk2.key)
+                self.assertEqual(chunk1.index, chunk2.index)
+                self.assertEqual(chunk1.shape, chunk2.shape)
+                self.assertEqual(chunk1.dtype, chunk2.dtype)
+
+            # check value
+            np.testing.assert_array_equal(session.fetch(arr), expected)
+
+            # check operations on the sealed tensor
+            np.testing.assert_array_equal(session.run(arr + 1), expected + 1)
+            np.testing.assert_array_equal(session.run(arr + arr), expected + expected)
+            np.testing.assert_array_equal(session.run(arr.sum()), expected.sum())
+
+    def assertRecordsEqual(self, records, expected):
+        np.testing.assert_array_equal(records['index'], expected[:,0])
+        np.testing.assert_array_equal(records['value'], expected[:,1])

--- a/mars/tests/test_mutable.py
+++ b/mars/tests/test_mutable.py
@@ -35,6 +35,8 @@ class Test(unittest.TestCase):
                 self.assertEqual(mut1.dtype, np.double)
                 self.assertEqual(mut1.nsplits, ((3, 1), (3, 2)))
 
+                # mut1 and mut2 are not the same object, but has the same properties.
+                self.assertNotEqual(mut1.id, mut2.id)
                 self.assertEqual(mut1.shape, mut2.shape)
                 self.assertEqual(mut1.dtype, mut2.dtype)
                 self.assertEqual(mut1.nsplits, mut2.nsplits)
@@ -135,19 +137,18 @@ class Test(unittest.TestCase):
                 expected = np.array([[0, 999.], [1, 999.]])
                 self.assertRecordsEqual(result, expected)
 
-
     def testMutableTensorSeal(self):
         with new_cluster(scheduler_n_process=2, worker_n_process=2,
                          shared_memory='20M') as cluster:
             session = cluster.session
 
-            mut = session.create_mutable_tensor("test", (4, 5), dtype=np.int32, chunk_size=3)
+            mut = session.create_mutable_tensor("test", (4, 5), dtype='int32', chunk_size=3)
             mut[1:4, 2] = 8
             mut[2:4] = np.arange(10).reshape(2, 5)
             mut[1] = np.arange(5)
             arr = mut.seal()
 
-            expected = np.zeros((4, 5), dtype=np.int32)
+            expected = np.zeros((4, 5), dtype='int32')
             expected[1:4, 2] = 8
             expected[2:4] = np.arange(10).reshape(2, 5)
             expected[1] = np.arange(5)
@@ -166,6 +167,65 @@ class Test(unittest.TestCase):
             np.testing.assert_array_equal(session.run(arr + 1), expected + 1)
             np.testing.assert_array_equal(session.run(arr + arr), expected + expected)
             np.testing.assert_array_equal(session.run(arr.sum()), expected.sum())
+
+    def testMutableTensorSession(self):
+        with new_session() as session:
+            with self.assertRaises(RuntimeError) as cm:
+                session.create_mutable_tensor("test", (4, 5), dtype=np.int32)
+
+            expected_msg = 'Only local cluster session can be used to manipulate mutable tensors.'
+            self.assertEqual(cm.exception.args[0], expected_msg)
+
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M', web=True) as cluster:
+            with new_session('http://' + cluster._web_endpoint) as session:
+                with self.assertRaises(RuntimeError) as cm:
+                    session.create_mutable_tensor("test", (4, 5), dtype=np.int32)
+
+                expected_msg = "Only local cluster session can be used to manipulate mutable tensors."
+                self.assertEqual(cm.exception.args[0], expected_msg)
+
+    def testMutableTensorDuplicateName(self):
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M') as cluster:
+            session = cluster.session
+
+            session.create_mutable_tensor("test", (4, 5), dtype='int32')
+
+            # The two unsealed mutable tensors cannot have the same name.
+            with self.assertRaises(ValueError) as cm:
+                session.create_mutable_tensor("test", (4, 5), dtype='int32')
+
+            expected_msg = "The mutable tensor named 'test' already exists."
+            self.assertEqual(cm.exception.args[0], expected_msg)
+
+    def testMutableTensorRaiseAfterSeal(self):
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M') as cluster:
+            session = cluster.session
+
+            mut = session.create_mutable_tensor("test", (4, 5), dtype='int32', chunk_size=3)
+            mut.seal()
+
+            expected_msg = "The mutable tensor named 'test' doesn't exist, or has already been sealed."
+
+            # Cannot get after seal
+            with self.assertRaises(ValueError) as cm:
+                session.get_mutable_tensor("test")
+
+            self.assertEqual(cm.exception.args[0], expected_msg)
+
+            # Cannot write after seal
+            with self.assertRaises(ValueError) as cm:
+                mut[:] = 111
+
+            self.assertEqual(cm.exception.args[0], expected_msg)
+
+            # Cannot seal after seal
+            with self.assertRaises(ValueError) as cm:
+                session.seal(mut)
+
+            self.assertEqual(cm.exception.args[0], expected_msg)
 
     def assertRecordsEqual(self, records, expected):
         np.testing.assert_array_equal(records['index'], expected[:,0])

--- a/mars/tests/test_mutable.py
+++ b/mars/tests/test_mutable.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+import numpy as np
+
+from mars.deploy.local.core import new_cluster
+
+@unittest.skipIf(sys.platform == 'win32', 'does not run in windows')
+class Test(unittest.TestCase):
+    def testMutableTensor(self):
+        with new_cluster(scheduler_n_process=2, worker_n_process=2,
+                         shared_memory='20M') as cluster:
+            session = cluster.session
+
+            mut = session.create_mutable_tensor("test", (4, 4), dtype=np.int32, chunk_size=3)
+            mut[1:4, 2] = 8
+            mut[2:4] = np.arange(8).reshape(2, 4)
+            mut[1] = np.arange(4).reshape(4)
+            result = session.fetch(mut.seal())
+
+            expected = np.zeros((4, 4), dtype=np.int32)
+            expected[1:4, 2] = 8
+            expected[2:4] = np.arange(8).reshape(2, 4)
+            expected[1] = np.arange(4).reshape(4)
+
+            np.testing.assert_array_equal(result, expected)

--- a/mars/worker/chunkholder.py
+++ b/mars/worker/chunkholder.py
@@ -232,6 +232,9 @@ class ChunkHolderActor(WorkerActor):
             del self._chunk_holder[chunk_key]
             self._chunk_store.delete(session_id, chunk_key)
 
+        if chunk_key in self._pinned_counter:
+            del self._pinned_counter[chunk_key]
+
         logger.debug('Chunk %s unregistered in %s. total_hold=%d', chunk_key, self.uid, self._total_hold)
 
         if self._status_ref:

--- a/mars/worker/seal.py
+++ b/mars/worker/seal.py
@@ -1,0 +1,84 @@
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pyarrow
+
+from ..serialize import dataserializer
+from ..errors import *
+from ..utils import log_unhandled
+from .spill import build_spill_file_name
+from .utils import WorkerActor
+
+
+class SealActor(WorkerActor):
+    """
+    Actor sealing a chunk from a serials of record chunks.
+    """
+    @staticmethod
+    def gen_uid(session_id, chunk_key):
+        return 's:0:seal$%s$%s' % (session_id, chunk_key)
+
+    def __init__(self):
+        super(SealActor, self).__init__()
+        self._chunk_holder_ref = None
+        self._mem_quota_ref = None
+
+    def post_create(self):
+        from .chunkholder import ChunkHolderActor
+        from .quota import MemQuotaActor
+        super(SealActor, self).post_create()
+        self._chunk_holder_ref = self.promise_ref(ChunkHolderActor.default_uid())
+        self._mem_quota_ref = self.promise_ref(MemQuotaActor.default_uid())
+
+    @log_unhandled
+    def seal_chunk(self, session_id, graph_key, chunk_key, keys, shape, record_type, dtype):
+        from ..serialize.dataserializer import decompressors, mars_serialize_context
+        chunk_bytes_size = np.prod(shape) * dtype.itemsize
+        self._mem_quota_ref.request_batch_quota({chunk_key: chunk_bytes_size})
+        ndarr = np.zeros(shape, dtype=dtype)
+        ndarr_ts = np.zeros(shape, dtype=np.dtype('datetime64[ns]'))
+
+        # consolidate
+        for key in keys:
+            try:
+                if self._chunk_store.contains(session_id, key):
+                    buf = self._chunk_store.get_buffer(session_id, key)
+                else:
+                    file_name = build_spill_file_name(key)
+                    # The `disk_compression` is used in `_create_writer`
+                    disk_compression = dataserializer.CompressType(options.worker.disk_compression)
+                    if not file_name:
+                        raise SpillNotConfigured('Spill not configured')
+                    with open(file_name, 'rb') as inf:
+                        buf = decompressors[disk_compression](inf.read())
+                buffer = pyarrow.deserialize(memoryview(buf), mars_serialize_context())
+                record_view = np.asarray(memoryview(buffer)).view(dtype=record_type, type=np.recarray)
+
+                for record in record_view:
+                    idx = np.unravel_index(record.index, shape)
+                    if record.ts > ndarr_ts[idx]:
+                        ndarr[idx] = record.value
+            finally:
+                del buf
+
+            # clean up
+            self._chunk_holder_ref.unregister_chunk(session_id, key)
+            self.get_meta_client().delete_meta(session_id, key, False)
+            self._mem_quota_ref.release_quota(key)
+
+        self._chunk_store.put(session_id, chunk_key, ndarr)
+        self.get_meta_client().set_chunk_meta(session_id, chunk_key, size=chunk_bytes_size,
+                                              shape=shape, workers=(self.address,))
+        self._chunk_holder_ref.register_chunk(session_id, chunk_key)

--- a/mars/worker/seal.py
+++ b/mars/worker/seal.py
@@ -79,7 +79,9 @@ class SealActor(WorkerActor):
             self.get_meta_client().delete_meta(session_id, key, False)
             self._mem_quota_ref.release_quota(key)
 
-        self._chunk_store.put(session_id, chunk_key, ndarr)
+        # Hold the reference of the chunk before register_chunk
+        chunk_ref = self._chunk_store.put(session_id, chunk_key, ndarr)
         self.get_meta_client().set_chunk_meta(session_id, chunk_key, size=chunk_bytes_size,
                                               shape=shape, workers=(self.address,))
         self._chunk_holder_ref.register_chunk(session_id, chunk_key)
+        del chunk_ref

--- a/mars/worker/seal.py
+++ b/mars/worker/seal.py
@@ -15,6 +15,8 @@
 import numpy as np
 import pyarrow
 
+from ..config import options
+from ..errors import SpillNotConfigured
 from ..serialize import dataserializer
 from ..utils import log_unhandled
 from .spill import build_spill_file_name

--- a/mars/worker/seal.py
+++ b/mars/worker/seal.py
@@ -16,7 +16,6 @@ import numpy as np
 import pyarrow
 
 from ..serialize import dataserializer
-from ..errors import *
 from ..utils import log_unhandled
 from .spill import build_spill_file_name
 from .utils import WorkerActor

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -203,17 +203,20 @@ class WorkerService(object):
             actor = actor_holder.create_actor(CpuCalcActor, uid=uid)
             self._cpu_calc_actors.append(actor)
 
+        start_pid = 1 + process_start_index + self._n_cpu_process
+
         if distributed:
             # create SenderActor and ReceiverActor
-            start_pid = 1 + process_start_index + self._n_cpu_process
             for sender_id in range(self._n_io_process):
                 uid = 'w:%d:mars-sender-%d-%d' % (start_pid + sender_id, os.getpid(), sender_id)
                 actor = actor_holder.create_actor(SenderActor, uid=uid)
                 self._sender_actors.append(actor)
-            for receiver_id in range(2 * self._n_io_process):
-                uid = 'w:%d:mars-receiver-%d-%d' % (start_pid + receiver_id // 2, os.getpid(), receiver_id)
-                actor = actor_holder.create_actor(ReceiverActor, uid=uid)
-                self._receiver_actors.append(actor)
+
+        # Mutable requires ReceiverActor (with LocalClusterSession)
+        for receiver_id in range(2 * self._n_io_process):
+            uid = 'w:%d:mars-receiver-%d-%d' % (start_pid + receiver_id // 2, os.getpid(), receiver_id)
+            actor = actor_holder.create_actor(ReceiverActor, uid=uid)
+            self._receiver_actors.append(actor)
 
         # create ProcessHelperActor
         for proc_id in range(pool.cluster_info.n_process - process_start_index):

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -699,8 +699,6 @@ class ResultSenderActor(WorkerActor):
         self._serialize_pool = None
 
     def post_create(self):
-        from .chunkholder import ChunkHolderActor
-        from .quota import MemQuotaActor
         super(ResultSenderActor, self).post_create()
         self._serialize_pool = self.ctx.threadpool(1)
 

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -20,6 +20,9 @@ import time
 import zlib
 from collections import defaultdict
 
+import numpy as np
+import pyarrow
+
 from .. import promise
 from ..compat import six, Enum, TimeoutError  # pylint: disable=W0622
 from ..config import options
@@ -391,8 +394,10 @@ class ReceiverActor(WorkerActor):
             otherwise the function returns directly and when sill is needed, a StorageFull will be raised instead.
         :param callback: promise callback
         """
+        sender_address = None if sender_ref is None else sender_ref.address
+
         logger.debug('Begin creating transmission data writer for chunk %s from %s',
-                     chunk_key, sender_ref.address)
+                     chunk_key, sender_address)
         session_chunk_key = (session_id, chunk_key)
 
         data_status = self.check_status(session_id, chunk_key)
@@ -417,7 +422,7 @@ class ReceiverActor(WorkerActor):
                 del self._data_meta_cache[session_chunk_key]
 
         self._data_meta_cache[session_chunk_key] = ReceiverDataMeta(
-            chunk_size=data_size, source_address=sender_ref.address,
+            chunk_size=data_size, source_address=sender_address,
             write_shared=True, status=ReceiveStatus.RECEIVING)
 
         # configure timeout callback
@@ -695,10 +700,16 @@ class ResultSenderActor(WorkerActor):
     def __init__(self):
         super(ResultSenderActor, self).__init__()
         self._serialize_pool = None
+        self._chunk_holder_ref = None
+        self._mem_quota_ref = None
 
     def post_create(self):
+        from .chunkholder import ChunkHolderActor
+        from .quota import MemQuotaActor
         super(ResultSenderActor, self).post_create()
         self._serialize_pool = self.ctx.threadpool(1)
+        self._chunk_holder_ref = self.promise_ref(ChunkHolderActor.default_uid())
+        self._mem_quota_ref = self.promise_ref(MemQuotaActor.default_uid())
 
     def fetch_data(self, session_id, chunk_key):
         buf = None
@@ -717,3 +728,44 @@ class ResultSenderActor(WorkerActor):
         finally:
             del buf
         return compressed
+
+    @log_unhandled
+    def finalize_chunk(self, session_id, graph_key, chunk_key, keys, shape, record_type, dtype):
+        from ..serialize.dataserializer import decompressors, mars_serialize_context
+        chunk_bytes_size = np.prod(shape) * dtype.itemsize
+        self._mem_quota_ref.request_batch_quota({chunk_key: chunk_bytes_size})
+        ndarr = np.zeros(shape, dtype=dtype)
+        ndarr_ts = np.zeros(shape, dtype=np.dtype('datetime64[ns]'))
+
+        # consolidate
+        for key in keys:
+            try:
+                if self._chunk_store.contains(session_id, key):
+                    buf = self._chunk_store.get_buffer(session_id, key)
+                else:
+                    file_name = build_spill_file_name(key)
+                    # The `disk_compression` is used in `_create_writer`
+                    disk_compression = dataserializer.CompressType(options.worker.disk_compression)
+                    if not file_name:
+                        raise SpillNotConfigured('Spill not configured')
+                    with open(file_name, 'rb') as inf:
+                        buf = decompressors[disk_compression](inf.read())
+                buffer = pyarrow.deserialize(memoryview(buf), mars_serialize_context())
+                record_view = np.asarray(memoryview(buffer)).view(dtype=record_type, type=np.recarray)
+
+                for record in record_view:
+                    idx = np.unravel_index(record.index, shape)
+                    if record.ts > ndarr_ts[idx]:
+                        ndarr[idx] = record.value
+            finally:
+                del buf
+
+            # clean up
+            self._chunk_holder_ref.unregister_chunk(session_id, key)
+            self.get_meta_client().delete_meta(session_id, key, False)
+            self._mem_quota_ref.release_quota(key)
+
+        self._chunk_store.put(session_id, chunk_key, ndarr)
+        self.get_meta_client().set_chunk_meta(session_id, chunk_key, size=chunk_bytes_size,
+                                              shape=shape, workers=(self.address,))
+        self._chunk_holder_ref.register_chunk(session_id, chunk_key)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Support mutable tensor.

+ A `MutableTensorActor` on scheduler to manager mutable tensors and perform the underlying operations.
+ A `MutableTensor` and `MutableTensorData` to manage chunks of mutable tensors.
+ `allocate/read/write` interface in `ResultSenderActor` (on workers).
+ Chunk allocation:

   - The chunks are stored in plasma store (currently pinned in memory for convenience) before seal.
   - No compression is performed on mutable tensor thunks, and `read/write` operation is implemented by reading/writing a `np.ndarray` constructed by the memory view directly (zero copy and no read/write overhead). 

TODO

- [x] Finish `write_mutable_tensor`.
- [x] Construct `Tensor` (and `TensorData`) using those thunks directly when seal.
- [x] Do the `read/write` dispatch logic on client (now it runs on scheduler)

## Related issue number

#415
Resolves #439 
Resolves #450.

<!-- Are there any issues opened that will be resolved by merging this change? -->
