### PR TITLE
[BACKPORT] Processing `index` and `columns` seperately (and correctly) in `from_tensor`

### DIFF
--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -253,7 +253,7 @@ class IndexValue(Serializable):
     def has_value(self):
         if isinstance(self._index_value, self.RangeIndex):
             return True
-        elif getattr(self, '_data', None) is not None:
+        elif getattr(self._index_value, '_data', None) is not None:
             return True
         return False
 

--- a/mars/dataframe/datasource/tests/test_datasource.py
+++ b/mars/dataframe/datasource/tests/test_datasource.py
@@ -302,6 +302,22 @@ class Test(TestBase):
         with self.assertRaises(TypeError):
             from_tensor(scalar)
 
+        # from tensor with given index
+        df = from_tensor(tensor, index=np.arange(0, 20, 2))
+        df.tiles()
+        pd.testing.assert_index_equal(df.chunks[0].index_value.to_pandas(), pd.Index(np.arange(0, 10, 2)))
+        pd.testing.assert_index_equal(df.chunks[1].index_value.to_pandas(), pd.Index(np.arange(0, 10, 2)))
+        pd.testing.assert_index_equal(df.chunks[2].index_value.to_pandas(), pd.Index(np.arange(10, 20, 2)))
+        pd.testing.assert_index_equal(df.chunks[3].index_value.to_pandas(), pd.Index(np.arange(10, 20, 2)))
+
+        # from tensor with given columns
+        df = from_tensor(tensor, columns=list('abcdefghij'))
+        df.tiles()
+        pd.testing.assert_index_equal(df.chunks[0].columns.to_pandas(), pd.Index(['a', 'b', 'c', 'd', 'e']))
+        pd.testing.assert_index_equal(df.chunks[1].columns.to_pandas(), pd.Index(['f', 'g', 'h', 'i', 'j']))
+        pd.testing.assert_index_equal(df.chunks[2].columns.to_pandas(), pd.Index(['a', 'b', 'c', 'd', 'e']))
+        pd.testing.assert_index_equal(df.chunks[3].columns.to_pandas(), pd.Index(['f', 'g', 'h', 'i', 'j']))
+
     def testFromRecords(self):
         dtype = np.dtype([('x', 'int'), ('y', 'double'), ('z', '<U16')])
 

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -86,6 +86,22 @@ class Test(TestBase):
         pdf_expected = pd.DataFrame(self.executor.execute_tensor(tensor4, concat=True)[0])
         pd.testing.assert_frame_equal(pdf_expected, result4)
 
+        # from tensor with given index
+        tensor5 = mt.ones((10, 10), chunk_size=3)
+        df5 = from_tensor(tensor5, index=np.arange(0, 20, 2))
+        result5 = self.executor.execute_dataframe(df5, concat=True)[0]
+        pdf_expected = pd.DataFrame(self.executor.execute_tensor(tensor5, concat=True)[0],
+                                    index=np.arange(0, 20, 2))
+        pd.testing.assert_frame_equal(pdf_expected, result5)
+
+        # from tensor with given columns
+        tensor6 = mt.ones((10, 10), chunk_size=3)
+        df6 = from_tensor(tensor6, columns=list('abcdefghij'))
+        result6 = self.executor.execute_dataframe(df6, concat=True)[0]
+        pdf_expected = pd.DataFrame(self.executor.execute_tensor(tensor6, concat=True)[0],
+                                    columns=list('abcdefghij'))
+        pd.testing.assert_frame_equal(pdf_expected, result6)
+
     def testFromRecordsExecution(self):
         dtype = np.dtype([('x', 'int'), ('y', 'double'), ('z', '<U16')])
 

--- a/mars/serialize/protos/operand_pb2.py
+++ b/mars/serialize/protos/operand_pb2.py
@@ -1339,18 +1339,18 @@ _OPERANDDEF_OPERANDTYPE.containing_type = _OPERANDDEF
 DESCRIPTOR.message_types_by_name['OperandDef'] = _OPERANDDEF
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
-OperandDef = _reflection.GeneratedProtocolMessageType('OperandDef', (_message.Message,), {
+OperandDef = _reflection.GeneratedProtocolMessageType('OperandDef', (_message.Message,), dict(
 
-  'AttrEntry' : _reflection.GeneratedProtocolMessageType('AttrEntry', (_message.Message,), {
-    'DESCRIPTOR' : _OPERANDDEF_ATTRENTRY,
-    '__module__' : 'mars.serialize.protos.operand_pb2'
+  AttrEntry = _reflection.GeneratedProtocolMessageType('AttrEntry', (_message.Message,), dict(
+    DESCRIPTOR = _OPERANDDEF_ATTRENTRY,
+    __module__ = 'mars.serialize.protos.operand_pb2'
     # @@protoc_insertion_point(class_scope:OperandDef.AttrEntry)
-    })
+    ))
   ,
-  'DESCRIPTOR' : _OPERANDDEF,
-  '__module__' : 'mars.serialize.protos.operand_pb2'
+  DESCRIPTOR = _OPERANDDEF,
+  __module__ = 'mars.serialize.protos.operand_pb2'
   # @@protoc_insertion_point(class_scope:OperandDef)
-  })
+  ))
 _sym_db.RegisterMessage(OperandDef)
 _sym_db.RegisterMessage(OperandDef.AttrEntry)
 

--- a/mars/serialize/protos/operand_pb2.py
+++ b/mars/serialize/protos/operand_pb2.py
@@ -1339,18 +1339,18 @@ _OPERANDDEF_OPERANDTYPE.containing_type = _OPERANDDEF
 DESCRIPTOR.message_types_by_name['OperandDef'] = _OPERANDDEF
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
-OperandDef = _reflection.GeneratedProtocolMessageType('OperandDef', (_message.Message,), dict(
+OperandDef = _reflection.GeneratedProtocolMessageType('OperandDef', (_message.Message,), {
 
-  AttrEntry = _reflection.GeneratedProtocolMessageType('AttrEntry', (_message.Message,), dict(
-    DESCRIPTOR = _OPERANDDEF_ATTRENTRY,
-    __module__ = 'mars.serialize.protos.operand_pb2'
+  'AttrEntry' : _reflection.GeneratedProtocolMessageType('AttrEntry', (_message.Message,), {
+    'DESCRIPTOR' : _OPERANDDEF_ATTRENTRY,
+    '__module__' : 'mars.serialize.protos.operand_pb2'
     # @@protoc_insertion_point(class_scope:OperandDef.AttrEntry)
-    ))
+    })
   ,
-  DESCRIPTOR = _OPERANDDEF,
-  __module__ = 'mars.serialize.protos.operand_pb2'
+  'DESCRIPTOR' : _OPERANDDEF,
+  '__module__' : 'mars.serialize.protos.operand_pb2'
   # @@protoc_insertion_point(class_scope:OperandDef)
-  ))
+  })
 _sym_db.RegisterMessage(OperandDef)
 _sym_db.RegisterMessage(OperandDef.AttrEntry)
 


### PR DESCRIPTION
Backport of #723 .