### PR TITLE
Fix promise reference counting issues

### DIFF
--- a/mars/actors/pool/gevent_pool.pyx
+++ b/mars/actors/pool/gevent_pool.pyx
@@ -196,8 +196,12 @@ cdef class ActorContext:
         return gevent.subprocess.Popen(*args, **kwargs)
 
     @staticmethod
-    def threadpool(num_threads):
-        return ThreadPool(num_threads)
+    def threadpool(size):
+        return ThreadPool(size)
+
+    @staticmethod
+    def asyncpool(size=None):
+        return gevent.pool.Pool(size)
 
 
 cdef class LocalActorPool:
@@ -1656,5 +1660,9 @@ cdef class ActorClient:
         return gevent.subprocess.Popen(*args, **kwargs)
 
     @staticmethod
-    def threadpool(num_threads):
-        return ThreadPool(num_threads)
+    def threadpool(size):
+        return ThreadPool(size)
+
+    @staticmethod
+    def asyncpool(size=None):
+        return gevent.pool.Pool(size)


### PR DESCRIPTION
## What do these changes do?

This PR mainly deals with reference counting issues in ``promise`` module.

1. Fix cycled references for accept / reject handlers (as is stated in #473) by setting these handlers to ``None`` after they are called.
2. Deal with ``_promise_pool`` more carefully. References are added to ``_promise_pool`` only when the promise object have unfinished calls.
3. Stop calling ``step_next`` directly in the wrapped function if the promise has immediate results. Instead the function will return a tuple containing ``_internal_step_next`` and args. This can help python cleaning previous results.
4. A ``spawn_promised`` function is added to ``PromiseActor`` to make use of async libraries.

## Related issue number

Fixes #473 