### PR TITLE
Generate seed instead of RandomState in tile of RandomOperand

### DIFF
--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -127,6 +127,8 @@ cdef inline object h_non_iterative(object ob):
         return h_numpy(ob)
     elif isinstance(ob, (np.dtype, np.generic)):
         return repr(ob)
+    elif isinstance(ob, np.random.RandomState):
+        return h_iterative(ob.get_state())
     elif isinstance(ob, Enum):
         return h((type(ob), ob.name))
     elif pd is not None and isinstance(ob, pd.Index):

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -616,6 +616,7 @@ class Executor(object):
         return calc_nsplits(chunk_idx_to_shape)
 
     def decref(self, *keys):
+        rs = set(self._chunk_result)
         for key in keys:
             tileable_key, tileable_id = key
             if key[0] not in self.stored_tileables:
@@ -626,9 +627,8 @@ class Executor(object):
                 # for those same key tileables, do decref only when all those tileables are garbage collected
                 if len(ids) != 0:
                     continue
-                for chunk_key in chunk_keys:
-                    if chunk_key in self.chunk_result:
-                        del self.chunk_result[chunk_key]
+                for chunk_key in (chunk_keys & rs):
+                    self._chunk_result.pop(chunk_key, None)
                 del self.stored_tileables[tileable_key]
 
 

--- a/mars/tensor/random/beta.py
+++ b/mars/tensor/random/beta.py
@@ -91,5 +91,5 @@ def beta(random_state, a, b, size=None, chunk_size=None, gpu=None, dtype=None):
         dtype = np.random.RandomState().beta(
             handle_array(a), handle_array(b), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorBeta(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorBeta(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(a, b, chunk_size=chunk_size)

--- a/mars/tensor/random/binomial.py
+++ b/mars/tensor/random/binomial.py
@@ -141,5 +141,5 @@ def binomial(random_state, n, p, size=None, chunk_size=None, gpu=None, dtype=Non
         dtype = np.random.RandomState().binomial(
             handle_array(n), handle_array(p), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorBinomial(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorBinomial(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(n, p, chunk_size=chunk_size)

--- a/mars/tensor/random/chisquare.py
+++ b/mars/tensor/random/chisquare.py
@@ -114,5 +114,5 @@ def chisquare(random_state, df, size=None, chunk_size=None, gpu=None, dtype=None
         dtype = np.random.RandomState().chisquare(
             handle_array(df), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorChisquare(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorChisquare(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(df, chunk_size=chunk_size)

--- a/mars/tensor/random/choice.py
+++ b/mars/tensor/random/choice.py
@@ -173,6 +173,6 @@ def choice(random_state, a, size=None, replace=True, p=None, chunk_size=None, gp
         raise ValueError("Cannot take a larger sample than population when 'replace=False'")
 
     size = random_state._handle_size(size)
-    op = TensorChoice(state=random_state._state, replace=replace,
+    op = TensorChoice(state=random_state.to_numpy(), replace=replace,
                       size=size, dtype=dtype, gpu=gpu)
     return op(a, p, chunk_size=chunk_size)

--- a/mars/tensor/random/core.py
+++ b/mars/tensor/random/core.py
@@ -304,10 +304,9 @@ class TensorRandomOperand(TensorOperand):
                 if slot not in set(TensorRandomOperand.__slots__)]
 
     def _update_key(self):
-        args = tuple(getattr(self, k, None) for k in self._keys_)
-        if self.state is None:
-            args += (np.random.random(),)
-        self._key = tokenize(type(self), *args)
+        self._key = tokenize(type(self),
+                             *tuple(getattr(self, k, None) for k in self._keys_))
+        return self
 
 
 class TensorDistribution(TensorRandomOperand):

--- a/mars/tensor/random/core.py
+++ b/mars/tensor/random/core.py
@@ -14,7 +14,7 @@
 
 
 import itertools
-from collections import Iterable, namedtuple
+from collections import Iterable
 from contextlib import contextmanager
 
 import numpy as np
@@ -276,7 +276,7 @@ class TensorRandomOperandMixin(TensorOperandMixin):
 
 
 def _on_serialize_random_state(rs):
-    return rs.get_state()
+    return rs.get_state() if rs is not None else None
 
 
 def _on_deserialize_random_state(tup):
@@ -302,6 +302,12 @@ class TensorRandomOperand(TensorOperand):
     def args(self):
         return [slot for slot in self.__slots__
                 if slot not in set(TensorRandomOperand.__slots__)]
+
+    def _update_key(self):
+        args = tuple(getattr(self, k, None) for k in self._keys_)
+        if self.state is None:
+            args += (np.random.random(),)
+        self._key = tokenize(type(self), *args)
 
 
 class TensorDistribution(TensorRandomOperand):

--- a/mars/tensor/random/core.py
+++ b/mars/tensor/random/core.py
@@ -20,12 +20,12 @@ from contextlib import contextmanager
 import numpy as np
 
 from ...config import options
-from ...compat import irange, izip, zip_longest
-from ...serialize import ValueType, TupleField
+from ...compat import irange, izip
+from ...serialize import ValueType, TupleField, Int32Field
 from ...utils import tokenize
 from ..core import TENSOR_TYPE, CHUNK_TYPE
-from ..utils import decide_chunk_sizes, random_state_data, broadcast_shape
-from ..array_utils import array_module
+from ..utils import decide_chunk_sizes, gen_random_seeds, broadcast_shape
+from ..array_utils import array_module, device
 from ..operands import TensorOperand, TensorOperandMixin
 from ..datasource import tensor as astensor
 from ..base import broadcast_to
@@ -54,9 +54,8 @@ class RandomState(object):
         """
         self._random_state.seed(seed=seed)
 
-    @property
-    def _state(self):
-        return State(self._random_state)
+    def to_numpy(self):
+        return self._random_state
 
     @classmethod
     def from_numpy(cls, np_random_state):
@@ -88,48 +87,6 @@ def handle_array(arg):
         return arg.op.data[(0,) * max(1, arg.ndim)]
 
     return np.empty((0,), dtype=arg.dtype)
-
-
-STATE = namedtuple('State', 'label keys pos has_gauss cached_gaussian')
-
-
-class State(STATE):
-    def __new__(cls, random_state=None, *args, **kwargs):
-        if isinstance(random_state, np.random.RandomState) and not kwargs:
-            return super(State, cls).__new__(cls, *random_state.get_state())
-        elif isinstance(random_state, tuple) and not kwargs:
-            return super(State, cls).__new__(cls, *random_state)
-        elif args:
-            return super(State, cls).__new__(cls, *((random_state,) + args))
-        elif not kwargs:
-            return super(State, cls).__new__(cls, *random_state)
-        else:
-            assert random_state is None
-            return super(State, cls).__new__(cls, **kwargs)
-
-    def __eq__(self, other):
-        if not isinstance(other, tuple):
-            return False
-
-        for it, other_it in zip_longest(self, other):
-            if isinstance(it, np.ndarray):
-                if not np.array_equal(it, other_it):
-                    return False
-            elif it != other_it:
-                return False
-
-        return True
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    @property
-    def random_state(self):
-        rs = np.random.RandomState()
-        s = (self.label, self.keys, self.pos, self.has_gauss, self.cached_gaussian)
-        rs.set_state(s)
-
-        return rs
 
 
 class TensorRandomOperandMixin(TensorOperandMixin):
@@ -165,19 +122,16 @@ class TensorRandomOperandMixin(TensorOperandMixin):
             op.inputs = new_inputs
 
         idxes = list(itertools.product(*[irange(len(s)) for s in nsplits]))
-        states = random_state_data(len(idxes), op.state.random_state) \
-            if op.state is not None else [None] * len(idxes)
+        seeds = gen_random_seeds(len(idxes), op.state)
 
         out_chunks = []
-        for state, idx, shape in izip(states, idxes, itertools.product(*nsplits)):
+        for seed, idx, shape in izip(seeds, idxes, itertools.product(*nsplits)):
             inputs = []
             for inp in op.inputs:
                 if len(inp.chunks) == 1:
                     inputs.append(inp.chunks[0])
                 else:
                     inputs.append(inp.cix[idx])
-            state = State(np.random.RandomState(state)) \
-                if state is not None else None
             try:
                 s = len(tuple(op.size))
                 size = shape[:s]
@@ -190,8 +144,9 @@ class TensorRandomOperandMixin(TensorOperandMixin):
                 size = shape
 
             chunk_op = op.copy().reset_key()
+            chunk_op._seed = seed
+            chunk_op._state = None
             chunk_op._size = size
-            chunk_op._state = state
             out_chunk = chunk_op.new_chunk(inputs, shape=shape, index=idx,
                                            order=tensor.order)
             out_chunks.append(out_chunk)
@@ -203,62 +158,53 @@ class TensorRandomOperandMixin(TensorOperandMixin):
     @classmethod
     def execute(cls, ctx, op):
         xp = array_module(op.gpu)
-        if op.state:
-            rs = op.state.random_state
+        if xp is np:
+            device_id = -1
         else:
-            if xp == np:
-                rs = xp.random.RandomState()
-            else:
-                rs = xp.random
+            device_id = op.device or 0
         get_val = lambda x: ctx[x.key] if isinstance(x, CHUNK_TYPE) else x
 
-        method_name = getattr(cls, '_func_name')
-        try:
-            if method_name in ('rand', 'randn'):
-                try:
-                    res = getattr(rs, method_name)(*op.size, dtype=op.dtype)
-                except TypeError:
-                    res = getattr(rs, method_name)(*op.size)
-            elif method_name == 'randint':
-                try:
-                    res = rs.randint(get_val(op.low), get_val(op.high), size=op.size,
-                                     dtype=op.dtype)
-                except TypeError:
-                    res = rs.randint(get_val(op.low), get_val(op.high), size=op.size)
-            else:
-                try:
-                    res = getattr(rs, method_name)(*(get_val(getattr(op, arg)) for arg in op.args),
-                                                   dtype=op.dtype)
-                except TypeError:
-                    res = getattr(rs, method_name)(*(get_val(getattr(op, arg)) for arg in op.args))
-            if hasattr(res, 'dtype') and res.dtype != op.dtype:
-                res = res.astype(op.dtype)
-            if xp != np:
-                with xp.cuda.Device(op.device or 0):
-                    ctx[op.outputs[0].key] = xp.asarray(res)
-            else:
-                ctx[op.outputs[0].key] = res
-        except AttributeError:
-            if xp != np:
-                if not op.state:
-                    rs = np.random.RandomState()
+        with device(device_id):
+            rs = xp.random.RandomState(op.seed)
+
+            method_name = getattr(cls, '_func_name')
+            try:
                 if method_name in ('rand', 'randn'):
                     try:
                         res = getattr(rs, method_name)(*op.size, dtype=op.dtype)
                     except TypeError:
                         res = getattr(rs, method_name)(*op.size)
+                elif method_name == 'randint':
+                    try:
+                        res = rs.randint(get_val(op.low), get_val(op.high), size=op.size,
+                                         dtype=op.dtype)
+                    except TypeError:
+                        res = rs.randint(get_val(op.low), get_val(op.high), size=op.size)
                 else:
                     try:
                         res = getattr(rs, method_name)(*(get_val(getattr(op, arg)) for arg in op.args),
                                                        dtype=op.dtype)
                     except TypeError:
                         res = getattr(rs, method_name)(*(get_val(getattr(op, arg)) for arg in op.args))
-                if res.dtype != op.dtype:
-                    res = res.astype(op.dtype)
-                with xp.cuda.Device(op.device or 0):
+                if hasattr(res, 'dtype') and res.dtype != op.dtype:
+                    res = res.astype(op.dtype, copy=False)
+                if xp is not np:
                     ctx[op.outputs[0].key] = xp.asarray(res)
-            else:
-                raise
+                else:
+                    ctx[op.outputs[0].key] = res
+            except AttributeError:
+                if xp is not np:
+                    # cupy cannot generate data, fallback to numpy
+                    rs = np.random.RandomState(op.seed)
+                    if method_name in ('rand', 'randn'):
+                        res = getattr(rs, method_name)(*op.size)
+                    else:
+                        res = getattr(rs, method_name)(*(get_val(getattr(op, arg)) for arg in op.args))
+                    if res.dtype != op.dtype:
+                        res = res.astype(op.dtype, copy=False)
+                    ctx[op.outputs[0].key] = xp.asarray(res)
+                else:
+                    raise
 
     def _get_shape(self, shapes):
         shapes = list(shapes)
@@ -329,29 +275,33 @@ class TensorRandomOperandMixin(TensorOperandMixin):
             return super(TensorRandomOperandMixin, self)._new_chunks(inputs, kws=kws, **kw)
 
 
+def _on_serialize_random_state(rs):
+    return rs.get_state()
+
+
+def _on_deserialize_random_state(tup):
+    rs = np.random.RandomState()
+    rs.set_state(tup)
+    return rs
+
+
 class TensorRandomOperand(TensorOperand):
-    _state = TupleField('state', on_serialize=lambda x: tuple(x) if x is not None else x,
-                        on_deserialize=lambda x: State(x) if x is not None else x)
+    _state = TupleField('state', on_serialize=_on_serialize_random_state,
+                        on_deserialize=_on_deserialize_random_state)
+    _seed = Int32Field('seed')
 
     @property
     def state(self):
         return getattr(self, '_state', None)
 
-    def __setattr__(self, attr, value):
-        if attr == '_state' and value is not None and not isinstance(value, State):
-            value = State(value)
-        super(TensorRandomOperand, self).__setattr__(attr, value)
+    @property
+    def seed(self):
+        return getattr(self, '_seed', None)
 
     @property
     def args(self):
         return [slot for slot in self.__slots__
                 if slot not in set(TensorRandomOperand.__slots__)]
-
-    def _update_key(self):
-        args = tuple(getattr(self, k, None) for k in self._keys_)
-        if self.state is None:
-            args += (np.random.random(),)
-        self._key = tokenize(type(self), *args)
 
 
 class TensorDistribution(TensorRandomOperand):
@@ -364,36 +314,37 @@ class TensorDistribution(TensorRandomOperand):
     @classmethod
     def execute(cls, ctx, op):
         xp = array_module(op.gpu)
-        if op.state:
-            rs = op.state.random_state
+        if xp is np:
+            device_id = -1
         else:
-            rs = xp.random.RandomState()
+            device_id = op.device or 0
 
-        args = []
-        for k in op.args:
-            val = getattr(op, k, None)
-            if isinstance(val, CHUNK_TYPE):
-                args.append(ctx[val.key])
-            else:
-                args.append(val)
+        with device(device_id):
+            rs = xp.random.RandomState(op.seed)
 
-        method_name = getattr(cls, '_func_name')
-        try:
-            res = getattr(rs, method_name)(*args)
-            if xp != np:
-                with xp.cuda.Device(op.device or 0):
-                    ctx[op.outputs[0].key] = xp.asarray(res)
-            else:
-                ctx[op.outputs[0].key] = res
-        except AttributeError:
-            if xp != np:
-                if not op.state:
-                    rs = np.random.RandomState()
+            args = []
+            for k in op.args:
+                val = getattr(op, k, None)
+                if isinstance(val, CHUNK_TYPE):
+                    args.append(ctx[val.key])
+                else:
+                    args.append(val)
+
+            method_name = getattr(cls, '_func_name')
+            try:
                 res = getattr(rs, method_name)(*args)
-                with xp.cuda.Device(op.device or 0):
+                if xp is not np:
                     ctx[op.outputs[0].key] = xp.asarray(res)
-            else:
-                raise
+                else:
+                    ctx[op.outputs[0].key] = res
+            except AttributeError:
+                if xp is not np:
+                    # cupy cannot generate, fall back to numpy
+                    rs = np.random.RandomState(op.seed)
+                    res = getattr(rs, method_name)(*args)
+                    ctx[op.outputs[0].key] = xp.asarray(res)
+                else:
+                    raise
 
 
 class TensorSimpleRandomData(TensorRandomOperand):

--- a/mars/tensor/random/exponential.py
+++ b/mars/tensor/random/exponential.py
@@ -94,5 +94,5 @@ def exponential(random_state, scale=1.0, size=None, chunk_size=None, gpu=None, d
         dtype = np.random.RandomState().exponential(
             handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorExponential(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorExponential(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(scale, chunk_size=chunk_size)

--- a/mars/tensor/random/f.py
+++ b/mars/tensor/random/f.py
@@ -139,5 +139,5 @@ def f(random_state, dfnum, dfden, size=None, chunk_size=None, gpu=None, dtype=No
         dtype = np.random.RandomState().f(
             handle_array(dfnum), handle_array(dfden), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorF(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorF(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(dfnum, dfden, chunk_size=chunk_size)

--- a/mars/tensor/random/gamma.py
+++ b/mars/tensor/random/gamma.py
@@ -130,5 +130,5 @@ def gamma(random_state, shape, scale=1.0, size=None, chunk_size=None, gpu=None, 
         dtype = np.random.RandomState().gamma(
             handle_array(shape), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorGamma(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorGamma(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(shape, scale, chunk_size=chunk_size)

--- a/mars/tensor/random/geometric.py
+++ b/mars/tensor/random/geometric.py
@@ -97,5 +97,5 @@ def geometric(random_state, p, size=None, chunk_size=None, gpu=None, dtype=None)
         dtype = np.random.RandomState().geometric(
             handle_array(p), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorGeometric(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorGeometric(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(p, chunk_size=chunk_size)

--- a/mars/tensor/random/gumbel.py
+++ b/mars/tensor/random/gumbel.py
@@ -169,5 +169,5 @@ def gumbel(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=Non
         dtype = np.random.RandomState().gumbel(
             handle_array(loc), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorGumbel(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorGumbel(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(loc, scale, chunk_size=chunk_size)

--- a/mars/tensor/random/hypergeometric.py
+++ b/mars/tensor/random/hypergeometric.py
@@ -149,5 +149,5 @@ def hypergeometric(random_state, ngood, nbad, nsample, size=None, chunk_size=Non
         dtype = np.random.RandomState().hypergeometric(
             handle_array(ngood), handle_array(nbad), handle_array(nsample), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorHypergeometric(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorHypergeometric(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(ngood, nbad, nsample, chunk_size=chunk_size)

--- a/mars/tensor/random/laplace.py
+++ b/mars/tensor/random/laplace.py
@@ -135,5 +135,5 @@ def laplace(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=No
         dtype = np.random.RandomState().laplace(
             handle_array(loc), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorLaplace(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorLaplace(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(loc, scale, chunk_size=chunk_size)

--- a/mars/tensor/random/logistic.py
+++ b/mars/tensor/random/logistic.py
@@ -131,5 +131,5 @@ def logistic(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=N
         dtype = np.random.RandomState().logistic(
             handle_array(loc), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorLogistic(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorLogistic(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(loc, scale, chunk_size=chunk_size)

--- a/mars/tensor/random/lognormal.py
+++ b/mars/tensor/random/lognormal.py
@@ -161,5 +161,5 @@ def lognormal(random_state, mean=0.0, sigma=1.0, size=None, chunk_size=None, gpu
         dtype = np.random.RandomState().lognormal(
             handle_array(mean), handle_array(sigma), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorLognormal(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorLognormal(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(mean, sigma, chunk_size=chunk_size)

--- a/mars/tensor/random/logseries.py
+++ b/mars/tensor/random/logseries.py
@@ -126,5 +126,5 @@ def logseries(random_state, p, size=None, chunk_size=None, gpu=None, dtype=None)
         dtype = np.random.RandomState().logseries(
             handle_array(p), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorLogseries(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorLogseries(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(p, chunk_size=chunk_size)

--- a/mars/tensor/random/multinomial.py
+++ b/mars/tensor/random/multinomial.py
@@ -139,6 +139,7 @@ def multinomial(random_state, n, pvals, size=None, chunk_size=None, gpu=None, dt
     if dtype is None:
         dtype = np.random.RandomState().multinomial(n, pvals, size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorMultinomial(n=n, pvals=pvals, state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorMultinomial(n=n, pvals=pvals, state=random_state.to_numpy(),
+                           size=size, gpu=gpu, dtype=dtype)
     return op(chunk_size=chunk_size)
 

--- a/mars/tensor/random/negative_binomial.py
+++ b/mars/tensor/random/negative_binomial.py
@@ -127,5 +127,5 @@ def negative_binomial(random_state, n, p, size=None, chunk_size=None, gpu=None, 
         dtype = np.random.RandomState().negative_binomial(
             handle_array(n), handle_array(p), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorNegativeBinomial(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorNegativeBinomial(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(n, p, chunk_size=chunk_size)

--- a/mars/tensor/random/noncentral_chisquare.py
+++ b/mars/tensor/random/noncentral_chisquare.py
@@ -134,5 +134,5 @@ def noncentral_chisquare(random_state, df, nonc, size=None, chunk_size=None, gpu
         dtype = np.random.RandomState().noncentral_chisquare(
             handle_array(df), handle_array(nonc), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorNoncentralChisquare(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorNoncentralChisquare(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(df, nonc, chunk_size=chunk_size)

--- a/mars/tensor/random/noncentral_f.py
+++ b/mars/tensor/random/noncentral_f.py
@@ -130,5 +130,5 @@ def noncentral_f(random_state, dfnum, dfden, nonc, size=None, chunk_size=None, g
         dtype = np.random.RandomState().noncentral_f(
             handle_array(dfnum), handle_array(dfden), handle_array(nonc), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorNoncentralF(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorNoncentralF(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(dfnum, dfden, nonc, chunk_size=chunk_size)

--- a/mars/tensor/random/normal.py
+++ b/mars/tensor/random/normal.py
@@ -145,5 +145,5 @@ def normal(random_state, loc=0.0, scale=1.0, size=None, chunk_size=None, gpu=Non
         dtype = np.random.RandomState().normal(
             handle_array(loc), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorNormal(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorNormal(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(loc, scale, chunk_size=chunk_size)

--- a/mars/tensor/random/pareto.py
+++ b/mars/tensor/random/pareto.py
@@ -144,5 +144,5 @@ def pareto(random_state, a, size=None, chunk_size=None, gpu=None, dtype=None):
         dtype = np.random.RandomState().pareto(
             handle_array(a), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorPareto(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorPareto(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(a, chunk_size=chunk_size)

--- a/mars/tensor/random/poisson.py
+++ b/mars/tensor/random/poisson.py
@@ -115,5 +115,5 @@ def poisson(random_state, lam=1.0, size=None, chunk_size=None, gpu=None, dtype=N
         dtype = np.random.RandomState().poisson(
             handle_array(lam), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorPoisson(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorPoisson(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(lam, chunk_size=chunk_size)

--- a/mars/tensor/random/power.py
+++ b/mars/tensor/random/power.py
@@ -146,5 +146,5 @@ def power(random_state, a, size=None, chunk_size=None, gpu=None, dtype=None):
         dtype = np.random.RandomState().power(
             handle_array(a), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorRandomPower(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorRandomPower(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(a, chunk_size=chunk_size)

--- a/mars/tensor/random/rand.py
+++ b/mars/tensor/random/rand.py
@@ -76,7 +76,7 @@ def rand(random_state, *dn, **kw):
     if 'dtype' not in kw:
         kw['dtype'] = np.dtype('f8')
     chunk_size = kw.pop('chunk_size', None)
-    op = TensorRand(state=random_state._state, size=dn, **kw)
+    op = TensorRand(state=random_state.to_numpy(), size=dn, **kw)
 
     for key in op.extra_params:
         if not key.startswith('_'):

--- a/mars/tensor/random/randint.py
+++ b/mars/tensor/random/randint.py
@@ -172,6 +172,6 @@ def randint(random_state, low, high=None, size=None, dtype='l', density=None,
     """
     sparse = bool(density)
     size = random_state._handle_size(size)
-    op = TensorRandint(state=random_state._state, low=low, high=high, size=size, dtype=dtype,
+    op = TensorRandint(state=random_state.to_numpy(), low=low, high=high, size=size, dtype=dtype,
                        gpu=gpu, sparse=sparse, density=density)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/random/randn.py
+++ b/mars/tensor/random/randn.py
@@ -90,7 +90,7 @@ def randn(random_state, *dn, **kw):
         kw['dtype'] = np.dtype('f8')
     chunk_size = kw.pop('chunk_size', None)
 
-    op = TensorRandn(state=random_state._state, size=dn, **kw)
+    op = TensorRandn(state=random_state.to_numpy(), size=dn, **kw)
 
     for key in op.extra_params:
         if not key.startswith('_'):

--- a/mars/tensor/random/random_integers.py
+++ b/mars/tensor/random/random_integers.py
@@ -130,6 +130,6 @@ def random_integers(random_state, low, high=None, size=None, chunk_size=None, gp
     >>> plt.show()
     """
     size = random_state._handle_size(size)
-    op = TensorRandomIntegers(state=random_state._state, size=size, dtype=np.dtype(int),
+    op = TensorRandomIntegers(state=random_state.to_numpy(), size=size, dtype=np.dtype(int),
                               low=low, high=high, gpu=gpu)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/random/random_sample.py
+++ b/mars/tensor/random/random_sample.py
@@ -85,5 +85,5 @@ def random_sample(random_state, size=None, chunk_size=None, gpu=None, dtype=None
     if dtype is None:
         dtype = np.dtype('f8')
     size = random_state._handle_size(size)
-    op = TensorRandomSample(state=random_state._state, size=size, gpu=gpu, dtype=dtype)
+    op = TensorRandomSample(state=random_state.to_numpy(), size=size, gpu=gpu, dtype=dtype)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/random/rayleigh.py
+++ b/mars/tensor/random/rayleigh.py
@@ -114,5 +114,5 @@ def rayleigh(random_state, scale=1.0, size=None, chunk_size=None, gpu=None, dtyp
         dtype = np.random.RandomState().rayleigh(
             handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorRayleigh(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorRayleigh(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(scale, chunk_size=chunk_size)

--- a/mars/tensor/random/standard_cauchy.py
+++ b/mars/tensor/random/standard_cauchy.py
@@ -104,5 +104,5 @@ def standard_cauchy(random_state, size=None, chunk_size=None, gpu=None, dtype=No
     if dtype is None:
         dtype = np.random.RandomState().standard_cauchy(size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorStandardCauchy(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorStandardCauchy(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/random/standard_exponential.py
+++ b/mars/tensor/random/standard_exponential.py
@@ -69,5 +69,5 @@ def standard_exponential(random_state, size=None, chunk_size=None, gpu=None, dty
     if dtype is None:
         dtype = np.random.RandomState().standard_exponential(size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorStandardExponential(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorStandardExponential(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/random/standard_gamma.py
+++ b/mars/tensor/random/standard_gamma.py
@@ -120,5 +120,5 @@ def standard_gamma(random_state, shape, size=None, chunk_size=None, gpu=None, dt
         dtype = np.random.RandomState().standard_gamma(
             handle_array(shape), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorStandardGamma(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorStandardGamma(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(shape, chunk_size=chunk_size)

--- a/mars/tensor/random/standard_normal.py
+++ b/mars/tensor/random/standard_normal.py
@@ -73,5 +73,5 @@ def standard_normal(random_state, size=None, chunk_size=None, gpu=None, dtype=No
     if dtype is None:
         dtype = np.random.RandomState().standard_normal(size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorStandardNormal(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorStandardNormal(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(chunk_size=chunk_size)

--- a/mars/tensor/random/standard_t.py
+++ b/mars/tensor/random/standard_t.py
@@ -139,5 +139,5 @@ def standard_t(random_state, df, size=None, chunk_size=None, gpu=None, dtype=Non
         dtype = np.random.RandomState().standard_t(
             handle_array(df), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorStandardT(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorStandardT(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(df, chunk_size=chunk_size)

--- a/mars/tensor/random/tests/test_random.py
+++ b/mars/tensor/random/tests/test_random.py
@@ -33,8 +33,8 @@ class Test(TestBase):
         chunk2 = self._pb_deserial(serials)[chunk.data]
 
         self.assertEqual(chunk.index, chunk2.index)
-        state, state2 = chunk.op.state, chunk2.op.state
-        self.assertTrue(np.array_equal(state.keys, state2.keys))
+        self.assertEqual(chunk.op.state, chunk2.op.state)
+        self.assertEqual(chunk.op.seed, chunk2.op.seed)
 
     def testRandom(self):
         arr = rand(2, 3)

--- a/mars/tensor/random/tests/test_random_execute.py
+++ b/mars/tensor/random/tests/test_random_execute.py
@@ -19,7 +19,6 @@ import unittest
 import numpy as np
 
 from mars.executor import Executor
-from mars.tensor.random.core import State
 from mars.tensor.datasource import tensor as from_ndarray
 from mars.lib.sparse.core import issparse
 from mars import tensor
@@ -43,7 +42,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.randn(10, 20, chunk_size=5).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).randn(5, 5)))
@@ -66,7 +65,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.random_integers(0, 10, size=(10, 20), chunk_size=5).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             np.testing.assert_equal(res, np.random.RandomState(0).random_integers(0, 10, size=(5, 5)))
@@ -77,7 +76,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.random_sample(size=(10, 20), chunk_size=5).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).random_sample(size=(5, 5))))
@@ -88,7 +87,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.random(size=(10, 20), chunk_size=5).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).random_sample(size=(5, 5))))
@@ -99,7 +98,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.ranf(size=(10, 20), chunk_size=5).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).random_sample(size=(5, 5))))
@@ -110,7 +109,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.sample(size=(10, 20), chunk_size=5).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).random_sample(size=(5, 5))))
@@ -121,7 +120,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.choice(5, size=(15,), chunk_size=5).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).choice(5, size=(5,))))
@@ -131,7 +130,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.choice([1, 4, 9], size=(15,), chunk_size=5).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).choice([1, 4, 9], size=(5,))))
@@ -144,7 +143,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.choice([1, 4, 9], size=(3,), replace=False, chunk_size=1).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(
@@ -155,7 +154,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.choice([1, 4, 9], size=(15,), chunk_size=5, p=[.2, .5, .3]).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(
@@ -178,12 +177,12 @@ class Test(unittest.TestCase):
 
     def testBetaExecute(self):
         arr = tensor.random.beta(1, 2, chunk_size=2).tiles()
-        arr.chunks[0].op._state = State(np.random.RandomState(0))
+        arr.chunks[0].op._seed = 0
 
         self.assertEqual(self.executor.execute_tensor(arr)[0], np.random.RandomState(0).beta(1, 2))
 
         arr = tensor.random.beta([1, 2], [3, 4], chunk_size=2).tiles()
-        arr.chunks[0].op._state = State(np.random.RandomState(0))
+        arr.chunks[0].op._seed = 0
 
         self.assertTrue(np.array_equal(self.executor.execute_tensor(arr)[0],
                                        np.random.RandomState(0).beta([1, 2], [3, 4])))
@@ -191,7 +190,7 @@ class Test(unittest.TestCase):
         arr = tensor.random.beta([[2, 3]], from_ndarray([[4, 6], [5, 2]], chunk_size=2),
                                  chunk_size=1, size=(3, 2, 2)).tiles()
         for c in arr.chunks:
-            c.op._state = State(np.random.RandomState(0))
+            c.op._seed = 0
 
         res = self.executor.execute_tensor(arr, concat=True)[0]
 
@@ -213,7 +212,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.binomial(10, .5, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).binomial(10, .5, 10)))
@@ -224,7 +223,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.chisquare(2, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).chisquare(2, 10)))
@@ -235,7 +234,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.dirichlet((10, 5, 3), 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).dirichlet((10, 5, 3), 10)))
@@ -246,7 +245,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.exponential(1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).exponential(1.0, 10)))
@@ -257,7 +256,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.f(1.0, 2.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).f(1.0, 2.0, 10)))
@@ -268,7 +267,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.gamma(1.0, 2.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).gamma(1.0, 2.0, 10)))
@@ -279,7 +278,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.geometric(1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).geometric(1.0, 10)))
@@ -290,7 +289,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.gumbel(.5, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).gumbel(.5, 1.0, 10)))
@@ -301,7 +300,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.hypergeometric(10, 20, 15, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).hypergeometric(10, 20, 15, 10)))
@@ -312,7 +311,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.laplace(.5, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).laplace(.5, 1.0, 10)))
@@ -323,7 +322,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.logistic(.5, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             np.testing.assert_equal(res, np.random.RandomState(0).logistic(.5, 1.0, 10))
@@ -334,7 +333,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.lognormal(.5, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).lognormal(.5, 1.0, 10)))
@@ -345,7 +344,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.logseries(.5, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).logseries(.5, 10)))
@@ -357,7 +356,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.multinomial(10, [.2, .5, .3], 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).multinomial(10, [.2, .5, .3], 10)))
@@ -368,7 +367,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.multivariate_normal([1, 2], [[1, 0], [0, 1]], 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).multivariate_normal(
@@ -380,7 +379,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.negative_binomial(5, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).negative_binomial(5, 1.0, 10)))
@@ -391,7 +390,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.noncentral_chisquare(.5, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).noncentral_chisquare(.5, 1.0, 10)))
@@ -402,7 +401,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.noncentral_f(1.5, 1.0, 1.1, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).noncentral_f(1.5, 1.0, 1.1, 10)))
@@ -413,7 +412,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.normal(10, 1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).normal(10, 1.0, 10)))
@@ -424,7 +423,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.pareto(1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).pareto(1.0, 10)))
@@ -435,7 +434,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.poisson(1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).poisson(1.0, 10)))
@@ -446,7 +445,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.power(1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).power(1.0, 10)))
@@ -457,7 +456,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.rayleigh(1.0, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).rayleigh(1.0, 10)))
@@ -468,7 +467,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.standard_cauchy(100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).standard_cauchy(10)))
@@ -479,7 +478,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.standard_exponential(100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).standard_exponential(10)))
@@ -490,7 +489,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.standard_gamma(.1, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).standard_gamma(.1, 10)))
@@ -501,7 +500,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.standard_normal(100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).standard_normal(10)))
@@ -512,7 +511,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.standard_t(.1, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).standard_t(.1, 10)))
@@ -523,7 +522,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.triangular(.1, .2, .3, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).triangular(.1, .2, .3, 10)))
@@ -534,7 +533,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.uniform(.1, .2, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).uniform(.1, .2, 10)))
@@ -545,7 +544,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.vonmises(.1, .2, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).vonmises(.1, .2, 10)))
@@ -556,7 +555,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.wald(.1, .2, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).wald(.1, .2, 10)))
@@ -567,7 +566,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.weibull(.1, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).weibull(.1, 10)))
@@ -578,7 +577,7 @@ class Test(unittest.TestCase):
 
         arr = tensor.random.zipf(1.1, 100, chunk_size=10).tiles()
         for chunk in arr.chunks:
-            chunk.op._state = State(np.random.RandomState(0))
+            chunk.op._seed = 0
 
         for res in self.executor.execute_tensor(arr):
             self.assertTrue(np.array_equal(res, np.random.RandomState(0).zipf(1.1, 10)))

--- a/mars/tensor/random/triangular.py
+++ b/mars/tensor/random/triangular.py
@@ -123,5 +123,5 @@ def triangular(random_state, left, mode, right, size=None, chunk_size=None, gpu=
         dtype = np.random.RandomState().triangular(
             handle_array(left), handle_array(mode), handle_array(right), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorTriangular(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorTriangular(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(left, mode, right, chunk_size=chunk_size)

--- a/mars/tensor/random/uniform.py
+++ b/mars/tensor/random/uniform.py
@@ -133,5 +133,5 @@ def uniform(random_state, low=0.0, high=1.0, size=None, chunk_size=None, gpu=Non
         dtype = np.random.RandomState().uniform(
             handle_array(low), handle_array(high), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorUniform(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorUniform(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(low, high, chunk_size=chunk_size)

--- a/mars/tensor/random/vonmises.py
+++ b/mars/tensor/random/vonmises.py
@@ -135,5 +135,5 @@ def vonmises(random_state, mu, kappa, size=None, chunk_size=None, gpu=None, dtyp
             handle_array(mu), handle_array(kappa), size=(0,)).dtype
 
     size = random_state._handle_size(size)
-    op = TensorVonmises(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorVonmises(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(mu, kappa, chunk_size=chunk_size)

--- a/mars/tensor/random/wald.py
+++ b/mars/tensor/random/wald.py
@@ -118,5 +118,5 @@ def wald(random_state, mean, scale, size=None, chunk_size=None, gpu=None, dtype=
         dtype = np.random.RandomState().wald(
             handle_array(mean), handle_array(scale), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorWald(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorWald(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(mean, scale, chunk_size=chunk_size)

--- a/mars/tensor/random/weibull.py
+++ b/mars/tensor/random/weibull.py
@@ -144,5 +144,5 @@ def weibull(random_state, a, size=None, chunk_size=None, gpu=None, dtype=None):
         dtype = np.random.RandomState().weibull(
             handle_array(a), size=(0,)).dtype
     size = random_state._handle_size(size)
-    op = TensorWeibull(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorWeibull(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(a, chunk_size=chunk_size)

--- a/mars/tensor/random/zipf.py
+++ b/mars/tensor/random/zipf.py
@@ -126,5 +126,5 @@ def zipf(random_state, a, size=None, chunk_size=None, gpu=None, dtype=None):
             handle_array(a), size=(0,)).dtype
 
     size = random_state._handle_size(size)
-    op = TensorZipf(size=size, state=random_state._state, gpu=gpu, dtype=dtype)
+    op = TensorZipf(size=size, state=random_state.to_numpy(), gpu=gpu, dtype=dtype)
     return op(a, chunk_size=chunk_size)

--- a/mars/tensor/utils.py
+++ b/mars/tensor/utils.py
@@ -92,14 +92,9 @@ def get_chunk_slices(nsplits, idx):
                  for idx, nsplit in zip(idx, nsplits))
 
 
-def random_state_data(n, random_state=None):
-    if not isinstance(random_state, np.random.RandomState):
-        random_state = np.random.RandomState(random_state)
-
-    random_data = random_state.bytes(624 * n * 4)  # `n * 624` 32-bit integers
-    l = list(np.frombuffer(random_data, dtype=np.uint32).reshape((n, -1)))
-    assert len(l) == n
-    return l
+def gen_random_seeds(n, random_state):
+    assert isinstance(random_state, np.random.RandomState)
+    return np.frombuffer(random_state.bytes(n * 4), dtype=np.uint32)
 
 
 def validate_axis(ndim, axis):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR optimizes tile and execution of tensor random.

1. Remove `mars.tensor.random.core.State` object.
2. Generate seeds instead of ndarrays for tiling which is useful for both numpy and cupy.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #647 .
