### PR TITLE
Extend the max_buffer_size of tornado server to 4G.

### DIFF
--- a/mars/web/server.py
+++ b/mars/web/server.py
@@ -214,6 +214,7 @@ class MarsWeb(object):
                     handlers, allow_websocket_origin=['*'],
                     address='0.0.0.0', port=use_port,
                     extra_patterns=extra_patterns,
+                    http_server_kwargs={'max_buffer_size': 2 ** 32},
                 )
                 self._server.start()
                 self._port = use_port


### PR DESCRIPTION
## What do these changes do?

The default `max_buffer_size` of the tornado HTTP server is 100M, when constructing dataframes from large pandas dataframes, it will raise `Content-Length too long` error.

This pr enlarge the `max_buffer_size` to 4G.

## Related issue number

Fixes #680.