### PR TITLE
Support `axis` argument for `permutation` and `shuffle`

### DIFF
--- a/mars/tensor/random/shuffle.py
+++ b/mars/tensor/random/shuffle.py
@@ -18,7 +18,7 @@ from ..datasource import tensor as astensor
 from ..core import TENSOR_TYPE
 
 
-def shuffle(random_state, x):
+def shuffle(random_state, x, axis=0):
     r"""
     Modify a sequence in-place by shuffling its contents.
     The order of sub-arrays is changed but their contents remains the same.
@@ -26,6 +26,8 @@ def shuffle(random_state, x):
     ----------
     x : array_like
         The array or list to be shuffled.
+    axis : int, optional
+        The axis which `x` is shuffled along. Default is 0.
     Returns
     -------
     None
@@ -51,5 +53,5 @@ def shuffle(random_state, x):
     else:
         raise TypeError('x should be list, numpy ndarray or tensor')
 
-    ret = permutation(random_state, x)
+    ret = permutation(random_state, x, axis=axis)
     x.data = ret.data

--- a/mars/tensor/random/tests/test_random.py
+++ b/mars/tensor/random/tests/test_random.py
@@ -161,3 +161,8 @@ class Test(TestBase):
         x = rand(10, 10, chunk_size=2)
         shuffle(x)
         self.assertIsInstance(x.op, TensorPermutation)
+
+        x = rand(10, 10, chunk_size=2)
+        shuffle(x, axis=1)
+        self.assertIsInstance(x.op, TensorPermutation)
+        self.assertEqual(x.op.axis, 1)

--- a/mars/tensor/random/tests/test_random_execute.py
+++ b/mars/tensor/random/tests/test_random_execute.py
@@ -595,7 +595,13 @@ class Test(unittest.TestCase):
         np.testing.assert_array_equal(np.sort(res), np.asarray([1, 4, 9, 12, 15]))
 
         arr = from_ndarray(np.arange(48).reshape(12, 4), chunk_size=2)
+        # axis = 0
         x = tensor.random.permutation(arr)
         res = self.executor.execute_tensor(x, concat=True)[0]
         self.assertFalse(np.all(res[:-1] < res[1:]))
         np.testing.assert_array_equal(np.sort(res, axis=0), np.arange(48).reshape(12, 4))
+        # axis != 0
+        x2 = tensor.random.permutation(arr, axis=1)
+        res = self.executor.execute_tensor(x2, concat=True)[0]
+        self.assertFalse(np.all(res[:, :-1] < res[:, 1:]))
+        np.testing.assert_array_equal(np.sort(res, axis=1), np.arange(48).reshape(12, 4))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR adds `axis` argument to `mt.random.permutation` and `mt.random.shuffle`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #802 .
