### PR TITLE
Fix execution of arithmetic on GPU

### DIFF
--- a/mars/tensor/arithmetic/core.py
+++ b/mars/tensor/arithmetic/core.py
@@ -282,8 +282,7 @@ class TensorUnaryOpMixin(TensorElementWiseWithInputs):
 
     @classmethod
     def _execute_gpu(cls, op, xp, inp, **kw):
-        func_name = getattr(cls, '_func_name')
-        r = getattr(xp, func_name)(inp, **kw)
+        r = cls._get_func(xp)(inp, **kw)
         out_order = op.outputs[0].order.value
         if xp.isfortran(r) != (out_order == 'F'):
             r = xp.array(r, order=out_order)
@@ -293,8 +292,7 @@ class TensorUnaryOpMixin(TensorElementWiseWithInputs):
     def _execute_cpu(cls, op, xp, inp, **kw):
         if op.order != 'K':
             kw['order'] = op.order
-        func_name = getattr(cls, '_func_name')
-        return getattr(xp, func_name)(inp, **kw)
+        return cls._get_func(xp)(inp, **kw)
 
     @classmethod
     def execute(cls, ctx, op):

--- a/mars/tensor/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/tensor/arithmetic/tests/test_arithmetic_execution.py
@@ -24,6 +24,7 @@ from mars.executor import Executor
 from mars.tensor.datasource import ones, tensor, zeros
 from mars.tensor.arithmetic import add, cos, truediv, frexp, \
     modf, clip, isclose
+from mars.tensor.array_utils import cp
 from mars.config import option_context
 
 
@@ -650,3 +651,16 @@ class Test(unittest.TestCase):
         expected.imag = np.array([9, 8, 7])
 
         np.testing.assert_equal(res, expected)
+
+    @unittest.skipIf(cp is None, 'cupy not installed')
+    def testCupy(self):
+        a_data = np.random.rand(10, 10)
+        b_data = np.random.rand(10, 10)
+
+        a = tensor(a_data, gpu=True, chunk_size=3)
+        b = tensor(b_data, gpu=True, chunk_size=3)
+        res_binary = self.executor.execute_tensor((a + b), concat=True)[0]
+        np.testing.assert_array_equal(res_binary.get(), (a_data + b_data))
+
+        res_unary = self.executor.execute_tensor(cos(a), concat=True)[0]
+        np.testing.assert_array_almost_equal(res_unary.get(), np.cos(a_data))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Fix arithmetic execution on GPU, mainly about  the`order` parameter.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #728 