### PR TITLE
Remove redundant RPC calls for schedulers

### DIFF
--- a/mars/cluster_info.py
+++ b/mars/cluster_info.py
@@ -175,8 +175,10 @@ class HasClusterInfoActor(PromiseActor):
         # cluster_info_actor is created when scheduler initialized
         self._cluster_info_ref = self.ctx.actor_ref(self.cluster_info_uid)
         # when some schedulers lost, notification will be received
-        self._cluster_info_ref.register_observer(self.ref(), set_schedulers_fun_name)
-        self.set_schedulers(self._cluster_info_ref.get_schedulers())
+        self._cluster_info_ref.register_observer(
+            self.ref(), set_schedulers_fun_name, _tell=True, _wait=False)
+        if not self._schedulers:
+            self.set_schedulers(self._cluster_info_ref.get_schedulers())
 
     def get_actor_ref(self, key):
         addr = self.get_scheduler(key)

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -123,7 +123,7 @@ class LocalClusterSession(object):
         graph_key = uuid.uuid4()
 
         # submit graph to local cluster
-        self._api.submit_graph(self._session_id, json.dumps(graph.to_json()),
+        self._api.submit_graph(self._session_id, json.dumps(graph.to_json(), separators=(',', ':')),
                                graph_key, targets, compose=compose)
 
         exec_start_time = time.time()

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import contextlib
 import itertools
 import logging
@@ -412,7 +413,7 @@ class GraphActor(SchedulerActor):
                                                       % (self._session_id, self._graph_key)).value
         else:
             raise GraphNotExists
-        self._chunk_graph_cache = deserialize_graph(chunk_graph_ser, graph_cls=DAG)
+        self._chunk_graph_cache = deserialize_graph(base64.b64decode(chunk_graph_ser), graph_cls=DAG)
 
         op_key_to_chunk = defaultdict(list)
         for n in self._chunk_graph_cache:
@@ -554,7 +555,8 @@ class GraphActor(SchedulerActor):
         if self._kv_store_ref is not None:
             graph_path = '/sessions/%s/graphs/%s' % (self._session_id, self._graph_key)
             self._kv_store_ref.write('%s/chunk_graph' % graph_path,
-                                     serialize_graph(chunk_graph, compress=True), _tell=True, _wait=False)
+                                     base64.b64encode(serialize_graph(chunk_graph, compress=True)),
+                                     _tell=True, _wait=False)
 
         self._chunk_graph_cache = chunk_graph
         for n in self._chunk_graph_cache:

--- a/mars/scheduler/operands/common.py
+++ b/mars/scheduler/operands/common.py
@@ -32,9 +32,10 @@ class OperandActor(BaseOperandActor):
     """
     Actor handling the whole lifecycle of a particular operand instance
     """
+    def __init__(self, session_id, graph_id, op_key, op_info, worker=None, **kwargs):
+        super(OperandActor, self).__init__(
+            session_id, graph_id, op_key, op_info, worker=worker, **kwargs)
 
-    def __init__(self, session_id, graph_id, op_key, op_info, worker=None):
-        super(OperandActor, self).__init__(session_id, graph_id, op_key, op_info, worker=worker)
         io_meta = self._io_meta
         self._input_chunks = io_meta['input_chunks']
         self._chunks = io_meta['chunks']

--- a/mars/web/apihandlers.py
+++ b/mars/web/apihandlers.py
@@ -28,7 +28,7 @@ from ..compat import six, futures
 from ..errors import GraphNotExists
 from ..lib.tblib import pickling_support
 from ..serialize.dataserializer import CompressType
-from ..utils import to_str, numpy_dtype_from_descr_json
+from ..utils import to_str, tokenize, numpy_dtype_from_descr_json
 from .server import MarsWebAPI, MarsRequestHandler, register_web_handler
 
 pickling_support.install()
@@ -84,7 +84,7 @@ class SessionsApiHandler(MarsApiRequestHandler):
         if python_version[0] != sys.version_info[0]:
             raise web.HTTPError(400, reason='Python version not consistent')
 
-        session_id = str(uuid.uuid1())
+        session_id = tokenize(str(uuid.uuid1()))
         self.web_api.create_session(session_id, **args)
         self.write(json.dumps(dict(session_id=session_id)))
 
@@ -117,7 +117,7 @@ class GraphsApiHandler(MarsApiRequestHandler):
             raise web.HTTPError(400, reason='Argument missing')
 
         try:
-            graph_key = str(uuid.uuid4())
+            graph_key = tokenize(str(uuid.uuid4()))
             self.web_api.submit_graph(session_id, graph, graph_key, target, compose)
             self.write(json.dumps(dict(graph_key=graph_key)))
         except:  # noqa: E722

--- a/mars/web/server.py
+++ b/mars/web/server.py
@@ -77,8 +77,13 @@ class MarsRequestHandler(web.RequestHandler):
 
 
 class MarsWebAPI(MarsAPI):
-    def __init__(self, scheduler_ip):
-        super(MarsWebAPI, self).__init__(scheduler_ip)
+    _schedulers_cache = None
+
+    def get_schedulers(self):
+        cls = type(self)
+        if not cls._schedulers_cache:
+            cls._schedulers_cache = self.cluster_info.get_schedulers()
+        return cls._schedulers_cache
 
     def get_tasks_info(self, select_session_id=None):
         from ..scheduler import GraphState
@@ -136,7 +141,7 @@ class MarsWebAPI(MarsAPI):
         session_uid = SessionActor.gen_uid(session_id)
         session_ref = self.get_actor_ref(session_uid)
 
-        index_json_size = np.asscalar(np.frombuffer(body[0:8], dtype=np.int64))
+        index_json_size = np.frombuffer(body[0:8], dtype=np.int64).item()
         index_json = json.loads(body[8:8+index_json_size].decode('ascii'))
         index = Indexes.from_json(index_json).indexes
         if payload_type is None:
@@ -146,7 +151,7 @@ class MarsWebAPI(MarsAPI):
             with pyarrow.BufferReader(body[tensor_chunk_offset:]) as reader:
                 value = pyarrow.read_tensor(reader).to_numpy()
         elif payload_type == 'record_batch':
-            schema_size = np.asscalar(np.frombuffer(body[8+index_json_size:8+index_json_size+8], dtype=np.int64))
+            schema_size = np.frombuffer(body[8+index_json_size:8+index_json_size+8], dtype=np.int64).item()
             schema_offset = 8 + index_json_size + 8
             with pyarrow.BufferReader(body[schema_offset:schema_offset+schema_size]) as reader:
                 schema = pyarrow.read_schema(reader)

--- a/mars/worker/storage/tests/test_sharedstore.py
+++ b/mars/worker/storage/tests/test_sharedstore.py
@@ -35,7 +35,10 @@ class Test(unittest.TestCase):
         with plasma.start_plasma_store(store_size) as (sckt, _), \
                 create_actor_pool(n_process=1, address=test_addr) as pool:
             km_ref = pool.create_actor(PlasmaKeyMapActor, uid=PlasmaKeyMapActor.default_uid())
-            plasma_client = plasma.connect(sckt)
+            try:
+                plasma_client = plasma.connect(sckt)
+            except TypeError:
+                plasma_client = plasma.connect(sckt, '', 0)
             store = PlasmaSharedStore(plasma_client, km_ref)
 
             self.assertGreater(store.get_actual_capacity(store_size), store_size / 2)

--- a/mars/worker/tests/base.py
+++ b/mars/worker/tests/base.py
@@ -91,7 +91,10 @@ class WorkerCase(unittest.TestCase):
 
         options.worker.spill_directory = cls.spill_dir
 
-        cls._plasma_client = plasma.connect(options.worker.plasma_socket)
+        try:
+            cls._plasma_client = plasma.connect(options.worker.plasma_socket)
+        except TypeError:
+            cls._plasma_client = plasma.connect(options.worker.plasma_socket, '', 0)
         cls._kv_store = kvstore.get(options.kv_store)
 
     @classmethod


### PR DESCRIPTION
##  What do these changes do?

This PR reduces RPC calls for schedulers in three occasions:

1. When session_manager is not needed, we do not create reference for it.
2. Cache schedulers as static variable for Web APIs.
3. Pass schedulers to operands and avoid massive queries for schedulers.

## Related issue number

Fixes #704 
