### PR TITLE
Define __str__ and __repr__ for DataFrame, Index, and Series.

### DIFF
--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -21,7 +21,7 @@ except ImportError:  # pragma: no cover
     pass
 
 from ..utils import on_serialize_shape, on_deserialize_shape, on_serialize_numpy_type
-from ..core import ChunkData, Chunk, Entity, TileableData
+from ..core import ChunkData, Chunk, Entity, TileableData, is_eager_mode
 from ..serialize import Serializable, ValueType, ProviderType, DataTypeField, AnyField, \
     SeriesField, BoolField, Int64Field, Int32Field, StringField, ListField, SliceField, \
     TupleField, OneOfField, ReferenceField, NDArrayField
@@ -305,8 +305,21 @@ class IndexData(TileableData):
             return IndexDef
         return super(IndexData, cls).cls(provider)
 
+    def __str__(self):
+        if is_eager_mode():
+            return 'Index(op={0}, data=\n{1})'.format(self.op.__class__.__name__,
+                                                      str(self.fetch()))
+        else:
+            return 'Index(op={0})'.format(self.op.__class__.__name__)
+
     def __repr__(self):
-        return 'Index <op={0}, key={1}>'.format(self.op.__class__.__name__, self.key)
+        if is_eager_mode():
+            return 'Index <op={0}, key={1}, data=\n{2}>'.format(self.op.__class__.__name__,
+                                                                self.key,
+                                                                repr(self.fetch()))
+        else:
+            return 'Index <op={0}, key={1}>'.format(self.op.__class__.__name__,
+                                                    self.key)
 
     @property
     def dtype(self):
@@ -366,6 +379,22 @@ class SeriesData(TileableData):
             from ..serialize.protos.dataframe_pb2 import SeriesDef
             return SeriesDef
         return super(SeriesData, cls).cls(provider)
+
+    def __str__(self):
+        if is_eager_mode():
+            return 'Series(op={0}, data=\n{1})'.format(self.op.__class__.__name__,
+                                                       str(self.fetch()))
+        else:
+            return 'Series(op={0})'.format(self.op.__class__.__name__)
+
+    def __repr__(self):
+        if is_eager_mode():
+            return 'Series <op={0}, key={1}, data=\n{2}>'.format(self.op.__class__.__name__,
+                                                                 self.key,
+                                                                 repr(self.fetch()))
+        else:
+            return 'Series <op={0}, key={1}>'.format(self.op.__class__.__name__,
+                                                     self.key)
 
     @property
     def dtype(self):
@@ -460,6 +489,22 @@ class DataFrameData(TileableData):
             from ..serialize.protos.dataframe_pb2 import DataFrameDef
             return DataFrameDef
         return super(DataFrameData, cls).cls(provider)
+
+    def __str__(self):
+        if is_eager_mode():
+            return 'DataFrame(op={0}, data=\n{1})'.format(self.op.__class__.__name__,
+                                                          str(self.fetch()))
+        else:
+            return 'DataFrame(op={0})'.format(self.op.__class__.__name__)
+
+    def __repr__(self):
+        if is_eager_mode():
+            return 'DataFrame <op={0}, key={1}, data=\n{2}>'.format(self.op.__class__.__name__,
+                                                                    self.key,
+                                                                    repr(self.fetch()))
+        else:
+            return 'DataFrame <op={0}, key={1}>'.format(self.op.__class__.__name__,
+                                                        self.key)
 
     @property
     def params(self):

--- a/mars/tests/test_eager_mode.py
+++ b/mars/tests/test_eager_mode.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 
 import mars.tensor as mt
+import mars.dataframe as md
 from mars.config import option_context
 from mars.dataframe.expressions.datasource.dataframe import from_pandas
 
@@ -163,7 +164,7 @@ class Test(unittest.TestCase):
             self.assertEqual(4, len(executor.chunk_result))
             np.testing.assert_array_equal(result, np.ones((8, 8)))
 
-    def testRepr(self):
+    def testReprTensor(self):
         a = mt.ones((10, 10), chunk_size=3)
         self.assertIn(a.key, repr(a))
 
@@ -174,6 +175,18 @@ class Test(unittest.TestCase):
 
         self.assertNotIn(repr(np.ones((10, 10))), repr(a))
         self.assertNotIn(str(np.ones((10, 10))), str(a))
+
+    def testReprDataFrame(self):
+        a = md.DataFrame(np.ones((10, 10)), chunk_size=3)
+        x = pd.DataFrame(np.ones((10, 10)))
+
+        with option_context({'eager_mode': True}):
+            a = md.DataFrame(np.ones((10, 10)), chunk_size=3)
+            self.assertIn(repr(x), repr(a))
+            self.assertIn(str(x), str(a))
+
+        self.assertNotIn(repr(x), repr(a))
+        self.assertNotIn(str(x), str(a))
 
     def testRuntimeError(self):
         from mars.utils import kernel_mode


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Define `__str__` and `__repr__` for `DataFrameData`, `IndexData` and `SeriesData` properly, as what we have done for `TensorData`, and respect the eager mode settings.

## Related issue number

#508.