### PR TITLE
Raise an error when Python version between client and server is different

### DIFF
--- a/mars/web/__init__.py
+++ b/mars/web/__init__.py
@@ -17,7 +17,7 @@
 from .session import Session
 
 try:
-    from . import api, dashboard, scheduler_pages, task_pages, worker_pages
+    from . import apihandlers, dashboard, scheduler_pages, task_pages, worker_pages
     from .server import MarsWeb
 except ImportError:  # pragma: no cover
     MarsUI = None

--- a/mars/worker/tests/base.py
+++ b/mars/worker/tests/base.py
@@ -72,7 +72,7 @@ class WorkerCase(unittest.TestCase):
 
         options.worker.spill_directory = cls.spill_dir
 
-        cls._plasma_client = plasma.connect(options.worker.plasma_socket, '', 0)
+        cls._plasma_client = plasma.connect(options.worker.plasma_socket)
         cls._kv_store = kvstore.get(options.kv_store)
 
     @classmethod

--- a/mars/worker/tests/test_transfer.py
+++ b/mars/worker/tests/test_transfer.py
@@ -153,7 +153,7 @@ def run_transfer_worker(pool_address, session_id, chunk_keys, spill_dir, msg_que
     # don't use multiple with-statement as we need the options be forked
     with plasma.start_plasma_store(plasma_size) as store_args:
         options.worker.plasma_socket = plasma_socket = store_args[0]
-        plasma_client = plasma.connect(plasma_socket, '', 0)
+        plasma_client = plasma.connect(plasma_socket)
 
         with start_transfer_test_pool(address=pool_address, plasma_size=plasma_size) as pool:
             chunk_holder_ref = pool.actor_ref(ChunkHolderActor.default_uid())
@@ -557,7 +557,7 @@ class Test(WorkerCase):
                             DispatchActor.default_uid(), address=remote_pool_addr)
                         remote_mapper_ref = pool.actor_ref(
                             PlasmaKeyMapActor.default_uid(), address=remote_pool_addr)
-                        remote_plasma_client = plasma.connect(remote_plasma_socket, '', 0)
+                        remote_plasma_client = plasma.connect(remote_plasma_socket)
                         remote_store = PlasmaChunkStore(remote_plasma_client, remote_mapper_ref)
 
                         def _call_send_data(sender_uid):

--- a/mars/worker/utils.py
+++ b/mars/worker/utils.py
@@ -60,7 +60,10 @@ class WorkerActor(WorkerHasClusterInfoActor, PromiseActor):
         from .chunkstore import PlasmaChunkStore, PlasmaKeyMapActor
 
         mapper_ref = self.ctx.actor_ref(uid=PlasmaKeyMapActor.default_uid())
-        self._plasma_client = plasma.connect(options.worker.plasma_socket, '', 0)
+        try:
+            self._plasma_client = plasma.connect(options.worker.plasma_socket)
+        except TypeError:  # pragma: no cover
+            self._plasma_client = plasma.connect(options.worker.plasma_socket, '', 0)
         self._chunk_store = PlasmaChunkStore(self._plasma_client, mapper_ref)
 
     def get_meta_client(self):


### PR DESCRIPTION
## What do these changes do?

When creating web sessions, we validate ``pyver`` arg. If the major version is different, the server side returns 400.

## Related issue number

Fixes #337
