### PR TITLE
Separate flags for initials and terminals for operands

### DIFF
--- a/mars/actors/pool/messages.pyx
+++ b/mars/actors/pool/messages.pyx
@@ -538,7 +538,7 @@ cdef inline object _pack_send_message(INT32_t from_index, INT32_t to_index, Acto
     return [message_id, buf] + m
 
 
-cdef inline object _unpack_send_message(bytes binary, send=True):
+cdef inline object _unpack_send_message(bytes binary, bint send=True):
     cdef object message_type
     cdef bytes message_id
     cdef INT32_t from_index
@@ -549,7 +549,7 @@ cdef inline object _unpack_send_message(bytes binary, send=True):
     cdef const char *binary_ptr = binary
 
     _unpack_message_type_value(binary_ptr, &pos)
-    message_type = MessageType.send_all if send else MessageType.tell_all
+    message_type = SEND_ALL if send else TELL_ALL
     message_id = _unpack_message_id(binary_ptr, &pos)
     from_index = _unpack_index(binary_ptr, &pos)
     to_index = _unpack_index(binary_ptr, &pos)
@@ -642,7 +642,7 @@ cpdef object unpack_create_actor_message(bytes binary):
     cdef const char *binary_ptr = binary
 
     _unpack_message_type_value(binary_ptr, &pos)
-    message_type = MessageType.create_actor
+    message_type = CREATE_ACTOR
     message_id = _unpack_message_id(binary_ptr, &pos)
     from_index = _unpack_index(binary_ptr, &pos)
     to_index = _unpack_index(binary_ptr, &pos)

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -26,7 +26,7 @@ import numpy as np
 from .analyzer import GraphAnalyzer
 from .assigner import AssignerActor
 from .kvstore import KVStoreActor
-from .operands import get_operand_actor_class, OperandState, OperandPosition
+from .operands import get_operand_actor_class, OperandState
 from .resource import ResourceActor
 from .session import SessionActor
 from .utils import SchedulerActor, GraphState
@@ -740,16 +740,13 @@ class GraphActor(SchedulerActor):
             else:
                 initial_keys.append(op_key)
                 state = OperandState.READY
+                op_info['is_initial'] = True
             op_info['retries'] = 0
             meta_op_info['state'] = op_info['state'] = state
             meta_op_info['worker'] = op_info.get('worker')
 
-            position = None
             if op_key in self._terminal_chunk_op_tileable:
-                position = OperandPosition.TERMINAL
-            elif not io_meta['predecessors']:
-                position = OperandPosition.INITIAL
-            op_info['position'] = position
+                op_info['is_terminal'] = True
 
             op_cls = get_operand_actor_class(type(op))
             op_uid = op_cls.gen_uid(self._session_id, op_key)

--- a/mars/scheduler/operands/__init__.py
+++ b/mars/scheduler/operands/__init__.py
@@ -14,6 +14,6 @@
 
 from .base import BaseOperandActor
 from .core import register_operand_class, get_operand_actor_class, \
-    OperandState, OperandPosition
+    OperandState
 from .common import OperandActor
 from .shuffle import ShuffleProxyActor

--- a/mars/scheduler/operands/base.py
+++ b/mars/scheduler/operands/base.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 
 from ...errors import WorkerDead
 from ..utils import SchedulerActor
-from .core import OperandState, OperandPosition, rewrite_worker_errors
+from .core import OperandState, rewrite_worker_errors
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,8 @@ class BaseOperandActor(SchedulerActor):
         self._op_key = op_key
         self._op_path = '/sessions/%s/operands/%s' % (self._session_id, self._op_key)
 
-        self._position = op_info.get('position')
+        self._is_initial = op_info.get('is_initial') or False
+        self._is_terminal = op_info.get('is_terminal') or False
         # worker actually assigned
         self._worker = worker
 
@@ -237,7 +238,7 @@ class BaseOperandActor(SchedulerActor):
             for in_key in self._pred_keys:
                 futures.append(self._get_operand_actor(in_key).remove_finished_successor(
                     self._op_key, _tell=True, _wait=False))
-            if self._position == OperandPosition.TERMINAL:
+            if self._is_terminal:
                 for graph_ref in self._graph_refs:
                     futures.append(graph_ref.remove_finished_terminal(
                         self._op_key, _tell=True, _wait=False))

--- a/mars/scheduler/operands/core.py
+++ b/mars/scheduler/operands/core.py
@@ -55,11 +55,6 @@ class OperandState(Enum):
         return self.FINISHED, self.CACHED, self.FREED, self.FATAL, self.CANCELLED
 
 
-class OperandPosition(Enum):
-    INITIAL = 'initial'
-    TERMINAL = 'terminal'
-
-
 @contextlib.contextmanager
 def rewrite_worker_errors(ignore_error=False):
     rewrite = False

--- a/mars/scheduler/tests/integrated/op_delayer.py
+++ b/mars/scheduler/tests/integrated/op_delayer.py
@@ -14,7 +14,7 @@
 
 import os
 
-from mars.scheduler.operands import OperandActor, OperandPosition, ShuffleProxyActor
+from mars.scheduler.operands import OperandActor, ShuffleProxyActor
 from mars.actors.core import register_actor_implementation
 
 
@@ -42,7 +42,7 @@ class DelayedOperandActor(OperandActor):
 
     def _on_finished(self):
         super(DelayedOperandActor, self)._on_finished()
-        if self._position == OperandPosition.TERMINAL:
+        if self._is_terminal:
             _write_state_file('OP_TERMINATE_STATE_FILE')
 
 


### PR DESCRIPTION
## What do these changes do?

Use ``is_terminal`` and ``is_initial`` instead of ``OperandPosition`` enum type, as an operand can be both initial and terminal.

## Related issue number

Fixes #702 
