### PR TITLE
Fix execution error caused by fused ShuffleReduces

### DIFF
--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -40,7 +40,8 @@ from ..serialize import dataserializer
 from ..core import ChunkData
 from ..tiles import handler, DataNotReady
 from ..utils import serialize_graph, deserialize_graph, log_unhandled, \
-    build_fetch_chunk, build_fetch_tileable, calc_nsplits
+    build_fetch_chunk, build_fetch_tileable, calc_nsplits, \
+    get_chunk_shuffle_key
 
 logger = logging.getLogger(__name__)
 
@@ -653,7 +654,7 @@ class GraphActor(SchedulerActor):
                 successor_keys.add(sn.op.key)
             if isinstance(c.op, ShuffleProxy):
                 for sn in graph.iter_successors(c):
-                    shuffle_keys[sn.op.key] = sn.op.shuffle_key
+                    shuffle_keys[sn.op.key] = get_chunk_shuffle_key(sn)
 
             chunk_keys.update(co.key for co in c.op.outputs)
 

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -93,8 +93,9 @@ class Test(SchedulerIntegratedTest):
         a = mt.ones((31, 27), chunk_size=10)
         b = a.reshape(27, 31)
         b.op.extra_params['_reshape_with_shuffle'] = True
-        graph = b.build_graph()
-        targets = [b.key]
+        r = b.sum(axis=1)
+        graph = r.build_graph()
+        targets = [r.key]
         graph_key = uuid.uuid1()
         session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
                                           graph_key, target_tileables=targets)
@@ -102,8 +103,8 @@ class Test(SchedulerIntegratedTest):
         state = self.wait_for_termination(actor_client, session_ref, graph_key)
         self.assertEqual(state, GraphState.SUCCEEDED)
 
-        result = session_ref.fetch_result(graph_key, b.key)
-        assert_allclose(loads(result), np.ones((27, 31)))
+        result = session_ref.fetch_result(graph_key, r.key)
+        assert_allclose(loads(result), np.ones((27, 31)).sum(axis=1))
 
         raw = np.random.RandomState(0).rand(10, 10)
         a = mt.tensor(raw, chunk_size=(5, 4))

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -530,6 +530,18 @@ def build_fuse_chunk(fused_chunks, **kwargs):
                              _composed=fused_chunks, **kwargs)
 
 
+def get_chunk_shuffle_key(chunk):
+    op = chunk.op
+    try:
+        return op.shuffle_key
+    except AttributeError:
+        from .operands import Fuse
+        if isinstance(op, Fuse):
+            return chunk.composed[0].op.shuffle_key
+        else:  # pragma: no cover
+            raise
+
+
 def merge_chunks(chunk_results):
     """
     Concatenate chunk results according to index.

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -22,7 +22,8 @@ from ..compat import six, OrderedDict3
 from ..config import options
 from ..errors import *
 from ..executor import Executor
-from ..utils import to_str, deserialize_graph, log_unhandled, calc_data_size
+from ..utils import to_str, deserialize_graph, log_unhandled, calc_data_size, \
+    get_chunk_shuffle_key
 from .events import EventContext, EventCategory, EventLevel, ProcedureEventType
 from .spill import read_spill_file, write_spill_file, spill_exists
 from .utils import WorkerActor, concat_operand_keys, build_load_key, get_chunk_key
@@ -211,7 +212,7 @@ class CpuCalcActor(WorkerActor):
             if isinstance(chunk.op, Fetch):
                 fetch_keys.add(chunk.op.to_fetch_key or chunk.key)
             elif isinstance(chunk.op, FetchShuffle):
-                shuffle_key = graph.successors(chunk)[0].op.shuffle_key
+                shuffle_key = get_chunk_shuffle_key(graph.successors(chunk)[0])
                 for k in chunk.op.to_fetch_keys:
                     fetch_keys.add((k, shuffle_key))
             else:


### PR DESCRIPTION
## What do these changes do?

Fix execution error caused by fused ShuffleReduces by supporting obtaining ``shuffle_key`` from Fuse nodes.

## Related issue number

Fixes #545 
