### PR TITLE
Fix incorrect chunk shape in QR decomposition

### DIFF
--- a/mars/tensor/linalg/core.py
+++ b/mars/tensor/linalg/core.py
@@ -139,9 +139,10 @@ class TSQR(object):
         stage2_q_chunks = []
         for c, s in zip(stage1_q_chunks, q_slices):
             slice_op = TensorSlice(slices=[s], dtype=c.dtype)
+            slice_length = s.stop - (s.start or 0)
             stage2_q_chunks.append(slice_op.new_chunk([stage2_q_chunk], index=c.index,
                                                       order=TensorOrder.C_ORDER,
-                                                      shape=(c.shape[0], stage2_q_chunk.shape[1])))
+                                                      shape=(slice_length, stage2_q_chunk.shape[1])))
         stage3_q_chunks = []
         for c1, c2 in izip(stage1_q_chunks, stage2_q_chunks):
             dot_op = TensorDot(dtype=q_dtype)

--- a/mars/tensor/linalg/tests/test_linalg.py
+++ b/mars/tensor/linalg/tests/test_linalg.py
@@ -42,6 +42,27 @@ class Test(unittest.TestCase):
         self.assertEqual(q.nsplits, ((3, 3, 3), (6,)))
         self.assertEqual(r.nsplits, ((6,), (6,)))
 
+        self.assertEqual(q.chunks[0].shape, (3, 6))
+        self.assertEqual(q.chunks[0].inputs[0].shape, (3, 3))
+        self.assertEqual(q.chunks[0].inputs[1].shape, (3, 6))
+
+        a = mt.random.rand(18, 6, chunk_size=(9, 6))
+        q, r = mt.linalg.qr(a)
+
+        self.assertEqual(q.shape, (18, 6))
+        self.assertEqual(r.shape, (6, 6))
+
+        q.tiles()
+
+        self.assertEqual(len(q.chunks), 2)
+        self.assertEqual(len(r.chunks), 1)
+        self.assertEqual(q.nsplits, ((9, 9), (6,)))
+        self.assertEqual(r.nsplits, ((6,), (6,)))
+
+        self.assertEqual(q.chunks[0].shape, (9, 6))
+        self.assertEqual(q.chunks[0].inputs[0].shape, (9, 6))
+        self.assertEqual(q.chunks[0].inputs[1].shape, (6, 6))
+
         # for Short-and-Fat QR
         a = mt.random.rand(6, 18, chunk_size=(6, 6))
         q, r = mt.linalg.qr(a, method='sfqr')
@@ -112,6 +133,10 @@ class Test(unittest.TestCase):
         self.assertEqual(s.chunks[0].shape, (6,))
         self.assertEqual(len(V.chunks), 1)
         self.assertEqual(V.chunks[0].shape, (6, 6))
+
+        self.assertEqual(U.chunks[0].inputs[0].shape, (3, 6))
+        self.assertEqual(U.chunks[0].inputs[0].inputs[0].shape, (3, 3))
+        self.assertEqual(U.chunks[0].inputs[0].inputs[1].shape, (3, 6))
 
         self.assertEqual(s.ndim, 1)
         self.assertEqual(len(s.chunks[0].index), 1)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Fix incorrect chunk shape in QR decomposition.

## Related issue number

Fixes #714 