### PR TITLE
Fix bug that redundant graphs are submitted unexpectedly when eager mode is on

### DIFF
--- a/mars/core.py
+++ b/mars/core.py
@@ -23,7 +23,7 @@ import numpy as np
 
 from .compat import six, izip, builtins, reduce
 from .utils import tokenize, AttributeDict, on_serialize_shape, \
-    on_deserialize_shape, on_serialize_nsplits, is_eager_mode
+    on_deserialize_shape, on_serialize_nsplits, is_eager_mode, kernel_mode
 from .serialize import HasKey, ValueType, ProviderType, Serializable, AttributeAsDict, \
     TupleField, ListField, DictField, KeyField, BoolField, StringField, OneOfField
 from .tiles import Tileable, handler
@@ -476,6 +476,7 @@ class TileableData(SerializableWithKey, Tileable):
     def single_tiles(self):
         return handler.single_tiles(self)
 
+    @kernel_mode
     def build_graph(self, graph=None, cls=DAG, tiled=False, compose=True, executed_keys=None):
         from .utils import build_fetch
 

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -20,7 +20,6 @@ import os
 import sys
 import time
 import unittest
-import json
 
 import numpy as np
 try:
@@ -480,9 +479,7 @@ class Test(unittest.TestCase):
                     np.testing.assert_array_almost_equal(r2, expected2)
 
                     web_session = Session.default_or_local()._sess
-                    tasks_url = 'http://{0}/api/session/{1}/graph'.format(cluster.web_endpoint,
-                                                                          web_session.session_id)
-                    self.assertEqual(len(json.loads(web_session._req_session.get(tasks_url).text)), 3)
+                    self.assertEqual(web_session.get_task_count(), 3)
 
                 a = mt.ones((10, 10), chunk_size=3)
                 with self.assertRaises(ValueError):
@@ -512,9 +509,7 @@ class Test(unittest.TestCase):
                     pd.testing.assert_frame_equal(df3.fetch(), data1 + data2)
 
                 web_session = Session.default_or_local()._sess
-                tasks_url = 'http://{0}/api/session/{1}/graph'.format(cluster.web_endpoint,
-                                                                      web_session.session_id)
-                self.assertEqual(len(json.loads(web_session._req_session.get(tasks_url).text)), 3)
+                self.assertEqual(web_session.get_task_count(), 3)
 
     def testSparse(self, *_):
         import scipy.sparse as sps

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -20,6 +20,7 @@ import os
 import sys
 import time
 import unittest
+import json
 
 import numpy as np
 try:
@@ -478,6 +479,11 @@ class Test(unittest.TestCase):
                     expected2 = expected1.dot(expected1)
                     np.testing.assert_array_almost_equal(r2, expected2)
 
+                    web_session = Session.default_or_local()._sess
+                    tasks_url = 'http://{0}/api/session/{1}/graph'.format(cluster.web_endpoint,
+                                                                          web_session.session_id)
+                    self.assertEqual(len(json.loads(web_session._req_session.get(tasks_url).text)), 3)
+
                 a = mt.ones((10, 10), chunk_size=3)
                 with self.assertRaises(ValueError):
                     a.fetch()
@@ -504,6 +510,11 @@ class Test(unittest.TestCase):
 
                     df3 = add(df1, df2)
                     pd.testing.assert_frame_equal(df3.fetch(), data1 + data2)
+
+                web_session = Session.default_or_local()._sess
+                tasks_url = 'http://{0}/api/session/{1}/graph'.format(cluster.web_endpoint,
+                                                                      web_session.session_id)
+                self.assertEqual(len(json.loads(web_session._req_session.get(tasks_url).text)), 3)
 
     def testSparse(self, *_):
         import scipy.sparse as sps

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -264,6 +264,10 @@ class Session(object):
         resp = self._req_session.get(self._endpoint + '/api/worker', timeout=1)
         return json.loads(resp.text)
 
+    def get_task_count(self):
+        resp = self._req_session.get(self._endpoint + '/api/session/{0}/graph'.format(self._session_id))
+        return len(json.loads(resp.text))
+
     def __enter__(self):
         return self
 

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 import requests
 import json
 import unittest


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
When eager mode is on, an entity will be executed once it is created, so we should use `kernel_mode` to decorate the function `build_graph` to avoid execution. 

## Related issue number
fixes #522 

<!-- Are there any issues opened that will be resolved by merging this change? -->
