### PR TITLE
Processing `index` and `columns` seperately (and correctly) in `from_tensor`

### DIFF
--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -253,7 +253,7 @@ class IndexValue(Serializable):
     def has_value(self):
         if isinstance(self._index_value, self.RangeIndex):
             return True
-        elif getattr(self, '_data', None) is not None:
+        elif getattr(self._index_value, '_data', None) is not None:
             return True
         return False
 

--- a/mars/dataframe/datasource/from_tensor.py
+++ b/mars/dataframe/datasource/from_tensor.py
@@ -17,6 +17,7 @@
 import numpy as np
 import pandas as pd
 
+from ...core import Base
 from ...serialize import KeyField, SeriesField
 from ... import opcodes as OperandDef
 from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
@@ -57,6 +58,8 @@ class DataFrameFromTensor(DataFrameOperand, DataFrameOperandMixin):
                 raise ValueError(
                     'index {0} should have the same shape with tensor: {1}'.format(index, input_tensor.shape[0]))
             if not isinstance(index, pd.Index):
+                if isinstance(index, Base):
+                    raise NotImplementedError('The index value cannot be a tileable')
                 index = pd.Index(index)
             index_value = parse_index(index, store_data=True)
         else:
@@ -67,6 +70,8 @@ class DataFrameFromTensor(DataFrameOperand, DataFrameOperandMixin):
                 raise ValueError(
                     'columns {0} should have the same shape with tensor: {1}'.format(columns, input_tensor.shape[1]))
             if not isinstance(columns, pd.Index):
+                if isinstance(index, Base):
+                    raise NotImplementedError('The index value cannot be a tileable')
                 columns = pd.Index(columns)
             columns_value = parse_index(columns, store_data=True)
         else:

--- a/mars/dataframe/datasource/from_tensor.py
+++ b/mars/dataframe/datasource/from_tensor.py
@@ -49,26 +49,32 @@ class DataFrameFromTensor(DataFrameOperand, DataFrameOperandMixin):
         self._input = inputs[0]
 
     def __call__(self, input_tensor, index, columns):
-        if index is not None or columns is not None:
-            if input_tensor.shape != (len(index), len(columns)):
-                raise ValueError(
-                    '({0},{1}) should have the same shape with tensor: {2}'.format(index, columns, input_tensor.shape))
-        if input_tensor.ndim == 1:
-            # convert to 1-d DataFrame
-            index_value = parse_index(pd.RangeIndex(start=0, stop=input_tensor.shape[0]))
-            columns_value = parse_index(pd.RangeIndex(start=0, stop=1))
-        elif input_tensor.ndim != 2:
+        if input_tensor.ndim != 1 and input_tensor.ndim != 2:
             raise ValueError('Must pass 1-d or 2-d input')
-        else:
-            # convert to DataFrame
-            index_value = parse_index(pd.RangeIndex(start=0, stop=input_tensor.shape[0]))
-            columns_value = parse_index(pd.RangeIndex(start=0, stop=input_tensor.shape[1]))
 
-        # overwrite index_value and columns_value if user has set them
         if index is not None:
+            if input_tensor.shape[0] != len(index):
+                raise ValueError(
+                    'index {0} should have the same shape with tensor: {1}'.format(index, input_tensor.shape[0]))
+            if not isinstance(index, pd.Index):
+                index = pd.Index(index)
             index_value = parse_index(index, store_data=True)
+        else:
+            index_value = parse_index(pd.RangeIndex(start=0, stop=input_tensor.shape[0]))
+
         if columns is not None:
+            if input_tensor.shape[1] != len(columns):
+                raise ValueError(
+                    'columns {0} should have the same shape with tensor: {1}'.format(columns, input_tensor.shape[1]))
+            if not isinstance(columns, pd.Index):
+                columns = pd.Index(columns)
             columns_value = parse_index(columns, store_data=True)
+        else:
+            if input_tensor.ndim == 1:
+                # convert to 1-d DataFrame
+                columns_value = parse_index(pd.RangeIndex(start=0, stop=1), store_data=True)
+            else:
+                columns_value = parse_index(pd.RangeIndex(start=0, stop=input_tensor.shape[1]), store_data=True)
 
         return self.new_dataframe([input_tensor], input_tensor.shape, dtypes=self.dtypes,
                                   index_value=index_value,
@@ -99,7 +105,7 @@ class DataFrameFromTensor(DataFrameOperand, DataFrameOperandMixin):
                                             store_data=True)
 
             index_stop = cum_size[0][i]
-            if out_df.index_value is not None:
+            if out_df.index_value.has_value():
                 index_value = parse_index(out_df.index_value.to_pandas()[index_stop - in_chunk.shape[0]:index_stop],
                                           store_data=True)
             else:

--- a/mars/dataframe/datasource/tests/test_datasource.py
+++ b/mars/dataframe/datasource/tests/test_datasource.py
@@ -302,6 +302,22 @@ class Test(TestBase):
         with self.assertRaises(TypeError):
             from_tensor(scalar)
 
+        # from tensor with given index
+        df = from_tensor(tensor, index=np.arange(0, 20, 2))
+        df.tiles()
+        pd.testing.assert_index_equal(df.chunks[0].index_value.to_pandas(), pd.Index(np.arange(0, 10, 2)))
+        pd.testing.assert_index_equal(df.chunks[1].index_value.to_pandas(), pd.Index(np.arange(0, 10, 2)))
+        pd.testing.assert_index_equal(df.chunks[2].index_value.to_pandas(), pd.Index(np.arange(10, 20, 2)))
+        pd.testing.assert_index_equal(df.chunks[3].index_value.to_pandas(), pd.Index(np.arange(10, 20, 2)))
+
+        # from tensor with given columns
+        df = from_tensor(tensor, columns=list('abcdefghij'))
+        df.tiles()
+        pd.testing.assert_index_equal(df.chunks[0].columns.to_pandas(), pd.Index(['a', 'b', 'c', 'd', 'e']))
+        pd.testing.assert_index_equal(df.chunks[1].columns.to_pandas(), pd.Index(['f', 'g', 'h', 'i', 'j']))
+        pd.testing.assert_index_equal(df.chunks[2].columns.to_pandas(), pd.Index(['a', 'b', 'c', 'd', 'e']))
+        pd.testing.assert_index_equal(df.chunks[3].columns.to_pandas(), pd.Index(['f', 'g', 'h', 'i', 'j']))
+
     def testFromRecords(self):
         dtype = np.dtype([('x', 'int'), ('y', 'double'), ('z', '<U16')])
 

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -86,6 +86,22 @@ class Test(TestBase):
         pdf_expected = pd.DataFrame(self.executor.execute_tensor(tensor4, concat=True)[0])
         pd.testing.assert_frame_equal(pdf_expected, result4)
 
+        # from tensor with given index
+        tensor5 = mt.ones((10, 10), chunk_size=3)
+        df5 = from_tensor(tensor5, index=np.arange(0, 20, 2))
+        result5 = self.executor.execute_dataframe(df5, concat=True)[0]
+        pdf_expected = pd.DataFrame(self.executor.execute_tensor(tensor5, concat=True)[0],
+                                    index=np.arange(0, 20, 2))
+        pd.testing.assert_frame_equal(pdf_expected, result5)
+
+        # from tensor with given columns
+        tensor6 = mt.ones((10, 10), chunk_size=3)
+        df6 = from_tensor(tensor6, columns=list('abcdefghij'))
+        result6 = self.executor.execute_dataframe(df6, concat=True)[0]
+        pdf_expected = pd.DataFrame(self.executor.execute_tensor(tensor6, concat=True)[0],
+                                    columns=list('abcdefghij'))
+        pd.testing.assert_frame_equal(pdf_expected, result6)
+
     def testFromRecordsExecution(self):
         dtype = np.dtype([('x', 'int'), ('y', 'double'), ('z', '<U16')])
 


### PR DESCRIPTION
## What do these changes do?

When constructing `DataFrame` from `Tensor`, the `index` and `columns` argument should be processed separately. When user feed a custom `index` argument we need to store the underlying value and when the argument is not `pd.Index` we should perform a conversion.

This pr also fixes a bug in `IndexValue.has_value`.

## Related issue number

Fixes #718