### PR TITLE
Refactor of DataFrame reduction and support more reduction operands

### DIFF
--- a/mars/dataframe/arithmetic/add.py
+++ b/mars/dataframe/arithmetic/add.py
@@ -16,9 +16,8 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from ..operands import DataFrameBinOp
 from ..utils import wrap_sequence
-from .core import DataFrameBinOpMixin
+from .core import DataFrameBinOpMixin, DataFrameBinOp
 
 
 class DataFrameAdd(DataFrameBinOp, DataFrameBinOpMixin):

--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -19,11 +19,56 @@ import numpy as np
 
 from pandas.core.dtypes.cast import find_common_type
 
+from ...serialize import AnyField, Float64Field
 from ...utils import classproperty
 from ..align import align_series_series, align_dataframe_series, align_dataframe_dataframe
 from ..core import DATAFRAME_TYPE, SERIES_TYPE, DATAFRAME_CHUNK_TYPE, SERIES_CHUNK_TYPE
-from ..operands import DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperandMixin, DataFrameOperand, ObjectType
 from ..utils import parse_index, infer_dtypes, infer_index_value
+
+
+class DataFrameBinOp(DataFrameOperand):
+    _axis = AnyField('axis')
+    _level = AnyField('level')
+    _fill_value = Float64Field('fill_value')
+    _lhs = AnyField('lhs')
+    _rhs = AnyField('rhs')
+
+    def __init__(self, axis=None, level=None, fill_value=None, object_type=None, lhs=None, rhs=None, **kw):
+        super(DataFrameBinOp, self).__init__(_axis=axis, _level=level,
+                                             _fill_value=fill_value,
+                                             _object_type=object_type, _lhs=lhs, _rhs=rhs, **kw)
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @property
+    def level(self):
+        return self._level
+
+    @property
+    def fill_value(self):
+        return self._fill_value
+
+    @property
+    def lhs(self):
+        return self._lhs
+
+    @property
+    def rhs(self):
+        return self._rhs
+
+    def _set_inputs(self, inputs):
+        super(DataFrameBinOp, self)._set_inputs(inputs)
+        if len(self._inputs) == 2:
+            self._lhs = self._inputs[0]
+            self._rhs = self._inputs[1]
+        else:
+            if isinstance(self._lhs, (DATAFRAME_TYPE, SERIES_TYPE)):
+                self._lhs = self._inputs[0]
+            elif np.isscalar(self._lhs):
+                self._rhs = self._inputs[0]
 
 
 class DataFrameBinOpMixin(DataFrameOperandMixin):

--- a/mars/dataframe/arithmetic/floordiv.py
+++ b/mars/dataframe/arithmetic/floordiv.py
@@ -16,9 +16,8 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from ..operands import DataFrameBinOp
 from ..utils import wrap_sequence
-from .core import DataFrameBinOpMixin
+from .core import DataFrameBinOpMixin, DataFrameBinOp
 
 
 class DataFrameFloorDiv(DataFrameBinOp, DataFrameBinOpMixin):

--- a/mars/dataframe/arithmetic/subtract.py
+++ b/mars/dataframe/arithmetic/subtract.py
@@ -16,9 +16,8 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from ..operands import DataFrameBinOp
 from ..utils import wrap_sequence
-from .core import DataFrameBinOpMixin
+from .core import DataFrameBinOpMixin, DataFrameBinOp
 
 
 class DataFrameSubtract(DataFrameBinOp, DataFrameBinOpMixin):

--- a/mars/dataframe/arithmetic/truediv.py
+++ b/mars/dataframe/arithmetic/truediv.py
@@ -16,9 +16,8 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from ..operands import DataFrameBinOp
 from ..utils import wrap_sequence
-from .core import DataFrameBinOpMixin
+from .core import DataFrameBinOpMixin, DataFrameBinOp
 
 
 class DataFrameTrueDiv(DataFrameBinOp, DataFrameBinOpMixin):

--- a/mars/dataframe/operands.py
+++ b/mars/dataframe/operands.py
@@ -17,7 +17,7 @@ import operator
 import numpy as np
 
 from ..compat import Enum
-from ..serialize import Int8Field, AnyField, Float64Field
+from ..serialize import Int8Field
 from ..operands import ShuffleProxy
 from ..core import TileableOperandMixin, FuseChunkData, FuseChunk
 from ..operands import Operand, ShuffleMap, ShuffleReduce, Fuse
@@ -133,50 +133,6 @@ class DataFrameOperand(Operand):
     @property
     def object_type(self):
         return self._object_type
-
-
-class DataFrameBinOp(DataFrameOperand):
-    _axis = AnyField('axis')
-    _level = AnyField('level')
-    _fill_value = Float64Field('fill_value')
-    _lhs = AnyField('lhs')
-    _rhs = AnyField('rhs')
-
-    def __init__(self, axis=None, level=None, fill_value=None, object_type=None, lhs=None, rhs=None, **kw):
-        super(DataFrameBinOp, self).__init__(_axis=axis, _level=level,
-                                             _fill_value=fill_value,
-                                             _object_type=object_type, _lhs=lhs, _rhs=rhs, **kw)
-
-    @property
-    def axis(self):
-        return self._axis
-
-    @property
-    def level(self):
-        return self._level
-
-    @property
-    def fill_value(self):
-        return self._fill_value
-
-    @property
-    def lhs(self):
-        return self._lhs
-
-    @property
-    def rhs(self):
-        return self._rhs
-
-    def _set_inputs(self, inputs):
-        super(DataFrameBinOp, self)._set_inputs(inputs)
-        if len(self._inputs) == 2:
-            self._lhs = self._inputs[0]
-            self._rhs = self._inputs[1]
-        else:
-            if isinstance(self._lhs, (DATAFRAME_TYPE, SERIES_TYPE)):
-                self._lhs = self._inputs[0]
-            elif np.isscalar(self._lhs):
-                self._rhs = self._inputs[0]
 
 
 class DataFrameShuffleProxy(ShuffleProxy, DataFrameOperandMixin):

--- a/mars/dataframe/reduction/__init__.py
+++ b/mars/dataframe/reduction/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .sum import sum_series, sum_dataframe, SeriesSum, DataFrameSum
+from .sum import sum_series, sum_dataframe, DataFrameSum
 
 
 def _install():

--- a/mars/dataframe/reduction/__init__.py
+++ b/mars/dataframe/reduction/__init__.py
@@ -12,14 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .sum import sum_series, sum_dataframe, DataFrameSum
+from .sum import DataFrameSum
+from .prod import DataFrameProd
+from .max import DataFrameMax
+from .min import DataFrameMin
 
 
 def _install():
     from ..core import DataFrame, Series
+    from .sum import sum_series, sum_dataframe
+    from .prod import prod_series, prod_dataframe
+    from .max import max_series, max_dataframe
+    from .min import min_series, min_dataframe
 
     setattr(DataFrame, 'sum', sum_dataframe)
     setattr(Series, 'sum', sum_series)
+    setattr(DataFrame, 'prod', prod_dataframe)
+    setattr(Series, 'prod', prod_series)
+    setattr(DataFrame, 'max', max_dataframe)
+    setattr(Series, 'max', max_series)
+    setattr(DataFrame, 'min', min_dataframe)
+    setattr(Series, 'min', min_series)
 
 
 _install()

--- a/mars/dataframe/reduction/core.py
+++ b/mars/dataframe/reduction/core.py
@@ -332,8 +332,8 @@ class DataFrameReductionMixin(DataFrameOperandMixin):
         return self.new_series([series], shape=(), dtype=series.dtype,
                                index_value=parse_index(pd.RangeIndex(0)), name=series.name)
 
-    def __call__(self, input_object):
-        if isinstance(input, DATAFRAME_TYPE):
-            return self._call_dataframe(input_object)
+    def __call__(self, a):
+        if isinstance(a, DATAFRAME_TYPE):
+            return self._call_dataframe(a)
         else:
-            return self._call_series(input_object)
+            return self._call_series(a)

--- a/mars/dataframe/reduction/core.py
+++ b/mars/dataframe/reduction/core.py
@@ -332,8 +332,8 @@ class DataFrameReductionMixin(DataFrameOperandMixin):
         return self.new_series([series], shape=(), dtype=series.dtype,
                                index_value=parse_index(pd.RangeIndex(0)), name=series.name)
 
-    def __call__(self, input):
+    def __call__(self, input_object):
         if isinstance(input, DATAFRAME_TYPE):
-            return self._call_dataframe(input)
+            return self._call_dataframe(input_object)
         else:
-            return self._call_series(input)
+            return self._call_series(input_object)

--- a/mars/dataframe/reduction/max.py
+++ b/mars/dataframe/reduction/max.py
@@ -16,18 +16,18 @@ from ... import opcodes as OperandDef
 from .core import DataFrameReductionOperand, DataFrameReductionMixin, ObjectType
 
 
-class DataFrameSum(DataFrameReductionOperand, DataFrameReductionMixin):
-    _op_type_ = OperandDef.SUM
-    _func_name = 'sum'
+class DataFrameMax(DataFrameReductionOperand, DataFrameReductionMixin):
+    _op_type_ = OperandDef.MAX
+    _func_name = 'max'
 
 
-def sum_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):
-    op = DataFrameSum(axis=axis, skipna=skipna, level=level, min_count=min_count, combine_size=combine_size,
+def max_series(df, axis=None, skipna=None, level=None, combine_size=None):
+    op = DataFrameMax(axis=axis, skipna=skipna, level=level, combine_size=combine_size,
                       object_type=ObjectType.series)
     return op(df)
 
 
-def sum_dataframe(df, axis=None, skipna=None, level=None, min_count=0, numeric_only=None, combine_size=None):
-    op = DataFrameSum(axis=axis, skipna=skipna, level=level, min_count=min_count,
-                      numeric_only=numeric_only, combine_size=combine_size, object_type=ObjectType.series)
+def max_dataframe(df, axis=None, skipna=None, level=None, numeric_only=None, combine_size=None):
+    op = DataFrameMax(axis=axis, skipna=skipna, level=level, numeric_only=numeric_only,
+                      combine_size=combine_size, object_type=ObjectType.series)
     return op(df)

--- a/mars/dataframe/reduction/min.py
+++ b/mars/dataframe/reduction/min.py
@@ -16,18 +16,18 @@ from ... import opcodes as OperandDef
 from .core import DataFrameReductionOperand, DataFrameReductionMixin, ObjectType
 
 
-class DataFrameSum(DataFrameReductionOperand, DataFrameReductionMixin):
-    _op_type_ = OperandDef.SUM
-    _func_name = 'sum'
+class DataFrameMin(DataFrameReductionOperand, DataFrameReductionMixin):
+    _op_type_ = OperandDef.MIN
+    _func_name = 'min'
 
 
-def sum_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):
-    op = DataFrameSum(axis=axis, skipna=skipna, level=level, min_count=min_count, combine_size=combine_size,
+def min_series(df, axis=None, skipna=None, level=None, combine_size=None):
+    op = DataFrameMin(axis=axis, skipna=skipna, level=level, combine_size=combine_size,
                       object_type=ObjectType.series)
     return op(df)
 
 
-def sum_dataframe(df, axis=None, skipna=None, level=None, min_count=0, numeric_only=None, combine_size=None):
-    op = DataFrameSum(axis=axis, skipna=skipna, level=level, min_count=min_count,
-                      numeric_only=numeric_only, combine_size=combine_size, object_type=ObjectType.series)
+def min_dataframe(df, axis=None, skipna=None, level=None, numeric_only=None, combine_size=None):
+    op = DataFrameMin(axis=axis, skipna=skipna, level=level, numeric_only=numeric_only,
+                      combine_size=combine_size, object_type=ObjectType.series)
     return op(df)

--- a/mars/dataframe/reduction/prod.py
+++ b/mars/dataframe/reduction/prod.py
@@ -16,18 +16,18 @@ from ... import opcodes as OperandDef
 from .core import DataFrameReductionOperand, DataFrameReductionMixin, ObjectType
 
 
-class DataFrameSum(DataFrameReductionOperand, DataFrameReductionMixin):
-    _op_type_ = OperandDef.SUM
-    _func_name = 'sum'
+class DataFrameProd(DataFrameReductionOperand, DataFrameReductionMixin):
+    _op_type_ = OperandDef.PROD
+    _func_name = 'prod'
 
 
-def sum_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):
-    op = DataFrameSum(axis=axis, skipna=skipna, level=level, min_count=min_count, combine_size=combine_size,
-                      object_type=ObjectType.series)
+def prod_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):
+    op = DataFrameProd(axis=axis, skipna=skipna, level=level, min_count=min_count, combine_size=combine_size,
+                       object_type=ObjectType.series)
     return op(df)
 
 
-def sum_dataframe(df, axis=None, skipna=None, level=None, min_count=0, numeric_only=None, combine_size=None):
-    op = DataFrameSum(axis=axis, skipna=skipna, level=level, min_count=min_count,
-                      numeric_only=numeric_only, combine_size=combine_size, object_type=ObjectType.series)
+def prod_dataframe(df, axis=None, skipna=None, level=None, min_count=0, numeric_only=None, combine_size=None):
+    op = DataFrameProd(axis=axis, skipna=skipna, level=level, min_count=min_count,
+                       numeric_only=numeric_only, combine_size=combine_size, object_type=ObjectType.series)
     return op(df)

--- a/mars/dataframe/reduction/sum.py
+++ b/mars/dataframe/reduction/sum.py
@@ -15,40 +15,20 @@
 from ... import opcodes as OperandDef
 from ...serialize import BoolField
 from ..operands import ObjectType
-from .core import DataFrameReductionOperand, SeriesReductionMixin, DataFrameReductionMixin
-
-
-class SeriesSum(DataFrameReductionOperand, SeriesReductionMixin):
-    _op_type_ = OperandDef.SUM
-    _func_name = 'sum'
-
-    _is_terminal = BoolField('is_terminal')
-
-    def __init__(self, is_terminal=None, **kw):
-        super(SeriesSum, self).__init__(_is_terminal=is_terminal, _object_type=ObjectType.series, **kw)
-
-    @property
-    def is_terminal(self):
-        return self._is_terminal
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 
 class DataFrameSum(DataFrameReductionOperand, DataFrameReductionMixin):
     _op_type_ = OperandDef.SUM
     _func_name = 'sum'
 
-    _numeric_only = BoolField('numeric_only')
-
     def __init__(self, numeric_only=None, object_type=ObjectType.series, **kw):
         super(DataFrameSum, self).__init__(_numeric_only=numeric_only,
                                            _object_type=object_type, **kw)
 
-    @property
-    def numeric_only(self):
-        return self._numeric_only
-
 
 def sum_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):
-    op = SeriesSum(axis=axis, skipna=skipna, level=level, min_count=min_count, combine_size=combine_size)
+    op = DataFrameSum(axis=axis, skipna=skipna, level=level, min_count=min_count, combine_size=combine_size)
     return op(df)
 
 

--- a/mars/dataframe/reduction/tests/test_reduction_execute.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execute.py
@@ -78,6 +78,9 @@ class Test(TestBase):
         sum_df2 = from_pandas_df(data, chunk_size=3).sum(skipna=False)
         pd.testing.assert_series_equal(data.sum(skipna=False), sum_df2.execute())
 
+        sum_df2 = from_pandas_df(data, chunk_size=3).sum(skipna=False)
+        pd.testing.assert_series_equal(data.sum(skipna=False), sum_df2.execute())
+
         sum_df3 = from_pandas_df(data, chunk_size=3).sum(min_count=15)
         pd.testing.assert_series_equal(data.sum(min_count=15), sum_df3.execute())
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Refactor `DataFrame.reduction.core` that use the same mixin class `DataFrameReductionMixin` to handle both DataFrame and Series.

Add `max`, `min`, `prod` support.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
