### PR TITLE
Implements more flexible `.cix[]`.

### DIFF
--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -274,3 +274,47 @@ class Test(unittest.TestCase):
         finally:
             shutil.rmtree(temp_dir)
             sys.path = old_sys_path
+
+    def testChunksIndexer(self):
+        a = mt.ones((3, 4, 5), chunk_size=2)
+        a.tiles()
+
+        self.assertEqual(a.chunk_shape, (2, 2, 3))
+
+        with self.assertRaises(ValueError):
+            _ = a.cix[1]
+        with self.assertRaises(ValueError):
+            _ = a.cix[1, :]
+
+        chunk_key = a.cix[0, 0, 0].key
+        expected = a.chunks[0].key
+        self.assertEqual(chunk_key, expected)
+
+        chunk_key = a.cix[1, 1, 1].key
+        expected = a.chunks[9].key
+        self.assertEqual(chunk_key, expected)
+
+        chunk_key = a.cix[1, 1, 2].key
+        expected = a.chunks[11].key
+        self.assertEqual(chunk_key, expected)
+
+        chunk_key = a.cix[0, -1, -1].key
+        expected = a.chunks[5].key
+        self.assertEqual(chunk_key, expected)
+
+        chunk_key = a.cix[0, -1, -1].key
+        expected = a.chunks[5].key
+        self.assertEqual(chunk_key, expected)
+
+        chunk_keys = [c.key for c in a.cix[0, 0, :]]
+        expected = [c.key for c in [a.cix[0, 0, 0], a.cix[0, 0, 1], a.cix[0, 0, 2]]]
+        self.assertEqual(chunk_keys, expected)
+
+        chunk_keys = [c.key for c in a.cix[:, 0, :]]
+        expected = [c.key for c in [a.cix[0, 0, 0], a.cix[0, 0, 1], a.cix[0, 0, 2],
+                                    a.cix[1, 0, 0], a.cix[1, 0, 1], a.cix[1, 0, 2]]]
+        self.assertEqual(chunk_keys, expected)
+
+        chunk_keys = [c.key for c in a.cix[:, :, :]]
+        expected = [c.key for c in a.chunks]
+        self.assertEqual(chunk_keys, expected)


### PR DESCRIPTION
## What do these changes do?

An often-used access pattern for `.cix[]` may look like "access the first chunk of every rows" or "access the first chunks of every columns". In the previous solution we need to construct a series of indices like `[0, x]` or `[x, 0]` and `.cix[]` one by one, which is a bit boilerplate.

This pr ralex the constraint and enable the `.cix[]` for `slice()` indices, and return the chunks in a list. Note that we still require the indices has the same length with `chunk_shape` and don't do broadcasting. It is enough for nearly all use cases and can help avoid unintended bugs and errors.

No new test case is added since the correctness of `.cix[]` has been guaranteed by nearly all existing test cases (since nearly all ops use `.cix` in `tile()`). 

## Related issue number

N/A