### PR TITLE
Fix assignment of structured data type arrays.

### DIFF
--- a/mars/tensor/execution/tests/test_index_execute.py
+++ b/mars/tensor/execution/tests/test_index_execute.py
@@ -242,6 +242,29 @@ class Test(unittest.TestCase):
         raw[idx] = replace
         np.testing.assert_array_equal(res[0], raw)
 
+    def testSetItemStructuredExecution(self):
+        rec_type = np.dtype([('a', np.int32), ('b', np.double), ('c', np.dtype([('a', np.int16), ('b', np.int64)]))])
+
+        raw = np.zeros((4, 5), dtype=rec_type)
+        arr = tensor(raw.copy(), chunk_size=3)
+
+        arr[1:4, 1] = (3, 4., (5, 6))
+        arr[1:4, 2] = 8
+        arr[1:3] = np.arange(5)
+        arr[2:4] = np.arange(10).reshape(2, 5)
+        arr[0] = np.arange(5)
+
+        raw[1:4, 1] = (3, 4., (5, 6))
+        raw[1:4, 2] = 8
+        raw[1:3] = np.arange(5)
+        raw[2:4] = np.arange(10).reshape(2, 5)
+        raw[0] = np.arange(5)
+
+        res = self.executor.execute_tensor(arr, concat=True)
+        self.assertEqual(arr.dtype, raw.dtype)
+        self.assertEqual(arr.shape, raw.shape)
+        np.testing.assert_array_equal(res[0], raw)
+
     def testTakeExecution(self):
         data = np.random.rand(10, 20, 30)
         t = tensor(data, chunk_size=10)

--- a/mars/tensor/expressions/indexing/setitem.py
+++ b/mars/tensor/expressions/indexing/setitem.py
@@ -107,9 +107,8 @@ def _setitem(a, item, value):
         if not isinstance(ix, (slice, Integral)):
             raise NotImplementedError('Only slice or int supported by now, got {0}'.format(type(ix)))
 
-    if np.isscalar(value):
-        value = a.dtype.type(value)
-    else:
+    # don't broadcast for tuple when dtype is record type.
+    if not (np.isscalar(value) or (isinstance(value, tuple) and a.dtype.fields)):
         value = broadcast_to(value, shape).astype(a.dtype)
 
     op = TensorIndexSetValue(dtype=a.dtype, sparse=a.issparse(), indexes=index, value=value)

--- a/mars/tensor/expressions/tests/test_indexing.py
+++ b/mars/tensor/expressions/tests/test_indexing.py
@@ -18,6 +18,7 @@ import unittest
 
 import numpy as np
 
+from mars.tensor.expressions.base.broadcast_to import TensorBroadcastTo
 from mars.tensor.expressions.datasource import ones, tensor
 from mars.tensor.expressions.datasource.ones import TensorOnes
 from mars.tensor.expressions.indexing import choose, unravel_index, nonzero
@@ -246,7 +247,7 @@ class Test(unittest.TestCase):
         t.tiles()
         self.assertIsInstance(t.chunks[0].op, TensorOnes)
         self.assertIsInstance(t.cix[1, 1, 0, 0].op, TensorIndexSetValue)
-        self.assertEqual(t.cix[1, 1, 0, 0].op.value, 2)
+        self.assertEqual(t.cix[1, 1, 0, 0].op.value, 2.2)
 
         t2 = ones(shape, chunk_size=5, dtype='i4')
         shape = t2[5:20:3, 5, ..., :-5].shape
@@ -259,6 +260,39 @@ class Test(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             t[0, 0, 0, 0] = ones(2, chunk_size=10)
+
+    def testSetItemStructured(self):
+        # Check to value is properly broadcast for `setitem` on complex record dtype arrays.
+        rec_type = np.dtype([('a', np.int32), ('b', np.double), ('c', np.dtype([('a', np.int16), ('b', np.int64)]))])
+
+        t = ones((4, 5), dtype=rec_type, chunk_size=3)
+
+        # assign tuple to record
+        t[1:4, 1] = (3, 4., (5, 6))
+        t.tiles()
+        self.assertEqual(t.cix[0, 0].op.value, (3, 4., (5, 6)))
+
+        # assign scalar to record
+        t[1:4, 2] = 8
+        t.tiles()
+        self.assertEqual(t.cix[0, 0].op.value, 8)
+
+        # assign scalar array to record array with broadcast
+        t[1:3] = np.arange(5)
+        t.tiles()
+        slices_op = t.cix[0, 0].op.value.op
+        self.assertEqual(slices_op.slices, (slice(None, None, None), slice(None, 3, None)))
+        broadcast_op = slices_op.inputs[0].op.inputs[0].op
+        self.assertIsInstance(broadcast_op, TensorBroadcastTo)
+        self.assertEqual(broadcast_op.shape, (2, 5))
+        np.testing.assert_array_equal(broadcast_op.inputs[0].op.data, np.arange(5))
+
+        # assign scalar array to record array of same shape, no broadcast
+        t[2:4] = np.arange(10).reshape(2, 5)
+        t.tiles()
+        slices_op = t.cix[0, 0].op.value.op
+        self.assertEqual(slices_op.slices, (slice(None, 1, None), slice(None, 3, None)))
+        np.testing.assert_array_equal(slices_op.inputs[0].op.inputs[0].op.data, np.arange(10).reshape(2, 5))
 
     def testChoose(self):
         with option_context() as options:


### PR DESCRIPTION
## What do these changes do?

Current code from the master branch suffers a trouble about `setitem` on structured arrays, that is, if we have `a = mt.ones(4, dtype=np.dtype([('a', np.int32), ('b', np.double)]))`, execute `a` is ok and the result is consistent with numpy. However, if we `setitem` to a like `a[0] = 100`, numpy will set `a[0]` to `(100, 100)`, mars raises an exception instead:

```python
~/mars/mars/tensor/execution/indexing.py in _index_set_value(ctx, chunk)
    171     if hasattr(input_, 'flags') and not input_.flags.writeable:
    172         input_.setflags(write=True)
--> 173     input_[tuple(indexes)] = value
    174     ctx[chunk.key] = input_
    175

ValueError: setting an array element with a sequence.
```

The issue is caused by

https://github.com/mars-project/mars/blob/ea2db4c2b95ad8ad97d2490edbf378c0d041618d/mars/tensor/expressions/indexing/setitem.py#L110-L113

Here we do `a.dtype.type(value)`, but it `a` is a record type, it also returns `void(b'\x00')`. Thus the exception.

After further thinking, I found that we don't need to cast the type of scalar type and the underlying `setitem` of `numpy/cupy` will take care of it. When the dtype is record type and the value is a tuple, we should treat it as a _scalar_ value (of type `a.dtype`) as well, such behaviour is consistent with numpy.

This pr fixes the above exception and make `setitem` available to structured arrays.

## Related issue number

This pr is related to #517, but doesn't fix that.