### PR TITLE
Check disks before adding into spill targets

### DIFF
--- a/mars/scheduler/analyzer.py
+++ b/mars/scheduler/analyzer.py
@@ -317,7 +317,7 @@ class GraphAnalyzer(object):
         else:
             for op_key, worker in self._iter_assignments_by_transfer_sizes(
                     pre_worker_quotas, input_chunk_metas):
-                if op_key in cur_assigns:
+                if op_key in cur_assigns or op_key not in op_keys:
                     continue
                 assigned_counts[worker] += 1
                 cur_assigns[op_key] = worker

--- a/mars/scheduler/operands/common.py
+++ b/mars/scheduler/operands/common.py
@@ -362,7 +362,7 @@ class OperandActor(BaseOperandActor):
             else:
                 six.reraise(*exc_info)
 
-        logger.debug('Applying for resources for operand %r', self._info)
+        logger.debug('Applying for resources for operand %s: %r', self._op_key, self._info)
         # if under retry, give application a delay
         delay = options.scheduler.retry_delay if self.retries else 0
         # Send resource application. Submit job when worker assigned

--- a/mars/scheduler/operands/shuffle.py
+++ b/mars/scheduler/operands/shuffle.py
@@ -165,7 +165,7 @@ class ShuffleProxyActor(BaseOperandActor):
                 continue
             new_mapper_metas = dict()
             for pred_key, meta in self._reducer_to_mapper[op_key].items():
-                meta.workers = [w for w in meta.workers if w not in dead_workers]
+                meta.workers = tuple(w for w in meta.workers if w not in dead_workers)
                 if meta.workers:
                     new_mapper_metas[pred_key] = meta
             self._reducer_to_mapper[op_key] = new_mapper_metas

--- a/mars/worker/spill.py
+++ b/mars/worker/spill.py
@@ -35,6 +35,19 @@ def parse_spill_dirs(dir_str):
     Parse paths from a:b to list while resolving asterisks in path
     """
     import glob
+
+    def _validate_dir(path):
+        try:
+            os.makedirs(path, exist_ok=True)
+            touch_file = os.path.join(path, '.touch')
+            with open(touch_file, 'wb'):
+                pass
+            os.unlink(touch_file)
+            return True
+        except OSError:
+            logger.exception('Fail to access directory %s', path)
+            return False
+
     final_dirs = []
     for pattern in dir_str.split(os.path.pathsep):
         sub_patterns = pattern.split(os.path.sep)
@@ -49,7 +62,7 @@ def parse_spill_dirs(dir_str):
         left_pattern = os.path.sep.join(sub_patterns[:pos + 1])
         for match in glob.glob(left_pattern):
             final_dirs.append(os.path.sep.join([match] + sub_patterns[pos + 1:]))
-    return sorted(final_dirs)
+    return sorted(d for d in final_dirs if _validate_dir(d))
 
 
 def build_spill_file_name(data_key, dirs=None, writing=False):

--- a/mars/worker/spill.py
+++ b/mars/worker/spill.py
@@ -38,13 +38,13 @@ def parse_spill_dirs(dir_str):
 
     def _validate_dir(path):
         try:
-            os.makedirs(path, exist_ok=True)
+            if not os.path.isdir(path):
+                os.makedirs(path)
             touch_file = os.path.join(path, '.touch')
-            with open(touch_file, 'wb'):
-                pass
+            open(touch_file, 'wb').close()
             os.unlink(touch_file)
             return True
-        except OSError:
+        except OSError:  # pragma: no cover
             logger.exception('Fail to access directory %s', path)
             return False
 


### PR DESCRIPTION
## What do these changes do?

Try creating spill directories and test file creation before adding directories as spill targets. This excludes malfunctioning disks from the cluster.

## Related issue number

Fixes #653 
