### PR TITLE
Support create mars session with given session_id.

### DIFF
--- a/mars/api.py
+++ b/mars/api.py
@@ -70,11 +70,11 @@ class MarsAPI(object):
     def delete_session(self, session_id):
         self.session_manager.delete_session(session_id)
 
-    def check_session(self, session_id):
+    def has_session(self, session_id):
         '''
         Check if the session with given session_id exists.
         '''
-        return self.session_manager.check_session(session_id)
+        return self.session_manager.has_session(session_id)
 
     def submit_graph(self, session_id, serialized_graph, graph_key, target,
                      compose=True, wait=True):

--- a/mars/api.py
+++ b/mars/api.py
@@ -70,6 +70,12 @@ class MarsAPI(object):
     def delete_session(self, session_id):
         self.session_manager.delete_session(session_id)
 
+    def check_session(self, session_id):
+        '''
+        Check if the session with given session_id exists.
+        '''
+        return self.session_manager.check_session(session_id)
+
     def submit_graph(self, session_id, serialized_graph, graph_key, target,
                      compose=True, wait=True):
         session_uid = SessionActor.gen_uid(session_id)

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -29,20 +29,30 @@ from ...tensor.indexing import TensorIndex
 
 
 class LocalClusterSession(object):
-    def __init__(self, endpoint, **kwargs):
-        self._session_id = uuid.uuid4()
+    def __init__(self, endpoint, session_id=None, **kwargs):
         self._endpoint = endpoint
         # dict structure: {tileable_key -> graph_key, tileable_ids}
         # dict value is a tuple object which records graph key and tilable id
         self._executed_tileables = dict()
         self._api = MarsAPI(self._endpoint)
 
-        # create session on the cluster side
-        self._api.create_session(self._session_id)
+        if session_id is None:
+            # create session on the cluster side
+            self._session_id = uuid.uuid4()
+            self._api.create_session(self._session_id)
+        else:
+            # Get the session actor ref using given session_id
+            self._session_id = session_id
+            if not self._api.check_session(self._session_id):
+                raise ValueError('The session with id = %s doesn\'t exist' % self._session_id)
 
         if kwargs:
             unexpected_keys = ', '.join(list(kwargs.keys()))
             raise TypeError('Local cluster session got unexpected arguments: %s' % unexpected_keys)
+
+    @property
+    def session_id(self):
+        return self._session_id
 
     @property
     def endpoint(self):

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -43,7 +43,7 @@ class LocalClusterSession(object):
         else:
             # Get the session actor ref using given session_id
             self._session_id = session_id
-            if not self._api.check_session(self._session_id):
+            if not self._api.has_session(self._session_id):
                 raise ValueError('The session with id = %s doesn\'t exist' % self._session_id)
 
         if kwargs:

--- a/mars/scheduler/session.py
+++ b/mars/scheduler/session.py
@@ -227,6 +227,10 @@ class SessionManagerActor(SchedulerActor):
         return session_ref
 
     @log_unhandled
+    def check_session(self, session_id):
+        return session_id in self._session_refs
+
+    @log_unhandled
     def delete_session(self, session_id):
         if session_id in self._session_refs:
             session_ref = self._session_refs[session_id]

--- a/mars/scheduler/session.py
+++ b/mars/scheduler/session.py
@@ -227,7 +227,7 @@ class SessionManagerActor(SchedulerActor):
         return session_ref
 
     @log_unhandled
-    def check_session(self, session_id):
+    def has_session(self, session_id):
         return session_id in self._session_refs
 
     @log_unhandled

--- a/mars/session.py
+++ b/mars/session.py
@@ -42,6 +42,10 @@ class LocalSession(object):
         return self._endpoint
 
     @property
+    def session_id(self):
+        return None
+
+    @property
     def executed_tileables(self):
         return self._executor.stored_tileables.keys()
 
@@ -192,6 +196,10 @@ class Session(object):
     @endpoint.setter
     def endpoint(self, endpoint):
         self._sess.endpoint = endpoint
+
+    @property
+    def session_id(self):
+        return self._sess.session_id
 
     def decref(self, *keys):
         if hasattr(self._sess, 'decref'):

--- a/mars/web/api.py
+++ b/mars/web/api.py
@@ -81,6 +81,10 @@ class SessionsApiHandler(MarsApiRequestHandler):
 
 
 class SessionApiHandler(MarsApiRequestHandler):
+    def head(self, session_id):
+        if not self.web_api.check_session(session_id):
+            raise web.HTTPError(404, 'Session doesn\'t not exists')
+
     def delete(self, session_id):
         self.web_api.delete_session(session_id)
 

--- a/mars/web/api.py
+++ b/mars/web/api.py
@@ -82,7 +82,7 @@ class SessionsApiHandler(MarsApiRequestHandler):
 
 class SessionApiHandler(MarsApiRequestHandler):
     def head(self, session_id):
-        if not self.web_api.check_session(session_id):
+        if not self.web_api.has_session(session_id):
             raise web.HTTPError(404, 'Session doesn\'t not exists')
 
     def delete(self, session_id):


### PR DESCRIPTION
## What do these changes do?

Support create mars session on the fly using given `session_id`, and do necessary checks. Available for `LocalClusterSession` and `WebSession`.

## Related issue number

resolve #605 