### PR TITLE
Refactor web using standalone tornado handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ matrix:
       language: generic
       env: PYTHON=3.7
 
+addons:
+  apt:
+    update: true
 before_install:
   - source ./bin/travis-install-conda.sh
   - if [[ "$PYTHON" =~ "2" ]]; then

--- a/bin/travis-install-conda.sh
+++ b/bin/travis-install-conda.sh
@@ -6,6 +6,7 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     ulimit -n 1024
     CONDA_OS="MacOSX"
 elif [[ $TRAVIS_OS_NAME == 'linux' ]]; then
+    sudo apt-get install -y liblz4-dev
     CONDA_OS="Linux"
 fi
 
@@ -17,7 +18,8 @@ fi
 
 curl -s -o miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE
 bash miniconda.sh -b -p $HOME/miniconda && rm miniconda.sh
-$HOME/miniconda/bin/conda create --quiet --yes -n test python=$PYTHON virtualenv gevent psutil pyyaml nomkl libopenblas
+$HOME/miniconda/bin/conda create --quiet --yes -n test python=$PYTHON virtualenv gevent psutil \
+    pyyaml nomkl libopenblas lz4
 export PATH="$HOME/miniconda/envs/test/bin:$HOME/miniconda/bin:$PATH"
 
 #check python version

--- a/mars/config.py
+++ b/mars/config.py
@@ -294,6 +294,9 @@ default_options.register_option('tcp_timeout', 30, validator=is_integer)
 default_options.register_option('verbose', False, validator=is_bool)
 default_options.register_option('kv_store', ':inproc:', validator=is_string)
 
+# deploy
+default_options.register_option('deploy.open_browser', True, validator=is_bool)
+
 # Tensor
 default_options.register_option('tensor.chunk_size', None, validator=any_validator(is_null, is_integer), serialize=True)
 default_options.register_option('tensor.chunk_store_limit', 128 * 1024 ** 2, validator=is_numeric)

--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -14,10 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import atexit
 import multiprocessing
 import os
 import signal
+import sys
 import time
 
 from ...actors import create_actor_pool
@@ -284,7 +287,8 @@ class LocalDistributedClusterClient(object):
         self._ensure_process_finish(self._web_process)
 
 
-def new_cluster(address='0.0.0.0', web=False, n_process=None, shared_memory=None, **kw):
+def new_cluster(address='0.0.0.0', web=False, n_process=None, shared_memory=None,
+                open_browser=True, **kw):
     endpoint = gen_endpoint(address)
     web_endpoint = None
     if web is True:
@@ -300,6 +304,10 @@ def new_cluster(address='0.0.0.0', web=False, n_process=None, shared_memory=None
     web_process = None
     if web_endpoint:
         web_process = _start_web_process(endpoint, web_endpoint)
+        print('Web endpoint started at http://%s' % web_endpoint, file=sys.stderr)
+        if open_browser:
+            import webbrowser
+            webbrowser.open_new_tab('http://%s' % web_endpoint)
 
     client = LocalDistributedClusterClient(endpoint, web_endpoint, process, web_process)
     _local_cluster_clients[id(client)] = client

--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -25,6 +25,7 @@ import time
 
 from ...actors import create_actor_pool
 from ...compat import six, TimeoutError  # pylint: disable=W0622
+from ...config import options
 from ...lib import gipc
 from ...resource import cpu_count
 from ...scheduler.service import SchedulerService
@@ -288,7 +289,8 @@ class LocalDistributedClusterClient(object):
 
 
 def new_cluster(address='0.0.0.0', web=False, n_process=None, shared_memory=None,
-                open_browser=True, **kw):
+                open_browser=None, **kw):
+    open_browser = open_browser or options.deploy.open_browser
     endpoint = gen_endpoint(address)
     web_endpoint = None
     if web is True:

--- a/mars/web/dashboard.py
+++ b/mars/web/dashboard.py
@@ -12,38 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .server import register_ui_handler, get_jinja_env, MarsWebAPI
+from .server import MarsWebAPI, MarsRequestHandler, register_web_handler, get_jinja_env
 
 _jinja_env = get_jinja_env()
 
 
-def dashboard(scheduler_ip, doc):
-    doc.title = 'Mars UI'
+class DashboardHandler(MarsRequestHandler):
+    def get(self):
+        web_api = MarsWebAPI(self._scheduler)
+        scheduler_infos = web_api.get_schedulers_info()
+        worker_infos = web_api.get_workers_meta()
 
-    web_api = MarsWebAPI(scheduler_ip)
-    scheduler_infos = web_api.get_schedulers_info()
-    worker_infos = web_api.get_workers_meta()
+        scheduler_summary = {
+            'count': len(scheduler_infos),
+            'cpu_used': sum(si['cpu_used'] for si in scheduler_infos.values()),
+            'cpu_total': sum(si['cpu_total'] for si in scheduler_infos.values()),
+            'memory_used': sum(si['memory_used'] for si in scheduler_infos.values()),
+            'memory_total': sum(si['memory_total'] for si in scheduler_infos.values()),
+            'git_branches': set(si['git_info'] for si in scheduler_infos.values()),
+        }
+        worker_summary = {
+            'count': len(worker_infos),
+            'cpu_used': sum(wi['hardware']['cpu_used'] for wi in worker_infos.values()),
+            'cpu_total': sum(wi['hardware']['cpu_total'] for wi in worker_infos.values()),
+            'memory_used': sum(wi['hardware']['memory_used'] for wi in worker_infos.values()),
+            'memory_total': sum(wi['hardware']['memory_total'] for wi in worker_infos.values()),
+            'git_branches': set(wi['details']['git_info'] for wi in worker_infos.values()),
+        }
 
-    scheduler_summary = {
-        'count': len(scheduler_infos),
-        'cpu_used': sum(si['cpu_used'] for si in scheduler_infos.values()),
-        'cpu_total': sum(si['cpu_total'] for si in scheduler_infos.values()),
-        'memory_used': sum(si['memory_used'] for si in scheduler_infos.values()),
-        'memory_total': sum(si['memory_total'] for si in scheduler_infos.values()),
-        'git_branches': set(si['git_info'] for si in scheduler_infos.values()),
-    }
-    worker_summary = {
-        'count': len(worker_infos),
-        'cpu_used': sum(wi['hardware']['cpu_used'] for wi in worker_infos.values()),
-        'cpu_total': sum(wi['hardware']['cpu_total'] for wi in worker_infos.values()),
-        'memory_used': sum(wi['hardware']['memory_used'] for wi in worker_infos.values()),
-        'memory_total': sum(wi['hardware']['memory_total'] for wi in worker_infos.values()),
-        'git_branches': set(wi['details']['git_info'] for wi in worker_infos.values()),
-    }
-
-    doc.template_variables['scheduler_summary'] = scheduler_summary
-    doc.template_variables['worker_summary'] = worker_summary
-    doc.template = _jinja_env.get_template('dashboard.html')
+        template = _jinja_env.get_template('dashboard.html')
+        self.write(template.render(
+            scheduler_summary=scheduler_summary, worker_summary=worker_summary
+        ))
 
 
-register_ui_handler('/', dashboard)
+register_web_handler('/', DashboardHandler)

--- a/mars/web/task_pages.py
+++ b/mars/web/task_pages.py
@@ -12,49 +12,70 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from bokeh.models import ColumnDataSource
+from bokeh.embed import server_document
+from bokeh.models import ColumnDataSource, Legend
 from bokeh.plotting import figure
 
-from .server import register_ui_handler, get_jinja_env
+from .server import MarsWebAPI, MarsRequestHandler, get_jinja_env, \
+    register_bokeh_app, register_web_handler
 from ..scheduler import OperandState
-from ..utils import to_str
 from ..actors import new_client
-from .server import MarsWebAPI
+from ..utils import to_str
 
 
 _actor_client = new_client()
 _jinja_env = get_jinja_env()
 
+PROGRESS_APP_NAME = 'bk_task_progress'
 _base_palette = ['#e0f9ff', '#81d4dd', '#ff9e3b', '#399e34', '#2679b2', '#b3de8e',
                  '#e01f27', '#b3b3cc', '#f0f0f5']
 
 
-def task_list(doc, web_api):
-    sessions = web_api.get_tasks_info()
+class TaskListHandler(MarsRequestHandler):
+    def get(self):
+        sessions = self.web_api.get_tasks_info()
 
-    doc.title = 'Mars UI'
-    doc.template_variables['sessions'] = sessions
-    doc.template = _jinja_env.get_template('task_list.html')
+        template = _jinja_env.get_template('task_list.html')
+        self.write(template.render(sessions=sessions))
 
 
-def task_operand(doc, cluster_info, session_id, task_id):
-    session_name = session_id
+class TaskHandler(MarsRequestHandler):
+    def get(self, session_id, graph_key):
+        session_name = session_id
+
+        template = _jinja_env.get_template('task_operands.html')
+        task_progress_script = server_document(
+            '%s://%s/%s' % (self.request.protocol, self.request.host, PROGRESS_APP_NAME),
+            arguments=dict(session_id=session_id, task_id=graph_key))
+        self.write(template.render(
+            session_id=session_id,
+            session_name=session_name,
+            task_id=graph_key,
+            task_progress_script=task_progress_script,
+        ))
+
+
+def task_progress(scheduler_ip, doc):
+    session_id = to_str(doc.session_context.request.arguments.get('session_id')[0])
+    task_id = to_str(doc.session_context.request.arguments.get('task_id')[0])
+    web_api = MarsWebAPI(scheduler_ip)
+
     states = list(OperandState.__members__.values())
 
-    ops, stats, progress = cluster_info.get_task_detail(session_id, task_id)
+    ops, stats, progress = web_api.get_task_detail(session_id, task_id)
     source = ColumnDataSource(stats)
     cols = list(stats)[1:]
-    p = figure(y_range=[''] + ops, plot_height=500, plot_width=800, x_range=(0, 100),
-               title="Task Progresses")
-    p.hbar_stack(cols, y='ops', height=0.9, color=_base_palette[0:len(states)],
-                 source=source, legend=['\0' + s for s in cols])
+    p = figure(y_range=ops, plot_height=500, plot_width=800, x_range=(0, 100),
+               title="Total Progress: %0.2f%%" % progress)
+    renderers = p.hbar_stack(cols, y='ops', height=0.9, color=_base_palette[0:len(states)],
+                             source=source)
 
-    p.legend.background_fill_alpha = 0.5
-    p.legend.location = 'bottom_left'
-    p.legend.orientation = "horizontal"
-    p.legend.label_text_font_size = '10px'
+    legend_items = [('\0' + s, [r]) for s, r in zip(cols, renderers)]
+    legend = Legend(items=legend_items, location='bottom_right',
+                    orientation='horizontal', label_text_font_size='10px')
 
-    p.y_range.range_padding = 0.1
+    p.add_layout(legend, 'below')
+
     p.ygrid.grid_line_color = None
     p.yaxis.major_tick_line_color = None
     p.yaxis.minor_tick_line_color = None
@@ -63,22 +84,16 @@ def task_operand(doc, cluster_info, session_id, task_id):
 
     doc.add_root(p)
 
-    doc.title = 'Mars UI'
-    doc.template_variables['session_id'] = session_id
-    doc.template_variables['session_name'] = session_name
-    doc.template_variables['task_id'] = task_id
-    doc.template_variables['progress'] = progress
-    doc.template = _jinja_env.get_template('task_operands.html')
+    def _refresher():
+        _, new_stats, new_progress = web_api.get_task_detail(session_id, task_id)
+        p.title.text = "Total Progress: %0.2f%%" % new_progress
+        source.data = new_stats
+
+    if progress < 100.0:
+        doc.add_periodic_callback(_refresher, 5000)
 
 
-def _route(scheduler_ip, doc):
-    web_api = MarsWebAPI(scheduler_ip)
-    session_id = doc.session_context.request.arguments.get('session_id')
-    task_id = doc.session_context.request.arguments.get('task_id')
-    if session_id and task_id:
-        task_operand(doc, web_api, to_str(session_id[0]), to_str(task_id[0]))
-    else:
-        task_list(doc, web_api)
+register_web_handler('/session', TaskListHandler)
+register_web_handler('/session/(?P<session_id>[^/]+)/graph/(?P<graph_key>[^/]+)', TaskHandler)
 
-
-register_ui_handler('/task', _route)
+register_bokeh_app('/' + PROGRESS_APP_NAME, task_progress)

--- a/mars/web/templates/base.html
+++ b/mars/web/templates/base.html
@@ -4,8 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
     <title>Mars UI</title>
-    {{ bokeh_css }}
-    {{ bokeh_js }}
     <script type="text/javascript" src="/static/js/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/static/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="/static/js/moment.min.js"></script>
@@ -47,7 +45,7 @@
                         {% endblock %}
                     </li>
                     <li>
-                        <a href="/task" {% if active_page == 'task_list' %}class="active"{% endif %}><i class="fa fa-tasks fa-fw"></i> Tasks</a>
+                        <a href="/session" {% if active_page == 'task_list' %}class="active"{% endif %}><i class="fa fa-tasks fa-fw"></i> Tasks</a>
                         {% block task_submenu %}
                         {% endblock %}
                     </li>

--- a/mars/web/templates/scheduler_list.html
+++ b/mars/web/templates/scheduler_list.html
@@ -30,7 +30,7 @@
                 {%- for endpoint in scheduler_metrics %}
                     {% set metrics = scheduler_metrics[endpoint] %}
                     <tr>
-                        <td><a href="/scheduler?endpoint={{ endpoint }}">{{ endpoint }}</a></td>
+                        <td><a href="/scheduler/{{ endpoint }}">{{ endpoint }}</a></td>
                         <td>{{ '%0.2f' % metrics['cpu_used'] }} / {{ metrics['cpu_total'] }}</td>
                         <td>{{ metrics['memory_used'] | readable_size }} / {{ metrics['memory_total'] | readable_size }}</td>
                         <td>{{ scheduler_metrics[endpoint]['update_time'] | format_ts }}</td>

--- a/mars/web/templates/task_list.html
+++ b/mars/web/templates/task_list.html
@@ -23,7 +23,7 @@
                         {% if task_desc['state'] == 'preparing'%}
                             <td>{{ task_id }}</td>
                         {% else %}
-                            <td><a href="/task?session_id={{ session_id }}&task_id={{ task_id }}">{{ task_id }}</a></td>
+                            <td><a href="/session/{{ session_id }}/graph/{{ task_id }}">{{ task_id }}</a></td>
                         {% endif %}
                         {% if task_desc['start_time'] is defined %}
                             <td>{{ task_desc['start_time'] | format_ts }}</td>

--- a/mars/web/templates/task_operands.html
+++ b/mars/web/templates/task_operands.html
@@ -2,12 +2,7 @@
 {% set active_page = 'task_operand' %}
 {% block body %}
     <div class="row">
-        <h2>Total Progress</h2>
-        {{ '%0.2f%%' % progress }}
         <h2>Task Progresses</h2>
-        {{ plot_div|safe }}
+        {{ task_progress_script|safe }}
     </div>
-{% endblock %}
-{% block footer %}
-    {{ plot_script|safe }}
 {% endblock %}

--- a/mars/web/templates/worker_list.html
+++ b/mars/web/templates/worker_list.html
@@ -31,7 +31,7 @@
                 {%- for endpoint in worker_metrics %}
                     {% set metrics = worker_metrics[endpoint]['hardware'] %}
                     <tr>
-                        <td><a href="/worker?endpoint={{ endpoint }}">{{ endpoint }}</a></td>
+                        <td><a href="/worker/{{ endpoint }}">{{ endpoint }}</a></td>
                         <td>{{ '%0.2f' % metrics['cpu_used'] }} / {{ metrics['cpu_total'] }}</td>
                         <td>{{ metrics['memory_used'] | readable_size }} / {{ metrics['memory_total'] | readable_size }}</td>
                         <td>{{ metrics['cached_hold'] | readable_size }} / {{ metrics['cached_total'] | readable_size }}</td>

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -21,6 +21,7 @@ import os
 import sys
 import signal
 import subprocess
+import time
 import uuid
 
 import gevent
@@ -196,6 +197,9 @@ class Test(unittest.TestCase):
 
             graphs = sess.get_graph_states()
 
+            # make sure status got uploaded
+            time.sleep(1.5)
+
             # check web UI requests
             res = requests.get(service_ep)
             self.assertEqual(res.status_code, 200)
@@ -214,6 +218,11 @@ class Test(unittest.TestCase):
             self.assertEqual(res.status_code, 200)
             task_id = next(iter(graphs.keys()))
             res = requests.get('%s/session/%s/graph/%s' % (service_ep, sess._session_id, task_id))
+            self.assertEqual(res.status_code, 200)
+
+            from mars.web.task_pages import PROGRESS_APP_NAME
+            res = requests.get('%s/%s?session_id=%s&task_id=%s'
+                               % (service_ep, PROGRESS_APP_NAME, sess._session_id, task_id))
             self.assertEqual(res.status_code, 200)
 
 

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -200,23 +200,20 @@ class Test(unittest.TestCase):
             res = requests.get(service_ep)
             self.assertEqual(res.status_code, 200)
 
-            res = requests.get('%s/task' % (service_ep,))
-            self.assertEqual(res.status_code, 200)
-
             res = requests.get('%s/scheduler' % (service_ep,))
             self.assertEqual(res.status_code, 200)
-            res = requests.get('%s/scheduler?endpoint=127.0.0.1:%s' % (service_ep, self.scheduler_port))
+            res = requests.get('%s/scheduler/127.0.0.1:%s' % (service_ep, self.scheduler_port))
             self.assertEqual(res.status_code, 200)
 
             res = requests.get('%s/worker' % (service_ep,))
             self.assertEqual(res.status_code, 200)
-            res = requests.get('%s/worker?endpoint=127.0.0.1:%s' % (service_ep, self.worker_port))
+            res = requests.get('%s/worker/127.0.0.1:%s' % (service_ep, self.worker_port))
             self.assertEqual(res.status_code, 200)
 
-            res = requests.get('%s/task' % (service_ep,))
+            res = requests.get('%s/session' % (service_ep,))
             self.assertEqual(res.status_code, 200)
             task_id = next(iter(graphs.keys()))
-            res = requests.get('%s/task?session_id=%s&task_id=%s' % (service_ep, sess._session_id, task_id))
+            res = requests.get('%s/session/%s/graph/%s' % (service_ep, sess._session_id, task_id))
             self.assertEqual(res.status_code, 200)
 
 


### PR DESCRIPTION
## What do these changes do?

Previously Mars web uses bokeh applications to render all the pages, which is inflexible as bokeh does not support urls with multiple slashes, and we have to use complex query strings. To avoid this and pave way for more information on the web ui, tornado handlers are now used and bokeh applications are limited to graphs and embedded into pages with scripts.

Dynamic refreshing issue of progress graphs are also fixed.

## Related issue number

Fixes #510 