### PR TITLE
[BACKPORT] Get more accurate memory stats from cgroup memory.stat in containers (#632)

### DIFF
--- a/mars/tests/test_resource.py
+++ b/mars/tests/test_resource.py
@@ -13,10 +13,24 @@
 # limitations under the License.
 
 import os
+import tempfile
 import time
 import unittest
 
 from mars.compat import reload_module
+
+# just a fragment of real memory.stat
+_memory_stat_content = """
+cache 489275392
+rss 218181632
+mapped_file 486768640
+swap 0
+inactive_anon 486744064
+active_anon 218103808
+inactive_file 2457600
+active_file 73728
+hierarchical_memory_limit 1073741824
+"""
 
 
 class Test(unittest.TestCase):
@@ -74,4 +88,25 @@ class Test(unittest.TestCase):
             del os.environ['MARS_USE_PROCESS_STAT']
             del os.environ['MARS_CPU_TOTAL']
             del os.environ['MARS_MEMORY_TOTAL']
+            reload_module(resource)
+
+    def testUseCGroupStats(self):
+        from mars import resource
+        fd, mem_stat_path = tempfile.mkstemp(prefix='test-mars-res-')
+        with os.fdopen(fd, 'w') as f:
+            f.write(_memory_stat_content)
+
+        old_stat_file = resource.CGROUP_MEM_STAT_FILE
+        try:
+            os.environ['MARS_MEM_USE_CGROUP_STAT'] = '1'
+            resource = reload_module(resource)
+            resource.CGROUP_MEM_STAT_FILE = mem_stat_path
+
+            mem_stats = resource.virtual_memory()
+            self.assertEqual(mem_stats.total, 1073741824)
+            self.assertEqual(mem_stats.used, 707457024)
+        finally:
+            resource.CGROUP_MEM_STAT_FILE = old_stat_file
+            del os.environ['MARS_MEM_USE_CGROUP_STAT']
+            os.unlink(mem_stat_path)
             reload_module(resource)


### PR DESCRIPTION
## What do these changes do?

Backport of #632 

## Related issue number

NA