### PR TITLE
Fix wrong result of negative indexing

### DIFF
--- a/mars/tensor/execution/tests/test_index_execute.py
+++ b/mars/tensor/execution/tests/test_index_execute.py
@@ -187,6 +187,10 @@ class Test(unittest.TestCase):
 
         np.testing.assert_array_equal(res[0], raw[2:9:2, 3:7, -1:-9:-2, 12:-11:-4])
 
+        arr3 = arr[-4, 2:]
+        res = self.executor.execute_tensor(arr3, concat=True)
+        np.testing.assert_equal(res[0], raw[-4, 2:])
+
         raw = sps.random(12, 14, density=.1)
         arr = tensor(raw, chunk_size=3)
 

--- a/mars/tensor/expressions/utils.py
+++ b/mars/tensor/expressions/utils.py
@@ -207,6 +207,7 @@ def slice_split(index, sizes):
     size = sum(sizes)
 
     if isinstance(index, Integral):
+        index = index if index >= 0 else size + index
         i = 0
         ind = index
         lens = list(sizes)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
handle the negative number of integral index in `slice_split`.

## Related issue number
Fixes #544 

<!-- Are there any issues opened that will be resolved by merging this change? -->
