### PR TITLE
Simplify data transfer protocol

### DIFF
--- a/mars/scheduler/chunkmeta.py
+++ b/mars/scheduler/chunkmeta.py
@@ -438,7 +438,7 @@ class ChunkMetaClient(object):
         :param workers: workers holding the chunk
         """
         addr = self.get_scheduler((session_id, chunk_key))
-        self.ctx.actor_ref(ChunkMetaActor.default_uid(), address=addr) \
+        return self.ctx.actor_ref(ChunkMetaActor.default_uid(), address=addr) \
             .set_chunk_meta(session_id, chunk_key, size=size, shape=shape, workers=workers,
                             _tell=_tell, _wait=_wait)
 

--- a/mars/scheduler/operands/common.py
+++ b/mars/scheduler/operands/common.py
@@ -326,6 +326,9 @@ class OperandActor(BaseOperandActor):
         if self.state in (OperandState.CANCELLED, OperandState.CANCELLING):
             self.start_operand()
             return
+        if self.state == OperandState.RUNNING:
+            # already running
+            return
 
         self.worker = worker
 

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -328,8 +328,12 @@ class ExecutionActor(WorkerActor):
             logger.debug('Fetching chunk %s in %s to %s with slot %s',
                          chunk_key, remote_addr, self.address, sender_uid)
 
+            try:
+                target_slot = self._dispatch_ref.get_hash_slot('receiver', chunk_key)
+            except KeyError:
+                target_slot = None
             return sender_ref.send_data(
-                session_id, chunk_key, self.address, ensure_cached=ensure_cached,
+                session_id, chunk_key, self.address, target_slot, ensure_cached=ensure_cached,
                 timeout=timeout, _timeout=timeout, _promise=True
             ).then(_finish_fetch)
 

--- a/mars/worker/tests/test_execution.py
+++ b/mars/worker/tests/test_execution.py
@@ -72,8 +72,8 @@ class MockSenderActor(WorkerActor):
         self._dispatch_ref.register_free_slot(self.uid, 'sender')
 
     @promise.reject_on_exception
-    def send_data(self, session_id, chunk_key, target_endpoints, ensure_cached=True,
-                  timeout=0, callback=None):
+    def send_data(self, session_id, chunk_key, target_endpoints, target_slots=None,
+                  ensure_cached=True, compression=None, timeout=None, callback=None):
         if self._mode == 'in':
             self._dispatch_ref.register_free_slot(self.uid, 'sender')
             self.storage_client.put_object(session_id, chunk_key, self._mock_data, [DataStorageDevice.SHARED_MEMORY]) \
@@ -562,8 +562,6 @@ class Test(WorkerCase):
             arr_add = mt.array(mock_data)
             result_tensor = arr + arr_add
             graph = result_tensor.build_graph(compose=False, tiled=True)
-
-            pool.create_actor(MockSenderActor, mock_data + np.ones((4,)), 'out', uid='w:mock_sender')
 
             def _validate(_):
                 data = test_actor.shared_store.get(session_id, result_tensor.chunks[0].key)

--- a/mars/worker/tests/test_transfer.py
+++ b/mars/worker/tests/test_transfer.py
@@ -104,23 +104,20 @@ class MockReceiverActor(WorkerActor):
         self._data_writers[query_key] = BytesIO()
         self.tell_promise(callback, self.address, None)
 
-    def receive_data_part(self, session_id, chunk_key, data_part, checksum):
+    def receive_data_part(self, session_id, chunk_key, data_part, checksum, is_last=False):
         query_key = (session_id, chunk_key)
         meta = self._data_metas[query_key]  # type: ReceiverDataMeta
-        new_checksum = zlib.crc32(data_part, meta.checksum)
-        if new_checksum != checksum:
-            raise ChecksumMismatch
-        meta.checksum = checksum
-        self._data_writers[query_key].write(data_part)
-
-    def finish_receive(self, session_id, chunk_key, checksum):
-        query_key = (session_id, chunk_key)
-        meta = self._data_metas[query_key]  # type: ReceiverDataMeta
-        if meta.checksum != checksum:
-            raise ChecksumMismatch
-        meta.status = ReceiveStatus.RECEIVED
+        if data_part:
+            new_checksum = zlib.crc32(data_part, meta.checksum)
+            if new_checksum != checksum:
+                raise ChecksumMismatch
+            meta.checksum = checksum
+            self._data_writers[query_key].write(data_part)
+        if is_last:
+            meta.status = ReceiveStatus.RECEIVED
         for cb in self._callbacks[query_key]:
             self.tell_promise(cb)
+
 
     def cancel_receive(self, session_id, chunk_key):
         pass
@@ -299,7 +296,7 @@ class Test(WorkerCase):
                 with self.assertRaises(BrokenPipeError):
                     self.get_result(5)
 
-                def mocked_receive_data_part(*_):
+                def mocked_receive_data_part(*_, **__):
                     raise ChecksumMismatch
 
                 with patch_method(MockReceiverActor.receive_data_part, new=mocked_receive_data_part):
@@ -327,7 +324,6 @@ class Test(WorkerCase):
         chunk_key5 = str(uuid.uuid4())
         chunk_key6 = str(uuid.uuid4())
         chunk_key7 = str(uuid.uuid4())
-        chunk_key8 = str(uuid.uuid4())
 
         with start_transfer_test_pool(address=pool_addr, plasma_size=self.plasma_storage_size) as pool:
             receiver_ref = pool.create_actor(ReceiverActor, uid=str(uuid.uuid4()))
@@ -400,21 +396,6 @@ class Test(WorkerCase):
                 with self.assertRaises(ChecksumMismatch):
                     self.get_result(5)
 
-                # test checksum error on finish_receive
-                receiver_ref_p.create_data_writer(session_id, chunk_key2, data_size, test_actor, _promise=True) \
-                    .then(lambda *s: test_actor.set_result(s))
-                self.assertTupleEqual(self.get_result(5), (receiver_ref.address, None))
-
-                receiver_ref_p.receive_data_part(session_id, chunk_key2, serialized_mock_data, serialized_crc32)
-                receiver_ref_p.finish_receive(session_id, chunk_key2, 0)
-
-                receiver_ref_p.register_finish_callback(session_id, chunk_key2, _promise=True) \
-                    .then(lambda *s: test_actor.set_result(s)) \
-                    .catch(lambda *exc: test_actor.set_result(exc, accept=False))
-
-                with self.assertRaises(ChecksumMismatch):
-                    self.get_result(5)
-
                 receiver_ref_p.cancel_receive(session_id, chunk_key2)
 
                 # test intermediate cancellation
@@ -445,8 +426,8 @@ class Test(WorkerCase):
 
                 receiver_ref_p.receive_data_part(session_id, chunk_key3, serialized_mock_data[:64],
                                                  zlib.crc32(serialized_mock_data[:64]))
-                receiver_ref_p.receive_data_part(session_id, chunk_key3, serialized_mock_data[64:], serialized_crc32)
-                receiver_ref_p.finish_receive(session_id, chunk_key3, serialized_crc32)
+                receiver_ref_p.receive_data_part(
+                    session_id, chunk_key3, serialized_mock_data[64:], serialized_crc32, is_last=True)
 
                 self.assertTupleEqual((), self.get_result(5))
 
@@ -488,9 +469,8 @@ class Test(WorkerCase):
                         .then(lambda *s: test_actor.set_result(s)) \
                         .catch(lambda *exc: test_actor.set_result(exc, accept=False))
 
-                    receiver_ref_p.receive_data_part(session_id, chunk_key4, serialized_mock_data, serialized_crc32)
-                    receiver_ref_p.finish_receive(session_id, chunk_key4, serialized_crc32)
-
+                    receiver_ref_p.receive_data_part(
+                        session_id, chunk_key4, serialized_mock_data, serialized_crc32, is_last=True)
                     self.assertTupleEqual((), self.get_result(5))
 
                 # test intermediate error
@@ -537,14 +517,6 @@ class Test(WorkerCase):
 
                 with self.assertRaises(WorkerDead):
                     self.get_result(5)
-
-                # test checksum error on finish_receive
-                result = receiver_ref_p.create_data_writer(session_id, chunk_key8, data_size, test_actor,
-                                                           use_promise=False)
-                self.assertTupleEqual(result, (receiver_ref.address, None))
-
-                receiver_ref_p.receive_data_part(session_id, chunk_key8, serialized_mock_data, serialized_crc32)
-                receiver_ref_p.finish_receive(session_id, chunk_key8, 0)
 
     def testSimpleTransfer(self):
         session_id = str(uuid.uuid4())


### PR DESCRIPTION
## What do these changes do?

Simplify transfer RPC calls to 2 calls (``create_data_writer`` and ``receive_data_part``).

## Related issue number

Fixes #724 
