### PR TITLE
Fix build issue under cp27-cp27m-manylinux1

### DIFF
--- a/bin/travis-build-wheels.sh
+++ b/bin/travis-build-wheels.sh
@@ -4,10 +4,19 @@ set -e -x
 # Install a system package required by our library
 yum install -y atlas-devel
 
-# Compile wheels
+# Install requirements
 PYBIN=/opt/python/${PYVER}/bin
-"${PYBIN}/pip" install -r /io/requirements-wheel.txt
+REQ_FILE=/io/requirements-wheel.txt
 
+# install packages without pandas first
+# todo remove this section when dropping support for Python 2.7
+REQ_FILE_NO_PD=/tmp/requirements-no-pd.txt
+grep -v "pandas" $REQ_FILE > $REQ_FILE_NO_PD
+"${PYBIN}/pip" install -r $REQ_FILE_NO_PD
+
+"${PYBIN}/pip" install -r $REQ_FILE
+
+# Compile wheels
 cd /io
 "${PYBIN}/python" setup.py bdist_wheel
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
-numpy>=1.14.0
-pandas>=0.20.0
+numpy>=1.14.0; python_version >= '3'
+numpy>=1.14.0,<1.17.0; python_version < '3'
+pandas>=0.20.0; python_version >= '3'
+pandas>=0.20.0,<0.25.0; python_version < '3'
 requests>=2.4.0
 pyarrow>=0.11.0
 cython>=0.29

--- a/requirements-wheel.txt
+++ b/requirements-wheel.txt
@@ -1,5 +1,5 @@
 numpy==1.14.5
-pandas>=0.20.0
+pandas==0.24.2
 cython==0.29.3
 requests>=2.4.0
 pyarrow>=0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-numpy>=1.14.0
-pandas>=0.20.0
+numpy>=1.14.0; python_version >= '3'
+numpy>=1.14.0,<1.17.0; python_version < '3'
+pandas>=0.20.0; python_version >= '3'
+pandas>=0.20.0,<0.25.0; python_version < '3'
 requests>=2.4.0
 pyarrow>=0.11.0


### PR DESCRIPTION
## What do these changes do?

Fix build error for abi cp27-cp27m-manylinux1 by changing installation sequence when building wheels under Linux, as when numpy headers are absent, pandas will look for master branch of numpy which is not compatible with Python<3.5.

## Related issue number

NA
