### PR TITLE
Remove --ui-port option for Mars Web

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -89,7 +89,7 @@ Web service can be started with the following command:
 
 .. code-block:: bash
 
-    mars-web -a <web_ip> -s <scheduler_endpoint> -p <communicator_port> --ui-port <ui_port_exposed_to_user>
+    mars-web -a <web_ip> -s <scheduler_endpoint> -p <web_port>
 
 Workers can be started with the following command:
 

--- a/mars/base_app.py
+++ b/mars/base_app.py
@@ -76,11 +76,11 @@ class BaseApplication(object):
         parser.add_argument('-k', '--kv-store', help='address of kv store service, '
                                                      'for instance, etcd://localhost:4001')
         parser.add_argument('-e', '--endpoint', help='endpoint of the service')
-        parser.add_argument('-s', '--schedulers', help='endpoint of scheduler, when single scheduler '
+        parser.add_argument('-s', '--schedulers', help='endpoint of schedulers, when single scheduler '
                                                        'and etcd is not available')
-        parser.add_argument('-H', '--host', help='host of the scheduler service, only available '
+        parser.add_argument('-H', '--host', help='host of the service, only available '
                                                  'when `endpoint` is absent')
-        parser.add_argument('-p', '--port', help='port of the scheduler service, only available '
+        parser.add_argument('-p', '--port', help='port of the service, only available '
                                                  'when `endpoint` is absent')
         parser.add_argument('--level', help='log level')
         parser.add_argument('--format', help='log format')
@@ -125,7 +125,7 @@ class BaseApplication(object):
 
         if getattr(self, 'require_pool', True):
             self.endpoint, self.pool = self._try_create_pool(endpoint=endpoint, host=host, port=port)
-        self.service_logger.info('%s started at %s.', self.service_description, self.endpoint)
+            self.service_logger.info('%s started at %s.', self.service_description, self.endpoint)
         self.main_loop()
 
     def config_logging(self):

--- a/mars/web/__main__.py
+++ b/mars/web/__main__.py
@@ -17,9 +17,10 @@
 import gevent.monkey
 gevent.monkey.patch_all(thread=False)
 
-import logging  # noqa: E402
-import random   # noqa: E402
-import time     # noqa: E402
+import argparse  # noqa: E402
+import logging   # noqa: E402
+import random    # noqa: E402
+import time      # noqa: E402
 
 from ..base_app import BaseApplication   # noqa: E402
 from ..compat import six                 # noqa: E402
@@ -35,7 +36,7 @@ class WebApplication(BaseApplication):
         self.require_pool = False
 
     def config_args(self, parser):
-        parser.add_argument('--ui-port', help='port of Mars UI')
+        parser.add_argument('--ui-port', help=argparse.SUPPRESS)
 
     def validate_arguments(self):
         if not self.args.schedulers and not self.args.kv_store:
@@ -55,7 +56,8 @@ class WebApplication(BaseApplication):
             self.mars_web = None
             logger.warning('Mars UI cannot be loaded. Please check if necessary components are installed.')
         else:
-            ui_port = int(self.args.ui_port) if self.args.ui_port else None
+            port_arg = self.args.ui_port or self.args.port
+            ui_port = int(port_arg) if port_arg else None
             scheduler_ip = self.args.schedulers or None
             if isinstance(scheduler_ip, six.string_types):
                 schedulers = scheduler_ip.split(',')

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -113,7 +113,7 @@ class Test(unittest.TestCase):
         proc_web = subprocess.Popen([sys.executable, '-m', 'mars.web',
                                     '-H', '127.0.0.1',
                                      '--level', 'debug',
-                                     '--ui-port', web_port,
+                                     '-p', web_port,
                                      '-s', '127.0.0.1:' + self.scheduler_port])
         self.proc_web = proc_web
 


### PR DESCRIPTION
## What do these changes do?

Merge --ui-port option into -p for Mars Web. The old option is still kept for compatibility.

## Related issue number

Fixes #481 