### PR TITLE
Ensure remaining data removed on session close

### DIFF
--- a/mars/api.py
+++ b/mars/api.py
@@ -182,10 +182,10 @@ class MarsAPI(object):
         future = sender_ref.fetch_data(session_id, chunk_key, index_obj, _wait=False)
         return future
 
-    def delete_data(self, session_id, graph_key, tileable_key):
+    def delete_data(self, session_id, graph_key, tileable_key, wait=False):
         graph_uid = GraphActor.gen_uid(session_id, graph_key)
         graph_ref = self.get_actor_ref(graph_uid)
-        graph_ref.free_tileable_data(tileable_key, _tell=True)
+        graph_ref.free_tileable_data(tileable_key, wait=wait, _tell=not wait)
 
     def get_tileable_nsplits(self, session_id, graph_key, tileable_key):
         # nsplits is essential for operator like `reshape` and shape can be calculated by nsplits

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -854,10 +854,13 @@ class GraphActor(SchedulerActor):
         return self._tileable_key_opid_to_tiled[(key, tid)][-1]
 
     @log_unhandled
-    def free_tileable_data(self, tileable_key):
+    def free_tileable_data(self, tileable_key, wait=False):
         tileable = self._get_tileable_by_key(tileable_key)
+        futures = []
         for chunk in tileable.chunks:
-            self._get_operand_ref(chunk.op.key).free_data(_tell=True)
+            futures.append(self._get_operand_ref(chunk.op.key).free_data(
+                check=False, _tell=not wait, _wait=False))
+        [f.result() for f in futures]
 
     def get_tileable_meta(self, tileable_key):
         """

--- a/mars/scheduler/operands/common.py
+++ b/mars/scheduler/operands/common.py
@@ -257,17 +257,19 @@ class OperandActor(BaseOperandActor):
 
         super(OperandActor, self).move_failover_state(from_states, state, new_target, dead_workers)
 
-    def free_data(self, state=OperandState.FREED):
+    def free_data(self, state=OperandState.FREED, check=True):
         """
         Free output data of current operand
         :param state: target state
+        :param check: ask GraphActor if we can free the data, useful when failover
         """
-        can_be_freed, deterministic = self.check_can_be_freed(state)
-        if not deterministic:
-            self.ref().free_data(state, _delay=1, _tell=True)
-            return
-        elif not can_be_freed:
-            return
+        if check:
+            can_be_freed, deterministic = self.check_can_be_freed(state)
+            if not deterministic:
+                self.ref().free_data(state, _delay=1, _tell=True)
+                return
+            elif not can_be_freed:
+                return
 
         self.start_operand(state)
 

--- a/mars/scheduler/operands/shuffle.py
+++ b/mars/scheduler/operands/shuffle.py
@@ -183,7 +183,7 @@ class ShuffleProxyActor(BaseOperandActor):
         super(ShuffleProxyActor, self).move_failover_state(
             from_states, state, new_target, dead_workers)
 
-    def free_data(self, state=OperandState.FREED):
+    def free_data(self, state=OperandState.FREED, check=True):
         pass
 
 

--- a/mars/tensor/__init__.py
+++ b/mars/tensor/__init__.py
@@ -55,6 +55,7 @@ from . import random
 from . import fft
 from . import linalg
 from . import lib
+from . import special
 
 from .utils import concat_tileable_chunks, get_fetch_op_cls, get_fuse_op_cls
 

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -309,10 +309,7 @@ class Session(object):
         tileable._update_shape(tuple(sum(nsplit) for nsplit in new_nsplits))
         tileable.nsplits = new_nsplits
 
-    def decref(self, *keys, **kwargs):
-        session_url = self._endpoint + '/api/session/' + self._session_id
-        force = kwargs.pop('force', False)
-        wait = kwargs.pop('wait', False)
+    def decref(self, *keys):
         for tileable_key, tileable_id in keys:
             if tileable_key not in self._executed_tileables:
                 continue
@@ -321,11 +318,18 @@ class Session(object):
             if tileable_id in ids:
                 ids.remove(tileable_id)
                 # for those same key tileables, do decref only when all those tileables are garbage collected
-                if len(ids) != 0 and not force:
+                if len(ids) != 0:
                     continue
-                data_url = session_url + '/graph/%s/data/%s?wait=%d' % (graph_key, tileable_key, 1 if wait else 0)
-                self._req_session.delete(data_url)
-                del self._executed_tileables[tileable_key]
+                self.delete_data(tileable_key)
+
+    def delete_data(self, tileable_key, wait=False):
+        if tileable_key not in self._executed_tileables:
+            return
+        graph_key, _ids = self._executed_tileables[tileable_key]
+        data_url = '%s/api/session/%s/graph/%s/data/%s?wait=%d' % \
+                   (self._endpoint, self._session_id, graph_key, tileable_key, 1 if wait else 0)
+        self._req_session.delete(data_url)
+        del self._executed_tileables[tileable_key]
 
     def stop(self, graph_key):
         session_url = self._endpoint + '/api/session/' + self._session_id
@@ -360,11 +364,8 @@ class Session(object):
         return resp_json
 
     def close(self):
-        executed_keys = []
-        for key, value in self._executed_tileables.items():
-            for tid in value[1]:
-                executed_keys.append((key, tid))
-        self.decref(*executed_keys, **dict(force=True, wait=True))
+        for key in list(self._executed_tileables.keys()):
+            self.delete_data(key, wait=True)
         resp = self._req_session.delete(self._endpoint + '/api/session/' + self._session_id)
         if resp.status_code >= 400:
             raise SystemError('Failed to close mars session.')

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -240,6 +240,13 @@ class Test(unittest.TestCase):
                                % (service_ep, TIMELINE_APP_NAME, self.worker_port))
             self.assertEqual(res.status_code, 200)
 
+        # make sure all chunks freed when session quits
+        from mars.worker.chunkholder import ChunkHolderActor
+        actor_client = new_client()
+        holder_ref = actor_client.actor_ref(ChunkHolderActor.default_uid(),
+                                            address='127.0.0.1:' + str(self.worker_port))
+        self.assertFalse(bool(holder_ref.dump_keys()))
+
     def testWebApiException(self):
         def normalize_tbs(tb_lines):
             new_lines = []


### PR DESCRIPTION
# What do these changes do?

Ensure remaining data removed on session delete by waiting all data removed before destroying GraphActor.

## Related issue number

Fixes #689 
