### PR TITLE
Submit metas obtained from schedulers

### DIFF
--- a/mars/scheduler/assigner.py
+++ b/mars/scheduler/assigner.py
@@ -353,7 +353,7 @@ class AssignEvaluationActor(SchedulerActor):
                 logger.debug('Operand %s(%s) allocated to run in %s', op_key, op_info['op_name'], worker_ep)
 
                 self.get_actor_ref(BaseOperandActor.gen_uid(session_id, op_key)) \
-                    .submit_to_worker(worker_ep, input_sizes, _tell=True, _wait=False)
+                    .submit_to_worker(worker_ep, input_metas, _tell=True, _wait=False)
                 return worker_ep, rejects
             rejects.append(worker_ep)
         return None, rejects

--- a/mars/scheduler/operands/tests/test_common_ut.py
+++ b/mars/scheduler/operands/tests/test_common_ut.py
@@ -50,7 +50,7 @@ class FakeExecutionActor(promise.PromiseActor):
         except KeyError:
             pass
 
-    def execute_graph(self, session_id, graph_key, graph_ser, io_meta, data_sizes,
+    def execute_graph(self, session_id, graph_key, graph_ser, io_meta, data_metas,
                       send_addresses=None, callback=None):
         if callback:
             self._finish_callbacks[graph_key].append(callback)

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -48,13 +48,13 @@ class GraphExecutionRecord(object):
     Execution records of the graph
     """
     __slots__ = ('graph', 'graph_serialized', '_state', 'op_string', 'data_targets',
-                 'chunk_targets', 'io_meta', 'data_sizes', 'shared_input_chunks',
+                 'chunk_targets', 'io_meta', 'data_metas', 'shared_input_chunks',
                  'state_time', 'mem_request', 'pinned_keys', 'est_finish_time',
                  'calc_actor_uid', 'send_addresses', 'retry_delay', 'finish_callbacks',
                  'stop_requested')
 
     def __init__(self, graph_serialized, state, chunk_targets=None, data_targets=None,
-                 io_meta=None, data_sizes=None, mem_request=None,
+                 io_meta=None, data_metas=None, mem_request=None,
                  shared_input_chunks=None, pinned_keys=None, est_finish_time=None,
                  calc_actor_uid=None, send_addresses=None, retry_delay=None,
                  finish_callbacks=None, stop_requested=False):
@@ -67,7 +67,7 @@ class GraphExecutionRecord(object):
         self.data_targets = data_targets or []
         self.chunk_targets = chunk_targets or []
         self.io_meta = io_meta or dict()
-        self.data_sizes = data_sizes or dict()
+        self.data_metas = data_metas or dict()
         self.shared_input_chunks = shared_input_chunks or set()
         self.mem_request = mem_request or dict()
         self.pinned_keys = set(pinned_keys or [])
@@ -184,7 +184,8 @@ class ExecutionActor(WorkerActor):
 
     def _estimate_calc_memory(self, session_id, graph_key):
         graph_record = self._graph_records[(session_id, graph_key)]
-        size_ctx = dict((k, (v, v)) for k, v in graph_record.data_sizes.items())
+        size_ctx = dict((k, (v.chunk_size, v.chunk_size))
+                        for k, v in graph_record.data_metas.items())
         executor = Executor(storage=size_ctx, sync_provider_type=Executor.SyncProviderType.MOCK)
         res = executor.execute_graph(graph_record.graph, graph_record.chunk_targets, mock=True)
 
@@ -212,7 +213,7 @@ class ExecutionActor(WorkerActor):
 
         graph = graph_record.graph
         storage_client = self.storage_client
-        input_data_sizes = graph_record.data_sizes
+        input_data_sizes = dict((k, v.chunk_size) for k, v in graph_record.data_metas.items())
         alloc_mem_batch = dict()
         alloc_cache_batch = dict()
         input_chunk_keys = dict()
@@ -244,7 +245,8 @@ class ExecutionActor(WorkerActor):
                     alloc_cache_batch[chunk.key] = cache_batch
 
         keys_to_pin = list(input_chunk_keys.keys())
-        graph_record.pinned_keys = set(storage_client.pin_data_keys(session_id, keys_to_pin, graph_key))
+        graph_record.pinned_keys = set()
+        self._pin_data_keys(session_id, graph_key, keys_to_pin)
 
         load_chunk_sizes = dict((k, v) for k, v in input_chunk_keys.items()
                                 if k not in graph_record.pinned_keys)
@@ -283,10 +285,11 @@ class ExecutionActor(WorkerActor):
 
         @log_unhandled
         def _finish_fetch(*_):
-            locations = storage_client.get_data_locations(session_id, chunk_key)
+            locations = storage_client.get_data_locations(session_id, chunk_key) or ()
             if (0, DataStorageDevice.SHARED_MEMORY) in locations:
                 self._pin_data_keys(session_id, graph_key, [chunk_key])
-                self._mem_quota_ref.release_quota(build_quota_key(session_id, chunk_key, owner=graph_key))
+                self._mem_quota_ref.release_quota(
+                    build_quota_key(session_id, chunk_key, owner=graph_key), _tell=True, _wait=False)
 
         @log_unhandled
         def _handle_network_error(*exc):
@@ -409,7 +412,7 @@ class ExecutionActor(WorkerActor):
 
     @promise.reject_on_exception
     @log_unhandled
-    def execute_graph(self, session_id, graph_key, graph_ser, io_meta, data_sizes,
+    def execute_graph(self, session_id, graph_key, graph_ser, io_meta, data_metas,
                       send_addresses=None, callback=None):
         """
         Submit graph to the worker and control the execution
@@ -417,7 +420,7 @@ class ExecutionActor(WorkerActor):
         :param graph_key: graph key
         :param graph_ser: serialized executable graph
         :param io_meta: io meta of the chunk
-        :param data_sizes: data size of each input chunk, as a dict
+        :param data_metas: data meta of each input chunk, as a dict
         :param send_addresses: targets to send results after execution
         :param callback: promise callback
         """
@@ -430,7 +433,7 @@ class ExecutionActor(WorkerActor):
         graph_record = self._graph_records[(session_id, graph_key)] = GraphExecutionRecord(
             graph_ser, ExecutionState.ALLOCATING,
             io_meta=io_meta,
-            data_sizes=data_sizes,
+            data_metas=data_metas,
             chunk_targets=io_meta['chunks'],
             data_targets=list(io_meta.get('data_targets') or io_meta['chunks']),
             shared_input_chunks=set(io_meta.get('shared_input_chunks', [])),
@@ -499,7 +502,7 @@ class ExecutionActor(WorkerActor):
                 graph_record.retry_delay = min(1 + graph_record.retry_delay, 30)
                 self.ref().execute_graph(
                     session_id, graph_key, graph_record.graph_serialized, graph_record.io_meta,
-                    graph_record.data_sizes, _tell=True, _delay=retry_delay)
+                    graph_record.data_metas, _tell=True, _delay=retry_delay)
                 return
 
             promise.finished() \
@@ -541,17 +544,24 @@ class ExecutionActor(WorkerActor):
                 input_keys.add(op.to_fetch_key or chunk.key)
             elif isinstance(op, FetchShuffle):
                 shuffle_key = get_chunk_shuffle_key(graph.successors(chunk)[0])
-                for k in op.to_fetch_keys:
-                    part_key = (k, shuffle_key)
+                for input_key in op.to_fetch_keys:
+                    part_key = (input_key, shuffle_key)
                     input_keys.add(part_key)
                     shuffle_keys.add(part_key)
 
         for input_key in input_keys:
-            if storage_client.get_data_locations(session_id, input_key):
+            if input_key in graph_record.pinned_keys:
+                # already pinned, we continue
+                loaded_keys.append(input_key)
+                self._mem_quota_ref.release_quota(
+                    build_quota_key(session_id, input_key, owner=graph_key), _tell=True)
+            elif storage_client.get_data_locations(session_id, input_key):
+                # load data from other devices
                 loaded_keys.append(input_key)
                 ensure_shared = input_key in graph_record.shared_input_chunks or input_key in shuffle_keys
                 if ensure_shared:
-                    self._mem_quota_ref.release_quota(build_quota_key(session_id, input_key, owner=graph_key))
+                    self._mem_quota_ref.release_quota(
+                        build_quota_key(session_id, input_key, owner=graph_key), _tell=True)
 
                 pin_fun = functools.partial(
                     lambda k, *_: self._pin_data_keys(session_id, graph_key, [k]), input_key)
@@ -560,28 +570,26 @@ class ExecutionActor(WorkerActor):
                         session_id, input_key, [DataStorageDevice.SHARED_MEMORY], ensure=ensure_shared)
                         .then(pin_fun, lambda *_: None)
                 )
-                continue
+            else:
+                # load data from another worker
+                chunk_meta = input_metas.get(input_key) or graph_record.data_metas.get(input_key)
+                if chunk_meta:
+                    chunk_meta.workers = tuple(w for w in chunk_meta.workers if w != self.address)
 
-            # load data from another worker
-            try:
-                chunk_meta = input_metas[input_key]
-                chunk_meta.workers = tuple(w for w in chunk_meta.workers if w != self.address)
-            except KeyError:
-                chunk_meta = self.get_meta_client().get_chunk_meta(session_id, input_key)
+                if chunk_meta is None or not chunk_meta.workers:
+                    raise DependencyMissing('Dependency %r not met on sending.' % (input_key,))
+                worker_results = list(chunk_meta.workers)
+                random.shuffle(worker_results)
 
-            if chunk_meta is None or not chunk_meta.workers:
-                raise DependencyMissing('Dependency %r not met on sending.' % (input_key,))
-            worker_results = list(chunk_meta.workers)
-            random.shuffle(worker_results)
+                transfer_keys.append(input_key)
 
-            transfer_keys.append(input_key)
-
-            # fetch data from other workers, if one fails, try another
-            p = promise.finished(_accept=False)
-            for worker in worker_results:
-                p = p.catch(functools.partial(self._fetch_remote_data, session_id, graph_key, input_key, worker,
-                                              ensure_cached=input_key in shared_input_chunks))
-            prepare_promises.append(p)
+                # fetch data from other workers, if one fails, try another
+                p = promise.finished(_accept=False)
+                for worker in worker_results:
+                    p = p.catch(functools.partial(
+                        self._fetch_remote_data, session_id, graph_key, input_key, worker,
+                        ensure_cached=input_key in shared_input_chunks))
+                prepare_promises.append(p)
 
         logger.debug('Graph key %s: Targets %r, loaded keys %r, transfer keys %r',
                      graph_key, graph_record.chunk_targets, loaded_keys, transfer_keys)


### PR DESCRIPTION
## What do these changes do?

Pass input metas from schedulers to workers to reduce worker RPC latency.

## Related issue number

Fixes #726 