### PR TITLE
Add ReceiverStatusActor to help listening at receiver end

### DIFF
--- a/.github/workflows/upload-packages.sh
+++ b/.github/workflows/upload-packages.sh
@@ -14,11 +14,11 @@ else
   fi
 
   if [ "$UNAME" = "linux" ]; then
-    sudo chmod 777 bin/*
     docker pull $DOCKER_IMAGE
 
     pyabis=$(echo $PYABI | tr ":" "\n")
     for abi in $pyabis; do
+      git clean -f -x
       docker run --rm -e "PYABI=$abi" -e "GIT_TAG=$GIT_TAG" -v `pwd`:/io \
         $DOCKER_IMAGE $PRE_CMD /io/.github/workflows/build-wheels.sh
     done

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -96,8 +96,8 @@ class BaseCalcActor(WorkerActor):
         return new_keys
 
     def _release_local_quota(self, session_id, data_key):
-        self._mem_quota_ref.release_quota(
-            build_quota_key(session_id, data_key, owner=self.proc_id), _tell=True, _wait=False)
+        self._mem_quota_ref.release_quotas(
+            [build_quota_key(session_id, data_key, owner=self.proc_id)], _tell=True, _wait=False)
 
     def _fetch_keys_to_process(self, session_id, keys_to_fetch):
         context_dict = dict()
@@ -109,7 +109,7 @@ class BaseCalcActor(WorkerActor):
             locations = storage_client.get_data_locations(session_id, [k])[0]
             quota_key = build_quota_key(session_id, k, owner=self.proc_id)
             if (self.proc_id, DataStorageDevice.PROC_MEMORY) not in locations:
-                self._mem_quota_ref.release_quota(quota_key, _tell=True, _wait=False)
+                self._mem_quota_ref.release_quotas([quota_key], _tell=True, _wait=False)
             else:
                 self._mem_quota_ref.hold_quota(quota_key, _tell=True)
                 if self._remove_intermediate:

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -14,7 +14,6 @@
 
 import logging
 import time
-import functools
 from collections import defaultdict
 
 from .. import promise
@@ -42,6 +41,7 @@ class BaseCalcActor(WorkerActor):
         self._remove_intermediate = self._calc_intermediate_device not in self._calc_dest_devices
 
         self._dispatch_ref = None
+        self._mem_quota_ref = None
         self._events_ref = None
         self._status_ref = None
         self._resource_ref = None
@@ -92,47 +92,50 @@ class BaseCalcActor(WorkerActor):
             old_keys.append(build_quota_key(session_id, k, owner=graph_key))
             new_keys.append(build_quota_key(session_id, k, owner=self.proc_id))
         self._mem_quota_ref.alter_allocations(
-            old_keys, new_keys=new_keys, process_quota=process_quota, _tell=True, _wait=False)
+            old_keys, new_keys=new_keys, process_quota=process_quota)
         return new_keys
 
-    def _release_local_quota(self, session_id, data_key):
+    def _release_local_quotas(self, session_id, data_keys):
         self._mem_quota_ref.release_quotas(
-            [build_quota_key(session_id, data_key, owner=self.proc_id)], _tell=True, _wait=False)
+            [build_quota_key(session_id, k, owner=self.proc_id) for k in data_keys],
+            _tell=True, _wait=False)
 
     def _fetch_keys_to_process(self, session_id, keys_to_fetch):
         context_dict = dict()
-        failed = [False]
-        promises = []
         storage_client = self.storage_client
 
-        def _handle_single_loaded(k, obj):
-            locations = storage_client.get_data_locations(session_id, [k])[0]
-            quota_key = build_quota_key(session_id, k, owner=self.proc_id)
-            if (self.proc_id, DataStorageDevice.PROC_MEMORY) not in locations:
-                self._mem_quota_ref.release_quotas([quota_key], _tell=True, _wait=False)
-            else:
-                self._mem_quota_ref.hold_quota(quota_key, _tell=True)
+        def _handle_loaded(objs):
+            data_locations = storage_client.get_data_locations(session_id, keys_to_fetch)
+            shared_quota_keys = []
+            inproc_keys = []
+            inproc_quota_keys = []
+
+            context_dict.update(zip(keys_to_fetch, objs))
+            for k, locations, obj in zip(keys_to_fetch, data_locations, objs):
+                quota_key = build_quota_key(session_id, k, owner=self.proc_id)
+                if (self.proc_id, DataStorageDevice.PROC_MEMORY) not in locations:
+                    shared_quota_keys.append(quota_key)
+                else:
+                    inproc_keys.append(k)
+                    inproc_quota_keys.append(quota_key)
+
+            if shared_quota_keys:
+                self._mem_quota_ref.release_quotas(shared_quota_keys, _tell=True, _wait=False)
+            if inproc_keys:
+                self._mem_quota_ref.hold_quotas(inproc_quota_keys, _tell=True)
                 if self._remove_intermediate:
-                    storage_client.delete(session_id, [k], [self._calc_intermediate_device])
-            if not failed[0]:
-                context_dict[k] = obj
+                    storage_client.delete(session_id, inproc_keys, [self._calc_intermediate_device])
 
-        def _handle_single_load_fail(*exc, **kwargs):
-            data_key = kwargs.pop('key')
+        def _handle_load_fail(*exc):
             if self._remove_intermediate:
-                storage_client.delete(session_id, [data_key], [self._calc_intermediate_device])
-            self._release_local_quota(session_id, data_key)
+                storage_client.delete(session_id, keys_to_fetch, [self._calc_intermediate_device])
+            self._release_local_quotas(session_id, keys_to_fetch)
 
-            failed[0] = True
             context_dict.clear()
             six.reraise(*exc)
 
-        for key in keys_to_fetch:
-            promises.append(storage_client.get_object(session_id, key, self._calc_source_devices)
-                            .then(functools.partial(_handle_single_loaded, key),
-                                  functools.partial(_handle_single_load_fail, key=key)))
-
-        return promise.all_(promises).then(lambda *_: context_dict)
+        return storage_client.get_objects(session_id, keys_to_fetch, self._calc_source_devices) \
+            .then(_handle_loaded, _handle_load_fail).then(lambda *_: context_dict)
 
     def _get_n_cpu(self):
         if self._n_cpu is None:
@@ -185,18 +188,20 @@ class BaseCalcActor(WorkerActor):
             raise KeyError([k for k in chunk_targets if k not in collected_chunk_keys])
 
         # adjust sizes in allocation
-        apply_alloc_sizes = defaultdict(lambda: 0)
+        apply_allocs = defaultdict(lambda: 0)
         for k, size in zip(result_keys, result_sizes):
-            apply_alloc_sizes[get_chunk_key(k)] += size
+            apply_allocs[get_chunk_key(k)] += size
 
-        for k, v in apply_alloc_sizes.items():
-            quota_key = build_quota_key(session_id, k, owner=self.proc_id)
-            self._mem_quota_ref.alter_allocation(quota_key, v, _tell=True)
-            self._mem_quota_ref.hold_quota(quota_key, _tell=True)
+        apply_alloc_quota_keys, apply_alloc_sizes = [], []
+        for k, v in apply_allocs.items():
+            apply_alloc_quota_keys.append(build_quota_key(session_id, k, owner=self.proc_id))
+            apply_alloc_sizes.append(v)
+        self._mem_quota_ref.alter_allocations(apply_alloc_quota_keys, apply_alloc_sizes, _tell=True, _wait=False)
+        self._mem_quota_ref.hold_quotas(apply_alloc_quota_keys, _tell=True)
 
         if self._status_ref:
             self._status_ref.update_mean_stats(
-                'calc_speed.' + op_name, sum(apply_alloc_sizes.values()) * 1.0 / (end_time - start_time),
+                'calc_speed.' + op_name, sum(apply_alloc_sizes) * 1.0 / (end_time - start_time),
                 _tell=True, _wait=False)
 
         logger.debug('Finish calculating operand %s.', graph_key)
@@ -225,18 +230,18 @@ class BaseCalcActor(WorkerActor):
         target_quotas = self._make_quotas_local(session_id, graph_key, chunk_targets)
 
         def _start_calc(context_dict):
-            for k in target_quotas:
-                self._mem_quota_ref.process_quota(k, _tell=True, _wait=False)
+            self._mem_quota_ref.process_quotas(target_quotas, _tell=True, _wait=False)
             return self._calc_results(session_id, graph_key, graph, context_dict, chunk_targets)
 
         def _finalize(keys, exc_info):
             self._dispatch_ref.register_free_slot(self.uid, self._slot_name, _tell=True, _wait=False)
+            keys_to_release = []
 
             for k in keys_to_fetch:
                 if get_chunk_key(k) not in chunk_targets:
                     if self._remove_intermediate:
                         self.storage_client.delete(session_id, [k], [self._calc_intermediate_device])
-                    self._release_local_quota(session_id, k)
+                    keys_to_release.append(k)
 
             if not exc_info:
                 self.tell_promise(callback, keys)
@@ -244,8 +249,10 @@ class BaseCalcActor(WorkerActor):
                 for k in chunk_targets:
                     if self._remove_intermediate:
                         self.storage_client.delete(session_id, [k], [self._calc_intermediate_device])
-                    self._release_local_quota(session_id, k)
+                    keys_to_release.append(k)
                 self.tell_promise(callback, *exc_info, **dict(_accept=False))
+
+            self._release_local_quotas(session_id, keys_to_release)
 
         return self._fetch_keys_to_process(session_id, keys_to_fetch) \
             .then(lambda context_dict: _start_calc(context_dict)) \
@@ -275,8 +282,7 @@ class BaseCalcActor(WorkerActor):
             if self._remove_intermediate:
                 storage_client.delete(
                     session_id, keys_to_store, [self._calc_intermediate_device], _tell=True)
-            quotas = [build_quota_key(session_id, k, owner=self.proc_id) for k in keys_to_store]
-            self._mem_quota_ref.release_quotas(quotas, _tell=True, _wait=False)
+            self._release_local_quotas(session_id, keys_to_store)
 
         return storage_client.copy_to(session_id, keys_to_store, self._calc_dest_devices) \
             .then(_delete_keys) \

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -111,7 +111,7 @@ class BaseCalcActor(WorkerActor):
             inproc_quota_keys = []
 
             context_dict.update(zip(keys_to_fetch, objs))
-            for k, locations, obj in zip(keys_to_fetch, data_locations, objs):
+            for k, locations in zip(keys_to_fetch, data_locations):
                 quota_key = build_quota_key(session_id, k, owner=self.proc_id)
                 if (self.proc_id, DataStorageDevice.PROC_MEMORY) not in locations:
                     shared_quota_keys.append(quota_key)

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -323,10 +323,7 @@ class ExecutionActor(WorkerActor):
                 six.reraise(*exc)
             except (BrokenPipeError, ConnectionRefusedError, TimeoutError,
                     WorkerDead, promise.PromiseTimeout):
-                self._resource_ref.detach_dead_workers(
-                    [remote_addr],
-                    reporter='%s@%s:_fetch_remote_data()' % (self.uid, self.address),
-                    _tell=True, _wait=False)
+                self._resource_ref.detach_dead_workers([remote_addr], _tell=True, _wait=False)
                 raise DependencyMissing((session_id, chunk_key))
 
         @log_unhandled

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -29,7 +29,7 @@ from ..operands import Fetch, FetchShuffle
 from ..utils import BlacklistSet, deserialize_graph, log_unhandled, build_exc_info, \
     calc_data_size, get_chunk_shuffle_key
 from .storage import DataStorageDevice
-from .transfer import ReceiverStatusActor
+from .transfer import ReceiverManagerActor
 from .utils import WorkerActor, ExpiringCache, concat_operand_keys, \
     build_quota_key, change_quota_key_owner
 
@@ -127,7 +127,7 @@ class ExecutionActor(WorkerActor):
         self._mem_quota_ref = None
         self._status_ref = None
         self._daemon_ref = None
-        self._receiver_status_ref = None
+        self._receiver_manager_ref = None
 
         self._resource_ref = None
 
@@ -158,11 +158,11 @@ class ExecutionActor(WorkerActor):
         if not self.ctx.has_actor(self._status_ref):
             self._status_ref = None
 
-        self._receiver_status_ref = self.ctx.actor_ref(ReceiverStatusActor.default_uid())
-        if not self.ctx.has_actor(self._receiver_status_ref):
-            self._receiver_status_ref = None
+        self._receiver_manager_ref = self.ctx.actor_ref(ReceiverManagerActor.default_uid())
+        if not self.ctx.has_actor(self._receiver_manager_ref):
+            self._receiver_manager_ref = None
         else:
-            self._receiver_status_ref = self.promise_ref(self._receiver_status_ref)
+            self._receiver_manager_ref = self.promise_ref(self._receiver_manager_ref)
 
         from ..scheduler import ResourceActor
         self._resource_ref = self.get_actor_ref(ResourceActor.default_uid())
@@ -623,8 +623,8 @@ class ExecutionActor(WorkerActor):
             promises.append(
                 self.storage_client.copy_to(
                     session_id, better_shared_keys, [graph_record.preferred_data_device],
-                    ensure=False, pin_token=graph_key) \
-                    .then(lambda *_: _release_copied_keys(better_shared_keys))
+                    ensure=False, pin_token=graph_key)
+                .then(lambda *_: _release_copied_keys(better_shared_keys))
             )
         return promises
 
@@ -634,13 +634,13 @@ class ExecutionActor(WorkerActor):
         graph_record = self._graph_records[(session_id, graph_key)]
 
         filtered_remote_keys = remote_keys
-        if self._receiver_status_ref:
-            transferring_keys = set(self._receiver_status_ref.filter_registered_keys(
+        if self._receiver_manager_ref:
+            transferring_keys = set(self._receiver_manager_ref.filter_registered_keys(
                 session_id, remote_keys))
             if transferring_keys:
                 logger.debug('Data %s already scheduled for fetch, just wait.', transferring_keys)
                 filtered_remote_keys = [k for k in remote_keys if k not in transferring_keys]
-                promises.append(self._receiver_status_ref.add_keys_callback(
+                promises.append(self._receiver_manager_ref.add_keys_callback(
                     session_id, transferring_keys, _promise=True,
                     _timeout=options.worker.prepare_data_timeout))
 
@@ -758,7 +758,7 @@ class ExecutionActor(WorkerActor):
                             .catch(lambda *_: None))
 
         for target, keys in address_to_data_keys.items():
-            self.ctx.actor_ref(ReceiverStatusActor.default_uid(), address=target) \
+            self.ctx.actor_ref(ReceiverManagerActor.default_uid(), address=target) \
                 .register_keys(session_id, keys, _tell=True, _wait=False)
 
         return promise.all_(promises)

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -617,13 +617,14 @@ class ExecutionActor(WorkerActor):
             promises.append(
                 self.storage_client.copy_to(
                     session_id, ensure_shared_keys, [graph_record.preferred_data_device],
-                    ensure=True, pin=True)
+                    ensure=True, pin_token=graph_key)
             )
         if better_shared_keys:
             promises.append(
                 self.storage_client.copy_to(
                     session_id, better_shared_keys, [graph_record.preferred_data_device],
-                    ensure=False, pin=True).then(lambda *_: _release_copied_keys(better_shared_keys))
+                    ensure=False, pin_token=graph_key) \
+                    .then(lambda *_: _release_copied_keys(better_shared_keys))
             )
         return promises
 

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -176,13 +176,15 @@ class ExecutionActor(WorkerActor):
 
     def _pin_data_keys(self, session_id, graph_key, data_keys):
         if not data_keys:
-            return
+            return []
         try:
             graph_record = self._graph_records[(session_id, graph_key)]
         except KeyError:
-            return
-        graph_record.pinned_keys.update(self.storage_client.pin_data_keys(
-            session_id, data_keys, graph_key, [graph_record.preferred_data_device]))
+            return []
+        pinned_keys = self.storage_client.pin_data_keys(
+            session_id, data_keys, graph_key, [graph_record.preferred_data_device])
+        graph_record.pinned_keys.update(pinned_keys)
+        return pinned_keys
 
     def _estimate_calc_memory(self, session_id, graph_key):
         graph_record = self._graph_records[(session_id, graph_key)]
@@ -290,8 +292,8 @@ class ExecutionActor(WorkerActor):
             locations = storage_client.get_data_locations(session_id, [chunk_key])[0]
             if (0, DataStorageDevice.SHARED_MEMORY) in locations:
                 self._pin_data_keys(session_id, graph_key, [chunk_key])
-                self._mem_quota_ref.release_quota(
-                    build_quota_key(session_id, chunk_key, owner=graph_key), _tell=True, _wait=False)
+                self._mem_quota_ref.release_quotas(
+                    build_quota_key(session_id, [chunk_key], owner=graph_key), _tell=True, _wait=False)
                 if (0, graph_record.preferred_data_device) not in locations:
                     return storage_client.copy_to(session_id, [chunk_key], [graph_record.preferred_data_device])
 
@@ -548,10 +550,6 @@ class ExecutionActor(WorkerActor):
         if graph_record.stop_requested:
             raise ExecutionInterrupted
 
-        loaded_keys = []
-        move_keys = []
-        transfer_keys = []
-
         logger.debug('Start preparing input data for graph %s', graph_key)
         self._update_state(session_id, graph_key, ExecutionState.PREPARING_INPUTS)
         prepare_promises = []
@@ -570,53 +568,93 @@ class ExecutionActor(WorkerActor):
                     input_keys.add(part_key)
                     shuffle_keys.add(part_key)
 
-        for input_key in input_keys:
-            if input_key in graph_record.pinned_keys:
-                # already pinned, we continue
-                loaded_keys.append(input_key)
-                self._mem_quota_ref.release_quota(
-                    build_quota_key(session_id, input_key, owner=graph_key), _tell=True)
-            elif storage_client.get_data_locations(session_id, [input_key])[0]:
-                # load data from other devices
-                move_keys.append(input_key)
-                ensure_shared = input_key in graph_record.shared_input_chunks or input_key in shuffle_keys
-                if ensure_shared:
-                    self._mem_quota_ref.release_quota(
-                        build_quota_key(session_id, input_key, owner=graph_key), _tell=True)
+        local_keys = graph_record.pinned_keys & set(input_keys)
+        non_local_keys = [k for k in input_keys if k not in local_keys]
+        non_local_locations = storage_client.get_data_locations(session_id, non_local_keys)
+        copy_keys = set(k for k, loc in zip(non_local_keys, non_local_locations) if loc)
+        remote_keys = [k for k in non_local_keys if k not in copy_keys]
 
-                pin_fun = functools.partial(
-                    lambda k, *_: self._pin_data_keys(session_id, graph_key, [k]), input_key)
-                prepare_promises.append(
-                    storage_client.copy_to(
-                        session_id, [input_key], [graph_record.preferred_data_device], ensure=ensure_shared)
-                        .then(pin_fun, lambda *_: None)
-                )
-            else:
-                # load data from another worker
-                chunk_meta = input_metas.get(input_key) or graph_record.data_metas.get(input_key)
-                if chunk_meta:
-                    chunk_meta.workers = tuple(w for w in chunk_meta.workers if w != self.address)
+        # handle local keys
+        self._mem_quota_ref.release_quotas(
+            [build_quota_key(session_id, k, owner=graph_key) for k in local_keys], _tell=True)
+        # handle move keys
+        prepare_promises.extend(
+            self._prepare_copy_keys(session_id, graph_key, copy_keys))
+        # handle remote keys
+        prepare_promises.extend(
+            self._prepare_remote_keys(session_id, graph_key, remote_keys, input_metas))
 
-                if chunk_meta is None or not chunk_meta.workers:
-                    raise DependencyMissing('Dependency %r not met on sending.' % (input_key,))
-                worker_results = list(chunk_meta.workers)
-                random.shuffle(worker_results)
-
-                transfer_keys.append(input_key)
-
-                # fetch data from other workers, if one fails, try another
-                p = promise.finished(_accept=False)
-                for worker in worker_results:
-                    p = p.catch(functools.partial(
-                        self._fetch_remote_data, session_id, graph_key, input_key, worker,
-                        ensure_cached=input_key in shared_input_chunks))
-                prepare_promises.append(p)
-
-        logger.debug('Graph key %s: Targets %r, loaded keys %r, move keys %s, transfer keys %r',
-                     graph_key, graph_record.chunk_targets, loaded_keys, move_keys, transfer_keys)
+        logger.debug('Graph key %s: Targets %r, loaded keys %r, copy keys %s, remote keys %r',
+                     graph_key, graph_record.chunk_targets, local_keys, copy_keys, remote_keys)
         p = promise.all_(prepare_promises) \
             .then(lambda *_: logger.debug('Data preparation for graph %s finished', graph_key))
         return p
+
+    @log_unhandled
+    def _prepare_copy_keys(self, session_id, graph_key, copy_keys):
+        promises = []
+        graph_record = self._graph_records[(session_id, graph_key)]
+        ensure_shared_keys = [k for k in copy_keys if k in graph_record.shared_input_chunks]
+        better_shared_keys = [k for k in copy_keys if k not in graph_record.shared_input_chunks]
+
+        def _release_copied_keys(keys):
+            actual_moved_keys = self._pin_data_keys(session_id, graph_key, keys)
+            self._mem_quota_ref.release_quotas(
+                [build_quota_key(session_id, k, owner=graph_key) for k in actual_moved_keys],
+                _tell=True)
+
+        if ensure_shared_keys:
+            self._mem_quota_ref.release_quotas(
+                [build_quota_key(session_id, k, owner=graph_key) for k in ensure_shared_keys],
+                _tell=True)
+            promises.append(
+                self.storage_client.copy_to(
+                    session_id, ensure_shared_keys, [graph_record.preferred_data_device],
+                    ensure=True, pin=True)
+            )
+        if better_shared_keys:
+            promises.append(
+                self.storage_client.copy_to(
+                    session_id, better_shared_keys, [graph_record.preferred_data_device],
+                    ensure=False, pin=True).then(lambda *_: _release_copied_keys(better_shared_keys))
+            )
+        return promises
+
+    @log_unhandled
+    def _prepare_remote_keys(self, session_id, graph_key, remote_keys, input_metas):
+        promises = []
+        graph_record = self._graph_records[(session_id, graph_key)]
+
+        filtered_remote_keys = remote_keys
+        if self._receiver_notifier_ref:
+            transferring_keys = set(self._receiver_notifier_ref.filter_registered_keys(
+                session_id, remote_keys))
+            if transferring_keys:
+                logger.debug('Data %s already scheduled for fetch, just wait.', transferring_keys)
+                filtered_remote_keys = [k for k in remote_keys if k not in transferring_keys]
+                promises.append(self._receiver_notifier_ref.add_keys_callback(
+                    session_id, transferring_keys, _promise=True,
+                    _timeout=options.worker.prepare_data_timeout))
+
+        for input_key in filtered_remote_keys:
+            # load data from another worker
+            chunk_meta = input_metas.get(input_key) or graph_record.data_metas.get(input_key)
+            if chunk_meta:
+                chunk_meta.workers = tuple(w for w in chunk_meta.workers if w != self.address)
+
+            if chunk_meta is None or not chunk_meta.workers:
+                raise DependencyMissing('Dependency %r not met on sending.' % (input_key,))
+            worker_results = list(chunk_meta.workers)
+            random.shuffle(worker_results)
+
+            # fetch data from other workers, if one fails, try another
+            p = promise.finished(_accept=False)
+            for worker in worker_results:
+                p = p.catch(functools.partial(
+                    self._fetch_remote_data, session_id, graph_key, input_key, worker,
+                    ensure_cached=input_key in graph_record.shared_input_chunks))
+            promises.append(p)
+        return promises
 
     @log_unhandled
     def _send_calc_request(self, session_id, graph_key, calc_uid):

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -293,7 +293,7 @@ class ExecutionActor(WorkerActor):
             if (0, DataStorageDevice.SHARED_MEMORY) in locations:
                 self._pin_data_keys(session_id, graph_key, [chunk_key])
                 self._mem_quota_ref.release_quotas(
-                    build_quota_key(session_id, [chunk_key], owner=graph_key), _tell=True, _wait=False)
+                    [build_quota_key(session_id, chunk_key, owner=graph_key)], _tell=True, _wait=False)
                 if (0, graph_record.preferred_data_device) not in locations:
                     return storage_client.copy_to(session_id, [chunk_key], [graph_record.preferred_data_device])
 
@@ -553,7 +553,6 @@ class ExecutionActor(WorkerActor):
         logger.debug('Start preparing input data for graph %s', graph_key)
         self._update_state(session_id, graph_key, ExecutionState.PREPARING_INPUTS)
         prepare_promises = []
-        shared_input_chunks = graph_record.shared_input_chunks
 
         input_keys = set()
         shuffle_keys = set()

--- a/mars/worker/seal.py
+++ b/mars/worker/seal.py
@@ -65,7 +65,8 @@ class SealActor(WorkerActor):
             # clean up
             self.storage_client.delete(session_id, [key])
             self.get_meta_client().delete_meta(session_id, key, False)
-            self._mem_quota_ref.release_quota(key)
+
+        self._mem_quota_ref.release_quotas(keys)
 
         self.storage_client.put_objects(
             session_id, [chunk_key], [ndarr], [DataStorageDevice.SHARED_MEMORY, DataStorageDevice.DISK])

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -31,9 +31,8 @@ from .dispatcher import DispatchActor
 from .events import EventsActor
 from .execution import ExecutionActor
 from .calc import CpuCalcActor, CudaCalcActor
-from .transfer import ReceiverActor, SenderActor
+from .transfer import ReceiverActor, SenderActor, ReceiverStatusActor, ResultSenderActor
 from .prochelper import ProcessHelperActor
-from .transfer import ResultSenderActor
 from .storage import IORunnerActor, StorageManagerActor, SharedHolderActor, \
     InProcHolderActor, CudaHolderActor
 from .utils import WorkerClusterInfoActor
@@ -55,6 +54,7 @@ class WorkerService(object):
         self._status_ref = None
         self._execution_ref = None
         self._daemon_ref = None
+        self._receiver_status_ref = None
 
         self._cluster_info_ref = None
         self._cpu_calc_actors = []
@@ -216,6 +216,8 @@ class WorkerService(object):
         self._dispatch_ref = pool.create_actor(DispatchActor, uid=DispatchActor.default_uid())
         # create EventsActor
         self._events_ref = pool.create_actor(EventsActor, uid=EventsActor.default_uid())
+        # create ReceiverNotifierActor
+        self._receiver_status_ref = pool.create_actor(ReceiverStatusActor, uid=ReceiverStatusActor.default_uid())
         # create ExecutionActor
         self._execution_ref = pool.create_actor(ExecutionActor, uid=ExecutionActor.default_uid())
 

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -31,7 +31,7 @@ from .dispatcher import DispatchActor
 from .events import EventsActor
 from .execution import ExecutionActor
 from .calc import CpuCalcActor, CudaCalcActor
-from .transfer import ReceiverActor, SenderActor, ReceiverStatusActor, ResultSenderActor
+from .transfer import ReceiverActor, SenderActor, ReceiverManagerActor, ResultSenderActor
 from .prochelper import ProcessHelperActor
 from .storage import IORunnerActor, StorageManagerActor, SharedHolderActor, \
     InProcHolderActor, CudaHolderActor
@@ -54,7 +54,7 @@ class WorkerService(object):
         self._status_ref = None
         self._execution_ref = None
         self._daemon_ref = None
-        self._receiver_status_ref = None
+        self._receiver_manager_ref = None
 
         self._cluster_info_ref = None
         self._cpu_calc_actors = []
@@ -217,7 +217,7 @@ class WorkerService(object):
         # create EventsActor
         self._events_ref = pool.create_actor(EventsActor, uid=EventsActor.default_uid())
         # create ReceiverNotifierActor
-        self._receiver_status_ref = pool.create_actor(ReceiverStatusActor, uid=ReceiverStatusActor.default_uid())
+        self._receiver_manager_ref = pool.create_actor(ReceiverManagerActor, uid=ReceiverManagerActor.default_uid())
         # create ExecutionActor
         self._execution_ref = pool.create_actor(ExecutionActor, uid=ExecutionActor.default_uid())
 

--- a/mars/worker/storage/client.py
+++ b/mars/worker/storage/client.py
@@ -201,7 +201,7 @@ class StorageClient(object):
 
         return self._do_with_spill(_action, data_keys, sum(sizes_dict.values()), device_order)
 
-    def copy_to(self, session_id, data_keys, device_order, ensure=True):
+    def copy_to(self, session_id, data_keys, device_order, ensure=True, pin=False):
         device_order = self._normalize_devices(device_order)
         existing_devs = self._manager_ref.get_data_locations(session_id, data_keys)
         data_sizes = self._manager_ref.get_data_sizes(session_id, data_keys)
@@ -232,7 +232,7 @@ class StorageClient(object):
             return promise.finished()
 
         def _action(src_handler, h, keys):
-            return h.load_from(session_id, keys, src_handler)
+            return h.load_from(session_id, keys, src_handler, pin=pin)
 
         def _handle_exc(keys, *exc):
             existing = self._manager_ref.get_data_locations(session_id, keys)

--- a/mars/worker/storage/core.py
+++ b/mars/worker/storage/core.py
@@ -165,7 +165,7 @@ class StorageHandler(object):
     def delete(self, session_id, data_keys, _tell=False):
         raise NotImplementedError
 
-    def load_from(self, session_id, data_keys, src_handler, pin=False):
+    def load_from(self, session_id, data_keys, src_handler, pin_token=None):
         """
         :param session_id:
         :param data_keys:
@@ -180,16 +180,16 @@ class StorageHandler(object):
         right_has_bytes_io = getattr(src_handler, '_has_bytes_io', False)
 
         if left_has_obj_io and right_has_obj_io:
-            return self.load_from_object_io(session_id, data_keys, src_handler, pin=pin)
+            return self.load_from_object_io(session_id, data_keys, src_handler, pin_token=pin_token)
         elif right_has_bytes_io:
-            return self.load_from_bytes_io(session_id, data_keys, src_handler, pin=pin)
+            return self.load_from_bytes_io(session_id, data_keys, src_handler, pin_token=pin_token)
         else:
-            return self.load_from_object_io(session_id, data_keys, src_handler, pin=pin)
+            return self.load_from_object_io(session_id, data_keys, src_handler, pin_token=pin_token)
 
-    def load_from_bytes_io(self, session_id, data_keys, src_handler, pin=False):
+    def load_from_bytes_io(self, session_id, data_keys, src_handler, pin_token=None):
         raise NotImplementedError
 
-    def load_from_object_io(self, session_id, data_keys, src_handler, pin=False):
+    def load_from_object_io(self, session_id, data_keys, src_handler, pin_token=None):
         raise NotImplementedError
 
     def register_data(self, session_id, data_keys, sizes, shapes=None):
@@ -260,7 +260,7 @@ class BytesStorageMixin(object):
         raise NotImplementedError
 
     def create_bytes_writer(self, session_id, data_key, total_bytes, packed=False,
-                            packed_compression=None, auto_register=True, pin=False,
+                            packed_compression=None, auto_register=True, pin_token=None,
                             _promise=False):
         raise NotImplementedError
 
@@ -319,7 +319,7 @@ class ObjectStorageMixin(object):
             return dataserializer.deserialize(obj)
 
     def _batch_load_objects(self, session_id, data_keys, key_loader,
-                            batch_get=False, store_serialized=False, pin=False):
+                            batch_get=False, store_serialized=False, pin_token=None):
         keys, objs = [], []
         sizes = self._storage_ctx.manager_ref.get_data_sizes(session_id, data_keys)
 
@@ -330,14 +330,14 @@ class ObjectStorageMixin(object):
         def _put_objects(*_):
             try:
                 return self.put_objects(session_id, keys, objs, sizes, serialized=store_serialized,
-                                        pin=pin, _promise=True)
+                                        pin_token=pin_token, _promise=True)
             finally:
                 objs[:] = []
 
         def _batch_put_objects(objs):
             try:
                 return self.put_objects(session_id, data_keys, objs, sizes,
-                                        serialized=store_serialized, pin=pin, _promise=True)
+                                        serialized=store_serialized, pin_token=pin_token, _promise=True)
             finally:
                 objs[:] = []
 
@@ -351,7 +351,7 @@ class ObjectStorageMixin(object):
     def get_objects(self, session_id, data_keys, serialized=False, _promise=False):
         raise NotImplementedError
 
-    def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False, pin=False,
+    def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False, pin_token=False,
                     _promise=False):
         raise NotImplementedError
 

--- a/mars/worker/storage/cudahandler.py
+++ b/mars/worker/storage/cudahandler.py
@@ -61,22 +61,23 @@ class CudaHandler(StorageHandler, ObjectStorageMixin):
         return o
 
     @wrap_promised
-    def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False, _promise=False):
+    def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False,
+                    pin=False, _promise=False):
         objs = [self._deserial(obj) if serialized else obj for obj in objs]
         sizes = sizes or [calc_data_size(obj) for obj in objs]
 
         objs = [self._obj_to_cuda(obj) for obj in objs]
         shapes = [getattr(obj, 'shape', None) for obj in objs]
 
-        self._cuda_store_ref.put_objects(session_id, data_keys, objs, sizes)
+        self._cuda_store_ref.put_objects(session_id, data_keys, objs, sizes, pin=pin)
         self.register_data(session_id, data_keys, sizes, shapes)
 
-    def load_from_object_io(self, session_id, data_keys, src_handler):
+    def load_from_object_io(self, session_id, data_keys, src_handler, pin=False):
         return self._batch_load_objects(
             session_id, data_keys,
-            lambda k: src_handler.get_object(session_id, k, _promise=True))
+            lambda k: src_handler.get_object(session_id, k, _promise=True), pin=pin)
 
-    def load_from_bytes_io(self, session_id, data_keys, src_handler):
+    def load_from_bytes_io(self, session_id, data_keys, src_handler, pin=False):
         def _read_serialized(reader):
             with reader:
                 return reader.get_io_pool().submit(reader.read).result()
@@ -84,7 +85,7 @@ class CudaHandler(StorageHandler, ObjectStorageMixin):
         return self._batch_load_objects(
             session_id, data_keys,
             lambda k: src_handler.create_bytes_reader(session_id, k, _promise=True).then(_read_serialized),
-            True
+            store_serialized=True, pin=pin,
         )
 
     def delete(self, session_id, data_keys, _tell=False):

--- a/mars/worker/storage/cudahandler.py
+++ b/mars/worker/storage/cudahandler.py
@@ -58,16 +58,16 @@ class CudaHandler(StorageHandler, ObjectStorageMixin):
         return o
 
     @wrap_promised
-    def get_objects(self, session_id, data_keys, serialized=False, _promise=False):
+    def get_objects(self, session_id, data_keys, serialize=False, _promise=False):
         objs = self._cuda_store_ref.get_objects(session_id, data_keys)
-        if serialized:
+        if serialize:
             objs = [dataserializer.serialize(self._obj_to_mem(o)) for o in objs]
         return objs
 
     @wrap_promised
-    def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False,
+    def put_objects(self, session_id, data_keys, objs, sizes=None, serialize=False,
                     pin_token=None, _promise=False):
-        objs = [self._deserial(obj) if serialized else obj for obj in objs]
+        objs = [self._deserial(obj) if serialize else obj for obj in objs]
         sizes = sizes or [calc_data_size(obj) for obj in objs]
 
         objs = [self._obj_to_cuda(obj) for obj in objs]
@@ -89,7 +89,7 @@ class CudaHandler(StorageHandler, ObjectStorageMixin):
         return self._batch_load_objects(
             session_id, data_keys,
             lambda k: src_handler.create_bytes_reader(session_id, k, _promise=True).then(_read_serialized),
-            store_serialized=True, pin_token=pin_token,
+            serialize=True, pin_token=pin_token,
         )
 
     def delete(self, session_id, data_keys, _tell=False):

--- a/mars/worker/storage/diskhandler.py
+++ b/mars/worker/storage/diskhandler.py
@@ -236,7 +236,7 @@ class DiskHandler(StorageHandler, BytesStorageMixin):
                 .then(lambda writer: self._copy_object_data(obj_data, writer))
 
         def _fallback(*_):
-            return src_handler.get_objects(session_id, data_keys, serialized=True, _promise=True) \
+            return src_handler.get_objects(session_id, data_keys, serialize=True, _promise=True) \
                 .then(lambda objs: promise.all_(_load_data(k, o) for k, o in zip(data_keys, objs)))
 
         return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)

--- a/mars/worker/storage/diskhandler.py
+++ b/mars/worker/storage/diskhandler.py
@@ -205,12 +205,12 @@ class DiskHandler(StorageHandler, BytesStorageMixin):
 
     @wrap_promised
     def create_bytes_writer(self, session_id, data_key, total_bytes, packed=False,
-                            packed_compression=None, auto_register=True, pin=False,
+                            packed_compression=None, auto_register=True, pin_token=None,
                             _promise=False):
         return DiskIO(session_id, data_key, 'w', total_bytes, compress=self._compress,
                       packed=packed, handler=self)
 
-    def load_from_bytes_io(self, session_id, data_keys, src_handler, pin=False):
+    def load_from_bytes_io(self, session_id, data_keys, src_handler, pin_token=None):
         def _fallback(*_):
             return promise.all_(
                 src_handler.create_bytes_reader(session_id, k, _promise=True)
@@ -229,7 +229,7 @@ class DiskHandler(StorageHandler, BytesStorageMixin):
         else:
             return len(serialized_obj)
 
-    def load_from_object_io(self, session_id, data_keys, src_handler, pin=False):
+    def load_from_object_io(self, session_id, data_keys, src_handler, pin_token=None):
         def _load_data(key, obj_data):
             data_size = self._get_serialized_data_size(obj_data)
             return self.create_bytes_writer(session_id, key, data_size, _promise=True) \

--- a/mars/worker/storage/diskhandler.py
+++ b/mars/worker/storage/diskhandler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 import os
 import shutil
 import sys
@@ -232,17 +231,13 @@ class DiskHandler(StorageHandler, BytesStorageMixin):
 
     def load_from_object_io(self, session_id, data_keys, src_handler, pin=False):
         def _load_data(key, obj_data):
-            try:
-                data_size = self._get_serialized_data_size(obj_data)
-                writer = self.create_bytes_writer(session_id, key, data_size, _promise=False)
-                return self._copy_object_data(obj_data, writer)
-            finally:
-                del obj_data
+            data_size = self._get_serialized_data_size(obj_data)
+            return self.create_bytes_writer(session_id, key, data_size, _promise=True) \
+                .then(lambda writer: self._copy_object_data(obj_data, writer))
 
         def _fallback(*_):
-            return promise.all_(
-                src_handler.get_object(session_id, key, serialized=True, _promise=True)
-                .then(functools.partial(_load_data, key)) for key in data_keys)
+            return src_handler.get_objects(session_id, data_keys, serialized=True, _promise=True) \
+                .then(lambda objs: promise.all_(_load_data(k, o) for k, o in zip(data_keys, objs)))
 
         return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 

--- a/mars/worker/storage/objectholder.py
+++ b/mars/worker/storage/objectholder.py
@@ -260,9 +260,11 @@ class SimpleObjectHolderActor(ObjectHolderActor):
         manager_ref.register_process_holder(
             self.proc_id, self._storage_device, self.ref())
 
-    def put_objects(self, session_id, data_keys, data_objs, data_sizes):
+    def put_objects(self, session_id, data_keys, data_objs, data_sizes, pin=False):
         for data_key, obj, size in zip(data_keys, data_objs, data_sizes):
             self._internal_put_objects(session_id, data_key, obj, size)
+        if pin:
+            self.pin_data_keys(session_id, data_keys)
         self._finish_put_objects(session_id, data_keys)
 
     def get_object(self, session_id, data_key):
@@ -293,13 +295,15 @@ class SharedHolderActor(ObjectHolderActor):
         self._shared_store.batch_delete(session_id, data_keys)
         self._storage_handler.unregister_data(session_id, data_keys)
 
-    def put_objects_by_keys(self, session_id, data_keys, shapes=None):
+    def put_objects_by_keys(self, session_id, data_keys, shapes=None, pin=False):
         sizes = []
         for data_key in data_keys:
             buf = self._shared_store.get_buffer(session_id, data_key)
             size = len(buf)
             self._internal_put_objects(session_id, data_key, buf, size)
             sizes.append(size)
+        if pin:
+            self.pin_data_keys(session_id, data_keys)
 
         self.storage_client.register_data(
             session_id, data_keys, (0, DataStorageDevice.SHARED_MEMORY), sizes, shapes=shapes)

--- a/mars/worker/storage/objectholder.py
+++ b/mars/worker/storage/objectholder.py
@@ -258,11 +258,11 @@ class SimpleObjectHolderActor(ObjectHolderActor):
         manager_ref.register_process_holder(
             self.proc_id, self._storage_device, self.ref())
 
-    def put_objects(self, session_id, data_keys, data_objs, data_sizes, pin=False):
+    def put_objects(self, session_id, data_keys, data_objs, data_sizes, pin_token=None):
         for data_key, obj, size in zip(data_keys, data_objs, data_sizes):
             self._internal_put_objects(session_id, data_key, obj, size)
-        if pin:
-            self.pin_data_keys(session_id, data_keys)
+        if pin_token:
+            self.pin_data_keys(session_id, data_keys, pin_token)
         self._finish_put_objects(session_id, data_keys)
 
     def get_object(self, session_id, data_key):
@@ -296,15 +296,15 @@ class SharedHolderActor(ObjectHolderActor):
         self._shared_store.batch_delete(session_id, data_keys)
         self._storage_handler.unregister_data(session_id, data_keys)
 
-    def put_objects_by_keys(self, session_id, data_keys, shapes=None, pin=False):
+    def put_objects_by_keys(self, session_id, data_keys, shapes=None, pin_token=None):
         sizes = []
         for data_key in data_keys:
             buf = self._shared_store.get_buffer(session_id, data_key)
             size = len(buf)
             self._internal_put_objects(session_id, data_key, buf, size)
             sizes.append(size)
-        if pin:
-            self.pin_data_keys(session_id, data_keys)
+        if pin_token:
+            self.pin_data_keys(session_id, data_keys, pin_token)
 
         self.storage_client.register_data(
             session_id, data_keys, (0, DataStorageDevice.SHARED_MEMORY), sizes, shapes=shapes)

--- a/mars/worker/storage/objectholder.py
+++ b/mars/worker/storage/objectholder.py
@@ -270,6 +270,9 @@ class SimpleObjectHolderActor(ObjectHolderActor):
     def get_object(self, session_id, data_key):
         return self._data_holder[(session_id, data_key)]
 
+    def get_objects(self, session_id, data_keys):
+        return [self._data_holder[(session_id, key)] for key in data_keys]
+
     def update_cache_status(self):
         pass
 

--- a/mars/worker/storage/objectholder.py
+++ b/mars/worker/storage/objectholder.py
@@ -167,8 +167,6 @@ class ObjectHolderActor(WorkerActor):
 
         self._data_holder[session_data_key] = obj
         self._data_sizes[session_data_key] = size
-        self._data_holder.move_to_end(session_data_key)
-
         self._total_hold += size
 
     def _finish_put_objects(self, _session_id, data_keys):

--- a/mars/worker/storage/procmemhandler.py
+++ b/mars/worker/storage/procmemhandler.py
@@ -34,16 +34,16 @@ class ProcMemHandler(StorageHandler, ObjectStorageMixin):
         return self._inproc_store_ref_attr
 
     @wrap_promised
-    def get_objects(self, session_id, data_keys, serialized=False, _promise=False):
+    def get_objects(self, session_id, data_keys, serialize=False, _promise=False):
         objs = self._inproc_store_ref.get_objects(session_id, data_keys)
-        if serialized:
+        if serialize:
             objs = [dataserializer.serialize(o) for o in objs]
         return objs
 
     @wrap_promised
-    def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False,
+    def put_objects(self, session_id, data_keys, objs, sizes=None, serialize=False,
                     pin_token=None, _promise=False):
-        objs = [self._deserial(obj) if serialized else obj for obj in objs]
+        objs = [self._deserial(obj) if serialize else obj for obj in objs]
         sizes = sizes or [calc_data_size(obj) for obj in objs]
         shapes = [getattr(obj, 'shape', None) for obj in objs]
         self._inproc_store_ref.put_objects(session_id, data_keys, objs, sizes, pin_token=pin_token)
@@ -58,7 +58,7 @@ class ProcMemHandler(StorageHandler, ObjectStorageMixin):
             return self._batch_load_objects(
                 session_id, data_keys,
                 lambda k: src_handler.create_bytes_reader(session_id, k, _promise=True).then(_read_serialized),
-                store_serialized=True
+                serialize=True
             )
 
         return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)

--- a/mars/worker/storage/procmemhandler.py
+++ b/mars/worker/storage/procmemhandler.py
@@ -42,14 +42,14 @@ class ProcMemHandler(StorageHandler, ObjectStorageMixin):
 
     @wrap_promised
     def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False,
-                    pin=False, _promise=False):
+                    pin_token=None, _promise=False):
         objs = [self._deserial(obj) if serialized else obj for obj in objs]
         sizes = sizes or [calc_data_size(obj) for obj in objs]
         shapes = [getattr(obj, 'shape', None) for obj in objs]
-        self._inproc_store_ref.put_objects(session_id, data_keys, objs, sizes, pin=pin)
+        self._inproc_store_ref.put_objects(session_id, data_keys, objs, sizes, pin_token=pin_token)
         self.register_data(session_id, data_keys, sizes, shapes)
 
-    def load_from_bytes_io(self, session_id, data_keys, src_handler, pin=False):
+    def load_from_bytes_io(self, session_id, data_keys, src_handler, pin_token=None):
         def _read_serialized(reader):
             with reader:
                 return reader.get_io_pool().submit(reader.read).result()
@@ -63,7 +63,7 @@ class ProcMemHandler(StorageHandler, ObjectStorageMixin):
 
         return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 
-    def load_from_object_io(self, session_id, data_keys, src_handler, pin=False):
+    def load_from_object_io(self, session_id, data_keys, src_handler, pin_token=None):
         def _fallback(*_):
             return self._batch_load_objects(
                 session_id, data_keys,

--- a/mars/worker/storage/procmemhandler.py
+++ b/mars/worker/storage/procmemhandler.py
@@ -34,11 +34,11 @@ class ProcMemHandler(StorageHandler, ObjectStorageMixin):
         return self._inproc_store_ref_attr
 
     @wrap_promised
-    def get_object(self, session_id, data_key, serialized=False, _promise=False):
-        obj = self._inproc_store_ref.get_object(session_id, data_key)
+    def get_objects(self, session_id, data_keys, serialized=False, _promise=False):
+        objs = self._inproc_store_ref.get_objects(session_id, data_keys)
         if serialized:
-            obj = dataserializer.serialize(obj)
-        return obj
+            objs = [dataserializer.serialize(o) for o in objs]
+        return objs
 
     @wrap_promised
     def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False,
@@ -67,7 +67,7 @@ class ProcMemHandler(StorageHandler, ObjectStorageMixin):
         def _fallback(*_):
             return self._batch_load_objects(
                 session_id, data_keys,
-                lambda k: src_handler.get_object(session_id, k, _promise=True))
+                lambda k: src_handler.get_objects(session_id, k, _promise=True), batch_get=True)
 
         return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 

--- a/mars/worker/storage/sharedhandler.py
+++ b/mars/worker/storage/sharedhandler.py
@@ -136,14 +136,14 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
                                handler=self, pin_token=pin_token)
 
     @wrap_promised
-    def get_objects(self, session_id, data_keys, serialized=False, _promise=False):
-        if serialized:
+    def get_objects(self, session_id, data_keys, serialize=False, _promise=False):
+        if serialize:
             return [self._shared_store.get_buffer(session_id, k) for k in data_keys]
         else:
             return [self._shared_store.get(session_id, k) for k in data_keys]
 
     @wrap_promised
-    def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False,
+    def put_objects(self, session_id, data_keys, objs, sizes=None, serialize=False,
                     pin_token=None, _promise=False):
         keys, shapes = [], []
         obj_refs = []
@@ -152,7 +152,7 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
 
         try:
             for key, obj in zip(data_keys, objs):
-                obj = self._deserial(obj) if serialized else obj
+                obj = self._deserial(obj) if serialize else obj
                 shape = getattr(obj, 'shape', None)
 
                 try:
@@ -225,8 +225,8 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
                          (DataStorageDevice.SHARED_MEMORY, DataStorageDevice.PROC_MEMORY)
             return self._batch_load_objects(
                 session_id, data_keys,
-                lambda k: src_handler.get_objects(session_id, k, serialized=ser_needed, _promise=True),
-                store_serialized=ser_needed, pin_token=pin_token, batch_get=True)
+                lambda k: src_handler.get_objects(session_id, k, serialize=ser_needed, _promise=True),
+                serialize=ser_needed, pin_token=pin_token, batch_get=True)
 
         return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 

--- a/mars/worker/storage/sharedhandler.py
+++ b/mars/worker/storage/sharedhandler.py
@@ -136,11 +136,11 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
                                handler=self)
 
     @wrap_promised
-    def get_object(self, session_id, data_key, serialized=False, _promise=False):
+    def get_objects(self, session_id, data_keys, serialized=False, _promise=False):
         if serialized:
-            return self._shared_store.get_buffer(session_id, data_key)
+            return [self._shared_store.get_buffer(session_id, k) for k in data_keys]
         else:
-            return self._shared_store.get(session_id, data_key)
+            return [self._shared_store.get(session_id, k) for k in data_keys]
 
     @wrap_promised
     def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False,
@@ -225,8 +225,8 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
                          (DataStorageDevice.SHARED_MEMORY, DataStorageDevice.PROC_MEMORY)
             return self._batch_load_objects(
                 session_id, data_keys,
-                lambda k: src_handler.get_object(session_id, k, serialized=ser_needed, _promise=True),
-                ser_needed, pin=pin)
+                lambda k: src_handler.get_objects(session_id, k, serialized=ser_needed, _promise=True),
+                store_serialized=ser_needed, pin=pin, batch_get=True)
 
         return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 

--- a/mars/worker/storage/sharedhandler.py
+++ b/mars/worker/storage/sharedhandler.py
@@ -32,7 +32,7 @@ class SharedStorageIO(BytesStorageIO):
 
     def __init__(self, session_id, data_key, mode='w', shared_store=None,
                  nbytes=None, packed=False, compress=None, auto_register=True,
-                 pin=False, handler=None):
+                 pin_token=None, handler=None):
         from .objectholder import SharedHolderActor
 
         super(SharedStorageIO, self).__init__(session_id, data_key, mode=mode,
@@ -45,7 +45,7 @@ class SharedStorageIO(BytesStorageIO):
         self._compress = compress or dataserializer.CompressType.NONE
         self._packed = packed
         self._auto_register = auto_register
-        self._pin = pin
+        self._pin_token = pin_token
 
         block_size = options.worker.copy_block_size
 
@@ -101,7 +101,7 @@ class SharedStorageIO(BytesStorageIO):
             if finished:
                 if self._auto_register:
                     self._holder_ref.put_objects_by_keys(
-                        self._session_id, [self._data_key], pin=self._pin)
+                        self._session_id, [self._data_key], pin_token=self._pin_token)
             else:
                 self._shared_store.delete(self._session_id, self._data_key)
 
@@ -129,11 +129,11 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
 
     @wrap_promised
     def create_bytes_writer(self, session_id, data_key, total_bytes, packed=False,
-                            packed_compression=None, auto_register=True, pin=False,
+                            packed_compression=None, auto_register=True, pin_token=None,
                             _promise=False):
         return SharedStorageIO(session_id, data_key, 'w', self._shared_store,
                                nbytes=total_bytes, packed=packed, auto_register=auto_register,
-                               handler=self)
+                               handler=self, pin_token=pin_token)
 
     @wrap_promised
     def get_objects(self, session_id, data_keys, serialized=False, _promise=False):
@@ -144,7 +144,7 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
 
     @wrap_promised
     def put_objects(self, session_id, data_keys, objs, sizes=None, serialized=False,
-                    pin=False, _promise=False):
+                    pin_token=None, _promise=False):
         keys, shapes = [], []
         obj_refs = []
         affected_keys = []
@@ -165,7 +165,7 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
                     capacity = ex.capacity
                 finally:
                     del obj
-            self._holder_ref.put_objects_by_keys(session_id, keys, shapes=shapes, pin=pin)
+            self._holder_ref.put_objects_by_keys(session_id, keys, shapes=shapes, pin_token=pin_token)
             if affected_keys:
                 raise StorageFull(request_size=request_size, capacity=capacity,
                                   affected_keys=affected_keys)
@@ -173,7 +173,7 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
             obj_refs[:] = []
             del objs
 
-    def load_from_bytes_io(self, session_id, data_keys, src_handler, pin=False):
+    def load_from_bytes_io(self, session_id, data_keys, src_handler, pin_token=None):
         shared_bufs = []
         failed_keys = set()
         storage_full_sizes = [0, 0]
@@ -198,7 +198,7 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
             try:
                 success_keys = [k for k in data_keys if k not in failed_keys]
                 if success_keys:
-                    self._holder_ref.put_objects_by_keys(session_id, success_keys, pin=pin)
+                    self._holder_ref.put_objects_by_keys(session_id, success_keys, pin_token=pin_token)
                 if failed_keys:
                     raise StorageFull(request_size=storage_full_sizes[0], capacity=storage_full_sizes[1],
                                       affected_keys=list(failed_keys))
@@ -219,14 +219,14 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
 
         return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 
-    def load_from_object_io(self, session_id, data_keys, src_handler, pin=False):
+    def load_from_object_io(self, session_id, data_keys, src_handler, pin_token=None):
         def _fallback(*_):
             ser_needed = src_handler.storage_type not in \
                          (DataStorageDevice.SHARED_MEMORY, DataStorageDevice.PROC_MEMORY)
             return self._batch_load_objects(
                 session_id, data_keys,
                 lambda k: src_handler.get_objects(session_id, k, serialized=ser_needed, _promise=True),
-                store_serialized=ser_needed, pin=pin, batch_get=True)
+                store_serialized=ser_needed, pin_token=pin_token, batch_get=True)
 
         return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 

--- a/mars/worker/storage/tests/test_client.py
+++ b/mars/worker/storage/tests/test_client.py
@@ -69,7 +69,7 @@ class OtherProcessTestActor(WorkerActor):
         proc_handler = self.storage_client.get_storage_handler((1, DataStorageDevice.PROC_MEMORY))
 
         def _verify_result(*_):
-            result = proc_handler.get_object(session_id, key1)
+            result = proc_handler.get_objects(session_id, [key1])[0]
             assert_allclose(result, data1)
 
             devices = self._manager_ref.get_data_locations(session_id, [key1])[0]
@@ -93,7 +93,7 @@ class OtherProcessTestActor(WorkerActor):
         proc_handler = self.storage_client.get_storage_handler((1, DataStorageDevice.PROC_MEMORY))
 
         def _verify_result(*_):
-            result = shared_handler.get_object(session_id, key1)
+            result = shared_handler.get_objects(session_id, [key1])[0]
             assert_allclose(result, data1)
 
             devices = self._manager_ref.get_data_locations(session_id, [key1])[0]
@@ -238,7 +238,7 @@ class Test(WorkerCase):
                 # check get object with all cases
                 with self.assertRaises(IOError):
                     first_shared_key = loc_to_keys[DataStorageDevice.SHARED_MEMORY][0]
-                    storage_client.get_object(session_id, first_shared_key,
+                    storage_client.get_objects(session_id, [first_shared_key],
                                               [DataStorageDevice.PROC_MEMORY], _promise=False)
 
                 storage_client.get_object(session_id, first_shared_key,

--- a/mars/worker/storage/tests/test_client.py
+++ b/mars/worker/storage/tests/test_client.py
@@ -238,8 +238,13 @@ class Test(WorkerCase):
                 # check get object with all cases
                 with self.assertRaises(IOError):
                     first_shared_key = loc_to_keys[DataStorageDevice.SHARED_MEMORY][0]
-                    storage_client.get_objects(session_id, [first_shared_key],
+                    storage_client.get_object(session_id, first_shared_key,
                                               [DataStorageDevice.PROC_MEMORY], _promise=False)
+
+                shared_objs = storage_client.get_objects(
+                    session_id, [first_shared_key], [DataStorageDevice.SHARED_MEMORY], _promise=False)
+                self.assertEqual(len(shared_objs), 1)
+                assert_allclose(shared_objs[0], data_dict[first_shared_key])
 
                 storage_client.get_object(session_id, first_shared_key,
                                           [DataStorageDevice.PROC_MEMORY], _promise=True) \

--- a/mars/worker/storage/tests/test_cuda_io.py
+++ b/mars/worker/storage/tests/test_cuda_io.py
@@ -73,7 +73,7 @@ class Test(WorkerCase):
                 with self.assertRaises(KeyError):
                     handler.get_objects(session_id, [data_key1])
 
-                handler.put_objects(session_id, [data_key2], [ser_data], serialized=True)
+                handler.put_objects(session_id, [data_key2], [ser_data], serialize=True)
                 self.assertIsInstance(handler.get_objects(session_id, [data_key2])[0], cuda_type)
                 assert_obj_equal(data, move_to_mem(handler.get_objects(session_id, [data_key2])[0]))
                 handler.delete(session_id, [data_key2])

--- a/mars/worker/storage/tests/test_cuda_io.py
+++ b/mars/worker/storage/tests/test_cuda_io.py
@@ -65,17 +65,17 @@ class Test(WorkerCase):
                 handler.put_objects(session_id, [data_key1], [data])
                 self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, [data_key1])[0]),
                                  [(0, DataStorageDevice.CUDA)])
-                self.assertIsInstance(handler.get_object(session_id, data_key1), cuda_type)
-                assert_obj_equal(data, move_to_mem(handler.get_object(session_id, data_key1)))
+                self.assertIsInstance(handler.get_objects(session_id, [data_key1])[0], cuda_type)
+                assert_obj_equal(data, move_to_mem(handler.get_objects(session_id, [data_key1])[0]))
 
                 handler.delete(session_id, [data_key1])
                 self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, [data_key1])[0]), [])
                 with self.assertRaises(KeyError):
-                    handler.get_object(session_id, data_key1)
+                    handler.get_objects(session_id, [data_key1])
 
                 handler.put_objects(session_id, [data_key2], [ser_data], serialized=True)
-                self.assertIsInstance(handler.get_object(session_id, data_key2), cuda_type)
-                assert_obj_equal(data, move_to_mem(handler.get_object(session_id, data_key2)))
+                self.assertIsInstance(handler.get_objects(session_id, [data_key2])[0], cuda_type)
+                assert_obj_equal(data, move_to_mem(handler.get_objects(session_id, [data_key2])[0]))
                 handler.delete(session_id, [data_key2])
 
     def testCudaMemLoad(self):
@@ -118,7 +118,7 @@ class Test(WorkerCase):
 
             disk_handler.delete(session_id, [data_key1])
 
-            data_load = handler.get_object(session_id, data_key1)
+            data_load = handler.get_objects(session_id, [data_key1])[0]
             ref_data = weakref.ref(data_load)
             del data_load
             handler.delete(session_id, [data_key1])
@@ -137,7 +137,7 @@ class Test(WorkerCase):
 
             shared_handler.delete(session_id, [data_key2])
 
-            data_load = handler.get_object(session_id, data_key2)
+            data_load = handler.get_objects(session_id, [data_key2])[0]
             ref_data = weakref.ref(data_load)
             del data_load
             handler.delete(session_id, [data_key2])

--- a/mars/worker/storage/tests/test_objectholder.py
+++ b/mars/worker/storage/tests/test_objectholder.py
@@ -132,7 +132,7 @@ class Test(WorkerCase):
             shared_handler.delete(session_id, [key_list[1]])
             shared_handler.put_objects(session_id, [key_list[last_idx]], [data_list[last_idx]])
             assert_allclose(data_list[last_idx],
-                            shared_handler.get_object(session_id, key_list[last_idx]))
+                            shared_handler.get_objects(session_id, [key_list[last_idx]])[0])
 
             pin_token2 = str(uuid.uuid4())
             pinned = shared_handler.pin_data_keys(session_id, key_list, pin_token2)
@@ -140,7 +140,7 @@ class Test(WorkerCase):
 
             shared_handler.put_objects(session_id, [key_list[last_idx]], [data_list[last_idx]])
             assert_allclose(data_list[last_idx],
-                            shared_handler.get_object(session_id, key_list[last_idx]))
+                            shared_handler.get_objects(session_id, [key_list[last_idx]])[0])
 
             unpinned = shared_handler.unpin_data_keys(session_id, key_list, pin_token1)
             self.assertEqual(sorted(key_list[2:last_idx]), sorted(unpinned))

--- a/mars/worker/storage/tests/test_procmem_io.py
+++ b/mars/worker/storage/tests/test_procmem_io.py
@@ -58,11 +58,11 @@ class Test(WorkerCase):
             with self.assertRaises(KeyError):
                 handler.get_objects(session_id, [data_key1])
 
-            handler.put_objects(session_id, [data_key2], [ser_data2], serialized=True)
+            handler.put_objects(session_id, [data_key2], [ser_data2], serialize=True)
             assert_allclose(data2, handler.get_objects(session_id, [data_key2])[0])
             handler.delete(session_id, [data_key2])
 
-            handler.put_objects(session_id, [data_key2], [bytes_data2], serialized=True)
+            handler.put_objects(session_id, [data_key2], [bytes_data2], serialize=True)
             assert_allclose(data2, handler.get_objects(session_id, [data_key2])[0])
             handler.delete(session_id, [data_key2])
 

--- a/mars/worker/storage/tests/test_procmem_io.py
+++ b/mars/worker/storage/tests/test_procmem_io.py
@@ -51,19 +51,19 @@ class Test(WorkerCase):
             handler.put_objects(session_id, [data_key1], [data1])
             self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, [data_key1])[0]),
                              [(0, DataStorageDevice.PROC_MEMORY)])
-            assert_allclose(data1, handler.get_object(session_id, data_key1))
+            assert_allclose(data1, handler.get_objects(session_id, [data_key1])[0])
 
             handler.delete(session_id, [data_key1])
             self.assertEqual(list(storage_manager_ref.get_data_locations(session_id, [data_key1])[0]), [])
             with self.assertRaises(KeyError):
-                handler.get_object(session_id, data_key1)
+                handler.get_objects(session_id, [data_key1])
 
             handler.put_objects(session_id, [data_key2], [ser_data2], serialized=True)
-            assert_allclose(data2, handler.get_object(session_id, data_key2))
+            assert_allclose(data2, handler.get_objects(session_id, [data_key2])[0])
             handler.delete(session_id, [data_key2])
 
             handler.put_objects(session_id, [data_key2], [bytes_data2], serialized=True)
-            assert_allclose(data2, handler.get_object(session_id, data_key2))
+            assert_allclose(data2, handler.get_objects(session_id, [data_key2])[0])
             handler.delete(session_id, [data_key2])
 
     def testProcMemLoad(self):
@@ -108,7 +108,7 @@ class Test(WorkerCase):
 
             disk_handler.delete(session_id, [data_key1])
 
-            data_load = handler.get_object(session_id, data_key1)
+            data_load = handler.get_objects(session_id, [data_key1])[0]
             ref_data = weakref.ref(data_load)
             del data_load
             handler.delete(session_id, [data_key1])
@@ -127,7 +127,7 @@ class Test(WorkerCase):
 
             shared_handler.delete(session_id, [data_key2])
 
-            data_load = handler.get_object(session_id, data_key2)
+            data_load = handler.get_objects(session_id, [data_key2])[0]
             ref_data = weakref.ref(data_load)
             del data_load
             handler.delete(session_id, [data_key2])

--- a/mars/worker/storage/tests/test_shared_io.py
+++ b/mars/worker/storage/tests/test_shared_io.py
@@ -221,19 +221,19 @@ class Test(WorkerCase):
             handler.put_objects(session_id, [data_key1], [data1])
             self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, [data_key1])[0]),
                              [(0, DataStorageDevice.SHARED_MEMORY)])
-            assert_allclose(data1, handler.get_object(session_id, data_key1))
+            assert_allclose(data1, handler.get_objects(session_id, [data_key1])[0])
 
             handler.delete(session_id, [data_key1])
             self.assertEqual(list(storage_manager_ref.get_data_locations(session_id, [data_key1])[0]), [])
             with self.assertRaises(KeyError):
-                handler.get_object(session_id, data_key1)
+                handler.get_objects(session_id, [data_key1])
 
             handler.put_objects(session_id, [data_key2], [ser_data2], serialized=True)
-            assert_allclose(data2, handler.get_object(session_id, data_key2))
+            assert_allclose(data2, handler.get_objects(session_id, [data_key2])[0])
             handler.delete(session_id, [data_key2])
 
             handler.put_objects(session_id, [data_key2], [bytes_data2], serialized=True)
-            assert_allclose(data2, handler.get_object(session_id, data_key2))
+            assert_allclose(data2, handler.get_objects(session_id, [data_key2])[0])
             handler.delete(session_id, [data_key2])
 
     def testSharedLoadFromBytes(self, *_):

--- a/mars/worker/storage/tests/test_shared_io.py
+++ b/mars/worker/storage/tests/test_shared_io.py
@@ -228,11 +228,11 @@ class Test(WorkerCase):
             with self.assertRaises(KeyError):
                 handler.get_objects(session_id, [data_key1])
 
-            handler.put_objects(session_id, [data_key2], [ser_data2], serialized=True)
+            handler.put_objects(session_id, [data_key2], [ser_data2], serialize=True)
             assert_allclose(data2, handler.get_objects(session_id, [data_key2])[0])
             handler.delete(session_id, [data_key2])
 
-            handler.put_objects(session_id, [data_key2], [bytes_data2], serialized=True)
+            handler.put_objects(session_id, [data_key2], [bytes_data2], serialize=True)
             assert_allclose(data2, handler.get_objects(session_id, [data_key2])[0])
             handler.delete(session_id, [data_key2])
 

--- a/mars/worker/tests/test_calc.py
+++ b/mars/worker/tests/test_calc.py
@@ -134,7 +134,7 @@ class Test(WorkerCase):
 
             def _extract_value_ref(*_):
                 inproc_handler = storage_client.get_storage_handler((0, DataStorageDevice.PROC_MEMORY))
-                obj = inproc_handler.get_object(session_id, add_chunk.key)
+                obj = inproc_handler.get_objects(session_id, [add_chunk.key])[0]
                 ref_store.append(weakref.ref(obj))
                 del obj
 

--- a/mars/worker/tests/test_quota.py
+++ b/mars/worker/tests/test_quota.py
@@ -36,8 +36,8 @@ class Test(WorkerCase):
 
             quota_ref = pool.create_actor(QuotaActor, 300, uid=QuotaActor.default_uid())
 
-            quota_ref.process_quota('non_exist')
-            quota_ref.hold_quota('non_exist')
+            quota_ref.process_quotas(['non_exist'])
+            quota_ref.hold_quotas(['non_exist'])
             quota_ref.release_quotas(['non_exist'])
 
             with self.assertRaises(ValueError):
@@ -47,12 +47,12 @@ class Test(WorkerCase):
             self.assertTrue(quota_ref.request_quota('0', 50))
             self.assertTrue(quota_ref.request_quota('0', 200))
 
-            quota_ref.process_quota('0')
+            quota_ref.process_quotas(['0'])
             self.assertIn('0', quota_ref.dump_data().proc_sizes)
             quota_ref.alter_allocation('0', 190, new_key=('0', 0))
             self.assertEqual(quota_ref.dump_data().allocations[('0', 0)], 190)
 
-            quota_ref.hold_quota(('0', 0))
+            quota_ref.hold_quotas([('0', 0)])
             self.assertIn(('0', 0), quota_ref.dump_data().hold_sizes)
             quota_ref.alter_allocation(('0', 0), new_key=('0', 1))
             self.assertEqual(quota_ref.dump_data().allocations[('0', 1)], 190)

--- a/mars/worker/tests/test_quota.py
+++ b/mars/worker/tests/test_quota.py
@@ -38,7 +38,7 @@ class Test(WorkerCase):
 
             quota_ref.process_quota('non_exist')
             quota_ref.hold_quota('non_exist')
-            quota_ref.release_quota('non_exist')
+            quota_ref.release_quotas(['non_exist'])
 
             with self.assertRaises(ValueError):
                 quota_ref.request_quota('ERROR', 1000)
@@ -106,7 +106,7 @@ class Test(WorkerCase):
                     .catch(lambda *exc: test_actor.set_result(exc, accept=False))
 
                 with patch_method(QuotaActor.alter_allocation, new=_raiser):
-                    quota_ref.release_quota('2')
+                    quota_ref.release_quotas(['2'])
 
                     with self.assertRaises(ValueError):
                         self.get_result(5)
@@ -122,7 +122,7 @@ class Test(WorkerCase):
                 ref = test_actor.promise_ref(QuotaActor.default_uid())
 
                 def actual_exec(x):
-                    ref.release_quota(x)
+                    ref.release_quotas([x])
                     end_time.append(time.time())
                     finished.add(x)
                     if len(finished) == 5:
@@ -154,7 +154,7 @@ class Test(WorkerCase):
 
                     def actual_exec(keys):
                         for k in keys:
-                            ref.release_quota(k)
+                            ref.release_quotas([k])
                         end_time.append(time.time())
                         test_actor.set_result(None)
 
@@ -190,7 +190,7 @@ class Test(WorkerCase):
                 time_recs.append(time.time())
 
                 def actual_exec(x):
-                    ref.release_quota(x)
+                    ref.release_quotas([x])
                     time_recs.append(time.time())
                     test_actor.set_result(None)
 

--- a/mars/worker/tests/test_transfer.py
+++ b/mars/worker/tests/test_transfer.py
@@ -143,9 +143,10 @@ def start_transfer_test_pool(**kwargs):
         pool.create_actor(StorageClientActor, uid=StorageClientActor.default_uid())
         pool.create_actor(InProcHolderActor)
 
-        yield pool
-
-        shared_holder_ref.destroy()
+        try:
+            yield pool
+        finally:
+            shared_holder_ref.destroy()
 
 
 def run_transfer_worker(pool_address, session_id, chunk_keys, spill_dir, msg_queue):


### PR DESCRIPTION
## What do these changes do?

ReceiverStatusActor is added for receiving end to listen to data transfer statuses for keys. Add pin options for object holders also.

## Related issue number

Fixes #830
Fixes #831 