### PR TITLE
Specify an __order__ attribute in Enum class OperandState

### DIFF
--- a/mars/scheduler/operands/core.py
+++ b/mars/scheduler/operands/core.py
@@ -21,6 +21,7 @@ from ...utils import classproperty
 
 
 class OperandState(Enum):
+    __order__ = 'UNSCHEDULED READY RUNNING FINISHED CACHED FREED FATAL CANCELLING CANCELLED'
     UNSCHEDULED = 'unscheduled'
     READY = 'ready'
     RUNNING = 'running'


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Specify an ` __order__ ` attribute in Enum class `OperandState`.

## Related issue number

fixed #501 