### PR TITLE
Fix shuffle failover error in cases

### DIFF
--- a/mars/scheduler/operands/base.py
+++ b/mars/scheduler/operands/base.py
@@ -113,7 +113,7 @@ class BaseOperandActor(SchedulerActor):
 
     @worker.setter
     def worker(self, value):
-        futures =[]
+        futures = []
         for graph_ref in self._graph_refs:
             futures.append(graph_ref.set_operand_worker(self._op_key, value, _tell=True, _wait=False))
         if self._kv_store_ref is not None:

--- a/mars/scheduler/tests/integrated/base.py
+++ b/mars/scheduler/tests/integrated/base.py
@@ -74,12 +74,13 @@ class SchedulerIntegratedTest(unittest.TestCase):
         self.scheduler_endpoints = []
         self.proc_schedulers = []
         self.proc_workers = []
-        self.state_files = []
+        self.state_files = dict()
         self.etcd_helper = None
         self.intentional_death_pids = set()
 
     def tearDown(self):
-        for fn in self.state_files:
+        for env, fn in self.state_files.items():
+            os.environ.pop(env)
             if os.path.exists(fn):
                 os.unlink(fn)
 
@@ -125,7 +126,7 @@ class SchedulerIntegratedTest(unittest.TestCase):
     def add_state_file(self, environ):
         fn = os.environ[environ] = os.path.join(
             tempfile.gettempdir(), 'test-main-%s-%d-%d' % (environ.lower(), os.getpid(), id(self)))
-        self.state_files.append(fn)
+        self.state_files[environ] = fn
         return fn
 
     def start_processes(self, n_schedulers=2, n_workers=2, etcd=False, modules=None,

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -260,7 +260,7 @@ class ExecutionActor(WorkerActor):
         from .dispatcher import DispatchActor
 
         if remote_addr in self._peer_blacklist:
-            raise DependencyMissing
+            raise DependencyMissing((session_id, graph_key))
 
         remote_disp_ref = self.promise_ref(uid=DispatchActor.default_uid(),
                                            address=remote_addr)
@@ -298,7 +298,7 @@ class ExecutionActor(WorkerActor):
         @log_unhandled
         def _fetch_step(sender_uid):
             if remote_addr in self._peer_blacklist:
-                raise DependencyMissing
+                raise DependencyMissing((session_id, chunk_key))
 
             if self._graph_records[(session_id, graph_key)].stop_requested:
                 remote_disp_ref.register_free_slot(sender_uid, 'sender', _tell=True)


### PR DESCRIPTION
## What do these changes do?

Fix errors when running integrated failover cases of Mars scheduler by inferring states of virtual nodes and removing dead workers from metas maintained by ShuffleActor.

## Related issue number

Fixes #612
