### PR TITLE
Submit initial operands together in one RPC call

### DIFF
--- a/mars/base_app.py
+++ b/mars/base_app.py
@@ -223,6 +223,8 @@ class BaseApplication(object):
                                 stopped.append(idx)
                         if stopped:
                             self.handle_process_down(stopped)
+                except KeyboardInterrupt:
+                    pass
                 finally:
                     self.stop()
         finally:

--- a/mars/config.py
+++ b/mars/config.py
@@ -293,6 +293,7 @@ default_options = Config()
 default_options.register_option('tcp_timeout', 30, validator=is_integer)
 default_options.register_option('verbose', False, validator=is_bool)
 default_options.register_option('kv_store', ':inproc:', validator=is_string)
+default_options.register_option('check_interval', 20, validator=is_integer)
 
 # the number of combined chunks in tree reduction or tree add
 default_options.register_option('combine_size', 4, validator=is_integer, serialize=True)

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -129,7 +129,7 @@ class LocalClusterSession(object):
         exec_start_time = time.time()
         time_elapsed = 0
         while timeout <= 0 or time_elapsed < timeout:
-            timeout_val = min(5, timeout - time_elapsed) if timeout > 0 else 5
+            timeout_val = min(20, timeout - time_elapsed) if timeout > 0 else 20
             self._api.wait_graph_finish(self._session_id, graph_key, timeout=timeout_val)
             graph_state = self._api.get_graph_state(self._session_id, graph_key)
             if graph_state == GraphState.SUCCEEDED:

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -21,9 +21,10 @@ from numbers import Integral
 
 from ...api import MarsAPI
 from ...compat import TimeoutError  # pylint: disable=W0622
+from ...config import options
+from ...errors import ExecutionFailed
 from ...scheduler.graph import GraphState
 from ...serialize import dataserializer
-from ...errors import ExecutionFailed
 from ...utils import build_graph, sort_dataframe_result
 
 
@@ -128,8 +129,9 @@ class LocalClusterSession(object):
 
         exec_start_time = time.time()
         time_elapsed = 0
+        check_interval = options.check_interval
         while timeout <= 0 or time_elapsed < timeout:
-            timeout_val = min(20, timeout - time_elapsed) if timeout > 0 else 20
+            timeout_val = min(check_interval, timeout - time_elapsed) if timeout > 0 else check_interval
             self._api.wait_graph_finish(self._session_id, graph_key, timeout=timeout_val)
             graph_state = self._api.get_graph_state(self._session_id, graph_key)
             if graph_state == GraphState.SUCCEEDED:

--- a/mars/promise.py
+++ b/mars/promise.py
@@ -490,9 +490,10 @@ class PromiseActor(FunctionActor):
         Tell promise results to the caller
         :param callback: promise callback
         """
+        wait = kwargs.pop('_wait', False)
         uid, address = callback[0]
         callback_args = callback[1:] + args + (kwargs, )
-        self.ctx.actor_ref(uid, address=address).tell(callback_args)
+        return self.ctx.actor_ref(uid, address=address).tell(callback_args, wait=wait)
 
     def handle_promise(self, promise_id, *args, **kwargs):
         """

--- a/mars/resource.py
+++ b/mars/resource.py
@@ -73,7 +73,10 @@ def virtual_memory():
         # see section 5.5 in https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
         cgroup_mem_info = _read_cgroup_stat_file()
         total = cgroup_mem_info['hierarchical_memory_limit']
-        used = cgroup_mem_info['cache'] + cgroup_mem_info['rss'] + cgroup_mem_info.get('swap', 0)
+        used = cgroup_mem_info['rss'] + cgroup_mem_info.get('swap', 0)
+        if _shm_path:
+            shm_stats = psutil.disk_usage(_shm_path)
+            used += shm_stats.used
         available = free = total - used
         percent = 100.0 * (total - available) / total
         return _virt_memory_stat(total, available, percent, used, free)

--- a/mars/scheduler/assigner.py
+++ b/mars/scheduler/assigner.py
@@ -25,6 +25,7 @@ from .. import promise
 from ..config import options
 from ..errors import DependencyMissing
 from ..utils import log_unhandled
+from .operands import BaseOperandActor
 from .resource import ResourceActor
 from .utils import SchedulerActor
 
@@ -148,6 +149,13 @@ class AssignerActor(SchedulerActor):
             self._refresh_worker_metrics()
         return [w for w in workers if w in self._worker_metrics] if self._worker_metrics else []
 
+    def _enqueue_operand(self, session_id, op_key, op_info, callback=None):
+        priority_item = ChunkPriorityItem(session_id, op_key, op_info, callback)
+        if priority_item.target_worker not in self._worker_metrics:
+            priority_item.target_worker = None
+        self._requests[op_key] = priority_item
+        heapq.heappush(self._req_heap, priority_item)
+
     @promise.reject_on_exception
     @log_unhandled
     def apply_for_resource(self, session_id, op_key, op_info, callback=None):
@@ -159,12 +167,17 @@ class AssignerActor(SchedulerActor):
         :param callback: promise callback, called when the resource is assigned
         """
         self._refresh_worker_metrics()
+        self._enqueue_operand(session_id, op_key, op_info, callback)
+        logger.debug('Operand %s enqueued', op_key)
+        self._actual_ref.allocate_top_resources(_tell=True)
 
-        priority_item = ChunkPriorityItem(session_id, op_key, op_info, callback)
-        if priority_item.target_worker not in self._worker_metrics:
-            priority_item.target_worker = None
-        self._requests[op_key] = priority_item
-        heapq.heappush(self._req_heap, priority_item)
+    @log_unhandled
+    def apply_for_multiple_resources(self, session_id, applications):
+        self._refresh_worker_metrics()
+        logger.debug('%d operands applied for session %s', len(applications), session_id)
+        for app in applications:
+            op_key, op_info = app
+            self._enqueue_operand(session_id, op_key, op_info)
         self._actual_ref.allocate_top_resources(_tell=True)
 
     @log_unhandled
@@ -274,10 +287,11 @@ class AssignEvaluationActor(SchedulerActor):
             try:
                 alloc_ep, rejects = self._allocate_resource(
                     item.session_id, item.op_key, item.op_info, item.target_worker,
-                    reject_workers=reject_workers, callback=item.callback)
+                    reject_workers=reject_workers)
             except:  # noqa: E722
                 logger.exception('Unexpected error occurred in %s', self.uid)
-                self.tell_promise(item.callback, *sys.exc_info(), **dict(_accept=False))
+                if item.callback:  # pragma: no branch
+                    self.tell_promise(item.callback, *sys.exc_info(), **dict(_accept=False))
                 continue
 
             # collect workers failed to assign operand to
@@ -293,7 +307,7 @@ class AssignEvaluationActor(SchedulerActor):
             self._assigner_ref.extend(unassigned)
 
     @log_unhandled
-    def _allocate_resource(self, session_id, op_key, op_info, target_worker=None, reject_workers=None, callback=None):
+    def _allocate_resource(self, session_id, op_key, op_info, target_worker=None, reject_workers=None):
         """
         Allocate resource for single operand
         :param session_id: session id
@@ -301,20 +315,19 @@ class AssignEvaluationActor(SchedulerActor):
         :param op_info: operand info dict
         :param target_worker: worker to allocate, can be None
         :param reject_workers: workers denied to assign to
-        :param callback: promise callback from operands
         """
         if target_worker not in self._worker_metrics:
             target_worker = None
 
         reject_workers = reject_workers or set()
 
-        op_io_meta = op_info['io_meta']
+        op_io_meta = op_info.get('io_meta', {})
         try:
             input_metas = op_io_meta['input_data_metas']
             input_data_keys = list(input_metas.keys())
             input_sizes = dict((k, v.chunk_size) for k, v in input_metas.items())
         except KeyError:
-            input_data_keys = op_io_meta['input_chunks']
+            input_data_keys = op_io_meta.get('input_chunks', {})
 
             input_metas = self._get_chunks_meta(session_id, input_data_keys)
             if any(m is None for m in input_metas.values()):
@@ -339,12 +352,15 @@ class AssignEvaluationActor(SchedulerActor):
             if self._resource_ref.allocate_resource(session_id, op_key, worker_ep, alloc_dict):
                 logger.debug('Operand %s(%s) allocated to run in %s', op_key, op_info['op_name'], worker_ep)
 
-                self.tell_promise(callback, worker_ep, input_sizes)
+                self.get_actor_ref(BaseOperandActor.gen_uid(session_id, op_key)) \
+                    .submit_to_worker(worker_ep, input_sizes, _tell=True, _wait=False)
                 return worker_ep, rejects
             rejects.append(worker_ep)
         return None, rejects
 
     def _get_chunks_meta(self, session_id, keys):
+        if not keys:
+            return dict()
         return dict(zip(keys, self.chunk_meta.batch_get_chunk_meta(session_id, keys)))
 
     def _get_eps_by_worker_locality(self, input_keys, chunk_workers, input_sizes):

--- a/mars/scheduler/chunkmeta.py
+++ b/mars/scheduler/chunkmeta.py
@@ -18,7 +18,7 @@ import os
 from collections import defaultdict
 
 from .kvstore import KVStoreActor
-from .utils import SchedulerActor
+from .utils import SchedulerActor, CombinedFutureWaiter
 from ..compat import PY27, OrderedDict3
 from ..config import options
 from ..utils import BlacklistSet
@@ -558,6 +558,8 @@ class ChunkMetaClient(object):
             )
         if _wait:
             [f.result() for f in futures]
+        else:
+            return CombinedFutureWaiter(futures)
 
     def delete_meta(self, session_id, chunk_key, _tell=False, _wait=True):
         query_key = (session_id, chunk_key)

--- a/mars/scheduler/operands/base.py
+++ b/mars/scheduler/operands/base.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import logging
 from collections import defaultdict
 
@@ -33,7 +32,7 @@ class BaseOperandActor(SchedulerActor):
         super(BaseOperandActor, self).__init__()
         self._session_id = session_id
         self._graph_ids = [graph_id]
-        op_info = self._info = copy.deepcopy(op_info)
+        self._info = op_info
         self._op_key = op_key
         self._op_path = '/sessions/%s/operands/%s' % (self._session_id, self._op_key)
 
@@ -92,6 +91,8 @@ class BaseOperandActor(SchedulerActor):
 
         if self._with_kvstore:
             self._kv_store_ref = self.ctx.actor_ref(KVStoreActor.default_uid())
+
+        self.ref().start_operand(_tell=True)
 
     @property
     def state(self):

--- a/mars/scheduler/operands/common.py
+++ b/mars/scheduler/operands/common.py
@@ -58,6 +58,8 @@ class OperandActor(BaseOperandActor):
         self._input_worker_scores = dict()
         self._worker_scores = dict()
 
+        self._submitted = self._is_initial
+
     @property
     def retries(self):
         return self._retries
@@ -105,7 +107,7 @@ class OperandActor(BaseOperandActor):
             # all predecessors done, the operand can be executed now
             self.start_operand(OperandState.READY)
             return True
-        self.update_demand_depths(self._info.get('optimize', {}).get('depth', 0))
+        self.ref().update_demand_depths(self._info.get('optimize', {}).get('depth', 0), _tell=True)
         return False
 
     def add_finished_successor(self, op_key, worker):
@@ -256,6 +258,7 @@ class OperandActor(BaseOperandActor):
                                  self._op_key, self._target_worker)
                     return
 
+        self._submitted = False
         super(OperandActor, self).move_failover_state(from_states, state, new_target, dead_workers)
 
     def free_data(self, state=OperandState.FREED, check=True):
@@ -318,43 +321,43 @@ class OperandActor(BaseOperandActor):
         return target_predicts
 
     @log_unhandled
+    def submit_to_worker(self, worker, data_sizes):
+        # worker assigned, submit job
+        if self.state in (OperandState.CANCELLED, OperandState.CANCELLING):
+            self.start_operand()
+            return
+
+        self.worker = worker
+
+        target_predicts = self._get_target_predicts(worker)
+        try:
+            input_metas = self._io_meta['input_data_metas']
+            input_chunks = [k[0] if isinstance(k, tuple) else k for k in input_metas]
+        except KeyError:
+            input_chunks = self._input_chunks
+
+        # submit job
+        if 'input_data_metas' not in self._io_meta and self._executable_dag is not None:
+            exec_graph = self._executable_dag
+        else:
+            exec_graph = self._graph_refs[0].get_executable_operand_dag(self._op_key, input_chunks)
+        self._execution_ref = self._get_execution_ref()
+        try:
+            with rewrite_worker_errors():
+                self._execution_ref.execute_graph(
+                    self._session_id, self._op_key, exec_graph, self._io_meta, data_sizes,
+                    send_addresses=target_predicts, _tell=True)
+        except WorkerDead:
+            logger.debug('Worker %s dead when submitting operand %s into queue',
+                         worker, self._op_key)
+            self._resource_ref.detach_dead_workers([worker], _tell=True)
+        else:
+            self.start_operand(OperandState.RUNNING)
+
+    @log_unhandled
     def _on_ready(self):
         self.worker = None
         self._execution_ref = None
-
-        @log_unhandled
-        def _submit_job(worker, data_sizes):
-            # worker assigned, submit job
-            if self.state in (OperandState.CANCELLED, OperandState.CANCELLING):
-                self.start_operand()
-                return
-
-            self.worker = worker
-
-            target_predicts = self._get_target_predicts(worker)
-            try:
-                input_metas = self._io_meta['input_data_metas']
-                input_chunks = [k[0] if isinstance(k, tuple) else k for k in input_metas]
-            except KeyError:
-                input_chunks = self._input_chunks
-
-            # submit job
-            if 'input_data_metas' not in self._io_meta and self._executable_dag is not None:
-                exec_graph = self._executable_dag
-            else:
-                exec_graph = self._graph_refs[0].get_executable_operand_dag(self._op_key, input_chunks)
-            self._execution_ref = self._get_execution_ref()
-            try:
-                with rewrite_worker_errors():
-                    self._execution_ref.execute_graph(
-                        self._session_id, self._op_key, exec_graph, self._io_meta, data_sizes,
-                        send_addresses=target_predicts, _promise=True)
-            except WorkerDead:
-                logger.debug('Worker %s dead when submitting operand %s into queue',
-                             worker, self._op_key)
-                self._resource_ref.detach_dead_workers([worker], _tell=True)
-            else:
-                self.start_operand(OperandState.RUNNING)
 
         def _apply_fail(*exc_info):
             if issubclass(exc_info[0], DependencyMissing):
@@ -365,13 +368,13 @@ class OperandActor(BaseOperandActor):
             else:
                 six.reraise(*exc_info)
 
-        logger.debug('Applying for resources for operand %s: %r', self._op_key, self._info)
         # if under retry, give application a delay
         delay = options.scheduler.retry_delay if self.retries else 0
         # Send resource application. Submit job when worker assigned
-        self._assigner_ref.apply_for_resource(
-            self._session_id, self._op_key, self._info, _delay=delay, _promise=True) \
-            .then(_submit_job, _apply_fail)
+        if not self._submitted:
+            self._assigner_ref.apply_for_resource(
+                self._session_id, self._op_key, self._info, _delay=delay, _promise=True) \
+                .catch(_apply_fail)
 
     @log_unhandled
     def _on_running(self):
@@ -379,6 +382,7 @@ class OperandActor(BaseOperandActor):
 
         @log_unhandled
         def _acceptor(data_sizes):
+            self._submitted = False
             if not self._is_worker_alive():
                 return
             self._resource_ref.deallocate_resource(self._session_id, self._op_key, self.worker, _tell=True)
@@ -389,6 +393,7 @@ class OperandActor(BaseOperandActor):
 
         @log_unhandled
         def _rejecter(*exc):
+            self._submitted = False
             # handling exception occurrence of operand execution
             exc_type = exc[0]
             self._resource_ref.deallocate_resource(self._session_id, self._op_key, self.worker, _tell=True)

--- a/mars/scheduler/tests/test_graph.py
+++ b/mars/scheduler/tests/test_graph.py
@@ -44,7 +44,7 @@ class Test(unittest.TestCase):
                               uid=SchedulerClusterInfoActor.default_uid())
             resource_ref = pool.create_actor(ResourceActor, uid=ResourceActor.default_uid())
             pool.create_actor(ChunkMetaActor, uid=ChunkMetaActor.default_uid())
-            pool.create_actor(AssignerActor, uid=AssignerActor.default_uid())
+            pool.create_actor(AssignerActor, uid=AssignerActor.gen_uid(session_id))
             graph_ref = pool.create_actor(GraphActor, session_id, graph_key, serialized_graph,
                                           uid=GraphActor.gen_uid(session_id, graph_key))
 
@@ -189,7 +189,7 @@ class Test(unittest.TestCase):
                               uid=SchedulerClusterInfoActor.default_uid())
             resource_ref = pool.create_actor(ResourceActor, uid=ResourceActor.default_uid())
             pool.create_actor(ChunkMetaActor, uid=ChunkMetaActor.default_uid())
-            pool.create_actor(AssignerActor, uid=AssignerActor.default_uid())
+            pool.create_actor(AssignerActor, uid=AssignerActor.gen_uid(session_id))
 
             resource_ref.set_worker_meta('localhost:12345', dict(hardware=dict(cpu_total=4)))
             resource_ref.set_worker_meta('localhost:23456', dict(hardware=dict(cpu_total=4)))

--- a/mars/scheduler/utils.py
+++ b/mars/scheduler/utils.py
@@ -62,6 +62,14 @@ class SchedulerActor(SchedulerHasClusterInfoActor, PromiseActor):
             return self._chunk_meta_client
 
 
+class CombinedFutureWaiter(object):
+    def __init__(self, futures):
+        self._futures = futures
+
+    def result(self):
+        return [f.result() for f in self._futures]
+
+
 if six.PY3:
     def array_to_bytes(typecode, initializer):
         return array.array(typecode, initializer).tobytes()

--- a/mars/tests/test_resource.py
+++ b/mars/tests/test_resource.py
@@ -97,16 +97,19 @@ class Test(unittest.TestCase):
             f.write(_memory_stat_content)
 
         old_stat_file = resource.CGROUP_MEM_STAT_FILE
+        old_shm_path = resource._shm_path
         try:
             os.environ['MARS_MEM_USE_CGROUP_STAT'] = '1'
             resource = reload_module(resource)
             resource.CGROUP_MEM_STAT_FILE = mem_stat_path
+            resource._shm_path = None
 
             mem_stats = resource.virtual_memory()
             self.assertEqual(mem_stats.total, 1073741824)
-            self.assertEqual(mem_stats.used, 707457024)
+            self.assertEqual(mem_stats.used, 218181632)
         finally:
             resource.CGROUP_MEM_STAT_FILE = old_stat_file
+            resource._shm_path = old_shm_path
             del os.environ['MARS_MEM_USE_CGROUP_STAT']
             os.unlink(mem_stat_path)
             reload_module(resource)

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -161,7 +161,7 @@ class Session(object):
         exec_start_time = time.time()
         time_elapsed = 0
         while timeout <= 0 or time_elapsed < timeout:
-            timeout_val = min(5, timeout - time_elapsed) if timeout > 0 else 5
+            timeout_val = min(20, timeout - time_elapsed) if timeout > 0 else 20
             try:
                 if self._check_response_finished(graph_url, timeout_val):
                     break

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -24,9 +24,10 @@ import uuid
 import numpy as np
 
 from ..compat import six, TimeoutError  # pylint: disable=W0622
-from ..serialize import dataserializer
+from ..config import options
 from ..errors import ResponseMalformed, ExecutionInterrupted, ExecutionFailed, \
     ExecutionStateUnknown, ExecutionNotStopped
+from ..serialize import dataserializer
 from ..tensor.core import Indexes
 from ..utils import build_graph, sort_dataframe_result, numpy_dtype_from_descr_json
 
@@ -160,8 +161,9 @@ class Session(object):
 
         exec_start_time = time.time()
         time_elapsed = 0
+        check_interval = options.check_interval
         while timeout <= 0 or time_elapsed < timeout:
-            timeout_val = min(20, timeout - time_elapsed) if timeout > 0 else 20
+            timeout_val = min(check_interval, timeout - time_elapsed) if timeout > 0 else check_interval
             try:
                 if self._check_response_finished(graph_url, timeout_val):
                     break

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -173,6 +173,8 @@ class ExecutionActor(WorkerActor):
         self.ref().periodical_dump(_tell=True, _delay=10)
 
     def _pin_data_keys(self, session_id, graph_key, data_keys):
+        if not data_keys:
+            return
         try:
             graph_record = self._graph_records[(session_id, graph_key)]
         except KeyError:
@@ -864,7 +866,9 @@ class ExecutionActor(WorkerActor):
         query_key = (session_id, graph_key)
         callbacks = self._graph_records[query_key].finish_callbacks
         args, kwargs = self._result_cache[query_key].build_args()
+
         logger.debug('Send finish callback for graph %s into %d targets', graph_key, len(callbacks))
+        kwargs['_wait'] = False
         for cb in callbacks:
             self.tell_promise(cb, *args, **kwargs)
         self._cleanup_graph(session_id, graph_key)


### PR DESCRIPTION
## What do these changes do?

Collect initial operands and submit them to AssignerActor in a batch when starting graphs.

## Related issue number

Fixes #710 
