### PR TITLE
[WIP]Fix mt.concatenate on sealed mutable tensor

### DIFF
--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -550,6 +550,9 @@ class GraphActor(SchedulerActor):
             for n in tileable_key_opid_to_tiled[(tk, topid)][-1].chunks:
                 self._terminal_chunk_op_tileable[n.op.key].add(tk)
                 self._target_tileable_chunk_ops[tk].add(n.op.key)
+                # treat fetch chunks (from sealed mutable tensor) as executed, see GH#713
+                if isinstance(n.op, Fetch):
+                    self._target_tileable_finished[tk].add(n.op.key)
 
         # sync chunk graph to kv store
         if self._kv_store_ref is not None:

--- a/mars/scheduler/session.py
+++ b/mars/scheduler/session.py
@@ -148,8 +148,10 @@ class SessionActor(SchedulerActor):
                                           state=GraphState.SUCCEEDED, final_state=GraphState.SUCCEEDED,
                                           uid=graph_uid, address=graph_addr)
         self._graph_refs[graph_key] = graph_ref
-        self._graph_meta_refs[graph_key] = self.ctx.actor_ref(
+        graph_meta_ref = self.ctx.actor_ref(
             GraphMetaActor.gen_uid(self._session_id, graph_key), address=tensor_ref.__getstate__()[0])
+        self._graph_meta_refs[graph_key] = graph_meta_ref
+        graph_meta_ref.set_state(GraphState.SUCCEEDED)
 
         # Add the tensor to the GraphActor
         graph_ref.add_fetch_tileable(tensor_key, tensor_id, shape, dtype, chunk_size, chunk_keys)

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -244,7 +244,7 @@ class Session(object):
             exc_info = pickle.loads(base64.b64decode(resp_json['exc_info']))
             six.reraise(*exc_info)
         shape, dtype, chunk_size, chunk_keys, chunk_eps = json.loads(resp.text)
-        return create_mutable_tensor(name, chunk_size, shape, numpy_dtype_from_descr_json(dtype),
+        return create_mutable_tensor(name, chunk_size, tuple(shape), numpy_dtype_from_descr_json(dtype),
                                      chunk_keys, chunk_eps)
 
     def get_mutable_tensor(self, name):
@@ -257,7 +257,7 @@ class Session(object):
             exc_info = pickle.loads(base64.b64decode(resp_json['exc_info']))
             six.reraise(*exc_info)
         shape, dtype, chunk_size, chunk_keys, chunk_eps = json.loads(resp.text)
-        return create_mutable_tensor(name, chunk_size, shape, numpy_dtype_from_descr_json(dtype),
+        return create_mutable_tensor(name, chunk_size, tuple(shape), numpy_dtype_from_descr_json(dtype),
                                      chunk_keys, chunk_eps)
 
     def write_mutable_tensor(self, tensor, index, value):
@@ -305,7 +305,7 @@ class Session(object):
 
         # # Construct Tensor on the fly.
         shape, dtype, chunk_size, chunk_keys, _ = tensor_meta
-        return create_fetch_tensor(chunk_size, shape, numpy_dtype_from_descr_json(dtype),
+        return create_fetch_tensor(chunk_size, tuple(shape), numpy_dtype_from_descr_json(dtype),
                                    tensor_key=tensor_key, chunk_keys=chunk_keys)
 
     def _update_tileable_shape(self, tileable):


### PR DESCRIPTION
## What do these changes do?

When sealing mutable tensors `TensorFetch` chunks are generated. When execting `mt.concatenate` on sealed mutable tensor, `TensorFetch` chunks are direct dependencies of the target op, however `Fetch` chunks are not added to chunk graph and no operand actor is created for it. Then the `Fetch` chunks won't be added to finished chunk set for the target tileable. Thus the bug.

This pr adds `Fetch` chunks to finished chunk sets when preparing graph. This pr also includes some improvements (not related to the original bug).

## Related issue number

Fixes #713