### PR TITLE
Fix `readable_size` accuracy issue under python2

### DIFF
--- a/mars/utils.py
+++ b/mars/utils.py
@@ -126,13 +126,13 @@ def readable_size(size):
     if size < 1024:
         return size
     elif 1024 <= size < 1024 ** 2:
-        return '{0:.2f}K'.format(size / 1024)
+        return '{0:.2f}K'.format(size * 1.0 / 1024)
     elif 1024 ** 2 <= size < 1024 ** 3:
-        return '{0:.2f}M'.format(size / (1024 ** 2))
+        return '{0:.2f}M'.format(size * 1.0 / (1024 ** 2))
     elif 1024 ** 3 <= size < 1024 ** 4:
-        return '{0:.2f}G'.format(size / (1024 ** 3))
+        return '{0:.2f}G'.format(size * 1.0 / (1024 ** 3))
     else:
-        return '{0:.2f}T'.format(size / (1024 ** 4))
+        return '{0:.2f}T'.format(size * 1.0 / (1024 ** 4))
 
 
 _commit_hash, _commit_ref = None, None


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Use  float division in `readable_size`.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #576 , the issue about used memory is fixed in #632.