### PR TITLE
Get more accurate memory stats from cgroup memory.stat in containers

### DIFF
--- a/mars/deploy/kubernetes/docker/Dockerfile
+++ b/mars/deploy/kubernetes/docker/Dockerfile
@@ -1,31 +1,7 @@
-ARG BASE_CONTAINER=continuumio/miniconda3:4.6.14
+ARG BASE_CONTAINER=marsproject/mars-base
 FROM ${BASE_CONTAINER}
 
 ARG MARS_VERSION
-
-COPY retry.sh /srv/retry.sh
-
-RUN /srv/retry.sh 3 /opt/conda/bin/conda install \
-    bokeh \
-    cython \
-    gevent \
-    jinja2 \
-    lz4 \
-    mkl \
-    numba \
-    numexpr \
-    numpy \
-    pandas \
-    protobuf \
-    psutil \
-    scipy \
-    tornado \
-  && /srv/retry.sh 3 /opt/conda/bin/conda install -c conda-forge \
-    libiconv \
-    pyarrow \
-    tiledb-py \
-    python-kubernetes \
-  && /opt/conda/bin/conda clean -tipsy
 
 RUN apt-get -yq update \
   && apt-get -yq install gcc g++ \

--- a/mars/deploy/kubernetes/docker/Dockerfile.base
+++ b/mars/deploy/kubernetes/docker/Dockerfile.base
@@ -1,0 +1,26 @@
+ARG BASE_CONTAINER=continuumio/miniconda3:4.6.14
+FROM ${BASE_CONTAINER}
+
+COPY retry.sh /srv/retry.sh
+
+RUN /srv/retry.sh 3 /opt/conda/bin/conda install \
+    bokeh \
+    cython \
+    gevent \
+    jinja2 \
+    lz4 \
+    mkl \
+    numba \
+    numexpr \
+    numpy \
+    pandas \
+    protobuf \
+    psutil \
+    scipy \
+    tornado \
+  && /srv/retry.sh 3 /opt/conda/bin/conda install -c conda-forge \
+    libiconv \
+    pyarrow \
+    tiledb-py \
+    python-kubernetes \
+  && /opt/conda/bin/conda clean -tipsy

--- a/mars/tests/test_resource.py
+++ b/mars/tests/test_resource.py
@@ -13,10 +13,24 @@
 # limitations under the License.
 
 import os
+import tempfile
 import time
 import unittest
 
 from mars.compat import reload_module
+
+# just a fragment of real memory.stat
+_memory_stat_content = """
+cache 489275392
+rss 218181632
+mapped_file 486768640
+swap 0
+inactive_anon 486744064
+active_anon 218103808
+inactive_file 2457600
+active_file 73728
+hierarchical_memory_limit 1073741824
+"""
 
 
 class Test(unittest.TestCase):
@@ -74,4 +88,25 @@ class Test(unittest.TestCase):
             del os.environ['MARS_USE_PROCESS_STAT']
             del os.environ['MARS_CPU_TOTAL']
             del os.environ['MARS_MEMORY_TOTAL']
+            reload_module(resource)
+
+    def testUseCGroupStats(self):
+        from mars import resource
+        fd, mem_stat_path = tempfile.mkstemp(prefix='test-mars-res-')
+        with os.fdopen(fd, 'w') as f:
+            f.write(_memory_stat_content)
+
+        old_stat_file = resource.CGROUP_MEM_STAT_FILE
+        try:
+            os.environ['MARS_MEM_USE_CGROUP_STAT'] = '1'
+            resource = reload_module(resource)
+            resource.CGROUP_MEM_STAT_FILE = mem_stat_path
+
+            mem_stats = resource.virtual_memory()
+            self.assertEqual(mem_stats.total, 1073741824)
+            self.assertEqual(mem_stats.used, 707457024)
+        finally:
+            resource.CGROUP_MEM_STAT_FILE = old_stat_file
+            del os.environ['MARS_MEM_USE_CGROUP_STAT']
+            os.unlink(mem_stat_path)
             reload_module(resource)


### PR DESCRIPTION
## What do these changes do?

Use memory.stat in containers to obtain more accurate memory stats, given https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt. This option can be used by setting env ``MARS_MEM_USE_CGROUP_STAT=1``.

## Related issue number

Fixes #631 