### PR TITLE
Handle worker storage in batches

### DIFF
--- a/mars/errors.py
+++ b/mars/errors.py
@@ -24,11 +24,7 @@ class MarsError(RuntimeError):
         super(MarsError, self).__init__(msg)
 
     def __str__(self):
-        if hasattr(self, 'message'):
-            message = self.message
-        else:
-            message = self.args[0]  # py3
-        return message or ''
+        return self.args[0] or ''
 
 
 class StartArgumentError(MarsError):
@@ -46,10 +42,12 @@ class DependencyMissing(MarsError):
 class StorageFull(MarsError):
     def __init__(self, msg=None, **kwargs):
         self._request_size = kwargs.pop('request_size', 0)
-        self._total_size = kwargs.pop('total_size', 0)
-        if self._request_size and self._total_size:
+        self._capacity = kwargs.pop('total_size', 0)
+        self._affected_keys = kwargs.pop('affected_keys', [])
+
+        if self._request_size and self._capacity:
             msg = (msg or '') + ' request_size=%s, total_size=%s' \
-                  % (self._request_size, self._total_size)
+                  % (self._request_size, self._capacity)
             msg = msg.strip()
         super(StorageFull, self).__init__(msg)
 
@@ -58,8 +56,12 @@ class StorageFull(MarsError):
         return self._request_size
 
     @property
-    def total_size(self):
-        return self._total_size
+    def capacity(self):
+        return self._capacity
+
+    @property
+    def affected_keys(self):
+        return self._affected_keys
 
 
 class StorageDataExists(MarsError):

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -40,7 +40,7 @@ from .compat import six, futures, OrderedDict, enum
 from .utils import kernel_mode, build_fetch, calc_nsplits
 
 if gevent:
-    from .actors.pool.gevent_pool import GeventThreadPoolExecutor
+    from .actors.pool.gevent_pool import GeventThreadPool
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,7 @@ class ThreadExecutorSyncProvider(ExecutorSyncProvider):
 class GeventExecutorSyncProvider(ExecutorSyncProvider):
     @classmethod
     def thread_pool_executor(cls, n_workers):
-        return GeventThreadPoolExecutor(n_workers)
+        return GeventThreadPool(n_workers)
 
     @classmethod
     def semaphore(cls, value):

--- a/mars/scheduler/tests/integrated/base.py
+++ b/mars/scheduler/tests/integrated/base.py
@@ -174,6 +174,8 @@ class SchedulerIntegratedTest(unittest.TestCase):
                              + append_args + append_args_scheduler, env=proc_env)
             for idx, p in enumerate(scheduler_ports)]
         cuda_count = resource.cuda_count()
+        cuda_devices = [int(d) for d in os.environ['CUDA_VISIBLE_DEVICES'].split(',')] \
+            if os.environ.get('CUDA_VISIBLE_DEVICES') else list(range(cuda_count))
         self.proc_workers = [
             subprocess.Popen([sys.executable, '-m', 'mars.worker',
                               '-a', '127.0.0.1',
@@ -182,7 +184,7 @@ class SchedulerIntegratedTest(unittest.TestCase):
                               '--log-format', 'WOR%d %%(asctime)-15s %%(message)s' % idx,
                               '--cache-mem', '16m',
                               '--ignore-avail-mem',
-                              '--cuda-device', str(idx % cuda_count) if cuda_count else '0',
+                              '--cuda-device', str(cuda_devices[idx % cuda_count]) if cuda_count else '0',
                               '-Dworker.prepare_data_timeout=30']
                              + append_args + append_args_worker, env=proc_env)
             for idx in range(n_workers)

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -287,15 +287,11 @@ def calc_data_size(dt):
     if dt is None:
         return 0
 
-    data_size = sys.getsizeof(dt)
     if isinstance(dt, tuple):
         return sum(calc_data_size(c) for c in dt)
 
-    try:
-        return max(data_size, dt.nbytes)
-    except AttributeError:
-        pass
-
+    if hasattr(dt, 'nbytes'):
+        return max(sys.getsizeof(dt), dt.nbytes)
     if hasattr(dt, 'shape') and len(dt.shape) == 0:
         return 0
     if hasattr(dt, 'memory_usage'):
@@ -306,7 +302,7 @@ def calc_data_size(dt):
         return dt.shape[0] * dt.dtype.itemsize
 
     # object chunk
-    return data_size
+    return sys.getsizeof(dt)
 
 
 def get_shuffle_input_keys_idxes(chunk):

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -102,21 +102,21 @@ class BaseCalcActor(WorkerActor):
         storage_client = self.storage_client
 
         def _handle_single_loaded(k, obj):
-            locations = storage_client.get_data_locations(session_id, k)
+            locations = storage_client.get_data_locations(session_id, [k])[0]
             quota_key = build_quota_key(session_id, k, owner=self.proc_id)
             if (self.proc_id, DataStorageDevice.PROC_MEMORY) not in locations:
                 self._mem_quota_ref.release_quota(quota_key, _tell=True, _wait=False)
             else:
                 self._mem_quota_ref.hold_quota(quota_key, _tell=True)
                 if self._remove_intermediate:
-                    storage_client.delete(session_id, k, [self._calc_intermediate_device])
+                    storage_client.delete(session_id, [k], [self._calc_intermediate_device])
             if not failed[0]:
                 context_dict[k] = obj
 
         def _handle_single_load_fail(*exc, **kwargs):
             data_key = kwargs.pop('key')
             if self._remove_intermediate:
-                storage_client.delete(session_id, data_key, [self._calc_intermediate_device])
+                storage_client.delete(session_id, [data_key], [self._calc_intermediate_device])
             self._release_local_quota(session_id, data_key)
 
             failed[0] = True
@@ -159,6 +159,7 @@ class BaseCalcActor(WorkerActor):
         # collect results
         result_keys = []
         result_values = []
+        result_sizes = []
         collected_chunk_keys = set()
         for k, v in local_context_dict.items():
             if isinstance(k, tuple):
@@ -170,6 +171,7 @@ class BaseCalcActor(WorkerActor):
             if chunk_key in chunk_targets:
                 result_keys.append(k)
                 result_values.append(v)
+                result_sizes.append(calc_data_size(v))
                 collected_chunk_keys.add(chunk_key)
 
         local_context_dict.clear()
@@ -180,8 +182,8 @@ class BaseCalcActor(WorkerActor):
 
         # adjust sizes in allocation
         apply_alloc_sizes = defaultdict(lambda: 0)
-        for k, v in zip(result_keys, result_values):
-            apply_alloc_sizes[get_chunk_key(k)] += calc_data_size(v)
+        for k, size in zip(result_keys, result_sizes):
+            apply_alloc_sizes[get_chunk_key(k)] += size
 
         for k, v in apply_alloc_sizes.items():
             quota_key = build_quota_key(session_id, k, owner=self.proc_id)
@@ -195,8 +197,8 @@ class BaseCalcActor(WorkerActor):
 
         logger.debug('Finish calculating operand %s.', graph_key)
 
-        return self.storage_client.batch_put_object(
-            session_id, result_keys, result_values, [self._calc_intermediate_device])\
+        return self.storage_client.put_objects(
+            session_id, result_keys, result_values, [self._calc_intermediate_device], sizes=result_sizes) \
             .then(lambda *_: result_keys)
 
     @promise.reject_on_exception
@@ -229,7 +231,7 @@ class BaseCalcActor(WorkerActor):
             for k in keys_to_fetch:
                 if get_chunk_key(k) not in chunk_targets:
                     if self._remove_intermediate:
-                        self.storage_client.delete(session_id, k, [self._calc_intermediate_device])
+                        self.storage_client.delete(session_id, [k], [self._calc_intermediate_device])
                     self._release_local_quota(session_id, k)
 
             if not exc_info:
@@ -237,7 +239,7 @@ class BaseCalcActor(WorkerActor):
             else:
                 for k in chunk_targets:
                     if self._remove_intermediate:
-                        self.storage_client.delete(session_id, k, [self._calc_intermediate_device])
+                        self.storage_client.delete(session_id, [k], [self._calc_intermediate_device])
                     self._release_local_quota(session_id, k)
                 self.tell_promise(callback, *exc_info, **dict(_accept=False))
 
@@ -257,24 +259,22 @@ class BaseCalcActor(WorkerActor):
 
         store_keys, store_metas = [], []
 
-        for k, size in sizes.items():
-            if isinstance(k, tuple):
+        for k, size, shape in zip(keys_to_store, sizes, shapes):
+            if size is None or isinstance(k, tuple):
                 continue
             store_keys.append(k)
-            store_metas.append(WorkerMeta(size, shapes.get(k), (self.address,)))
+            store_metas.append(WorkerMeta(size, shape, (self.address,)))
         meta_future = self.get_meta_client().batch_set_chunk_meta(
             session_id, store_keys, store_metas, _wait=False)
 
         def _delete_keys(*_):
             if self._remove_intermediate:
-                storage_client.batch_delete(
+                storage_client.delete(
                     session_id, keys_to_store, [self._calc_intermediate_device], _tell=True)
             quotas = [build_quota_key(session_id, k, owner=self.proc_id) for k in keys_to_store]
             self._mem_quota_ref.release_quotas(quotas, _tell=True, _wait=False)
 
-        promise.all_([
-            storage_client.copy_to(session_id, k, self._calc_dest_devices)
-            for k in keys_to_store]) \
+        return storage_client.copy_to(session_id, keys_to_store, self._calc_dest_devices) \
             .then(_delete_keys) \
             .then(lambda *_: meta_future.result()) \
             .then(lambda *_: self.tell_promise(callback),

--- a/mars/worker/dispatcher.py
+++ b/mars/worker/dispatcher.py
@@ -102,6 +102,12 @@ class DispatchActor(WorkerActor):
         return uid
 
     @log_unhandled
+    def get_hash_slots(self, queue_name, keys):
+        slots = list(self._all_slots[queue_name])
+        uids = [slots[mod_hash(key, len(slots))] for key in keys]
+        return uids
+
+    @log_unhandled
     def get_slots(self, queue_name):
         """
         Get all uids of slots of a queue

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -588,7 +588,7 @@ class ExecutionActor(WorkerActor):
                     lambda k, *_: self._pin_data_keys(session_id, graph_key, [k]), input_key)
                 prepare_promises.append(
                     storage_client.copy_to(
-                        session_id, input_key, [graph_record.preferred_data_device], ensure=ensure_shared)
+                        session_id, [input_key], [graph_record.preferred_data_device], ensure=ensure_shared)
                         .then(pin_fun, lambda *_: None)
                 )
             else:

--- a/mars/worker/seal.py
+++ b/mars/worker/seal.py
@@ -63,11 +63,11 @@ class SealActor(WorkerActor):
                 del buffer
 
             # clean up
-            self.storage_client.delete(session_id, key)
+            self.storage_client.delete(session_id, [key])
             self.get_meta_client().delete_meta(session_id, key, False)
             self._mem_quota_ref.release_quota(key)
 
-        self.storage_client.put_object(
-            session_id, chunk_key, ndarr, [DataStorageDevice.SHARED_MEMORY, DataStorageDevice.DISK])
+        self.storage_client.put_objects(
+            session_id, [chunk_key], [ndarr], [DataStorageDevice.SHARED_MEMORY, DataStorageDevice.DISK])
         self.get_meta_client().set_chunk_meta(session_id, chunk_key, size=chunk_bytes_size,
                                               shape=shape, workers=(self.address,))

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -75,8 +75,11 @@ class WorkerService(object):
             self._n_cuda_process = 0
         else:
             if cuda_devices is None:
-                cuda_devices = [0]
-            os.environ['CUDA_VISIBLE_DEVICES'] = ','.join(str(d) for d in cuda_devices)
+                cuda_devices = [int(d) for d in os.environ['CUDA_VISIBLE_DEVICES'].split(',')] \
+                    if os.environ.get('CUDA_VISIBLE_DEVICES') else []
+            cuda_devices = os.environ['CUDA_VISIBLE_DEVICES'] = ','.join(str(d) for d in cuda_devices)
+            if cuda_devices:
+                logger.info('Started Mars worker with CUDA cards %s', cuda_devices)
             self._n_cuda_process = resource.cuda_count()
 
         self._n_cpu_process = int(kwargs.pop('n_cpu_process', None) or resource.cpu_count())

--- a/mars/worker/storage/client.py
+++ b/mars/worker/storage/client.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import logging
+import operator
+from collections import defaultdict
 
 from ... import promise
-from ...compat import six
+from ...compat import six, reduce
 from ...errors import StorageFull
 from ...utils import calc_data_size, build_exc_info
 from .core import DataStorageDevice, get_storage_handler_cls
@@ -75,35 +78,32 @@ class StorageClient(object):
     def __getattr__(self, item):
         return getattr(self._manager_ref, item)
 
-    def _get_stored_devices(self, session_id, data_key):
-        return [loc for loc in (self._manager_ref.get_data_locations(session_id, data_key) or ())]
-
     def _normalize_devices(self, devices):
         return [d if isinstance(d, tuple) else d.build_location(self.proc_id)
                 for d in devices] if devices is not None else None
 
-    def _do_with_spill(self, action, total_bytes, device_order,
+    def _do_with_spill(self, action, data_keys, total_bytes, device_order,
                        device_pos=0, spill_multiplier=1.0, ensure=True):
         def _handle_err(*exc_info):
             if issubclass(exc_info[0], StorageFull):
                 req_bytes = max(total_bytes, exc_info[1].request_size)
                 if device_pos < len(device_order) - 1:
                     return self._do_with_spill(
-                        action, req_bytes, device_order,
+                        action, exc_info[1].affected_keys, req_bytes, device_order,
                         device_pos=device_pos + 1, spill_multiplier=1.0, ensure=ensure,
                     )
                 elif ensure:
                     new_multiplier = min(spill_multiplier + 0.1, 10)
                     return handler.spill_size(req_bytes, spill_multiplier) \
                         .then(lambda *_: self._do_with_spill(
-                            action, req_bytes, device_order, device_pos=device_pos,
-                            spill_multiplier=new_multiplier, ensure=ensure,
+                            action, exc_info[1].affected_keys, req_bytes, device_order,
+                            device_pos=device_pos, spill_multiplier=new_multiplier, ensure=ensure,
                         ))
             six.reraise(*exc_info)
 
         cur_device = device_order[device_pos]
         handler = self.get_storage_handler(cur_device)
-        return action(handler).catch(_handle_err)
+        return action(handler, data_keys).catch(_handle_err)
 
     def create_reader(self, session_id, data_key, source_devices, packed=False,
                       packed_compression=None, _promise=True):
@@ -120,7 +120,7 @@ class StorageClient(object):
         :param _promise: return a promise
         """
         source_devices = self._normalize_devices(source_devices)
-        stored_devs = set(self._get_stored_devices(session_id, data_key))
+        stored_devs = set(self._manager_ref.get_data_locations(session_id, [data_key])[0])
         for src_dev in source_devices:
             if src_dev not in stored_devs:
                 continue
@@ -135,7 +135,7 @@ class StorageClient(object):
                 raise IOError('Device %r does not support direct reading.' % src_dev)
 
         if _promise:
-            return self.copy_to(session_id, data_key, source_devices) \
+            return self.copy_to(session_id, [data_key], source_devices) \
                 .then(lambda *_: self.create_reader(session_id, data_key, source_devices, packed=packed))
         else:
             raise IOError('Cannot return a non-promise result')
@@ -144,7 +144,7 @@ class StorageClient(object):
                       packed_compression=None, _promise=True):
         device_order = self._normalize_devices(device_order)
 
-        def _action(handler, _promise=True):
+        def _action(handler, _keys, _promise=True):
             logger.debug('Creating %s writer for (%s, %s) on %s', 'packed' if packed else 'bytes',
                          session_id, data_key, handler.storage_type)
             return handler.create_bytes_writer(
@@ -152,19 +152,20 @@ class StorageClient(object):
                 packed_compression=packed_compression, _promise=_promise)
 
         if _promise:
-            return self._do_with_spill(_action, total_bytes, device_order)
+            return self._do_with_spill(_action, [data_key], total_bytes, device_order)
         else:
+            exc = ValueError('Missing device type')
             for device_type in device_order:
                 try:
                     handler = self.get_storage_handler(device_type)
-                    return _action(handler, _promise=False)
-                except StorageFull:
-                    pass
-            raise StorageFull
+                    return _action(handler, [data_key], _promise=False)
+                except StorageFull as ex:
+                    exc = ex
+            raise exc
 
     def get_object(self, session_id, data_key, source_devices, serialized=False, _promise=True):
         source_devices = self._normalize_devices(source_devices)
-        stored_devs = set(self._get_stored_devices(session_id, data_key))
+        stored_devs = set(self._manager_ref.get_data_locations(session_id, [data_key])[0])
         for src_dev in source_devices:
             if src_dev not in stored_devs:
                 continue
@@ -175,73 +176,87 @@ class StorageClient(object):
                 raise IOError('Device %r does not support direct reading.' % src_dev)
 
         if _promise:
-            return self.copy_to(session_id, data_key, source_devices) \
+            return self.copy_to(session_id, [data_key], source_devices) \
                 .then(lambda *_: self.get_object(session_id, data_key, source_devices, serialized=serialized))
         else:
             raise IOError('Getting object without promise not supported')
 
-    def put_object(self, session_id, data_key, obj, device_order, serialized=False):
+    def put_objects(self, session_id, data_keys, objs, device_order, sizes=None, serialized=False):
         device_order = self._normalize_devices(device_order)
-        data_size = calc_data_size(obj)
+        if sizes:
+            sizes_dict = dict(zip(data_keys, sizes))
+        else:
+            sizes_dict = dict((k, calc_data_size(obj)) for k, obj in zip(data_keys, objs))
 
-        def _action(h):
-            return h.put_object(session_id, data_key, obj, serialized=serialized, _promise=True)
+        data_dict = dict(zip(data_keys, objs))
 
-        return self._do_with_spill(_action, data_size, device_order)
+        def _action(h, keys):
+            objects = [data_dict[k] for k in keys]
+            data_sizes = [sizes_dict[k] for k in keys]
+            try:
+                return h.put_objects(session_id, keys, objects, sizes=data_sizes, serialized=serialized,
+                                     _promise=True)
+            finally:
+                objects[:] = []
 
-    def batch_put_object(self, session_id, data_keys, objs, device_order, serialized=False):
+        return self._do_with_spill(_action, data_keys, sum(sizes_dict.values()), device_order)
+
+    def copy_to(self, session_id, data_keys, device_order, ensure=True):
         device_order = self._normalize_devices(device_order)
-        data_size = sum(calc_data_size(obj) for obj in objs)
+        existing_devs = self._manager_ref.get_data_locations(session_id, data_keys)
+        data_sizes = self._manager_ref.get_data_sizes(session_id, data_keys)
 
-        def _action(h):
-            return h.batch_put_object(session_id, data_keys, objs, serialized=serialized, _promise=True)
+        device_to_keys = defaultdict(list)
+        device_total_size = defaultdict(lambda: 0)
+        lift_reqs = defaultdict(list)
+        for k, devices, size in zip(data_keys, existing_devs, data_sizes):
+            if not devices or not size:
+                return promise.finished(
+                    *build_exc_info(KeyError, 'Data key (%s, %s) does not exist.' % (session_id, k)),
+                    **dict(_accept=False)
+                )
 
-        return self._do_with_spill(_action, data_size, device_order)
+            target = next((d for d in device_order if d in devices), None)
+            if target is not None:
+                lift_reqs[target].append(k)
+            else:
+                max_device = max(devices)
+                device_to_keys[max_device].append(k)
+                device_total_size[max_device] += size
 
-    def copy_to(self, session_id, data_key, device_order, ensure=True):
-        device_order = self._normalize_devices(device_order)
-        existing_devs = set(self._get_stored_devices(session_id, data_key))
-        data_size = self._manager_ref.get_data_size(session_id, data_key)
-
-        if not existing_devs or not data_size:
-            return promise.finished(
-                *build_exc_info(KeyError, 'Data key (%s, %s) does not exist.' % (session_id, data_key)),
-                **dict(_accept=False)
-            )
-
-        target = next((d for d in device_order if d in existing_devs), None)
-        if target is not None:
+        for target, data_keys in lift_reqs.items():
             handler = self.get_storage_handler(target)
             if getattr(handler, '_spillable', False):
-                handler.lift_data_key(session_id, data_key)
-            return promise.finished(target)
+                handler.lift_data_keys(session_id, data_keys)
+        if not device_to_keys:
+            return promise.finished()
 
-        source_handler = self.get_storage_handler(max(existing_devs))
+        def _action(src_handler, h, keys):
+            return h.load_from(session_id, keys, src_handler)
 
-        def _action(h):
-            return h.load_from(session_id, data_key, source_handler)
+        def _handle_exc(keys, *exc):
+            existing = self._manager_ref.get_data_locations(session_id, keys)
+            for devices in existing:
+                if not any(d for d in device_order if d in devices):
+                    six.reraise(*exc)
 
-        def _handle_exc(*exc):
-            existing = set(self._get_stored_devices(session_id, data_key))
-            if not any(d for d in device_order if d in existing):
-                six.reraise(*exc)
+        promises = []
+        for d in device_to_keys.keys():
+            action = functools.partial(_action, self.get_storage_handler(d))
+            keys = device_to_keys[d]
+            total_size = device_total_size[d]
+            promises.append(
+                self._do_with_spill(action, keys, total_size, device_order, ensure=ensure)
+                    .catch(functools.partial(_handle_exc, keys))
+            )
+        return promise.all_(promises)
 
-        return self._do_with_spill(_action, data_size, device_order, ensure=ensure) \
-            .catch(_handle_exc)
-
-    def delete(self, session_id, data_key, devices=None, _tell=False):
-        devices = devices or self._get_stored_devices(session_id, data_key) or ()
+    def delete(self, session_id, data_keys, devices=None, _tell=False):
+        devices = devices or reduce(operator.or_, self._manager_ref.get_data_locations(session_id, data_keys))
         devices = self._normalize_devices(devices)
         for dev_type in devices:
             handler = self.get_storage_handler(dev_type)
-            handler.delete(session_id, data_key, _tell=_tell)
-
-    def batch_delete(self, session_id, data_keys, devices=None, _tell=False):
-        devices = devices or self._manager_ref.get_all_data_locations(session_id, data_keys)
-        devices = self._normalize_devices(devices)
-        for dev_type in devices:
-            handler = self.get_storage_handler(dev_type)
-            handler.batch_delete(session_id, data_keys, _tell=_tell)
+            handler.delete(session_id, data_keys, _tell=_tell)
 
     def filter_exist_keys(self, session_id, data_keys, devices=None):
         devices = self._normalize_devices(devices or DataStorageDevice.__members__.values())

--- a/mars/worker/storage/core.py
+++ b/mars/worker/storage/core.py
@@ -164,6 +164,9 @@ class StorageHandler(object):
     def delete(self, session_id, data_key, _tell=False):
         raise NotImplementedError
 
+    def batch_delete(self, session_id, data_keys, _tell=False):
+        raise NotImplementedError
+
     def load_from(self, session_id, data_key, src_handler):
         """
         :param session_id:
@@ -193,6 +196,10 @@ class StorageHandler(object):
     def register_data(self, session_id, data_key, size, shape=None):
         self._storage_ctx.manager_ref \
             .register_data(session_id, data_key, self.location, size, shape=shape)
+
+    def batch_register_data(self, session_id, data_keys, sizes, shapes=None):
+        self._storage_ctx.manager_ref \
+            .batch_register_data(session_id, data_keys, self.location, sizes, shapes=shapes)
 
     def transfer_in_runner(self, session_id, data_key, src_handler, fallback=None):
         if self.is_io_runner():
@@ -234,6 +241,10 @@ class StorageHandler(object):
     def unregister_data(self, session_id, data_key, _tell=False):
         self._storage_ctx.manager_ref \
             .unregister_data(session_id, data_key, self.location, _tell=_tell)
+
+    def batch_unregister_data(self, session_id, data_keys, _tell=False):
+        self._storage_ctx.manager_ref \
+            .batch_unregister_data(session_id, data_keys, self.location, _tell=_tell)
 
 
 class BytesStorageMixin(object):
@@ -303,6 +314,9 @@ class ObjectStorageMixin(object):
         raise NotImplementedError
 
     def put_object(self, session_id, data_key, obj, serialized=False, _promise=False):
+        raise NotImplementedError
+
+    def batch_put_object(self, session_id, data_keys, objs, serialized=False, _promise=False):
         raise NotImplementedError
 
 

--- a/mars/worker/storage/diskhandler.py
+++ b/mars/worker/storage/diskhandler.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import os
 import shutil
 import sys
 import time
 
+from ... import promise
 from ...config import options
 from ...serialize import dataserializer
 from ...errors import SpillNotConfigured, StorageDataExists
@@ -75,7 +77,7 @@ class DiskIO(BytesStorageIO):
         filename = self._dest_filename = self._filename = _build_file_name(session_id, data_key)
         if self.is_writable:
             if os.path.exists(self._dest_filename):
-                exist_devs = self._storage_ctx.manager_ref.get_data_locations(session_id, data_key) or ()
+                exist_devs = self._storage_ctx.manager_ref.get_data_locations(session_id, [data_key])[0]
                 if (0, DataStorageDevice.DISK) in exist_devs:
                     self._closed = True
                     raise StorageDataExists('File for data (%s, %s) already exists.' % (session_id, data_key))
@@ -169,7 +171,7 @@ class DiskIO(BytesStorageIO):
         if self._handler.status_ref and transfer_speed is not None:
             self._handler.status_ref.update_mean_stats(status_key, transfer_speed, _tell=True, _wait=False)
         if self._event_id:
-            self._handler.events_ref.close_event(self._event_id, _tell=True)
+            self._handler.events_ref.close_event(self._event_id, _tell=True, _wait=False)
 
         super(DiskIO, self).close(finished=finished)
 
@@ -208,15 +210,17 @@ class DiskHandler(StorageHandler, BytesStorageMixin):
         return DiskIO(session_id, data_key, 'w', total_bytes, compress=self._compress,
                       packed=packed, handler=self)
 
-    def load_from_bytes_io(self, session_id, data_key, src_handler):
+    def load_from_bytes_io(self, session_id, data_keys, src_handler):
         def _fallback(*_):
-            return src_handler.create_bytes_reader(session_id, data_key, _promise=True) \
+            return promise.all_(
+                src_handler.create_bytes_reader(session_id, k, _promise=True) \
                 .then(lambda reader: self.create_bytes_writer(
-                    session_id, data_key, reader.nbytes, _promise=True)
+                    session_id, k, reader.nbytes, _promise=True)
                       .then(lambda writer: self._copy_bytes_data(reader, writer),
                             lambda *exc: self.pass_on_exc(reader.close, exc)))
+                for k in data_keys)
 
-        return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
+        return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 
     @staticmethod
     def _get_serialized_data_size(serialized_obj):
@@ -225,31 +229,23 @@ class DiskHandler(StorageHandler, BytesStorageMixin):
         else:
             return len(serialized_obj)
 
-    def load_from_object_io(self, session_id, data_key, src_handler):
-        def _load_data(obj_data):
+    def load_from_object_io(self, session_id, data_keys, src_handler):
+        def _load_data(key, obj_data):
             try:
                 data_size = self._get_serialized_data_size(obj_data)
-                writer = self.create_bytes_writer(session_id, data_key, data_size, _promise=False)
+                writer = self.create_bytes_writer(session_id, key, data_size, _promise=False)
                 return self._copy_object_data(obj_data, writer)
             finally:
                 del obj_data
 
         def _fallback(*_):
-            return src_handler.get_object(session_id, data_key, serialized=True, _promise=True) \
-                .then(_load_data)
+            return promise.all_(
+                src_handler.get_object(session_id, key, serialized=True, _promise=True)
+                .then(functools.partial(_load_data, key)) for key in data_keys)
 
-        return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
+        return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 
-    def delete(self, session_id, data_key, _tell=False):
-        file_name = _build_file_name(session_id, data_key)
-        if sys.platform == 'win32':  # pragma: no cover
-            CREATE_NO_WINDOW = 0x08000000
-            self._actor_ctx.popen(['del', file_name], creationflags=CREATE_NO_WINDOW)
-        else:
-            self._actor_ctx.popen(['rm', '-f', file_name])
-        self.unregister_data(session_id, data_key, _tell=_tell)
-
-    def batch_delete(self, session_id, data_keys, _tell=False):
+    def delete(self, session_id, data_keys, _tell=False):
         for data_key in data_keys:
             file_name = _build_file_name(session_id, data_key)
             if sys.platform == 'win32':  # pragma: no cover
@@ -257,7 +253,7 @@ class DiskHandler(StorageHandler, BytesStorageMixin):
                 self._actor_ctx.popen(['del', file_name], creationflags=CREATE_NO_WINDOW)
             else:
                 self._actor_ctx.popen(['rm', '-f', file_name])
-        self.batch_unregister_data(session_id, data_keys, _tell=_tell)
+        self.unregister_data(session_id, data_keys, _tell=_tell)
 
 
 register_storage_handler_cls(DataStorageDevice.DISK, DiskHandler)

--- a/mars/worker/storage/diskhandler.py
+++ b/mars/worker/storage/diskhandler.py
@@ -249,5 +249,15 @@ class DiskHandler(StorageHandler, BytesStorageMixin):
             self._actor_ctx.popen(['rm', '-f', file_name])
         self.unregister_data(session_id, data_key, _tell=_tell)
 
+    def batch_delete(self, session_id, data_keys, _tell=False):
+        for data_key in data_keys:
+            file_name = _build_file_name(session_id, data_key)
+            if sys.platform == 'win32':  # pragma: no cover
+                CREATE_NO_WINDOW = 0x08000000
+                self._actor_ctx.popen(['del', file_name], creationflags=CREATE_NO_WINDOW)
+            else:
+                self._actor_ctx.popen(['rm', '-f', file_name])
+        self.batch_unregister_data(session_id, data_keys, _tell=_tell)
+
 
 register_storage_handler_cls(DataStorageDevice.DISK, DiskHandler)

--- a/mars/worker/storage/manager.py
+++ b/mars/worker/storage/manager.py
@@ -40,7 +40,7 @@ class StorageManagerActor(WorkerActor):
 
         from ..daemon import WorkerDaemonActor
         daemon_ref = self.ctx.actor_ref(WorkerDaemonActor.default_uid())
-        if self.ctx.has_actor(daemon_ref):
+        if self.ctx.has_actor(daemon_ref):  # pragma: no branch
             daemon_ref.register_process_callback(
                 self.ref(), self.handle_process_down.__name__)
 
@@ -50,86 +50,58 @@ class StorageManagerActor(WorkerActor):
     def get_process_holder(self, proc_id, device):
         return self._proc_holders[(proc_id, device)]
 
-    def register_data(self, session_id, data_key, location, size, shape=None):
-        session_data_key = (session_id, data_key)
-        try:
-            location_set = self._data_to_locations[session_data_key]
-        except KeyError:
-            location_set = self._data_to_locations[session_data_key] = set()
-
-        location_set.add(location)
-        try:
-            attrs = self._data_attrs[session_data_key]
-            attrs.size = max(size, attrs.size)
-            if shape:
-                attrs.shape = shape
-        except KeyError:
-            attrs = DataAttrs(size, shape)
-        self._data_attrs[session_data_key] = attrs
-        if location[0] > 0:
-            self._proc_to_data[location[0]].add(session_data_key)
-
-    def batch_register_data(self, session_id, data_keys, location, sizes, shapes=None):
+    def register_data(self, session_id, data_keys, location, sizes, shapes=None):
         shapes = shapes or itertools.repeat(None)
         for key, size, shape in zip(data_keys, sizes, shapes):
-            self.register_data(session_id, key, location, size, shape)
-
-    def unregister_data(self, session_id, data_key, location):
-        session_data_key = (session_id, data_key)
-        if location[0] > 0:
-            self._proc_to_data[location[0]].difference_update([session_data_key])
-        try:
-            self._data_to_locations[session_data_key].difference_update([location])
-            if not self._data_to_locations[session_data_key]:
-                del self._data_to_locations[session_data_key]
-                try:
-                    del self._data_attrs[session_data_key]
-                except KeyError:
-                    pass
-        except KeyError:
-            pass
-
-    def batch_unregister_data(self, session_id, data_keys, location):
-        for k in data_keys:
-            self.unregister_data(session_id, k, location)
-
-    def get_data_locations(self, session_id, data_key):
-        try:
-            return self._data_to_locations[(session_id, data_key)]
-        except KeyError:
-            return None
-
-    def get_all_data_locations(self, session_id, data_keys):
-        locations = set()
-        for k in data_keys:
+            session_data_key = (session_id, key)
             try:
-                locations.update(self._data_to_locations[(session_id, k)])
+                location_set = self._data_to_locations[session_data_key]
+            except KeyError:
+                location_set = self._data_to_locations[session_data_key] = set()
+
+            location_set.add(location)
+            try:
+                attrs = self._data_attrs[session_data_key]
+                attrs.size = max(size, attrs.size)
+                if shape:
+                    attrs.shape = shape
+            except KeyError:
+                attrs = DataAttrs(size, shape)
+            self._data_attrs[session_data_key] = attrs
+            if location[0] > 0:
+                self._proc_to_data[location[0]].add(session_data_key)
+
+    def unregister_data(self, session_id, data_keys, location):
+        for data_key in data_keys:
+            session_data_key = (session_id, data_key)
+            if location[0] > 0:
+                self._proc_to_data[location[0]].difference_update([session_data_key])
+            try:
+                location_set = self._data_to_locations[session_data_key]
+                location_set.difference_update([location])
+                if not location_set:
+                    del self._data_to_locations[session_data_key]
+                    self._data_attrs.pop(session_data_key, None)
             except KeyError:
                 pass
-        return locations
 
-    def get_data_size(self, session_id, data_key):
-        sizes = self.get_data_sizes(session_id, [data_key])
-        return sizes[data_key] if sizes else None
+    def get_data_locations(self, session_id, data_keys):
+        return [self._data_to_locations.get((session_id, key)) or set() for key in data_keys]
 
     def get_data_sizes(self, session_id, data_keys):
-        res = dict()
-        for k in data_keys:
+        res = [None] * len(data_keys)
+        for idx, k in enumerate(data_keys):
             try:
-                res[k] = self._data_attrs[(session_id, k)].size
+                res[idx] = self._data_attrs[(session_id, k)].size
             except KeyError:
                 pass
         return res
 
-    def get_data_shape(self, session_id, data_key):
-        shapes = self.get_data_shapes(session_id, [data_key])
-        return shapes[data_key] if shapes else None
-
     def get_data_shapes(self, session_id, data_keys):
-        res = dict()
-        for k in data_keys:
+        res = [None] * len(data_keys)
+        for idx, k in enumerate(data_keys):
             try:
-                res[k] = self._data_attrs[(session_id, k)].shape
+                res[idx] = self._data_attrs[(session_id, k)].shape
             except KeyError:
                 pass
         return res
@@ -158,10 +130,7 @@ class StorageManagerActor(WorkerActor):
             location_set.difference_update(affected_locs)
             if not location_set:
                 del self._data_to_locations[k]
-                try:
-                    del self._data_attrs[k]
-                except KeyError:
-                    pass
+                self._data_attrs.pop(k, None)
 
     def dump_keys(self):
         return list(self._data_attrs.keys())

--- a/mars/worker/storage/objectholder.py
+++ b/mars/worker/storage/objectholder.py
@@ -274,13 +274,11 @@ class SharedHolderActor(ObjectHolderActor):
         self._shared_store.batch_delete(session_id, data_keys)
         self._storage_handler.batch_unregister_data(session_id, data_keys)
 
-    def put_object_by_key(self, session_id, data_key, pin=False):
+    def put_object_by_key(self, session_id, data_key, shape=None):
         buf = self._shared_store.get_buffer(session_id, data_key)
         self._internal_put_object(session_id, data_key, buf, len(buf))
-        if pin:
-            token = tokenize(time.time(), str(uuid.uuid4()))
-            self.pin_data_keys(session_id, [data_key], token)
-            return token
+        self.storage_client.register_data(
+            session_id, data_key, (0, DataStorageDevice.SHARED_MEMORY), len(buf), shape=shape)
 
 
 class InProcHolderActor(ObjectHolderActor):

--- a/mars/worker/storage/procmemhandler.py
+++ b/mars/worker/storage/procmemhandler.py
@@ -41,45 +41,38 @@ class ProcMemHandler(StorageHandler, ObjectStorageMixin):
         return obj
 
     @wrap_promised
-    def put_object(self, session_id, data_key, obj, serialized=False, _promise=False):
-        o = self._deserial(obj) if serialized else obj
-        self._inproc_store_ref.put_object(session_id, data_key, o)
-        self.register_data(session_id, data_key, calc_data_size(o), shape=getattr(o, 'shape', None))
-
-    @wrap_promised
-    def batch_put_object(self, session_id, data_keys, objs, serialized=False, _promise=False):
+    def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False, _promise=False):
         objs = [self._deserial(obj) if serialized else obj for obj in objs]
-        data_sizes = [calc_data_size(obj) for obj in objs]
+        sizes = sizes or [calc_data_size(obj) for obj in objs]
         shapes = [getattr(obj, 'shape', None) for obj in objs]
-        self._inproc_store_ref.batch_put_object(session_id, data_keys, objs)
-        self.batch_register_data(session_id, data_keys, data_sizes, shapes)
+        self._inproc_store_ref.put_objects(session_id, data_keys, objs, sizes)
+        self.register_data(session_id, data_keys, sizes, shapes)
 
-    def load_from_bytes_io(self, session_id, data_key, src_handler):
-        def _read_and_put(reader):
+    def load_from_bytes_io(self, session_id, data_keys, src_handler):
+        def _read_serialized(reader):
             with reader:
-                result = reader.get_io_pool().submit(reader.read).result()
-            self.put_object(session_id, data_key, result, serialized=True)
+                return reader.get_io_pool().submit(reader.read).result()
 
         def _fallback(*_):
-            return src_handler.create_bytes_reader(session_id, data_key, _promise=True) \
-                .then(_read_and_put)
+            return self._batch_load_objects(
+                session_id, data_keys,
+                lambda k: src_handler.create_bytes_reader(session_id, k, _promise=True).then(_read_serialized),
+                True
+            )
 
-        return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
+        return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 
-    def load_from_object_io(self, session_id, data_key, src_handler):
+    def load_from_object_io(self, session_id, data_keys, src_handler):
         def _fallback(*_):
-            return src_handler.get_object(session_id, data_key, _promise=True) \
-                .then(lambda obj: self.put_object(session_id, data_key, obj))
+            return self._batch_load_objects(
+                session_id, data_keys,
+                lambda k: src_handler.get_object(session_id, k, _promise=True))
 
-        return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
+        return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 
-    def delete(self, session_id, data_key, _tell=False):
-        self._inproc_store_ref.delete_objects(session_id, [data_key], _tell=_tell)
-        self.unregister_data(session_id, data_key, _tell=_tell)
-
-    def batch_delete(self, session_id, data_keys, _tell=False):
+    def delete(self, session_id, data_keys, _tell=False):
         self._inproc_store_ref.delete_objects(session_id, data_keys, _tell=_tell)
-        self.batch_unregister_data(session_id, data_keys, _tell=_tell)
+        self.unregister_data(session_id, data_keys, _tell=_tell)
 
 
 register_storage_handler_cls(DataStorageDevice.PROC_MEMORY, ProcMemHandler)

--- a/mars/worker/storage/sharedhandler.py
+++ b/mars/worker/storage/sharedhandler.py
@@ -16,7 +16,9 @@ import functools
 
 import pyarrow
 
+from ... import promise
 from ...config import options
+from ...errors import StorageFull
 from ...serialize import dataserializer
 from ..dataio import ArrowBufferIO
 from .core import StorageHandler, BytesStorageMixin, ObjectStorageMixin, \
@@ -29,7 +31,8 @@ class SharedStorageIO(BytesStorageIO):
     filename = None
 
     def __init__(self, session_id, data_key, mode='w', shared_store=None,
-                 nbytes=None, packed=False, compress=None, handler=None):
+                 nbytes=None, packed=False, compress=None, auto_register=True,
+                 handler=None):
         from .objectholder import SharedHolderActor
 
         super(SharedStorageIO, self).__init__(session_id, data_key, mode=mode,
@@ -41,6 +44,7 @@ class SharedStorageIO(BytesStorageIO):
         self._holder_ref = self._storage_ctx.actor_ctx.actor_ref(SharedHolderActor.default_uid())
         self._compress = compress or dataserializer.CompressType.NONE
         self._packed = packed
+        self._auto_register = auto_register
 
         block_size = options.worker.copy_block_size
 
@@ -62,9 +66,16 @@ class SharedStorageIO(BytesStorageIO):
         else:
             raise NotImplementedError
 
+    def __del__(self):
+        self._mv = None
+        self._buf = self._shared_buf = None
+
     @property
     def nbytes(self):
         return self._nbytes
+
+    def get_shared_buffer(self):
+        return self._shared_buf
 
     def read(self, size=-1):
         if self._packed:
@@ -87,7 +98,8 @@ class SharedStorageIO(BytesStorageIO):
         if self.is_writable and self._shared_buf is not None:
             self._shared_store.seal(self._session_id, self._data_key)
             if finished:
-                self._holder_ref.put_object_by_key(self._session_id, self._data_key)
+                if self._auto_register:
+                    self._holder_ref.put_objects_by_keys(self._session_id, [self._data_key])
             else:
                 self._shared_store.delete(self._session_id, self._data_key)
 
@@ -115,9 +127,10 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
 
     @wrap_promised
     def create_bytes_writer(self, session_id, data_key, total_bytes, packed=False,
-                            packed_compression=None, _promise=False):
+                            packed_compression=None, auto_register=True, _promise=False):
         return SharedStorageIO(session_id, data_key, 'w', self._shared_store,
-                               nbytes=total_bytes, packed=packed, handler=self)
+                               nbytes=total_bytes, packed=packed, auto_register=auto_register,
+                               handler=self)
 
     @wrap_promised
     def get_object(self, session_id, data_key, serialized=False, _promise=False):
@@ -127,56 +140,100 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
             return self._shared_store.get(session_id, data_key)
 
     @wrap_promised
-    def put_object(self, session_id, data_key, obj, serialized=False, _promise=False):
-        obj = self._deserial(obj) if serialized else obj
-        shape = getattr(obj, 'shape', None)
+    def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False, _promise=False):
+        keys, shapes = [], []
+        obj_refs = []
+        affected_keys = []
+        request_size, capacity = 0, 0
 
-        buf = None
         try:
-            buf = self._shared_store.put(session_id, data_key, obj)
-            self._holder_ref.put_object_by_key(session_id, data_key, shape=shape)
+            for key, obj in zip(data_keys, objs):
+                obj = self._deserial(obj) if serialized else obj
+                shape = getattr(obj, 'shape', None)
+
+                try:
+                    obj_refs.append(self._shared_store.put(session_id, key, obj))
+                    keys.append(key)
+                    shapes.append(shape)
+                except StorageFull as ex:
+                    affected_keys.extend(ex.affected_keys)
+                    request_size += ex.request_size
+                    capacity = ex.capacity
+                finally:
+                    del obj
+            self._holder_ref.put_objects_by_keys(session_id, keys, shapes=shapes)
+            if affected_keys:
+                raise StorageFull(request_size=request_size, capacity=capacity,
+                                  affected_keys=affected_keys)
         finally:
-            del obj, buf
+            obj_refs[:] = []
+            del objs
 
-    def load_from_bytes_io(self, session_id, data_key, src_handler):
-        def _fallback(*_):
-            return src_handler.create_bytes_reader(session_id, data_key, _promise=True) \
-                .then(lambda reader: self.create_bytes_writer(
-                    session_id, data_key, reader.nbytes, _promise=True)
-                      .then(lambda writer: self._copy_bytes_data(reader, writer),
-                            lambda *exc: self.pass_on_exc(reader.close, exc)))
+    def load_from_bytes_io(self, session_id, data_keys, src_handler):
+        shared_bufs = []
+        failed_keys = set()
+        storage_full_sizes = [0, 0]
 
-        return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
+        def _handle_writer_create_fail(key, reader, exc_info):
+            reader.close()
+            failed_keys.add(key)
+            exc = exc_info[1]
+            if isinstance(exc, StorageFull):
+                storage_full_sizes[0] += exc.request_size
+                storage_full_sizes[1] = exc.capacity
+            else:
+                self.pass_on_exc(reader.close, exc_info)
 
-    def load_from_object_io(self, session_id, data_key, src_handler):
-        def _load(data_or_ser, serialized):
+        def _on_file_close(key, _reader, writer, finished):
+            if finished:
+                shared_bufs.append(writer.get_shared_buffer())
+            else:
+                failed_keys.add(key)
+
+        def _finalize_load(*_):
             try:
-                return self.put_object(
-                    session_id, data_key, data_or_ser, serialized=serialized, _promise=True)
+                success_keys = [k for k in data_keys if k not in failed_keys]
+                if success_keys:
+                    self._holder_ref.put_objects_by_keys(session_id, success_keys)
+                if failed_keys:
+                    raise StorageFull(request_size=storage_full_sizes[0], capacity=storage_full_sizes[1],
+                                      affected_keys=list(failed_keys))
             finally:
-                del data_or_ser
+                shared_bufs[:] = []
 
+        def _load_single_key(k):
+            on_close = functools.partial(_on_file_close, k)
+            handle_worker_create_fail = functools.partial(_handle_writer_create_fail, k)
+            return src_handler.create_bytes_reader(session_id, k, _promise=True) \
+                .then(lambda reader: self.create_bytes_writer(
+                    session_id, k, reader.nbytes, auto_register=False, _promise=True)
+                        .then(lambda writer: self._copy_bytes_data(reader, writer, on_close),
+                              lambda *exc: handle_worker_create_fail(reader, exc)))
+
+        def _fallback(*_):
+            return promise.all_(_load_single_key(k) for k in data_keys).then(_finalize_load)
+
+        return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
+
+    def load_from_object_io(self, session_id, data_keys, src_handler):
         def _fallback(*_):
             ser_needed = src_handler.storage_type not in \
                          (DataStorageDevice.SHARED_MEMORY, DataStorageDevice.PROC_MEMORY)
-            return src_handler.get_object(session_id, data_key, serialized=ser_needed, _promise=True) \
-                .then(functools.partial(_load, serialized=ser_needed))
+            return self._batch_load_objects(
+                session_id, data_keys,
+                lambda k: src_handler.get_object(session_id, k, _promise=True), ser_needed)
 
-        return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
+        return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 
-    def delete(self, session_id, data_key, _tell=False):
-        self._holder_ref.delete_objects(session_id, [data_key], _tell=_tell)
-        self.unregister_data(session_id, data_key, _tell=_tell)
-
-    def batch_delete(self, session_id, data_keys, _tell=False):
+    def delete(self, session_id, data_keys, _tell=False):
         self._holder_ref.delete_objects(session_id, data_keys, _tell=_tell)
-        self.batch_unregister_data(session_id, data_keys, _tell=_tell)
+        self.unregister_data(session_id, data_keys, _tell=_tell)
 
     def spill_size(self, size, multiplier=1):
         return self._holder_ref.spill_size(size, multiplier, _promise=True)
 
-    def lift_data_key(self, session_id, data_key):
-        self._holder_ref.lift_data_key(session_id, data_key, _tell=True)
+    def lift_data_keys(self, session_id, data_keys):
+        self._holder_ref.lift_data_keys(session_id, data_keys, _tell=True)
 
     def pin_data_keys(self, session_id, data_keys, token):
         return self._holder_ref.pin_data_keys(session_id, data_keys, token)

--- a/mars/worker/storage/sharedhandler.py
+++ b/mars/worker/storage/sharedhandler.py
@@ -221,7 +221,7 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
                          (DataStorageDevice.SHARED_MEMORY, DataStorageDevice.PROC_MEMORY)
             return self._batch_load_objects(
                 session_id, data_keys,
-                lambda k: src_handler.get_object(session_id, k, _promise=True), ser_needed)
+                lambda k: src_handler.get_object(session_id, k, serialized=ser_needed, _promise=True), ser_needed)
 
         return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 

--- a/mars/worker/storage/sharedhandler.py
+++ b/mars/worker/storage/sharedhandler.py
@@ -174,8 +174,12 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
         return self.transfer_in_runner(session_id, data_key, src_handler, _fallback)
 
     def delete(self, session_id, data_key, _tell=False):
-        self._holder_ref.delete_object(session_id, data_key, _tell=_tell)
+        self._holder_ref.delete_objects(session_id, [data_key], _tell=_tell)
         self.unregister_data(session_id, data_key, _tell=_tell)
+
+    def batch_delete(self, session_id, data_keys, _tell=False):
+        self._holder_ref.delete_objects(session_id, data_keys, _tell=_tell)
+        self.batch_unregister_data(session_id, data_keys, _tell=_tell)
 
     def spill_size(self, size, multiplier=1):
         return self._holder_ref.spill_size(size, multiplier, _promise=True)

--- a/mars/worker/storage/sharedstore.py
+++ b/mars/worker/storage/sharedstore.py
@@ -55,6 +55,10 @@ class PlasmaKeyMapActor(FunctionActor):
         except KeyError:
             pass
 
+    def batch_delete(self, session_id, chunk_keys):
+        for k in chunk_keys:
+            self.delete(session_id, k)
+
 
 class PlasmaSharedStore(object):
     """
@@ -245,3 +249,6 @@ class PlasmaSharedStore(object):
 
     def delete(self, session_id, data_key):
         self._mapper_ref.delete(session_id, data_key)
+
+    def batch_delete(self, session_id, data_keys):
+        self._mapper_ref.batch_delete(session_id, data_keys)

--- a/mars/worker/storage/sharedstore.py
+++ b/mars/worker/storage/sharedstore.py
@@ -16,7 +16,6 @@ import logging
 
 from ...actors import FunctionActor
 from ...errors import StorageFull, StorageDataExists
-from ...utils import calc_data_size
 
 try:
     import pyarrow
@@ -138,7 +137,8 @@ class PlasmaSharedStore(object):
             raise
 
         if exc_type is PlasmaStoreFull:
-            raise StorageFull(request_size=size, total_size=self._actual_size)
+            raise StorageFull(request_size=size, capacity=self._actual_size,
+                              affected_keys=[data_key])
 
     def seal(self, session_id, data_key):
         obj_id = self._get_object_id(session_id, data_key)
@@ -192,7 +192,7 @@ class PlasmaSharedStore(object):
         :param data_key: chunk key
         :param value: Mars object to be put
         """
-        data_size = calc_data_size(value)
+        data_size = None
 
         try:
             obj_id = self._new_object_id(session_id, data_key)
@@ -231,7 +231,8 @@ class PlasmaSharedStore(object):
             raise
 
         if exc is PlasmaStoreFull:
-            raise StorageFull(request_size=data_size, total_size=self._actual_size)
+            raise StorageFull(request_size=data_size, capacity=self._actual_size,
+                              affected_keys=[data_key])
 
     def contains(self, session_id, data_key):
         """

--- a/mars/worker/storage/tests/test_cuda_io.py
+++ b/mars/worker/storage/tests/test_cuda_io.py
@@ -62,21 +62,21 @@ class Test(WorkerCase):
                 storage_client = test_actor.storage_client
                 handler = storage_client.get_storage_handler((0, DataStorageDevice.CUDA))
 
-                handler.put_object(session_id, data_key1, data)
-                self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, data_key1)),
+                handler.put_objects(session_id, [data_key1], [data])
+                self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, [data_key1])[0]),
                                  [(0, DataStorageDevice.CUDA)])
                 self.assertIsInstance(handler.get_object(session_id, data_key1), cuda_type)
                 assert_obj_equal(data, move_to_mem(handler.get_object(session_id, data_key1)))
 
-                handler.delete(session_id, data_key1)
-                self.assertIsNone(storage_manager_ref.get_data_locations(session_id, data_key1))
+                handler.delete(session_id, [data_key1])
+                self.assertIsNone(storage_manager_ref.get_data_locations(session_id, [data_key1])[0])
                 with self.assertRaises(KeyError):
                     handler.get_object(session_id, data_key1)
 
-                handler.put_object(session_id, data_key2, ser_data, serialized=True)
+                handler.put_objects(session_id, [data_key2], [ser_data], serialized=True)
                 self.assertIsInstance(handler.get_object(session_id, data_key2), cuda_type)
                 assert_obj_equal(data, move_to_mem(handler.get_object(session_id, data_key2)))
-                handler.delete(session_id, data_key2)
+                handler.delete(session_id, [data_key2])
 
     def testCudaMemLoad(self):
         test_addr = '127.0.0.1:%d' % get_next_port()
@@ -109,36 +109,36 @@ class Test(WorkerCase):
                     session_id, data_key1, ser_data1.total_bytes) as writer:
                 ser_data1.write_to(writer)
 
-            handler.load_from_bytes_io(session_id, data_key1, disk_handler) \
+            handler.load_from_bytes_io(session_id, [data_key1], disk_handler) \
                 .then(lambda *_: test_actor.set_result(None),
                       lambda *exc: test_actor.set_result(exc, accept=False))
             self.get_result(5)
-            self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, data_key1)),
+            self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, [data_key1])[0]),
                              [(0, DataStorageDevice.CUDA), (0, DataStorageDevice.DISK)])
 
-            disk_handler.delete(session_id, data_key1)
+            disk_handler.delete(session_id, [data_key1])
 
             data_load = handler.get_object(session_id, data_key1)
             ref_data = weakref.ref(data_load)
             del data_load
-            handler.delete(session_id, data_key1)
+            handler.delete(session_id, [data_key1])
             self.assertIsNone(ref_data())
 
             # load from object io
             shared_handler = storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
-            shared_handler.put_object(session_id, data_key2, data2)
+            shared_handler.put_objects(session_id, [data_key2], [data2])
 
-            handler.load_from_object_io(session_id, data_key2, shared_handler) \
+            handler.load_from_object_io(session_id, [data_key2], shared_handler) \
                 .then(lambda *_: test_actor.set_result(None),
                       lambda *exc: test_actor.set_result(exc, accept=False))
             self.get_result(5)
-            self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, data_key2)),
+            self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, [data_key2])[0]),
                              [(0, DataStorageDevice.CUDA), (0, DataStorageDevice.SHARED_MEMORY)])
 
-            shared_handler.delete(session_id, data_key2)
+            shared_handler.delete(session_id, [data_key2])
 
             data_load = handler.get_object(session_id, data_key2)
             ref_data = weakref.ref(data_load)
             del data_load
-            handler.delete(session_id, data_key2)
+            handler.delete(session_id, [data_key2])
             self.assertIsNone(ref_data())

--- a/mars/worker/storage/tests/test_cuda_io.py
+++ b/mars/worker/storage/tests/test_cuda_io.py
@@ -69,7 +69,7 @@ class Test(WorkerCase):
                 assert_obj_equal(data, move_to_mem(handler.get_object(session_id, data_key1)))
 
                 handler.delete(session_id, [data_key1])
-                self.assertIsNone(storage_manager_ref.get_data_locations(session_id, [data_key1])[0])
+                self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, [data_key1])[0]), [])
                 with self.assertRaises(KeyError):
                     handler.get_object(session_id, data_key1)
 

--- a/mars/worker/storage/tests/test_manager.py
+++ b/mars/worker/storage/tests/test_manager.py
@@ -33,47 +33,47 @@ class Test(WorkerCase):
             manager_ref = pool.create_actor(StorageManagerActor,
                                             uid=StorageManagerActor.default_uid())
 
-            self.assertIsNone(manager_ref.get_data_locations(session_id, 'NON_EXIST'))
+            self.assertEqual(list(manager_ref.get_data_locations(session_id, ['NON_EXIST'])[0]), [])
 
-            manager_ref.register_data(session_id, data_key1,
-                                      (0, DataStorageDevice.SHARED_MEMORY), 1024, (16, 8))
-            manager_ref.register_data(session_id, data_key1,
-                                      (1, DataStorageDevice.PROC_MEMORY), 1024, (16, 8))
-            manager_ref.register_data(session_id, data_key1,
-                                      (0, DataStorageDevice.DISK), 2048)
+            manager_ref.register_data(session_id, [data_key1],
+                                      (0, DataStorageDevice.SHARED_MEMORY), [1024], shapes=[(16, 8)])
+            manager_ref.register_data(session_id, [data_key1],
+                                      (1, DataStorageDevice.PROC_MEMORY), [1024], shapes=[(16, 8)])
+            manager_ref.register_data(session_id, [data_key1],
+                                      (0, DataStorageDevice.DISK), [2048])
             self.assertEqual([(0, DataStorageDevice.SHARED_MEMORY), (0, DataStorageDevice.DISK),
                               (1, DataStorageDevice.PROC_MEMORY)],
-                             sorted(manager_ref.get_data_locations(session_id, data_key1)))
-            self.assertEqual(2048, manager_ref.get_data_size(session_id, data_key1))
-            self.assertEqual((16, 8), manager_ref.get_data_shape(session_id, data_key1))
+                             sorted(manager_ref.get_data_locations(session_id, [data_key1])[0]))
+            self.assertEqual(2048, manager_ref.get_data_sizes(session_id, [data_key1])[0])
+            self.assertEqual((16, 8), manager_ref.get_data_shapes(session_id, [data_key1])[0])
 
-            manager_ref.register_data(session_id, data_key2,
-                                      (0, DataStorageDevice.SHARED_MEMORY), 1024)
-            manager_ref.register_data(session_id, data_key2,
-                                      (1, DataStorageDevice.PROC_MEMORY), 1024)
+            manager_ref.register_data(session_id, [data_key2],
+                                      (0, DataStorageDevice.SHARED_MEMORY), [1024])
+            manager_ref.register_data(session_id, [data_key2],
+                                      (1, DataStorageDevice.PROC_MEMORY), [1024])
             self.assertEqual([(0, DataStorageDevice.SHARED_MEMORY), (1, DataStorageDevice.PROC_MEMORY)],
-                             sorted(manager_ref.get_data_locations(session_id, data_key2)))
+                             sorted(manager_ref.get_data_locations(session_id, [data_key2])[0]))
 
-            manager_ref.unregister_data(session_id, data_key2,
+            manager_ref.unregister_data(session_id, [data_key2],
                                         (0, DataStorageDevice.SHARED_MEMORY))
             self.assertEqual([(1, DataStorageDevice.PROC_MEMORY)],
-                             sorted(manager_ref.get_data_locations(session_id, data_key2)))
-            self.assertEqual(1024, manager_ref.get_data_size(session_id, data_key2))
+                             sorted(manager_ref.get_data_locations(session_id, [data_key2])[0]))
+            self.assertEqual(1024, manager_ref.get_data_sizes(session_id, [data_key2])[0])
             self.assertEqual([data_key1],
                              list(manager_ref.filter_exist_keys(session_id, [data_key1, data_key2, 'non-exist'],
                                                                 [(0, DataStorageDevice.SHARED_MEMORY)])))
 
-            manager_ref.unregister_data(session_id, data_key2,
+            manager_ref.unregister_data(session_id, [data_key2],
                                         (1, DataStorageDevice.PROC_MEMORY))
-            self.assertIsNone(manager_ref.get_data_locations(session_id, data_key2))
-            self.assertIsNone(manager_ref.get_data_size(session_id, data_key2))
-            self.assertIsNone(manager_ref.get_data_shape(session_id, data_key2))
+            self.assertEqual(list(manager_ref.get_data_locations(session_id, [data_key2])[0]), [])
+            self.assertIsNone(manager_ref.get_data_sizes(session_id, [data_key2])[0])
+            self.assertIsNone(manager_ref.get_data_shapes(session_id, data_key2)[0])
 
-            manager_ref.register_data(session_id, data_key2,
-                                      (1, DataStorageDevice.PROC_MEMORY), 1024)
+            manager_ref.register_data(session_id, [data_key2],
+                                      (1, DataStorageDevice.PROC_MEMORY), [1024])
             manager_ref.handle_process_down([1])
             self.assertEqual([(0, DataStorageDevice.SHARED_MEMORY), (0, DataStorageDevice.DISK)],
-                             sorted(manager_ref.get_data_locations(session_id, data_key1)))
-            self.assertIsNone(manager_ref.get_data_locations(session_id, data_key2))
-            self.assertIsNone(manager_ref.get_data_size(session_id, data_key2))
-            self.assertIsNone(manager_ref.get_data_shape(session_id, data_key2))
+                             sorted(manager_ref.get_data_locations(session_id, [data_key1])[0]))
+            self.assertEqual(list(manager_ref.get_data_locations(session_id, [data_key2])[0]), [])
+            self.assertIsNone(manager_ref.get_data_sizes(session_id, [data_key2])[0])
+            self.assertIsNone(manager_ref.get_data_shapes(session_id, [data_key2])[0])

--- a/mars/worker/tests/test_calc.py
+++ b/mars/worker/tests/test_calc.py
@@ -96,10 +96,10 @@ class Test(WorkerCase):
 
             for fetch_chunk, d in zip(fetch_chunks, data_list):
                 self.waitp(
-                    storage_client.put_object(
-                        session_id, fetch_chunk.key, d, [DataStorageDevice.SHARED_MEMORY]),
+                    storage_client.put_objects(
+                        session_id, [fetch_chunk.key], [d], [DataStorageDevice.SHARED_MEMORY]),
                 )
-            self.assertEqual(list(storage_client.get_data_locations(session_id, fetch_chunks[0].key)),
+            self.assertEqual(list(storage_client.get_data_locations(session_id, [fetch_chunks[0].key])[0]),
                              [(0, DataStorageDevice.SHARED_MEMORY)])
 
             quota_batch = {
@@ -111,12 +111,12 @@ class Test(WorkerCase):
                     = data_list[idx].nbytes
 
                 self.waitp(
-                    storage_client.copy_to(session_id, fetch_chunks[idx].key, [DataStorageDevice.DISK])
+                    storage_client.copy_to(session_id, [fetch_chunks[idx].key], [DataStorageDevice.DISK])
                         .then(lambda *_: storage_client.delete(
-                            session_id, fetch_chunks[idx].key, [DataStorageDevice.SHARED_MEMORY]))
+                            session_id, [fetch_chunks[idx].key], [DataStorageDevice.SHARED_MEMORY]))
                 )
                 self.assertEqual(
-                    list(storage_client.get_data_locations(session_id, fetch_chunks[idx].key)),
+                    list(storage_client.get_data_locations(session_id, [fetch_chunks[idx].key])[0]),
                     [(0, DataStorageDevice.DISK)])
 
             self.waitp(
@@ -154,13 +154,13 @@ class Test(WorkerCase):
             self.assertEqual(len(quota_dump.proc_sizes), 0)
             self.assertEqual(len(quota_dump.hold_sizes), 0)
 
-            self.assertEqual(sorted(storage_client.get_data_locations(session_id, fetch_chunks[0].key)),
+            self.assertEqual(sorted(storage_client.get_data_locations(session_id, [fetch_chunks[0].key])[0]),
                              [(0, DataStorageDevice.SHARED_MEMORY)])
-            self.assertEqual(sorted(storage_client.get_data_locations(session_id, fetch_chunks[1].key)),
+            self.assertEqual(sorted(storage_client.get_data_locations(session_id, [fetch_chunks[1].key])[0]),
                              [(0, DataStorageDevice.SHARED_MEMORY), (0, DataStorageDevice.DISK)])
-            self.assertEqual(sorted(storage_client.get_data_locations(session_id, fetch_chunks[2].key)),
+            self.assertEqual(sorted(storage_client.get_data_locations(session_id, [fetch_chunks[2].key])[0]),
                              [(0, DataStorageDevice.DISK)])
-            self.assertEqual(sorted(storage_client.get_data_locations(session_id, add_chunk.key)),
+            self.assertEqual(sorted(storage_client.get_data_locations(session_id, [add_chunk.key])[0]),
                              [(0, DataStorageDevice.SHARED_MEMORY)])
 
     def testCpuCalcErrorInRunning(self):
@@ -175,8 +175,8 @@ class Test(WorkerCase):
 
             for fetch_chunk, d in zip(fetch_chunks, data_list):
                 self.waitp(
-                    storage_client.put_object(
-                        session_id, fetch_chunk.key, d, [DataStorageDevice.SHARED_MEMORY]),
+                    storage_client.put_objects(
+                        session_id, [fetch_chunk.key], [d], [DataStorageDevice.SHARED_MEMORY]),
                 )
 
             def _mock_calc_results_error(*_, **__):

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -70,7 +70,7 @@ class SenderActor(WorkerActor):
         :param chunk_key: chunk key
         :return: size of data
         """
-        nbytes = self.storage_client.get_data_size(session_id, chunk_key)
+        nbytes = self.storage_client.get_data_sizes(session_id, [chunk_key])[0]
         if nbytes is None:
             raise DependencyMissing('Dependency %s not met on sending.' % chunk_key)
         return nbytes
@@ -282,7 +282,7 @@ class ReceiverActor(WorkerActor):
         """
         session_chunk_key = (session_id, chunk_key)
 
-        if self.storage_client.get_data_locations(session_id, chunk_key):
+        if self.storage_client.get_data_locations(session_id, [chunk_key])[0]:
             return ReceiveStatus.RECEIVED
         if session_chunk_key in self._data_writers:
             # data still being transferred
@@ -551,11 +551,11 @@ class ReceiverActor(WorkerActor):
 
 class ResultCopyActor(WorkerActor):
     def start_copy(self, session_id, chunk_key, targets):
-        locations = [v[1] for v in self.storage_client.get_data_locations(session_id, chunk_key)]
+        locations = [v[1] for v in self.storage_client.get_data_locations(session_id, [chunk_key])[0]]
         if set(locations).intersection(targets):
             return
         ev = self.ctx.event()
-        self.storage_client.copy_to(session_id, chunk_key, targets) \
+        self.storage_client.copy_to(session_id, [chunk_key], targets) \
             .then(lambda *_: ev.set())
         return ev
 


### PR DESCRIPTION
## What do these changes do?

Change most of the storage interfaces into batch interfaces to improve performance on shuffle.

## Related issue number

Fixes #817 
