### PR TITLE
Spawn promise to utilize async network libs

### DIFF
--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -133,7 +133,7 @@ class Test(TestBase):
 
         # accessing non-existing attributes should trigger exception
         with self.assertRaises(AttributeError):
-            _ = df.zzz
+            _ = df.zzz  # noqa: F841
 
     def testSeriesGetitem(self):
         data = pd.Series(np.random.rand(10))

--- a/mars/promise.py
+++ b/mars/promise.py
@@ -28,6 +28,7 @@ from .utils import wraps, build_exc_info
 
 logger = logging.getLogger(__name__)
 _promise_pool = dict()
+_pack_qword = struct.Struct('<Q').pack
 
 
 class Promise(object):
@@ -37,7 +38,7 @@ class Promise(object):
     def __init__(self, resolve=None, reject=None, done=False, failed=False,
                  args=None, kwargs=None):
         # use random promise id
-        self._id = struct.pack('<Q', id(self)) + np.random.bytes(32)
+        self._id = _pack_qword(id(self)) + np.random.bytes(32)
 
         self._accept_handler = self._wrap_handler(resolve)
         self._reject_handler = self._wrap_handler(reject)
@@ -308,18 +309,27 @@ class PromiseRefWrapper(object):
                 return ref_fun(*args, **kwargs)
 
             p = Promise()
+            promise_id = p.id
             self._caller.register_promise(p, self._ref)
 
             timeout = kwargs.pop('_timeout', 0)
 
             kwargs['callback'] = ((self._caller.uid, self._caller.address),
-                                  'handle_promise', p.id)
+                                  'handle_promise', promise_id)
             kwargs['_tell'] = True
-            ref_fun(*args, **kwargs)
+
+            def _promise_runner():
+                try:
+                    ref_fun(*args, **kwargs)
+                except:  # noqa: E722
+                    self._caller.ref().handle_promise(
+                        promise_id, *sys.exc_info(), **dict(_accept=False, _tell=True))
+
+            self._caller.async_group.spawn(_promise_runner)
 
             if timeout and timeout > 0:
                 # add a callback that triggers some times later to deal with timeout
-                self._caller.ref().handle_promise_timeout(p.id, _tell=True, _delay=timeout)
+                self._caller.ref().handle_promise_timeout(promise_id, _tell=True, _delay=timeout)
 
             return p
 
@@ -384,6 +394,12 @@ class PromiseActor(FunctionActor):
             ref = self.ctx.actor_ref(*args, **kwargs)
         return PromiseRefWrapper(ref, self)
 
+    @property
+    def async_group(self):
+        if not hasattr(self, '_async_group'):
+            self._async_group = self.ctx.asyncpool()
+        return self._async_group
+
     def spawn_promised(self, func, *args, **kwargs):
         """
         Run func asynchronously in a pool and returns a promise.
@@ -393,9 +409,6 @@ class PromiseActor(FunctionActor):
         :return: promise
         """
         self._prepare_promise_registration()
-
-        if not hasattr(self, '_async_group'):
-            self._async_group = self.ctx.asyncpool()
 
         p = Promise()
         ref = self.ref()
@@ -412,7 +425,7 @@ class PromiseActor(FunctionActor):
                 del a, kw
 
         try:
-            self._async_group.spawn(_wrapped, *args, **kwargs)
+            self.async_group.spawn(_wrapped, *args, **kwargs)
         finally:
             del args, kwargs
         return p

--- a/mars/promise.py
+++ b/mars/promise.py
@@ -313,6 +313,7 @@ class PromiseRefWrapper(object):
             self._caller.register_promise(p, self._ref)
 
             timeout = kwargs.pop('_timeout', 0)
+            spawn = kwargs.pop('_spawn', True)
 
             kwargs['callback'] = ((self._caller.uid, self._caller.address),
                                   'handle_promise', promise_id)
@@ -325,7 +326,10 @@ class PromiseRefWrapper(object):
                     self._caller.ref().handle_promise(
                         promise_id, *sys.exc_info(), **dict(_accept=False, _tell=True))
 
-            self._caller.async_group.spawn(_promise_runner)
+            if spawn:
+                self._caller.async_group.spawn(_promise_runner)
+            else:
+                ref_fun(*args, **kwargs)
 
             if timeout and timeout > 0:
                 # add a callback that triggers some times later to deal with timeout

--- a/mars/scheduler/operands/common.py
+++ b/mars/scheduler/operands/common.py
@@ -425,7 +425,8 @@ class OperandActor(BaseOperandActor):
 
         try:
             with rewrite_worker_errors():
-                self._execution_ref.add_finish_callback(self._session_id, self._op_key, _promise=True) \
+                self._execution_ref.add_finish_callback(
+                    self._session_id, self._op_key, _promise=True, _spawn=False) \
                     .then(_acceptor, _rejecter)
         except WorkerDead:
             logger.debug('Worker %s dead when adding callback for operand %s',

--- a/mars/tests/test_promise.py
+++ b/mars/tests/test_promise.py
@@ -599,7 +599,7 @@ class Test(unittest.TestCase):
                 test_ref.test_ref_reject()
 
                 wait_test_actor_result(test_ref, 30)
-                self.assertListEqual(serve_ref.get_result(), [0, 'WorkerProcessStopped'])
+                self.assertListEqual(serve_ref.get_result(), ['WorkerProcessStopped', 0])
         finally:
             self.assertEqual(promise.get_active_promise_count(), 0)
 
@@ -612,7 +612,7 @@ class Test(unittest.TestCase):
                 test_ref.test_addr_reject()
 
                 wait_test_actor_result(test_ref, 30)
-                self.assertListEqual(serve_ref.get_result(), [0, 'WorkerDead'])
+                self.assertListEqual(serve_ref.get_result(), ['WorkerDead', 0])
         finally:
             self.assertEqual(promise.get_active_promise_count(), 0)
 

--- a/mars/web/apihandlers.py
+++ b/mars/web/apihandlers.py
@@ -141,7 +141,7 @@ class GraphApiHandler(MarsApiRequestHandler):
                     web_api = MarsWebAPI(self._scheduler)
                     return web_api.wait_graph_finish(session_id, graph_key, wait_timeout)
 
-                _ = yield self._executor.submit(_wait_fun)
+                _ = yield self._executor.submit(_wait_fun)  # noqa: F841
 
             state = self.web_api.get_graph_state(session_id, graph_key)
         except GraphNotExists:

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -15,7 +15,6 @@
 import functools
 import logging
 import random
-import sys
 import time
 from collections import defaultdict
 
@@ -325,13 +324,11 @@ class ExecutionActor(WorkerActor):
             sender_ref = self.promise_ref(sender_uid, address=remote_addr)
             logger.debug('Fetching chunk %s in %s to %s with slot %s',
                          chunk_key, remote_addr, self.address, sender_uid)
-            try:
-                return sender_ref.send_data(
-                    session_id, chunk_key, self.address, ensure_cached=ensure_cached,
-                    timeout=timeout, _timeout=timeout, _promise=True
-                ).then(_finish_fetch)
-            except:  # noqa: E722
-                _handle_network_error(*sys.exc_info())
+
+            return sender_ref.send_data(
+                session_id, chunk_key, self.address, ensure_cached=ensure_cached,
+                timeout=timeout, _timeout=timeout, _promise=True
+            ).then(_finish_fetch)
 
         return promise.finished() \
             .then(lambda *_: remote_disp_ref.get_free_slot('sender', _promise=True, _timeout=timeout)) \

--- a/mars/worker/tests/test_quota.py
+++ b/mars/worker/tests/test_quota.py
@@ -62,7 +62,9 @@ class Test(WorkerCase):
                 ref = test_actor.promise_ref(QuotaActor.default_uid())
 
                 ref.request_quota('1', 150, _promise=True) \
+                    .then(lambda *_: test_actor.set_result(True)) \
                     .catch(lambda *exc: test_actor.set_result(exc, accept=False))
+                pool.sleep(0.5)
 
                 self.assertFalse(quota_ref.request_quota('2', 50))
                 self.assertFalse(quota_ref.request_quota('3', 200))


### PR DESCRIPTION
## What do these changes do?

Spawn remote promise calls with gevent to facilitate async operations.

## Related issue number

Fixes #724 