### PR TITLE
Fix `infer_index_value` when one of input indexes is `RangeIndex`

### DIFF
--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -702,7 +702,7 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
             index.value.should_be_monotonic = True
             index_shape = x1.shape[0]
         elif x1.index_value is not None and x2.index_value is not None:
-            index = infer_index_value(x1.index_value, x2.index_value, cls._operator)
+            index = infer_index_value(x1.index_value, x2.index_value)
             index.value.should_be_monotonic = True
             if index.key == x1.index_value.key == x2.index_value.key and \
                     (not np.isnan(x1.shape[0]) or not np.isnan(x2.shape[0])):

--- a/mars/dataframe/arithmetic/tests/test_utils.py
+++ b/mars/dataframe/arithmetic/tests/test_utils.py
@@ -41,7 +41,7 @@ class Test(unittest.TestCase):
 
         ival1 = parse_index(index1)
         ival2 = parse_index(index2)
-        oival = infer_index_value(ival1, ival2, operator.add)
+        oival = infer_index_value(ival1, ival2)
 
         self.assertEqual(oival.key, ival1.key)
         self.assertEqual(oival.key, ival2.key)
@@ -52,7 +52,7 @@ class Test(unittest.TestCase):
 
         ival1 = parse_index(index1)
         ival2 = parse_index(index2)
-        oival = infer_index_value(ival1, ival2, operator.add)
+        oival = infer_index_value(ival1, ival2)
 
         self.assertIsInstance(oival.value, IndexValue.Int64Index)
         self.assertNotEqual(oival.key, ival1.key)
@@ -64,7 +64,7 @@ class Test(unittest.TestCase):
 
         ival1 = parse_index(index1)
         ival2 = parse_index(index2)
-        oival = infer_index_value(ival1, ival2, operator.add)
+        oival = infer_index_value(ival1, ival2)
 
         self.assertIsInstance(oival.value, IndexValue.Int64Index)
         self.assertEqual(oival.key, ival1.key)
@@ -76,7 +76,7 @@ class Test(unittest.TestCase):
 
         ival1 = parse_index(index1)
         ival2 = parse_index(index2)
-        oival = infer_index_value(ival1, ival2, operator.add)
+        oival = infer_index_value(ival1, ival2)
 
         self.assertIsInstance(oival.value, IndexValue.Int64Index)
         self.assertNotEqual(oival.key, ival1.key)
@@ -88,7 +88,7 @@ class Test(unittest.TestCase):
 
         ival1 = parse_index(index1)
         ival2 = parse_index(index2)
-        oival = infer_index_value(ival1, ival2, operator.add)
+        oival = infer_index_value(ival1, ival2)
 
         self.assertIsInstance(oival.value, IndexValue.Int64Index)
         self.assertNotEqual(oival.key, ival1.key)
@@ -100,7 +100,7 @@ class Test(unittest.TestCase):
 
         ival1 = parse_index(index1)
         ival2 = parse_index(index2)
-        oival = infer_index_value(ival1, ival2, operator.add)
+        oival = infer_index_value(ival1, ival2)
 
         self.assertIsInstance(oival.value, IndexValue.Float64Index)
         self.assertNotEqual(oival.key, ival1.key)
@@ -112,19 +112,19 @@ class Test(unittest.TestCase):
 
         ival1 = parse_index(index1)
         ival2 = parse_index(index2)
-        oival = infer_index_value(ival1, ival2, operator.add)
+        oival = infer_index_value(ival1, ival2)
 
         self.assertIsInstance(oival.value, IndexValue.Float64Index)
         self.assertNotEqual(oival.key, ival1.key)
         self.assertNotEqual(oival.key, ival2.key)
 
-        index1 = pd.Int64Index([1, 2])
+        index1 = pd.DatetimeIndex([])
         index2 = pd.RangeIndex(2)
 
         ival1 = parse_index(index1)
         ival2 = parse_index(index2)
-        oival = infer_index_value(ival1, ival2, operator.add)
+        oival = infer_index_value(ival1, ival2)
 
-        self.assertIsInstance(oival.value, IndexValue.Int64Index)
+        self.assertIsInstance(oival.value, IndexValue.Index)
         self.assertNotEqual(oival.key, ival1.key)
         self.assertNotEqual(oival.key, ival2.key)

--- a/mars/dataframe/arithmetic/tests/test_utils.py
+++ b/mars/dataframe/arithmetic/tests/test_utils.py
@@ -105,3 +105,26 @@ class Test(unittest.TestCase):
         self.assertIsInstance(oival.value, IndexValue.Float64Index)
         self.assertNotEqual(oival.key, ival1.key)
         self.assertNotEqual(oival.key, ival2.key)
+
+        # range index and other index
+        index1 = pd.RangeIndex(1, 4)
+        index2 = pd.Float64Index([2, 3, 4])
+
+        ival1 = parse_index(index1)
+        ival2 = parse_index(index2)
+        oival = infer_index_value(ival1, ival2, operator.add)
+
+        self.assertIsInstance(oival.value, IndexValue.Float64Index)
+        self.assertNotEqual(oival.key, ival1.key)
+        self.assertNotEqual(oival.key, ival2.key)
+
+        index1 = pd.Int64Index([1, 2])
+        index2 = pd.RangeIndex(2)
+
+        ival1 = parse_index(index1)
+        ival2 = parse_index(index2)
+        oival = infer_index_value(ival1, ival2, operator.add)
+
+        self.assertIsInstance(oival.value, IndexValue.Int64Index)
+        self.assertNotEqual(oival.key, ival1.key)
+        self.assertNotEqual(oival.key, ival2.key)

--- a/mars/dataframe/arithmetic/utils.py
+++ b/mars/dataframe/arithmetic/utils.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import operator
+import pandas as pd
 
-try:
-    import pandas as pd
-except ImportError:  # pragma: no cover
-    pass
+import operator
 
 from ..utils import build_empty_df, parse_index
 from ..core import IndexValue
@@ -46,7 +43,11 @@ def infer_index_value(left_index_value, right_index_value, operator):
         return left_index_value
 
     left_index = left_index_value.to_pandas()
+    if isinstance(left_index, pd.RangeIndex):
+        left_index = pd.RangeIndex(0)
     right_index = right_index_value.to_pandas()
+    if isinstance(right_index, pd.RangeIndex):
+        right_index = pd.RangeIndex(0)
     out_index = operator(left_index, right_index)
     key = tokenize(left_index_value.key, right_index_value.key, operator.__name__)
     return parse_index(out_index, key=key)

--- a/mars/dataframe/arithmetic/utils.py
+++ b/mars/dataframe/arithmetic/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pandas as pd
+from pandas.core.dtypes.cast import find_common_type
 
 import operator
 
@@ -27,13 +28,12 @@ def infer_dtypes(left_dtypes, right_dtypes, operator):
     return operator(left, right).dtypes
 
 
-def infer_index_value(left_index_value, right_index_value, operator):
+def infer_index_value(left_index_value, right_index_value):
     if isinstance(left_index_value.value, IndexValue.RangeIndex) and \
             isinstance(right_index_value.value, IndexValue.RangeIndex):
         if left_index_value.value.slice == right_index_value.value.slice:
             return left_index_value
-        key = tokenize(left_index_value.key, right_index_value.key,
-                       operator.__name__)
+        key = tokenize(left_index_value.key, right_index_value.key)
         return parse_index(pd.Int64Index([]), key=key)
 
     # when left index and right index is identical, and both of them are elements unique,
@@ -43,13 +43,9 @@ def infer_index_value(left_index_value, right_index_value, operator):
         return left_index_value
 
     left_index = left_index_value.to_pandas()
-    if isinstance(left_index, pd.RangeIndex):
-        left_index = pd.RangeIndex(0)
     right_index = right_index_value.to_pandas()
-    if isinstance(right_index, pd.RangeIndex):
-        right_index = pd.RangeIndex(0)
-    out_index = operator(left_index, right_index)
-    key = tokenize(left_index_value.key, right_index_value.key, operator.__name__)
+    out_index = pd.Index([], dtype=find_common_type([left_index.dtype, right_index.dtype]))
+    key = tokenize(left_index_value.key, right_index_value.key)
     return parse_index(out_index, key=key)
 
 


### PR DESCRIPTION

## What do these changes do?
Use `pd.RangeIndex(0)` to infer the out index if one of the input indexes is `RangeIndex`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #621 