### PR TITLE
Add support for controlling data copy across processes

### DIFF
--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -214,6 +214,10 @@ class WorkerService(object):
             actor = actor_holder.create_actor(InProcHolderActor, uid=uid)
             self._inproc_holder_actors.append(actor)
 
+            uid = 'w:%d:mars-inproc-io-runner-%d-%d' % (cpu_id + 1, os.getpid(), cpu_id)
+            actor = actor_holder.create_actor(IORunnerActor, lock_free=True, dispatched=False, uid=uid)
+            self._inproc_holder_actors.append(actor)
+
         start_pid = 1 + process_start_index + self._n_cpu_process
 
         if distributed:
@@ -242,7 +246,7 @@ class WorkerService(object):
         start_pid = pool.cluster_info.n_process - 1
         if options.worker.spill_directory:
             for spill_id in range(len(options.worker.spill_directory)):
-                uid = 'w:%d:mars-io-runner-%d-%d' % (start_pid, os.getpid(), spill_id)
+                uid = 'w:%d:mars-global-io-runner-%d-%d' % (start_pid, os.getpid(), spill_id)
                 actor = actor_holder.create_actor(IORunnerActor, uid=uid)
                 self._spill_actors.append(actor)
 

--- a/mars/worker/storage/client.py
+++ b/mars/worker/storage/client.py
@@ -64,20 +64,23 @@ class StorageClient(object):
     def promise_ref(self, *args, **kw):
         return self._host_actor.promise_ref(*args, **kw)
 
-    def get_storage_handler(self, storage_type):
+    def get_storage_handler(self, location):
         try:
-            return self._storage_handlers[storage_type]
+            return self._storage_handlers[location]
         except KeyError:
-            handler = self._storage_handlers[storage_type] = \
-                get_storage_handler_cls(storage_type)(self)
+            handler = self._storage_handlers[location] = \
+                get_storage_handler_cls(location[1])(self, proc_id=location[0])
             return handler
 
     def __getattr__(self, item):
         return getattr(self._manager_ref, item)
 
     def _get_stored_devices(self, session_id, data_key):
-        return [loc[1] for loc in (self._manager_ref.get_data_locations(session_id, data_key) or ())
-                if loc[0] == self._proc_id or loc[1] in DataStorageDevice.GLOBAL_DEVICES]
+        return [loc for loc in (self._manager_ref.get_data_locations(session_id, data_key) or ())]
+
+    def _normalize_devices(self, devices):
+        return [d if isinstance(d, tuple) else d.build_location(self.proc_id)
+                for d in devices] if devices is not None else None
 
     def _do_with_spill(self, action, total_bytes, device_order,
                        device_pos=0, spill_multiplier=1.0, ensure=True):
@@ -98,8 +101,8 @@ class StorageClient(object):
                         ))
             six.reraise(*exc_info)
 
-        cur_device_type = device_order[device_pos]
-        handler = self.get_storage_handler(cur_device_type)
+        cur_device = device_order[device_pos]
+        handler = self.get_storage_handler(cur_device)
         return action(handler).catch(_handle_err)
 
     def create_reader(self, session_id, data_key, source_devices, packed=False,
@@ -116,6 +119,7 @@ class StorageClient(object):
         :param packed_compression: compression format to use when reading as packed
         :param _promise: return a promise
         """
+        source_devices = self._normalize_devices(source_devices)
         stored_devs = set(self._get_stored_devices(session_id, data_key))
         for src_dev in source_devices:
             if src_dev not in stored_devs:
@@ -138,6 +142,8 @@ class StorageClient(object):
 
     def create_writer(self, session_id, data_key, total_bytes, device_order, packed=False,
                       packed_compression=None, _promise=True):
+        device_order = self._normalize_devices(device_order)
+
         def _action(handler, _promise=True):
             logger.debug('Creating %s writer for (%s, %s) on %s', 'packed' if packed else 'bytes',
                          session_id, data_key, handler.storage_type)
@@ -157,6 +163,7 @@ class StorageClient(object):
             raise StorageFull
 
     def get_object(self, session_id, data_key, source_devices, serialized=False, _promise=True):
+        source_devices = self._normalize_devices(source_devices)
         stored_devs = set(self._get_stored_devices(session_id, data_key))
         for src_dev in source_devices:
             if src_dev not in stored_devs:
@@ -174,6 +181,7 @@ class StorageClient(object):
             raise IOError('Getting object without promise not supported')
 
     def put_object(self, session_id, data_key, obj, device_order, serialized=False):
+        device_order = self._normalize_devices(device_order)
         data_size = self._manager_ref.get_data_size(session_id, data_key) or calc_data_size(obj)
 
         def _action(h):
@@ -182,6 +190,7 @@ class StorageClient(object):
         return self._do_with_spill(_action, data_size, device_order)
 
     def copy_to(self, session_id, data_key, device_order, ensure=True):
+        device_order = self._normalize_devices(device_order)
         existing_devs = set(self._get_stored_devices(session_id, data_key))
         data_size = self._manager_ref.get_data_size(session_id, data_key)
 
@@ -213,17 +222,17 @@ class StorageClient(object):
 
     def delete(self, session_id, data_key, devices=None, _tell=False):
         devices = devices or self._get_stored_devices(session_id, data_key) or ()
+        devices = self._normalize_devices(devices)
         for dev_type in devices:
             handler = self.get_storage_handler(dev_type)
             handler.delete(session_id, data_key, _tell=_tell)
 
     def filter_exist_keys(self, session_id, data_keys, devices=None):
-        devices = [d.build_location(self.proc_id)
-                   for d in (devices or DataStorageDevice.__members__.values())]
+        devices = self._normalize_devices(devices or DataStorageDevice.__members__.values())
         return self.manager_ref.filter_exist_keys(session_id, data_keys, devices)
 
     def pin_data_keys(self, session_id, data_keys, token, devices=None):
-        devices = devices or DataStorageDevice.__members__.values()
+        devices = self._normalize_devices(devices or DataStorageDevice.__members__.values())
         pinned = set()
         for dev in devices:
             handler = self.get_storage_handler(dev)
@@ -234,7 +243,7 @@ class StorageClient(object):
         return list(pinned)
 
     def unpin_data_keys(self, session_id, data_keys, token, devices=None):
-        devices = devices or DataStorageDevice.__members__.values()
+        devices = self._normalize_devices(devices or DataStorageDevice.__members__.values())
         for dev in devices:
             handler = self.get_storage_handler(dev)
             if not getattr(handler, '_spillable', False):
@@ -243,6 +252,7 @@ class StorageClient(object):
 
     def spill_size(self, data_size, devices):
         promises = []
+        devices = self._normalize_devices(devices)
         for dev in devices:
             handler = self.get_storage_handler(dev)
             if not getattr(handler, '_spillable', False):

--- a/mars/worker/storage/core.py
+++ b/mars/worker/storage/core.py
@@ -21,6 +21,7 @@ from ...compat import Enum, six
 from ...config import options
 from ...utils import classproperty
 from ...serialize import dataserializer
+from .iorunner import IORunnerActor
 
 logger = logging.getLogger(__name__)
 
@@ -105,9 +106,12 @@ class BytesStorageIO(object):
 class StorageHandler(object):
     storage_type = None
 
-    def __init__(self, storage_ctx):
+    def __init__(self, storage_ctx, proc_id=None):
         self._storage_ctx = storage_ctx
         self._actor_ctx = storage_ctx.actor_ctx
+        self._proc_id = proc_id if proc_id is not None else storage_ctx.host_actor.proc_id
+        if self.is_device_global():
+            self._proc_id = 0
 
         from ..dispatcher import DispatchActor
         self._dispatch_ref = self.actor_ref(DispatchActor.default_uid())
@@ -123,6 +127,9 @@ class StorageHandler(object):
     def is_device_global(cls):
         return cls.storage_type in DataStorageDevice.GLOBAL_DEVICES
 
+    def is_other_process(self):
+        return not self.is_device_global() and self.proc_id != self._storage_ctx.proc_id
+
     @staticmethod
     def pass_on_exc(func, exc):
         func()
@@ -137,8 +144,12 @@ class StorageHandler(object):
         return self._storage_ctx.host_actor
 
     @property
+    def proc_id(self):
+        return self._proc_id
+
+    @property
     def location(self):
-        return self.storage_type.build_location(self._storage_ctx.proc_id)
+        return self.storage_type.build_location(self._proc_id)
 
     def is_io_runner(self):
         return getattr(self.host_actor, '_io_runner', False)
@@ -182,30 +193,42 @@ class StorageHandler(object):
         self._storage_ctx.manager_ref \
             .register_data(session_id, data_key, self.location, size, shape=shape)
 
-    def transfer_in_global_runner(self, session_id, data_key, src_handler, fallback=None):
-        if fallback:
-            if self.is_io_runner():
-                return fallback()
-            elif src_handler.storage_type != DataStorageDevice.DISK and \
-                    self.storage_type != DataStorageDevice.DISK:
-                return fallback()
+    def transfer_in_runner(self, session_id, data_key, src_handler, fallback=None):
+        if self.is_io_runner():
+            return fallback() if fallback is not None else promise.finished()
 
-        runner_ref = self.promise_ref(self._dispatch_ref.get_hash_slot(
-            'iorunner', (session_id, data_key)))
-
-        if src_handler.is_device_global():
+        if self.is_device_global() and src_handler.is_device_global():
+            runner_ref = self.promise_ref(self._dispatch_ref.get_hash_slot(
+                'iorunner', (session_id, data_key)))
             return runner_ref.load_from(
-                self.storage_type, session_id, data_key, src_handler.storage_type, _promise=True)
-        elif fallback is not None:
-            def _unlocker(*exc):
-                runner_ref.unlock(session_id, data_key)
-                if exc:
-                    six.reraise(*exc)
+                self.location, session_id, data_key, src_handler.location, _promise=True)
+        elif self.is_device_global() or src_handler.is_device_global():
+            if self.is_other_process() or src_handler.is_other_process():
+                runner_proc_id = self.proc_id or src_handler.proc_id
+                runner_ref = self.promise_ref(IORunnerActor.gen_uid(runner_proc_id))
+                return runner_ref.load_from(
+                    self.location, session_id, data_key, src_handler.location, _promise=True)
+            elif fallback is not None:
+                if src_handler.storage_type != DataStorageDevice.DISK and \
+                        self.storage_type != DataStorageDevice.DISK:
+                    return fallback()
 
-            return runner_ref.lock(session_id, data_key, _promise=True) \
-                .then(fallback) \
-                .then(lambda *_: _unlocker(), _unlocker)
-        return promise.finished()
+                runner_ref = self.promise_ref(self._dispatch_ref.get_hash_slot(
+                    'iorunner', (session_id, data_key)))
+
+                def _unlocker(*exc):
+                    runner_ref.unlock(session_id, data_key)
+                    if exc:
+                        six.reraise(*exc)
+
+                return runner_ref.lock(session_id, data_key, _promise=True) \
+                    .then(fallback) \
+                    .then(lambda *_: _unlocker(), _unlocker)
+            else:
+                return promise.finished()
+        else:
+            raise NotImplementedError('Copying from %r to %r not supported now' %
+                                      (src_handler.storage_type, self.storage_type))
 
     def unregister_data(self, session_id, data_key, _tell=False):
         self._storage_ctx.manager_ref \

--- a/mars/worker/storage/diskhandler.py
+++ b/mars/worker/storage/diskhandler.py
@@ -177,8 +177,8 @@ class DiskIO(BytesStorageIO):
 class DiskHandler(StorageHandler, BytesStorageMixin):
     storage_type = DataStorageDevice.DISK
 
-    def __init__(self, storage_ctx):
-        super(DiskHandler, self).__init__(storage_ctx)
+    def __init__(self, storage_ctx, proc_id=None):
+        super(DiskHandler, self).__init__(storage_ctx, proc_id=proc_id)
         self._compress = dataserializer.CompressType(options.worker.disk_compression)
 
         self._status_ref = self._storage_ctx.actor_ref(StatusActor.default_uid())
@@ -216,7 +216,7 @@ class DiskHandler(StorageHandler, BytesStorageMixin):
                       .then(lambda writer: self._copy_bytes_data(reader, writer),
                             lambda *exc: self.pass_on_exc(reader.close, exc)))
 
-        return self.transfer_in_global_runner(session_id, data_key, src_handler, _fallback)
+        return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
 
     @staticmethod
     def _get_serialized_data_size(serialized_obj):
@@ -238,7 +238,7 @@ class DiskHandler(StorageHandler, BytesStorageMixin):
             return src_handler.get_object(session_id, data_key, serialized=True, _promise=True) \
                 .then(_load_data)
 
-        return self.transfer_in_global_runner(session_id, data_key, src_handler, _fallback)
+        return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
 
     def delete(self, session_id, data_key, _tell=False):
         file_name = _build_file_name(session_id, data_key)

--- a/mars/worker/storage/objectholder.py
+++ b/mars/worker/storage/objectholder.py
@@ -67,7 +67,8 @@ class ObjectHolderActor(WorkerActor):
         status_ref = self.ctx.actor_ref(StatusActor.default_uid())
         self._status_ref = status_ref if self.ctx.has_actor(status_ref) else None
 
-        self._storage_handler = self.storage_client.get_storage_handler(self._storage_device)
+        self._storage_handler = self.storage_client.get_storage_handler(
+            self._storage_device.build_location(self.proc_id))
 
     def pre_destroy(self):
         for k in self._data_holder:

--- a/mars/worker/storage/procmemhandler.py
+++ b/mars/worker/storage/procmemhandler.py
@@ -21,10 +21,8 @@ from .core import DataStorageDevice, StorageHandler, ObjectStorageMixin, \
 class ProcMemHandler(StorageHandler, ObjectStorageMixin):
     storage_type = DataStorageDevice.PROC_MEMORY
 
-    def __init__(self, storage_ctx):
-        StorageHandler.__init__(self, storage_ctx)
-
-        self._proc_id = storage_ctx.proc_id
+    def __init__(self, storage_ctx, proc_id=None):
+        StorageHandler.__init__(self, storage_ctx, proc_id=proc_id)
         self._inproc_store_ref_attr = None
 
     @property
@@ -55,12 +53,18 @@ class ProcMemHandler(StorageHandler, ObjectStorageMixin):
                     .submit(reader.read).result()
             self.put_object(session_id, data_key, result, serialized=True)
 
-        return src_handler.create_bytes_reader(session_id, data_key, _promise=True) \
-            .then(_read_and_put)
+        def _fallback(*_):
+            return src_handler.create_bytes_reader(session_id, data_key, _promise=True) \
+                .then(_read_and_put)
+
+        return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
 
     def load_from_object_io(self, session_id, data_key, src_handler):
-        return src_handler.get_object(session_id, data_key, _promise=True) \
-            .then(lambda obj: self.put_object(session_id, data_key, obj))
+        def _fallback(*_):
+            return src_handler.get_object(session_id, data_key, _promise=True) \
+                .then(lambda obj: self.put_object(session_id, data_key, obj))
+
+        return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
 
     def delete(self, session_id, data_key, _tell=False):
         self._inproc_store_ref.delete_object(session_id, data_key, _tell=_tell)

--- a/mars/worker/storage/sharedhandler.py
+++ b/mars/worker/storage/sharedhandler.py
@@ -102,10 +102,10 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
                            SpillableStorageMixin):
     storage_type = DataStorageDevice.SHARED_MEMORY
 
-    def __init__(self, storage_ctx):
+    def __init__(self, storage_ctx, proc_id=None):
         from .objectholder import SharedHolderActor
 
-        StorageHandler.__init__(self, storage_ctx)
+        StorageHandler.__init__(self, storage_ctx, proc_id=proc_id)
         self._shared_store = storage_ctx.shared_store
         self._holder_ref = storage_ctx.promise_ref(SharedHolderActor.default_uid())
 
@@ -153,7 +153,7 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
                       .then(lambda writer: self._copy_bytes_data(reader, writer),
                             lambda *exc: self.pass_on_exc(reader.close, exc)))
 
-        return self.transfer_in_global_runner(session_id, data_key, src_handler, _fallback)
+        return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
 
     def load_from_object_io(self, session_id, data_key, src_handler):
         def _load(obj):
@@ -166,7 +166,7 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
             return src_handler.get_object(session_id, data_key, _promise=True) \
                 .then(_load)
 
-        return self.transfer_in_global_runner(session_id, data_key, src_handler, _fallback)
+        return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
 
     def delete(self, session_id, data_key, _tell=False):
         self._holder_ref.delete_object(session_id, data_key, _tell=_tell)

--- a/mars/worker/storage/tests/test_disk_io.py
+++ b/mars/worker/storage/tests/test_disk_io.py
@@ -35,7 +35,7 @@ def mock_transfer_in_global_runner(self, session_id, data_key, src_handler, fall
         return fallback()
 
 
-@patch_method(StorageHandler.transfer_in_global_runner, new=mock_transfer_in_global_runner)
+@patch_method(StorageHandler.transfer_in_runner, new=mock_transfer_in_global_runner)
 class Test(WorkerCase):
     @staticmethod
     def _get_compress_types():
@@ -58,7 +58,7 @@ class Test(WorkerCase):
             session_id = str(uuid.uuid4())
 
             storage_client = test_actor.storage_client
-            handler = storage_client.get_storage_handler(DataStorageDevice.DISK)
+            handler = storage_client.get_storage_handler((0, DataStorageDevice.DISK))
 
             for handler._compress in self._get_compress_types():
                 data_key1 = str(uuid.uuid4())
@@ -153,7 +153,7 @@ class Test(WorkerCase):
             ser_data1 = dataserializer.serialize(data1)
 
             storage_client = test_actor.storage_client
-            handler = storage_client.get_storage_handler(DataStorageDevice.DISK)
+            handler = storage_client.get_storage_handler((0, DataStorageDevice.DISK))
 
             for handler._compress in self._get_compress_types():
                 data_key1 = str(uuid.uuid4())
@@ -211,10 +211,10 @@ class Test(WorkerCase):
             data_key2 = str(uuid.uuid4())
 
             storage_client = test_actor.storage_client
-            handler = storage_client.get_storage_handler(DataStorageDevice.DISK)
+            handler = storage_client.get_storage_handler((0, DataStorageDevice.DISK))
 
             # load from bytes io
-            shared_handler = storage_client.get_storage_handler(DataStorageDevice.SHARED_MEMORY)
+            shared_handler = storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
             with shared_handler.create_bytes_writer(
                     session_id, data_key1, ser_data1.total_bytes) as writer:
                 ser_data1.write_to(writer)
@@ -231,7 +231,7 @@ class Test(WorkerCase):
 
             # load from object io
             ref_data2 = weakref.ref(data2)
-            proc_handler = storage_client.get_storage_handler(DataStorageDevice.PROC_MEMORY)
+            proc_handler = storage_client.get_storage_handler((0, DataStorageDevice.PROC_MEMORY))
             proc_handler.put_object(session_id, data_key2, data2)
             del data2
 

--- a/mars/worker/storage/tests/test_objectholder.py
+++ b/mars/worker/storage/tests/test_objectholder.py
@@ -103,7 +103,7 @@ class Test(WorkerCase):
 
     def _fill_shared_storage(self, session_id, key_list, data_list, idx=0):
         storage_client = self._test_actor.storage_client
-        shared_handler = storage_client.get_storage_handler(DataStorageDevice.SHARED_MEMORY)
+        shared_handler = storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
         i = 0
         for i, (key, data) in enumerate(zip(key_list[idx:], data_list)):
             try:
@@ -121,7 +121,7 @@ class Test(WorkerCase):
                          for _ in range(20)]
             key_list = [str(uuid.uuid4()) for _ in range(20)]
 
-            shared_handler = storage_client.get_storage_handler(DataStorageDevice.SHARED_MEMORY)
+            shared_handler = storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
             last_idx = self._fill_shared_storage(session_id, key_list, data_list)
 
             pin_token1 = str(uuid.uuid4())
@@ -158,7 +158,7 @@ class Test(WorkerCase):
             mock_runner_ref = pool.actor_ref(MockIORunnerActor.default_uid())
 
             storage_client = test_actor.storage_client
-            shared_handler = storage_client.get_storage_handler(DataStorageDevice.SHARED_MEMORY)
+            shared_handler = storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
 
             session_id = str(uuid.uuid4())
             data_list = [np.random.randint(0, 32767, (655360,), np.int16)

--- a/mars/worker/storage/tests/test_shared_io.py
+++ b/mars/worker/storage/tests/test_shared_io.py
@@ -34,7 +34,7 @@ def mock_transfer_in_global_runner(self, session_id, data_key, src_handler, fall
         return fallback()
 
 
-@patch_method(StorageHandler.transfer_in_global_runner, new=mock_transfer_in_global_runner)
+@patch_method(StorageHandler.transfer_in_runner, new=mock_transfer_in_global_runner)
 class Test(WorkerCase):
     plasma_storage_size = 1024 * 1024 * 10
 
@@ -57,7 +57,7 @@ class Test(WorkerCase):
             data_key1 = str(uuid.uuid4())
 
             storage_client = test_actor.storage_client
-            handler = storage_client.get_storage_handler(DataStorageDevice.SHARED_MEMORY)
+            handler = storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
 
             def _write_data(ser, writer):
                 self.assertEqual(writer.nbytes, ser_data1.total_bytes)
@@ -134,7 +134,7 @@ class Test(WorkerCase):
             data_key1 = str(uuid.uuid4())
 
             storage_client = test_actor.storage_client
-            handler = storage_client.get_storage_handler(DataStorageDevice.SHARED_MEMORY)
+            handler = storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
 
             def _write_data(ser, writer):
                 with writer:
@@ -216,7 +216,7 @@ class Test(WorkerCase):
             data_key2 = str(uuid.uuid4())
 
             storage_client = test_actor.storage_client
-            handler = storage_client.get_storage_handler(DataStorageDevice.SHARED_MEMORY)
+            handler = storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
 
             handler.put_object(session_id, data_key1, data1)
             self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, data_key1)),
@@ -259,10 +259,10 @@ class Test(WorkerCase):
             data_key2 = str(uuid.uuid4())
 
             storage_client = test_actor.storage_client
-            handler = storage_client.get_storage_handler(DataStorageDevice.SHARED_MEMORY)
+            handler = storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
 
             # load from bytes io
-            disk_handler = storage_client.get_storage_handler(DataStorageDevice.DISK)
+            disk_handler = storage_client.get_storage_handler((0, DataStorageDevice.DISK))
             with disk_handler.create_bytes_writer(
                     session_id, data_key1, ser_data1.total_bytes) as writer:
                 ser_data1.write_to(writer)
@@ -280,7 +280,7 @@ class Test(WorkerCase):
             ref_data2 = weakref.ref(data2)
 
             # load from object io
-            proc_handler = storage_client.get_storage_handler(DataStorageDevice.PROC_MEMORY)
+            proc_handler = storage_client.get_storage_handler((0, DataStorageDevice.PROC_MEMORY))
             proc_handler.put_object(session_id, data_key2, data2)
             del data2
 
@@ -314,7 +314,7 @@ class Test(WorkerCase):
             data_keys = [str(uuid.uuid4()) for _ in range(20)]
 
             storage_client = test_actor.storage_client
-            handler = storage_client.get_storage_handler(DataStorageDevice.SHARED_MEMORY)
+            handler = storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
             idx = 0
 
             def _fill_data():

--- a/mars/worker/tests/test_calc.py
+++ b/mars/worker/tests/test_calc.py
@@ -133,7 +133,7 @@ class Test(WorkerCase):
             ref_store = []
 
             def _extract_value_ref(*_):
-                inproc_handler = storage_client.get_storage_handler(DataStorageDevice.PROC_MEMORY)
+                inproc_handler = storage_client.get_storage_handler((0, DataStorageDevice.PROC_MEMORY))
                 obj = inproc_handler.get_object(session_id, add_chunk.key)
                 ref_store.append(weakref.ref(obj))
                 del obj


### PR DESCRIPTION
## What do these changes do?

Add support for controlling data copy across processes by declaring proc_id explicitly in handlers and adding IORunnerActor for every calculation actor holding local data.

## Related issue number

Fixes #765 
