### PR TITLE
Backport patch from pyarrow.

### DIFF
--- a/mars/serialize/dataserializer.py
+++ b/mars/serialize/dataserializer.py
@@ -315,9 +315,11 @@ _serialize_context = None
 def mars_serialize_context():
     global _serialize_context
     if _serialize_context is None:
+        from ..compat import apply_pyarrow_serialization_patch
         ctx = pyarrow.default_serialization_context()
         ctx.register_type(SparseNDArray, 'mars.SparseNDArray',
                           custom_serializer=_serialize_sparse_csr_list,
                           custom_deserializer=_deserialize_sparse_csr_list)
+        apply_pyarrow_serialization_patch(ctx)
         _serialize_context = ctx
     return _serialize_context

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -527,6 +527,13 @@ class Test(unittest.TestCase):
                 assert_array_equal(array, dataserializer.loads(dataserializer.dumps(
                     array, compress=dataserializer.CompressType.GZIP)))
 
+            # test structured arrays.
+            rec_dtype = np.dtype([('a', 'int64'), ('b', 'double'), ('c', '<U8')])
+            array = np.ones((100,), dtype=rec_dtype)
+            array_loaded = dataserializer.loads(dataserializer.dumps(array))
+            self.assertEqual(array.dtype, array_loaded.dtype)
+            assert_array_equal(array, array_loaded)
+
             fn = os.path.join(tempfile.gettempdir(), 'test_dump_file_%d.bin' % id(self))
             try:
                 array = np.random.rand(1000, 100).T  # test non c-contiguous

--- a/mars/tests/test_mutable.py
+++ b/mars/tests/test_mutable.py
@@ -263,7 +263,7 @@ class Test(unittest.TestCase):
 
             # check dtype and value
             self.assertEqual(np.dtype(arr.dtype), expected.dtype)
-            np.testing.assert_array_equal(session.fetch(arr).view(dtype=rec_type), expected)
+            np.testing.assert_array_equal(session.fetch(arr), expected)
 
         with new_session().as_default() as session:
             testWithGivenSession(session)
@@ -401,7 +401,7 @@ class Test(unittest.TestCase):
             expected = np.full((4, 5), fill_value=123.456, dtype=dtype)
             expected[1:4, 2] = (1, 2.)
             expected[2:4] = np.arange(10).reshape(2, 5)
-            np.testing.assert_array_equal(session.fetch(arr2).view(dtype=dtype), expected)
+            np.testing.assert_array_equal(session.fetch(arr2), expected)
 
         with new_session().as_default() as session:
             testWithGivenSession(session)


### PR DESCRIPTION
## What do these changes do?

Backport upstream patch from pyarrow (apache/arrow#4953), which has already been merged. And we don't need the workaround in `test_mutable.py` anymore.

## Related issue number

Fixes #586