### PR TITLE
Fix proto-serialization for certain dtypes.

### DIFF
--- a/mars/serialize/pbserializer.pyx
+++ b/mars/serialize/pbserializer.pyx
@@ -102,7 +102,7 @@ cdef class ProtobufSerializeProvider(Provider):
             return
         try:
             return np.dtype(obj.dtype)
-        except TypeError:
+        except (TypeError, ValueError):
             return np.dtype(pickle.loads(obj.dtype))
 
     cdef inline void _set_index(self, value, obj, tp=None) except *:

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -308,6 +308,25 @@ class Test(unittest.TestCase):
         self.assertAlmostEqual(node9.d3, d_node9.d3)
         self.assertEqual(node9.f, d_node9.f)
 
+        node_rec1 = Node9(f=np.dtype([('label', 'int32'),
+                                      ('s0', '<U16'), ('s1', 'int32'), ('s2', 'int32'),
+                                      ('d0', '<U16'), ('d1', 'int32'), ('d2', 'int32'), ('d3', '<U256')]))
+        node_rec2 = Node9(f=np.dtype([('label', 'int32'),
+                                      ('s0', '<U16'), ('s1', 'int32'), ('s2', 'int32'), ('s3', '<U256'),
+                                      ('d0', '<U16'), ('d1', 'int32'), ('d2', 'int32'), ('d3', '<U256')]))
+
+        serials = serializes(provider, [node_rec1])
+        d_node_rec1, = deserializes(provider, [Node9], serials)
+
+        self.assertIsNot(node_rec1, d_node_rec1)
+        self.assertEqual(node_rec1.f, d_node_rec1.f)
+
+        serials = serializes(provider, [node_rec2])
+        d_node_rec2, = deserializes(provider, [Node9], serials)
+
+        self.assertIsNot(node_rec2, d_node_rec2)
+        self.assertEqual(node_rec2.f, d_node_rec2.f)
+
     def testNumpyDtypeJSONSerialize(self):
         provider = JsonSerializeProvider()
 
@@ -332,6 +351,25 @@ class Test(unittest.TestCase):
         self.assertAlmostEqual(node9.d2, d_node9.d2, places=4)
         self.assertAlmostEqual(node9.d3, d_node9.d3)
         self.assertEqual(node9.f, d_node9.f)
+
+        node_rec1 = Node9(f=np.dtype([('label', 'int32'),
+                                      ('s0', '<U16'), ('s1', 'int32'), ('s2', 'int32'),
+                                      ('d0', '<U16'), ('d1', 'int32'), ('d2', 'int32'), ('d3', '<U256')]))
+        node_rec2 = Node9(f=np.dtype([('label', 'int32'),
+                                      ('s0', '<U16'), ('s1', 'int32'), ('s2', 'int32'), ('s3', '<U256'),
+                                      ('d0', '<U16'), ('d1', 'int32'), ('d2', 'int32'), ('d3', '<U256')]))
+
+        serials = serializes(provider, [node_rec1])
+        d_node_rec1, = deserializes(provider, [Node9], serials)
+
+        self.assertIsNot(node_rec1, d_node_rec1)
+        self.assertEqual(node_rec1.f, d_node_rec1.f)
+
+        serials = serializes(provider, [node_rec2])
+        d_node_rec2, = deserializes(provider, [Node9], serials)
+
+        self.assertIsNot(node_rec2, d_node_rec2)
+        self.assertEqual(node_rec2.f, d_node_rec2.f)
 
     def testAttributeAsDict(self):
         other_data = {}


### PR DESCRIPTION
## What do these changes do?

`np.dtype(pickle.dumps(dtype))` will raise `ValueError`, rather than `TypeError` for certain dtypes (see the following two examples).

The bug was initially observed by code like follow example:

```python
dtype = np.dtype([('label', 'int32'),
                    ('s0', '<U16'), ('s1', 'int32'), ('s2', 'int32'), ('s3', '<U256'),
                    ('d0', '<U16'), ('d1', 'int32'), ('d2', 'int32'), ('d3', '<U256')])

# dtype = np.dtype([('label', 'int32'), ('s0', '<U16')])

tensor = mt.ones((4,), dtype=dtype, chunk_size=3).execute()
```

This patch fix that, and the json deserializer isn't affected since it tries `np.dtype(base64.encode(pickle.dumps(dtype)))`, rather than directly on the pickled bytes.

```python
In [6]: dtype = np.dtype([('label', 'int32'),
   ...:                     ('s0', '<U16'), ('s1', 'int32'), ('s2', 'int32'), ('s3', '<U256'),
   ...:                     ('d0', '<U16'), ('d1', 'int32'), ('d2', 'int32'), ('d3', '<U256')])
   ...:

In [7]: np.dtype(pickle.dumps(dtype))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-7-d270c79f06e6> in <module>
----> 1 np.dtype(pickle.dumps(dtype))

/usr/local/lib/python3.7/site-packages/numpy/core/_internal.py in _commastring(astr)
    177                     raise ValueError(
    178                         'format number %d of "%s" is not recognized' %
--> 179                         (len(result)+1, astr))
    180                 startindex = mo.end()
    181

ValueError: format number 1 of "b'\x80\x03cnumpy\ndtype\nq\x00X\x05\x00\x00\x00V2196q\x01K\x00K\x01\x87q\x02Rq\x03(K\x03X\x01\x00\x00\x00|q\x04N(X\x05\x00\x00\x00labelq\x05X\x02\x00\x00\x00s0q\x06X\x02\x00\x00\x00s1q\x07X\x02\x00\x00\x00s2q\x08X\x02\x00\x00\x00s3q\tX\x02\x00\x00\x00d0q\nX\x02\x00\x00\x00d1q\x0bX\x02\x00\x00\x00d2q\x0cX\x02\x00\x00\x00d3q\rtq\x0e}q\x0f(h\x05h\x00X\x02\x00\x00\x00i4q\x10K\x00K\x01\x87q\x11Rq\x12(K\x03X\x01\x00\x00\x00<q\x13NNNJ\xff\xff\xff\xffJ\xff\xff\xff\xffK\x00tq\x14bK\x00\x86q\x15h\x06h\x00X\x03\x00\x00\x00U16q\x16K\x00K\x01\x87q\x17Rq\x18(K\x03h\x13NNNK@K\x04K\x08tq\x19bK\x04\x86q\x1ah\x07h\x12KD\x86q\x1bh\x08h\x12KH\x86q\x1ch\th\x00X\x04\x00\x00\x00U256q\x1dK\x00K\x01\x87q\x1eRq\x1f(K\x03h\x13NNNM\x00\x04K\x04K\x08tq bKL\x86q!h\nh\x00X\x03\x00\x00\x00U16q"K\x00K\x01\x87q#Rq$(K\x03h\x13NNNK@K\x04K\x08tq%bML\x04\x86q&h\x0bh\x12M\x8c\x04\x86q\'h\x0ch\x12M\x90\x04\x86q(h\rh\x00X\x04\x00\x00\x00U256q)K\x00K\x01\x87q*Rq+(K\x03h\x13NNNM\x00\x04K\x04K\x08tq,bM\x94\x04\x86q-uM\x94\x08K\x01K\x18tq.b.'" is not recognized

In [8]: dtype = np.dtype([('label', 'int32'),
   ...:                     ('s0', '<U16'), ('s1', 'int32'), ('s2', 'int32'),
   ...:                     ('d0', '<U16'), ('d1', 'int32'), ('d2', 'int32'), ('d3', '<U256')])
   ...:

In [9]: np.dtype(pickle.dumps(dtype))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-9-d270c79f06e6> in <module>
----> 1 np.dtype(pickle.dumps(dtype))

TypeError: data type "�cnumpy
dtype
q" not understood
```

## Related issue number

N/A