### PR TITLE
[BACKPORT] Fix the default value parsing of `open_browser`

### DIFF
--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -290,7 +290,8 @@ class LocalDistributedClusterClient(object):
 
 def new_cluster(address='0.0.0.0', web=False, n_process=None, shared_memory=None,
                 open_browser=None, **kw):
-    open_browser = open_browser or options.deploy.open_browser
+    if open_browser is None:
+        open_browser = options.deploy.open_browser
     endpoint = gen_endpoint(address)
     web_endpoint = None
     if web is True:


### PR DESCRIPTION

<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Backport of #602.

## Related issue number

Fixes #604