### PR TITLE
Support view behavior in numpy and add `tensor.view()` as well as `tensor.flat`

### DIFF
--- a/mars/core.py
+++ b/mars/core.py
@@ -17,7 +17,7 @@
 import threading
 import itertools
 from operator import attrgetter, mul
-from weakref import WeakKeyDictionary, ref
+from weakref import WeakKeyDictionary, WeakSet, ref
 
 import numpy as np
 
@@ -349,7 +349,7 @@ FUSE_CHUNK_TYPE = (FuseChunkData, FuseChunk)
 
 
 class TileableData(SerializableWithKey, Tileable):
-    __slots__ = '__weakref__', '_siblings', '_cix'
+    __slots__ = '__weakref__', '_siblings', '_cix', '_entities'
     _no_copy_attrs_ = SerializableWithKey._no_copy_attrs_ | {'_cix'}
 
     # required fields
@@ -372,6 +372,8 @@ class TileableData(SerializableWithKey, Tileable):
 
         if hasattr(self, '_chunks') and self._chunks:
             self._chunks = sorted(self._chunks, key=attrgetter('index'))
+
+        self._entities = WeakSet()
 
     @property
     def ndim(self):
@@ -452,6 +454,10 @@ class TileableData(SerializableWithKey, Tileable):
         except (TypeError, ValueError):
             return ChunksIndexer(self)
 
+    @property
+    def entities(self):
+        return self._entities
+
     def is_coarse(self):
         return not hasattr(self, '_chunks') or self._chunks is None or len(self._chunks) == 0
 
@@ -469,6 +475,14 @@ class TileableData(SerializableWithKey, Tileable):
         return self.op.is_sparse()
 
     issparse = is_sparse
+
+    @enter_build_mode
+    def attach(self, entity):
+        self._entities.add(entity)
+
+    @enter_build_mode
+    def detach(self, entity):
+        self._entities.discard(entity)
 
     def tiles(self):
         return handler.tiles(self)
@@ -565,6 +579,20 @@ class TileableData(SerializableWithKey, Tileable):
         _cleaner.register(self, session)
 
     _execute_session = property(fset=_set_execute_session)
+
+
+class TileableEntity(Entity):
+    __slots__ = '__weakref__',
+
+    def __init__(self, data):
+        super(TileableEntity, self).__init__(data)
+        self._data.attach(self)
+        if data.op.create_view:
+            entity_view_handler.add_observer(data.inputs[0], self)
+
+    @Entity.data.setter
+    def data(self, new_data):
+        entity_view_handler.data_changed(self._data, new_data)
 
 
 class ChunksIndexer(object):
@@ -732,6 +760,66 @@ class _TileableDataCleaner(object):
             self._tileable_to_sessions[tensor] = [_TileableSession(tensor, session)]
 
 
-# we don't use __del__ to decref because a tensor holds an op,
-# and op's outputs contains the tensor, so a circular references exists
+# we don't use __del__ to avoid potential Circular reference
 _cleaner = _TileableDataCleaner()
+
+
+class EntityDataModificationHandler(object):
+    def __init__(self):
+        self._data_to_entities = WeakKeyDictionary()
+
+    def _add_observer(self, data, entity):
+        # only tileable data should be considered
+        assert isinstance(data, TileableData)
+        assert isinstance(entity, TileableEntity)
+
+        if data not in self._data_to_entities:
+            self._data_to_entities[data] = WeakSet()
+
+        self._data_to_entities[data].add(entity)
+
+    @enter_build_mode
+    def add_observer(self, data, entity):
+        self._add_observer(data, entity)
+
+    def _update_observe_data(self, observer, data, new_data):
+        self._data_to_entities.get(data, set()).discard(observer)
+        self._add_observer(new_data, observer)
+
+    @staticmethod
+    def _set_data(entity, data):
+        entity._data.detach(entity)
+        entity._data = data
+        data.attach(entity)
+
+    @enter_build_mode
+    def data_changed(self, old_data, new_data):
+        notified = set()
+        old_to_new = {old_data: new_data}
+        q = [old_data] if old_data.op.create_view else []
+        while len(q) > 0:
+            data = q.pop()
+
+            # handle entities
+            for entity in data.entities:
+                self._set_data(entity, old_to_new[data])
+                notified.add(entity)
+
+            observers = {ob for ob in self._data_to_entities.pop(data, set())
+                         if ob not in notified}
+            for ob in observers:
+                new_data = ob.op.on_input_modify(data)
+                old_data = ob.data
+                self._update_observe_data(ob, ob.data, new_data)
+                old_to_new[old_data] = new_data
+                q.append(old_data)
+                notified.add(ob)
+
+            if data.op.create_view:
+                old_input_data = data.inputs[0]
+                new_input_data = data.op.on_output_modify(old_to_new[data])
+                old_to_new[old_input_data] = new_input_data
+                q.append(old_input_data)
+
+
+entity_view_handler = EntityDataModificationHandler()

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -22,7 +22,7 @@ except ImportError:  # pragma: no cover
     pass
 
 from ..utils import on_serialize_shape, on_deserialize_shape, on_serialize_numpy_type
-from ..core import ChunkData, Chunk, Entity, TileableData, is_eager_mode
+from ..core import ChunkData, Chunk, TileableEntity, TileableData, is_eager_mode
 from ..serialize import Serializable, ValueType, ProviderType, DataTypeField, AnyField, \
     SeriesField, BoolField, Int64Field, Int32Field, StringField, ListField, SliceField, \
     TupleField, OneOfField, ReferenceField, NDArrayField
@@ -373,7 +373,8 @@ class IndexData(TileableData):
         return self._index_value
 
 
-class Index(Entity):
+class Index(TileableEntity):
+    __slots__ = ()
     _allow_data_type_ = (IndexData,)
 
 
@@ -497,7 +498,7 @@ class SeriesData(TileableData):
         return self._index_value
 
 
-class Series(Entity):
+class Series(TileableEntity):
     __slots__ = ()
     _allow_data_type_ = (SeriesData,)
 
@@ -633,7 +634,7 @@ class DataFrameData(TileableData):
         return self._columns_value
 
 
-class DataFrame(Entity):
+class DataFrame(TileableEntity):
     __slots__ = ()
     _allow_data_type_ = (DataFrameData,)
 

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -63,6 +63,8 @@ class Operand(six.with_metaclass(OperandMetaclass, AttributeAsDictKey)):
     _sparse = BoolField('sparse')
     _gpu = BoolField('gpu')
     _device = Int32Field('device')
+    # will this operand create a view of input data or not
+    _create_view = BoolField('create_view')
 
     _inputs = ListField('inputs', ValueType.key)
     _outputs = ListField('outputs', ValueType.key, weak_ref=True)
@@ -122,6 +124,10 @@ class Operand(six.with_metaclass(OperandMetaclass, AttributeAsDictKey)):
     @property
     def device(self):
         return getattr(self, '_device', None)
+
+    @property
+    def create_view(self):
+        return getattr(self, '_create_view', False)
 
     @property
     def extra_params(self):

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -179,6 +179,19 @@ class Operand(six.with_metaclass(OperandMetaclass, AttributeAsDictKey)):
 
         return new_op
 
+    def on_output_modify(self, data):
+        # when `create_view` is True, if the output is modified,
+        # the modification should be set back to the input.
+        # This function is for this sort of usage.
+        # Remember, if `create_view` is False, this function should take no effect.
+        pass
+
+    def on_input_modify(self, data):
+        # when `create_view` is True, if the input is modified,
+        # this function could be used to respond the modification.
+        # Remember, if `create_view` is False, this function should take no effect.
+        pass
+
 
 class HasInput(Operand):
     __slots__ = ()

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -179,14 +179,14 @@ class Operand(six.with_metaclass(OperandMetaclass, AttributeAsDictKey)):
 
         return new_op
 
-    def on_output_modify(self, data):
+    def on_output_modify(self, new_output):
         # when `create_view` is True, if the output is modified,
         # the modification should be set back to the input.
         # This function is for this sort of usage.
         # Remember, if `create_view` is False, this function should take no effect.
         pass
 
-    def on_input_modify(self, data):
+    def on_input_modify(self, new_input):
         # when `create_view` is True, if the input is modified,
         # this function could be used to respond the modification.
         # Remember, if `create_view` is False, this function should take no effect.

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -184,13 +184,13 @@ class Operand(six.with_metaclass(OperandMetaclass, AttributeAsDictKey)):
         # the modification should be set back to the input.
         # This function is for this sort of usage.
         # Remember, if `create_view` is False, this function should take no effect.
-        pass
+        raise NotImplementedError
 
     def on_input_modify(self, new_input):
         # when `create_view` is True, if the input is modified,
         # this function could be used to respond the modification.
         # Remember, if `create_view` is False, this function should take no effect.
-        pass
+        raise NotImplementedError
 
 
 class HasInput(Operand):

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -195,13 +195,6 @@ class TensorData(TileableData):
 
         return reshape(self, shape)
 
-    def ravel(self):
-        from .expressions.base import ravel
-
-        return ravel(self)
-
-    flatten = ravel
-
     def _equals(self, o):
         return self is o
 
@@ -217,9 +210,6 @@ class Tensor(TileableEntity):
 
     def __len__(self):
         return len(self._data)
-
-    def copy(self):
-        return Tensor(self._data)
 
     def tiles(self):
         return handler.tiles(self)
@@ -357,37 +347,6 @@ class Tensor(TileableEntity):
         array([ 1.,  2.,  3.,  4.])
         """
         return self._data.T
-
-    def ravel(self):
-        """
-        Return a flattened tensor.
-
-        Refer to `mt.ravel` for full documentation.
-
-        See Also
-        --------
-        mt.ravel : equivalent function
-        """
-        return self._data.ravel()
-
-    def reshape(self, shape, *shapes):
-        """
-        Returns a tensor containing the same data with a new shape.
-
-        Refer to `mt.reshape` for full documentation.
-
-        See Also
-        --------
-        mt.reshape : equivalent function
-
-        Notes
-        -----
-        Unlike the free function `mt.reshape`, this method on `Tensor` allows
-        the elements of the shape parameter to be passed in as separate arguments.
-        For example, ``a.reshape(10, 11)`` is equivalent to
-        ``a.reshape((10, 11))``.
-        """
-        return self._data.reshape(shape, *shapes)
 
     def totiledb(self, uri, ctx=None, key=None, timestamp=None):
         return self._data.totiledb(uri, ctx=ctx, key=key, timestamp=timestamp)

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -20,7 +20,7 @@ from datetime import datetime
 
 import numpy as np
 
-from ..core import Entity, ChunkData, Chunk, TileableData, is_eager_mode, build_mode
+from ..core import Entity, TileableEntity, ChunkData, Chunk, TileableData, is_eager_mode, build_mode
 from ..tiles import handler
 from ..serialize import ProviderType, ValueType, DataTypeField, ListField, TupleField, BoolField, StringField
 from ..utils import log_unhandled, on_serialize_shape, on_deserialize_shape
@@ -211,7 +211,7 @@ class TensorData(TileableData):
         return totiledb(uri, self, ctx=ctx, key=key, timestamp=timestamp)
 
 
-class Tensor(Entity):
+class Tensor(TileableEntity):
     __slots__ = ()
     _allow_data_type_ = (TensorData,)
 

--- a/mars/tensor/execution/tests/test_core_execute.py
+++ b/mars/tensor/execution/tests/test_core_execute.py
@@ -52,3 +52,15 @@ class Test(unittest.TestCase):
         # test qr
         q, r = np.linalg.qr(a)
         self.assertTrue(np.allclose(np.dot(q, r), a).execute())
+
+    def testViewData(self):
+        a = ones((10, 20), chunk_size=6)
+        b = a[:5, 5:10]
+        b[:3, :3] = 3
+
+        npa = np.ones((10, 20))
+        npb = npa[:5, 5:10]
+        npb[:3, :3] = 3
+
+        np.testing.assert_array_equal(b.execute(), npb)
+        np.testing.assert_array_equal(a.execute(), npa)

--- a/mars/tensor/execution/tests/test_core_execute.py
+++ b/mars/tensor/execution/tests/test_core_execute.py
@@ -152,3 +152,51 @@ class Test(unittest.TestCase):
 
         np.testing.assert_array_equal(b.execute(), npb)
         np.testing.assert_array_equal(a.execute(), npa)
+
+    def testViewDataOnRavel(self):
+        # ravel creates a view
+        a = ones((3, 4, 5), chunk_size=2)
+        b = a.ravel()
+        b[:10] = 10
+
+        npa = np.ones((3, 4, 5))
+        npb = npa.ravel()
+        npb[:10] = 10
+
+        np.testing.assert_array_equal(b.execute(), npb)
+        np.testing.assert_array_equal(a.execute(), npa)
+
+        # flatten creates a copy
+        a = ones((3, 4, 5), chunk_size=2)
+        b = a.flatten()
+        b[:10] = 10
+
+        npa = np.ones((3, 4, 5))
+        npb = npa.flatten()
+        npb[:10] = 10
+
+        np.testing.assert_array_equal(b.execute(), npb)
+        np.testing.assert_array_equal(a.execute(), npa)
+
+    def testCopyAndView(self):
+        a = ones((10, 20), chunk_size=6)
+        b = a.view()
+        b[:5] = 10
+
+        npa = np.ones((10, 20))
+        npb = npa.view()
+        npb[:5] = 10
+
+        np.testing.assert_array_equal(b.execute(), npb)
+        np.testing.assert_array_equal(a.execute(), npa)
+
+        a = ones((10, 20), chunk_size=6)
+        b = a.copy()
+        b[:5] = 10
+
+        npa = np.ones((10, 20))
+        npb = npa.copy()
+        npb[:5] = 10
+
+        np.testing.assert_array_equal(b.execute(), npb)
+        np.testing.assert_array_equal(a.execute(), npa)

--- a/mars/tensor/execution/tests/test_core_execute.py
+++ b/mars/tensor/execution/tests/test_core_execute.py
@@ -200,3 +200,19 @@ class Test(unittest.TestCase):
 
         np.testing.assert_array_equal(b.execute(), npb)
         np.testing.assert_array_equal(a.execute(), npa)
+
+    def testFlat(self):
+        a = ones((10, 20), chunk_size=4)
+        fl = a.flat
+        fl[1: 10] = 10
+        b = fl[10: 20]
+        b[0: 4] = 20
+
+        npa = np.ones((10, 20))
+        npfl = npa.flat
+        npfl[1: 10] = 10
+        npb = npfl[10: 20]
+        npb[0: 4] = 20
+
+        np.testing.assert_array_equal(b.execute(), npb)
+        np.testing.assert_array_equal(a.execute(), npa)

--- a/mars/tensor/execution/tests/test_core_execute.py
+++ b/mars/tensor/execution/tests/test_core_execute.py
@@ -19,7 +19,8 @@ import unittest
 import numpy as np
 
 from mars.executor import Executor
-from mars.tensor import ones, add, swapaxes
+from mars.tensor import ones, add, swapaxes, moveaxis, atleast_1d, atleast_2d, \
+    atleast_3d, squeeze
 from mars.session import LocalSession, Session
 
 
@@ -81,6 +82,73 @@ class Test(unittest.TestCase):
         npa = np.ones((10, 20))
         npb = np.swapaxes(npa, 1, 0)
         npa[1] = 10
+
+        np.testing.assert_array_equal(b.execute(), npb)
+        np.testing.assert_array_equal(a.execute(), npa)
+
+    def testViewDataOnMoveaxis(self):
+        a = ones((10, 20), chunk_size=6)
+        b = moveaxis(a, 1, 0)
+        a[0][1] = 10
+
+        npa = np.ones((10, 20))
+        npb = np.moveaxis(npa, 1, 0)
+        npa[0][1] = 10
+
+        np.testing.assert_array_equal(b.execute(), npb)
+        np.testing.assert_array_equal(a.execute(), npa)
+
+    def testViewDataOnAtleast1d(self):
+        a = atleast_1d(1)
+        b = a[:]
+        b[0] = 10
+
+        np.testing.assert_array_equal(b.execute(), np.array([10]))
+        np.testing.assert_array_equal(a.execute(), np.array([10]))
+
+    def testViewDataOnAtleast2d(self):
+        a = atleast_2d(ones(10, chunk_size=5))
+        b = add(a[:, :5], 1, out=a[:, 5:])
+
+        npa = np.atleast_2d(np.ones(10))
+        npb = np.add(npa[:, :5], 1, out=npa[:, 5:])
+
+        np.testing.assert_array_equal(b.execute(), npb)
+        np.testing.assert_array_equal(a.execute(), npa)
+
+    def testViewDataOnAtleast3d(self):
+        a = atleast_3d(ones((10, 20), chunk_size=5))
+        b = a[:, :5, :10][0]
+        c = add(b[:4], b[1:], out=a[0, 16:])
+
+        npa = np.atleast_3d(np.ones((10, 20)))
+        npb = npa[:, :5, :10][0]
+        npc = np.add(npb[:4], npb[1:], out=npa[0, 16:])
+
+        np.testing.assert_array_equal(c.execute(), npc)
+        np.testing.assert_array_equal(b.execute(), npb)
+        np.testing.assert_array_equal(a.execute(), npa)
+
+    def testViewDataOnSqueeze(self):
+        a = ones((1, 4, 1), chunk_size=2)
+        b = squeeze(a, axis=0)
+        b[:3] = 10
+
+        npa = np.ones((1, 4, 1))
+        npb = np.squeeze(npa, axis=0)
+        npb[:3] = 10
+
+        np.testing.assert_array_equal(b.execute(), npb)
+        np.testing.assert_array_equal(a.execute(), npa)
+
+    def testViewDataOnReshape(self):
+        a = ones((3, 4, 5), chunk_size=2)
+        b = a.reshape((5, 4, 3))
+        b[:3] = 10
+
+        npa = np.ones((3, 4, 5))
+        npb = npa.reshape((5, 4, 3))
+        npb[:3] = 10
 
         np.testing.assert_array_equal(b.execute(), npb)
         np.testing.assert_array_equal(a.execute(), npa)

--- a/mars/tensor/execution/tests/test_fft_execute.py
+++ b/mars/tensor/execution/tests/test_fft_execute.py
@@ -35,17 +35,17 @@ class Test(unittest.TestCase):
         r = fft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fft(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fft(t, n=11)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft(raw, n=11)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         raw = np.random.rand(10, 20, 30)
         t = tensor(raw, chunk_size=(4, 4, 4))
@@ -53,17 +53,17 @@ class Test(unittest.TestCase):
         r = fft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fft(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fft(t, n=11)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft(raw, n=11)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testIFFTExecution(self):
         raw = np.random.rand(10, 20, 30)
@@ -72,17 +72,17 @@ class Test(unittest.TestCase):
         r = ifft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifft(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifft(t, n=11)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft(raw, n=11)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         raw = np.random.rand(10, 20, 30)
         t = tensor(raw, chunk_size=(4, 4, 5))
@@ -90,17 +90,17 @@ class Test(unittest.TestCase):
         r = ifft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifft(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifft(t, n=11)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft(raw, n=11)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testFFT2Execution(self):
         raw = np.random.rand(10, 20, 30)
@@ -109,22 +109,22 @@ class Test(unittest.TestCase):
         r = fft2(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft2(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fft2(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft2(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fft2(t, s=(11, 12))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft2(raw, s=(11, 12))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fft2(t, s=(11, 12), axes=(-1, -2))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft2(raw, s=(11, 12), axes=(-1, -2))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         raw = np.random.rand(10, 20, 30)
         t = tensor(raw, chunk_size=(4, 5, 6))
@@ -132,22 +132,22 @@ class Test(unittest.TestCase):
         r = fft2(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft2(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fft2(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft2(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fft2(t, s=(11, 12))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft2(raw, s=(11, 12))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fft2(t, s=(11, 12), axes=(-1, -2))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fft2(raw, s=(11, 12), axes=(-1, -2))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testIFFT2Execution(self):
         raw = np.random.rand(10, 20, 30)
@@ -156,22 +156,22 @@ class Test(unittest.TestCase):
         r = ifft2(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft2(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifft2(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft2(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifft2(t, s=(11, 12))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft2(raw, s=(11, 12))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifft2(t, s=(11, 12), axes=(-1, -2))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft2(raw, s=(11, 12), axes=(-1, -2))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         raw = np.random.rand(10, 20, 30)
         t = tensor(raw, chunk_size=(4, 3, 5))
@@ -179,22 +179,22 @@ class Test(unittest.TestCase):
         r = ifft2(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft2(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifft2(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft2(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifft2(t, s=(11, 12))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft2(raw, s=(11, 12))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifft2(t, s=(11, 12), axes=(-1, -2))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifft2(raw, s=(11, 12), axes=(-1, -2))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testFFTNExecution(self):
         raw = np.random.rand(10, 20, 30)
@@ -203,22 +203,22 @@ class Test(unittest.TestCase):
         r = fftn(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fftn(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fftn(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fftn(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fftn(t, s=(11, 12, 5))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fftn(raw, s=(11, 12, 5))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fftn(t, s=(11, 12, 5), axes=(-1, -2, -3))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fftn(raw, s=(11, 12, 5), axes=(-1, -2, -3))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         raw = np.random.rand(10, 20, 30)
         t = tensor(raw, chunk_size=(3, 3, 4))
@@ -226,22 +226,22 @@ class Test(unittest.TestCase):
         r = fftn(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fftn(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fftn(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fftn(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fftn(t, s=(11, 12, 5))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fftn(raw, s=(11, 12, 5))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = fftn(t, s=(11, 12, 5), axes=(-1, -2, -3))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fftn(raw, s=(11, 12, 5), axes=(-1, -2, -3))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testIFFTNExecution(self):
         raw = np.random.rand(10, 20, 30)
@@ -250,22 +250,22 @@ class Test(unittest.TestCase):
         r = ifftn(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifftn(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifftn(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifftn(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifftn(t, s=(11, 12, 5))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifftn(raw, s=(11, 12, 5))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifftn(t, s=(11, 12, 5), axes=(-1, -2, -3))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifftn(raw, s=(11, 12, 5), axes=(-1, -2, -3))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         raw = np.random.rand(10, 20, 30)
         t = tensor(raw, chunk_size=(3, 4, 7))
@@ -273,22 +273,22 @@ class Test(unittest.TestCase):
         r = ifftn(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifftn(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifftn(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifftn(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifftn(t, s=(11, 12, 5))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifftn(raw, s=(11, 12, 5))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ifftn(t, s=(11, 12, 5), axes=(-1, -2, -3))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifftn(raw, s=(11, 12, 5), axes=(-1, -2, -3))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testRFFTExecution(self):
         raw = np.random.rand(10, 20, 30)
@@ -297,17 +297,17 @@ class Test(unittest.TestCase):
         r = rfft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.rfft(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = rfft(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.rfft(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = rfft(t, n=11)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.rfft(raw, n=11)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testIRFFTExecution(self):
         raw = np.random.rand(10, 20, 30)
@@ -316,17 +316,17 @@ class Test(unittest.TestCase):
         r = irfft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.irfft(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = irfft(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.irfft(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = irfft(t, n=11)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.irfft(raw, n=11)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testRFFT2Execution(self):
         raw = np.random.rand(10, 20, 30)
@@ -335,22 +335,22 @@ class Test(unittest.TestCase):
         r = rfft2(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.rfft2(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = rfft2(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.rfft2(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = rfft2(t, s=(11, 12))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.rfft2(raw, s=(11, 12))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = rfft2(t, s=(11, 12), axes=(-1, -2))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.rfft2(raw, s=(11, 12), axes=(-1, -2))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testIRFFT2Execution(self):
         raw = np.random.rand(10, 20, 30)
@@ -359,22 +359,22 @@ class Test(unittest.TestCase):
         r = irfft2(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.irfft2(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = irfft2(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.irfft2(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = irfft2(t, s=(11, 12))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.irfft2(raw, s=(11, 12))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = irfft2(t, s=(11, 12), axes=(-1, -2))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.irfft2(raw, s=(11, 12), axes=(-1, -2))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testRFFTNExecution(self):
         raw = np.random.rand(10, 20, 30)
@@ -383,22 +383,22 @@ class Test(unittest.TestCase):
         r = rfftn(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.rfftn(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = rfftn(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.rfftn(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = rfftn(t, s=(11, 12, 5))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.rfftn(raw, s=(11, 12, 5))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = rfftn(t, s=(11, 12, 11), axes=(-1, -2, -3))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.rfftn(raw, s=(11, 12, 11), axes=(-1, -2, -3))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testIRFFTNExecution(self):
         raw = np.random.rand(10, 20, 30)
@@ -407,22 +407,22 @@ class Test(unittest.TestCase):
         r = irfftn(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.irfftn(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = irfftn(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.irfftn(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = irfftn(t, s=(11, 21, 5))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.irfftn(raw, s=(11, 21, 5))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = irfftn(t, s=(11, 21, 30), axes=(-1, -2, -3))
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.irfftn(raw, s=(11, 21, 30), axes=(-1, -2, -3))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testHFFTExecution(self):
         raw = np.random.rand(10, 20, 30)
@@ -431,17 +431,17 @@ class Test(unittest.TestCase):
         r = hfft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.hfft(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = hfft(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.hfft(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = hfft(t, n=11)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.hfft(raw, n=11)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testIHFFTExecution(self):
         raw = np.random.rand(10, 20, 30)
@@ -450,58 +450,58 @@ class Test(unittest.TestCase):
         r = ihfft(t)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ihfft(raw)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ihfft(t, norm='ortho')
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ihfft(raw, norm='ortho')
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ihfft(t, n=11)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ihfft(raw, n=11)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
         r = ihfft(t, n=12)
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ihfft(raw, n=12)
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testFFTFreqExecution(self):
         t = fftfreq(10, .1, chunk_size=3)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
-        self.assertTrue(np.allclose(res, np.fft.fftfreq(10, .1)))
+        np.testing.assert_allclose(res, np.fft.fftfreq(10, .1))
 
         t = fftfreq(11, .01, chunk_size=3)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
-        self.assertTrue(np.allclose(res, np.fft.fftfreq(11, .01)))
+        np.testing.assert_allclose(res, np.fft.fftfreq(11, .01))
 
     def testRFFTFreqExecution(self):
         t = rfftfreq(20, .1, chunk_size=3)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
-        self.assertTrue(np.allclose(res, np.fft.rfftfreq(20, .1)))
+        np.testing.assert_allclose(res, np.fft.rfftfreq(20, .1))
 
         t = rfftfreq(21, .01, chunk_size=3)
 
         res = self.executor.execute_tensor(t, concat=True)[0]
-        self.assertTrue(np.allclose(res, np.fft.rfftfreq(21, .01)))
+        np.testing.assert_allclose(res, np.fft.rfftfreq(21, .01))
 
     def testFFTShiftExecution(self):
         t = fftfreq(10, .1, chunk_size=3)
         r = fftshift(t)
 
         res = self.executor.execute_tensor(r, concat=True)[0]
-        self.assertTrue(np.allclose(res, np.fft.fftshift(np.fft.fftfreq(10, .1))))
+        np.testing.assert_allclose(res, np.fft.fftshift(np.fft.fftfreq(10, .1)))
 
         freqs = fftfreq(9, d=1./9, chunk_size=2).reshape(3, 3)
         r = fftshift(freqs, axes=(1,))
 
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.fftshift(np.fft.fftfreq(9, d=1./9).reshape(3, 3), axes=(1,))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)
 
     def testIFFTShiftExecution(self):
         t = fftfreq(9, d=1./9, chunk_size=2).reshape(3, 3)
@@ -509,4 +509,4 @@ class Test(unittest.TestCase):
 
         res = self.executor.execute_tensor(r, concat=True)[0]
         expected = np.fft.ifftshift(np.fft.fftfreq(9, d=1./9).reshape(3, 3))
-        self.assertTrue(np.allclose(res, expected))
+        np.testing.assert_allclose(res, expected)

--- a/mars/tensor/expressions/base/__init__.py
+++ b/mars/tensor/expressions/base/__init__.py
@@ -26,6 +26,7 @@ from .rollaxis import rollaxis
 from .swapaxes import swapaxes, TensorSwapAxes
 from .moveaxis import moveaxis
 from .ravel import ravel
+from .flatten import flatten
 from .atleast_1d import atleast_1d
 from .atleast_2d import atleast_2d
 from .atleast_3d import atleast_3d
@@ -60,10 +61,14 @@ def _install():
     setattr(Tensor, 'swapaxes', swapaxes)
     setattr(Tensor, 'squeeze', squeeze)
     setattr(Tensor, 'repeat', repeat)
+    setattr(Tensor, 'ravel', ravel)
+    setattr(Tensor, 'flatten', flatten)
     setattr(TensorData, 'astype', _astype)
     setattr(TensorData, 'swapaxes', swapaxes)
     setattr(TensorData, 'squeeze', squeeze)
     setattr(TensorData, 'repeat', repeat)
+    setattr(TensorData, 'ravel', ravel)
+    setattr(TensorData, 'flatten', flatten)
 
 
 _install()

--- a/mars/tensor/expressions/base/flatten.py
+++ b/mars/tensor/expressions/base/flatten.py
@@ -1,0 +1,52 @@
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+
+def flatten(a):
+    """
+    Return a copy of the tensor collapsed into one dimension.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    y : Tensor
+        A copy of the input tensor, flattened to one dimension.
+
+    See Also
+    --------
+    ravel : Return a flattened array.
+    flat : A 1-D flat iterator over the array.
+
+    Examples
+    --------
+
+    >>> import mars.tensor as mt
+
+    >>> a = mt.array([[1,2], [3,4]])
+    >>> a.flatten().execute()
+    array([1, 2, 3, 4])
+    """
+
+    from ..reshape.reshape import TensorReshape, calc_shape
+
+    if np.isnan(sum(a.shape)):
+        raise ValueError('tensor shape is unknown, {0}'.format(a.shape))
+
+    new_shape = calc_shape(a.size, -1)
+    op = TensorReshape(new_shape, dtype=a.dtype, create_view=False)
+    return op(a)

--- a/mars/tensor/expressions/base/squeeze.py
+++ b/mars/tensor/expressions/base/squeeze.py
@@ -50,6 +50,16 @@ class TensorSqueeze(TensorHasInput, TensorOperandMixin):
         super(TensorSqueeze, self).__init__(_axis=axis, _dtype=dtype,
                                             _sparse=sparse, _create_view=True, **kw)
 
+    def on_output_modify(self, new_output):
+        slcs = [slice(None)] * new_output.ndim
+        for axis in self._axis:
+            slcs.insert(axis, None)
+        return new_output[slcs]
+
+    def on_input_modify(self, new_input):
+        op = self.copy().reset_key()
+        return op(new_input, self.outputs[0].shape)
+
     @property
     def axis(self):
         return self._axis

--- a/mars/tensor/expressions/base/squeeze.py
+++ b/mars/tensor/expressions/base/squeeze.py
@@ -48,7 +48,7 @@ class TensorSqueeze(TensorHasInput, TensorOperandMixin):
 
     def __init__(self, axis=None, dtype=None, sparse=False, **kw):
         super(TensorSqueeze, self).__init__(_axis=axis, _dtype=dtype,
-                                            _sparse=sparse, **kw)
+                                            _sparse=sparse, _create_view=True, **kw)
 
     @property
     def axis(self):

--- a/mars/tensor/expressions/base/swapaxes.py
+++ b/mars/tensor/expressions/base/swapaxes.py
@@ -36,7 +36,7 @@ class TensorSwapAxes(TensorHasInput, TensorOperandMixin):
 
     def __init__(self, axis1=None, axis2=None, dtype=None, sparse=False, **kw):
         super(TensorSwapAxes, self).__init__(_axis1=axis1, _axis2=axis2, _dtype=dtype,
-                                             _sparse=sparse, **kw)
+                                             _sparse=sparse, _create_view=True, **kw)
 
     @property
     def axis1(self):

--- a/mars/tensor/expressions/base/swapaxes.py
+++ b/mars/tensor/expressions/base/swapaxes.py
@@ -54,14 +54,14 @@ class TensorSwapAxes(TensorHasInput, TensorOperandMixin):
         super(TensorSwapAxes, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
-    def on_output_modify(self, data):
-        op = TensorSwapAxes(axis1=self._axis2, axis2=self._axis1, dtype=data.dtype,
-                            sparse=data.issparse())
-        return op(data)
+    def on_output_modify(self, new_output):
+        op = TensorSwapAxes(axis1=self._axis2, axis2=self._axis1, dtype=new_output.dtype,
+                            sparse=new_output.issparse())
+        return op(new_output)
 
-    def on_input_modify(self, data):
+    def on_input_modify(self, new_input):
         op = self.copy().reset_key()
-        return op(data)
+        return op(new_input)
 
     @classmethod
     def tile(cls, op):

--- a/mars/tensor/expressions/base/swapaxes.py
+++ b/mars/tensor/expressions/base/swapaxes.py
@@ -54,6 +54,15 @@ class TensorSwapAxes(TensorHasInput, TensorOperandMixin):
         super(TensorSwapAxes, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def on_output_modify(self, data):
+        op = TensorSwapAxes(axis1=self._axis2, axis2=self._axis1, dtype=data.dtype,
+                            sparse=data.issparse())
+        return op(data)
+
+    def on_input_modify(self, data):
+        op = self.copy().reset_key()
+        return op(data)
+
     @classmethod
     def tile(cls, op):
         axis1, axis2 = op.axis1, op.axis2

--- a/mars/tensor/expressions/base/transpose.py
+++ b/mars/tensor/expressions/base/transpose.py
@@ -52,6 +52,14 @@ class TensorTranspose(TensorHasInput, TensorOperandMixin):
         super(TensorTranspose, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def on_output_modify(self, new_output):
+        op = self.copy().reset_key()
+        return op(new_output)
+
+    def on_input_modify(self, new_input):
+        op = self.copy().reset_key()
+        return op(new_input)
+
     @classmethod
     def tile(cls, op):
         out_chunks = []

--- a/mars/tensor/expressions/base/transpose.py
+++ b/mars/tensor/expressions/base/transpose.py
@@ -36,7 +36,9 @@ class TensorTranspose(TensorHasInput, TensorOperandMixin):
 
     def __init__(self, axes=None, dtype=None, sparse=False, **kw):
         super(TensorTranspose, self).__init__(_axes=axes, _dtype=dtype,
-                                              _sparse=sparse, **kw)
+                                              _sparse=sparse,
+                                              # transpose will create a view
+                                              _create_view=True, **kw)
 
     @property
     def axes(self):

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -56,19 +56,19 @@ class TensorIndex(TensorHasInput, TensorOperandMixin):
                        for index in self._indexes]
         self._indexes = new_indexes
 
-    def on_output_modify(self, data):
+    def on_output_modify(self, new_output):
         from .setitem import TensorIndexSetValue
 
         if self._create_view:
             a = self.input
             op = TensorIndexSetValue(dtype=a.dtype, sparse=a.issparse(),
-                                     indexes=self._indexes, value=data)
-            return op(a, self._indexes, data)
+                                     indexes=self._indexes, value=new_output)
+            return op(a, self._indexes, new_output)
 
-    def on_input_modify(self, data):
+    def on_input_modify(self, new_input):
         if self._create_view:
             new_op = self.copy().reset_key()
-            new_inputs = [data] + self.inputs[1:]
+            new_inputs = [new_input] + self.inputs[1:]
             return new_op.new_tensor(new_inputs, shape=self.outputs[0].shape)
 
     def __call__(self, a, index, shape):

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -70,7 +70,7 @@ class TensorIndex(TensorHasInput, TensorOperandMixin):
         if self._create_view:
             new_op = self.copy().reset_key()
             new_inputs = [data] + self.inputs[1:]
-            return new_op.new_tensor(new_inputs, shape=self.outputs[0].shape).data
+            return new_op.new_tensor(new_inputs, shape=self.outputs[0].shape)
 
     def __call__(self, a, index, shape):
         self._indexes = index

--- a/mars/tensor/expressions/indexing/getitem.py
+++ b/mars/tensor/expressions/indexing/getitem.py
@@ -24,7 +24,6 @@ from .... import opcodes as OperandDef
 from ....serialize import ValueType, KeyField, ListField, TupleField, Int32Field
 from ....core import Base, Entity
 from ....compat import OrderedDict, Enum, reduce
-from ....utils import kernel_mode
 from ...core import TENSOR_TYPE
 from ..utils import unify_chunks, slice_split, split_indexes_into_chunks, \
     calc_pos, broadcast_shape, calc_sliced_size, recursive_tile, filter_inputs

--- a/mars/tensor/expressions/reshape/reshape.py
+++ b/mars/tensor/expressions/reshape/reshape.py
@@ -45,6 +45,13 @@ class TensorReshape(TensorHasInput, TensorOperandMixin):
         super(TensorReshape, self)._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def on_output_modify(self, new_output):
+        return reshape(new_output, self._input.shape)
+
+    def on_input_modify(self, new_input):
+        op = self.copy().reset_key()
+        return op(new_input)
+
     def __call__(self, a):
         return self.new_tensor([a], self._newshape)
 

--- a/mars/tensor/expressions/reshape/reshape.py
+++ b/mars/tensor/expressions/reshape/reshape.py
@@ -34,7 +34,8 @@ class TensorReshape(TensorHasInput, TensorOperandMixin):
     _newshape = TupleField('newshape', ValueType.int64)
 
     def __init__(self, newshape=None, dtype=None, **kw):
-        super(TensorReshape, self).__init__(_newshape=newshape, _dtype=dtype, **kw)
+        super(TensorReshape, self).__init__(_newshape=newshape, _dtype=dtype,
+                                            _create_view=True, **kw)
 
     @property
     def newshape(self):

--- a/mars/tests/test_eager_mode.py
+++ b/mars/tests/test_eager_mode.py
@@ -208,6 +208,19 @@ class Test(unittest.TestCase):
         with self.assertRaises(ValueError):
             a.fetch()
 
+    def testView(self):
+        with option_context({'eager_mode': True}):
+            a = mt.ones((10, 20), chunk_size=3)
+            b = a[0][1:4]
+            b[1] = 10
+
+            npa = np.ones((10, 20))
+            npb = npa[0][1:4]
+            npb[1] = 10
+
+            np.testing.assert_array_equal(a.fetch(), npa)
+            np.testing.assert_array_equal(b.fetch(), npb)
+
     def testDataFrame(self):
         with option_context({'eager_mode': True}):
             from mars.dataframe.expressions.arithmetic import add

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -212,6 +212,15 @@ class Test(unittest.TestCase):
             self.assertTrue(options.eager_mode)
             self.assertFalse(wrapped())
 
+        @utils.kernel_mode
+        def wrapped2():
+            wrapped()
+            with option_context({'eager_mode': True}):
+                self.assertTrue(options.eager_mode)
+                self.assertFalse(utils.is_eager_mode())
+
+        wrapped2()
+
     def testBlacklistSet(self):
         blset = utils.BlacklistSet(0.1)
         blset.update([1, 2])

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -379,10 +379,15 @@ def kernel_mode(func):
 
     def _wrapped(*args, **kwargs):
         try:
-            _kernel_mode.eager = False
+            enter_eager_count = getattr(_kernel_mode, 'eager_count', 0)
+            if enter_eager_count == 0:
+                _kernel_mode.eager = False
+            _kernel_mode.eager_count = enter_eager_count + 1
             return func(*args, **kwargs)
         finally:
-            _kernel_mode.eager = None
+            _kernel_mode.eager_count -= 1
+            if _kernel_mode.eager_count == 0:
+                _kernel_mode.eager = None
 
     return _wrapped
 

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -364,19 +364,14 @@ _kernel_mode = threading.local()
 
 
 def is_eager_mode():
-    if getattr(_kernel_mode, 'kernel', None) is None:
+    if getattr(_kernel_mode, 'eager', None) is None:
         return options.eager_mode
-    return _kernel_mode.kernel
-
-
-def kernel_entered():
-    return getattr(_kernel_mode, 'kernel', None) is not None
+    return _kernel_mode.eager
 
 
 def kernel_mode(func):
     """
     A decorator for kernel functions.
-
     When eager mode is on, expressions will be executed after `new_entities`, however
     `new_entities` is also called in `Executor` and `OperandTilesHandler`, this decorator
     provides an options context for kernel functions to avoid execution.
@@ -384,10 +379,10 @@ def kernel_mode(func):
 
     def _wrapped(*args, **kwargs):
         try:
-            _kernel_mode.kernel = True
+            _kernel_mode.eager = False
             return func(*args, **kwargs)
         finally:
-            _kernel_mode.kernel = None
+            _kernel_mode.eager = None
 
     return _wrapped
 

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -364,9 +364,13 @@ _kernel_mode = threading.local()
 
 
 def is_eager_mode():
-    if getattr(_kernel_mode, 'eager', None) is None:
+    if getattr(_kernel_mode, 'kernel', None) is None:
         return options.eager_mode
-    return _kernel_mode.eager
+    return _kernel_mode.kernel
+
+
+def kernel_entered():
+    return getattr(_kernel_mode, 'kernel', None) is not None
 
 
 def kernel_mode(func):
@@ -380,10 +384,10 @@ def kernel_mode(func):
 
     def _wrapped(*args, **kwargs):
         try:
-            _kernel_mode.eager = False
+            _kernel_mode.kernel = True
             return func(*args, **kwargs)
         finally:
-            _kernel_mode.eager = None
+            _kernel_mode.kernel = None
 
     return _wrapped
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Support view behavior in numpy for Mars tensor. It would also be workable for DataFrame as well. Also add `tensor.flat` property, but does not support iteration yet.

Operands that create view include:

- [x] Basic indexing
- [x] `transpose`
- [x] `swapaxes`
- [x] `moveaxis`
- [x] `atleast_1d`
- [x] `atleast_2d`
- [x] `atleast_3d`
- [x] `squeeze`
- [x] `reshape`
- [x] `ravel`
- [x] `tensor.view`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #533 
Resolves #527 
Fixes #442 