### PR TITLE
Fix error in importing new_client in Python 2.7

### DIFF
--- a/mars/actors/__init__.py
+++ b/mars/actors/__init__.py
@@ -14,8 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from .core import create_actor_pool, Actor, FunctionActor, new_client, \
     register_actor_implementation, unregister_actor_implementation
 from .errors import ActorPoolNotStarted, ActorNotExist, ActorAlreadyExist
 from .distributor import Distributor
+
+# import gipc first to avoid stack issue of `call stack is not deep enough`
+try:
+    from ..lib import gipc
+    del gipc
+except ImportError:  # pragma: no cover
+    pass

--- a/mars/actors/core.pyx
+++ b/mars/actors/core.pyx
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+
 import multiprocessing
 
 from .cluster cimport ClusterInfo

--- a/mars/actors/distributor.pyx
+++ b/mars/actors/distributor.pyx
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mars.lib.mmh3 import hash as mmh_hash
+from __future__ import absolute_import
+
+from ..lib.mmh3 import hash as mmh_hash
 
 
 cdef class Distributor(object):

--- a/mars/actors/pool/gevent_pool.pyx
+++ b/mars/actors/pool/gevent_pool.pyx
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+
 import weakref
 import sys
 import pickle

--- a/mars/actors/pool/messages.pyx
+++ b/mars/actors/pool/messages.pyx
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+
 import errno
 import socket
 from pickle import dumps, loads

--- a/mars/actors/pool/utils.pyx
+++ b/mars/actors/pool/utils.pyx
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+
 import numpy as np
 
 from ..._utils cimport to_str


### PR DESCRIPTION
## What do these changes do?

Fix error in importing new_client in Python 2.7 by adding absolute_import options and importing ``gipc`` in advance.

## Related issue number

Fixes #557 
