### PR TITLE
Fix unify chunks when add a scalar with out

### DIFF
--- a/mars/tensor/execution/tests/test_arithmetic_execute.py
+++ b/mars/tensor/execution/tests/test_arithmetic_execute.py
@@ -262,6 +262,13 @@ class Test(unittest.TestCase):
         expected = np.add(data1, 1, where=data1 > .5)
         self.assertTrue(np.array_equal(res[data1 > .5], expected[data1 > .5]))
 
+        arr1 = tensor(data2.copy(), chunk_size=3)
+
+        arr3 = add(arr1[:5, :], 1, out=arr1[-5:, :])
+        res = self.executor.execute_tensor(arr3, concat=True)[0]
+        expected = np.add(data2[:5, :], 1)
+        self.assertTrue(np.array_equal(res, expected))
+
     def testFrexpExecution(self):
         data1 = np.random.random((5, 9, 4))
 

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -360,7 +360,7 @@ def unify_nsplits(*tensor_axes):
 
     tensor_splits = [dict((a, split) for a, split in izip(axes, t.nsplits) if split != (1,))
                      for t, axes in tensor_axes if t.nsplits]
-    common_axes = reduce(operator.and_, [set(lkeys(ts)) for ts in tensor_splits])
+    common_axes = reduce(operator.and_, [set(lkeys(ts)) for ts in tensor_splits]) if tensor_splits else set()
     axes_unified_splits = dict((ax, decide_unify_split(*(t[ax] for t in tensor_splits)))
                                for ax in common_axes)
 

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -359,7 +359,7 @@ def unify_nsplits(*tensor_axes):
     from .rechunk import rechunk
 
     tensor_splits = [dict((a, split) for a, split in izip(axes, t.nsplits) if split != (1,))
-                     for t, axes in tensor_axes]
+                     for t, axes in tensor_axes if t.nsplits]
     common_axes = reduce(operator.and_, [set(lkeys(ts)) for ts in tensor_splits])
     axes_unified_splits = dict((ax, decide_unify_split(*(t[ax] for t in tensor_splits)))
                                for ax in common_axes)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Fix the function `unify_nsplits` when input tensor is a scalar tensor.

This issue was undiscovered before because add a scalar should generate a constant operand, however, in this case, `out` is specified and will not convert to constant op, the scalar tensor's `nsplits` is an empty tuple which will lead to the unexpected behavior in function `unify_nsplits`.

<!-- Please give a short brief about these changes. -->

## Related issue number

Fixes #535 

<!-- Are there any issues opened that will be resolved by merging this change? -->
