### PR TITLE
Mutable tensor for local session and web session

### DIFF
--- a/mars/api.py
+++ b/mars/api.py
@@ -90,7 +90,7 @@ class MarsAPI(object):
     def send_chunk_records(self, session_id, name, chunk_records_to_send, directly=True):
         from .worker.dispatcher import DispatchActor
         from .worker.quota import MemQuotaActor
-        from .worker.utils import put_chunk
+        from .worker.transfer import put_remote_chunk
         session_uid = SessionActor.gen_uid(session_id)
         session_ref = self.get_actor_ref(session_uid)
 
@@ -105,7 +105,7 @@ class MarsAPI(object):
             dispatch_ref = self.actor_client.actor_ref(DispatchActor.default_uid(), address=ep)
             receiver_uid = dispatch_ref.get_hash_slot('receiver', chunk_key)
             receiver_ref = self.actor_client.actor_ref(receiver_uid, address=ep)
-            put_chunk(session_id, record_chunk_key, records, receiver_ref)
+            put_remote_chunk(session_id, record_chunk_key, records, receiver_ref)
             chunk_records.append((chunk_key, record_chunk_key))
 
         # register the record chunk to MutableTensorActor

--- a/mars/api.py
+++ b/mars/api.py
@@ -16,9 +16,6 @@ import itertools
 import logging
 import random
 import uuid
-import zlib
-
-import pyarrow
 
 from .actors import new_client
 from .errors import GraphNotExists
@@ -28,7 +25,6 @@ from .scheduler.node_info import NodeInfoActor
 from .scheduler.utils import SchedulerClusterInfoActor
 from .worker.transfer import ResultSenderActor
 from .tensor.expressions.utils import slice_split
-from .config import options
 from .serialize import dataserializer
 from .utils import tokenize, merge_chunks
 

--- a/mars/api.py
+++ b/mars/api.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import logging
+import random
 import uuid
 import zlib
-import itertools
-import random
 
 import pyarrow
 
@@ -61,13 +61,6 @@ class MarsAPI(object):
             infos[scheduler] = info_ref.get_info()
         return infos
 
-    def _get_receiver_ref(self, chunk_key):
-        from .worker.dispatcher import DispatchActor
-        ep = self.cluster_info.get_scheduler(chunk_key)
-        dispatch_ref = self.actor_client.actor_ref(DispatchActor.default_uid(), address=ep)
-        uid = dispatch_ref.get_hash_slot('receiver', chunk_key)
-        return self.actor_client.actor_ref(uid, address=ep)
-
     def count_workers(self):
         try:
             uid = ResourceActor.default_uid()
@@ -99,8 +92,9 @@ class MarsAPI(object):
         return session_ref.get_mutable_tensor(name)
 
     def send_chunk_records(self, session_id, name, chunk_records_to_send, directly=True):
-        from .worker.dataio import ArrowBufferIO
+        from .worker.dispatcher import DispatchActor
         from .worker.quota import MemQuotaActor
+        from .worker.utils import put_chunk
         session_uid = SessionActor.gen_uid(session_id)
         session_ref = self.get_actor_ref(session_uid)
 
@@ -112,32 +106,10 @@ class MarsAPI(object):
             quota_ref = self.actor_client.actor_ref(MemQuotaActor.default_uid(), address=ep)
             quota_ref.request_batch_quota({record_chunk_key: records.nbytes})
             # send record chunk
-            buf = pyarrow.serialize(records).to_buffer()
-            receiver_ref = self._get_receiver_ref(chunk_key)
-            receiver_ref.create_data_writer(session_id, record_chunk_key, buf.size, None,
-                                            ensure_cached=False, use_promise=False)
-
-            block_size = options.worker.transfer_block_size
-
-            try:
-                reader = ArrowBufferIO(buf, 'r', block_size=block_size)
-                checksum = 0
-                while True:
-                    next_chunk = reader.read(block_size)
-                    if not next_chunk:
-                        reader.close()
-                        receiver_ref.finish_receive(session_id, record_chunk_key, checksum)
-                        break
-                    checksum = zlib.crc32(next_chunk, checksum)
-                    receiver_ref.receive_data_part(session_id, record_chunk_key, next_chunk, checksum)
-            except:
-                receiver_ref.cancel_receive(session_id, chunk_key)
-                raise
-            finally:
-                if reader:
-                    reader.close()
-                del reader
-
+            dispatch_ref = self.actor_client.actor_ref(DispatchActor.default_uid(), address=ep)
+            receiver_uid = dispatch_ref.get_hash_slot('receiver', chunk_key)
+            receiver_ref = self.actor_client.actor_ref(receiver_uid, address=ep)
+            put_chunk(session_id, record_chunk_key, records, receiver_ref)
             chunk_records.append((chunk_key, record_chunk_key))
 
         # register the record chunk to MutableTensorActor

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -97,7 +97,7 @@ class LocalClusterSession(object):
 
         # Construct Tensor on the fly.
         shape, dtype, chunk_size, chunk_keys = tensor_meta
-        return create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
+        return create_fetch_tensor(chunk_size, shape, dtype, tensor_key=tensor_key, chunk_keys=chunk_keys)
 
     def run(self, *tileables, **kw):
         timeout = kw.pop('timeout', -1)

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -92,8 +92,8 @@ class LocalClusterSession(object):
         chunk_records_to_send = tensor._do_flush()
         self._api.send_chunk_records(self._session_id, tensor.name, chunk_records_to_send)
 
-        graph_key, tensor_key, tensor_id, tensor_meta = self._api.seal(self._session_id, tensor.name)
-        self._executed_tileables[tensor_key] = graph_key, {tensor_id}
+        graph_key_hex, tensor_key, tensor_id, tensor_meta = self._api.seal(self._session_id, tensor.name)
+        self._executed_tileables[tensor_key] = uuid.UUID(graph_key_hex), {tensor_id}
 
         # Construct Tensor on the fly.
         shape, dtype, chunk_size, chunk_keys = tensor_meta

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -71,19 +71,33 @@ class LocalClusterSession(object):
         tileable.nsplits = new_nsplits
 
     def create_mutable_tensor(self, name, shape, dtype, *args, **kwargs):
-        return self._api.create_mutable_tensor(self._session_id, name, shape,
-                                               dtype, *args, **kwargs)
+        from ...tensor.expressions.utils import create_mutable_tensor
+        shape, dtype, chunk_size, chunk_keys = \
+                self._api.create_mutable_tensor(self._session_id, name, shape,
+                                                dtype, *args, **kwargs)
+        return create_mutable_tensor(name, chunk_size, shape, dtype, chunk_keys)
 
     def get_mutable_tensor(self, name):
-        return self._api.get_mutable_tensor(self._session_id, name)
+        from ...tensor.expressions.utils import create_mutable_tensor
+        shape, dtype, chunk_size, chunk_keys = \
+                 self._api.get_mutable_tensor(self._session_id, name)
+        return create_mutable_tensor(name, chunk_size, shape, dtype, chunk_keys)
 
-    def send_chunk_records(self, name, chunk_records_to_send):
-        return self._api.send_chunk_records(self._session_id, name, chunk_records_to_send)
+    def write_mutable_tensor(self, tensor, index, value):
+        chunk_records_to_send = tensor._do_write(index, value)
+        self._api.send_chunk_records(self._session_id, tensor.name, chunk_records_to_send)
 
-    def seal(self, name):
-        graph_key, tensor_key, tensor_id, tensor_meta = self._api.seal(self._session_id, name)
+    def seal(self, tensor):
+        from ...tensor.expressions.utils import create_fetch_tensor
+        chunk_records_to_send = tensor._do_flush()
+        self._api.send_chunk_records(self._session_id, tensor.name, chunk_records_to_send)
+
+        graph_key, tensor_key, tensor_id, tensor_meta = self._api.seal(self._session_id, tensor.name)
         self._executed_tileables[tensor_key] = graph_key, {tensor_id}
-        return tensor_meta
+
+        # Construct Tensor on the fly.
+        shape, dtype, chunk_size, chunk_keys = tensor_meta
+        return create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
 
     def run(self, *tileables, **kw):
         timeout = kw.pop('timeout', -1)

--- a/mars/scheduler/mutable.py
+++ b/mars/scheduler/mutable.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 from collections import defaultdict
+import uuid
 
 import numpy as np
 
-from ..utils import log_unhandled
+from ..utils import log_unhandled, tokenize
 from .utils import SchedulerActor
 
 
@@ -46,14 +47,14 @@ class MutableTensorActor(SchedulerActor):
 
     @log_unhandled
     def post_create(self):
-        from ..tensor.expressions.utils import create_fetch_tensor
+        from ..tensor.expressions.utils import create_mutable_tensor
 
         super(MutableTensorActor, self).post_create()
         self.set_cluster_info_ref()
-        self._tensor = create_fetch_tensor(self._chunk_size, self._shape, self._dtype)
+        self._tensor = create_mutable_tensor(self._name, self._chunk_size, self._shape, self._dtype)
 
     def tensor_meta(self):
-        return self._shape, self._dtype, self._chunk_size, [c.key for c in self._tensor.chunks]
+        return self._shape, str(self._dtype), self._chunk_size, [c.key for c in self._tensor.chunks]
 
     def tensor_key(self):
         return self._tensor.key
@@ -66,6 +67,11 @@ class MutableTensorActor(SchedulerActor):
         raise NotImplementedError
 
     @log_unhandled
+    def write(self, index, value):
+        chunk_records_to_send = self._tensor._do_write(index, value)
+        self._send_chunk_records(chunk_records_to_send)
+
+    @log_unhandled
     def append_chunk_records(self, chunk_records):
         for chunk_key, record_chunk_key in chunk_records:
             self._chunk_map[chunk_key].append(record_chunk_key)
@@ -74,12 +80,41 @@ class MutableTensorActor(SchedulerActor):
     def seal(self):
         from ..worker.seal import SealActor
         self._sealed = True
+
+        # dump current buffers to worker
+        chunk_records_to_send = self._tensor._do_flush()
+        self._send_chunk_records(chunk_records_to_send)
+
+        # consolidate chunks
         for chunk in self._tensor.chunks:
             ep = self.get_scheduler(chunk.key)
             sealer_uid = SealActor.gen_uid(self._session_id, chunk.key)
             sealer_ref = self.ctx.create_actor(SealActor, uid=sealer_uid, address=ep)
-
             sealer_ref.seal_chunk(self._session_id, self._graph_key,
                                   chunk.key, self._chunk_map[chunk.key],
                                   chunk.shape, self._record_type, self._dtype)
-        return self._graph_key, self._tensor.key, self._tensor.id, self.tensor_meta()
+        # return the hex of self._graph_key since UUID is not json serializable.
+        return self._graph_key.hex, self._tensor.key, self._tensor.id, self.tensor_meta()
+
+    @log_unhandled
+    def _send_chunk_records(self, chunk_records_to_send):
+        from ..worker.dispatcher import DispatchActor
+        from ..worker.quota import MemQuotaActor
+        from ..worker.utils import put_chunk
+
+        chunk_records = []
+        for chunk_key, records in chunk_records_to_send.items():
+            record_chunk_key = tokenize(chunk_key, uuid.uuid4().hex)
+            ep = self.get_scheduler(chunk_key)
+            # register quota
+            quota_ref = self.ctx.actor_ref(MemQuotaActor.default_uid(), address=ep)
+            quota_ref.request_batch_quota({record_chunk_key: records.nbytes})
+            # send record chunk
+            dispatch_ref = self.ctx.actor_ref(DispatchActor.default_uid(), address=ep)
+            receiver_uid = dispatch_ref.get_hash_slot('receiver', chunk_key)
+            receiver_ref = self.ctx.actor_ref(receiver_uid, address=ep)
+            put_chunk(self._session_id, record_chunk_key, records, receiver_ref)
+            chunk_records.append((chunk_key, record_chunk_key))
+
+        # register the record chunks
+        self.append_chunk_records(chunk_records)

--- a/mars/scheduler/mutable.py
+++ b/mars/scheduler/mutable.py
@@ -29,7 +29,7 @@ class MutableTensorActor(SchedulerActor):
     def gen_uid(session_id, name):
         return 's:0:mutable-tensor$%s$%s' % (session_id, name)
 
-    def __init__(self, session_id, name, shape, dtype, graph_key, chunk_size=None, *args, **kwargs):
+    def __init__(self, session_id, name, shape, dtype, graph_key, fill_value=None, chunk_size=None, *args, **kwargs):
         super(MutableTensorActor, self).__init__(*args, **kwargs)
         self._session_id = session_id
         self._name = name
@@ -40,6 +40,7 @@ class MutableTensorActor(SchedulerActor):
             self._dtype = np.dtype(dtype)
         self._graph_key = graph_key
         self._chunk_size = chunk_size
+        self._fill_value = fill_value
         self._tensor = None
         self._sealed = False
         self._chunk_map = defaultdict(lambda: [])
@@ -97,7 +98,7 @@ class MutableTensorActor(SchedulerActor):
             sealer_ref = self.ctx.create_actor(SealActor, uid=sealer_uid, address=ep)
             sealer_ref.seal_chunk(self._session_id, self._graph_key,
                                   chunk.key, self._chunk_map[chunk.key],
-                                  chunk.shape, self._record_type, self._dtype)
+                                  chunk.shape, self._record_type, self._dtype, self._fill_value)
         # return the hex of self._graph_key since UUID is not json serializable.
         return self._graph_key.hex, self._tensor.key, self._tensor.id, self.tensor_meta()
 

--- a/mars/scheduler/mutable.py
+++ b/mars/scheduler/mutable.py
@@ -54,7 +54,12 @@ class MutableTensorActor(SchedulerActor):
         self._tensor = create_mutable_tensor(self._name, self._chunk_size, self._shape, self._dtype)
 
     def tensor_meta(self):
-        return self._shape, str(self._dtype), self._chunk_size, [c.key for c in self._tensor.chunks]
+        # avoid built-in scalar dtypes are made into one-field record type.
+        if self._dtype.fields:
+            dtype_descr = self._dtype.descr
+        else:
+            dtype_descr = str(self._dtype)
+        return self._shape, dtype_descr, self._chunk_size, [c.key for c in self._tensor.chunks]
 
     def tensor_key(self):
         return self._tensor.key

--- a/mars/scheduler/mutable.py
+++ b/mars/scheduler/mutable.py
@@ -106,7 +106,7 @@ class MutableTensorActor(SchedulerActor):
     def _send_chunk_records(self, chunk_records_to_send):
         from ..worker.dispatcher import DispatchActor
         from ..worker.quota import MemQuotaActor
-        from ..worker.utils import put_chunk
+        from ..worker.transfer import put_remote_chunk
 
         chunk_records = []
         for chunk_key, records in chunk_records_to_send.items():
@@ -119,7 +119,7 @@ class MutableTensorActor(SchedulerActor):
             dispatch_ref = self.ctx.actor_ref(DispatchActor.default_uid(), address=ep)
             receiver_uid = dispatch_ref.get_hash_slot('receiver', chunk_key)
             receiver_ref = self.ctx.actor_ref(receiver_uid, address=ep)
-            put_chunk(self._session_id, record_chunk_key, records, receiver_ref)
+            put_remote_chunk(self._session_id, record_chunk_key, records, receiver_ref)
             chunk_records.append((chunk_key, record_chunk_key))
 
         # register the record chunks

--- a/mars/scheduler/mutable.py
+++ b/mars/scheduler/mutable.py
@@ -105,16 +105,12 @@ class MutableTensorActor(SchedulerActor):
     @log_unhandled
     def _send_chunk_records(self, chunk_records_to_send):
         from ..worker.dispatcher import DispatchActor
-        from ..worker.quota import MemQuotaActor
         from ..worker.transfer import put_remote_chunk
 
         chunk_records = []
         for chunk_key, records in chunk_records_to_send.items():
             record_chunk_key = tokenize(chunk_key, uuid.uuid4().hex)
             ep = self.get_scheduler(chunk_key)
-            # register quota
-            quota_ref = self.ctx.actor_ref(MemQuotaActor.default_uid(), address=ep)
-            quota_ref.request_batch_quota({record_chunk_key: records.nbytes})
             # send record chunk
             dispatch_ref = self.ctx.actor_ref(DispatchActor.default_uid(), address=ep)
             receiver_uid = dispatch_ref.get_hash_slot('receiver', chunk_key)

--- a/mars/scheduler/session.py
+++ b/mars/scheduler/session.py
@@ -111,6 +111,13 @@ class SessionActor(SchedulerActor):
         return tensor_ref.tensor_meta()
 
     @log_unhandled
+    def write_mutable_tensor(self, name, index, value):
+        tensor_ref = self._mut_tensor_refs.get(name)
+        if tensor_ref is None or tensor_ref.sealed():
+            raise ValueError("The mutable tensor named '%s' doesn't exist, or has already been sealed." % name)
+        return tensor_ref.write(index, value)
+
+    @log_unhandled
     def append_chunk_records(self, name, chunk_records):
         tensor_ref = self._mut_tensor_refs.get(name)
         if tensor_ref is None or tensor_ref.sealed():
@@ -126,8 +133,9 @@ class SessionActor(SchedulerActor):
         if tensor_ref is None or tensor_ref.sealed():
             raise ValueError("The mutable tensor named '%s' doesn't exist, or has already been sealed." % name)
 
-        graph_key, tensor_key, tensor_id, tensor_meta = tensor_ref.seal()
+        graph_key_hex, tensor_key, tensor_id, tensor_meta = tensor_ref.seal()
         shape, dtype, chunk_size, chunk_keys = tensor_meta
+        graph_key = uuid.UUID(graph_key_hex)
 
         # Create a GraphActor
         graph_uid = GraphActor.gen_uid(self._session_id, graph_key)
@@ -147,7 +155,7 @@ class SessionActor(SchedulerActor):
 
         # Clean up mutable tensor refs.
         self._mut_tensor_refs.pop(name)
-        return graph_key, tensor_key, tensor_id, tensor_meta
+        return graph_key_hex, tensor_key, tensor_id, tensor_meta
 
     def graph_state(self, graph_key):
         return self._graph_refs[graph_key].get_state()

--- a/mars/scheduler/session.py
+++ b/mars/scheduler/session.py
@@ -69,6 +69,8 @@ class SessionActor(SchedulerActor):
         self.ctx.destroy_actor(self._assigner_ref)
         for graph_ref in self._graph_refs.values():
             self.ctx.destroy_actor(graph_ref)
+        for mut_tensor_ref in self._mut_tensor_refs.values():
+            self.ctx.destroy_actor(mut_tensor_ref)
 
     @log_unhandled
     def submit_tileable_graph(self, serialized_graph, graph_key, target_tileables=None, compose=True):
@@ -154,7 +156,9 @@ class SessionActor(SchedulerActor):
         self._tileable_to_graph[tensor_key] = graph_ref
 
         # Clean up mutable tensor refs.
-        self._mut_tensor_refs.pop(name)
+        actor_ref = self._mut_tensor_refs[name]
+        actor_ref.destroy()
+        del self._mut_tensor_refs[name]
         return graph_key_hex, tensor_key, tensor_id, tensor_meta
 
     def graph_state(self, graph_key):

--- a/mars/session.py
+++ b/mars/session.py
@@ -71,13 +71,16 @@ class LocalSession(object):
             kw['n_parallel'] = cpu_count()
         return self._executor.fetch_tileables(tileables, **kw)
 
-    def create_mutable_tensor(self, name, shape, dtype, *args, **kwargs):
+    def create_mutable_tensor(self, name, shape, dtype, fill_value=None, *args, **kwargs):
         from .tensor.core import MutableTensor, MutableTensorData
         if name in self._mut_tensor:
             raise ValueError("The mutable tensor named '%s' already exists." % name)
         mut_tensor = MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype))
         self._mut_tensor[name] = mut_tensor
-        self._mut_tensor_data[name] = np.zeros(shape, dtype=dtype)
+        if fill_value is None:
+            self._mut_tensor_data[name] = np.zeros(shape, dtype=dtype)
+        else:
+            self._mut_tensor_data[name] = np.full(shape, fill_value, dtype=dtype)
         return mut_tensor
 
     def get_mutable_tensor(self, name):
@@ -220,8 +223,8 @@ class Session(object):
         cls._default_session = Session()
         return cls._default_session
 
-    def create_mutable_tensor(self, name, shape, dtype, *args, **kwargs):
-        return self._sess.create_mutable_tensor(name, shape, dtype, *args, **kwargs)
+    def create_mutable_tensor(self, name, shape, dtype, fill_value=None, *args, **kwargs):
+        return self._sess.create_mutable_tensor(name, shape, dtype, fill_value=fill_value, *args, **kwargs)
 
     def get_mutable_tensor(self, name):
         return self._sess.get_mutable_tensor(name)

--- a/mars/session.py
+++ b/mars/session.py
@@ -30,6 +30,9 @@ class LocalSession(object):
         self._executor = Executor()
         self._endpoint = None
 
+        self._mut_tensor = dict()
+        self._mut_tensor_data = dict()
+
         if kwargs:
             unexpected_keys = ', '.join(list(kwargs.keys()))
             raise TypeError('Local session got unexpected arguments: %s' % unexpected_keys)
@@ -67,6 +70,36 @@ class LocalSession(object):
         if 'n_parallel' not in kw:
             kw['n_parallel'] = cpu_count()
         return self._executor.fetch_tileables(tileables, **kw)
+
+    def create_mutable_tensor(self, name, shape, dtype, *args, **kwargs):
+        from .tensor.core import MutableTensor, MutableTensorData
+        if name in self._mut_tensor:
+            raise ValueError("The mutable tensor named '%s' already exists." % name)
+        mut_tensor = MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype))
+        self._mut_tensor[name] = mut_tensor
+        self._mut_tensor_data[name] = np.zeros(shape, dtype=dtype)
+        return mut_tensor
+
+    def get_mutable_tensor(self, name):
+        if name not in self._mut_tensor:
+            raise ValueError("The mutable tensor named '%s' doesn't exist, or has already been sealed." % name)
+        return self._mut_tensor.get(name)
+
+    def write_mutable_tensor(self, tensor, index, value):
+        if tensor.name not in self._mut_tensor:
+            raise ValueError("The mutable tensor named '%s' doesn't exist, or has already been sealed." % tensor.name)
+        tensor_data = self._mut_tensor_data.get(tensor.name)
+        tensor_data[index] = value
+
+    def seal(self, tensor):
+        from .tensor.expressions.datasource.array import ArrayDataSource
+        if tensor.name not in self._mut_tensor:
+            raise ValueError("The mutable tensor named '%s' doesn't exist, or has already been sealed." % tensor.name)
+        mut_tensor = self._mut_tensor.pop(tensor.name)
+        tensor_data = self._mut_tensor_data.pop(tensor.name)
+        sealed_tensor = ArrayDataSource(tensor_data, dtype=mut_tensor.dtype)(shape=mut_tensor.shape)
+        self._executor.execute_tileables([sealed_tensor])
+        return sealed_tensor
 
     def decref(self, *keys):
         self._executor.decref(*keys)
@@ -188,44 +221,17 @@ class Session(object):
         return cls._default_session
 
     def create_mutable_tensor(self, name, shape, dtype, *args, **kwargs):
-        from .tensor.core import MutableTensor, MutableTensorData
-        from .tensor.expressions.utils import create_fetch_tensor
-        self._ensure_local_cluster()
-        shape, dtype, chunk_size, chunk_keys = \
-                self._sess.create_mutable_tensor(name, shape, dtype, *args, **kwargs)
-        # Construct MutableTensor on the fly.
-        tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
-        return MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
-                                                    _nsplits=tensor.nsplits, _chunks=tensor.chunks))
+        return self._sess.create_mutable_tensor(name, shape, dtype, *args, **kwargs)
 
     def get_mutable_tensor(self, name):
-        from .tensor.core import MutableTensor, MutableTensorData
-        from .tensor.expressions.utils import create_fetch_tensor
-        self._ensure_local_cluster()
-        shape, dtype, chunk_size, chunk_keys = self._sess.get_mutable_tensor(name)
-        # Construct MutableTensor on the fly.
-        tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
-        return MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
-                                                    _nsplits=tensor.nsplits, _chunks=tensor.chunks))
+        return self._sess.get_mutable_tensor(name)
 
     def write_mutable_tensor(self, tensor, index, value):
-        self._ensure_local_cluster()
-        chunk_records_to_send = tensor._do_write(index, value)
-        return self._sess.send_chunk_records(tensor.name, chunk_records_to_send)
+        self._sess.write_mutable_tensor(tensor, index, value)
 
     def seal(self, tensor):
-        from .tensor.expressions.utils import create_fetch_tensor
-        self._ensure_local_cluster()
-        chunk_records_to_send = tensor._do_flush()
-        self._sess.send_chunk_records(tensor.name, chunk_records_to_send)
-        shape, dtype, chunk_size, chunk_keys = self._sess.seal(tensor.name)
-        # Construct Tensor on the fly.
-        return create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
+        return self._sess.seal(tensor)
 
-    def _ensure_local_cluster(self):
-        from .deploy.local.session import LocalClusterSession
-        if not isinstance(self._sess, LocalClusterSession):
-            raise RuntimeError("Only local cluster session can be used to manipulate mutable tensors.")
 
 
 def new_session(scheduler=None, **kwargs):

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -460,7 +460,11 @@ class MutableTensor(Entity):
         super(MutableTensor, self).__init__(*args, **kwargs)
         self._chunk_buffers = defaultdict(lambda: [])
         self._record_type = np.dtype([("index", np.uint32), ("ts", np.dtype('datetime64[ns]')), ("value", self.dtype)])
-        self._buffer_size = np.prod(self.chunks[0].shape)
+        if self.chunks:
+            self._buffer_size = np.prod(self.chunks[0].shape)
+        else:
+            # MutableTensor doesn't hold chunks in LocalSession, thus we don't care the buffer
+            self._buffer_size = 0
 
     def __len__(self):
         return len(self._data)

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -456,6 +456,27 @@ class MutableTensor(Entity):
     __slots__ = ("_chunk_buffers", "_record_type", "_buffer_size")
     _allow_data_type_ = (MutableTensorData,)
 
+    class Index(Serializable):
+        '''
+        Define a `Index` class to contain the raw index value of read/write
+        Operation on the mutable tensor.
+
+        This class is used to serialize `index` value at client and send it to
+        scheduler (mainly for WebSession). That says, the index will be wrapped
+        into a `Index` object and use the `to_json/from_json` to serialize and
+        deserialize.
+
+        This class is defined as a inner class to avoid name pollution.
+        '''
+        _index = AnyField('index')
+
+        def __init__(self, *args, **kwargs):
+            super(MutableTensor.Index, self).__init__(*args, **kwargs)
+
+        @property
+        def index(self):
+            return self._index
+
     def __init__(self, *args, **kwargs):
         super(MutableTensor, self).__init__(*args, **kwargs)
         self._chunk_buffers = defaultdict(lambda: [])

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -456,6 +456,7 @@ class MutableTensor(Entity):
     __slots__ = ("_chunk_buffers", "_record_type", "_buffer_size")
     _allow_data_type_ = (MutableTensorData,)
 
+
     class Index(Serializable):
         '''
         Define a `Index` class to contain the raw index value of read/write
@@ -476,6 +477,7 @@ class MutableTensor(Entity):
         @property
         def index(self):
             return self._index
+
 
     def __init__(self, *args, **kwargs):
         super(MutableTensor, self).__init__(*args, **kwargs)

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -468,29 +468,6 @@ class MutableTensor(Entity):
     __slots__ = ("_chunk_buffers", "_record_type", "_buffer_size")
     _allow_data_type_ = (MutableTensorData,)
 
-
-    class Index(Serializable):
-        '''
-        Define a `Index` class to contain the raw index value of read/write
-        Operation on the mutable tensor.
-
-        This class is used to serialize `index` value at client and send it to
-        scheduler (mainly for WebSession). That says, the index will be wrapped
-        into a `Index` object and use the `to_json/from_json` to serialize and
-        deserialize.
-
-        This class is defined as a inner class to avoid name pollution.
-        '''
-        _index = AnyField('index')
-
-        def __init__(self, *args, **kwargs):
-            super(MutableTensor.Index, self).__init__(*args, **kwargs)
-
-        @property
-        def index(self):
-            return self._index
-
-
     def __init__(self, *args, **kwargs):
         super(MutableTensor, self).__init__(*args, **kwargs)
         self._chunk_buffers = defaultdict(lambda: [])

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -561,7 +561,7 @@ class MutableTensor(Entity):
         return chunk_records_to_send
 
 
-def mutable_tensor(name, shape=None, dtype=np.float_, chunk_size=None):
+def mutable_tensor(name, shape=None, dtype=np.float_, fill_value=None, chunk_size=None):
     """
     Create or get a mutable tensor using the local or default session.
 
@@ -578,6 +578,9 @@ def mutable_tensor(name, shape=None, dtype=np.float_, chunk_size=None):
         The desired data-type for the mutable tensor, e.g., `mt.int8`.  Default is `mt.float_`.
     chunk_size: int or tuple of ints, optional
         Specifies chunk size for each dimension.
+    fill_value: scalar, optional
+        The created mutable tensor will be filled by `fill_value` defaultly, if the parameter is None,
+        the newly created mutable tensor will be initialized with `np.zeros`. See also `numpy.full`.
     """
     from ..session import Session
     session = Session.default_or_local()
@@ -585,7 +588,8 @@ def mutable_tensor(name, shape=None, dtype=np.float_, chunk_size=None):
     if shape is None:
         return session.get_mutable_tensor(name)
     else:
-        return session.create_mutable_tensor(name, shape=shape, dtype=dtype, chunk_size=chunk_size)
+        return session.create_mutable_tensor(name, shape=shape, dtype=dtype,
+                                             fill_value=fill_value, chunk_size=chunk_size)
 
 
 TENSOR_TYPE = (Tensor, TensorData)

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -411,6 +411,18 @@ class flatiter(object):
         self._ravel_tensor[key] = value
 
 
+class Indexes(Serializable):
+    _indexes = AnyField('indexes')
+
+    def __init__(self, indexes=None, **kw):
+        self._indexes = indexes
+        super(Indexes, self).__init__(**kw)
+
+    @property
+    def indexes(self):
+        return self._indexes
+
+
 class MutableTensorData(TensorData):
     __slots__ = ()
 
@@ -572,16 +584,31 @@ class MutableTensor(Entity):
         return chunk_records_to_send
 
 
-class Indexes(Serializable):
-    _indexes = AnyField('indexes')
+def mutable_tensor(name, shape=None, dtype=np.float_, chunk_size=None):
+    """
+    Create or get a mutable tensor using the local or default session.
 
-    def __init__(self, indexes=None, **kw):
-        self._indexes = indexes
-        super(Indexes, self).__init__(**kw)
+    When `shape` is `None`, it will try to get the mutable tensor with name `name`. Otherwise,
+    it will try to create a mutable tensor using the provided `name` and `shape`.
 
-    @property
-    def indexes(self):
-        return self._indexes
+    Parameters
+    ----------
+    name : str
+        Name of the mutable tensor.
+    shape : int or sequence of ints
+        Shape of the new mutable tensor, e.g., ``(2, 3)`` or ``2``.
+    dtype : data-type, optional
+        The desired data-type for the mutable tensor, e.g., `mt.int8`.  Default is `mt.float_`.
+    chunk_size: int or tuple of ints, optional
+        Specifies chunk size for each dimension.
+    """
+    from ..session import Session
+    session = Session.default_or_local()
+
+    if shape is None:
+        return session.get_mutable_tensor(name)
+    else:
+        return session.create_mutable_tensor(name, shape=shape, dtype=dtype, chunk_size=chunk_size)
 
 
 TENSOR_TYPE = (Tensor, TensorData)

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -529,6 +529,10 @@ def concat_tileable_chunks(tensor):
 
 
 def create_fetch_tensor(chunk_size, shape, dtype, tensor_key=None, tensor_id=None, chunk_keys=None):
+    '''
+    Construct Fetch tensor on the fly, using given chunk_size, shape, dtype,
+    as well as possible tensor_key, tensor_id and chunk keys.
+    '''
     from ...config import options
     from .fetch import TensorFetch
 
@@ -556,8 +560,11 @@ def create_fetch_tensor(chunk_size, shape, dtype, tensor_key=None, tensor_id=Non
 
 
 def create_mutable_tensor(name, chunk_size, shape, dtype, chunk_keys=None):
+    '''
+    Construct MutableTensor on the fly, using given name, chunk_size, shape, dtype,
+    as well as possible chunk keys.
+    '''
     from ..core import MutableTensor, MutableTensorData
-    # Construct MutableTensor on the fly.
     tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
     return MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=tensor.dtype,
                                                 _nsplits=tensor.nsplits, _key=tensor.key, _chunks=tensor.chunks))

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -555,6 +555,14 @@ def create_fetch_tensor(chunk_size, shape, dtype, tensor_key=None, tensor_id=Non
                                       chunks=chunks, _key=tensor_key, _id=tensor_id)
 
 
+def create_mutable_tensor(name, chunk_size, shape, dtype, chunk_keys=None):
+    from ..core import MutableTensor, MutableTensorData
+    # Construct MutableTensor on the fly.
+    tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
+    return MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
+                                                _nsplits=tensor.nsplits, _chunks=tensor.chunks))
+
+
 def setitem_as_records(nsplits_acc, output_chunk, value, ts):
     """
     Turns a `__setitem__`  to a list of index-value records.

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -532,17 +532,17 @@ def create_fetch_tensor(chunk_size, shape, dtype, tensor_key=None, tensor_id=Non
     from ...config import options
     from .fetch import TensorFetch
 
+    if not isinstance(dtype, np.dtype):
+        dtype = np.dtype(dtype)
+    if chunk_keys is None:
+        chunk_keys = itertools.repeat(None)
+
     # compute chunks
     chunk_size = chunk_size or options.tensor.chunk_size
     chunk_size = decide_chunk_sizes(shape, chunk_size, dtype.itemsize)
     chunk_size_idxes = (range(len(size)) for size in chunk_size)
 
     fetch_op = TensorFetch(dtype=dtype).reset_key()
-
-    if not isinstance(dtype, np.dtype):
-        dtype = np.dtype(dtype)
-    if chunk_keys is None:
-        chunk_keys = itertools.repeat(None)
 
     chunks = []
     for chunk_shape, chunk_idx, chunk_key in izip(itertools.product(*chunk_size),
@@ -559,8 +559,8 @@ def create_mutable_tensor(name, chunk_size, shape, dtype, chunk_keys=None):
     from ..core import MutableTensor, MutableTensorData
     # Construct MutableTensor on the fly.
     tensor = create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
-    return MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=dtype,
-                                                _nsplits=tensor.nsplits, _chunks=tensor.chunks))
+    return MutableTensor(data=MutableTensorData(_name=name, _op=None, _shape=shape, _dtype=tensor.dtype,
+                                                _nsplits=tensor.nsplits, _key=tensor.key, _chunks=tensor.chunks))
 
 
 def setitem_as_records(nsplits_acc, output_chunk, value, ts):

--- a/mars/tests/test_mutable.py
+++ b/mars/tests/test_mutable.py
@@ -186,7 +186,7 @@ class Test(unittest.TestCase):
 
     @mock.patch('webbrowser.open_new_tab', new=lambda *_, **__: True)
     def testMutableTensorDuplicateName(self):
-        def testWithGivenSession(session, check_message=True):
+        def testWithGivenSession(session):
             session.create_mutable_tensor("test", (4, 5), dtype='int32')
 
             # The two unsealed mutable tensors cannot have the same name.
@@ -194,9 +194,7 @@ class Test(unittest.TestCase):
                 session.create_mutable_tensor("test", (4, 5), dtype='int32')
 
             expected_msg = "The mutable tensor named 'test' already exists."
-
-            if check_message:
-                self.assertEqual(cm.exception.args[0], expected_msg)
+            self.assertEqual(cm.exception.args[0], expected_msg)
 
         with new_session().as_default() as session:
             testWithGivenSession(session)
@@ -206,11 +204,11 @@ class Test(unittest.TestCase):
             testWithGivenSession(session)
 
             with new_session('http://' + cluster._web_endpoint).as_default() as web_session:
-                testWithGivenSession(web_session, check_message=False)
+                testWithGivenSession(web_session)
 
     @mock.patch('webbrowser.open_new_tab', new=lambda *_, **__: True)
     def testMutableTensorRaiseAfterSeal(self):
-        def testWithGivenSession(session, check_message=True):
+        def testWithGivenSession(session):
             mut = session.create_mutable_tensor("test", (4, 5), dtype='int32', chunk_size=3)
             mut.seal()
 
@@ -220,22 +218,19 @@ class Test(unittest.TestCase):
             with self.assertRaises(ValueError) as cm:
                 session.get_mutable_tensor("test")
 
-            if check_message:
-                self.assertEqual(cm.exception.args[0], expected_msg)
+            self.assertEqual(cm.exception.args[0], expected_msg)
 
             # Cannot write after seal
             with self.assertRaises(ValueError) as cm:
                 mut[:] = 111
 
-            if check_message:
-                self.assertEqual(cm.exception.args[0], expected_msg)
+            self.assertEqual(cm.exception.args[0], expected_msg)
 
             # Cannot seal after seal
             with self.assertRaises(ValueError) as cm:
                 session.seal(mut)
 
-            if check_message:
-                self.assertEqual(cm.exception.args[0], expected_msg)
+            self.assertEqual(cm.exception.args[0], expected_msg)
 
         with new_session().as_default() as session:
             testWithGivenSession(session)
@@ -246,7 +241,7 @@ class Test(unittest.TestCase):
             testWithGivenSession(session)
 
             with new_session('http://' + cluster._web_endpoint).as_default() as web_session:
-                testWithGivenSession(web_session, check_message=False)
+                testWithGivenSession(web_session)
 
     def testMutableTensorLocal(self):
         with new_session().as_default() as session:

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -605,3 +605,16 @@ def sort_dataframe_result(df, result):
                 result.sort_index(axis=1, inplace=True)
     return result
 
+
+def numpy_dtype_from_descr_json(obj):
+    '''
+    Construct numpy dtype from it's np.dtype.descr.
+
+    The dtype can be trivial, but can also be very complex (nested) record type. In that
+    case, the tuple in `descr` will be made as `list`, which can be understood by `np.dtype()`.
+    This utility helps the reconstruct work.
+    '''
+    print(obj)
+    if isinstance(obj, str):
+        return obj
+    return np.dtype([(k, numpy_dtype_from_descr_json(v)) for k, v in obj])

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -614,7 +614,6 @@ def numpy_dtype_from_descr_json(obj):
     case, the tuple in `descr` will be made as `list`, which can be understood by `np.dtype()`.
     This utility helps the reconstruct work.
     '''
-    print(obj)
-    if isinstance(obj, str):
-        return obj
-    return np.dtype([(k, numpy_dtype_from_descr_json(v)) for k, v in obj])
+    if isinstance(obj, list):
+        return np.dtype([(k, numpy_dtype_from_descr_json(v)) for k, v in obj])
+    return obj

--- a/mars/web/api.py
+++ b/mars/web/api.py
@@ -197,9 +197,10 @@ class MutableTensorHandler(MarsApiRequestHandler):
                 req_json = json.loads(self.request.body.decode('ascii'))
                 shape = req_json['shape']
                 dtype = numpy_dtype_from_descr_json(req_json['dtype'])
+                fill_value = req_json['fill_value']
                 chunk_size = req_json['chunk_size']
                 meta = self.web_api.create_mutable_tensor(session_id, name, shape, dtype,
-                                                          chunk_size=chunk_size)
+                                                          fill_value=fill_value, chunk_size=chunk_size)
                 self.write(json.dumps(meta))
             else:
                 info = self.web_api.seal(session_id, name)

--- a/mars/web/api.py
+++ b/mars/web/api.py
@@ -15,9 +15,10 @@
 import sys
 import base64
 import json
-import pickle
-import uuid
 import logging
+import pickle
+import traceback
+import uuid
 
 import numpy as np
 from tornado import gen, concurrent, web, ioloop
@@ -58,10 +59,13 @@ class MarsApiRequestHandler(MarsRequestHandler):
 
     def _dump_exception(self, exc_info):
         pickled_exc = pickle.dumps(exc_info)
+        # return pickled exc_info for python client, and textual exc_info for web.
         self.write(json.dumps(dict(
             exc_info=base64.b64encode(pickled_exc).decode('ascii'),
+            exc_info_text=traceback.format_exception(*exc_info),
         )))
-        raise web.HTTPError(500, 'Internal server error')
+        self.set_status(500)
+        self.finish()
 
 
 class ApiEntryHandler(MarsApiRequestHandler):

--- a/mars/web/api.py
+++ b/mars/web/api.py
@@ -20,7 +20,6 @@ import pickle
 import traceback
 import uuid
 
-import numpy as np
 from tornado import gen, concurrent, web, ioloop
 
 from ..tensor.core import Indexes

--- a/mars/web/api.py
+++ b/mars/web/api.py
@@ -187,7 +187,7 @@ class MutableTensorHandler(MarsApiRequestHandler):
 
     def post(self, session_id):
         try:
-            req_json = json.loads(self.request.body)
+            req_json = json.loads(self.request.body.decode('ascii'))
             name = req_json['name']
             shape = req_json['shape']
             dtype = np.dtype(req_json['dtype'])

--- a/mars/web/api.py
+++ b/mars/web/api.py
@@ -29,7 +29,7 @@ from ..compat import six, futures
 from ..errors import GraphNotExists
 from ..lib.tblib import pickling_support
 from ..serialize.dataserializer import CompressType
-from ..utils import to_str
+from ..utils import to_str, numpy_dtype_from_descr_json
 from .server import MarsWebAPI, MarsRequestHandler, register_web_handler
 
 pickling_support.install()
@@ -194,7 +194,7 @@ class MutableTensorHandler(MarsApiRequestHandler):
             req_json = json.loads(self.request.body.decode('ascii'))
             name = req_json['name']
             shape = req_json['shape']
-            dtype = np.dtype(req_json['dtype'])
+            dtype = numpy_dtype_from_descr_json(req_json['dtype'])
             chunk_size = req_json['chunk_size']
             meta = self.web_api.create_mutable_tensor(session_id, name, shape, dtype, chunk_size=chunk_size)
             self.write(json.dumps(meta))

--- a/mars/web/server.py
+++ b/mars/web/server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import json
 import logging
 import random
 import threading
@@ -30,7 +31,7 @@ from .. import kvstore
 from ..compat import six
 from ..utils import get_next_port
 from ..config import options
-from ..scheduler import ResourceActor
+from ..scheduler import ResourceActor, SessionActor
 from ..api import MarsAPI
 
 logger = logging.getLogger(__name__)
@@ -130,6 +131,18 @@ class MarsWebAPI(MarsAPI):
         from ..worker import EventsActor
         ref = self.actor_client.actor_ref(EventsActor.default_uid(), address=endpoint)
         return ref.query_by_time(category, time_start=time_start, time_end=time_end)
+
+    def write_mutable_tensor(self, session_id, name, body):
+        from ..serialize import dataserializer
+        from ..tensor.core import MutableTensor
+        session_uid = SessionActor.gen_uid(session_id)
+        session_ref = self.get_actor_ref(session_uid)
+
+        index_json_size = np.asscalar(np.frombuffer(body[0:8], dtype=np.int64))
+        index_json = json.loads(body[8:8+index_json_size].decode('ascii'))
+        index = MutableTensor.Index.from_json(index_json)
+        value = dataserializer.loads(body[8+index_json_size:], raw=False)
+        return session_ref.write_mutable_tensor(name, index.index, value)
 
 
 class MarsWeb(object):

--- a/mars/web/server.py
+++ b/mars/web/server.py
@@ -134,15 +134,15 @@ class MarsWebAPI(MarsAPI):
 
     def write_mutable_tensor(self, session_id, name, body):
         from ..serialize import dataserializer
-        from ..tensor.core import MutableTensor
+        from ..tensor.core import Indexes
         session_uid = SessionActor.gen_uid(session_id)
         session_ref = self.get_actor_ref(session_uid)
 
         index_json_size = np.asscalar(np.frombuffer(body[0:8], dtype=np.int64))
         index_json = json.loads(body[8:8+index_json_size].decode('ascii'))
-        index = MutableTensor.Index.from_json(index_json)
+        index = Indexes.from_json(index_json).indexes
         value = dataserializer.loads(body[8+index_json_size:], raw=False)
-        return session_ref.write_mutable_tensor(name, index.index, value)
+        return session_ref.write_mutable_tensor(name, index, value)
 
 
 class MarsWeb(object):

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -202,7 +202,7 @@ class Session(object):
     def create_mutable_tensor(self, name, shape, dtype, fill_value=None, chunk_size=None, *args, **kwargs):
         from ..tensor.expressions.utils import create_mutable_tensor
         session_url = self._endpoint + '/api/session/' + self._session_id
-        tensor_url = session_url + '/mutable-tensor/%s' % name
+        tensor_url = session_url + '/mutable-tensor/%s?action=create' % name
         if not isinstance(dtype, np.dtype):
             dtype = np.dtype(dtype)
         # avoid built-in scalar dtypes are made into one-field record type.
@@ -270,7 +270,7 @@ class Session(object):
     def seal(self, tensor):
         from ..tensor.expressions.utils import create_fetch_tensor
         session_url = self._endpoint + '/api/session/' + self._session_id
-        tensor_url = session_url + '/mutable-tensor/%s' % tensor.name
+        tensor_url = session_url + '/mutable-tensor/%s?action=seal' % tensor.name
         resp = self._req_session.post(tensor_url)
         if resp.status_code >= 400:
             resp_json = json.loads(resp.text)

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -246,11 +246,11 @@ class Session(object):
             * ascii-encoded bytes of index json
             * pyarrow serialized bytes of `value`
         '''
-        from ..tensor.core import MutableTensor
+        from ..tensor.core import Indexes
         from ..compat import BytesIO
         from ..serialize import dataserializer
 
-        index = MutableTensor.Index(_index=index)
+        index = Indexes(_indexes=index)
         index_bytes = json.dumps(index.to_json()).encode('ascii')
         bio = BytesIO()
         bio.write(np.int64(len(index_bytes)).tobytes())

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -272,7 +272,7 @@ class Session(object):
 
         # # Construct Tensor on the fly.
         shape, dtype, chunk_size, chunk_keys = tensor_meta
-        return create_fetch_tensor(chunk_size, shape, dtype, chunk_keys=chunk_keys)
+        return create_fetch_tensor(chunk_size, shape, dtype, tensor_key=tensor_key, chunk_keys=chunk_keys)
 
     def _update_tileable_shape(self, tileable):
         tileable_key = tileable.key

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -199,7 +199,7 @@ class Session(object):
             results.append(sort_dataframe_result(tileable, result_data))
         return results
 
-    def create_mutable_tensor(self, name, shape, dtype, *args, **kwargs):
+    def create_mutable_tensor(self, name, shape, dtype, fill_value=None, chunk_size=None, *args, **kwargs):
         from ..tensor.expressions.utils import create_mutable_tensor
         session_url = self._endpoint + '/api/session/' + self._session_id
         tensor_url = session_url + '/mutable-tensor/%s' % name
@@ -213,7 +213,8 @@ class Session(object):
         tensor_json = {
             'shape': shape,
             'dtype': dtype_descr,
-            'chunk_size': kwargs.pop('chunk_size', None),
+            'fill_value': fill_value,
+            'chunk_size': chunk_size,
         }
         resp = self._req_session.post(tensor_url, json=tensor_json)
         if resp.status_code >= 400:

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -249,7 +249,6 @@ class Session(object):
         bio.write(index_bytes)
         dataserializer.dump(value, bio, raw=False)
 
-        from ..tensor.expressions.utils import create_fetch_tensor
         session_url = self._endpoint + '/api/session/' + self._session_id
         tensor_url = session_url + '/mutable-tensor/write?name=%s' % tensor.name
         resp = self._req_session.post(tensor_url, data=bio.getvalue(),

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -17,6 +17,7 @@ import json
 import time
 import logging
 from numbers import Integral
+import pickle
 import uuid
 
 import numpy as np
@@ -210,7 +211,7 @@ class Session(object):
         resp = self._req_session.post(session_url + '/mutable-tensor', json=tensor_json)
         if resp.status_code >= 400:
             resp_json = json.loads(resp.text)
-            exc_info = base64.b64decode(resp_json['exc_info'])
+            exc_info = pickle.loads(base64.b64decode(resp_json['exc_info']))
             six.reraise(*exc_info)
         shape, dtype, chunk_size, chunk_keys = json.loads(resp.text)
         return create_mutable_tensor(name, chunk_size, shape, dtype, chunk_keys)
@@ -222,7 +223,7 @@ class Session(object):
         resp = self._req_session.get(tensor_url)
         if resp.status_code >= 400:
             resp_json = json.loads(resp.text)
-            exc_info = base64.b64decode(resp_json['exc_info'])
+            exc_info = pickle.loads(base64.b64decode(resp_json['exc_info']))
             six.reraise(*exc_info)
         shape, dtype, chunk_size, chunk_keys = json.loads(resp.text)
         return create_mutable_tensor(name, chunk_size, shape, dtype, chunk_keys)
@@ -255,7 +256,7 @@ class Session(object):
                                       headers={'Content-Type': 'application/octet-stream'})
         if resp.status_code >= 400:
             resp_json = json.loads(resp.text)
-            exc_info = base64.b64decode(resp_json['exc_info'])
+            exc_info = pickle.loads(base64.b64decode(resp_json['exc_info']))
             six.reraise(*exc_info)
 
     def seal(self, tensor):
@@ -265,7 +266,7 @@ class Session(object):
         resp = self._req_session.get(tensor_url)
         if resp.status_code >= 400:
             resp_json = json.loads(resp.text)
-            exc_info = base64.b64decode(resp_json['exc_info'])
+            exc_info = pickle.loads(base64.b64decode(resp_json['exc_info']))
             six.reraise(*exc_info)
         graph_key_hex, tensor_key, tensor_id, tensor_meta = json.loads(resp.text)
         self._executed_tileables[tensor_key] = uuid.UUID(graph_key_hex), {tensor_id}
@@ -317,7 +318,7 @@ class Session(object):
         ))
         if resp.status_code >= 400:
             resp_json = json.loads(resp.text)
-            exc_info = base64.b64decode(resp_json['exc_info'])
+            exc_info = pickle.loads(base64.b64decode(resp_json['exc_info']))
             six.reraise(*exc_info)
         resp_json = json.loads(resp.text)
         return resp_json
@@ -327,7 +328,7 @@ class Session(object):
         resp = self._req_session.get(session_url + '/graph')
         if resp.status_code >= 400:
             resp_json = json.loads(resp.text)
-            exc_info = base64.b64decode(resp_json['exc_info'])
+            exc_info = pickle.loads(base64.b64decode(resp_json['exc_info']))
             six.reraise(*exc_info)
         resp_json = json.loads(resp.text)
         return resp_json

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -13,14 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import requests
 import json
 import unittest
 import os
+import pickle
 import sys
 import signal
 import subprocess
 import time
+import traceback
 import uuid
 
 import gevent
@@ -29,6 +32,7 @@ from numpy.testing import assert_array_equal
 
 from mars import tensor as mt
 from mars.actors import new_client
+from mars.actors.errors import ActorNotExist
 from mars.config import options
 from mars.scheduler import ResourceActor
 from mars.session import new_session
@@ -232,6 +236,26 @@ class Test(unittest.TestCase):
             res = requests.get('%s/%s?endpoint=127.0.0.1:%s'
                                % (service_ep, TIMELINE_APP_NAME, self.worker_port))
             self.assertEqual(res.status_code, 200)
+
+    def testWebApiException(self):
+        service_ep = 'http://127.0.0.1:' + self.web_port
+        with new_session(service_ep) as sess:
+            # Stop non-existing graph should raise an exception
+            graph_key = str(uuid.uuid4())
+            res = requests.delete('%s/api/session/%s/graph/%s' % (service_ep, sess._session_id, graph_key))
+            self.assertEqual(res.status_code, 404)
+            resp_json = json.loads(res.text)
+            typ, value, tb = pickle.loads(base64.b64decode(resp_json['exc_info']))
+            self.assertEqual(typ, ActorNotExist)
+            self.assertEqual(traceback.format_exception(typ, value, tb), resp_json['exc_info_text'])
+
+            # get graph states of non-existing session should raise an exception
+            res = requests.get('%s/api/session/%s/graph' % (service_ep, 'xxxx'))
+            self.assertEqual(res.status_code, 500)
+            resp_json = json.loads(res.text)
+            typ, value, tb = pickle.loads(base64.b64decode(resp_json['exc_info']))
+            self.assertEqual(typ, KeyError)
+            self.assertEqual(traceback.format_exception(typ, value, tb), resp_json['exc_info_text'])
 
 
 class MockResponse:

--- a/mars/worker/seal.py
+++ b/mars/worker/seal.py
@@ -44,11 +44,14 @@ class SealActor(WorkerActor):
         self._mem_quota_ref = self.promise_ref(MemQuotaActor.default_uid())
 
     @log_unhandled
-    def seal_chunk(self, session_id, graph_key, chunk_key, keys, shape, record_type, dtype):
+    def seal_chunk(self, session_id, graph_key, chunk_key, keys, shape, record_type, dtype, fill_value):
         from ..serialize.dataserializer import decompressors, mars_serialize_context
         chunk_bytes_size = np.prod(shape) * dtype.itemsize
         self._mem_quota_ref.request_batch_quota({chunk_key: chunk_bytes_size})
-        ndarr = np.zeros(shape, dtype=dtype)
+        if fill_value is None:
+            ndarr = np.zeros(shape, dtype=dtype)
+        else:
+            ndarr = np.full(shape, fill_value, dtype=dtype)
         ndarr_ts = np.zeros(shape, dtype=np.dtype('datetime64[ns]'))
 
         # consolidate

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -17,6 +17,7 @@ import logging
 import os
 import sys
 import time
+import pyarrow
 import zlib
 from collections import defaultdict
 
@@ -764,3 +765,33 @@ class ResultSenderActor(WorkerActor):
         finally:
             del buf
         return compressed
+
+
+def put_remote_chunk(session_id, chunk_key, data, receiver_ref):
+    '''Put a chunk to target machine using given receiver_ref.
+    '''
+    from .dataio import ArrowBufferIO
+    buf = pyarrow.serialize(data).to_buffer()
+    receiver_ref.create_data_writer(session_id, chunk_key, buf.size, None,
+                                    ensure_cached=False, use_promise=False)
+
+    block_size = options.worker.transfer_block_size
+
+    try:
+        reader = ArrowBufferIO(buf, 'r', block_size=block_size)
+        checksum = 0
+        while True:
+            next_chunk = reader.read(block_size)
+            if not next_chunk:
+                reader.close()
+                receiver_ref.finish_receive(session_id, chunk_key, checksum)
+                break
+            checksum = zlib.crc32(next_chunk, checksum)
+            receiver_ref.receive_data_part(session_id, chunk_key, next_chunk, checksum)
+    except:
+        receiver_ref.cancel_receive(session_id, chunk_key)
+        raise
+    finally:
+        if reader:
+            reader.close()
+        del reader

--- a/mars/worker/utils.py
+++ b/mars/worker/utils.py
@@ -18,6 +18,9 @@ import os
 import time
 from collections import OrderedDict
 
+import pyarrow
+import zlib
+
 from ..actors import ActorNotExist
 from ..cluster_info import ClusterInfoActor, HasClusterInfoActor
 from ..compat import OrderedDict3
@@ -165,3 +168,33 @@ def build_load_key(graph_key, chunk_key):
     if isinstance(chunk_key, tuple):
         chunk_key = '@'.join(chunk_key)
     return '%s_load_memory_%s' % (graph_key, chunk_key)
+
+
+def put_chunk(session_id, chunk_key, data, receiver_ref):
+    '''Put a chunk to target machine using given receiver_ref.
+    '''
+    from .dataio import ArrowBufferIO
+    buf = pyarrow.serialize(data).to_buffer()
+    receiver_ref.create_data_writer(session_id, chunk_key, buf.size, None,
+                                    ensure_cached=False, use_promise=False)
+
+    block_size = options.worker.transfer_block_size
+
+    try:
+        reader = ArrowBufferIO(buf, 'r', block_size=block_size)
+        checksum = 0
+        while True:
+            next_chunk = reader.read(block_size)
+            if not next_chunk:
+                reader.close()
+                receiver_ref.finish_receive(session_id, chunk_key, checksum)
+                break
+            checksum = zlib.crc32(next_chunk, checksum)
+            receiver_ref.receive_data_part(session_id, chunk_key, next_chunk, checksum)
+    except:
+        receiver_ref.cancel_receive(session_id, chunk_key)
+        raise
+    finally:
+        if reader:
+            reader.close()
+        del reader


### PR DESCRIPTION
## What do these changes do?

Support mutable tensor in local session and web session.

+ For the `LocalSession`, we
   1. maintain a map of `name -> mut tensor` in `LocalSession`, and do write to the ndarray directly.
  2. when `seal`, we use the ndarray to construct a `mt.tensor` and execute it with `self._executor` know the tensor is executed.
+ For the `WebSession`, we
  1. add several necessary endpoints to web api server.
  2. when `write`, we forward the `index` and `value` to `MutableTensorActor`, the `MutableTensorActor` maintains the buffer, and send record chunks to corresponding workers.
  3. When `seal`, do the same thing with `LocalClusterSession`.

Some design point that needs to clarify:

1. The `index` (such as `(slice(1, None, None))`) cannot be serialized to json directly, thus I add a helper class `MutableTensor.Index` and leverage the `Serializable.to_json` to do the serialization.
2. In `WebSession`, the index calculation and chunk transfer are done in `MutableTensorActor`.
3. All functionalities of mutable tensor in `LocalSession` work well with the `WebSession` (as shown by the unit test).
4. Along this PR I also do some refactor and improvement on the previous implementation to avoid code duplication.

About the (known) failed test cases:

It seems that there is no way to obtain the information and message of exception that initially raised in server at client side. We have `dump_exception` and `reraise`,

(Edit: this exception info issue has been fixed in [commit 31520ebc9](https://github.com/mars-project/mars/pull/536/commits/31520ebc9ab3ee31ce65b369c076998269783b34) of this PR.)

```python
    def _dump_exception(self, exc_info):
        pickled_exc = pickle.dumps(exc_info)
        self.write(json.dumps(dict(
            exc_info=base64.b64encode(pickled_exc),
        )))
        raise web.HTTPError(500, 'Internal server error')
```

```python
    if resp.status_code >= 400:
        resp_json = json.loads(resp.text)
        exc_info = base64.b64decode(resp_json['exc_info'])
        six.reraise(*exc_info)
```

But it doesn't work because:

1. The `base64.b64encode(pickled_exc)` is `bytes`, not `str`, which cannot be `json.dumps`.
2. Even after fixing the problem (by `.decode('ascii')`), we will found that `resp.text` is something like

```
<html><title>500: Internal Server Error</title><body>500: Internal Server Error</body></html>
```

rather than the serialized exception information. Not sure if this limitation is a bug or just by-design.

## Related issue number

#415 