### PR TITLE
Generate unique key for chunks of mutable tensors which have identical properties

### DIFF
--- a/mars/tensor/utils.py
+++ b/mars/tensor/utils.py
@@ -537,7 +537,6 @@ def create_fetch_tensor(chunk_size, shape, dtype, tensor_key=None, tensor_id=Non
     as well as possible tensor_key, tensor_id and chunk keys.
     """
     from ..config import options
-    from ..utils import tokenize
     from .fetch import TensorFetch
 
     if not isinstance(dtype, np.dtype):
@@ -556,15 +555,11 @@ def create_fetch_tensor(chunk_size, shape, dtype, tensor_key=None, tensor_id=Non
     for chunk_shape, chunk_idx, chunk_key in izip(itertools.product(*chunk_size),
                                                   itertools.product(*chunk_size_idxes),
                                                   chunk_keys):
-        if chunk_key is None:
-            chunk_key = tokenize(uuid.uuid4().hex)
         chunk = fetch_op.copy().reset_key().new_chunk(None, shape=chunk_shape, index=chunk_idx,
-                                                      _key=chunk_key)
+                                                      _key=chunk_key, hex=uuid.uuid4().hex)
         chunks.append(chunk)
-    if tensor_key is None:
-        tensor_key = tokenize(uuid.uuid4().hex)
     return fetch_op.copy().new_tensor(None, shape=shape, dtype=dtype, nsplits=chunk_size,
-                                      chunks=chunks, _key=tensor_key, _id=tensor_id)
+                                      chunks=chunks, _key=tensor_key, _id=tensor_id, hex=uuid.uuid4().hex)
 
 
 def create_mutable_tensor(name, chunk_size, shape, dtype, chunk_keys=None, chunk_eps=None):

--- a/mars/tensor/utils.py
+++ b/mars/tensor/utils.py
@@ -21,6 +21,7 @@ import operator
 import inspect
 import itertools
 from functools import wraps
+import uuid
 
 import numpy as np
 try:
@@ -536,6 +537,7 @@ def create_fetch_tensor(chunk_size, shape, dtype, tensor_key=None, tensor_id=Non
     as well as possible tensor_key, tensor_id and chunk keys.
     """
     from ..config import options
+    from ..utils import tokenize
     from .fetch import TensorFetch
 
     if not isinstance(dtype, np.dtype):
@@ -554,9 +556,13 @@ def create_fetch_tensor(chunk_size, shape, dtype, tensor_key=None, tensor_id=Non
     for chunk_shape, chunk_idx, chunk_key in izip(itertools.product(*chunk_size),
                                                   itertools.product(*chunk_size_idxes),
                                                   chunk_keys):
+        if chunk_key is None:
+            chunk_key = tokenize(uuid.uuid4().hex)
         chunk = fetch_op.copy().reset_key().new_chunk(None, shape=chunk_shape, index=chunk_idx,
                                                       _key=chunk_key)
         chunks.append(chunk)
+    if tensor_key is None:
+        tensor_key = tokenize(uuid.uuid4().hex)
     return fetch_op.copy().new_tensor(None, shape=shape, dtype=dtype, nsplits=chunk_size,
                                       chunks=chunks, _key=tensor_key, _id=tensor_id)
 


### PR DESCRIPTION
## What do these changes do?

As described in #659, we need to generate unique keys for mutable tensor chunks. This pr add a test that can reproduce the problem.

## Related issue number

Fixes #659