### PR TITLE
Fix certifi version after installing tiledb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ install:
     pip install virtualenv coveralls flake8 etcd-gevent
   - if [ -z "$NO_COMMON_TESTS" ]; then
       conda install --quiet --yes -n test -c conda-forge python=$PYTHON "tiledb-py>=0.4.3" || true;
+      conda install --quiet --yes -n test -c pkgs/main python=$PYTHON certifi;
     fi
   - if [ -z "$NO_COMMON_TESTS" ]; then
       virtualenv testenv && source testenv/bin/activate;


### PR DESCRIPTION
## What do these changes do?

Fix version of certifi after installing tiledb. This will fix errors when uploading packages.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
