### PR TITLE
Add a config to use cpuacct.stat to calculate cpu usage

### DIFF
--- a/mars/deploy/kubernetes/config.py
+++ b/mars/deploy/kubernetes/config.py
@@ -414,8 +414,7 @@ class MarsReplicationControllerConfig(ReplicationControllerConfig):
         if self._cpu:
             self.add_env('MKL_NUM_THREADS', str(self._cpu))
             self.add_env('MARS_CPU_TOTAL', str(self._cpu))
-            self.add_env('MARS_CPU_USE_PROCESS_STAT', '1')
-            self.add_env('MARS_MEM_USE_CGROUP_STAT', '1')
+            self.add_env('MARS_USE_CGROUP_STAT', '1')
 
         if self._memory:
             self.add_env('MARS_MEMORY_TOTAL', str(int(self._memory)))


### PR DESCRIPTION
## What do these changes do?

Use cpuacct.stat to calculate cpu usage in Docker containers when enabling MARS_USE_CGROUP_STAT according to https://www.kernel.org/doc/Documentation/cgroup-v1/cpuacct.txt

## Related issue number

Fixes #739 