### PR TITLE
Fix the default value parsing of `open_browser`

### DIFF
--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -290,7 +290,8 @@ class LocalDistributedClusterClient(object):
 
 def new_cluster(address='0.0.0.0', web=False, n_process=None, shared_memory=None,
                 open_browser=None, **kw):
-    open_browser = open_browser or options.deploy.open_browser
+    if open_browser is None:
+        open_browser = options.deploy.open_browser
     endpoint = gen_endpoint(address)
     web_endpoint = None
     if web is True:


### PR DESCRIPTION
## What do these changes do?

For the parameter `open_browser`, we should use the value from `options` only when the given parameter is `None`. Otherwise `open_browser=False` won't take effect.

## Related issue number

Fixes #604