### PR TITLE
Add resource heartbeat to avoid fake worker death

### DIFF
--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -42,7 +42,7 @@ cpdef str to_str(s, encoding='utf-8'):
     elif s is None:
         return s
     else:
-        raise TypeError("Could not convert from unicode.")
+        raise TypeError("Could not convert from %r to str." % (s,))
 
 
 cpdef bytes to_binary(s, encoding='utf-8'):
@@ -55,7 +55,7 @@ cpdef bytes to_binary(s, encoding='utf-8'):
     elif s is None:
         return None
     else:
-        raise TypeError("Could not convert to bytes.")
+        raise TypeError("Could not convert from %r to bytes." % (s,))
 
 
 cpdef unicode to_text(s, encoding='utf-8'):
@@ -68,7 +68,7 @@ cpdef unicode to_text(s, encoding='utf-8'):
     elif s is None:
         return None
     else:
-        raise TypeError("Could not convert to unicode.")
+        raise TypeError("Could not convert from %r to unicode." % (s,))
 
 
 cdef inline build_canonical_bytes(tuple args, kwargs):

--- a/mars/actors/pool/messages.pxd
+++ b/mars/actors/pool/messages.pxd
@@ -19,7 +19,9 @@ cimport numpy as np
 from ..core cimport ActorRef
 
 
+ctypedef np.int64_t INT64_t
 ctypedef np.int32_t INT32_t
+ctypedef np.int16_t INT16_t
 ctypedef np.uint8_t BYTE_t
 
 
@@ -39,33 +41,33 @@ cpdef enum MessageType:
     tell_chunk_end = 12
 
 
-cpdef int unpack_message_type_value(bytes binary)
+cpdef INT32_t unpack_message_type_value(bytes binary)
 cpdef object unpack_message_type(bytes binary)
 cpdef bytes unpack_message_id(bytes binary)
 cpdef bytes pack_actor_ref(ActorRef actor_ref)
 cpdef void unpack_actor_ref(bytes binary, ActorRef actor_ref)
 cpdef object unpack_send_message(bytes message)
 cpdef object pack_send_message(INT32_t from_index, INT32_t to_index, ActorRef actor_ref, object message,
-                               object write=*, int protocol=*)
+                               object write=*, INT32_t protocol=*)
 cpdef object unpack_send_message(bytes message)
 cpdef object pack_tell_message(INT32_t from_index, INT32_t to_index, ActorRef actor_ref, object message,
-                               object write=*, int protocol=*)
+                               object write=*, INT32_t protocol=*)
 cpdef object unpack_tell_message(bytes message)
 cpdef tuple get_index(bytes binary, object calc_from_uid)
-cpdef object pack_create_actor_message(INT32_t from_index, int to_index, ActorRef actor_ref, object actor_cls,
-                                       tuple args, dict kw, object write=*, int protocol=*)
+cpdef object pack_create_actor_message(INT32_t from_index, INT32_t to_index, ActorRef actor_ref, object actor_cls,
+                                       tuple args, dict kw, object write=*, INT32_t protocol=*)
 cpdef object unpack_create_actor_message(bytes binary)
 cpdef object pack_destroy_actor_message(INT32_t from_index, INT32_t to_index, ActorRef actor_ref,
-                                        object write=*, int protocol=*)
+                                        object write=*, INT32_t protocol=*)
 cpdef object unpack_destroy_actor_message(bytes binary)
-cpdef object pack_has_actor_message(INT32_t from_index, int to_index, ActorRef actor_ref,
-                                    object write=*, int protocol=*)
+cpdef object pack_has_actor_message(INT32_t from_index, INT32_t to_index, ActorRef actor_ref,
+                                    object write=*, INT32_t protocol=*)
 cpdef object unpack_has_actor_message(bytes binary)
-cpdef object pack_result_message(bytes message_id, INT32_t from_index, int to_index, object result,
-                                 object write=*, int protocol=*)
+cpdef object pack_result_message(bytes message_id, INT32_t from_index, INT32_t to_index, object result,
+                                 object write=*, INT32_t protocol=*)
 cpdef object unpack_result_message(bytes binary, object from_index=*, object to_index=*)
 cpdef object pack_error_message(bytes message_id, INT32_t from_index, INT32_t to_index,
                                 object error_type, object error, object tb,
-                                object write=*, int protocol=*)
+                                object write=*, INT32_t protocol=*)
 cpdef object unpack_error_message(bytes binary)
 cpdef bytes read_remote_message(object read_func)

--- a/mars/config.py
+++ b/mars/config.py
@@ -315,7 +315,7 @@ default_options.register_option('scheduler.retry_delay', 60, validator=is_intege
 default_options.register_option('scheduler.dump_graph_data', False, validator=is_bool)
 
 default_options.register_option('scheduler.enable_failover', True, validator=is_bool, serialize=True)
-default_options.register_option('scheduler.status_timeout', 30, validator=is_numeric, serialize=True)
+default_options.register_option('scheduler.status_timeout', 60, validator=is_numeric, serialize=True)
 default_options.register_option('scheduler.worker_blacklist_time', 3600, validator=is_numeric, serialize=True)
 
 # Worker

--- a/mars/scheduler/tests/test_main.py
+++ b/mars/scheduler/tests/test_main.py
@@ -132,7 +132,8 @@ class Test(unittest.TestCase):
                               '--level', 'debug' if log_scheduler else 'warning',
                               '-p', p,
                               '--format', '%(asctime)-15s %(message)s',
-                              '-Dscheduler.retry_delay=5']
+                              '-Dscheduler.retry_delay=5',
+                              '-Dscheduler.status_timeout=30']
                              + append_args)
             for p in scheduler_ports]
         self.proc_workers = [


### PR DESCRIPTION
## What do these changes do?

1. Add a heartbeat actor to help judging whether the scheduler is busy.
2. Record worker list when assigning initial nodes to help decide whether to start fail-over.

## Related issue number

Fixes #469
Fixes #470 