### PR TITLE
Access column using __getattr__ syntax for DataFrame.

### DIFF
--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -687,6 +687,15 @@ class DataFrame(TileableEntity):
     def __mars_tensor__(self, dtype=None, order='K'):
         return self._data.to_tensor().astype(dtype=dtype, order=order, copy=False)
 
+    def __getattr__(self, key):
+        try:
+            return getattr(self._data, key)
+        except AttributeError:
+            if key in self.dtypes:
+                return self[key]
+            else:
+                raise
+
 
 INDEX_TYPE = (Index, IndexData)
 INDEX_CHUNK_TYPE = (IndexChunk, IndexChunkData)

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -133,7 +133,7 @@ class Test(TestBase):
 
         # accessing non-existing attributes should trigger exception
         with self.assertRaises(AttributeError):
-            df.zzz
+            _ = df.zzz
 
     def testSeriesGetitem(self):
         data = pd.Series(np.random.rand(10))

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -119,6 +119,22 @@ class Test(TestBase):
         series3 = df['c1'][0]
         self.assertEqual(series3.execute(), data['c1'][0])
 
+    def testDataFrameGetitemUsingAttr(self):
+        data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'key', 'dtypes', 'size'])
+        df = md.DataFrame(data, chunk_size=2)
+
+        series1 = df.c2
+        pd.testing.assert_series_equal(series1.execute(), data.c2)
+
+        # accessing column using attribute shouldn't overwrite existing attributes
+        self.assertEqual(df.key, getattr(getattr(df, '_data'), '_key'))
+        self.assertEqual(df.size, data.size)
+        pd.testing.assert_series_equal(df.dtypes, data.dtypes)
+
+        # accessing non-existing attributes should trigger exception
+        with self.assertRaises(AttributeError):
+            df.zzz
+
     def testSeriesGetitem(self):
         data = pd.Series(np.random.rand(10))
         series = md.Series(data)


### PR DESCRIPTION
## What do these changes do?

This PR is the subsequent work for #682, which implements the `__getitem__` for `DataFrame`. Pandas also support accessing columns using the column names, and this PR fills the missing part.

Test cases are also added to ensure column names don't overwrite existing `DataFrame` attributes.

## Related issue number

Improve #625.