### PR TITLE
Use lazy import for cupy and cudf

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,6 +13,7 @@ omit =
     mars/lib/enum.py
     mars/lib/six.py
     mars/lib/gipc.pyx
+    mars/lib/nvutils.py
     mars/lib/tblib/*
     mars/lib/uhashring/*
     mars/serialize/protos/*

--- a/.coveragerc-tensor
+++ b/.coveragerc-tensor
@@ -16,6 +16,7 @@ omit =
     mars/lib/enum.py
     mars/lib/six.py
     mars/lib/gipc.pyx
+    mars/lib/nvutils.py
     mars/lib/tblib/*
     mars/lib/uhashring/*
     mars/serialize/protos/*

--- a/mars/lib/nvutils.py
+++ b/mars/lib/nvutils.py
@@ -1,0 +1,272 @@
+# -*- coding: utf-8 -*-
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import sys
+import uuid
+from collections import namedtuple
+from ctypes import c_char, c_char_p, c_int, c_uint, c_ulonglong, byref,\
+    create_string_buffer, Structure, POINTER, CDLL
+
+logger = logging.getLogger(__name__)
+
+# Some constants taken from cuda.h
+CUDA_SUCCESS = 0
+CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT = 16
+CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR = 39
+CU_DEVICE_ATTRIBUTE_CLOCK_RATE = 13
+CU_DEVICE_ATTRIBUTE_PCI_BUS_ID = 33
+CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID = 34
+CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE = 36
+
+# nvml constants
+NVML_SUCCESS = 0
+NVML_TEMPERATURE_GPU = 0
+
+
+class _CUuuid_t(Structure):
+    _fields_ = [
+        ('bytes', c_char * 16)
+    ]
+class _nvmlUtilization_t(Structure):
+    _fields_ = [
+        ('gpu', c_uint),
+        ('memory', c_uint),
+    ]
+
+class _struct_nvmlDevice_t(Structure):
+    pass  # opaque handle
+_nvmlDevice_t = POINTER(_struct_nvmlDevice_t)
+
+class _nvmlBAR1Memory_t(Structure):
+    _fields_ = [
+        ('total', c_ulonglong),
+        ('free', c_ulonglong),
+        ('used', c_ulonglong),
+    ]
+
+
+def _load_nv_library(*libnames):
+    for lib in libnames:
+        try:
+            return CDLL(lib)
+        except OSError:
+            continue
+
+
+_cuda_lib = _nvml_lib = None
+
+_cu_device_info = namedtuple('_cu_device_info', 'uuid name multiprocessors cuda_cores threads')
+_nvml_driver_info = namedtuple('_nvml_driver_info', 'driver_version cuda_version')
+_nvml_device_status = namedtuple(
+    '_nvml_device_status', 'gpu_util mem_util temperature fb_total_mem fb_used_mem fb_free_mem')
+
+
+_initialized = False
+_gpu_count = None
+_driver_info = None
+_device_infos = dict()
+
+
+class NVError(Exception):
+    pass
+
+
+def _cu_check_error(result):
+    if result != CUDA_SUCCESS:
+        _error_str = c_char_p()
+        _cuda_lib.cuGetErrorString(result, byref(_error_str))
+        raise NVError('Device API Error %d: %s' % (result, _error_str.value.decode()))
+
+
+if _nvml_lib is not None:
+    _nvmlErrorString = _nvml_lib.nvmlErrorString
+    _nvmlErrorString.restype = c_char_p
+
+
+def _nvml_check_error(result):
+    if result != NVML_SUCCESS:
+        _error_str = _nvmlErrorString(result)
+        if _error_str:
+            raise NVError('NVML API Error %d: %s' % (result, _error_str.decode()))
+        else:
+            raise NVError('Unknown NVML API Error %d' % result)
+
+
+_cu_process_var_to_cores = {
+    (1, 0): 8,
+    (1, 1): 8,
+    (1, 2): 8,
+    (1, 3): 8,
+    (2, 0): 32,
+    (2, 1): 48,
+}
+
+
+def _cu_get_processor_cores(major, minor):
+    return _cu_process_var_to_cores.get((major, minor), 192)
+
+
+def _init_cp():
+    global _cuda_lib
+    if _initialized:
+        return
+
+    _cuda_lib = _load_nv_library('libcuda.so', 'libcuda.dylib', 'cuda.dll')
+
+    if _cuda_lib is None:
+        return
+    try:
+        _cu_check_error(_cuda_lib.cuInit(0))
+    except NVError:
+        logger.exception('Failed to initialize libcuda.')
+        return
+
+
+def _init_nvml():
+    global _nvml_lib
+    if _initialized:
+        return
+
+    _nvml_lib = _load_nv_library('libnvidia-ml.so', 'libnvidia-ml.dylib', 'nvml.dll')
+
+    if _nvml_lib is None:
+        return
+    try:
+        _nvml_check_error(_nvml_lib.nvmlInit_v2())
+    except NVError:
+        logger.exception('Failed to initialize libnvidia-ml.')
+        return
+
+
+def _init():
+    global _initialized
+
+    _init_cp()
+    _init_nvml()
+
+    _initialized = _nvml_lib is not None and _cuda_lib is not None
+
+
+def get_device_count():
+    global _gpu_count
+
+    if _gpu_count is not None:
+        return _gpu_count
+
+    _init_nvml()
+    if _nvml_lib is None:
+        return None
+
+    if 'CUDA_VISIBLE_DEVICES' in os.environ:
+        _gpu_count = len(os.environ['CUDA_VISIBLE_DEVICES'].split(','))
+    else:
+        n_gpus = c_uint()
+        _cu_check_error(_nvml_lib.nvmlDeviceGetCount(byref(n_gpus)))
+        _gpu_count = n_gpus.value
+    return _gpu_count
+
+
+def get_driver_info():
+    global _driver_info
+
+    _init_nvml()
+    if _nvml_lib is None:
+        return None
+    if _driver_info is not None:
+        return _driver_info
+
+    version_buf = create_string_buffer(100)
+    cuda_version = c_uint()
+
+    _nvml_check_error(_nvml_lib.nvmlSystemGetDriverVersion(version_buf, len(version_buf)))
+    _nvml_check_error(_nvml_lib.nvmlSystemGetCudaDriverVersion(byref(cuda_version)))
+
+    _driver_info = _nvml_driver_info(
+        driver_version=version_buf.value.decode(),
+        cuda_version='%d.%d' % (cuda_version.value // 1000, cuda_version.value % 1000)
+    )
+    return _driver_info
+
+
+def get_device_info(dev_index):
+    try:
+        return _device_infos[dev_index]
+    except KeyError:
+        pass
+
+    _init()
+    if not _initialized:
+        return None
+
+    device = c_int()
+    name_buf = create_string_buffer(100)
+    uuid_t = _CUuuid_t()
+    cc_major = c_int()
+    cc_minor = c_int()
+    cores = c_int()
+    threads_per_core = c_int()
+
+    _cu_check_error(_cuda_lib.cuDeviceGet(byref(device), c_int(dev_index)))
+    _cu_check_error(_cuda_lib.cuDeviceGetName(name_buf, len(name_buf), device))
+    _cu_check_error(_cuda_lib.cuDeviceGetUuid(byref(uuid_t), device))
+    _cu_check_error(_cuda_lib.cuDeviceComputeCapability(
+        byref(cc_major), byref(cc_minor), device))
+    _cu_check_error(_cuda_lib.cuDeviceGetAttribute(
+        byref(cores), CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, device))
+    _cu_check_error(_cuda_lib.cuDeviceGetAttribute(
+        byref(threads_per_core), CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR, device))
+
+    info = _device_infos[dev_index] = _cu_device_info(
+        uuid=uuid.UUID(bytes=uuid_t.bytes),
+        name=name_buf.value.decode(),
+        multiprocessors=cores.value,
+        cuda_cores=cores.value * _cu_get_processor_cores(cc_major.value, cc_minor.value),
+        threads=cores.value * threads_per_core.value,
+    )
+    return info
+
+
+def get_device_status(dev_index):
+    _init()
+    if not _initialized:
+        return None
+
+    device = _nvmlDevice_t()
+    utils = _nvmlUtilization_t()
+    temperature = c_uint()
+    memory_info = _nvmlBAR1Memory_t()
+
+    dev_uuid = get_device_info(dev_index).uuid
+
+    uuid_str = 'GPU-' + str(dev_uuid)
+    if sys.version_info[0] >= 3:
+        uuid_str = uuid_str.encode()
+
+    _nvml_check_error(_nvml_lib.nvmlDeviceGetHandleByUUID(uuid_str, byref(device)))
+    _nvml_check_error(_nvml_lib.nvmlDeviceGetUtilizationRates(device, byref(utils)))
+    _nvml_check_error(_nvml_lib.nvmlDeviceGetTemperature(
+        device, NVML_TEMPERATURE_GPU, byref(temperature)))
+    _nvml_check_error(_nvml_lib.nvmlDeviceGetBAR1MemoryInfo(device, byref(memory_info)))
+
+    return _nvml_device_status(
+        gpu_util=utils.gpu,
+        mem_util=utils.memory,
+        temperature=temperature.value,
+        fb_total_mem=memory_info.total,
+        fb_free_mem=memory_info.free,
+        fb_used_mem=memory_info.used,
+    )

--- a/mars/lib/sparse/core.py
+++ b/mars/lib/sparse/core.py
@@ -16,21 +16,17 @@
 
 import numpy as np
 try:
-    import cupy.sparse as cps
-except ImportError:  # pragma: no cover
-    cps = None
-try:
     import scipy.sparse as sps
     import scipy.sparse.linalg as splinalg
 except ImportError:  # pragma: no cover
     sps = None
     splinalg = None
-try:
-    import cupy as cp
-except ImportError:  # pragma: no cover
-    cp = None
+
+from ...utils import lazy_import
 
 splinalg = splinalg
+cp = lazy_import('cupy', globals=globals(), rename='cp')
+cps = lazy_import('cupy.sparse', globals=globals(), rename='cps')
 
 
 def issparse(x):

--- a/mars/node_info.py
+++ b/mars/node_info.py
@@ -19,7 +19,7 @@ import sys
 import time
 
 from . import resource
-from .utils import git_info
+from .utils import git_info, lazy_import
 
 try:
     import numpy as np
@@ -33,19 +33,14 @@ try:
     import pandas
 except ImportError:  # pragma: no cover
     pandas = None
-try:
-    import cupy as cp
-except ImportError:  # pragma: no cover
-    cp = None
-try:
-    import cudf
-except ImportError:  # pragma: no cover
-    cudf = None
+
+cp = lazy_import('cupy', globals=globals(), rename='cp')
+cudf = lazy_import('cudf', globals=globals())
 
 logger = logging.getLogger(__name__)
 
 
-def gather_node_info(async_ctx=None):
+def gather_node_info():
     from .lib.mkl_interface import mkl_get_version
     mem_stats = resource.virtual_memory()
 
@@ -61,7 +56,7 @@ def gather_node_info(async_ctx=None):
         'update_time': time.time(),
     }
 
-    cuda_info = resource.cuda_info(async_ctx=async_ctx)
+    cuda_info = resource.cuda_info()
     if cuda_info:
         node_info['cuda_info'] = 'Driver: %s\nCUDA: %s\nProducts: %s\n' % \
                                  (cuda_info.driver_version, cuda_info.cuda_version,

--- a/mars/scheduler/node_info.py
+++ b/mars/scheduler/node_info.py
@@ -36,7 +36,7 @@ class NodeInfoActor(FunctionActor):
         self.ref().gather_info()
 
     def gather_info(self):
-        self._node_info = gather_node_info(self.ctx)
+        self._node_info = gather_node_info()
         self.ref().gather_info(_tell=True, _delay=1)
 
     def get_info(self):

--- a/mars/serialize/dataserializer.py
+++ b/mars/serialize/dataserializer.py
@@ -29,10 +29,6 @@ try:
     import scipy.sparse as sps
 except ImportError:  # pragma: no cover
     sps = None
-try:
-    import cupy as cp
-except ImportError:  # pragma: no cover
-    cp = None
 
 from ..lib.sparse import SparseNDArray
 

--- a/mars/tensor/execution/array.py
+++ b/mars/tensor/execution/array.py
@@ -18,13 +18,12 @@ from collections import defaultdict
 from contextlib import contextmanager
 
 import numpy as np
-try:
-    import cupy as cp
-except ImportError:  # pragma: no cover
-    cp = None
 
 from ...lib import sparse
 from ...lib.sparse.core import issparse, get_dense_module
+from ...utils import lazy_import
+
+cp = lazy_import('cupy', globals=globals(), rename='cp')
 
 
 def get_array_module(x, nosparse=False):

--- a/mars/tensor/execution/core.py
+++ b/mars/tensor/execution/core.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ...utils import lazy_import
 from .datasource import register_data_source_handler
 from .datastore import register_data_store_handler
 from .random import register_random_handler
@@ -28,19 +29,11 @@ from .linalg import register_linalg_handler
 from .reshape import register_reshape_handler
 
 
-NUMEXPR_INSTALLED = False
-try:
-    import numexpr  # noqa: F401
-    NUMEXPR_INSTALLED = True
-except ImportError:  # pragma: no cover
-    pass
+ne = lazy_import('numexpr', globals=globals(), rename='ne')
+cp = lazy_import('cupy', globals=globals(), rename='cp')
 
-CP_INSTALLED = False
-try:
-    import cupy  # noqa: F401
-    CP_INSTALLED = True
-except ImportError:  # pragma: no cover
-    pass
+NUMEXPR_INSTALLED = ne is not None
+CP_INSTALLED = cp is not None
 
 
 def register_tensor_execution_handler():

--- a/mars/tests/test_resource.py
+++ b/mars/tests/test_resource.py
@@ -18,28 +18,6 @@ import unittest
 
 from mars.compat import reload_module
 
-_MOCK_NVIDIA_SMI_RESULT = b'''<?xml version="1.0" ?>
-<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v10.dtd">
-<nvidia_smi_log>
-  <driver_version>410.79</driver_version>
-  <cuda_version>10.0</cuda_version>
-  <attached_gpus>1</attached_gpus>
-  <gpu id="00000000:00:04.0">
-    <product_name>Tesla K80</product_name>
-    <fb_memory_usage>
-      <total>1024 MiB</total>
-      <used>512 MiB</used>
-      <free>512 MiB</free>
-    </fb_memory_usage>
-    <utilization>
-      <gpu_util>10 %</gpu_util>
-    </utilization>
-    <temperature>
-      <gpu_temp>34 C</gpu_temp>
-    </temperature>
-  </gpu>
-</nvidia_smi_log>'''
-
 
 class Test(unittest.TestCase):
     def testStats(self):
@@ -96,35 +74,4 @@ class Test(unittest.TestCase):
             del os.environ['MARS_USE_PROCESS_STAT']
             del os.environ['MARS_CPU_TOTAL']
             del os.environ['MARS_MEMORY_TOTAL']
-            reload_module(resource)
-
-    def testCUDAInfo(self):
-        from mars import resource
-        from xml.etree import ElementTree
-
-        self.assertTrue(
-            (resource.cuda_info() is None and resource.cuda_card_stats() is None) or
-            (resource.cuda_info() is not None and resource.cuda_card_stats() is not None)
-        )
-
-        try:
-            resource._last_nvml_output = ElementTree.fromstring(_MOCK_NVIDIA_SMI_RESULT)
-            resource._last_nvml_output_time = time.time()
-
-            cuda_info = resource.cuda_info()
-            self.assertEqual(cuda_info.driver_version, '410.79')
-            self.assertEqual(cuda_info.cuda_version, '10.0')
-            self.assertListEqual(cuda_info.products, ['Tesla K80'])
-            self.assertEqual(cuda_info.gpu_count, 1)
-
-            cuda_card_stats = resource.cuda_card_stats()
-            self.assertEqual(len(cuda_card_stats), 1)
-            self.assertEqual(cuda_card_stats[0].product_name, 'Tesla K80')
-            self.assertAlmostEqual(cuda_card_stats[0].temperature, 34)
-            self.assertAlmostEqual(cuda_card_stats[0].gpu_usage, 0.1)
-            self.assertAlmostEqual(cuda_card_stats[0].fb_mem_info.total, 1024 ** 3)
-            self.assertAlmostEqual(cuda_card_stats[0].fb_mem_info.used, 1024 ** 3 / 2)
-            self.assertAlmostEqual(cuda_card_stats[0].fb_mem_info.free, 1024 ** 3 / 2)
-            self.assertAlmostEqual(cuda_card_stats[0].fb_mem_info.percent, 0.5)
-        finally:
             reload_module(resource)

--- a/mars/worker/status.py
+++ b/mars/worker/status.py
@@ -120,7 +120,7 @@ class StatusReporterActor(WorkerActor):
                 hw_metrics['disk_used'] = agg_disk_used
                 hw_metrics['disk_total'] = agg_disk_total
 
-            cuda_card_stats = resource.cuda_card_stats(async_ctx=self.ctx)
+            cuda_card_stats = resource.cuda_card_stats()
             if cuda_card_stats:
                 hw_metrics['cuda_stats'] = [dict(
                     product_name=stat.product_name,
@@ -145,7 +145,7 @@ class StatusReporterActor(WorkerActor):
                 meta_dict['slots'][k] = v
 
             meta_dict['progress'] = self._status_ref.get_progress()
-            meta_dict['details'] = gather_node_info(self.ctx)
+            meta_dict['details'] = gather_node_info()
 
             self._resource_ref.set_worker_meta(self._endpoint, meta_dict)
         except Exception as ex:


### PR DESCRIPTION
## What do these changes do?

1. Use lazy import for cupy and cudf to stop calling cuInit() before forking
2. Use ctypes instead of calling nvidia-smi to retrieve GPU status

## Related issue number

Fixes #479 