### PR TITLE
Add lock free option for workers

### DIFF
--- a/mars/config.py
+++ b/mars/config.py
@@ -336,6 +336,7 @@ default_options.register_option('worker.transfer_block_size', 1 * 1024 ** 2, val
 default_options.register_option('worker.transfer_compression', 'lz4', validator=is_string, serialize=True)
 default_options.register_option('worker.prepare_data_timeout', 600, validator=is_integer)
 default_options.register_option('worker.peer_blacklist_time', 3600, validator=is_numeric, serialize=True)
+default_options.register_option('worker.lock_free_fileio', False, validator=is_bool, serialize=True)
 
 default_options.register_option('worker.plasma_socket', '/tmp/plasma', validator=is_string)
 

--- a/mars/worker/__main__.py
+++ b/mars/worker/__main__.py
@@ -47,6 +47,8 @@ class WorkerApplication(BaseApplication):
         parser.add_argument('--cache-mem', help='cache memory size limit')
         parser.add_argument('--min-mem', help='minimal free memory required to start worker')
         parser.add_argument('--spill-dir', help='spill directory')
+        parser.add_argument('--lock-free-fileio', action='store_true',
+                            help='make file io lock free, add this when using a mounted dfs')
         parser.add_argument('--plasma-dir', help='path of plasma directory. When specified, the size '
                                                  'of plasma store will not be taken into account when '
                                                  'managing host memory')
@@ -78,11 +80,14 @@ class WorkerApplication(BaseApplication):
         # and distribute them over processes
 
         plasma_dir = self.args.plasma_dir or os.environ.get('MARS_PLASMA_DIRS')
+        lock_free_fileio = self.args.lock_free_fileio \
+            or bool(int(os.environ.get('MARS_LOCK_FREE_FILEIO', '0')))
         self._service = WorkerService(
             advertise_addr=self.args.advertise,
             n_cpu_process=self.args.cpu_procs,
             n_net_process=self.args.net_procs or self.args.io_procs,
             spill_dirs=self.args.spill_dir or os.environ.get('MARS_SPILL_DIRS'),
+            lock_free_fileio=lock_free_fileio,
             total_mem=self.args.phy_mem,
             cache_mem_limit=self.args.cache_mem or os.environ.get('MARS_CACHE_MEM_SIZE'),
             ignore_avail_mem=self.args.ignore_avail_mem,

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -83,6 +83,7 @@ class WorkerService(object):
             options.worker.disk_compression
         options.worker.transfer_compression = kwargs.pop('transfer_compression', None) or \
             options.worker.transfer_compression
+        options.worker.lock_free_fileio = kwargs.pop('lock_free_fileio', None) or False
 
         self._total_mem = kwargs.pop('total_mem', None)
         self._cache_mem_limit = kwargs.pop('cache_mem_limit', None)

--- a/mars/worker/storage/tests/test_client.py
+++ b/mars/worker/storage/tests/test_client.py
@@ -22,6 +22,7 @@ from numpy.testing import assert_allclose
 
 from mars import promise
 from mars.actors import create_actor_pool
+from mars.config import options
 from mars.errors import StorageFull
 from mars.serialize import dataserializer
 from mars.tests.core import patch_method
@@ -32,9 +33,14 @@ from mars.worker.storage import *
 
 
 class Test(WorkerCase):
+    def tearDown(self):
+        options.worker.lock_free_fileio = False
+        super(Test, self).tearDown()
+
     def testClientReadAndWrite(self):
         test_addr = '127.0.0.1:%d' % get_next_port()
         with create_actor_pool(n_process=1, address=test_addr) as pool:
+            options.worker.lock_free_fileio = True
             pool.create_actor(
                 WorkerDaemonActor, uid=WorkerDaemonActor.default_uid())
             storage_manager_ref = pool.create_actor(


### PR DESCRIPTION
## What do these changes do?

Allow running workers without locks on file systems, useful when the path is a distributed FS.

## Related issue number

Fixes #715 