### PR TITLE
Add `mars.learn.utils.shuffle` to support shuffling multiple tileable objects in a consistent way

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -11,10 +11,10 @@ if [ -z "$NO_COMMON_TESTS" ]; then
     coverage report
   else
     mkdir -p build
-    pytest $PYTEST_CONFIG --cov-config .coveragerc-threaded mars/tensor mars/dataframe mars/web \
-        mars/learn/contrib/xgboost
+    pytest $PYTEST_CONFIG --cov-config .coveragerc-threaded mars/tensor mars/dataframe mars/web mars/learn
     mv .coverage build/.coverage.tensor.file
-    pytest $PYTEST_CONFIG --cov-config .coveragerc --forked --ignore mars/tensor --ignore mars/dataframe mars
+    pytest $PYTEST_CONFIG --cov-config .coveragerc --forked --ignore mars/tensor --ignore mars/dataframe \
+     --ignore mars/learn mars
     mv .coverage build/.coverage.main.file
     coverage combine build/ && coverage report --fail-under=85
 

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -524,6 +524,9 @@ class Series(TileableEntity):
     def from_tensor(self, in_tensor, index=None, name=None):
         return self._data.from_tensor(in_tensor, index=index, name=name)
 
+    def __mars_tensor__(self, dtype=None, order='K'):
+        return self._data.to_tensor().astype(dtype=dtype, order=order, copy=False)
+
 
 class DataFrameChunkData(ChunkData):
     __slots__ = ()

--- a/mars/dataframe/initializer.py
+++ b/mars/dataframe/initializer.py
@@ -28,6 +28,8 @@ class DataFrame(_Frame):
     def __init__(self, data=None, index=None, columns=None, dtype=None, copy=False,
                  chunk_size=None, gpu=None, sparse=None):
         if isinstance(data, TENSOR_TYPE):
+            if chunk_size is not None:
+                data = data.rechunk(chunk_size)
             df = dataframe_from_tensor(data, index=index, columns=columns, gpu=gpu, sparse=sparse)
         elif isinstance(data, DATAFRAME_TYPE):
             df = data

--- a/mars/learn/__init__.py
+++ b/mars/learn/__init__.py
@@ -14,5 +14,7 @@
 
 # register operands
 from .contrib.xgboost import train as xgboost_train
+from .utils.shuffle import shuffle
 del xgboost_train
+del shuffle
 

--- a/mars/learn/contrib/xgboost/dmatrix.py
+++ b/mars/learn/contrib/xgboost/dmatrix.py
@@ -14,17 +14,15 @@
 
 import itertools
 
-import pandas as pd
-
 from ....core import ExecutableTuple
 from .... import opcodes as OperandDef
 from ....serialize.core import KeyField, Float64Field, ListField, BoolField
 from ....tensor.core import TENSOR_TYPE, CHUNK_TYPE as TENSOR_CHUNK_TYPE
 from ....tensor import tensor as astensor
-from ....dataframe.core import DATAFRAME_TYPE, SERIES_TYPE
+from ....dataframe.core import DATAFRAME_TYPE
 from ....dataframe.operands import ObjectType
-from ....dataframe.initializer import DataFrame as create_dataframe, Series as create_series
-from ...operands import LearnOperand, LearnOperandMixin, OutputType
+from ...operands import LearnOperand, LearnOperandMixin
+from ...utils import convert_to_tensor_or_dataframe, get_output_types
 
 
 def _on_serialize_object_type(object_type):
@@ -307,61 +305,35 @@ class ToDMatrix(LearnOperand, LearnOperandMixin):
 
 
 def check_data(data):
-    if isinstance(data, (DATAFRAME_TYPE, pd.DataFrame)):
-        data = create_dataframe(data)
-    else:
-        data = astensor(data)
-
+    data = convert_to_tensor_or_dataframe(data)
     if data.ndim != 2:
         raise ValueError('Expecting 2-d data, got: {0}-d'.format(data.ndim))
 
     return data
 
 
-def _get_output_types(*objs):
-    output_types = []
-    for obj in objs:
-        if obj is None:
-            continue
-        if isinstance(obj, TENSOR_TYPE):
-            output_types.append(OutputType.tensor)
-        elif isinstance(obj, DATAFRAME_TYPE):
-            output_types.append(OutputType.dataframe)
-        elif isinstance(obj, SERIES_TYPE):
-            output_types.append(OutputType.series)
-        else:  # pragma: no cover
-            raise TypeError('Output can only be tensor, dataframe or series')
-    return output_types
-
-
 def to_dmatrix(data, label=None, missing=None, weight=None,
                feature_names=None, feature_types=None, session=None, run_kwargs=None):
     data = check_data(data)
     if label is not None:
-        if isinstance(label, (DATAFRAME_TYPE, pd.DataFrame)):
-            label = create_dataframe(label)
-            label = label.iloc[:, 0].to_tensor()
-        elif isinstance(label, (SERIES_TYPE, pd.Series)):
-            label = create_series(label).to_tensor()
-        else:
-            label = astensor(label)
-            if label.ndim != 1:
-                raise ValueError('Expecting 1-d label, got: {0}-d'.format(label.ndim))
+        label = convert_to_tensor_or_dataframe(label)
+        if isinstance(label, DATAFRAME_TYPE):
+            label = label.iloc[:, 0]
+        label = astensor(label)
+        if label.ndim != 1:
+            raise ValueError('Expecting 1-d label, got: {0}-d'.format(label.ndim))
     if weight is not None:
-        if isinstance(weight, (DATAFRAME_TYPE, pd.DataFrame)):
-            weight = create_dataframe(weight)
-            weight = weight.iloc[:, 0].to_tensor()
-        elif isinstance(weight, (SERIES_TYPE, pd.Series)):
-            weight = create_series(weight).to_tensor()
-        else:
-            weight = astensor(weight)
-            if weight.ndim != 1:
-                raise ValueError('Expecting 1-d weight, got {0}-d'.format(weight.ndim))
+        weight = convert_to_tensor_or_dataframe(weight)
+        if isinstance(weight, DATAFRAME_TYPE):
+            weight = weight.iloc[:, 0]
+        weight = astensor(weight)
+        if weight.ndim != 1:
+            raise ValueError('Expecting 1-d weight, got {0}-d'.format(weight.ndim))
 
     op = ToDMatrix(data=data, label=label, missing=missing, weight=weight,
                    feature_names=feature_names, feature_types=feature_types,
                    gpu=data.op.gpu, multi_output=True,
-                   output_types=_get_output_types(data, label, weight))
+                   output_types=get_output_types(data, label, weight))
     outs = ExecutableTuple(op())
     # Execute first, to make sure the counterpart chunks of data, label and weight are co-allocated
     outs.execute(session=session, fetch=False, **(run_kwargs or dict()))
@@ -374,7 +346,7 @@ def to_dmatrix(data, label=None, missing=None, weight=None,
     op = ToDMatrix(data=data, label=label, missing=missing, weight=weight,
                    feature_names=feature_names, feature_types=feature_types,
                    gpu=data.op.gpu, multi_output=False,
-                   output_types=_get_output_types(data))
+                   output_types=get_output_types(data))
     return op()
 
 

--- a/mars/learn/contrib/xgboost/dmatrix.py
+++ b/mars/learn/contrib/xgboost/dmatrix.py
@@ -25,16 +25,6 @@ from ...operands import LearnOperand, LearnOperandMixin
 from ...utils import convert_to_tensor_or_dataframe, get_output_types
 
 
-def _on_serialize_object_type(object_type):
-    if object_type is not None:
-        return object_type.value
-
-
-def _on_deserialize_object_type(ser):
-    if ser is not None:
-        return ObjectType(ser)
-
-
 class ToDMatrix(LearnOperand, LearnOperandMixin):
     _op_type_ = OperandDef.TO_DMATRIX
 

--- a/mars/learn/contrib/xgboost/dmatrix.py
+++ b/mars/learn/contrib/xgboost/dmatrix.py
@@ -20,7 +20,6 @@ from ....serialize.core import KeyField, Float64Field, ListField, BoolField
 from ....tensor.core import TENSOR_TYPE, CHUNK_TYPE as TENSOR_CHUNK_TYPE
 from ....tensor import tensor as astensor
 from ....dataframe.core import DATAFRAME_TYPE
-from ....dataframe.operands import ObjectType
 from ...operands import LearnOperand, LearnOperandMixin
 from ...utils import convert_to_tensor_or_dataframe, get_output_types
 

--- a/mars/learn/datasets/__init__.py
+++ b/mars/learn/datasets/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .samples_generator import make_classification, make_low_rank_matrix

--- a/mars/learn/datasets/samples_generator.py
+++ b/mars/learn/datasets/samples_generator.py
@@ -12,14 +12,236 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from ... import tensor as mt
 from ...tensor.utils import check_random_state
 from ...tensor import linalg
+from ..utils import shuffle as util_shuffle
 
 
 # -------------------------------------------------------------------
 # Original implementation is in `sklearn.datasets.samples_generator`.
 # -------------------------------------------------------------------
+
+
+def make_classification(n_samples=100, n_features=20, n_informative=2,
+                        n_redundant=2, n_repeated=0, n_classes=2,
+                        n_clusters_per_class=2, weights=None, flip_y=0.01,
+                        class_sep=1.0, hypercube=True, shift=0.0, scale=1.0,
+                        shuffle=True, random_state=None):
+    """Generate a random n-class classification problem.
+
+    This initially creates clusters of points normally distributed (std=1)
+    about vertices of an ``n_informative``-dimensional hypercube with sides of
+    length ``2*class_sep`` and assigns an equal number of clusters to each
+    class. It introduces interdependence between these features and adds
+    various types of further noise to the data.
+
+    Without shuffling, ``X`` horizontally stacks features in the following
+    order: the primary ``n_informative`` features, followed by ``n_redundant``
+    linear combinations of the informative features, followed by ``n_repeated``
+    duplicates, drawn randomly with replacement from the informative and
+    redundant features. The remaining features are filled with random noise.
+    Thus, without shuffling, all useful features are contained in the columns
+    ``X[:, :n_informative + n_redundant + n_repeated]``.
+
+    Read more in the :ref:`User Guide <sample_generators>`.
+
+    Parameters
+    ----------
+    n_samples : int, optional (default=100)
+        The number of samples.
+
+    n_features : int, optional (default=20)
+        The total number of features. These comprise ``n_informative``
+        informative features, ``n_redundant`` redundant features,
+        ``n_repeated`` duplicated features and
+        ``n_features-n_informative-n_redundant-n_repeated`` useless features
+        drawn at random.
+
+    n_informative : int, optional (default=2)
+        The number of informative features. Each class is composed of a number
+        of gaussian clusters each located around the vertices of a hypercube
+        in a subspace of dimension ``n_informative``. For each cluster,
+        informative features are drawn independently from  N(0, 1) and then
+        randomly linearly combined within each cluster in order to add
+        covariance. The clusters are then placed on the vertices of the
+        hypercube.
+
+    n_redundant : int, optional (default=2)
+        The number of redundant features. These features are generated as
+        random linear combinations of the informative features.
+
+    n_repeated : int, optional (default=0)
+        The number of duplicated features, drawn randomly from the informative
+        and the redundant features.
+
+    n_classes : int, optional (default=2)
+        The number of classes (or labels) of the classification problem.
+
+    n_clusters_per_class : int, optional (default=2)
+        The number of clusters per class.
+
+    weights : list of floats or None (default=None)
+        The proportions of samples assigned to each class. If None, then
+        classes are balanced. Note that if ``len(weights) == n_classes - 1``,
+        then the last class weight is automatically inferred.
+        More than ``n_samples`` samples may be returned if the sum of
+        ``weights`` exceeds 1.
+
+    flip_y : float, optional (default=0.01)
+        The fraction of samples whose class are randomly exchanged. Larger
+        values introduce noise in the labels and make the classification
+        task harder.
+
+    class_sep : float, optional (default=1.0)
+        The factor multiplying the hypercube size.  Larger values spread
+        out the clusters/classes and make the classification task easier.
+
+    hypercube : boolean, optional (default=True)
+        If True, the clusters are put on the vertices of a hypercube. If
+        False, the clusters are put on the vertices of a random polytope.
+
+    shift : float, array of shape [n_features] or None, optional (default=0.0)
+        Shift features by the specified value. If None, then features
+        are shifted by a random value drawn in [-class_sep, class_sep].
+
+    scale : float, array of shape [n_features] or None, optional (default=1.0)
+        Multiply features by the specified value. If None, then features
+        are scaled by a random value drawn in [1, 100]. Note that scaling
+        happens after shifting.
+
+    shuffle : boolean, optional (default=True)
+        Shuffle the samples and the features.
+
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation for dataset creation. Pass an int
+        for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
+
+    Returns
+    -------
+    X : array of shape [n_samples, n_features]
+        The generated samples.
+
+    y : array of shape [n_samples]
+        The integer labels for class membership of each sample.
+
+    Notes
+    -----
+    The algorithm is adapted from Guyon [1] and was designed to generate
+    the "Madelon" dataset.
+
+    References
+    ----------
+    .. [1] I. Guyon, "Design of experiments for the NIPS 2003 variable
+           selection benchmark", 2003.
+
+    See also
+    --------
+    make_blobs: simplified variant
+    make_multilabel_classification: unrelated generator for multilabel tasks
+    """
+    from sklearn.datasets.samples_generator import _generate_hypercube
+
+    generator = check_random_state(random_state)
+    np_generator = generator.to_numpy()
+
+    # Count features, clusters and samples
+    if n_informative + n_redundant + n_repeated > n_features:
+        raise ValueError("Number of informative, redundant and repeated "
+                         "features must sum to less than the number of total"
+                         " features")
+    # Use log2 to avoid overflow errors
+    if n_informative < np.log2(n_classes * n_clusters_per_class):
+        raise ValueError("n_classes * n_clusters_per_class must"
+                         " be smaller or equal 2 ** n_informative")
+    if weights and len(weights) not in [n_classes, n_classes - 1]:
+        raise ValueError("Weights specified but incompatible with number "
+                         "of classes.")
+
+    n_useless = n_features - n_informative - n_redundant - n_repeated
+    n_clusters = n_classes * n_clusters_per_class
+
+    if weights and len(weights) == (n_classes - 1):
+        weights = weights + [1.0 - sum(weights)]
+
+    if weights is None:
+        weights = [1.0 / n_classes] * n_classes
+        weights[-1] = 1.0 - sum(weights[:-1])
+
+    # Distribute samples among clusters by weight
+    n_samples_per_cluster = [
+        int(n_samples * weights[k % n_classes] / n_clusters_per_class)
+        for k in range(n_clusters)]
+
+    for i in range(n_samples - sum(n_samples_per_cluster)):
+        n_samples_per_cluster[i % n_clusters] += 1
+
+    # Initialize X and y
+    X = mt.zeros((n_samples, n_features))
+    y = mt.zeros(n_samples, dtype=mt.int)
+
+    # Build the polytope whose vertices become cluster centroids
+    centroids = _generate_hypercube(n_clusters, n_informative,
+                                    np_generator).astype(float, copy=False)
+    centroids *= 2 * class_sep
+    centroids -= class_sep
+    if not hypercube:
+        centroids *= np_generator.rand(n_clusters, 1)
+        centroids *= np_generator.rand(1, n_informative)
+
+    # Initially draw informative features from the standard normal
+    X[:, :n_informative] = generator.randn(n_samples, n_informative)
+
+    # Create each cluster; a variant of make_blobs
+    stop = 0
+    for k, centroid in enumerate(centroids):
+        start, stop = stop, stop + n_samples_per_cluster[k]
+        y[start:stop] = k % n_classes  # assign labels
+        X_k = X[start:stop, :n_informative]  # slice a view of the cluster
+
+        A = 2 * generator.rand(n_informative, n_informative) - 1
+        X_k[...] = mt.dot(X_k, A)  # introduce random covariance
+
+        X_k += centroid  # shift the cluster to a vertex
+
+    # Create redundant features
+    if n_redundant > 0:
+        B = 2 * generator.rand(n_informative, n_redundant) - 1
+        X[:, n_informative:n_informative + n_redundant] = \
+            mt.dot(X[:, :n_informative], B)
+
+    # Repeat some features
+    if n_repeated > 0:
+        n = n_informative + n_redundant
+        indices = ((n - 1) * generator.rand(n_repeated) + 0.5).astype(mt.intp)
+        X[:, n:n + n_repeated] = X[:, indices]
+
+    # Fill useless features
+    if n_useless > 0:
+        X[:, -n_useless:] = generator.randn(n_samples, n_useless)
+
+    # Randomly replace labels
+    if flip_y >= 0.0:
+        flip_mask = generator.rand(n_samples) < flip_y
+        y = mt.where(flip_mask, generator.randint(n_classes, size=len(y)), y)
+
+    # Randomly shift and scale
+    if shift is None:
+        shift = (2 * generator.rand(n_features) - 1) * class_sep
+    X += shift
+
+    if scale is None:
+        scale = 1 + 100 * generator.rand(n_features)
+    X *= scale
+
+    if shuffle:
+        # Randomly permute samples
+        X, y = util_shuffle(X, y, random_state=generator, axes=(0, 1))
+
+    return X, y
 
 
 def make_low_rank_matrix(n_samples=100, n_features=100, effective_rank=10,

--- a/mars/learn/datasets/tests/test_samples_generator.py
+++ b/mars/learn/datasets/tests/test_samples_generator.py
@@ -13,12 +13,134 @@
 # limitations under the License.
 
 import unittest
+from functools import partial
+from collections import defaultdict
 
-from mars.learn.datasets.samples_generator import make_low_rank_matrix
+import numpy as np
+try:
+    import sklearn
+    from sklearn.utils.testing import assert_array_almost_equal, assert_raises
+except ImportError:  # pragma: no cover
+    sklearn = None
+
+from mars.learn.datasets.samples_generator import make_low_rank_matrix, make_classification
 from mars.tensor.linalg import svd
+from mars import tensor as mt
 
 
 class Test(unittest.TestCase):
+    @unittest.skipIf(sklearn is None, 'sklearn not installed')
+    def testMakeClassification(self):
+        weights = [0.1, 0.25]
+        X, y = make_classification(n_samples=100, n_features=20, n_informative=5,
+                                   n_redundant=1, n_repeated=1, n_classes=3,
+                                   n_clusters_per_class=1, hypercube=False,
+                                   shift=None, scale=None, weights=weights,
+                                   random_state=0)
+
+        self.assertEqual(weights, [0.1, 0.25])
+        self.assertEqual(X.shape, (100, 20), "X shape mismatch")
+        self.assertEqual(y.shape, (100,), "y shape mismatch")
+        self.assertEqual(mt.unique(y).execute().shape, (3,), "Unexpected number of classes")
+        self.assertEqual((y == 0).sum().execute(), 10, "Unexpected number of samples in class #0")
+        self.assertEqual((y == 1).sum().execute(), 25, "Unexpected number of samples in class #1")
+        self.assertEqual((y == 2).sum().execute(), 65, "Unexpected number of samples in class #2")
+
+        # Test for n_features > 30
+        X, y = make_classification(n_samples=2000, n_features=31, n_informative=31,
+                                   n_redundant=0, n_repeated=0, hypercube=True,
+                                   scale=0.5, random_state=0)
+
+        X = X.execute()
+        self.assertEqual(X.shape, (2000, 31), "X shape mismatch")
+        self.assertEqual(y.shape, (2000,), "y shape mismatch")
+        self.assertEqual(np.unique(X.view([('', X.dtype)]*X.shape[1])).view(X.dtype)
+                         .reshape(-1, X.shape[1]).shape[0], 2000,
+                         "Unexpected number of unique rows")
+
+    @unittest.skipIf(sklearn is None, 'sklearn not installed')
+    def testMakeClassificationInformativeFeatures(self):
+        """Test the construction of informative features in make_classification
+
+        Also tests `n_clusters_per_class`, `n_classes`, `hypercube` and
+        fully-specified `weights`.
+        """
+        # Create very separate clusters; check that vertices are unique and
+        # correspond to classes
+        class_sep = 1e6
+        make = partial(make_classification, class_sep=class_sep, n_redundant=0,
+                       n_repeated=0, flip_y=0, shift=0, scale=1, shuffle=False)
+
+        for n_informative, weights, n_clusters_per_class in [(2, [1], 1),
+                                                             (2, [1/3] * 3, 1),
+                                                             (2, [1/4] * 4, 1),
+                                                             (2, [1/2] * 2, 2),
+                                                             (2, [3/4, 1/4], 2),
+                                                             (10, [1/3] * 3, 10),
+                                                             (np.int(64), [1], 1)
+                                                             ]:
+            n_classes = len(weights)
+            n_clusters = n_classes * n_clusters_per_class
+            n_samples = n_clusters * 50
+
+            for hypercube in (False, True):
+                X, y = make(n_samples=n_samples, n_classes=n_classes,
+                            weights=weights, n_features=n_informative,
+                            n_informative=n_informative,
+                            n_clusters_per_class=n_clusters_per_class,
+                            hypercube=hypercube, random_state=0)
+
+                self.assertEqual(X.shape, (n_samples, n_informative))
+                self.assertEqual(y.shape, (n_samples,))
+
+                # Cluster by sign, viewed as strings to allow uniquing
+                signs = mt.sign(X).execute()
+                signs = signs.view(dtype='|S{0}'.format(signs.strides[0]))
+                unique_signs, cluster_index = np.unique(signs,
+                                                        return_inverse=True)
+
+                self.assertEqual(len(unique_signs), n_clusters,
+                                 "Wrong number of clusters, or not in distinct "
+                                 "quadrants")
+
+                clusters_by_class = defaultdict(set)
+                for cluster, cls in zip(cluster_index, y):
+                    clusters_by_class[cls].add(cluster)
+                for clusters in clusters_by_class.values():
+                    self.assertEqual(len(clusters), n_clusters_per_class,
+                                     "Wrong number of clusters per class")
+                self.assertEqual(len(clusters_by_class), n_classes,
+                                 "Wrong number of classes")
+
+                assert_array_almost_equal(np.bincount(y) / len(y) // weights,
+                                          [1] * n_classes,
+                                          err_msg="Wrong number of samples "
+                                                  "per class")
+
+                # Ensure on vertices of hypercube
+                for cluster in range(len(unique_signs)):
+                    centroid = X[cluster_index == cluster].mean(axis=0)
+                    if hypercube:
+                        assert_array_almost_equal(np.abs(centroid) / class_sep,
+                                                  np.ones(n_informative),
+                                                  decimal=5,
+                                                  err_msg="Clusters are not "
+                                                          "centered on hypercube "
+                                                          "vertices")
+                    else:
+                        assert_raises(AssertionError,
+                                      assert_array_almost_equal,
+                                      np.abs(centroid) / class_sep,
+                                      np.ones(n_informative),
+                                      decimal=5,
+                                      err_msg="Clusters should not be centered "
+                                              "on hypercube vertices")
+
+        assert_raises(ValueError, make, n_features=2, n_informative=2, n_classes=5,
+                      n_clusters_per_class=1)
+        assert_raises(ValueError, make, n_features=2, n_informative=2, n_classes=3,
+                      n_clusters_per_class=2)
+
     def testMakeLowRankMatrix(self):
         X = make_low_rank_matrix(n_samples=50, n_features=25, effective_rank=5,
                                  tail_strength=0.01, random_state=0)

--- a/mars/learn/datasets/tests/test_samples_generator.py
+++ b/mars/learn/datasets/tests/test_samples_generator.py
@@ -37,7 +37,7 @@ class Test(unittest.TestCase):
                                    n_redundant=1, n_repeated=1, n_classes=3,
                                    n_clusters_per_class=1, hypercube=False,
                                    shift=None, scale=None, weights=weights,
-                                   random_state=0)
+                                   random_state=0, flip_y=-1)
 
         self.assertEqual(weights, [0.1, 0.25])
         self.assertEqual(X.shape, (100, 20), "X shape mismatch")

--- a/mars/learn/datasets/tests/test_samples_generator.py
+++ b/mars/learn/datasets/tests/test_samples_generator.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import division
 import unittest
 from functools import partial
 from collections import defaultdict

--- a/mars/learn/datasets/tests/test_samples_generator.py
+++ b/mars/learn/datasets/tests/test_samples_generator.py
@@ -84,17 +84,18 @@ class Test(unittest.TestCase):
             n_samples = n_clusters * 50
 
             for hypercube in (False, True):
-                X, y = make(n_samples=n_samples, n_classes=n_classes,
-                            weights=weights, n_features=n_informative,
-                            n_informative=n_informative,
-                            n_clusters_per_class=n_clusters_per_class,
-                            hypercube=hypercube, random_state=0)
+                generated = make(n_samples=n_samples, n_classes=n_classes,
+                                 weights=weights, n_features=n_informative,
+                                 n_informative=n_informative,
+                                 n_clusters_per_class=n_clusters_per_class,
+                                 hypercube=hypercube, random_state=0)
 
+                X, y = mt.ExecutableTuple(generated).execute()
                 self.assertEqual(X.shape, (n_samples, n_informative))
                 self.assertEqual(y.shape, (n_samples,))
 
                 # Cluster by sign, viewed as strings to allow uniquing
-                signs = mt.sign(X).execute()
+                signs = np.sign(X)
                 signs = signs.view(dtype='|S{0}'.format(signs.strides[0]))
                 unique_signs, cluster_index = np.unique(signs,
                                                         return_inverse=True)

--- a/mars/learn/operands.py
+++ b/mars/learn/operands.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..operands import Operand, TileableOperandMixin, Fetch, FetchMixin, Fuse, FuseChunkMixin
+from ..operands import Operand, TileableOperandMixin, Fetch, FetchMixin, \
+    Fuse, FuseChunkMixin, ShuffleMap, ShuffleReduce, ShuffleProxy
 from ..compat import enum
 from ..serialize import ValueType, ListField
 from ..tensor.core import TensorChunkData, TensorChunk, TensorData, Tensor, \
@@ -181,3 +182,38 @@ class LearnObjectFuseChunk(Fuse, LearnObjectFuseChunkMixin):
     @property
     def output_types(self):
         return [OutputType.object]
+
+
+class LearnShuffleProxy(ShuffleProxy, LearnOperandMixin):
+    _output_types = ListField('output_type', tp=ValueType.int8,
+                              on_serialize=_on_serialize_output_types,
+                              on_deserialize=_on_deserialize_output_types)
+
+    def __init__(self, output_types=None, **kw):
+        super(LearnShuffleProxy, self).__init__(_output_types=output_types, **kw)
+        if self._output_types is None:
+            self._output_types = [OutputType.object]
+
+    @property
+    def output_types(self):
+        return self._output_types
+
+
+class LearnShuffleMap(ShuffleMap):
+    _output_types = ListField('output_type', tp=ValueType.int8,
+                              on_serialize=_on_serialize_output_types,
+                              on_deserialize=_on_deserialize_output_types)
+
+    @property
+    def output_types(self):
+        return self._output_types
+
+
+class LearnShuffleReduce(ShuffleReduce):
+    _output_types = ListField('output_type', tp=ValueType.int8,
+                              on_serialize=_on_serialize_output_types,
+                              on_deserialize=_on_deserialize_output_types)
+
+    @property
+    def output_types(self):
+        return self._output_types

--- a/mars/learn/operands.py
+++ b/mars/learn/operands.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Alibaba Group Holding Ltd.
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mars/learn/utils/__init__.py
+++ b/mars/learn/utils/__init__.py
@@ -13,4 +13,6 @@
 # limitations under the License.
 
 
+from .core import convert_to_tensor_or_dataframe, get_output_types
 from .validation import check_array
+from .shuffle import shuffle

--- a/mars/learn/utils/core.py
+++ b/mars/learn/utils/core.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Alibaba Group Holding Ltd.
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mars/learn/utils/core.py
+++ b/mars/learn/utils/core.py
@@ -1,0 +1,48 @@
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+
+from ...tensor import tensor as astensor
+from ...tensor.core import TENSOR_TYPE, CHUNK_TYPE as TENSOR_CHUNK_TYPE
+from ...dataframe import DataFrame, Series
+from ...dataframe.core import DATAFRAME_TYPE, SERIES_TYPE, \
+    DATAFRAME_CHUNK_TYPE, SERIES_CHUNK_TYPE
+from ..operands import OutputType
+
+
+def convert_to_tensor_or_dataframe(item):
+    if isinstance(item, (DATAFRAME_TYPE, pd.DataFrame)):
+        item = DataFrame(item)
+    elif isinstance(item, (SERIES_TYPE, pd.Series)):
+        item = Series(item)
+    else:
+        item = astensor(item)
+    return item
+
+
+def get_output_types(*objs):
+    output_types = []
+    for obj in objs:
+        if obj is None:
+            continue
+        if isinstance(obj, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
+            output_types.append(OutputType.tensor)
+        elif isinstance(obj, (DATAFRAME_TYPE, DATAFRAME_CHUNK_TYPE)):
+            output_types.append(OutputType.dataframe)
+        elif isinstance(obj, (SERIES_TYPE, SERIES_CHUNK_TYPE)):
+            output_types.append(OutputType.series)
+        else:  # pragma: no cover
+            raise TypeError('Output can only be tensor, dataframe or series')
+    return output_types

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -89,7 +89,7 @@ class LearnShuffle(LearnOperand, LearnOperandMixin):
                     param['index_value'] = self._shuffle_index_value(param['index_value'])
                 if 1 in axes:
                     dtypes = param['dtypes'] = self._shuffle_dtypes(param['dtypes'])
-                    param['columns'] = parse_index(dtypes.index, store_data=True)
+                    param['columns_value'] = parse_index(dtypes.index, store_data=True)
             elif output_type == OutputType.series:
                 if 0 in axes:
                     param['index_value'] = self._shuffle_index_value(param['index_value'])
@@ -124,7 +124,7 @@ class LearnShuffle(LearnOperand, LearnOperandMixin):
                 chunk_shape[0] = np.nan
             params['shape'] = tuple(chunk_shape)
             params['dtypes'] = output.dtypes
-            params['columns_value'] = output.columns
+            params['columns_value'] = output.columns_value
             params['index_value'] = _shuffle_index_value(chunk_op, in_chunk.index_value)
         else:
             assert output_type == OutputType.series

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -1,0 +1,451 @@
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+from collections import defaultdict, Iterable
+
+import numpy as np
+import pandas as pd
+
+from ... import opcodes as OperandDef
+from ...serialize import ValueType, TupleField, KeyField
+from ...tensor.utils import validate_axis, check_random_state, gen_random_seeds, decide_unify_split
+from ...tensor.array_utils import get_array_module
+from ...dataframe.utils import parse_index
+from ...utils import tokenize, get_shuffle_input_keys_idxes, lazy_import
+from ...compat import reduce
+from ...core import ExecutableTuple
+from ..operands import LearnOperand, LearnOperandMixin, OutputType, \
+    LearnShuffleMap as LearnShuffleMapBase, LearnShuffleReduce as LearnShuffleReduceBase, LearnShuffleProxy
+from ..utils import convert_to_tensor_or_dataframe, get_output_types
+
+
+cudf = lazy_import('cudf')
+
+
+def _shuffle_index_value(op, index_value):
+    key = tokenize((op._values_, index_value.key))
+    return parse_index(pd.Index([], index_value.to_pandas().dtype), key=key)
+
+
+def _safe_slice(obj, slc, output_type):
+    if output_type == OutputType.tensor:
+        return obj[slc]
+    else:
+        return obj.iloc[slc]
+
+
+class LearnShuffle(LearnOperand, LearnOperandMixin):
+    _op_type_ = OperandDef.PERMUTATION
+
+    _axes = TupleField('axes', ValueType.int32)
+    _seeds = TupleField('seeds', ValueType.uint32)
+
+    def __init__(self, axes=None, seeds=None, output_types=None, **kw):
+        super(LearnShuffle, self).__init__(_axes=axes, _seeds=seeds,
+                                           _output_types=output_types, **kw)
+
+    @property
+    def axes(self):
+        return self._axes
+
+    @property
+    def seeds(self):
+        return self._seeds
+
+    @property
+    def output_limit(self):
+        return len(self._output_types)
+
+    def __call__(self, arrays):
+        params = self._calc_params([ar.params for ar in arrays])
+        return self.new_tileables(arrays, kws=params)
+
+    def _shuffle_index_value(self, index_value):
+        return _shuffle_index_value(self, index_value)
+
+    def _shuffle_dtypes(self, dtypes):
+        seed = self.seeds[self.axes.index(1)]
+        rs = np.random.RandomState(seed)
+        shuffled_dtypes = dtypes[rs.permutation(np.arange(len(dtypes)))]
+        return shuffled_dtypes
+
+    def _calc_params(self, params):
+        axes = set(self.axes)
+        for output_type, param in zip(self._output_types, params):
+            if output_type == OutputType.dataframe:
+                if 0 in axes:
+                    param['index_value'] = self._shuffle_index_value(param['index_value'])
+                if 1 in axes:
+                    dtypes = param['dtypes'] = self._shuffle_dtypes(param['dtypes'])
+                    param['columns'] = parse_index(dtypes.index, store_data=True)
+            elif output_type == OutputType.series:
+                if 0 in axes:
+                    param['index_value'] = self._shuffle_index_value(param['index_value'])
+        return params
+
+    @staticmethod
+    def _safe_rechunk(tileable, ax_nsplit):
+        do_rechunk = False
+        for ax, nsplit in ax_nsplit.items():
+            if ax >= tileable.ndim:
+                continue
+            if tuple(tileable.nsplits[ax]) != tuple(nsplit):
+                do_rechunk = True
+        if do_rechunk:
+            return tileable.rechunk(ax_nsplit).single_tiles()
+        else:
+            return tileable
+
+    @classmethod
+    def _calc_chunk_params(cls, in_chunk, axes, output, output_type, chunk_op):
+        params = {'index': in_chunk.index}
+        if output_type == OutputType.tensor:
+            chunk_shape = list(in_chunk.shape)
+            for ax in axes:
+                chunk_shape[ax] = np.nan
+            params['shape'] = tuple(chunk_shape)
+            params['dtype'] = in_chunk.dtype
+            params['order'] = output.order
+        elif output_type == OutputType.dataframe:
+            chunk_shape = list(in_chunk.shape)
+            if 0 in axes:
+                chunk_shape[0] = np.nan
+            params['shape'] = tuple(chunk_shape)
+            params['dtypes'] = output.dtypes
+            params['columns_value'] = output.columns
+            params['index_value'] = _shuffle_index_value(chunk_op, in_chunk.index_value)
+        else:
+            assert output_type == OutputType.series
+            params['shape'] = (np.nan,)
+            params['name'] = in_chunk.name
+            params['index_value'] = _shuffle_index_value(chunk_op, in_chunk.index_value)
+            params['dtype'] = in_chunk.dtype
+        return params
+
+    @classmethod
+    def tile(cls, op):
+        inputs = op.inputs
+        axis_to_nsplits = defaultdict(list)
+        has_dataframe = any(output_type == OutputType.dataframe
+                            for output_type in op.output_types)
+        for ax in op.axes:
+            if has_dataframe and ax == 1:
+                # if DataFrame exists, for the columns axis,
+                # we only allow 1 chunk to ensure the columns consistent
+                axis_to_nsplits[ax].append((inputs[0].shape[ax],))
+                continue
+            for inp in inputs:
+                if ax < inp.ndim:
+                    axis_to_nsplits[ax].append(inp.nsplits[ax])
+        ax_nsplit = {ax: decide_unify_split(*ns) for ax, ns in axis_to_nsplits.items()}
+        inputs = [cls._safe_rechunk(inp, ax_nsplit) for inp in inputs]
+
+        mapper_seeds = [None] * len(op.axes)
+        reducer_seeds = [None] * len(op.axes)
+        for i, ax in enumerate(op.axes):
+            rs = np.random.RandomState(op.seeds[i])
+            size = len(ax_nsplit[ax])
+            if size > 1:
+                mapper_seeds[i] = gen_random_seeds(size, rs)
+                reducer_seeds[i] = gen_random_seeds(size, rs)
+            else:
+                mapper_seeds[i] = reducer_seeds[i] = [op.seeds[i]] * size
+        out_chunks = []
+        out_nsplits = []
+        for output_type, inp, oup in zip(op.output_types, inputs, op.outputs):
+            inp_axes = tuple(ax for ax in op.axes if ax < inp.ndim)
+            reduce_sizes = tuple(inp.chunk_shape[ax] for ax in inp_axes)
+            output_types = [output_type]
+
+            if len(inp_axes) == 0:
+                continue
+
+            nsplits = list(inp.nsplits)
+            for ax in inp_axes:
+                cs = len(nsplits[ax])
+                if cs > 1:
+                    nsplits[ax] = (np.nan,) * cs
+            out_nsplits.append(tuple(nsplits))
+
+            if all(reduce_size == 1 for reduce_size in reduce_sizes):
+                # no need to do shuffle
+                chunks = []
+                for c in inp.chunks:
+                    chunk_op = LearnShuffle(axes=inp_axes, seeds=op.seeds[:len(inp_axes)],
+                                            output_types=output_types)
+                    params = cls._calc_chunk_params(c, inp_axes, oup, output_type, chunk_op)
+                    out_chunk = chunk_op.new_chunk([c], kws=[params])
+                    chunks.append(out_chunk)
+                out_chunks.append(chunks)
+                continue
+
+            if inp.ndim > 1:
+                left_chunk_shape = [s for ax, s in enumerate(inp.chunk_shape) if ax not in inp_axes]
+                idx_iter = itertools.product(*[range(s) for s in left_chunk_shape])
+            else:
+                idx_iter = [()]
+            reduce_chunks = []
+            out_chunks.append(reduce_chunks)
+            for idx in idx_iter:
+                map_chunks = []
+                for reducer_inds in itertools.product(*[range(s) for s in reduce_sizes]):
+                    inp_index = list(idx)
+                    for ax, reducer_ind in zip(inp_axes, reducer_inds):
+                        inp_index.insert(ax, reducer_ind)
+                    inp_index = tuple(inp_index)
+                    in_chunk = inp.cix[inp_index]
+                    params = in_chunk.params
+                    map_chunk_op = LearnShuffleMap(
+                        output_types=output_types, axes=inp_axes,
+                        seeds=[mapper_seeds[j][in_chunk.index[ax]]
+                               for j, ax in enumerate(inp_axes)],
+                        reduce_sizes=reduce_sizes
+                    )
+                    map_chunk = map_chunk_op.new_chunk([in_chunk], **params)
+                    map_chunks.append(map_chunk)
+
+                proxy_chunk = LearnShuffleProxy(_tensor_keys=[inp.key]).new_chunk(map_chunks)
+
+                reduce_axes = tuple(ax for j, ax in enumerate(inp_axes) if reduce_sizes[j] > 1)
+                reduce_sizes_ = tuple(rs for rs in reduce_sizes if rs > 1)
+                for c in map_chunks:
+                    shuffle_key = ','.join(str(idx) for idx in c.index)
+                    chunk_op = LearnShuffleReduce(
+                        output_types=output_types, axes=reduce_axes,
+                        seeds=[reducer_seeds[j][c.index[ax]] for j, ax in enumerate(inp_axes)
+                               if reduce_sizes[j] > 1],
+                        reduce_sizes=reduce_sizes_,
+                        shuffle_key=shuffle_key)
+                    params = cls._calc_chunk_params(c, inp_axes, oup, output_type, chunk_op)
+                    reduce_chunk = chunk_op.new_chunk([proxy_chunk], kws=[params])
+                    reduce_chunks.append(reduce_chunk)
+
+        new_op = op.copy()
+        params = [out.params for out in op.outputs]
+        if len(out_chunks) < len(op.outputs):
+            # axes are all higher than its ndim
+            for i, inp in enumerate(op.inputs):
+                if all(ax >= inp.ndim for ax in op.axes):
+                    out_chunks.insert(i, inp.chunks)
+                    out_nsplits.insert(i, inp.nsplits)
+            assert len(out_chunks) == len(op.outputs)
+        for param, chunks, ns in zip(params, out_chunks, out_nsplits):
+            param['chunks'] = chunks
+            param['nsplits'] = ns
+        return new_op.new_tileables(op.inputs, kws=params)
+
+    @classmethod
+    def execute(cls, ctx, op):
+        x = ctx[op.inputs[0].key]
+
+        for axis, seed in zip(op.axes, op.seeds):
+            size = x.shape[axis]
+            ind = np.random.RandomState(seed).permutation(np.arange(size))
+            slc = (slice(None),) * axis + (ind,)
+            x = _safe_slice(x, slc, op.output_types[0])
+
+        ctx[op.outputs[0].key] = x
+
+
+class LearnShuffleMap(LearnShuffleMapBase, LearnOperandMixin):
+    _op_type_ = OperandDef.PERMUTATION_MAP
+
+    _input = KeyField('input')
+    _axes = TupleField('axes', ValueType.int32)
+    _seeds = TupleField('seeds', ValueType.uint32)
+    _reduce_sizes = TupleField('reduce_sizes', ValueType.uint32)
+
+    def __init__(self, output_types=None, axes=None, seeds=None,
+                 reduce_sizes=None, **kw):
+        super(LearnShuffleMap, self).__init__(_output_types=output_types,
+                                              _axes=axes, _seeds=seeds,
+                                              _reduce_sizes=reduce_sizes, **kw)
+
+    @property
+    def input(self):
+        return self._input
+
+    @property
+    def axes(self):
+        return self._axes
+
+    @property
+    def seeds(self):
+        return self._seeds
+
+    @property
+    def reduce_sizes(self):
+        return self._reduce_sizes
+
+    def _set_inputs(self, inputs):
+        super(LearnShuffleMap, self)._set_inputs(inputs)
+        self._input = self._inputs[0]
+
+    @classmethod
+    def execute(cls, ctx, op):
+        out = op.outputs[0]
+        x = ctx[op.input.key]
+        axes, seeds, reduce_sizes = op.axes, op.seeds, op.reduce_sizes
+        if 1 in set(op.reduce_sizes):
+            # if chunk size on shuffle axis == 0
+            inds = [slice(None) for _ in range(x.ndim)]
+            extra_axes, extra_seeds, extra_reduce_sizes = [], [], []
+            for ax, seed, reduce_size in zip(axes, seeds, reduce_sizes):
+                rs = np.random.RandomState(seed)
+                if reduce_size == 1:
+                    inds[ax] = rs.permutation(np.arange(x.shape[ax]))
+                else:
+                    extra_axes.append(ax)
+                    extra_seeds.append(seed)
+                    extra_reduce_sizes.append(reduce_size)
+            # for the reduce == 1
+            # do shuffle on the map phase
+            x = _safe_slice(x, tuple(inds), op.output_types[0])
+            axes, seeds, reduce_sizes = extra_axes, extra_seeds, extra_reduce_sizes
+
+        to_hash_inds = []
+        for ax, seed, reduce_size in zip(axes, seeds, reduce_sizes):
+            rs = np.random.RandomState(seed)
+            to_hash_inds.append(rs.randint(reduce_size, size=x.shape[ax]))
+
+        for reduce_index in itertools.product(*(range(rs) for rs in reduce_sizes)):
+            index = list(out.index)
+            for ax, ind in zip(axes, reduce_index):
+                index[ax] = ind
+            group_key = ','.join(str(i) for i in index)
+            selected = x
+            for ax, to_hash_ind in zip(axes, to_hash_inds):
+                slc = (slice(None),) * ax + (to_hash_ind == index[ax],)
+                selected = _safe_slice(selected, slc, op.output_types[0])
+            ctx[(out.key, group_key)] = selected
+
+
+class LearnShuffleReduce(LearnShuffleReduceBase, LearnOperandMixin):
+    _op_type_ = OperandDef.PERMUTATION_REDUCE
+
+    _input = KeyField('input')
+    _axes = TupleField('axes', ValueType.int32)
+    _seeds = TupleField('seeds', ValueType.uint32)
+    _reduce_sizes = TupleField('reduce_sizes', ValueType.uint32)
+
+    def __init__(self, output_types=None, axes=None, seeds=None, reduce_sizes=None,
+                 shuffle_key=None, **kw):
+        super(LearnShuffleReduce, self).__init__(_output_types=output_types,
+                                                 _axes=axes, _seeds=seeds,
+                                                 _shuffle_key=shuffle_key,
+                                                 _reduce_sizes=reduce_sizes, **kw)
+
+    @property
+    def input(self):
+        return self._input
+
+    @property
+    def axes(self):
+        return self._axes
+
+    @property
+    def seeds(self):
+        return self._seeds
+
+    @property
+    def reduce_sizes(self):
+        return self._reduce_sizes
+
+    def _set_inputs(self, inputs):
+        super(LearnShuffleReduce, self)._set_inputs(inputs)
+        self._input = self._inputs[0]
+
+    @classmethod
+    def execute(cls, ctx, op):
+        in_chunk = op.input
+        input_keys, input_indexes = get_shuffle_input_keys_idxes(in_chunk)
+        inputs = [ctx[(input_key, op.shuffle_key)] for input_key in input_keys]
+        inputs_grid = np.empty(op.reduce_sizes, dtype=object)
+        for input_index, inp in zip(input_indexes, inputs):
+            reduce_index = tuple(input_index[ax] for ax in op.axes)
+            inputs_grid[reduce_index] = inp
+        ret = cls._concat_grid(inputs_grid, op.axes, op.output_types[0])
+        for ax, seed in zip(op.axes, op.seeds):
+            ind = np.random.RandomState(seed).permutation(np.arange(ret.shape[ax]))
+            slc = (slice(None),) * ax + (ind,)
+            ret = _safe_slice(ret, slc, op.output_types[0])
+        ctx[op.outputs[0].key] = ret
+
+    @classmethod
+    def _concat_grid(cls, grid, axes, output_type):
+        if output_type == OutputType.tensor:
+            return cls._concat_tensor_grid(grid, axes)
+        elif output_type == OutputType.dataframe:
+            return cls._concat_dataframe_grid(grid, axes)
+        else:
+            assert output_type == OutputType.series
+            return cls._concat_series_grid(grid, axes)
+
+    @classmethod
+    def _concat_dataframe_grid(cls, grid, axes):
+        xdf = pd if isinstance(grid.ravel()[0], pd.DataFrame) else cudf
+        # if 1 exists in axes, the shuffle would have been done in map phase
+        assert len(axes) == 1
+        return xdf.concat(grid, axis=axes[0])
+
+    @classmethod
+    def _concat_series_grid(cls, grid, axes):
+        assert axes == (0,) and grid.ndim == 1
+
+        return reduce(lambda a, b: a.append(b), grid)
+
+    @classmethod
+    def _concat_tensor_grid(cls, grid, axes):
+        cur = grid
+        xp = get_array_module(grid.ravel()[0])
+        for ax, i in zip(axes[:0:-1], range(len(axes) - 1, 0, -1)):
+            new_shape = grid.shape[:i]
+            new_grid = np.empty(new_shape, dtype=object)
+            for idx in itertools.product(*(range(s) for s in new_shape)):
+                new_grid[idx] = xp.concatenate(cur[idx], axis=ax)
+            cur = new_grid
+        return xp.concatenate(cur, axis=axes[0])
+
+
+def shuffle(*arrays, **options):
+    arrays = [convert_to_tensor_or_dataframe(ar) for ar in arrays]
+    axes = options.pop('axes', (0,))
+    if not isinstance(axes, Iterable):
+        axes = (axes,)
+    elif not isinstance(axes, tuple):
+        axes = tuple(axes)
+    random_state = check_random_state(
+        options.pop('random_state', None)).to_numpy()
+    if options:
+        raise TypeError('shuffle() got an unexpected '
+                        'keyword argument {0}'.format(next(iter(options))))
+
+    max_ndim = max(ar.ndim for ar in arrays)
+    axes = tuple(np.unique([validate_axis(max_ndim, ax) for ax in axes]))
+    seeds = gen_random_seeds(len(axes), random_state)
+
+    # verify shape
+    for ax in axes:
+        shapes = {ar.shape[ax] for ar in arrays if ax < ar.ndim}
+        if len(shapes) > 1:
+            raise ValueError('arrays do not have same shape on axis {0}'.format(ax))
+
+    op = LearnShuffle(axes=axes, seeds=seeds,
+                      output_types=get_output_types(*arrays))
+    shuffled_arrays = op(arrays)
+    if len(arrays) == 1:
+        return shuffled_arrays[0]
+    else:
+        return ExecutableTuple(shuffled_arrays)

--- a/mars/learn/utils/tests/test_shuffle.py
+++ b/mars/learn/utils/tests/test_shuffle.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Alibaba Group Holding Ltd.
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mars/learn/utils/tests/test_shuffle.py
+++ b/mars/learn/utils/tests/test_shuffle.py
@@ -1,0 +1,134 @@
+# Copyright 1999-2018 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+import mars.tensor as mt
+import mars.dataframe as md
+from mars.learn.utils import shuffle
+from mars.learn.utils.shuffle import LearnShuffle
+
+
+class Test(unittest.TestCase):
+    def testShuffleExpr(self):
+        a = mt.random.rand(10, 3, chunk_size=2)
+        b = md.DataFrame(mt.random.rand(10, 5), chunk_size=2)
+
+        new_a, new_b = shuffle(a, b, random_state=0)
+
+        self.assertIs(new_a.op, new_b.op)
+        self.assertIsInstance(new_a.op, LearnShuffle)
+        self.assertEqual(new_a.shape, a.shape)
+        self.assertEqual(new_b.shape, b.shape)
+        self.assertNotEqual(b.index_value.key, new_b.index_value.key)
+
+        new_a.tiles()
+
+        self.assertEqual(len(new_a.chunks), 10)
+        self.assertTrue(np.isnan(new_a.chunks[0].shape[0]))
+        self.assertEqual(len(new_b.chunks), 15)
+        self.assertTrue(np.isnan(new_b.chunks[0].shape[0]))
+        self.assertNotEqual(new_b.chunks[0].index_value.key, new_b.chunks[1].index_value.key)
+        self.assertEqual(new_a.chunks[0].op.seeds, new_b.chunks[0].op.seeds)
+
+        c = mt.random.rand(10, 5, 3, chunk_size=2)
+        d = md.DataFrame(mt.random.rand(10, 5), chunk_size=(2, 5))
+
+        new_c, new_d = shuffle(c, d, axes=(0, 1), random_state=0)
+
+        self.assertIs(new_c.op, new_d.op)
+        self.assertIsInstance(new_c.op, LearnShuffle)
+        self.assertEqual(new_c.shape, c.shape)
+        self.assertEqual(new_d.shape, d.shape)
+        self.assertNotEqual(d.index_value.key, new_d.index_value.key)
+        self.assertFalse(np.all(new_d.dtypes.index[:-1] < new_d.dtypes.index[1:]))
+        pd.testing.assert_series_equal(d.dtypes, new_d.dtypes.sort_index())
+
+        new_c.tiles()
+
+        self.assertEqual(len(new_c.chunks), 5 * 1 * 2)
+        self.assertTrue(np.isnan(new_c.chunks[0].shape[0]))
+        self.assertEqual(len(new_d.chunks), 5)
+        self.assertTrue(np.isnan(new_d.chunks[0].shape[0]))
+        self.assertEqual(new_d.chunks[0].shape[1], 5)
+        self.assertNotEqual(new_d.chunks[0].index_value.key, new_d.chunks[1].index_value.key)
+        pd.testing.assert_series_equal(new_d.chunks[0].dtypes.sort_index(), d.dtypes)
+        self.assertEqual(new_c.chunks[0].op.seeds, new_d.chunks[0].op.seeds)
+        self.assertEqual(len(new_c.chunks[0].op.seeds), 1)
+        self.assertEqual(new_c.chunks[0].op.reduce_sizes, (5,))
+
+        with self.assertRaises(ValueError):
+            a = mt.random.rand(10, 5)
+            b = mt.random.rand(10, 4, 3)
+            shuffle(a, b, axes=1)
+
+        with self.assertRaises(TypeError):
+            shuffle(a, b, unknown_param=True)
+
+        self.assertIsInstance(shuffle(mt.random.rand(10, 5)), mt.Tensor)
+
+    @staticmethod
+    def _sort(data, axes):
+        cur = data
+        for ax in axes:
+            if ax < data.ndim:
+                cur = np.sort(cur, axis=ax)
+        return cur
+
+    def testShuffleExecution(self):
+        raw1 = np.random.rand(10, 15, 20)
+        t1 = mt.array(raw1, chunk_size=8)
+        raw2 = np.random.rand(10, 15, 20)
+        t2 = mt.array(raw2, chunk_size=5)
+
+        for axes in [(0,), (0, 1), (0, 2), (1, 2), (0, 1, 2)]:
+            ret = shuffle(t1, t2, axes=axes, random_state=0)
+            res1, res2 = ret.execute()
+
+            self.assertEqual(res1.shape, raw1.shape)
+            self.assertEqual(res2.shape, raw2.shape)
+            np.testing.assert_array_equal(Test._sort(raw1, axes), Test._sort(res1, axes))
+            np.testing.assert_array_equal(Test._sort(raw2, axes), Test._sort(res2, axes))
+
+        raw3 = np.random.rand(10, 15)
+        t3 = mt.array(raw3, chunk_size=(8, 15))
+        raw4 = np.random.rand(10, 15, 20)
+        t4 = mt.array(raw4, chunk_size=(5, 15, 10))
+
+        for axes in [(1,), (0, 1), (1, 2)]:
+            ret = shuffle(t3, t4, axes=axes, random_state=0)
+            res3, res4 = ret.execute()
+
+            self.assertEqual(res3.shape, raw3.shape)
+            self.assertEqual(res4.shape, raw4.shape)
+            np.testing.assert_array_equal(Test._sort(raw3, axes), Test._sort(res3, axes))
+            np.testing.assert_array_equal(Test._sort(raw4, axes), Test._sort(res4, axes))
+
+        raw5 = np.random.rand(10, 15, 20)
+        t5 = mt.array(raw5, chunk_size=8)
+        raw6 = pd.DataFrame(np.random.rand(10, 15))
+        df = md.DataFrame(raw6, chunk_size=(8, 15))
+        raw7 = pd.Series(np.random.rand(10))
+        series = md.Series(raw7, chunk_size=8)
+
+        for axes in [(0,), (1,), (0, 1), (1, 2), [0, 1, 2]]:
+            ret = shuffle(t5, df, series, axes=axes, random_state=0)
+            res5, res_df, res_series = ret.execute()
+
+            self.assertEqual(res5.shape, raw5.shape)
+            self.assertEqual(res_df.shape, df.shape)
+            self.assertEqual(res_series.shape, series.shape)

--- a/mars/tensor/__init__.py
+++ b/mars/tensor/__init__.py
@@ -61,6 +61,7 @@ from . import special
 
 # types
 from .core import Tensor, MutableTensor
+from ..core import ExecutableTuple
 
 # register fuse op and fetch op
 from .fuse import TensorFuseChunk, TensorCpFuseChunk, TensorNeFuseChunk

--- a/mars/tensor/random/permutation.py
+++ b/mars/tensor/random/permutation.py
@@ -110,7 +110,9 @@ class TensorPermutation(TensorRandomOperand, TensorOperandMixin):
                 shuffle_key = ','.join(str(idx) for idx in c.index)
                 chunk_op = TensorPermutationReduce(seed=reduce_seeds[c.index[op.axis]], axis=op.axis,
                                                    shuffle_key=shuffle_key)
-                reduce_chunk = chunk_op.new_chunk([proxy_chunk], shape=(np.nan,) + c.shape[1:],
+                chunk_shape = list(c.shape)
+                chunk_shape[op.axis] = np.nan
+                reduce_chunk = chunk_op.new_chunk([proxy_chunk], shape=tuple(chunk_shape),
                                                   order=out_tensor.order, index=c.index)
                 reduce_chunks.append(reduce_chunk)
 

--- a/mars/tensor/rechunk/rechunk.py
+++ b/mars/tensor/rechunk/rechunk.py
@@ -149,10 +149,10 @@ def plan_rechunks(tensor, new_chunk_size, threshold=None, chunk_size_limit=None)
 
 def _find_split_rechunk(old_chunk_size, new_chunk_size, graph_size_limit):
     """
-        Find an intermediate rechunk that would merge some adjacent blocks
-        together in order to get us nearer the *new_chunk_size* target, without
-        violating the *graph_size_limit* (in number of elements).
-        """
+    Find an intermediate rechunk that would merge some adjacent blocks
+    together in order to get us nearer the *new_chunk_size* target, without
+    violating the *graph_size_limit* (in number of elements).
+    """
     ndim = len(old_chunk_size)
 
     old_largest_width = [max(c) for c in old_chunk_size]

--- a/mars/tensor/reduction/__init__.py
+++ b/mars/tensor/reduction/__init__.py
@@ -25,7 +25,7 @@ from .nanmin import nanmin, TensorNanMin
 from .all import all, TensorAll
 from .any import any, TensorAny
 from .mean import mean, TensorMean, TensorMeanChunk, TensorMeanCombine
-from .nanmean import nanmean, TensorNanMean, TensorNanMeanChunk, TensorMeanCombine
+from .nanmean import nanmean, TensorNanMean, TensorNanMeanChunk
 from .argmax import argmax, TensorArgmax, TensorArgmaxMap, TensorArgmaxCombine
 from .nanargmax import nanargmax, TensorNanArgmax, \
     TensorNanArgmaxMap, TensorNanArgmaxCombine


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR aims to add two APIs.

- [x] `mars.learn.utils.shuffle` which support shuffling more than 1 tensors or DataFrames on axes in a consistent way.
- [x] `mars.learn.datasets.make_classification` which generates a random n-class classification problem.

This PR requires #805 and #813 being merged first.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA
