### PR TITLE
Fix numpy and pandas version for requirements

### DIFF
--- a/requirements-wheel.txt
+++ b/requirements-wheel.txt
@@ -1,5 +1,5 @@
 numpy==1.14.5
-pandas>=0.20.0
+pandas==0.24.2
 cython==0.29.3
 requests>=2.4.0
 pyarrow>=0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-numpy>=1.14.0
-pandas>=0.20.0
+numpy>=1.14.0; python_version >= '3'
+pandas>=0.20.0	numpy>=1.14.0,<1.17.0; python_version < '3'
+pandas>=0.20.0; python_version >= '3'
+pandas>=0.20.0,<0.25.0; python_version < '3'
 requests>=2.4.0
 pyarrow>=0.11.0


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix pandas version to 0.24.2 in requirements-wheel.txt, and fix requirements for the reason that newest version of numpy and pandas drop support for Python 2.7.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA
