### PR TITLE
__setitem__ on a view should be still a view.

### DIFF
--- a/mars/tensor/base/tests/test_base.py
+++ b/mars/tensor/base/tests/test_base.py
@@ -489,8 +489,14 @@ class Test(unittest.TestCase):
         # no view cuz of fancy indexing
         self.assertFalse(arr9.op.create_view)
 
+        arr9[0][0][0] = 100
+        self.assertFalse(arr9.op.create_view)
+
         arr10 = arr[:3, None, :5]
         self.assertTrue(arr10.op.create_view)
+
+        arr10[0][0][0] = 100
+        self.assertFalse(arr10.op.create_view)
 
         data = np.array([[[0], [1], [2]]])
         x = tensor(data)

--- a/mars/tensor/reshape/reshape.py
+++ b/mars/tensor/reshape/reshape.py
@@ -297,7 +297,7 @@ class TensorReshapeMap(TensorShuffleMap, TensorOperandMixin):
 
         data = ctx[op.inputs[0].key]
         indices = list(np.nonzero(data))
-        nz_data = data[indices]
+        nz_data = data[tuple(indices)]
 
         for idx in range(len(old_shape)):
             indices[idx] = np.add(indices[idx], axis_offset[idx], out=indices[idx])

--- a/mars/tensor/tests/test_core_execute.py
+++ b/mars/tensor/tests/test_core_execute.py
@@ -67,6 +67,23 @@ class Test(unittest.TestCase):
         np.testing.assert_array_equal(b.execute(), npb)
         np.testing.assert_array_equal(a.execute(), npa)
 
+    def testSetItemOnView(self):
+        a = ones((5, 8), dtype=int)
+        b = a[:3]
+        b[0, 0] = 2
+        c = b.ravel()  # create view
+        c[1] = 4
+
+        npa = np.ones((5, 8), dtype=int)
+        npb = npa[:3]
+        npb[0, 0] = 2
+        npc = npb.ravel()  # create view
+        npc[1] = 4
+
+        np.testing.assert_array_equal(a.execute(), npa)
+        np.testing.assert_array_equal(b.execute(), npb)
+        np.testing.assert_array_equal(c.execute(), npc)
+
     def testViewDataOnTranspose(self):
         data = np.random.rand(10, 20)
         a = tensor(data, chunk_size=6)


### PR DESCRIPTION
## What do these changes do?

Add `view` behavior to the result of `TensorIndexSetValue` op.

## Related issue number

Fixes #732