### PR TITLE
Wait for graph to finish instead of querying with fixed intervals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ mars/*.c*
 mars/lib/*.c*
 mars/actors/*.c*
 mars/actors/pool/*.c*
+mars/optimizes/**/*.c*
 mars/scheduler/*.c*
 mars/serialize/*.c*
 mars/worker/*.c*

--- a/mars/actors/pool/gevent_pool.pyx
+++ b/mars/actors/pool/gevent_pool.pyx
@@ -186,6 +186,10 @@ cdef class ActorContext:
                                wait=wait, callback=callback)
 
     @staticmethod
+    def event():
+        return gevent.event.Event()
+
+    @staticmethod
     def sleep(seconds):
         gevent.sleep(seconds)
 
@@ -1654,6 +1658,10 @@ cdef class ActorClient:
         if ref.address is None:
             raise ValueError('address must be provided')
         return ref
+
+    @staticmethod
+    def event():
+        return gevent.event.Event()
 
     @staticmethod
     def sleep(seconds):

--- a/mars/api.py
+++ b/mars/api.py
@@ -147,6 +147,10 @@ class MarsAPI(object):
         state = GraphState(state.lower())
         return state
 
+    def wait_graph_finish(self, session_id, graph_key, timeout=None):
+        graph_meta_ref = self.get_graph_meta_ref(session_id, graph_key)
+        self.actor_client.actor_ref(graph_meta_ref.get_wait_ref()).wait(timeout)
+
     def fetch_data(self, session_id, graph_key, tileable_key, index_obj=None, compressions=None):
         graph_uid = GraphActor.gen_uid(session_id, graph_key)
         graph_ref = self.get_actor_ref(graph_uid)

--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -139,6 +139,8 @@ class LocalDistributedCluster(object):
     def serve_forever(self):
         try:
             self._pool.join()
+        except KeyboardInterrupt:
+            pass
         finally:
             self.stop_service()
 

--- a/mars/tensor/__init__.py
+++ b/mars/tensor/__init__.py
@@ -48,6 +48,7 @@ from .reduction import sum, nansum, prod, prod as product, nanprod, \
     var, std, nanvar, nanstd, nancumsum, nancumprod, count_nonzero, allclose, array_equal
 from .reshape import reshape
 from .merge import concatenate, stack, hstack, vstack, dstack, column_stack
+from .indexing import take, compress, extract, choose, unravel_index, nonzero, flatnonzero
 from .rechunk import rechunk
 from .lib.index_tricks import mgrid, ogrid, ndindex
 

--- a/mars/web/apihandlers.py
+++ b/mars/web/apihandlers.py
@@ -128,8 +128,20 @@ class GraphApiHandler(MarsApiRequestHandler):
     @gen.coroutine
     def get(self, session_id, graph_key):
         from ..scheduler.utils import GraphState
+        wait_timeout = int(self.get_argument('wait_timeout', None))
 
         try:
+            if wait_timeout:
+                executor = futures.ThreadPoolExecutor(1)
+                if wait_timeout <= 0:
+                    wait_timeout = None
+
+                def _wait_fun():
+                    web_api = MarsWebAPI(self._scheduler)
+                    return web_api.wait_graph_finish(session_id, graph_key, wait_timeout)
+
+                _ = yield executor.submit(_wait_fun)
+
             state = self.web_api.get_graph_state(session_id, graph_key)
         except GraphNotExists:
             raise web.HTTPError(404, 'Graph not exists')
@@ -154,7 +166,7 @@ class GraphApiHandler(MarsApiRequestHandler):
             self._dump_exception(sys.exc_info(), 404)
 
 
-class GraphDataHandler(MarsApiRequestHandler):
+class GraphDataApiHandler(MarsApiRequestHandler):
     @gen.coroutine
     def get(self, session_id, graph_key, tileable_key):
         data_type = self.get_argument('type', None)
@@ -198,7 +210,7 @@ class WorkersApiHandler(MarsApiRequestHandler):
             self.write(json.dumps(self.web_api.get_workers_meta()))
 
 
-class MutableTensorHandler(MarsApiRequestHandler):
+class MutableTensorApiHandler(MarsApiRequestHandler):
     def get(self, session_id, name):
         try:
             meta = self.web_api.get_mutable_tensor(session_id, name)
@@ -242,5 +254,5 @@ register_web_handler('/api/session/(?P<session_id>[^/]+)', SessionApiHandler)
 register_web_handler('/api/session/(?P<session_id>[^/]+)/graph', GraphsApiHandler)
 register_web_handler('/api/session/(?P<session_id>[^/]+)/graph/(?P<graph_key>[^/]+)', GraphApiHandler)
 register_web_handler('/api/session/(?P<session_id>[^/]+)/graph/(?P<graph_key>[^/]+)/data/(?P<tileable_key>[^/]+)',
-                     GraphDataHandler)
-register_web_handler('/api/session/(?P<session_id>[^/]+)/mutable-tensor/(?P<name>[^/]+)', MutableTensorHandler)
+                     GraphDataApiHandler)
+register_web_handler('/api/session/(?P<session_id>[^/]+)/mutable-tensor/(?P<name>[^/]+)', MutableTensorApiHandler)

--- a/mars/web/apihandlers.py
+++ b/mars/web/apihandlers.py
@@ -191,8 +191,11 @@ class GraphDataHandler(MarsApiRequestHandler):
 
 class WorkersApiHandler(MarsApiRequestHandler):
     def get(self):
-        workers_num = self.web_api.count_workers()
-        self.write(json.dumps(workers_num))
+        action = self.get_argument('action', None)
+        if action == 'count':
+            self.write(json.dumps(self.web_api.count_workers()))
+        else:
+            self.write(json.dumps(self.web_api.get_workers_meta()))
 
 
 class MutableTensorHandler(MarsApiRequestHandler):

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -384,7 +384,7 @@ class Session(object):
         return True
 
     def count_workers(self):
-        resp = self._req_session.get(self._endpoint + '/api/worker', timeout=1)
+        resp = self._req_session.get(self._endpoint + '/api/worker?action=count', timeout=1)
         return json.loads(resp.text)
 
     def get_task_count(self):

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -93,10 +93,10 @@ class Session(object):
         else:
             self._executed_tileables[tileable_key] = graph_key, {tileable_id}
 
-    def _check_response_finished(self, graph_url):
+    def _check_response_finished(self, graph_url, timeout=None):
         import requests
         try:
-            resp = self._req_session.get(graph_url)
+            resp = self._req_session.get(graph_url, params={'wait_timeout': timeout})
         except requests.ConnectionError as ex:
             err_msg = str(ex)
             if 'ConnectionResetError' in err_msg or 'Connection refused' in err_msg:
@@ -153,16 +153,17 @@ class Session(object):
 
         resp_json = self._submit_graph(graph_json, targets_join, compose=compose)
         graph_key = resp_json['graph_key']
-        graph_url = session_url + '/graph/' + graph_key
+        graph_url = '%s/graph/%s' % (session_url, graph_key)
 
         for t in tileables:
             self._set_tileable_graph_key(t, graph_key)
 
         exec_start_time = time.time()
-        while timeout <= 0 or time.time() - exec_start_time <= timeout:
+        time_elapsed = 0
+        while timeout <= 0 or time_elapsed < timeout:
+            timeout_val = min(5, timeout - time_elapsed) if timeout > 0 else 5
             try:
-                time.sleep(1)
-                if self._check_response_finished(graph_url):
+                if self._check_response_finished(graph_url, timeout_val):
                     break
             except KeyboardInterrupt:
                 resp = self._req_session.delete(graph_url)
@@ -170,9 +171,12 @@ class Session(object):
                     raise ExecutionNotStopped(
                         'Failed to stop graph execution. Code: %d, Reason: %s, Content:\n%s' %
                         (resp.status_code, resp.reason, resp.text))
+            finally:
+                time_elapsed = time.time() - exec_start_time
 
         if 0 < timeout < time.time() - exec_start_time:
             raise TimeoutError
+
         if not fetch:
             return
         else:

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -257,6 +257,14 @@ class Test(unittest.TestCase):
 
         service_ep = 'http://127.0.0.1:' + self.web_port
 
+        # query worker info
+        res = requests.get('%s/api/worker' % service_ep)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(json.loads(res.text)), 1)
+        res = requests.get('%s/api/worker?action=count' % service_ep)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(int(res.text), 1)
+
         # raise on malicious python version
         res = requests.post('%s/api/session' % service_ep, dict(pyver='mal.version'))
         self.assertEqual(res.status_code, 400)

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -327,7 +327,7 @@ class MockedServer(object):
     @staticmethod
     def mocked_requests_get(*arg, **_):
         url = arg[0]
-        if url.endswith('worker'):
+        if '/worker' in url:
             return MockResponse(200, json_text=1)
         if url.split('/')[-2] == 'graph':
             return MockResponse(200, json_text={"state": 'success'})


### PR DESCRIPTION
## What do these changes do?

A GraphWaitActor is created after graph creation. It holds an event object which can be triggered by GraphMetaActor.

## Related issue number

Fixes #700 