### PR TITLE
Fix race condition when starting tasks and adding callbacks

### DIFF
--- a/bin/ci/travis-install-minikube.sh
+++ b/bin/ci/travis-install-minikube.sh
@@ -7,7 +7,7 @@ K8S_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$K8S_VERSION/bin/linux/amd64/kubectl && \
   chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && \
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.3.1/minikube-linux-amd64 && \
   chmod +x minikube && sudo mv minikube /usr/local/bin/
 
 sudo minikube start --vm-driver=none --kubernetes-version=$K8S_VERSION

--- a/mars/worker/tests/test_calc.py
+++ b/mars/worker/tests/test_calc.py
@@ -141,7 +141,7 @@ class Test(WorkerCase):
             with patch_method(PlasmaSharedStore.create, _mock_plasma_create):
                 self.waitp(
                     calc_ref.calc(session_id, add_chunk.op.key, serialize_graph(exec_graph),
-                                  [add_chunk.key], quota_batch, _promise=True)
+                                  [add_chunk.key], _promise=True)
                         .then(_extract_value_ref)
                         .then(lambda *_: calc_ref.store_results(session_id, [add_chunk.key], _promise=True))
                 )
@@ -186,6 +186,6 @@ class Test(WorkerCase):
                     self.assertRaises(ValueError):
                 self.waitp(
                     calc_ref.calc(session_id, add_chunk.op.key, serialize_graph(exec_graph),
-                                    [add_chunk.key], {}, _promise=True)
+                                  [add_chunk.key], _promise=True)
                         .then(lambda *_: calc_ref.store_results(session_id, [add_chunk.key], _promise=True))
                 )

--- a/mars/worker/tests/test_execution.py
+++ b/mars/worker/tests/test_execution.py
@@ -53,7 +53,7 @@ class MockCpuCalcActor(WorkerActor):
         self._dispatch_ref.register_free_slot(self.uid, 'cpu')
 
     @promise.reject_on_exception
-    def calc(self, session_id, graph_key, ser_graph, targets, mem_requests, callback):
+    def calc(self, session_id, graph_key, ser_graph, targets, callback):
         self.ctx.sleep(self._delay)
         self.tell_promise(callback)
         self._dispatch_ref.register_free_slot(self.uid, 'cpu')


### PR DESCRIPTION
## What do these changes do?

Add finish callback when running ``execute_graph``. This resolves potential race condition when executing graphs.

## Related issue number

Fixes #753 