### PR TITLE
Support iterative tiling 

### DIFF
--- a/mars/dataframe/arithmetic/__init__.py
+++ b/mars/dataframe/arithmetic/__init__.py
@@ -21,9 +21,9 @@ from .truediv import truediv, rtruediv, DataFrameTrueDiv
 
 
 def _install():
-    from ..core import DataFrame, Series
+    from ..core import DATAFRAME_TYPE, SERIES_TYPE
 
-    for entity in (DataFrame, Series):
+    for entity in DATAFRAME_TYPE + SERIES_TYPE:
         setattr(entity, 'abs', abs)
 
         setattr(entity, '__add__', wrap_notimplemented_exception(add))

--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -208,11 +208,11 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
         rhs_is_tensor = isinstance(op.rhs, TENSOR_TYPE)
         tensor, other = (op.rhs, op.lhs) if rhs_is_tensor else (op.lhs, op.rhs)
         if tensor.shape == other.shape:
-            tensor = tensor.rechunk(other.nsplits).single_tiles()
+            tensor = tensor.rechunk(other.nsplits)._inplace_tile()
         else:
             # shape differs only when dataframe add 1-d tensor, we need rechunk on columns axis.
             rechunk_size = other.nsplits[1] if op.axis == 'columns' or op.axis == 1 else other.nsplits[0]
-            tensor = tensor.rechunk((rechunk_size,)).single_tiles()
+            tensor = tensor.rechunk((rechunk_size,))._inplace_tile()
 
         out_chunks = []
         for out_index in itertools.product(*(map(range, other.chunk_shape))):

--- a/mars/dataframe/arithmetic/tests/test_arithmetic.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic.py
@@ -29,6 +29,7 @@ from mars.dataframe.arithmetic import abs, DataFrameAbs, DataFrameAdd, DataFrame
     DataFrameFloorDiv, DataFrameTrueDiv
 from mars.dataframe.align import DataFrameIndexAlignMap, \
     DataFrameIndexAlignReduce, DataFrameShuffleProxy
+from mars.tiles import get_tiled
 from mars.tests.core import TestBase, parameterized
 
 
@@ -71,7 +72,8 @@ class TestBinary(TestBase):
         self.assertNotEqual(df3.index_value.key, df2.index_value.key)
         self.assertEqual(df3.shape[1], 11)  # columns is recorded, so we can get it
 
-        df3.tiles()
+        df3 = df3.tiles()
+        df1, df2 = get_tiled(df1), get_tiled(df2)
 
         # test df3's index and columns after tiling
         pd.testing.assert_index_equal(df3.columns_value.to_pandas(), self.func(data1, data2).columns)
@@ -154,7 +156,8 @@ class TestBinary(TestBase):
         s1 = df1[3]
 
         df2 = self.func(df1, s1)
-        df2.tiles()
+        df2 = df2.tiles()
+        df1, s1 = get_tiled(df1), get_tiled(s1)
 
         self.assertEqual(df2.shape, (df1.shape[0], np.nan))
         self.assertEqual(df2.index_value.key, df1.index_value.key)
@@ -208,7 +211,8 @@ class TestBinary(TestBase):
         s1 = from_pandas_series(data1[3], chunk_size=5)
 
         df2 = self.func(df1, s1)
-        df2.tiles()
+        df2 = df2.tiles()
+        df1, s1 = get_tiled(df1), get_tiled(s1)
 
         self.assertEqual(df2.shape, (10, 10))
         self.assertEqual(df2.index_value.key, df1.index_value.key)
@@ -251,7 +255,8 @@ class TestBinary(TestBase):
         self.assertNotEqual(df2.columns_value.key, df1.columns_value.key)
         self.assertTrue(df2.columns_value.should_be_monotonic)
 
-        df2.tiles()
+        df2 = df2.tiles()
+        df1, s1 = get_tiled(df1), get_tiled(s1)
 
         self.assertEqual(df2.chunk_shape, (2, 2))
         for c in df2.chunks:
@@ -308,7 +313,8 @@ class TestBinary(TestBase):
         s2 = df1[3]
 
         s3 = self.func(s1, s2)
-        s3.tiles()
+        s3 = s3.tiles()
+        s1, s2 = get_tiled(s1), get_tiled(s2)
 
         self.assertEqual(s3.shape, (np.nan,))
 
@@ -364,7 +370,8 @@ class TestBinary(TestBase):
         s2 = from_pandas_series(data1[3], chunk_size=5)
 
         s3 = self.func(s1, s2)
-        s3.tiles()
+        s3 = s3.tiles()
+        s1, s2 = get_tiled(s1), get_tiled(s2)
 
         self.assertEqual(s3.shape, (10,))
         self.assertEqual(s3.index_value.key, s1.index_value.key)
@@ -402,7 +409,8 @@ class TestBinary(TestBase):
         pd.testing.assert_index_equal(s3.index_value.to_pandas(), pd.Int64Index([]))
         self.assertTrue(s3.index_value.should_be_monotonic)
 
-        s3.tiles()
+        s3 = s3.tiles()
+        s1, s2 = get_tiled(s1), get_tiled(s2)
 
         self.assertEqual(s3.chunk_shape, (2,))
         for c in s3.chunks:
@@ -455,7 +463,8 @@ class TestBinary(TestBase):
         self.assertEqual(df3.index_value.key, df2.index_value.key)
         self.assertEqual(df3.shape, (10, 10))  # columns is recorded, so we can get it
 
-        df3.tiles()
+        df3 = df3.tiles()
+        df1, df2 = get_tiled(df1), get_tiled(df2)
 
         self.assertEqual(df3.chunk_shape, (2, 2))
         for c in df3.chunks:
@@ -498,7 +507,8 @@ class TestBinary(TestBase):
         self.assertNotEqual(df3.index_value.key, df2.index_value.key)
         self.assertEqual(df3.shape[1], 12)  # columns is recorded, so we can get it
 
-        df3.tiles()
+        df3 = df3.tiles()
+        df1, df2 = get_tiled(df1), get_tiled(df2)
 
         data1_index_min_max = [(0, True, 4, True), (5, True, 9, True)]
         data2_index_min_max = [(2, True, 5, True), (6, True, 11, True)]
@@ -599,7 +609,8 @@ class TestBinary(TestBase):
         self.assertNotEqual(df3.index_value.key, df2.index_value.key)
         self.assertEqual(df3.shape[1], 12)  # columns is recorded, so we can get it
 
-        df3.tiles()
+        df3 = df3.tiles()
+        df1, df2 = get_tiled(df1), get_tiled(df2)
 
         self.assertEqual(df3.chunk_shape, (2, 2))
         proxy_keys = set()
@@ -671,7 +682,8 @@ class TestBinary(TestBase):
         self.assertNotEqual(df6.index_value.key, df5.index_value.key)
         self.assertEqual(df6.shape[1], 20)  # columns is recorded, so we can get it
 
-        df6.tiles()
+        df6 = df6.tiles()
+        df4, df5 = get_tiled(df4), get_tiled(df5)
 
         self.assertEqual(df6.chunk_shape, (4, 4))
         proxy_keys = set()
@@ -746,7 +758,8 @@ class TestBinary(TestBase):
         self.assertNotEqual(df3.index_value.key, df2.index_value.key)
         self.assertEqual(df3.shape[1], 12)  # columns is recorded, so we can get it
 
-        df3.tiles()
+        df3 = df3.tiles()
+        df1, df2 = get_tiled(df1), get_tiled(df2)
 
         data1_index_min_max = [(0, True, 4, True), (5, True, 9, True)]
         data2_index_min_max = [(2, True, 5, True), (6, True, 11, True)]
@@ -821,7 +834,8 @@ class TestBinary(TestBase):
         self.assertNotEqual(df3.index_value.key, df2.index_value.key)
         self.assertEqual(df3.shape[1], 12)  # columns is recorded, so we can get it
 
-        df3.tiles()
+        df3 = df3.tiles()
+        df1, df2 = get_tiled(df1), get_tiled(df2)
 
         self.assertEqual(df3.chunk_shape, (1, 1))
         for c in df3.chunks:
@@ -853,7 +867,8 @@ class TestBinary(TestBase):
         self.assertNotEqual(df3.index_value.key, df2.index_value.key)
         self.assertEqual(df3.shape[1], 12)  # columns is recorded, so we can get it
 
-        df3.tiles()
+        df3 = df3.tiles()
+        df1, df2 = get_tiled(df1), get_tiled(df2)
 
         self.assertEqual(df3.chunk_shape, (2, 1))
         proxy_keys = set()
@@ -920,7 +935,8 @@ class TestBinary(TestBase):
         self.assertEqual(df2.columns_value.key, df.columns_value.key)
         self.assertEqual(df2.shape[1], 10)
 
-        df2.tiles()
+        df2 = df2.tiles()
+        df = get_tiled(df)
 
         self.assertEqual(df2.chunk_shape, df.chunk_shape)
         for c in df2.chunks:
@@ -971,7 +987,8 @@ class TestBinary(TestBase):
         data = pd.Series(range(10), index=[1, 3, 4, 2, 9, 10, 33, 23, 999, 123])
         s1 = from_pandas_series(data, chunk_size=3)
         r = getattr(s1, self.func_name)(456)
-        r.tiles()
+        r = r.tiles()
+        s1 = get_tiled(s1)
 
         self.assertEqual(r.index_value.key, s1.index_value.key)
         self.assertEqual(r.chunk_shape, s1.chunk_shape)
@@ -985,7 +1002,8 @@ class TestBinary(TestBase):
             self.assertEqual(cr.op.rhs, 456)
 
         r = getattr(s1, self.rfunc_name)(789)
-        r.tiles()
+        r = r.tiles()
+        s1 = get_tiled(s1)
 
         self.assertEqual(r.index_value.key, s1.index_value.key)
         self.assertEqual(r.chunk_shape, s1.chunk_shape)
@@ -1034,7 +1052,8 @@ class TestUnary(TestBase):
         self.assertIsInstance(df2.index_value.value, IndexValue.Int64Index)
         self.assertEqual(df2.shape, (10, 10))
 
-        df2.tiles()
+        df2 = df2.tiles()
+        df1 = get_tiled(df1)
 
         self.assertEqual(df2.chunk_shape, (2, 1))
         for c2, c1 in zip(df2.chunks, df1.chunks):

--- a/mars/dataframe/base/rechunk.py
+++ b/mars/dataframe/base/rechunk.py
@@ -20,7 +20,7 @@ from ...serialize import KeyField, AnyField, Int32Field, Int64Field
 from ...tensor.rechunk.core import get_nsplits, plan_rechunks, compute_rechunk_slices
 from ...tensor.utils import calc_sliced_size
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..operands import DataFrameOperand, DataFrameOperandMixin, DATAFRAME_TYPE, ObjectType
 from ..utils import indexing_index_value, merge_index_value
 
@@ -65,7 +65,7 @@ class DataFrameRechunk(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def tile(cls, op):
-        check_chunks_unknown_shape(op.inputs, TilesFail)
+        check_chunks_unknown_shape(op.inputs, TilesError)
         out = op.outputs[0]
         new_chunk_size = op.chunk_size
         if isinstance(out, DATAFRAME_TYPE):

--- a/mars/dataframe/base/rechunk.py
+++ b/mars/dataframe/base/rechunk.py
@@ -19,6 +19,8 @@ from ...compat import izip, lzip
 from ...serialize import KeyField, AnyField, Int32Field, Int64Field
 from ...tensor.rechunk.core import get_nsplits, plan_rechunks, compute_rechunk_slices
 from ...tensor.utils import calc_sliced_size
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..operands import DataFrameOperand, DataFrameOperandMixin, DATAFRAME_TYPE, ObjectType
 from ..utils import indexing_index_value, merge_index_value
 
@@ -63,6 +65,7 @@ class DataFrameRechunk(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def tile(cls, op):
+        check_chunks_unknown_shape(op.inputs, TilesFail)
         out = op.outputs[0]
         new_chunk_size = op.chunk_size
         if isinstance(out, DATAFRAME_TYPE):

--- a/mars/dataframe/base/tests/test_base.py
+++ b/mars/dataframe/base/tests/test_base.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 
 from mars.tests.core import TestBase
+from mars.tiles import get_tiled
 from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
 from mars.dataframe.base import to_gpu, to_cpu
@@ -34,7 +35,8 @@ class Test(TestBase):
         self.assertTrue(cdf.op.gpu)
         pd.testing.assert_series_equal(df.dtypes, cdf.dtypes)
 
-        cdf.tiles()
+        cdf = cdf.tiles()
+        df = get_tiled(df)
 
         self.assertEqual(df.nsplits, cdf.nsplits)
         self.assertEqual(df.chunks[0].index_value, cdf.chunks[0].index_value)
@@ -52,7 +54,8 @@ class Test(TestBase):
         self.assertEqual(series.index_value, cseries.index_value)
         self.assertTrue(cseries.op.gpu)
 
-        cseries.tiles()
+        cseries = cseries.tiles()
+        series = get_tiled(series)
 
         self.assertEqual(series.nsplits, cseries.nsplits)
         self.assertEqual(series.chunks[0].index_value, cseries.chunks[0].index_value)
@@ -72,7 +75,8 @@ class Test(TestBase):
         self.assertFalse(df2.op.gpu)
         pd.testing.assert_series_equal(df.dtypes, df2.dtypes)
 
-        df2.tiles()
+        df2 = df2.tiles()
+        df = get_tiled(df)
 
         self.assertEqual(df.nsplits, df2.nsplits)
         self.assertEqual(df.chunks[0].index_value, df2.chunks[0].index_value)

--- a/mars/dataframe/base/tests/test_base.py
+++ b/mars/dataframe/base/tests/test_base.py
@@ -152,5 +152,6 @@ class Test(TestBase):
 
         # no need to rechunk
         series2 = series.rechunk(3).tiles()
+        series = get_tiled(series)
         self.assertEqual(series2.chunk_shape, series.chunk_shape)
         self.assertEqual(series2.nsplits, series.nsplits)

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -493,15 +493,6 @@ class SeriesData(HasShapeTileableData):
             return 'Series <op={0}, key={1}>'.format(self.op.__class__.__name__,
                                                      self.key)
 
-    def _equal(self, o):
-        from ..core import build_mode
-        # FIXME We need to implemented a true `==` operator for DataFrame, current we just need
-        # to do `self is o` under build mode to make the `iloc.__setitem__` happy.
-        if build_mode().is_build_mode:
-            return self is o
-        else:
-            return self == o
-
     @property
     def dtype(self):
         return getattr(self, '_dtype', None) or self.op.dtype

--- a/mars/dataframe/datasource/tests/test_datasource.py
+++ b/mars/dataframe/datasource/tests/test_datasource.py
@@ -138,7 +138,7 @@ class Test(TestBase):
         self.assertEqual(df.index_value.max_val, 9)
         np.testing.assert_equal(df.columns_value._index_value._data, data.columns.values)
 
-        df.tiles()
+        df = df.tiles()
 
         self.assertEqual(len(df.chunks), 9)
         pd.testing.assert_frame_equal(df.chunks[0].op.data, df.op.data.iloc[:4, :4])
@@ -194,7 +194,7 @@ class Test(TestBase):
         self.assertIsInstance(df2.index_value._index_value, IndexValue.RangeIndex)
         self.assertEqual(df2.index_value._index_value._slice, slice(0, 10, 2))
 
-        df2.tiles()
+        df2 = df2.tiles()
 
         self.assertEqual(len(df2.chunks), 6)
         pd.testing.assert_frame_equal(df2.chunks[0].op.data, df2.op.data.iloc[:4, :4])
@@ -223,7 +223,7 @@ class Test(TestBase):
         self.assertEqual(series.index_value.min_val, 0)
         self.assertEqual(series.index_value.max_val, 9)
 
-        series.tiles()
+        series = series.tiles()
 
         self.assertEqual(len(series.chunks), 3)
         pd.testing.assert_series_equal(series.chunks[0].op.data, series.op.data.iloc[:4])
@@ -247,7 +247,7 @@ class Test(TestBase):
         # pb
         tensor = mt.random.rand(10, 10)
         df = dataframe_from_tensor(tensor)
-        df.tiles()
+        df = df.tiles()
         chunk = df.chunks[0]
         serials = self._pb_serial(chunk)
         op, pb = serials[chunk.op, chunk.data]
@@ -283,7 +283,7 @@ class Test(TestBase):
         self.assertIsInstance(df.index_value._index_value, IndexValue.RangeIndex)
         self.assertEqual(df.op.dtypes[0], tensor.dtype, 'DataFrame converted from tensor have the wrong dtype')
 
-        df.tiles()
+        df = df.tiles()
         self.assertEqual(len(df.chunks), 4)
         self.assertIsInstance(df.chunks[0].index_value._index_value, IndexValue.RangeIndex)
         self.assertIsInstance(df.chunks[0].index_value, IndexValue)
@@ -295,8 +295,8 @@ class Test(TestBase):
 
         df2 = dataframe_from_tensor(tensor2)
         df3 = dataframe_from_tensor(tensor3)
-        df2.tiles()
-        df3.tiles()
+        df2 = df2.tiles()
+        df3 = df3.tiles()
         np.testing.assert_equal(df2.chunks[0].index, (0, 0))
         np.testing.assert_equal(df3.chunks[0].index, (0, 0))
 
@@ -308,7 +308,7 @@ class Test(TestBase):
 
         # from tensor with given index
         df = dataframe_from_tensor(tensor, index=np.arange(0, 20, 2))
-        df.tiles()
+        df = df.tiles()
         pd.testing.assert_index_equal(df.chunks[0].index_value.to_pandas(), pd.Index(np.arange(0, 10, 2)))
         pd.testing.assert_index_equal(df.chunks[1].index_value.to_pandas(), pd.Index(np.arange(0, 10, 2)))
         pd.testing.assert_index_equal(df.chunks[2].index_value.to_pandas(), pd.Index(np.arange(10, 20, 2)))
@@ -316,7 +316,7 @@ class Test(TestBase):
 
         # from tensor with given columns
         df = dataframe_from_tensor(tensor, columns=list('abcdefghij'))
-        df.tiles()
+        df = df.tiles()
         pd.testing.assert_index_equal(df.chunks[0].columns_value.to_pandas(), pd.Index(['a', 'b', 'c', 'd', 'e']))
         pd.testing.assert_index_equal(df.chunks[1].columns_value.to_pandas(), pd.Index(['f', 'g', 'h', 'i', 'j']))
         pd.testing.assert_index_equal(df.chunks[2].columns_value.to_pandas(), pd.Index(['a', 'b', 'c', 'd', 'e']))
@@ -330,7 +330,7 @@ class Test(TestBase):
         self.assertEqual(series.name, 'a')
         pd.testing.assert_index_equal(series.index_value.to_pandas(), pd.RangeIndex(10))
 
-        series.tiles()
+        series = series.tiles()
         self.assertEqual(len(series.chunks), 3)
         pd.testing.assert_index_equal(series.chunks[0].index_value.to_pandas(), pd.RangeIndex(0, 4))
         self.assertEqual(series.chunks[0].name, 'a')
@@ -347,7 +347,7 @@ class Test(TestBase):
 
         tensor = mt.ones((10,), dtype=dtype, chunk_size=3)
         df = from_records(tensor)
-        df.tiles()
+        df = df.tiles()
 
         self.assertEqual(df.chunk_shape, (4, 1))
         self.assertEqual(df.chunks[0].shape, (3, 3))
@@ -387,7 +387,7 @@ class Test(TestBase):
             self.assertEqual(mdf.shape[1], 3)
             pd.testing.assert_index_equal(df.columns, mdf.columns_value.to_pandas())
 
-            mdf.tiles()
+            mdf = mdf.tiles()
             self.assertEqual(len(mdf.chunks), 4)
             for chunk in mdf.chunks:
                 pd.testing.assert_index_equal(df.columns, chunk.columns_value.to_pandas())

--- a/mars/dataframe/datasource/tests/test_hdfs.py
+++ b/mars/dataframe/datasource/tests/test_hdfs.py
@@ -40,7 +40,7 @@ A,B,C,D,E
 """.strip()
 
 
-@unittest.skipIf(not os.environ['WITH_HDFS'], 'Only run when hdfs is installed')
+@unittest.skipIf(not os.environ.get('WITH_HDFS'), 'Only run when hdfs is installed')
 class TestHDFS(TestBase):
     def setUp(self):
         super(TestHDFS, self).setUp()

--- a/mars/dataframe/groupby/tests/test_groupby.py
+++ b/mars/dataframe/groupby/tests/test_groupby.py
@@ -34,7 +34,7 @@ class Test(TestBase):
         self.assertIsInstance(grouped, DataFrameGroupBy)
         self.assertIsInstance(grouped.op, DataFrameGroupByOperand)
 
-        grouped.tiles()
+        grouped = grouped.tiles()
         self.assertEqual(len(grouped.chunks), 5)
         for chunk in grouped.chunks:
             self.assertIsInstance(chunk.op, DataFrameGroupByOperand)
@@ -49,7 +49,7 @@ class Test(TestBase):
         self.assertIsInstance(r.op, DataFrameGroupByAgg)
         self.assertIsInstance(r, DataFrame)
 
-        r.tiles()
+        r = r.tiles()
         self.assertEqual(len(r.chunks), 5)
         for chunk in r.chunks:
             self.assertIsInstance(chunk.op, DataFrameGroupByAgg)

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -20,7 +20,8 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...config import options
 from ...serialize import AnyField, Int32Field, BoolField
-from ...utils import tokenize
+from ...utils import tokenize, check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..align import align_dataframe_series
 from ..core import SERIES_TYPE
 from ..merge import DataFrameConcat
@@ -269,6 +270,7 @@ class DataFrameIndex(DataFrameOperand, DataFrameOperandMixin):
                 out_chunks.append(out_chunk)
 
         else:
+            check_chunks_unknown_shape([in_df], TilesFail)
             nsplits_acc = np.cumsum((0,) + in_df.nsplits[0])
             for idx in range(in_df.chunk_shape[0]):
                 for idxj in range(in_df.chunk_shape[1]):

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -21,7 +21,7 @@ from ... import opcodes as OperandDef
 from ...config import options
 from ...serialize import AnyField, Int32Field, BoolField
 from ...utils import tokenize, check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..align import align_dataframe_series
 from ..core import SERIES_TYPE
 from ..merge import DataFrameConcat
@@ -270,7 +270,7 @@ class DataFrameIndex(DataFrameOperand, DataFrameOperandMixin):
                 out_chunks.append(out_chunk)
 
         else:
-            check_chunks_unknown_shape([in_df], TilesFail)
+            check_chunks_unknown_shape([in_df], TilesError)
             nsplits_acc = np.cumsum((0,) + in_df.nsplits[0])
             for idx in range(in_df.chunk_shape[0]):
                 for idxj in range(in_df.chunk_shape[1]):

--- a/mars/dataframe/indexing/tests/test_indexing.py
+++ b/mars/dataframe/indexing/tests/test_indexing.py
@@ -29,13 +29,13 @@ class Test(TestBase):
         df2 = md.DataFrame(df1, chunk_size=2)
 
         df3 = df2.set_index('y', drop=True)
-        df3.tiles()
+        df3 = df3.tiles()
         self.assertEqual(df3.chunk_shape, (2, 2))
         pd.testing.assert_index_equal(df3.chunks[0].columns_value.to_pandas(), pd.Index(['x']))
         pd.testing.assert_index_equal(df3.chunks[1].columns_value.to_pandas(), pd.Index(['z']))
 
         df4 = df2.set_index('y', drop=False)
-        df4.tiles()
+        df4 = df4.tiles()
         self.assertEqual(df4.chunk_shape, (2, 2))
         pd.testing.assert_index_equal(df4.chunks[0].columns_value.to_pandas(), pd.Index(['x', 'y']))
         pd.testing.assert_index_equal(df4.chunks[1].columns_value.to_pandas(), pd.Index(['z']))
@@ -47,7 +47,7 @@ class Test(TestBase):
 
         # plain index
         df3 = df2.iloc[1]
-        df3.tiles()
+        df3 = df3.tiles()
         self.assertIsInstance(df3, Series)
         self.assertIsInstance(df3.op, DataFrameIlocGetItem)
         self.assertEqual(df3.shape, (3,))
@@ -63,7 +63,7 @@ class Test(TestBase):
 
         # slice index
         df4 = df2.iloc[:, 2:4]
-        df4.tiles()
+        df4 = df4.tiles()
         self.assertIsInstance(df4, DataFrame)
         self.assertIsInstance(df4.op, DataFrameIlocGetItem)
         self.assertEqual(df4.shape, (3, 1))
@@ -79,7 +79,7 @@ class Test(TestBase):
 
         # plain fancy index
         df5 = df2.iloc[[0], [0, 1, 2]]
-        df5.tiles()
+        df5 = df5.tiles()
         self.assertIsInstance(df5, DataFrame)
         self.assertIsInstance(df5.op, DataFrameIlocGetItem)
         self.assertEqual(df5.shape, (1, 3))
@@ -97,7 +97,7 @@ class Test(TestBase):
 
         # fancy index
         df6 = df2.iloc[[1, 2], [0, 1, 2]]
-        df6.tiles()
+        df6 = df6.tiles()
         self.assertIsInstance(df6, DataFrame)
         self.assertIsInstance(df6.op, DataFrameIlocGetItem)
         self.assertEqual(df6.shape, (2, 3))
@@ -125,7 +125,7 @@ class Test(TestBase):
 
         # plain index
         df7 = df2.iloc[1, 2]
-        df7.tiles()
+        df7 = df7.tiles()
         self.assertIsInstance(df7, Series)
         self.assertIsInstance(df7.op, DataFrameIlocGetItem)
         self.assertEqual(df7.shape, ())
@@ -173,12 +173,12 @@ class Test(TestBase):
         df1 = pd.DataFrame([[1,3,3], [4,2,6], [7, 8, 9]],
                             index=['a1', 'a2', 'a3'], columns=['x', 'y', 'z'])
         df2 = md.DataFrame(df1, chunk_size=2)
-        df2.tiles()
+        df2 = df2.tiles()
 
         # plain index
         df3 = md.DataFrame(df1, chunk_size=2)
         df3.iloc[1] = 100
-        df3.tiles()
+        df3 = df3.tiles()
         self.assertIsInstance(df3.op, DataFrameIlocSetItem)
         self.assertEqual(df3.chunk_shape, df2.chunk_shape)
         pd.testing.assert_index_equal(df2.index_value.to_pandas(), df3.index_value.to_pandas())
@@ -197,7 +197,7 @@ class Test(TestBase):
         # # slice index
         df4 = md.DataFrame(df1, chunk_size=2)
         df4.iloc[:, 2:4] = 1111
-        df4.tiles()
+        df4 = df4.tiles()
         self.assertIsInstance(df4.op, DataFrameIlocSetItem)
         self.assertEqual(df4.chunk_shape, df2.chunk_shape)
         pd.testing.assert_index_equal(df2.index_value.to_pandas(), df4.index_value.to_pandas())
@@ -216,7 +216,7 @@ class Test(TestBase):
         # plain fancy index
         df5 = md.DataFrame(df1, chunk_size=2)
         df5.iloc[[0], [0, 1, 2]] = 2222
-        df5.tiles()
+        df5 = df5.tiles()
         self.assertIsInstance(df5.op, DataFrameIlocSetItem)
         self.assertEqual(df5.chunk_shape, df2.chunk_shape)
         pd.testing.assert_index_equal(df2.index_value.to_pandas(), df5.index_value.to_pandas())
@@ -237,7 +237,7 @@ class Test(TestBase):
         # fancy index
         df6 = md.DataFrame(df1, chunk_size=2)
         df6.iloc[[1, 2], [0, 1, 2]] = 3333
-        df6.tiles()
+        df6 = df6.tiles()
         self.assertIsInstance(df6.op, DataFrameIlocSetItem)
         self.assertEqual(df6.chunk_shape, df2.chunk_shape)
         pd.testing.assert_index_equal(df2.index_value.to_pandas(), df6.index_value.to_pandas())
@@ -262,7 +262,7 @@ class Test(TestBase):
         # plain index
         df7 = md.DataFrame(df1, chunk_size=2)
         df7.iloc[1, 2] = 4444
-        df7.tiles()
+        df7 = df7.tiles()
         self.assertIsInstance(df7.op, DataFrameIlocSetItem)
         self.assertEqual(df7.chunk_shape, df2.chunk_shape)
         pd.testing.assert_index_equal(df2.index_value.to_pandas(), df7.index_value.to_pandas())
@@ -321,7 +321,7 @@ class Test(TestBase):
         self.assertEqual(series.dtype, data['c3'].dtype)
         self.assertEqual(series.index_value, df.index_value)
 
-        series.tiles()
+        series = series.tiles()
         self.assertEqual(series.nsplits, ((2, 2, 2, 2, 2),))
         self.assertEqual(len(series.chunks), 5)
         for i, c in enumerate(series.chunks):
@@ -336,7 +336,7 @@ class Test(TestBase):
         pd.testing.assert_index_equal(df1.columns_value.to_pandas(), data[['c1', 'c2', 'c3']].columns)
         pd.testing.assert_series_equal(df1.dtypes, data[['c1', 'c2', 'c3']].dtypes)
 
-        df1.tiles()
+        df1 = df1.tiles()
         self.assertEqual(df1.nsplits, ((2, 2, 2, 2, 2), (2, 1)))
         self.assertEqual(len(df1.chunks), 10)
         for i, c in enumerate(df1.chunks[slice(0, 10, 2)]):
@@ -381,7 +381,7 @@ class Test(TestBase):
         result1 = series[2]
         self.assertEqual(result1.shape, ())
 
-        result1.tiles()
+        result1 = result1.tiles()
         self.assertEqual(result1.nsplits, ())
         self.assertEqual(len(result1.chunks), 1)
         self.assertIsInstance(result1.chunks[0], TENSOR_CHUNK_TYPE)
@@ -391,7 +391,7 @@ class Test(TestBase):
         result2 = series[[4, 5, 1, 2, 3]]
         self.assertEqual(result2.shape, (5,))
 
-        result2.tiles()
+        result2 = result2.tiles()
         self.assertEqual(result2.nsplits, ((2, 2, 1),))
         self.assertEqual(len(result2.chunks), 3)
         self.assertEqual(result2.chunks[0].op.labels, [4, 5])
@@ -404,7 +404,7 @@ class Test(TestBase):
         result1 = series['i2']
         self.assertEqual(result1.shape, ())
 
-        result1.tiles()
+        result1 = result1.tiles()
         self.assertEqual(result1.nsplits, ())
         self.assertEqual(result1.chunks[0].dtype, data.dtype)
         self.assertTrue(result1.chunks[0].op.labels, ['i2'])
@@ -412,7 +412,7 @@ class Test(TestBase):
         result2 = series[['i2', 'i4']]
         self.assertEqual(result2.shape, (2,))
 
-        result2.tiles()
+        result2 = result2.tiles()
         self.assertEqual(result2.nsplits, ((2,),))
         self.assertEqual(result2.chunks[0].dtype, data.dtype)
         self.assertTrue(result2.chunks[0].op.labels, [['i2', 'i4']])

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -19,7 +19,7 @@ import pandas as pd
 from ...serialize import AnyField, BoolField, StringField, TupleField, KeyField, Int32Field
 from ... import opcodes as OperandDef
 from ...utils import get_shuffle_input_keys_idxes, check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType, \
     DataFrameShuffleMap, DataFrameShuffleReduce, DataFrameShuffleProxy
 from ..utils import build_concated_rows_frame, build_empty_df, parse_index, hash_dataframe_on, \
@@ -212,10 +212,10 @@ class DataFrameShuffleMerge(_DataFrameMergeBase):
 
         # left and right now are guaranteed only chunked along index axis, not column axis.
         if left.chunk_shape[1] > 1:
-            check_chunks_unknown_shape([left], TilesFail)
+            check_chunks_unknown_shape([left], TilesError)
             left = left.rechunk({1: left.shape[1]})._inplace_tile()
         if right.chunk_shape[1] > 1:
-            check_chunks_unknown_shape([right], TilesFail)
+            check_chunks_unknown_shape([right], TilesError)
             right = right.rechunk({1: right.shape[1]})._inplace_tile()
 
         left_row_chunk_size = left.chunk_shape[0]

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -18,7 +18,8 @@ import pandas as pd
 
 from ...serialize import AnyField, BoolField, StringField, TupleField, KeyField, Int32Field
 from ... import opcodes as OperandDef
-from ...utils import get_shuffle_input_keys_idxes
+from ...utils import get_shuffle_input_keys_idxes, check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType, \
     DataFrameShuffleMap, DataFrameShuffleReduce, DataFrameShuffleProxy
 from ..utils import build_concated_rows_frame, build_empty_df, parse_index, hash_dataframe_on, \
@@ -210,8 +211,12 @@ class DataFrameShuffleMerge(_DataFrameMergeBase):
         right = build_concated_rows_frame(op.inputs[1])
 
         # left and right now are guaranteed only chunked along index axis, not column axis.
-        assert left.chunk_shape[1] == 1
-        assert right.chunk_shape[1] == 1
+        if left.chunk_shape[1] > 1:
+            check_chunks_unknown_shape([left], TilesFail)
+            left = left.rechunk({1: left.shape[1]})._inplace_tile()
+        if right.chunk_shape[1] > 1:
+            check_chunks_unknown_shape([right], TilesFail)
+            right = right.rechunk({1: right.shape[1]})._inplace_tile()
 
         left_row_chunk_size = left.chunk_shape[0]
         right_row_chunk_size = right.chunk_shape[0]

--- a/mars/dataframe/merge/tests/test_merge.py
+++ b/mars/dataframe/merge/tests/test_merge.py
@@ -45,7 +45,7 @@ class Test(TestBase):
 
         for kw in parameters:
             df = mdf1.merge(mdf2, **kw)
-            df.tiles()
+            df = df.tiles()
 
             self.assertEqual(df.chunk_shape, (2, 1))
             for chunk in df.chunks:
@@ -84,7 +84,7 @@ class Test(TestBase):
 
         for kw in parameters:
             df = mdf1.join(mdf2, **kw)
-            df.tiles()
+            df = df.tiles()
 
             self.assertEqual(df.chunk_shape, (3, 1))
             for chunk in df.chunks:
@@ -123,7 +123,7 @@ class Test(TestBase):
 
         for kw in parameters:
             df = mdf1.join(mdf2, **kw)
-            df.tiles()
+            df = df.tiles()
 
             self.assertEqual(df.chunk_shape, (3, 1))
             for chunk in df.chunks:

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -85,7 +85,7 @@ class Test(TestBase):
         self.assertIsInstance(series.index_value._index_value, IndexValue.RangeIndex)
         self.assertEqual(series.shape, ())
 
-        series.tiles()
+        series = series.tiles()
 
         self.assertEqual(len(series.chunks), 1)
         self.assertIsInstance(series.chunks[0].op, self.op)
@@ -100,7 +100,7 @@ class Test(TestBase):
         self.assertIsInstance(series.index_value._index_value, IndexValue.RangeIndex)
         self.assertEqual(series.shape, ())
 
-        series.tiles()
+        series = series.tiles()
 
         self.assertEqual(len(series.chunks), 1)
         self.assertIsInstance(series.chunks[0].op, self.op)
@@ -155,7 +155,7 @@ class Test(TestBase):
         self.assertIsInstance(reduction_df.index_value._index_value, IndexValue.Index)
         self.assertEqual(reduction_df.shape, (2,))
 
-        reduction_df.tiles()
+        reduction_df = reduction_df.tiles()
 
         self.assertEqual(len(reduction_df.chunks), 1)
         self.assertIsInstance(reduction_df.chunks[0].op, self.op)
@@ -169,7 +169,7 @@ class Test(TestBase):
         self.assertIsInstance(reduction_df.index_value._index_value, IndexValue.RangeIndex)
         self.assertEqual(reduction_df.shape, (10,))
 
-        reduction_df.tiles()
+        reduction_df = reduction_df.tiles()
 
         self.assertEqual(len(reduction_df.chunks), 4)
         self.assertEqual(reduction_df.nsplits, ((3, 3, 3, 1),))
@@ -182,7 +182,7 @@ class Test(TestBase):
 
         self.assertEqual(reduction_df.shape, (20,))
 
-        reduction_df.tiles()
+        reduction_df = reduction_df.tiles()
 
         self.assertEqual(len(reduction_df.chunks), 5)
         self.assertEqual(reduction_df.nsplits, ((np.nan,) * 5,))

--- a/mars/deploy/local/session.py
+++ b/mars/deploy/local/session.py
@@ -25,7 +25,7 @@ from ...config import options
 from ...errors import ExecutionFailed
 from ...scheduler.graph import GraphState
 from ...serialize import dataserializer
-from ...utils import build_graph, sort_dataframe_result
+from ...utils import build_tileable_graph, sort_dataframe_result
 
 
 class LocalClusterSession(object):
@@ -119,7 +119,7 @@ class LocalClusterSession(object):
         # those executed tileables should fetch data directly, submit the others
         run_tileables = [t for t in tileables if t.key not in self._executed_tileables]
 
-        graph = build_graph(run_tileables, executed_keys=list(self._executed_tileables.keys()))
+        graph = build_tileable_graph(run_tileables, set(self._executed_tileables.keys()))
         targets = [t.key for t in run_tileables]
         graph_key = uuid.uuid4()
 

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -629,12 +629,12 @@ class Test(unittest.TestCase):
             session = cluster.session
             a = mt.ones((10, 10), chunk_size=3)
             b = a.dot(a)
-            b.tiles()
+            b = b.tiles()
 
             r = session.run(b, timeout=_exec_timeout)
             np.testing.assert_array_equal(r, np.ones((10, 10)) * 10)
 
-            a.tiles()
+            a = a.tiles()
             b = a + 1
 
             r = session.run(b, timeout=_exec_timeout)

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -27,7 +27,6 @@ try:
     from numpy.core._exceptions import UFuncTypeError
 except ImportError:  # pragma: no cover
     UFuncTypeError = None
-import pandas as pd
 
 try:
     import gevent
@@ -36,8 +35,10 @@ except ImportError:  # pragma: no cover
 
 from .operands import Fetch, ShuffleProxy
 from .graph import DirectedGraph
+from .tiles import TileableGraphBuilder, IterativeChunkGraphBuilder, \
+    ChunkGraphBuilder, get_tiled
 from .compat import six, futures, OrderedDict, enum
-from .utils import kernel_mode, build_fetch, calc_nsplits
+from .utils import kernel_mode, enter_build_mode, build_fetch, calc_nsplits, has_unknown_shape
 
 if gevent:
     from .actors.pool.gevent_pool import GeventThreadPool
@@ -615,19 +616,28 @@ class Executor(object):
         return res
 
     @kernel_mode
+    @enter_build_mode
     def execute_tileable(self, tileable, n_parallel=None, n_thread=None, concat=False,
                          print_progress=False, mock=False, compose=True):
-        if concat:
-            # only for tests
-            tileable.tiles()
-            if len(tileable.chunks) > 1:
-                tileable = tileable.op.concat_tileable_chunks(tileable)
+        result_keys = []
+        tileable_data = tileable.data if hasattr(tileable, 'data') else tileable
+
+        def _on_tile_success(before_tile_data, after_tile_data):
+            if before_tile_data is tileable_data:
+                if concat and len(after_tile_data.chunks) > 1:
+                    after_tile_data = after_tile_data.op.concat_tileable_chunks(after_tile_data)
+                result_keys.extend(c.key for c in after_tile_data.chunks)
+
+            return after_tile_data
 
         # shallow copy
         chunk_result = self._chunk_result.copy()
-        graph = tileable.build_graph(cls=DirectedGraph, tiled=True, compose=compose)
-        ret = self.execute_graph(graph, [c.key for c in tileable.chunks],
-                                 n_parallel=n_parallel or n_thread,
+        tileable_graph_builder = TileableGraphBuilder()
+        tileable_graph = tileable_graph_builder.build([tileable])
+        chunk_graph_builder = ChunkGraphBuilder(graph_cls=DirectedGraph, compose=compose,
+                                                on_tile_success=_on_tile_success)
+        chunk_graph = chunk_graph_builder.build([tileable], tileable_graph=tileable_graph)
+        ret = self.execute_graph(chunk_graph, result_keys, n_parallel=n_parallel or n_thread,
                                  print_progress=print_progress, mock=mock,
                                  chunk_result=chunk_result)
         self._chunk_result.update(chunk_result)
@@ -636,126 +646,187 @@ class Executor(object):
     execute_tensor = execute_tileable
     execute_dataframe = execute_tileable
 
+    def _update_tileable_and_chunk_shape(self, tileable_graph, chunk_result, failed_ops):
+        for n in tileable_graph:
+            if n.op in failed_ops:
+                continue
+            tiled_n = get_tiled(n)
+            if has_unknown_shape(tiled_n):
+                if any(c.key not in chunk_result for c in tiled_n.chunks):
+                    # some of the chunks has been fused
+                    continue
+                for c in tiled_n.chunks:
+                    c.data._shape = chunk_result[c.key].shape
+                new_nsplits = self.get_tileable_nsplits(n, chunk_result=chunk_result)
+                for node in (n, tiled_n):
+                    node._update_shape(tuple(sum(nsplit) for nsplit in new_nsplits))
+                tiled_n._nsplits = new_nsplits
+
     @kernel_mode
+    @enter_build_mode
     def execute_tileables(self, tileables, fetch=True, n_parallel=None, n_thread=None,
                           print_progress=False, mock=False, compose=True):
-        graph = DirectedGraph()
-
-        # shallow copy, prevent from any chunk key decref
+        # shallow copy chunk_result, prevent from any chunk key decref
         chunk_result = self._chunk_result.copy()
-        result_keys = []
-        to_release_keys = []
-        concat_keys = []
-        for tileable in tileables:
-            tileable.tiles()
-            chunk_keys = [c.key for c in tileable.chunks]
-            result_keys.extend(chunk_keys)
+        tileables = [tileable.data if hasattr(tileable, 'data') else tileable
+                     for tileable in tileables]
+        tileable_keys = [t.key for t in tileables]
+        tileable_keys_set = set(tileable_keys)
 
+        result_keys = []
+        to_release_keys = set()
+        tileable_data_to_concat_keys = weakref.WeakKeyDictionary()
+        tileable_data_to_chunk_keys = weakref.WeakKeyDictionary()
+
+        executed_keys = set(chunk_result)
+        node_to_fetch = weakref.WeakKeyDictionary()
+
+        def _generate_fetch_if_executed(nd):
+            # node processor that if the node is executed
+            # replace it with a fetch node
+            _keys, _to_fetch = executed_keys, node_to_fetch  # noqa: F821
+            if nd.key not in _keys:
+                return nd
+            if nd in _to_fetch:
+                return _to_fetch[nd]
+            fn = build_fetch(nd).data
+            _to_fetch[nd] = fn
+            return fn
+
+        def _on_tile_success(before_tile_data, after_tile_data):
+            if before_tile_data.key not in tileable_keys_set:
+                return after_tile_data
+            tile_chunk_keys = [c.key for c in after_tile_data.chunks]
+            result_keys.extend(tile_chunk_keys)
+            tileable_data_to_chunk_keys[before_tile_data] = tile_chunk_keys
+            if not fetch:
+                pass
+            elif len(after_tile_data.chunks) > 1:
+                # need to fetch data and chunks more than 1, we concatenate them into 1
+                after_tile_data = after_tile_data.op.concat_tileable_chunks(after_tile_data)
+                chunk = after_tile_data.chunks[0]
+                result_keys.append(chunk.key)
+                tileable_data_to_concat_keys[before_tile_data] = chunk.key
+                # after return the data to user, we release the reference
+                to_release_keys.add(chunk.key)
+            else:
+                tileable_data_to_concat_keys[before_tile_data] = after_tile_data.chunks[0].key
+            return after_tile_data
+
+        # build tileable graph
+        tileable_graph_builder = TileableGraphBuilder()
+        tileable_graph = tileable_graph_builder.build(tileables)
+        chunk_graph_builder = IterativeChunkGraphBuilder(
+            graph_cls=DirectedGraph, node_processor=_generate_fetch_if_executed,
+            compose=compose, on_tile_success=_on_tile_success)
+        intermediate_result_keys = set()
+        while True:
+            # build chunk graph, tile will be done during building
+            chunk_graph = chunk_graph_builder.build(tileables, tileable_graph=tileable_graph)
+            tileable_graph = chunk_graph_builder.prev_tileable_graph
+            temp_result_keys = set(result_keys)
+            if not chunk_graph_builder.done:
+                # add temporary chunks keys into result keys
+                for n in chunk_graph:
+                    if chunk_graph.count_successors(n) == 0:
+                        temp_result_keys.add(n.key)
+            # execute chunk graph
+            self.execute_graph(chunk_graph, list(temp_result_keys), n_parallel=n_parallel or n_thread,
+                               print_progress=print_progress, mock=mock,
+                               chunk_result=chunk_result)
+            if chunk_graph_builder.done:
+                if len(intermediate_result_keys) > 0:
+                    # failed before
+                    intermediate_to_release_keys = \
+                        {k for k in intermediate_result_keys
+                         if k not in result_keys and k in chunk_result}
+                    to_release_keys.update(intermediate_to_release_keys)
+                delattr(chunk_graph_builder, '_prev_tileable_graph')
+                break
+            else:
+                # update shape of tileable and its chunks
+                self._update_tileable_and_chunk_shape(
+                    tileable_graph, chunk_result, chunk_graph_builder.failed_ops)
+                executed_keys.update(temp_result_keys)
+                intermediate_result_keys.update(temp_result_keys)
+                # add the node that failed
+                to_run_tileables = list(itertools.chain(
+                    *(op.outputs for op in chunk_graph_builder.failed_ops)))
+                to_run_tileables_set = set(to_run_tileables)
+                for op in chunk_graph_builder.failed_ops:
+                    for inp in op.inputs:
+                        if inp not in to_run_tileables_set:
+                            to_run_tileables_set.add(inp)
+                tileable_graph_builder = TileableGraphBuilder(
+                    inputs_selector=lambda inps: [inp for inp in inps if inp in to_run_tileables_set])
+                tileable_graph = tileable_graph_builder.build(to_run_tileables_set)
+
+        for tileable in tileables:
             if tileable.key in self.stored_tileables:
                 self.stored_tileables[tileable.key][0].add(tileable.id)
             else:
+                chunk_keys = tileable_data_to_chunk_keys[tileable]
                 self.stored_tileables[tileable.key] = tuple([{tileable.id}, set(chunk_keys)])
-            if not fetch:
-                # no need to generate concat keys
-                pass
-            elif len(tileable.chunks) > 1:
-                # if need to fetch data and chunks more than 1, we concatenate them into 1
-                tileable = tileable.op.concat_tileable_chunks(tileable)
-                chunk = tileable.chunks[0]
-                result_keys.append(chunk.key)
-                # the concatenated key
-                concat_keys.append(chunk.key)
-                # after return the data to user, we release the reference
-                to_release_keys.append(chunk.key)
-            else:
-                concat_keys.append(tileable.chunks[0].key)
-
-            # Do not do compose here, because building graph has not finished yet
-            tileable.build_graph(graph=graph, tiled=True, compose=False,
-                                 executed_keys=list(chunk_result.keys()))
-        if compose:
-            # finally do compose according to option
-            graph.compose(keys=list(itertools.chain(*[[c.key for c in t.chunks]
-                                                      for t in tileables])))
-
-        self.execute_graph(graph, result_keys, n_parallel=n_parallel or n_thread,
-                           print_progress=print_progress, mock=mock,
-                           chunk_result=chunk_result)
-
-        self._chunk_result.update(chunk_result)
-        results = self._chunk_result
         try:
             if fetch:
-                return [results[k] for k in concat_keys]
+                concat_keys = [tileable_data_to_concat_keys[t] for t in tileables]
+                return [chunk_result[k] for k in concat_keys]
             else:
                 return
         finally:
-            for k in to_release_keys:
-                del results[k]
+            for to_release_key in to_release_keys:
+                del chunk_result[to_release_key]
+            self._chunk_result.update(
+                {k: chunk_result[k] for k in result_keys if k in chunk_result})
 
     execute_tensors = execute_tileables
     execute_dataframes = execute_tileables
+
+    @classmethod
+    def _check_slice_on_tileable(cls, tileable):
+        from .tensor.indexing import TensorIndex
+        from .dataframe.indexing.iloc import DataFrameIlocGetItem
+
+        if isinstance(tileable.op, (TensorIndex, DataFrameIlocGetItem)):
+            indexes = tileable.op.indexes
+            if not all(isinstance(ind, (slice, Integral)) for ind in indexes):
+                raise ValueError('Only support fetch data slices')
 
     @kernel_mode
     def fetch_tileables(self, tileables, **kw):
         from .tensor.indexing import TensorIndex
         from .dataframe.indexing.iloc import DataFrameIlocGetItem
 
-        results = []
-        to_concat_tileables = OrderedDict()
-
-        tileable_indexes = []
-        for i, tileable in enumerate(tileables):
+        to_release_tileables = []
+        for tileable in tileables:
             if tileable.key not in self.stored_tileables and \
                     isinstance(tileable.op, (TensorIndex, DataFrameIlocGetItem)):
-                key = tileable.inputs[0].key
                 indexes = tileable.op.indexes
-                tileable = tileable.inputs[0]
                 if not all(isinstance(ind, (slice, Integral)) for ind in indexes):
                     raise ValueError('Only support fetch data slices')
+                key = tileable.inputs[0].key
+                to_release_tileables.append(tileable)
             else:
                 key = tileable.key
-                indexes = None
-
-            tileable_indexes.append(indexes)
-
             if key not in self.stored_tileables:
                 # check if the tileable is executed before
                 raise ValueError(
-                    'Tileable object to fetch must be executed before, got {0}'.format(tileable))
+                    'Tileable object {} to fetch must be executed first'.format(tileable))
 
-            if len(tileable.chunks) == 1:
-                result = self._chunk_result[tileable.chunks[0].key]
-                results.append(result)
-                continue
+        try:
+            # if chunk executed, fetch chunk mechanism will be triggered in execute_tileables
+            return self.execute_tileables(tileables, **kw)
+        finally:
+            for to_release_tileable in to_release_tileables:
+                for c in get_tiled(to_release_tileable).chunks:
+                    del self._chunk_result[c.key]
 
-            # generate Fetch op for each chunk
-            tileable = build_fetch(tileable)
-            # add this concat tileable into the list which shall be executed later
-            to_concat_tileables[i] = tileable
-            results.append(None)
-
-        # execute the concat tileables together
-        if to_concat_tileables:
-            concat_results = self.execute_tileables(list(to_concat_tileables.values()), **kw)
-            for j, concat_result in zip(to_concat_tileables, concat_results):
-                results[j] = concat_result
-
-        indexed_results = []
-        for indexes, result in zip(tileable_indexes, results):
-            if indexes:
-                if isinstance(result, (pd.DataFrame, pd.Series)):
-                    indexed_results.append(result.iloc[indexes])
-                else:
-                    indexed_results.append(result[indexes])
-            else:
-                indexed_results.append(result)
-        return indexed_results
-
-    def get_tileable_nsplits(self, tileable):
-        chunk_idx_to_shape = OrderedDict(
-            (c.index, r.shape) for c, r in zip(tileable.chunks, [self._chunk_result[c.key]
-                                                                 for c in tileable.chunks]))
+    def get_tileable_nsplits(self, tileable, chunk_result=None):
+        chunk_idx_to_shape = OrderedDict()
+        tiled = get_tiled(tileable)
+        chunk_result = chunk_result if chunk_result is not None else self._chunk_result
+        for chunk in tiled.chunks:
+            chunk_idx_to_shape[chunk.index] = chunk_result[chunk.key].shape
         return calc_nsplits(chunk_idx_to_shape)
 
     def decref(self, *keys):

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -746,14 +746,14 @@ class Executor(object):
             else:
                 # update shape of tileable and its chunks
                 self._update_tileable_and_chunk_shape(
-                    tileable_graph, chunk_result, chunk_graph_builder.failed_ops)
+                    tileable_graph, chunk_result, chunk_graph_builder.interrupted_ops)
                 executed_keys.update(temp_result_keys)
                 intermediate_result_keys.update(temp_result_keys)
                 # add the node that failed
                 to_run_tileables = list(itertools.chain(
-                    *(op.outputs for op in chunk_graph_builder.failed_ops)))
+                    *(op.outputs for op in chunk_graph_builder.interrupted_ops)))
                 to_run_tileables_set = set(to_run_tileables)
-                for op in chunk_graph_builder.failed_ops:
+                for op in chunk_graph_builder.interrupted_ops:
                     for inp in op.inputs:
                         if inp not in to_run_tileables_set:
                             to_run_tileables_set.add(inp)

--- a/mars/graph.pyx
+++ b/mars/graph.pyx
@@ -478,6 +478,9 @@ cdef class DAG(DirectedGraph):
             set visited = set()
             list stack
 
+        if len(self) == 0:
+            return
+
         if reverse:
             preds, succs = self._successors, self._predecessors
         else:

--- a/mars/learn/contrib/xgboost/dmatrix.py
+++ b/mars/learn/contrib/xgboost/dmatrix.py
@@ -130,15 +130,15 @@ class ToDMatrix(LearnOperand, LearnOperandMixin):
 
         if data.chunk_shape[1] > 1:
             # make sure data's second dimension has only 1 chunk
-            data = data.rechunk({1: data.shape[1]}).single_tiles()
+            data = data.rechunk({1: data.shape[1]})._inplace_tile()
 
         nsplit = data.nsplits[0]
         # rechunk label
         if label is not None:
-            label = label.rechunk({0: nsplit}).single_tiles()
+            label = label.rechunk({0: nsplit})._inplace_tile()
         # rechunk weight
         if weight is not None:
-            weight = weight.rechunk({0: nsplit}).single_tiles()
+            weight = weight.rechunk({0: nsplit})._inplace_tile()
 
         out_chunkss = [[] for _ in range(op.output_limit)]
         for i in range(len(nsplit)):

--- a/mars/learn/contrib/xgboost/predict.py
+++ b/mars/learn/contrib/xgboost/predict.py
@@ -93,7 +93,7 @@ class XGBPredict(LearnOperand, LearnOperandMixin):
         out_chunks = []
         data = op.data
         if data.chunk_shape[1] > 1:
-            data = data.rechunk({1: op.data.shape[1]}).single_tiles()
+            data = data.rechunk({1: op.data.shape[1]})._inplace_tile()
         for in_chunk in data.chunks:
             chunk_op = op.copy().reset_key()
             chunk_index = (in_chunk.index[0],)

--- a/mars/learn/decomposition/base.py
+++ b/mars/learn/decomposition/base.py
@@ -96,7 +96,7 @@ class _BasePCA(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMixin)):
         return precision
 
     @abstractmethod
-    def fit(X, y=None, session=None):
+    def fit(X, y=None, session=None, run_kwargs=None):
         """Placeholder for fit. Subclasses should implement this method!
 
         Fit the model with X.

--- a/mars/learn/decomposition/pca.py
+++ b/mars/learn/decomposition/pca.py
@@ -305,7 +305,7 @@ class PCA(_BasePCA):
         self.iterated_power = iterated_power
         self.random_state = random_state
 
-    def fit(self, X, y=None, session=None):
+    def fit(self, X, y=None, session=None, run_kwargs=None):
         """Fit the model with X.
 
         Parameters
@@ -321,7 +321,7 @@ class PCA(_BasePCA):
         self : object
             Returns the instance itself.
         """
-        self._fit(X, session=session, run=True)
+        self._fit(X, session=session, run=True, run_kwargs=run_kwargs)
         return self
 
     def fit_transform(self, X, y=None, session=None):
@@ -353,7 +353,7 @@ class PCA(_BasePCA):
         self._run([U], session=session)
         return U
 
-    def _run(self, result, session=None):
+    def _run(self, result, session=None, run_kwargs=None):
         to_run_tensors = list(result)
         if isinstance(self.noise_variance_, TENSOR_TYPE):
             to_run_tensors.append(self.noise_variance_)
@@ -362,9 +362,9 @@ class PCA(_BasePCA):
         to_run_tensors.append(self.explained_variance_ratio_)
         to_run_tensors.append(self.singular_values_)
 
-        ExecutableTuple(to_run_tensors).execute(session=session, fetch=False)
+        ExecutableTuple(to_run_tensors).execute(session=session, fetch=False, **(run_kwargs or {}))
 
-    def _fit(self, X, session=None, run=True):
+    def _fit(self, X, session=None, run=True, run_kwargs=None):
         """Dispatch to the right submethod depending on the chosen solver."""
 
         # Raise an error for sparse input.
@@ -407,7 +407,7 @@ class PCA(_BasePCA):
                              "".format(self._fit_svd_solver))
 
         if run:
-            self._run(ret, session=session)
+            self._run(ret, session=session, run_kwargs=run_kwargs)
         return ret
 
     def _fit_full(self, X, n_components, session=None):

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -24,7 +24,7 @@ from ...tensor.utils import validate_axis, check_random_state, gen_random_seeds,
 from ...tensor.array_utils import get_array_module
 from ...dataframe.utils import parse_index
 from ...utils import tokenize, get_shuffle_input_keys_idxes, lazy_import, check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ...compat import reduce
 from ...core import ExecutableTuple
 from ..operands import LearnOperand, LearnOperandMixin, OutputType, \
@@ -139,7 +139,7 @@ class LearnShuffle(LearnOperand, LearnOperandMixin):
     @classmethod
     def tile(cls, op):
         inputs = op.inputs
-        check_chunks_unknown_shape(inputs, TilesFail)
+        check_chunks_unknown_shape(inputs, TilesError)
         axis_to_nsplits = defaultdict(list)
         has_dataframe = any(output_type == OutputType.dataframe
                             for output_type in op.output_types)

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -23,7 +23,8 @@ from ...serialize import ValueType, TupleField, KeyField
 from ...tensor.utils import validate_axis, check_random_state, gen_random_seeds, decide_unify_split
 from ...tensor.array_utils import get_array_module
 from ...dataframe.utils import parse_index
-from ...utils import tokenize, get_shuffle_input_keys_idxes, lazy_import
+from ...utils import tokenize, get_shuffle_input_keys_idxes, lazy_import, check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ...compat import reduce
 from ...core import ExecutableTuple
 from ..operands import LearnOperand, LearnOperandMixin, OutputType, \
@@ -83,7 +84,7 @@ class LearnShuffle(LearnOperand, LearnOperandMixin):
 
     def _calc_params(self, params):
         axes = set(self.axes)
-        for output_type, param in zip(self._output_types, params):
+        for i, output_type, param in zip(itertools.count(0), self._output_types, params):
             if output_type == OutputType.dataframe:
                 if 0 in axes:
                     param['index_value'] = self._shuffle_index_value(param['index_value'])
@@ -93,6 +94,7 @@ class LearnShuffle(LearnOperand, LearnOperandMixin):
             elif output_type == OutputType.series:
                 if 0 in axes:
                     param['index_value'] = self._shuffle_index_value(param['index_value'])
+            param['_position_'] = i
         return params
 
     @staticmethod
@@ -104,7 +106,7 @@ class LearnShuffle(LearnOperand, LearnOperandMixin):
             if tuple(tileable.nsplits[ax]) != tuple(nsplit):
                 do_rechunk = True
         if do_rechunk:
-            return tileable.rechunk(ax_nsplit).single_tiles()
+            return tileable.rechunk(ax_nsplit)._inplace_tile()
         else:
             return tileable
 
@@ -137,6 +139,7 @@ class LearnShuffle(LearnOperand, LearnOperandMixin):
     @classmethod
     def tile(cls, op):
         inputs = op.inputs
+        check_chunks_unknown_shape(inputs, TilesFail)
         axis_to_nsplits = defaultdict(list)
         has_dataframe = any(output_type == OutputType.dataframe
                             for output_type in op.output_types)

--- a/mars/learn/utils/tests/test_shuffle.py
+++ b/mars/learn/utils/tests/test_shuffle.py
@@ -21,6 +21,7 @@ import mars.tensor as mt
 import mars.dataframe as md
 from mars.learn.utils import shuffle
 from mars.learn.utils.shuffle import LearnShuffle
+from mars.tiles import get_tiled
 
 
 class Test(unittest.TestCase):
@@ -36,7 +37,8 @@ class Test(unittest.TestCase):
         self.assertEqual(new_b.shape, b.shape)
         self.assertNotEqual(b.index_value.key, new_b.index_value.key)
 
-        new_a.tiles()
+        new_a = new_a.tiles()
+        new_b = get_tiled(new_b)
 
         self.assertEqual(len(new_a.chunks), 10)
         self.assertTrue(np.isnan(new_a.chunks[0].shape[0]))
@@ -58,7 +60,8 @@ class Test(unittest.TestCase):
         self.assertFalse(np.all(new_d.dtypes.index[:-1] < new_d.dtypes.index[1:]))
         pd.testing.assert_series_equal(d.dtypes, new_d.dtypes.sort_index())
 
-        new_c.tiles()
+        new_c = new_c.tiles()
+        new_d = get_tiled(new_d)
 
         self.assertEqual(len(new_c.chunks), 5 * 1 * 2)
         self.assertTrue(np.isnan(new_c.chunks[0].shape[0]))

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -584,12 +584,12 @@ class GraphActor(SchedulerActor):
             # some TilesFail happens before
             # build tileable graph from failed ops and their inputs
             failed_tileable_set = set(itertools.chain(
-                *(op.outputs for op in chunk_graph_builder.failed_ops)))
+                *(op.outputs for op in chunk_graph_builder.interrupted_ops)))
             tileable_graph_builder = TileableGraphBuilder(
                 inputs_selector=lambda inps: [inp for inp in inps if inp in failed_tileable_set])
             to_run_tileable_graph = tileable_graph_builder.build(failed_tileable_set)
             to_fetch_tileables = []
-            for failed_op in chunk_graph_builder.failed_ops:
+            for failed_op in chunk_graph_builder.interrupted_ops:
                 for inp in failed_op.inputs:
                     if inp not in failed_tileable_set:
                         fetch_inp = build_fetch_tileable(inp).data

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 import contextlib
 import itertools
 import logging
@@ -20,7 +19,7 @@ import operator
 import os
 import random
 import time
-from collections import deque, defaultdict
+from collections import defaultdict
 
 import numpy as np
 
@@ -38,11 +37,11 @@ from ..errors import ExecutionInterrupted, GraphNotExists
 from ..graph import DAG
 from ..operands import Fetch, ShuffleProxy, VirtualOperand
 from ..serialize import dataserializer
-from ..core import ChunkData
-from ..tiles import handler, DataNotReady
+from ..tiles import handler, IterativeChunkGraphBuilder, \
+    TileableGraphBuilder, get_tiled
 from ..utils import serialize_graph, deserialize_graph, log_unhandled, \
     build_fetch_chunk, build_fetch_tileable, calc_nsplits, \
-    get_chunk_shuffle_key
+    get_chunk_shuffle_key, enter_build_mode, has_unknown_shape
 from ..context import DistributedContext
 
 logger = logging.getLogger(__name__)
@@ -243,20 +242,26 @@ class GraphActor(SchedulerActor):
         self._tileable_graph_cache = None
         self._chunk_graph_cache = None
 
-        self._op_key_to_chunk = defaultdict(list)
+        # chunk graph builder
+        self._chunk_graph_builder = None
 
         self._resource_actor = None
-        self._tileable_key_opid_to_tiled = defaultdict(list)
+        # generated once
+        self._target_tileable_keys = target_tileables
+        self._target_tileable_datas = []
         self._tileable_key_to_opid = dict()
-        self._terminal_chunk_op_tileable = defaultdict(set)
-        self._terminated_tileables = set()
+        # used over all iteration
+        self._tileable_key_opid_to_tiled = defaultdict(list)
+        self._chunk_key_id_to_chunk = dict()
+        self._all_terminated_tileable_keys = set()
+        # used only for current iteration
+        self._tileable_to_fetch = dict()
         self._operand_infos = dict()
-        if target_tileables:
-            self._target_tileable_chunk_ops = dict((k, set()) for k in target_tileables)
-            self._target_tileable_finished = dict((k, set()) for k in self._target_tileable_chunk_ops)
-        else:
-            self._target_tileable_chunk_ops = dict()
-            self._target_tileable_finished = dict()
+        self._op_key_to_chunk = defaultdict(list)
+        self._terminal_chunk_op_key_to_tileable_key = defaultdict(set)
+        self._terminal_tileable_key_to_chunk_op_keys = defaultdict(set)
+        self._terminated_tileable_keys = set()
+        self._target_tileable_finished = dict()
 
         self._assigned_workers = set()
         self._worker_adds = set()
@@ -339,30 +344,33 @@ class GraphActor(SchedulerActor):
         self._final_state = value
         self._graph_meta_ref.set_final_state(value, _tell=True, _wait=False)
 
+    def _detect_cancel(self, callback=None):
+        if self.reload_state() == GraphState.CANCELLING:
+            logger.info('Cancel detected, stopping')
+            if callback:
+                callback()
+            else:
+                self._graph_meta_ref.set_graph_end(_tell=True, _wait=False)
+                self.state = GraphState.CANCELLED
+            raise ExecutionInterrupted
+
     @log_unhandled
     def execute_graph(self, compose=True):
         """
         Start graph execution
         """
-        def _detect_cancel(callback=None):
-            if self.reload_state() == GraphState.CANCELLING:
-                logger.info('Cancel detected, stopping')
-                if callback:
-                    callback()
-                else:
-                    self._graph_meta_ref.set_graph_end(_tell=True, _wait=False)
-                    self.state = GraphState.CANCELLED
-                raise ExecutionInterrupted
 
         self._graph_meta_ref.set_graph_start(_tell=True, _wait=False)
         self.state = GraphState.PREPARING
+        self._execute_graph(compose=compose)
 
+    def _execute_graph(self, compose=True):
         try:
             self.prepare_graph(compose=compose)
-            _detect_cancel()
+            self._detect_cancel()
 
             with self._open_dump_file('graph') as outf:  # pragma: no cover
-                graph = self.get_chunk_graph()
+                graph = self._chunk_graph_cache
                 for n in graph:
                     outf.write(
                         '%s(%s)[%s] -> %s\n' % (
@@ -371,10 +379,10 @@ class GraphActor(SchedulerActor):
                     )
 
             self.analyze_graph()
-            _detect_cancel()
+            self._detect_cancel()
 
             self.create_operand_actors()
-            _detect_cancel(self.stop_graph)
+            self._detect_cancel(self.stop_graph)
         except ExecutionInterrupted:
             pass
         except:  # noqa: E722
@@ -400,7 +408,7 @@ class GraphActor(SchedulerActor):
 
         try:
             chunk_graph = self.get_chunk_graph()
-        except (KeyError, GraphNotExists):
+        except (KeyError, GraphNotExists, AttributeError):
             self.state = GraphState.CANCELLED
             return
 
@@ -421,165 +429,203 @@ class GraphActor(SchedulerActor):
             self._graph_meta_ref.set_graph_end(_tell=True, _wait=False)
 
     @log_unhandled
-    def reload_chunk_graph(self):
-        """
-        Reload chunk graph from kv store
-        """
-        if self._kv_store_ref is not None:
-            chunk_graph_ser = self._kv_store_ref.read('/sessions/%s/graphs/%s/chunk_graph'
-                                                      % (self._session_id, self._graph_key)).value
-        else:
-            raise GraphNotExists
-        self._chunk_graph_cache = deserialize_graph(base64.b64decode(chunk_graph_ser), graph_cls=DAG)
-
-        op_key_to_chunk = defaultdict(list)
-        for n in self._chunk_graph_cache:
-            op_key_to_chunk[n.op.key].append(n)
-        self._op_key_to_chunk = op_key_to_chunk
-
-    @log_unhandled
     def get_chunk_graph(self):
+        return self._chunk_graph_builder.iterative_chunk_graphs[-1]
+
+    def _gen_tileable_graph(self):
+        if self._tileable_graph_cache is None:
+            tileable_graph = deserialize_graph(self._serialized_tileable_graph, graph_cls=DAG)
+            self._tileable_graph_cache = tileable_graph
+
+            logger.debug('Begin preparing graph %s with %d tileables to chunk graph.',
+                         self._graph_key, len(tileable_graph))
+
+        return self._tileable_graph_cache
+
+    def _gen_chunk_graph(self):
         if self._chunk_graph_cache is None:
-            self.reload_chunk_graph()
+            self._chunk_graph_cache = DAG()
         return self._chunk_graph_cache
 
+    def _scan_tileable_graph(self):
+        tileable_graph = self._tileable_graph_cache
+        target_tileable_provided = self._target_tileable_keys is not None
+        if self._target_tileable_keys is None:
+            self._target_tileable_keys = []
+            self._target_tileable_datas = []
+        for tn in tileable_graph:
+            self._tileable_key_to_opid[tn.key] = tn.op.id
+            if tileable_graph.count_successors(tn) == 0:
+                # no successors
+                if not target_tileable_provided:
+                    self._target_tileable_keys.append(tn.key)
+                    self._target_tileable_datas.append(tn)
+            if target_tileable_provided and tn.key in self._target_tileable_keys:
+                self._target_tileable_datas.append(tn)
+
+    @classmethod
+    def _merge_chunk_graph(cls, chunk_graph, update_chunk_graph):
+        chunk_key_id_to_chunk = dict()
+        for c in chunk_graph:
+            chunk_key_id_to_chunk[c.key, c.id] = c
+        for update_c in update_chunk_graph:
+            if isinstance(update_c.op, Fetch):
+                continue
+            chunk_graph.add_node(update_c)
+            for inp in update_c.inputs or []:
+                if inp in chunk_graph:
+                    chunk_graph.add_edge(inp, update_c)
+                elif isinstance(inp.op, Fetch):
+                    if (inp.key, inp.id) in chunk_key_id_to_chunk:
+                        inp = chunk_key_id_to_chunk[inp.key, inp.id]
+                    else:
+                        chunk_graph.add_node(inp)
+                    chunk_graph.add_edge(inp, update_c)
+        return chunk_graph
+
+    @classmethod
+    def _prune_chunk_graph(cls, chunk_graph, result_chunk_keys):
+        reverse_chunk_graph = chunk_graph.build_reversed()
+        marked = set()
+        for c in reverse_chunk_graph.topological_iter():
+            if reverse_chunk_graph.count_predecessors(c) == 0 and \
+                    c.key in result_chunk_keys:
+                marked.add(c)
+            elif any(inp in marked for inp in reverse_chunk_graph.iter_predecessors(c)):
+                marked.add(c)
+        for n in list(chunk_graph):
+            if n not in marked:
+                chunk_graph.remove_node(n)
+
+    def _clear_for_iteration(self):
+        self._tileable_to_fetch.clear()
+        self._operand_infos.clear()
+        self._op_key_to_chunk.clear()
+        self._terminal_chunk_op_key_to_tileable_key.clear()
+        self._terminal_tileable_key_to_chunk_op_keys.clear()
+        self._target_tileable_finished.clear()
+        self._terminated_tileable_keys.clear()
+
+    def _gen_target_info(self, target_chunk_keys):
+        chunk_graph_builder = self._chunk_graph_builder
+        is_done = chunk_graph_builder.done
+        cur_tileable_graph = chunk_graph_builder.prev_tileable_graph
+
+        for tn in cur_tileable_graph:
+            if is_done:
+                # only consider those target tileables
+                is_target = tn.key in self._target_tileable_keys
+            else:
+                is_target = tn.key in self._target_tileable_keys or \
+                            cur_tileable_graph.count_successors(tn) == 0
+            if is_target:
+                self._target_tileable_finished[tn.key] = set()
+                tiled_tn = self._tileable_key_opid_to_tiled[tn.key, tn.op.id][-1]
+                for c in tiled_tn.chunks:
+                    self._terminal_chunk_op_key_to_tileable_key[c.op.key].add(tn.key)
+                    self._terminal_tileable_key_to_chunk_op_keys[tn.key].add(c.op.key)
+                    target_chunk_keys.add(c.key)
+
     @log_unhandled
+    @enter_build_mode
     def prepare_graph(self, compose=True):
         """
         Tile and compose tileable graph into chunk graph
         :param compose: if True, do compose after tiling
         """
-        tileable_graph = deserialize_graph(self._serialized_tileable_graph)
-        self._tileable_graph_cache = tileable_graph
+        tileable_graph = self._gen_tileable_graph()
+        chunk_graph = self._gen_chunk_graph()
+        self._clear_for_iteration()
 
-        logger.debug('Begin preparing graph %s with %d tileables to chunk graph.',
-                     self._graph_key, len(tileable_graph))
+        if self._chunk_graph_builder is None:
+            # gen target tileable keys if not provided
+            self._scan_tileable_graph()
 
-        if not self._target_tileable_chunk_ops:
-            for tn in tileable_graph:
-                if not tileable_graph.count_successors(tn):
-                    self._target_tileable_chunk_ops[tn.key] = set()
-                    self._target_tileable_finished[tn.key] = set()
-
-        if self._serialized_chunk_graph:
-            serialized_chunk_graph = self._serialized_chunk_graph
-            chunk_graph = DAG.from_pb(serialized_chunk_graph)
-        else:
-            chunk_graph = DAG()
-
-        key_to_chunk = {c.key: c for c in chunk_graph}
-
-        tileable_key_opid_to_tiled = self._tileable_key_opid_to_tiled
-
-        for t in tileable_graph:
-            self._tileable_key_to_opid[t.key] = t.op.id
-            if (t.key, t.op.id) not in tileable_key_opid_to_tiled:
-                continue
-            t._chunks = [key_to_chunk[k] for k in [tileable_key_opid_to_tiled[(t.key, t.op.id)][-1]]]
-
-        tq = deque()
-        for t in tileable_graph:
-            if t.inputs and not all((ti.key, ti.op.id) in tileable_key_opid_to_tiled for ti in t.inputs):
-                continue
-            tq.append(t)
-
-        while tq:
-            tileable = tq.popleft()
-            if not tileable.is_coarse() or (tileable.key, tileable.op.id) in tileable_key_opid_to_tiled:
-                continue
-            inputs = [tileable_key_opid_to_tiled[(it.key, it.op.id)][-1] for it in tileable.inputs or ()]
-
-            op = tileable.op.copy()
-            _ = op.new_tileables(inputs,  # noqa: F841
-                                 kws=[o.params for o in tileable.op.outputs],
-                                 output_limit=len(tileable.op.outputs),
-                                 **tileable.extra_params)
-
-            total_tiled = []
-            for j, t, to_tile in zip(itertools.count(0), tileable.op.outputs, op.outputs):
-                # replace inputs with tiled ones
-                if not total_tiled:
-                    try:
-                        if isinstance(to_tile.op, Fetch):
-                            td = self.tile_fetch_tileable(tileable)
+            def on_tile(raw_tileables, tileds):
+                first = tileds[0]
+                if any(inp in self._tileable_to_fetch for inp in raw_tileables[0].inputs):
+                    new_inputs = []
+                    for inp in raw_tileables[0].inputs:
+                        if inp in self._tileable_to_fetch:
+                            tiled_inp = get_tiled(self._tileable_to_fetch[inp])
+                            new_inputs.append(tiled_inp)
                         else:
-                            td = self._graph_analyze_pool.submit(
-                                self.context.wraps(handler.dispatch), to_tile).result()
-                    except DataNotReady:
-                        continue
-
-                    if isinstance(td, (tuple, list)):
-                        total_tiled.extend(td)
+                            new_inputs.append(get_tiled(inp))
+                    first.op.inputs = new_inputs
+                if isinstance(first.op, Fetch):
+                    raw_first = raw_tileables[0]
+                    if (raw_first.key, raw_first.op.id) in self._tileable_key_opid_to_tiled:
+                        # fetch op generated by iterative tiling graph builder
+                        tiled = self._tileable_key_opid_to_tiled[raw_first.key, raw_first.op.id][-1]
+                        return [build_fetch_tileable(tiled)]
                     else:
-                        total_tiled.append(td)
+                        return [self.tile_fetch_tileable(first)]
+                else:
+                    return self._graph_analyze_pool.submit(
+                        self.context.wraps(handler.dispatch), first.op).result()
 
-                tiled = total_tiled[j]
-                tileable_key_opid_to_tiled[(t.key, t.op.id)].append(tiled)
+            def on_tile_success(tiled_before, tiled_after):
+                if not isinstance(tiled_before.op, Fetch):
+                    self._tileable_key_opid_to_tiled[
+                        tiled_before.key, tiled_before.op.id].append(tiled_after)
+                return tiled_after
 
-                # add chunks to fine grained graph
-                q = deque([tiled_c if isinstance(tiled_c, ChunkData) else tiled_c.data
-                           for tiled_c in tiled.chunks])
-                input_chunk_keys = set(itertools.chain(*([(it.key, it.id) for it in input.chunks]
-                                                         for input in to_tile.inputs)))
-                while len(q) > 0:
-                    c = q.popleft()
-                    if (c.key, c.id) in input_chunk_keys:
-                        continue
-                    if c not in chunk_graph:
-                        chunk_graph.add_node(c)
-                    for ic in c.inputs or []:
-                        if ic not in chunk_graph:
-                            chunk_graph.add_node(ic)
-                            q.append(ic)
-                        chunk_graph.add_edge(ic, c)
+            self._chunk_graph_builder = IterativeChunkGraphBuilder(
+                on_tile=on_tile, on_tile_success=on_tile_success, compose=compose)
 
-                for succ in tileable_graph.successors(t):
-                    if any((t.key, t.op.id) not in tileable_key_opid_to_tiled for t in succ.inputs):
-                        continue
-                    tq.append(succ)
+        chunk_graph_builder = self._chunk_graph_builder
+        if chunk_graph_builder.prev_tileable_graph is None:
+            # first tile
+            fetch_tileables = [t for t in tileable_graph if isinstance(t.op, Fetch)]
+            cur_chunk_graph = chunk_graph_builder.build(
+                # add fetch tileables to make sure that they won't be fused
+                self._target_tileable_datas + fetch_tileables, tileable_graph)
+        else:
+            # some TilesFail happens before
+            # build tileable graph from failed ops and their inputs
+            failed_tileable_set = set(itertools.chain(
+                *(op.outputs for op in chunk_graph_builder.failed_ops)))
+            tileable_graph_builder = TileableGraphBuilder(
+                inputs_selector=lambda inps: [inp for inp in inps if inp in failed_tileable_set])
+            to_run_tileable_graph = tileable_graph_builder.build(failed_tileable_set)
+            to_fetch_tileables = []
+            for failed_op in chunk_graph_builder.failed_ops:
+                for inp in failed_op.inputs:
+                    if inp not in failed_tileable_set:
+                        fetch_inp = build_fetch_tileable(inp).data
+                        self._tileable_to_fetch[inp] = fetch_inp
+                        to_fetch_tileables.append(fetch_inp)
+                        to_run_tileable_graph.add_node(fetch_inp)
+                        for o in failed_op.outputs:
+                            to_run_tileable_graph.add_edge(fetch_inp, o)
+            cur_chunk_graph = chunk_graph_builder.build(
+                # add to_fetch_tileables to make sure that fetch chunk would not be fused
+                self._target_tileable_datas + to_fetch_tileables,
+                tileable_graph=to_run_tileable_graph)
 
-        # record the chunk nodes in graph
-        reserve_chunk = set()
-        result_chunk_keys = list()
-        for tk, topid in tileable_key_opid_to_tiled:
-            if tk not in self._target_tileable_chunk_ops:
+        target_chunk_keys = set()
+        self._gen_target_info(target_chunk_keys)
+        if chunk_graph_builder.done:
+            self._prune_chunk_graph(cur_chunk_graph, target_chunk_keys)
+
+        for c in list(cur_chunk_graph):
+            if not isinstance(c.op, Fetch):
+                self._op_key_to_chunk[c.op.key].append(c)
+
+            # merge current chunk into self.chunk_graph_cache
+            if isinstance(c.op, Fetch):
                 continue
-            for n in [c.data for t in tileable_key_opid_to_tiled[(tk, topid)] for c in t.chunks]:
-                result_chunk_keys.append(n.key)
-                dq_predecessors = deque([n])
-                while dq_predecessors:
-                    current = dq_predecessors.popleft()
-                    reserve_chunk.update(n.op.outputs)
-                    predecessors = chunk_graph.predecessors(current)
-                    dq_predecessors.extend([p for p in predecessors if p not in reserve_chunk])
-                    reserve_chunk.update(predecessors)
-        # delete redundant chunk
-        for n in list(chunk_graph.iter_nodes()):
-            if n not in reserve_chunk:
-                chunk_graph.remove_node(n)
-            elif isinstance(n.op, Fetch):
-                chunk_graph.remove_node(n)
-
-        if compose:
-            chunk_graph.compose(keys=result_chunk_keys)
-
-        for tk, topid in tileable_key_opid_to_tiled:
-            if tk not in self._target_tileable_chunk_ops:
-                continue
-            for n in tileable_key_opid_to_tiled[(tk, topid)][-1].chunks:
-                self._terminal_chunk_op_tileable[n.op.key].add(tk)
-                self._target_tileable_chunk_ops[tk].add(n.op.key)
-
-        # sync chunk graph to kv store
-        if self._kv_store_ref is not None:
-            graph_path = '/sessions/%s/graphs/%s' % (self._session_id, self._graph_key)
-            self._kv_store_ref.write('%s/chunk_graph' % graph_path,
-                                     base64.b64encode(serialize_graph(chunk_graph, compress=True)),
-                                     _tell=True, _wait=False)
-
-        self._chunk_graph_cache = chunk_graph
-        for n in self._chunk_graph_cache:
-            self._op_key_to_chunk[n.op.key].append(n)
+            chunk_graph.add_node(c)
+            self._chunk_key_id_to_chunk[c.key, c.id] = c
+            for inp in cur_chunk_graph.iter_predecessors(c):
+                if inp in chunk_graph:
+                    chunk_graph.add_edge(inp, c)
+                elif isinstance(inp.op, Fetch):
+                    if (inp.key, inp.id) in self._chunk_key_id_to_chunk:
+                        inp = self._chunk_key_id_to_chunk[inp.key, inp.id]
+                    else:
+                        chunk_graph.add_node(inp)
+                    chunk_graph.add_edge(inp, c)
 
     def _get_worker_slots(self):
         metrics = self._resource_actor_ref.get_workers_meta()
@@ -632,6 +678,13 @@ class GraphActor(SchedulerActor):
     def analyze_graph(self, **kwargs):
         operand_infos = self._operand_infos
         chunk_graph = self.get_chunk_graph()
+
+        # remove fetch chunk if exists
+        if any(isinstance(c.op, Fetch) for c in chunk_graph):
+            chunk_graph = chunk_graph.copy()
+            for c in list(chunk_graph):
+                if isinstance(c.op, Fetch):
+                    chunk_graph.remove_node(c)
 
         if len(chunk_graph) == 0:
             return
@@ -708,7 +761,8 @@ class GraphActor(SchedulerActor):
         for c in chunks:
             # handling predecessor args
             for pn in graph.iter_predecessors(c):
-                predecessor_keys.add(pn.op.key)
+                if not isinstance(pn.op, Fetch):
+                    predecessor_keys.add(pn.op.key)
                 input_chunk_keys.add(pn.key)
                 if graph.count_successors(pn) > 1:
                     shared_input_chunk_keys.add(pn.key)
@@ -747,6 +801,7 @@ class GraphActor(SchedulerActor):
         op_refs = dict()
         meta_op_infos = dict()
         initial_keys = []
+        to_allocate_op_keys = set()
         for op_key in self._op_key_to_chunk:
             chunks = self._op_key_to_chunk[op_key]
             op = chunks[0].op
@@ -775,18 +830,23 @@ class GraphActor(SchedulerActor):
             meta_op_info['state'] = op_info['state'] = state
             meta_op_info['worker'] = op_info.get('worker')
 
-            if op_key in self._terminal_chunk_op_tileable:
+            if op_key in self._terminal_chunk_op_key_to_tileable_key:
                 op_info['is_terminal'] = True
 
             op_cls = get_operand_actor_class(type(op))
             op_uid = op_cls.gen_uid(session_id, op_key)
             scheduler_addr = self.get_scheduler(op_uid)
+            kw = {}
+            # for the **real** initial chunks, we do batch submitting
+            if chunk_graph.count_predecessors(chunks[0]) == 0:
+                kw['allocated'] = True
+                to_allocate_op_keys.add(op_key)
 
             op_refs[op_key] = self.ctx.create_actor(
                 op_cls, session_id, self._graph_key, op_key, op_info.copy(),
                 with_kvstore=self._kv_store_ref is not None,
                 schedulers=self.get_schedulers(),
-                uid=op_uid, address=scheduler_addr, wait=False
+                uid=op_uid, address=scheduler_addr, wait=False, **kw
             )
             if _clean_info:
                 op_info.pop('executable_dag', None)
@@ -821,7 +881,7 @@ class GraphActor(SchedulerActor):
             [future.result() for future in append_futures]
 
             res_applications = [(op_key, op_info) for op_key, op_info in operand_infos.items()
-                                if op_info.get('is_initial', False)]
+                                if op_key in to_allocate_op_keys]
             self._assigner_actor_ref.apply_for_multiple_resources(
                 session_id, res_applications, _tell=True)
 
@@ -833,7 +893,7 @@ class GraphActor(SchedulerActor):
         :param op_key: operand key
         :param final_state: state of the operand
         """
-        tileable_keys = self._terminal_chunk_op_tileable[op_key]
+        tileable_keys = self._terminal_chunk_op_key_to_tileable_key[op_key]
         for tileable_key in tileable_keys:
             self._target_tileable_finished[tileable_key].add(op_key)
             if final_state == GraphState.FAILED:
@@ -841,13 +901,51 @@ class GraphActor(SchedulerActor):
                     self.final_state = GraphState.FAILED
             elif final_state == GraphState.CANCELLED:
                 self.final_state = final_state
-            if self._target_tileable_finished[tileable_key] == self._target_tileable_chunk_ops[tileable_key]:
-                self._terminated_tileables.add(tileable_key)
-                if len(self._terminated_tileables) == len(self._target_tileable_chunk_ops):
-                    self.state = self.final_state if self.final_state is not None else GraphState.SUCCEEDED
-                    self._graph_meta_ref.set_graph_end(_tell=True)
+            if self._target_tileable_finished[tileable_key] == self._terminal_tileable_key_to_chunk_op_keys[tileable_key]:
+                self._terminated_tileable_keys.add(tileable_key)
+                self._all_terminated_tileable_keys.add(tileable_key)
+                if len(self._terminated_tileable_keys) == len(self._terminal_tileable_key_to_chunk_op_keys):
+                    # update shape if tileable or its chunks have unknown shape
+                    self._update_tileable_and_its_chunk_shapes()
+                    if self._chunk_graph_builder.done:
+                        if self._chunk_graph_builder.prev_tileable_graph is not None:
+                            # if failed before, clear intermediate data
+                            to_free_tileable_keys = \
+                                self._all_terminated_tileable_keys - set(self._target_tileable_keys)
+                            [self.free_tileable_data(k) for k in to_free_tileable_keys]
+                        self.state = self.final_state if self.final_state is not None else GraphState.SUCCEEDED
+                        self._graph_meta_ref.set_graph_end(_tell=True)
+                    else:
+                        self._execute_graph(compose=self._chunk_graph_builder.is_compose)
         if exc is not None:
             self._graph_meta_ref.set_exc_info(exc, _tell=True, _wait=False)
+
+    def _update_tileable_and_its_chunk_shapes(self):
+        need_update_tileable_to_tiled = dict()
+        for tileable in self._chunk_graph_builder.prev_tileable_graph:
+            if tileable.key in self._target_tileable_finished:
+                tiled = self._tileable_key_opid_to_tiled[tileable.key, tileable.op.id][-1]
+                if not has_unknown_shape(tiled):
+                    continue
+                need_update_tileable_to_tiled[tileable] = tiled
+
+        if len(need_update_tileable_to_tiled) == 0:
+            return
+
+        need_update_chunks = list(c for t in need_update_tileable_to_tiled.values() for c in t.chunks)
+        chunk_metas = self.chunk_meta.batch_get_chunk_meta(
+            self._session_id, list(c.key for c in need_update_chunks))
+        for chunk, chunk_meta in zip(need_update_chunks, chunk_metas):
+            chunk.data._shape = chunk_meta.chunk_shape
+
+        for tileable, tiled in need_update_tileable_to_tiled.items():
+            chunk_idx_to_shape = {c.index: c.shape for c in tiled.chunks}
+            nsplits = calc_nsplits(chunk_idx_to_shape)
+            tiled._nsplits = nsplits
+            if any(np.isnan(s) for s in tileable.shape):
+                shape = tuple(sum(ns) for ns in nsplits)
+                tileable._update_shape(shape)
+                tiled._update_shape(shape)
 
     @log_unhandled
     def remove_finished_terminal(self, op_key):
@@ -855,17 +953,17 @@ class GraphActor(SchedulerActor):
         Remove a terminal operand from finished set as the data is lost.
         :param op_key: operand key
         """
-        tileable_keys = self._terminal_chunk_op_tileable[op_key]
+        tileable_keys = self._terminal_chunk_op_key_to_tileable_key[op_key]
         for tileable_key in tileable_keys:
             self._target_tileable_finished[tileable_key].difference_update([op_key])
-            self._terminated_tileables.difference_update([tileable_key])
+            self._terminated_tileable_keys.difference_update([tileable_key])
 
     def dump_unfinished_terminals(self):  # pragma: no cover
         """
         Dump unfinished terminal chunks into logger, only for debug purposes.
         """
         unfinished_dict = dict()
-        for tileable_key, chunk_ops in self._target_tileable_chunk_ops.items():
+        for tileable_key, chunk_ops in self._terminal_tileable_key_to_chunk_op_keys.items():
             executed_ops = self._target_tileable_finished.get(tileable_key, ())
             unfinished = sorted(set(chunk_ops) - set(executed_ops))
             if unfinished:
@@ -970,30 +1068,34 @@ class GraphActor(SchedulerActor):
         return list(fetch_graph)[0]
 
     @log_unhandled
-    def fetch_tileable_result(self, tileable_key):
+    @enter_build_mode
+    def fetch_tileable_result(self, tileable_key, _check=True):
+        # this function is for test usage
         from ..executor import Executor
         from ..worker.transfer import ResultSenderActor
 
-        # TODO for test
         tileable = self._get_tileable_by_key(tileable_key)
-        if tileable_key not in self._terminated_tileables:
+        if _check and tileable_key not in self._terminated_tileable_keys:
             return None
 
         ctx = dict()
-        for chunk_key in [c.key for c in tileable.chunks]:
-            if chunk_key in ctx:
-                continue
-            endpoints = self.chunk_meta.get_workers(self._session_id, chunk_key)
+        for chunk in tileable.chunks:
+            endpoints = self.chunk_meta.get_workers(self._session_id, chunk.key)
             sender_ref = self.ctx.actor_ref(ResultSenderActor.default_uid(), address=endpoints[-1])
-            ctx[chunk_key] = dataserializer.loads(sender_ref.fetch_data(self._session_id, chunk_key))
+            ctx[chunk.key] = dataserializer.loads(sender_ref.fetch_data(self._session_id, chunk.key))
 
         if len(tileable.chunks) == 1:
             return dataserializer.dumps(ctx[tileable.chunks[0].key])
 
-        tileable = build_fetch_tileable(tileable)
-
+        fetch_tileable = build_fetch_tileable(tileable)
+        concat_chunk = fetch_tileable.op.concat_tileable_chunks(fetch_tileable).chunks[0].data
+        chunk_graph = DAG()
+        chunk_graph.add_node(concat_chunk)
+        for fetch_chunk in fetch_tileable.chunks:
+            chunk_graph.add_node(fetch_chunk.data)
+            chunk_graph.add_edge(fetch_chunk.data, concat_chunk)
         executor = Executor(storage=ctx)
-        concat_result = executor.execute_tileable(tileable, concat=True)[0]
+        concat_result = executor.execute_graph(chunk_graph, keys=[concat_chunk.key])[0]
         return dataserializer.dumps(concat_result)
 
     @log_unhandled

--- a/mars/scheduler/operands/common.py
+++ b/mars/scheduler/operands/common.py
@@ -32,7 +32,7 @@ class OperandActor(BaseOperandActor):
     """
     Actor handling the whole lifecycle of a particular operand instance
     """
-    def __init__(self, session_id, graph_id, op_key, op_info, worker=None, **kwargs):
+    def __init__(self, session_id, graph_id, op_key, op_info, worker=None, allocated=False, **kwargs):
         super(OperandActor, self).__init__(
             session_id, graph_id, op_key, op_info, worker=worker, **kwargs)
 
@@ -59,7 +59,7 @@ class OperandActor(BaseOperandActor):
         self._input_worker_scores = dict()
         self._worker_scores = dict()
 
-        self._allocated = self._is_initial
+        self._allocated = allocated
         self._submit_promise = None
 
         # record the exception info when failed to execute the graph
@@ -345,7 +345,7 @@ class OperandActor(BaseOperandActor):
             input_chunks = self._input_chunks
 
         # submit job
-        if len(input_chunks) != self._input_chunks:
+        if set(input_chunks) != set(self._input_chunks) or self._executable_dag is None:
             exec_graph = self._graph_refs[0].get_executable_operand_dag(self._op_key, input_chunks)
         else:
             exec_graph = self._executable_dag

--- a/mars/scheduler/session.py
+++ b/mars/scheduler/session.py
@@ -164,10 +164,10 @@ class SessionActor(SchedulerActor):
     def graph_state(self, graph_key):
         return self._graph_refs[graph_key].get_state()
 
-    def fetch_result(self, graph_key, tileable_key):
+    def fetch_result(self, graph_key, tileable_key, check=False):
         # TODO just for test, should move to web handler
         graph_ref = self._graph_refs[graph_key]
-        return graph_ref.fetch_tileable_result(tileable_key)
+        return graph_ref.fetch_tileable_result(tileable_key, _check=check)
 
     @log_unhandled
     def handle_worker_change(self, adds, removes):

--- a/mars/tensor/arithmetic/core.py
+++ b/mars/tensor/arithmetic/core.py
@@ -22,7 +22,7 @@ from ...compat import lrange
 from ...core import ExecutableTuple
 from ...serialize import ValueType, AnyField, DictField, KeyField, StringField
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..core import Tensor, TensorOrder
 from ..datasource import tensor as astensor
 from ..utils import unify_chunks, broadcast_shape, check_out_param, filter_inputs, check_order
@@ -36,7 +36,7 @@ class TensorElementWise(TensorOperandMixin):
     @classmethod
     def tile(cls, op):
         if len(op.inputs) > 1:
-            check_chunks_unknown_shape(op.inputs, TilesFail)
+            check_chunks_unknown_shape(op.inputs, TilesError)
         inputs = unify_chunks(*[(input, lrange(input.ndim)[::-1]) for input in op.inputs])
 
         chunk_shapes = [t.chunk_shape for t in inputs]

--- a/mars/tensor/arithmetic/core.py
+++ b/mars/tensor/arithmetic/core.py
@@ -21,6 +21,8 @@ import numpy as np
 from ...compat import lrange
 from ...core import ExecutableTuple
 from ...serialize import ValueType, AnyField, DictField, KeyField, StringField
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..core import Tensor, TensorOrder
 from ..datasource import tensor as astensor
 from ..utils import unify_chunks, broadcast_shape, check_out_param, filter_inputs, check_order
@@ -33,6 +35,8 @@ class TensorElementWise(TensorOperandMixin):
 
     @classmethod
     def tile(cls, op):
+        if len(op.inputs) > 1:
+            check_chunks_unknown_shape(op.inputs, TilesFail)
         inputs = unify_chunks(*[(input, lrange(input.ndim)[::-1]) for input in op.inputs])
 
         chunk_shapes = [t.chunk_shape for t in inputs]
@@ -538,7 +542,8 @@ class TensorOutBinOp(TensorOperand, TensorElementWiseWithInputs):
 
         inputs = filter_inputs([x, out1, out2, where])
         t1, t2 = self.new_tensors(inputs, shape, dtype=dtype,
-                                  kws=[{'order': order1}, {'order': order2}])
+                                  kws=[{'order': order1, 'side': 'left'},
+                                       {'order': order2, 'side': 'right'}])
 
         if out1 is None and out2 is None:
             return ExecutableTuple([t1, t2])

--- a/mars/tensor/base/argwhere.py
+++ b/mars/tensor/base/argwhere.py
@@ -21,7 +21,7 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import KeyField
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..utils import recursive_tile
 from ..operands import TensorHasInput, TensorOperandMixin
 from ..datasource import tensor as astensor
@@ -53,7 +53,7 @@ class TensorArgwhere(TensorHasInput, TensorOperandMixin):
         in_tensor = op.input
         out_tensor = op.outputs[0]
 
-        check_chunks_unknown_shape([in_tensor], TilesFail)
+        check_chunks_unknown_shape([in_tensor], TilesError)
 
         flattened = ravel(in_tensor)._inplace_tile()
         indices = arange(flattened.size, dtype=np.intp, chunks=flattened.nsplits)

--- a/mars/tensor/base/argwhere.py
+++ b/mars/tensor/base/argwhere.py
@@ -20,6 +20,8 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...serialize import KeyField
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..utils import recursive_tile
 from ..operands import TensorHasInput, TensorOperandMixin
 from ..datasource import tensor as astensor
@@ -51,7 +53,9 @@ class TensorArgwhere(TensorHasInput, TensorOperandMixin):
         in_tensor = op.input
         out_tensor = op.outputs[0]
 
-        flattened = ravel(in_tensor).single_tiles()
+        check_chunks_unknown_shape([in_tensor], TilesFail)
+
+        flattened = ravel(in_tensor)._inplace_tile()
         indices = arange(flattened.size, dtype=np.intp, chunks=flattened.nsplits)
         indices = indices[flattened]
         dim_indices = unravel_index(indices, in_tensor.shape)

--- a/mars/tensor/base/copyto.py
+++ b/mars/tensor/base/copyto.py
@@ -22,7 +22,7 @@ from ... import opcodes as OperandDef
 from ...serialize import KeyField, StringField
 from ...compat import lrange
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..utils import unify_chunks, broadcast_shape
 from ..operands import TensorOperand, TensorOperandMixin
 from ..datasource import tensor as astensor
@@ -120,7 +120,7 @@ class TensorCopyTo(TensorOperand, TensorOperandMixin):
 
     @classmethod
     def tile(cls, op):
-        check_chunks_unknown_shape(op.inputs, TilesFail)
+        check_chunks_unknown_shape(op.inputs, TilesError)
         inputs = unify_chunks(*[(input, lrange(input.ndim)[::-1]) for input in op.inputs])
         output = op.outputs[0]
 

--- a/mars/tensor/base/copyto.py
+++ b/mars/tensor/base/copyto.py
@@ -21,6 +21,8 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, StringField
 from ...compat import lrange
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..utils import unify_chunks, broadcast_shape
 from ..operands import TensorOperand, TensorOperandMixin
 from ..datasource import tensor as astensor
@@ -118,6 +120,7 @@ class TensorCopyTo(TensorOperand, TensorOperandMixin):
 
     @classmethod
     def tile(cls, op):
+        check_chunks_unknown_shape(op.inputs, TilesFail)
         inputs = unify_chunks(*[(input, lrange(input.ndim)[::-1]) for input in op.inputs])
         output = op.outputs[0]
 

--- a/mars/tensor/base/digitize.py
+++ b/mars/tensor/base/digitize.py
@@ -19,6 +19,8 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, AnyField, BoolField
 from ...lib.sparse.core import get_array_module
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..operands import TensorHasInput, TensorOperandMixin, Tensor
 from ..datasource import tensor as astensor
 from ..array_utils import as_same_device, device
@@ -68,7 +70,8 @@ class TensorDigitize(TensorHasInput, TensorOperandMixin):
         bins = op.bins
         if len(op.inputs) == 2:
             # bins is TensorData
-            bins = bins.rechunk(tensor.shape).single_tiles().chunks[0]
+            check_chunks_unknown_shape([bins], TilesFail)
+            bins = bins.rechunk(tensor.shape)._inplace_tile().chunks[0]
 
         out_chunks = []
         for c in in_tensor.chunks:

--- a/mars/tensor/base/digitize.py
+++ b/mars/tensor/base/digitize.py
@@ -20,7 +20,7 @@ from ... import opcodes as OperandDef
 from ...serialize import KeyField, AnyField, BoolField
 from ...lib.sparse.core import get_array_module
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..operands import TensorHasInput, TensorOperandMixin, Tensor
 from ..datasource import tensor as astensor
 from ..array_utils import as_same_device, device
@@ -70,7 +70,7 @@ class TensorDigitize(TensorHasInput, TensorOperandMixin):
         bins = op.bins
         if len(op.inputs) == 2:
             # bins is TensorData
-            check_chunks_unknown_shape([bins], TilesFail)
+            check_chunks_unknown_shape([bins], TilesError)
             bins = bins.rechunk(tensor.shape)._inplace_tile().chunks[0]
 
         out_chunks = []

--- a/mars/tensor/base/isin.py
+++ b/mars/tensor/base/isin.py
@@ -19,7 +19,7 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, BoolField
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..operands import TensorOperand, TensorOperandMixin
 from ..datasource import tensor as astensor
 from ..array_utils import as_same_device, device
@@ -73,7 +73,7 @@ class TensorIsIn(TensorOperand, TensorOperandMixin):
         out_tensor = op.outputs[0]
 
         if len(test_elements.chunks) != 1:
-            check_chunks_unknown_shape([test_elements], TilesFail)
+            check_chunks_unknown_shape([test_elements], TilesError)
             test_elements = test_elements.rechunk(len(test_elements))._inplace_tile()
         test_elements_chunk = test_elements.chunks[0]
 

--- a/mars/tensor/base/isin.py
+++ b/mars/tensor/base/isin.py
@@ -18,6 +18,8 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, BoolField
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..operands import TensorOperand, TensorOperandMixin
 from ..datasource import tensor as astensor
 from ..array_utils import as_same_device, device
@@ -71,7 +73,8 @@ class TensorIsIn(TensorOperand, TensorOperandMixin):
         out_tensor = op.outputs[0]
 
         if len(test_elements.chunks) != 1:
-            test_elements = test_elements.rechunk(len(test_elements)).single_tiles()
+            check_chunks_unknown_shape([test_elements], TilesFail)
+            test_elements = test_elements.rechunk(len(test_elements))._inplace_tile()
         test_elements_chunk = test_elements.chunks[0]
 
         out_chunks = []

--- a/mars/tensor/base/repeat.py
+++ b/mars/tensor/base/repeat.py
@@ -22,7 +22,7 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, AnyField, Int32Field
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..core import Tensor, TENSOR_TYPE, CHUNK_TYPE, TensorOrder
 from ..utils import broadcast_shape, unify_chunks
 from ..operands import TensorHasInput, TensorOperandMixin
@@ -102,7 +102,7 @@ class TensorRepeat(TensorHasInput, TensorOperandMixin):
         ax = axis or 0
         out = op.outputs[0]
 
-        check_chunks_unknown_shape(op.inputs, TilesFail)
+        check_chunks_unknown_shape(op.inputs, TilesError)
 
         if isinstance(repeats, TENSOR_TYPE):
             a, repeats = unify_chunks(a, (repeats, (ax,)))

--- a/mars/tensor/base/repeat.py
+++ b/mars/tensor/base/repeat.py
@@ -21,6 +21,8 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, AnyField, Int32Field
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..core import Tensor, TENSOR_TYPE, CHUNK_TYPE, TensorOrder
 from ..utils import broadcast_shape, unify_chunks
 from ..operands import TensorHasInput, TensorOperandMixin
@@ -100,6 +102,8 @@ class TensorRepeat(TensorHasInput, TensorOperandMixin):
         ax = axis or 0
         out = op.outputs[0]
 
+        check_chunks_unknown_shape(op.inputs, TilesFail)
+
         if isinstance(repeats, TENSOR_TYPE):
             a, repeats = unify_chunks(a, (repeats, (ax,)))
 
@@ -114,7 +118,7 @@ class TensorRepeat(TensorHasInput, TensorOperandMixin):
                 if split % s != 0:
                     new_nsplit.append(split % s)
 
-            a = a.rechunk({ax: new_nsplit}).single_tiles()
+            a = a.rechunk({ax: new_nsplit})._inplace_tile()
 
         out_chunks = []
         ax_cum_count = np.cumsum((0,) + a.nsplits[ax])

--- a/mars/tensor/base/searchsorted.py
+++ b/mars/tensor/base/searchsorted.py
@@ -22,7 +22,7 @@ from ...serialize import KeyField, StringField, AnyField, Int64Field, Int32Field
 from ...config import options
 from ...compat import enum
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..operands import TensorOperand, TensorOperandMixin
 from ..core import TENSOR_TYPE, TensorOrder
 from ..datasource.array import tensor as astensor
@@ -131,7 +131,7 @@ class TensorSearchsorted(TensorOperand, TensorOperandMixin):
 
     @classmethod
     def _tile_tree_reduction(cls, op, a, v, out):
-        check_chunks_unknown_shape(op.inputs, TilesFail)
+        check_chunks_unknown_shape(op.inputs, TilesError)
 
         combine_size = op.combine_size or options.combine_size
         input_len = len(op.inputs)

--- a/mars/tensor/base/searchsorted.py
+++ b/mars/tensor/base/searchsorted.py
@@ -21,6 +21,8 @@ from ... import opcodes as OperandDef
 from ...serialize import KeyField, StringField, AnyField, Int64Field, Int32Field
 from ...config import options
 from ...compat import enum
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..operands import TensorOperand, TensorOperandMixin
 from ..core import TENSOR_TYPE, TensorOrder
 from ..datasource.array import tensor as astensor
@@ -129,6 +131,8 @@ class TensorSearchsorted(TensorOperand, TensorOperandMixin):
 
     @classmethod
     def _tile_tree_reduction(cls, op, a, v, out):
+        check_chunks_unknown_shape(op.inputs, TilesFail)
+
         combine_size = op.combine_size or options.combine_size
         input_len = len(op.inputs)
         v_chunks = [v] if input_len == 1 else v.chunks

--- a/mars/tensor/base/sort.py
+++ b/mars/tensor/base/sort.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...serialize import ValueType, Int32Field, StringField, ListField, BoolField
-from ...tiles import NotSupportTile, TilesFail
+from ...tiles import NotSupportTile, TilesError
 from ...utils import get_shuffle_input_keys_idxes
 from ..operands import TensorOperand, TensorOperandMixin, \
     TensorShuffleMap, TensorShuffleReduce, TensorShuffleProxy, TensorOrder
@@ -115,7 +115,7 @@ class PSRSSorter(object):
         # rechunk to ensure all chunks on axis have rough same size
         axis_chunk_shape = min(axis_chunk_shape, int(np.sqrt(axis_shape)))
         if np.isnan(axis_shape) or any(np.isnan(s) for s in in_tensor.nsplits[op.axis]):
-            raise TilesFail('fail to tile because either the shape of '
+            raise TilesError('fail to tile because either the shape of '
                             'input tensor on axis {} has unknown shape or chunk shape'.format(op.axis))
         chunk_size = int(axis_shape / axis_chunk_shape)
         chunk_sizes = [chunk_size for _ in range(int(axis_shape // chunk_size))]

--- a/mars/tensor/base/tests/test_base_execute.py
+++ b/mars/tensor/base/tests/test_base_execute.py
@@ -223,9 +223,16 @@ class Test(unittest.TestCase):
         arr = tensor(raw, chunk_size=2)
         arr2 = broadcast_to(arr, (5, 10, 5, 6))
 
-        res = self.executor.execute_tensor(arr2, concat=True)
+        res = self.executor.execute_tensor(arr2, concat=True)[0]
+        np.testing.assert_array_equal(res, np.broadcast_to(raw, (5, 10, 5, 6)))
 
-        self.assertTrue(np.array_equal(res[0], np.broadcast_to(raw, (5, 10, 5, 6))))
+        # test chunk with unknown shape
+        arr1 = mt.random.rand(3, 4, chunk_size=2)
+        arr2 = mt.random.permutation(arr1)
+        arr3 = broadcast_to(arr2, (2, 3, 4))
+
+        res = self.executor.execute_tensor(arr3, concat=True)[0]
+        self.assertEqual(res.shape, (2, 3, 4))
 
     def testBroadcastArraysExecutions(self):
         x_data = [[1, 2, 3]]

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -20,7 +20,7 @@ from ... import opcodes as OperandDef
 from ...serialize import BoolField, Int32Field, Int64Field
 from ...utils import get_shuffle_input_keys_idxes, check_chunks_unknown_shape
 from ...config import options
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..operands import TensorOperand, TensorOperandMixin, \
     TensorShuffleMap, TensorShuffleReduce, TensorShuffleProxy
 from ..array_utils import as_same_device, device
@@ -161,10 +161,10 @@ class TensorUnique(TensorOperand, TensorOperandMixin):
                 if axis == op.axis:
                     continue
                 if np.isnan(inp.shape[axis]):
-                    raise TilesFail('input tensor has unknown shape '
+                    raise TilesError('input tensor has unknown shape '
                                     'on axis {}'.format(axis))
                 new_chunk_size[axis] = inp.shape[axis]
-            check_chunks_unknown_shape([inp], TilesFail)
+            check_chunks_unknown_shape([inp], TilesError)
             inp = inp.rechunk(new_chunk_size)._inplace_tile()
 
         aggregate_size = op.aggregate_size

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -18,8 +18,9 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...serialize import BoolField, Int32Field, Int64Field
-from ...utils import get_shuffle_input_keys_idxes
+from ...utils import get_shuffle_input_keys_idxes, check_chunks_unknown_shape
 from ...config import options
+from ...tiles import TilesFail
 from ..operands import TensorOperand, TensorOperandMixin, \
     TensorShuffleMap, TensorShuffleReduce, TensorShuffleProxy
 from ..array_utils import as_same_device, device
@@ -159,8 +160,12 @@ class TensorUnique(TensorOperand, TensorOperandMixin):
             for axis in range(inp.ndim):
                 if axis == op.axis:
                     continue
+                if np.isnan(inp.shape[axis]):
+                    raise TilesFail('input tensor has unknown shape '
+                                    'on axis {}'.format(axis))
                 new_chunk_size[axis] = inp.shape[axis]
-            inp = inp.rechunk(new_chunk_size).single_tiles()
+            check_chunks_unknown_shape([inp], TilesFail)
+            inp = inp.rechunk(new_chunk_size)._inplace_tile()
 
         aggregate_size = op.aggregate_size
         if aggregate_size is None:

--- a/mars/tensor/base/where.py
+++ b/mars/tensor/base/where.py
@@ -22,7 +22,7 @@ from ... import opcodes as OperandDef
 from ...serialize import KeyField
 from ...compat import lrange
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..utils import broadcast_shape, unify_chunks
 from ..array_utils import as_same_device, device
 from ..core import TENSOR_TYPE
@@ -65,7 +65,7 @@ class TensorWhere(TensorOperand, TensorOperandMixin):
 
     @classmethod
     def tile(cls, op):
-        check_chunks_unknown_shape(op.inputs, TilesFail)
+        check_chunks_unknown_shape(op.inputs, TilesError)
         inputs = unify_chunks(*[(input, lrange(input.ndim)[::-1]) for input in op.inputs])
         chunk_shapes = [t.chunk_shape if isinstance(t, TENSOR_TYPE) else t
                         for t in inputs]

--- a/mars/tensor/base/where.py
+++ b/mars/tensor/base/where.py
@@ -21,6 +21,8 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import KeyField
 from ...compat import lrange
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..utils import broadcast_shape, unify_chunks
 from ..array_utils import as_same_device, device
 from ..core import TENSOR_TYPE
@@ -63,6 +65,7 @@ class TensorWhere(TensorOperand, TensorOperandMixin):
 
     @classmethod
     def tile(cls, op):
+        check_chunks_unknown_shape(op.inputs, TilesFail)
         inputs = unify_chunks(*[(input, lrange(input.ndim)[::-1]) for input in op.inputs])
         chunk_shapes = [t.chunk_shape if isinstance(t, TENSOR_TYPE) else t
                         for t in inputs]

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -23,7 +23,6 @@ import numpy as np
 
 from ..core import Entity, TileableEntity, ChunkData, Chunk, HasShapeTileableData, \
     build_mode, Serializable
-from ..tiles import handler
 from ..serialize import ProviderType, ValueType, DataTypeField, ListField, TupleField, \
     BoolField, StringField, AnyField
 from ..compat import Enum
@@ -269,12 +268,6 @@ class Tensor(TileableEntity):
 
     def __len__(self):
         return len(self._data)
-
-    def tiles(self):
-        return handler.tiles(self)
-
-    def single_tiles(self):
-        return handler.single_tiles(self)
 
     @property
     def shape(self):
@@ -667,7 +660,7 @@ class MutableTensor(Entity):
         output_shape = calc_shape(self.shape, tensor_index)
 
         index_tensor_op = TensorIndex(dtype=self.dtype, sparse=False, indexes=tensor_index)
-        index_tensor = index_tensor_op.new_tensor([self], tuple(output_shape)).single_tiles()
+        index_tensor = index_tensor_op.new_tensor([self], tuple(output_shape))._inplace_tile()
         output_chunks = index_tensor.chunks
 
         is_scalar = np.isscalar(value) or isinstance(value, tuple) and self.dtype.fields

--- a/mars/tensor/datasource/array.py
+++ b/mars/tensor/datasource/array.py
@@ -20,7 +20,7 @@ from ...lib.sparse.core import issparse, get_array_module, cp, cps, sps
 from ...lib.sparse import SparseNDArray
 from ...utils import on_serialize_shape, on_deserialize_shape
 from ...serialize import ValueType, NDArrayField, TupleField
-from ..core import TENSOR_TYPE, TensorOrder
+from ..core import TENSOR_TYPE, TensorOrder, TensorData, Tensor
 from ..utils import get_chunk_slices
 from ..array_utils import array_module
 from .core import TensorNoInput
@@ -145,6 +145,8 @@ def _from_spmatrix(spmatrix, dtype=None, chunk_size=None, gpu=None):
 def tensor(data, dtype=None, order='K', chunk_size=None, gpu=None, sparse=False):
     order = order or 'K'
     if isinstance(data, TENSOR_TYPE):
+        if isinstance(data, TensorData):
+            data = Tensor(data)
         return data.astype(dtype or data.dtype, order=order, copy=False)
     elif isinstance(data, (tuple, list)) and len(data) > 0 and \
             all(isinstance(d, TENSOR_TYPE) for d in data):

--- a/mars/tensor/datasource/diag.py
+++ b/mars/tensor/datasource/diag.py
@@ -21,7 +21,7 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, Int32Field
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..core import TENSOR_TYPE
 from ...lib.sparse import diag as sparse_diag
 from ...lib.sparse.core import issparse, get_array_module, get_sparse_module
@@ -63,7 +63,7 @@ class TensorDiagBase(object):
     @classmethod
     def tile(cls, op):
         if op.inputs:
-            check_chunks_unknown_shape(op.inputs, TilesFail)
+            check_chunks_unknown_shape(op.inputs, TilesError)
         tensor = op.outputs[0]
 
         # op can be TensorDiag or TensorEye
@@ -149,7 +149,7 @@ class TensorDiag(TensorDiagBase, TensorHasInput):
         k = op.k
         idx = itertools.count(0)
         if v.ndim == 2:
-            check_chunks_unknown_shape(op.inputs, TilesFail)
+            check_chunks_unknown_shape(op.inputs, TilesError)
             chunks = []
             nsplit = []
 

--- a/mars/tensor/datasource/diag.py
+++ b/mars/tensor/datasource/diag.py
@@ -20,6 +20,8 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, Int32Field
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..core import TENSOR_TYPE
 from ...lib.sparse import diag as sparse_diag
 from ...lib.sparse.core import issparse, get_array_module, get_sparse_module
@@ -60,6 +62,8 @@ class TensorDiagBase(object):
 
     @classmethod
     def tile(cls, op):
+        if op.inputs:
+            check_chunks_unknown_shape(op.inputs, TilesFail)
         tensor = op.outputs[0]
 
         # op can be TensorDiag or TensorEye
@@ -145,6 +149,7 @@ class TensorDiag(TensorDiagBase, TensorHasInput):
         k = op.k
         idx = itertools.count(0)
         if v.ndim == 2:
+            check_chunks_unknown_shape(op.inputs, TilesFail)
             chunks = []
             nsplit = []
 

--- a/mars/tensor/datasource/tests/test_datasource.py
+++ b/mars/tensor/datasource/tests/test_datasource.py
@@ -187,28 +187,28 @@ class Test(TestBase):
 
     def testOnes(self):
         tensor = ones((10, 10, 8), chunk_size=(3, 3, 5))
-        tensor.tiles()
+        tensor = tensor.tiles()
         self.assertEqual(tensor.shape, (10, 10, 8))
         self.assertEqual(len(tensor.chunks), 32)
 
         tensor = ones((10, 3), chunk_size=(4, 2))
-        tensor.tiles()
+        tensor = tensor.tiles()
         self.assertEqual(tensor.shape, (10, 3))
 
         chunk = tensor.cix[1, 1]
         self.assertEqual(tensor.get_chunk_slices(chunk.index), (slice(4, 8), slice(2, 3)))
 
         tensor = ones((10, 5), chunk_size=(2, 3), gpu=True)
-        tensor.tiles()
+        tensor = tensor.tiles()
 
         self.assertTrue(tensor.op.gpu)
         self.assertTrue(tensor.chunks[0].op.gpu)
 
         tensor1 = ones((10, 10, 8), chunk_size=(3, 3, 5))
-        tensor1.tiles()
+        tensor1 = tensor1.tiles()
 
         tensor2 = ones((10, 10, 8), chunk_size=(3, 3, 5))
-        tensor2.tiles()
+        tensor2 = tensor2.tiles()
 
         self.assertEqual(tensor1.chunks[0].op.key, tensor2.chunks[0].op.key)
         self.assertEqual(tensor1.chunks[0].key, tensor2.chunks[0].key)
@@ -236,7 +236,7 @@ class Test(TestBase):
         self.assertNotEqual(chunk1.key, chunk2.key)
 
         tensor = ones((100, 100), chunk_size=50)
-        tensor.tiles()
+        tensor = tensor.tiles()
         self.assertEqual(len({c.op.key for c in tensor.chunks}), 1)
         self.assertEqual(len({c.key for c in tensor.chunks}), 1)
 
@@ -263,7 +263,7 @@ class Test(TestBase):
         self.assertNotEqual(chunk1.key, chunk2.key)
 
         tensor = zeros((100, 100), chunk_size=50)
-        tensor.tiles()
+        tensor = tensor.tiles()
         self.assertEqual(len({c.op.key for c in tensor.chunks}), 1)
         self.assertEqual(len({c.key for c in tensor.chunks}), 1)
 
@@ -273,7 +273,7 @@ class Test(TestBase):
         data = np.random.random((10, 3))
         t = tensor(data, chunk_size=2)
         self.assertFalse(t.op.gpu)
-        t.tiles()
+        t = t.tiles()
         self.assertTrue((t.chunks[0].op.data == data[:2, :2]).all())
         self.assertTrue((t.chunks[1].op.data == data[:2, 2:3]).all())
         self.assertTrue((t.chunks[2].op.data == data[2:4, :2]).all())
@@ -284,7 +284,7 @@ class Test(TestBase):
         self.assertNotEqual(t.key, tensor(np.random.random((10, 3)), chunk_size=2).tiles().key)
 
         t = tensor(data, chunk_size=2, gpu=True)
-        t.tiles()
+        t = t.tiles()
 
         self.assertTrue(t.op.gpu)
         self.assertTrue(t.chunks[0].op.gpu)
@@ -403,7 +403,7 @@ class Test(TestBase):
         t = arange(10, chunk_size=3)
 
         self.assertFalse(t.op.gpu)
-        t.tiles()
+        t = t.tiles()
 
         self.assertEqual(t.shape, (10,))
         self.assertEqual(t.nsplits, ((3, 3, 3, 1),))
@@ -411,7 +411,7 @@ class Test(TestBase):
         self.assertEqual(t.chunks[1].op.stop, 6)
 
         t = arange(0, 10, 3, chunk_size=2)
-        t.tiles()
+        t = t.tiles()
 
         self.assertEqual(t.shape, (4,))
         self.assertEqual(t.nsplits, ((2, 2),))
@@ -434,14 +434,14 @@ class Test(TestBase):
 
         self.assertEqual(t.shape, (4,))
         self.assertFalse(t.op.gpu)
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(t.nsplits, ((2, 2),))
 
         v = tensor(np.arange(16).reshape(4, 4), chunk_size=(2, 3))
         t = diag(v)
 
         self.assertEqual(t.shape, (4,))
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(t.nsplits, ((2, 1, 1),))
 
         # test 1-d, k == 0
@@ -449,7 +449,7 @@ class Test(TestBase):
         t = diag(v, sparse=True)
 
         self.assertEqual(t.shape, (3, 3))
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(t.nsplits, ((2, 1), (2, 1)))
         self.assertEqual(len([c for c in t.chunks
                               if c.op.__class__.__name__ == 'TensorDiag']), 2)
@@ -460,35 +460,35 @@ class Test(TestBase):
         t = diag(v)
 
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6)).shape)
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
 
         v = tensor(np.arange(24).reshape(4, 6), chunk_size=2)
 
         t = diag(v, k=1)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=1).shape)
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
 
         t = diag(v, k=2)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=2).shape)
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
 
         t = diag(v, k=-1)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=-1).shape)
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
 
         t = diag(v, k=-2)
         self.assertEqual(t.shape, np.diag(np.arange(24).reshape(4, 6), k=-2).shape)
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(tuple(sum(s) for s in t.nsplits), t.shape)
 
         # test tiled zeros' keys
         a = arange(5, chunk_size=2)
         t = diag(a)
-        t.tiles()
+        t = t.tiles()
         # 1 and 2 of t.chunks is ones, they have different shapes
         self.assertNotEqual(t.chunks[1].op.key, t.chunks[2].op.key)
 
@@ -497,7 +497,7 @@ class Test(TestBase):
 
         self.assertEqual(a.shape, (5,))
 
-        a.tiles()
+        a = a.tiles()
         self.assertEqual(a.nsplits, ((2, 2, 1),))
         self.assertEqual(a.chunks[0].op.start, 2.)
         self.assertEqual(a.chunks[0].op.stop, 2.25)
@@ -510,7 +510,7 @@ class Test(TestBase):
 
         self.assertEqual(a.shape, (5,))
 
-        a.tiles()
+        a = a.tiles()
         self.assertEqual(a.nsplits, ((2, 2, 1),))
         self.assertEqual(a.chunks[0].op.start, 2.)
         self.assertEqual(a.chunks[0].op.stop, 2.2)
@@ -530,7 +530,7 @@ class Test(TestBase):
 
         self.assertFalse(t.op.gpu)
 
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorTriu)
         self.assertIsInstance(t.chunks[1].op, TensorTriu)
@@ -539,7 +539,7 @@ class Test(TestBase):
 
         t = triu(a, k=1)
 
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorTriu)
         self.assertIsInstance(t.chunks[1].op, TensorTriu)
@@ -548,7 +548,7 @@ class Test(TestBase):
 
         t = triu(a, k=2)
 
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorZeros)
         self.assertIsInstance(t.chunks[1].op, TensorTriu)
@@ -557,7 +557,7 @@ class Test(TestBase):
 
         t = triu(a, k=-1)
 
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorTriu)
         self.assertIsInstance(t.chunks[1].op, TensorTriu)
@@ -568,7 +568,7 @@ class Test(TestBase):
 
         self.assertFalse(t.op.gpu)
 
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorTril)
         self.assertIsInstance(t.chunks[1].op, TensorZeros)
@@ -577,7 +577,7 @@ class Test(TestBase):
 
         t = tril(a, k=1)
 
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorTril)
         self.assertIsInstance(t.chunks[1].op, TensorTril)
@@ -586,7 +586,7 @@ class Test(TestBase):
 
         t = tril(a, k=-1)
 
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorTril)
         self.assertIsInstance(t.chunks[1].op, TensorZeros)
@@ -595,7 +595,7 @@ class Test(TestBase):
 
         t = tril(a, k=-2)
 
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(len(t.chunks), 4)
         self.assertIsInstance(t.chunks[0].op, TensorZeros)
         self.assertIsInstance(t.chunks[1].op, TensorZeros)
@@ -642,7 +642,7 @@ class Test(TestBase):
         self.assertTrue(t.issparse())
         self.assertFalse(t.op.gpu)
 
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(t.chunks[0].index, (0, 0))
         self.assertIsInstance(t.op, CSRMatrixDataSource)
         self.assertFalse(t.op.gpu)
@@ -659,7 +659,7 @@ class Test(TestBase):
         self.assertIsInstance(t.op, DenseToSparse)
         self.assertTrue(t.issparse())
 
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(t.chunks[0].index, (0, 0))
         self.assertIsInstance(t.op, DenseToSparse)
 
@@ -672,7 +672,7 @@ class Test(TestBase):
         self.assertTrue(t.issparse())
         self.assertFalse(t.op.gpu)
 
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(t.chunks[0].index, (0, 0))
         self.assertIsInstance(t.op, TensorOnesLike)
         self.assertTrue(t.chunks[0].issparse())
@@ -717,7 +717,7 @@ class Test(TestBase):
                 self.assertIsNone(tensor.op.tiledb_key)
                 self.assertIsNone(tensor.op.tiledb_timestamp)
 
-                tensor.tiles()
+                tensor = tensor.tiles()
 
                 self.assertEqual(len(tensor.chunks), 105)
                 self.assertIsInstance(tensor.chunks[0].op, TensorTileDBDataSource)
@@ -739,7 +739,7 @@ class Test(TestBase):
                 tensor2 = fromtiledb(tempdir, ctx=ctx)
                 self.assertEqual(tensor2.op.tiledb_config, ctx.config().dict())
 
-                tensor2.tiles()
+                tensor2 = tensor2.tiles()
 
                 self.assertEqual(tensor2.chunks[0].op.tiledb_config, ctx.config().dict())
             finally:

--- a/mars/tensor/datasource/tri.py
+++ b/mars/tensor/datasource/tri.py
@@ -21,6 +21,8 @@ import numpy as np
 from ...lib import sparse
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, Int32Field
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..array_utils import create_array
 from ..core import TensorOrder
 from .core import TensorHasInput
@@ -41,6 +43,7 @@ class TensorTri(TensorHasInput):
 
     @classmethod
     def tile(cls, op):
+        check_chunks_unknown_shape(op.inputs, TilesFail)
         tensor = op.outputs[0]
 
         m = op.input

--- a/mars/tensor/datasource/tri.py
+++ b/mars/tensor/datasource/tri.py
@@ -22,7 +22,7 @@ from ...lib import sparse
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, Int32Field
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..array_utils import create_array
 from ..core import TensorOrder
 from .core import TensorHasInput
@@ -43,7 +43,7 @@ class TensorTri(TensorHasInput):
 
     @classmethod
     def tile(cls, op):
-        check_chunks_unknown_shape(op.inputs, TilesFail)
+        check_chunks_unknown_shape(op.inputs, TilesError)
         tensor = op.outputs[0]
 
         m = op.input

--- a/mars/tensor/datastore/tests/test_datastore.py
+++ b/mars/tensor/datastore/tests/test_datastore.py
@@ -85,7 +85,7 @@ class Test(TestBase):
                 tiledb.DenseArray(ctx=ctx, uri=tempdir)
 
             # tiledb array is created in the tile
-            saved.tiles()
+            saved = saved.tiles()
 
             # no error
             tiledb.DenseArray(ctx=ctx, uri=tempdir)

--- a/mars/tensor/fft/core.py
+++ b/mars/tensor/fft/core.py
@@ -19,6 +19,8 @@ from collections import Iterable
 from ...compat import izip
 from ...serialize import ValueType, KeyField, StringField, Int32Field, \
     Int64Field, ListField
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..utils import validate_axis, decide_chunk_sizes, recursive_tile
 from ..operands import TensorHasInput, TensorOperandMixin
 from ..array_utils import get_array_module
@@ -37,10 +39,11 @@ class TensorFFTBaseMixin(TensorOperandMixin):
         out_tensor = op.outputs[0]
 
         if any(in_tensor.chunk_shape[axis] != 1 for axis in axes):
+            check_chunks_unknown_shape([in_tensor], TilesFail)
             # fft requires only 1 chunk for the specified axis, so we do rechunk first
             chunks = {validate_axis(in_tensor.ndim, axis): in_tensor.shape[axis] for axis in axes}
             new_chunks = decide_chunk_sizes(in_tensor.shape, chunks, in_tensor.dtype.itemsize)
-            in_tensor = in_tensor.rechunk(new_chunks).single_tiles()
+            in_tensor = in_tensor.rechunk(new_chunks)._inplace_tile()
 
         out_chunks = []
         for c in in_tensor.chunks:
@@ -165,6 +168,8 @@ class TensorFFTShiftMixin(TensorOperandMixin):
         axes = op.axes
         in_tensor = op.input
         is_inverse = cls._is_inverse()
+
+        check_chunks_unknown_shape([in_tensor], TilesFail)
 
         x = in_tensor
         for axis in axes:

--- a/mars/tensor/fft/core.py
+++ b/mars/tensor/fft/core.py
@@ -20,7 +20,7 @@ from ...compat import izip
 from ...serialize import ValueType, KeyField, StringField, Int32Field, \
     Int64Field, ListField
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..utils import validate_axis, decide_chunk_sizes, recursive_tile
 from ..operands import TensorHasInput, TensorOperandMixin
 from ..array_utils import get_array_module
@@ -39,7 +39,7 @@ class TensorFFTBaseMixin(TensorOperandMixin):
         out_tensor = op.outputs[0]
 
         if any(in_tensor.chunk_shape[axis] != 1 for axis in axes):
-            check_chunks_unknown_shape([in_tensor], TilesFail)
+            check_chunks_unknown_shape([in_tensor], TilesError)
             # fft requires only 1 chunk for the specified axis, so we do rechunk first
             chunks = {validate_axis(in_tensor.ndim, axis): in_tensor.shape[axis] for axis in axes}
             new_chunks = decide_chunk_sizes(in_tensor.shape, chunks, in_tensor.dtype.itemsize)
@@ -169,7 +169,7 @@ class TensorFFTShiftMixin(TensorOperandMixin):
         in_tensor = op.input
         is_inverse = cls._is_inverse()
 
-        check_chunks_unknown_shape([in_tensor], TilesFail)
+        check_chunks_unknown_shape([in_tensor], TilesError)
 
         x = in_tensor
         for axis in axes:

--- a/mars/tensor/fft/fftfreq.py
+++ b/mars/tensor/fft/fftfreq.py
@@ -50,7 +50,7 @@ class TensorFFTFreq(TensorOperand, TensorOperandMixin):
     def tile(cls, op):
         tensor = op.outputs[0]
         in_tensor = arange(op.n, gpu=op.gpu, dtype=op.dtype,
-                           chunks=tensor.extra_params.raw_chunk_size).single_tiles()
+                           chunks=tensor.extra_params.raw_chunk_size)._inplace_tile()
 
         out_chunks = []
         for c in in_tensor.chunks:

--- a/mars/tensor/fft/rfftfreq.py
+++ b/mars/tensor/fft/rfftfreq.py
@@ -49,9 +49,9 @@ class TensorRFFTFreq(TensorOperand, TensorOperandMixin):
     def tile(cls, op):
         tensor = op.outputs[0]
         t = arange(tensor.shape[0], dtype=op.dtype, gpu=op.gpu,
-                   chunk_size=tensor.extra_params.raw_chunk_size).single_tiles()
+                   chunk_size=tensor.extra_params.raw_chunk_size)._inplace_tile()
         t = t / (op.n * op.d)
-        t.single_tiles()
+        t._inplace_tile()
 
         new_op = op.copy()
         return new_op.new_tensors(None, tensor.shape, order=tensor.order,

--- a/mars/tensor/fft/tests/test_fft.py
+++ b/mars/tensor/fft/tests/test_fft.py
@@ -29,42 +29,42 @@ class Test(unittest.TestCase):
 
         t1 = fft(t)
         self.assertEqual(t1.shape, (10, 20, 30))
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = ifft(t)
         self.assertEqual(t1.shape, (10, 20, 30))
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fft2(t, s=(23, 21))
         self.assertEqual(t1.shape, (10, 23, 21))
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = ifft2(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, (10, 11, 9))
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = fftn(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, (10, 11, 9))
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = ifftn(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, (10, 11, 9))
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
     def testRealFFT(self):
@@ -72,42 +72,42 @@ class Test(unittest.TestCase):
 
         t1 = rfft(t)
         self.assertEqual(t1.shape, np.fft.rfft(np.ones(t.shape)).shape)
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = irfft(t)
         self.assertEqual(t1.shape, np.fft.irfft(np.ones(t.shape)).shape)
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = rfft2(t, s=(23, 21))
         self.assertEqual(t1.shape, np.fft.rfft2(np.ones(t.shape), s=(23, 21)).shape)
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = irfft2(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.irfft2(np.ones(t.shape), s=(11, 9), axes=(1, 2)).shape)
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = rfftn(t, s=(11, 30), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.rfftn(np.ones(t.shape), s=(11, 30), axes=(1, 2)).shape)
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = irfftn(t, s=(11, 9), axes=(1, 2))
         self.assertEqual(t1.shape, np.fft.irfftn(np.ones(t.shape), s=(11, 9), axes=(1, 2)).shape)
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
     def testHermitianFFT(self):
@@ -115,33 +115,33 @@ class Test(unittest.TestCase):
 
         t1 = hfft(t)
         self.assertEqual(t1.shape, np.fft.hfft(np.ones(t.shape)).shape)
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = hfft(t, n=100)
         self.assertEqual(t1.shape, np.fft.hfft(np.ones(t.shape), n=100).shape)
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = ihfft(t)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape)).shape)
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t = ones((10, 20, 30), chunk_size=(3, 20, 30))
 
         t1 = ihfft(t, n=100)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape), n=100).shape)
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
         t1 = ihfft(t, n=101)
         self.assertEqual(t1.shape, np.fft.ihfft(np.ones(t.shape), n=101).shape)
-        t1.tiles()
+        t1 = t1.tiles()
         self.assertEqual(t1.shape, tuple(sum(ns) for ns in t1.nsplits))
 
     def testFFTShift(self):
@@ -156,11 +156,11 @@ class Test(unittest.TestCase):
         t = fftfreq(10, .1, chunk_size=3)
 
         self.assertEqual(t.shape, np.fft.fftfreq(10, .1).shape)
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(t.shape, tuple(sum(ns) for ns in t.nsplits))
 
         t = rfftfreq(10, .1, chunk_size=3)
 
         self.assertEqual(t.shape, np.fft.rfftfreq(10, .1).shape)
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(t.shape, tuple(sum(ns) for ns in t.nsplits))

--- a/mars/tensor/indexing/getitem.py
+++ b/mars/tensor/indexing/getitem.py
@@ -21,7 +21,7 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import ValueType, KeyField, ListField, TupleField, Int32Field
 from ...core import Base, Entity
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ...utils import get_shuffle_input_keys_idxes, check_chunks_unknown_shape
 from ...compat import OrderedDict, Enum, reduce
 from ..core import TENSOR_TYPE, TensorOrder
@@ -175,7 +175,7 @@ class TensorIndexTilesHandler(object):
         for raw_index_obj in self._op.indexes:
             if _is_bool_index(raw_index_obj):
                 # bool indexing
-                check_chunks_unknown_shape([self._in_tensor, raw_index_obj], TilesFail)
+                check_chunks_unknown_shape([self._in_tensor, raw_index_obj], TilesError)
                 # unify chunk first
                 index_obj_axes = (raw_index_obj,
                                   tuple(in_axis + i_dim for i_dim in range(raw_index_obj.ndim)))
@@ -202,7 +202,7 @@ class TensorIndexTilesHandler(object):
                     out_axis += 1
             elif isinstance(raw_index_obj, slice):
                 # check if inputs do not have chunks with unknown shape
-                check_chunks_unknown_shape([self._in_tensor], TilesFail)
+                check_chunks_unknown_shape([self._in_tensor], TilesError)
                 reverse = (raw_index_obj.step or 0) < 0
                 idx_to_slices = sorted(slice_split(raw_index_obj, self._in_tensor.nsplits[in_axis]).items(),
                                        key=operator.itemgetter(0), reverse=reverse)
@@ -215,7 +215,7 @@ class TensorIndexTilesHandler(object):
                 in_axis += 1
                 out_axis += 1
             elif isinstance(raw_index_obj, Integral):
-                check_chunks_unknown_shape([self._in_tensor], TilesFail)
+                check_chunks_unknown_shape([self._in_tensor], TilesError)
                 index_obj = slice_split(raw_index_obj, self._in_tensor.nsplits[in_axis])
                 self._index_infos.append(IndexInfo(raw_index_obj, index_obj, IndexType.integral,
                                                    in_axis, out_axis))

--- a/mars/tensor/indexing/getitem.py
+++ b/mars/tensor/indexing/getitem.py
@@ -21,13 +21,14 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import ValueType, KeyField, ListField, TupleField, Int32Field
 from ...core import Base, Entity
+from ...tiles import TilesFail
+from ...utils import get_shuffle_input_keys_idxes, check_chunks_unknown_shape
 from ...compat import OrderedDict, Enum, reduce
 from ..core import TENSOR_TYPE, TensorOrder
 from ..utils import unify_chunks, slice_split, split_indexes_into_chunks, \
     calc_pos, broadcast_shape, calc_sliced_size, recursive_tile, filter_inputs
 from ..operands import TensorHasInput, TensorOperandMixin, \
     TensorShuffleMap, TensorShuffleReduce, TensorShuffleProxy
-from ...utils import get_shuffle_input_keys_idxes
 from ..array_utils import get_array_module
 from .core import process_index, calc_shape
 
@@ -174,6 +175,7 @@ class TensorIndexTilesHandler(object):
         for raw_index_obj in self._op.indexes:
             if _is_bool_index(raw_index_obj):
                 # bool indexing
+                check_chunks_unknown_shape([self._in_tensor, raw_index_obj], TilesFail)
                 # unify chunk first
                 index_obj_axes = (raw_index_obj,
                                   tuple(in_axis + i_dim for i_dim in range(raw_index_obj.ndim)))
@@ -199,6 +201,8 @@ class TensorIndexTilesHandler(object):
                 if first_fancy_index:
                     out_axis += 1
             elif isinstance(raw_index_obj, slice):
+                # check if inputs do not have chunks with unknown shape
+                check_chunks_unknown_shape([self._in_tensor], TilesFail)
                 reverse = (raw_index_obj.step or 0) < 0
                 idx_to_slices = sorted(slice_split(raw_index_obj, self._in_tensor.nsplits[in_axis]).items(),
                                        key=operator.itemgetter(0), reverse=reverse)
@@ -211,6 +215,7 @@ class TensorIndexTilesHandler(object):
                 in_axis += 1
                 out_axis += 1
             elif isinstance(raw_index_obj, Integral):
+                check_chunks_unknown_shape([self._in_tensor], TilesFail)
                 index_obj = slice_split(raw_index_obj, self._in_tensor.nsplits[in_axis])
                 self._index_infos.append(IndexInfo(raw_index_obj, index_obj, IndexType.integral,
                                                    in_axis, out_axis))
@@ -236,7 +241,7 @@ class TensorIndexTilesHandler(object):
             self._fancy_index_info.chunk_unified_fancy_indexes = \
                 [np.broadcast_to(fancy_index, shape) for fancy_index in fancy_indexes]
         else:
-            broadcast_fancy_indexes = [broadcast_to(fancy_index, shape).single_tiles()
+            broadcast_fancy_indexes = [broadcast_to(fancy_index, shape)._inplace_tile()
                                        for fancy_index in fancy_indexes]
             broadcast_fancy_indexes = unify_chunks(*broadcast_fancy_indexes)
             self._fancy_index_info.chunk_unified_fancy_indexes = broadcast_fancy_indexes
@@ -270,7 +275,7 @@ class TensorIndexTilesHandler(object):
 
         # stack fancy indexes into one
         concat_fancy_index = recursive_tile(stack(fancy_indexes))
-        concat_fancy_index = concat_fancy_index.rechunk({0: len(fancy_indexes)}).single_tiles()
+        concat_fancy_index = concat_fancy_index.rechunk({0: len(fancy_indexes)})._inplace_tile()
 
         # generate shuffle map, for concatenated fancy index,
         # calculated a counterpart index chunk for each chunk of input tensor

--- a/mars/tensor/indexing/nonzero.py
+++ b/mars/tensor/indexing/nonzero.py
@@ -39,9 +39,9 @@ class TensorNonzero(TensorHasInput, TensorOperandMixin):
         return float('inf')
 
     def __call__(self, a):
-        return ExecutableTuple(self.new_tensors([a], shape=(np.nan,),
-                                                order=TensorOrder.C_ORDER,
-                                                output_limit=a.ndim))
+        kws = [{'shape': (np.nan,), 'order': TensorOrder.C_ORDER, '_idx_': i}
+               for i in range(a.ndim)]
+        return ExecutableTuple(self.new_tensors([a], kws=kws, output_limit=len(kws)))
 
     @classmethod
     def tile(cls, op):

--- a/mars/tensor/indexing/setitem.py
+++ b/mars/tensor/indexing/setitem.py
@@ -20,7 +20,7 @@ from ... import opcodes as OperandDef
 from ...serialize import KeyField, ListField, AnyField
 from ...core import Base, Entity
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..core import TENSOR_TYPE
 from ..operands import TensorHasInput, TensorOperandMixin
 from ..utils import filter_inputs
@@ -82,7 +82,7 @@ class TensorIndexSetValue(TensorHasInput, TensorOperandMixin):
         to_check_tensors = [index_tensor]
         if is_value_tensor:
             to_check_tensors.append(value)
-        check_chunks_unknown_shape(to_check_tensors, TilesFail)
+        check_chunks_unknown_shape(to_check_tensors, TilesError)
 
         nsplits = index_tensor.nsplits
         if is_value_tensor:

--- a/mars/tensor/indexing/setitem.py
+++ b/mars/tensor/indexing/setitem.py
@@ -19,6 +19,8 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, ListField, AnyField
 from ...core import Base, Entity
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..core import TENSOR_TYPE
 from ..operands import TensorHasInput, TensorOperandMixin
 from ..utils import filter_inputs
@@ -75,14 +77,16 @@ class TensorIndexSetValue(TensorHasInput, TensorOperandMixin):
 
         index_tensor_op = TensorIndex(dtype=tensor.dtype, sparse=op.sparse, indexes=op.indexes)
         index_tensor_inputs = filter_inputs([op.input] + op.indexes)
-        index_tensor = index_tensor_op.new_tensor(index_tensor_inputs, tensor.shape).single_tiles()
+        index_tensor = index_tensor_op.new_tensor(index_tensor_inputs, tensor.shape)._inplace_tile()
+
+        to_check_tensors = [index_tensor]
+        if is_value_tensor:
+            to_check_tensors.append(value)
+        check_chunks_unknown_shape(to_check_tensors, TilesFail)
 
         nsplits = index_tensor.nsplits
-        if any(any(np.isnan(ns) for ns in nsplit) for nsplit in nsplits):
-            raise NotImplementedError
-
         if is_value_tensor:
-            value = op.value.rechunk(nsplits).single_tiles()
+            value = value.rechunk(nsplits)._inplace_tile()
 
         chunk_mapping = {c.op.input.index: c for c in index_tensor.chunks}
         out_chunks = []

--- a/mars/tensor/indexing/tests/test_indexing_execute.py
+++ b/mars/tensor/indexing/tests/test_indexing_execute.py
@@ -20,6 +20,7 @@ import numpy as np
 import scipy.sparse as sps
 
 from mars.executor import Executor
+from mars.tiles import get_tiled
 from mars.tensor.datasource import tensor, arange
 from mars.tensor.indexing import take, compress, extract, choose, \
     unravel_index, nonzero, flatnonzero
@@ -102,7 +103,7 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(arr6, concat=True)
         np.testing.assert_array_equal(res[0], raw[index1, :, index2])
         # fancy index is ordered, no concat required
-        self.assertGreater(len(arr6.nsplits[0]), 1)
+        self.assertGreater(len(get_tiled(arr6).nsplits[0]), 1)
 
         index1 = [[8, 10, 3], [1, 9, 10]]
         index2 = [[1, 3, 9], [10, 2, 7]]

--- a/mars/tensor/lib/tests/test_index_tricks.py
+++ b/mars/tensor/lib/tests/test_index_tricks.py
@@ -23,7 +23,7 @@ class Test(unittest.TestCase):
     def testIndexTricks(self):
         mgrid = nd_grid()
         g = mgrid[0:5, 0:5]
-        g.tiles()  # tilesable means no loop exists
+        g.tiles()  # tileable means no loop exists
 
         ogrid = nd_grid(sparse=True)
         o = ogrid[0:5, 0:5]

--- a/mars/tensor/linalg/cholesky.py
+++ b/mars/tensor/linalg/cholesky.py
@@ -19,6 +19,8 @@ from numpy.linalg import LinAlgError
 
 from ...serialize import KeyField, BoolField
 from ... import opcodes as OperandDef
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..operands import TensorHasInput, TensorOperand, TensorOperandMixin
 from ..datasource import tensor as astensor
 from ..core import TensorOrder
@@ -55,10 +57,11 @@ class TensorCholesky(TensorHasInput, TensorOperandMixin):
 
         tensor = op.outputs[0]
         in_tensor = op.input
+        check_chunks_unknown_shape([in_tensor], TilesFail)
         if in_tensor.nsplits[0] != in_tensor.nsplits[1]:
             # all chunks on diagonal should be square
             nsplits = in_tensor.nsplits[0]
-            in_tensor = in_tensor.rechunk([nsplits, nsplits]).single_tiles()
+            in_tensor = in_tensor.rechunk([nsplits, nsplits])._inplace_tile()
 
         lower_chunks, upper_chunks = {}, {}
         for i in range(in_tensor.chunk_shape[0]):

--- a/mars/tensor/linalg/cholesky.py
+++ b/mars/tensor/linalg/cholesky.py
@@ -20,7 +20,7 @@ from numpy.linalg import LinAlgError
 from ...serialize import KeyField, BoolField
 from ... import opcodes as OperandDef
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..operands import TensorHasInput, TensorOperand, TensorOperandMixin
 from ..datasource import tensor as astensor
 from ..core import TensorOrder
@@ -57,7 +57,7 @@ class TensorCholesky(TensorHasInput, TensorOperandMixin):
 
         tensor = op.outputs[0]
         in_tensor = op.input
-        check_chunks_unknown_shape([in_tensor], TilesFail)
+        check_chunks_unknown_shape([in_tensor], TilesError)
         if in_tensor.nsplits[0] != in_tensor.nsplits[1]:
             # all chunks on diagonal should be square
             nsplits = in_tensor.nsplits[0]

--- a/mars/tensor/linalg/core.py
+++ b/mars/tensor/linalg/core.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from ...compat import izip
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..core import TensorOrder
 from ..utils import decide_chunk_sizes
 from .utils import calc_svd_shapes
@@ -56,7 +56,7 @@ class SFQR(object):
                 rechunk_size[1] = a.shape[0]
 
         if check_nan_shape:
-            check_chunks_unknown_shape([a], TilesFail)
+            check_chunks_unknown_shape([a], TilesError)
 
         if rechunk_size:
             new_chunks = decide_chunk_sizes(a.shape, rechunk_size, a.dtype.itemsize)
@@ -111,7 +111,7 @@ class TSQR(object):
         q_dtype, r_dtype = tinyq.dtype, tinyr.dtype
 
         if a.chunk_shape[1] != 1:
-            check_chunks_unknown_shape([a], TilesFail)
+            check_chunks_unknown_shape([a], TilesError)
             new_chunk_size = decide_chunk_sizes(a.shape, {1: a.shape[1]}, a.dtype.itemsize)
             a = a.rechunk(new_chunk_size)._inplace_tile()
 

--- a/mars/tensor/linalg/inv.py
+++ b/mars/tensor/linalg/inv.py
@@ -56,25 +56,25 @@ class TensorInv(TensorHasInput, TensorOperandMixin):
         is_sparse = in_tensor.is_sparse()
 
         b_eye = eye(in_tensor.shape[0], chunk_size=in_tensor.nsplits, sparse=is_sparse)
-        b_eye.single_tiles()
+        b_eye._inplace_tile()
 
         p, l, u = lu(in_tensor)
-        p.single_tiles()
+        p._inplace_tile()
 
         # transposed p equals to inverse of p
         p_transpose = TensorTranspose(
             dtype=p.dtype, sparse=p.op.sparse, axes=list(range(in_tensor.ndim))[::-1]).new_tensor([p], p.shape)
-        p_transpose.single_tiles()
+        p_transpose._inplace_tile()
 
         b = tensordot(p_transpose, b_eye, axes=((p_transpose.ndim - 1,), (b_eye.ndim - 2,)))
-        b.single_tiles()
+        b._inplace_tile()
 
         # as `l` is a lower matrix, `lower=True` should be specified.
         uy = solve_triangular(l, b, lower=True, sparse=op.sparse)
-        uy.single_tiles()
+        uy._inplace_tile()
 
         a_inv = solve_triangular(u, uy, sparse=op.sparse)
-        a_inv.single_tiles()
+        a_inv._inplace_tile()
         return [a_inv]
 
 

--- a/mars/tensor/linalg/lu.py
+++ b/mars/tensor/linalg/lu.py
@@ -21,7 +21,7 @@ from ... import opcodes as OperandDef
 from ...serialize import KeyField
 from ...core import ExecutableTuple
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..utils import recursive_tile
 from ..array_utils import device, as_same_device, is_sparse_module
 from ..operands import TensorHasInput, TensorOperandMixin
@@ -105,7 +105,7 @@ class TensorLU(TensorHasInput, TensorOperandMixin):
             in_tensor = vstack([in_tensor, zero_tensor])
             recursive_tile(in_tensor)
 
-        check_chunks_unknown_shape([in_tensor], TilesFail)
+        check_chunks_unknown_shape([in_tensor], TilesError)
         if in_tensor.nsplits[0] != in_tensor.nsplits[1]:
             # all chunks on diagonal should be square
             nsplits = in_tensor.nsplits[0]

--- a/mars/tensor/linalg/matmul.py
+++ b/mars/tensor/linalg/matmul.py
@@ -21,6 +21,8 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, StringField
 from ...compat import lrange
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..core import Tensor, TensorOrder
 from ..utils import broadcast_shape, check_out_param, unify_chunks, check_order
 from ..array_utils import device, as_same_device, is_sparse_module
@@ -133,6 +135,7 @@ class TensorMatmul(TensorOperand, TensorOperandMixin):
         # the axes to align on
         a_axes = lrange(a.ndim - 2)[::-1] + [tensor.ndim - 2, tensor.ndim - 1]
         b_axes = lrange(b.ndim - 2)[::-1] + [tensor.ndim - 1, tensor.ndim]
+        check_chunks_unknown_shape(op.inputs, TilesFail)
         a, b = unify_chunks((a, a_axes), (b, b_axes))
 
         get_nsplit = lambda i: a.nsplits[i] if a.nsplits[i] != (1,) else b.nsplits[i]

--- a/mars/tensor/linalg/matmul.py
+++ b/mars/tensor/linalg/matmul.py
@@ -22,7 +22,7 @@ from ... import opcodes as OperandDef
 from ...serialize import KeyField, StringField
 from ...compat import lrange
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..core import Tensor, TensorOrder
 from ..utils import broadcast_shape, check_out_param, unify_chunks, check_order
 from ..array_utils import device, as_same_device, is_sparse_module
@@ -135,7 +135,7 @@ class TensorMatmul(TensorOperand, TensorOperandMixin):
         # the axes to align on
         a_axes = lrange(a.ndim - 2)[::-1] + [tensor.ndim - 2, tensor.ndim - 1]
         b_axes = lrange(b.ndim - 2)[::-1] + [tensor.ndim - 1, tensor.ndim]
-        check_chunks_unknown_shape(op.inputs, TilesFail)
+        check_chunks_unknown_shape(op.inputs, TilesError)
         a, b = unify_chunks((a, a_axes), (b, b_axes))
 
         get_nsplit = lambda i: a.nsplits[i] if a.nsplits[i] != (1,) else b.nsplits[i]

--- a/mars/tensor/linalg/solve_triangular.py
+++ b/mars/tensor/linalg/solve_triangular.py
@@ -20,7 +20,7 @@ from numpy.linalg import LinAlgError
 from ... import opcodes as OperandDef
 from ...serialize import BoolField, KeyField
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..array_utils import device, as_same_device, cp
 from ..operands import TensorOperand, TensorOperandMixin
 from ..datasource import tensor as astensor
@@ -70,7 +70,7 @@ class TensorSolveTriangular(TensorOperand, TensorOperandMixin):
         from ..arithmetic.utils import tree_add
         from .dot import TensorDot
 
-        check_chunks_unknown_shape(op.inputs, TilesFail)
+        check_chunks_unknown_shape(op.inputs, TilesError)
 
         a, b = op.a, op.b
         unified_nsplit = decide_unify_split(a.nsplits[0], a.nsplits[1], b.nsplits[0])

--- a/mars/tensor/linalg/tensordot.py
+++ b/mars/tensor/linalg/tensordot.py
@@ -22,6 +22,8 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import ValueType, KeyField, TupleField
 from ...compat import izip
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..utils import unify_chunks
 from ..array_utils import as_same_device, device, is_sparse_module
 from ..operands import TensorOperand, TensorOperandMixin
@@ -91,6 +93,7 @@ class TensorTensorDot(TensorOperand, TensorOperandMixin):
         c = itertools.count(max(a.ndim, b.ndim))
         a_ax = tuple(a_axes.index(i) if i in a_axes else next(c) for i in range(a.ndim))
         b_ax = tuple(b_axes.index(i) if i in b_axes else next(c) for i in range(b.ndim))
+        check_chunks_unknown_shape(op.inputs, TilesFail)
         a, b = unify_chunks((a, a_ax), (b, b_ax))
         out = op.outputs[0]
 

--- a/mars/tensor/linalg/tensordot.py
+++ b/mars/tensor/linalg/tensordot.py
@@ -23,7 +23,7 @@ from ... import opcodes as OperandDef
 from ...serialize import ValueType, KeyField, TupleField
 from ...compat import izip
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..utils import unify_chunks
 from ..array_utils import as_same_device, device, is_sparse_module
 from ..operands import TensorOperand, TensorOperandMixin
@@ -93,7 +93,7 @@ class TensorTensorDot(TensorOperand, TensorOperandMixin):
         c = itertools.count(max(a.ndim, b.ndim))
         a_ax = tuple(a_axes.index(i) if i in a_axes else next(c) for i in range(a.ndim))
         b_ax = tuple(b_axes.index(i) if i in b_axes else next(c) for i in range(b.ndim))
-        check_chunks_unknown_shape(op.inputs, TilesFail)
+        check_chunks_unknown_shape(op.inputs, TilesError)
         a, b = unify_chunks((a, a_ax), (b, b_ax))
         out = op.outputs[0]
 

--- a/mars/tensor/linalg/tests/test_linalg.py
+++ b/mars/tensor/linalg/tests/test_linalg.py
@@ -25,6 +25,7 @@ from mars.tensor import ones, tensor, dot, empty
 from mars.graph import DirectedGraph
 from mars.tensor.core import SparseTensor, Tensor
 from mars.tensor.linalg import matmul
+from mars.tiles import get_tiled
 
 
 class Test(unittest.TestCase):
@@ -35,7 +36,8 @@ class Test(unittest.TestCase):
         self.assertEqual(q.shape, (9, 6))
         self.assertEqual(r.shape, (6, 6))
 
-        q.tiles()
+        q = q.tiles()
+        r = get_tiled(r)
 
         self.assertEqual(len(q.chunks), 3)
         self.assertEqual(len(r.chunks), 1)
@@ -52,7 +54,8 @@ class Test(unittest.TestCase):
         self.assertEqual(q.shape, (18, 6))
         self.assertEqual(r.shape, (6, 6))
 
-        q.tiles()
+        q = q.tiles()
+        r = get_tiled(r)
 
         self.assertEqual(len(q.chunks), 2)
         self.assertEqual(len(r.chunks), 1)
@@ -69,7 +72,9 @@ class Test(unittest.TestCase):
 
         self.assertEqual(q.shape, (6, 6))
         self.assertEqual(r.shape, (6, 18))
-        q.tiles()
+
+        q = q.tiles()
+        r = get_tiled(r)
 
         self.assertEqual(len(q.chunks), 1)
         self.assertEqual(len(r.chunks), 3)
@@ -83,7 +88,8 @@ class Test(unittest.TestCase):
         self.assertEqual(q.shape, (6, 6))
         self.assertEqual(r.shape, (6, 9))
 
-        q.tiles()
+        q = q.tiles()
+        r = get_tiled(r)
 
         self.assertEqual(len(q.chunks), 1)
         self.assertEqual(len(r.chunks), 2)
@@ -96,7 +102,8 @@ class Test(unittest.TestCase):
         self.assertEqual(q.shape, (9, 6))
         self.assertEqual(r.shape, (6, 6))
 
-        q.tiles()
+        q = q.tiles()
+        r = get_tiled(r)
 
         self.assertEqual(len(q.chunks), 1)
         self.assertEqual(len(r.chunks), 1)
@@ -126,7 +133,9 @@ class Test(unittest.TestCase):
         self.assertEqual(s.shape, (6,))
         self.assertEqual(V.shape, (6, 6))
 
-        U.tiles()
+        U = U.tiles()
+        s, V = get_tiled(s), get_tiled(V)
+
         self.assertEqual(len(U.chunks), 3)
         self.assertEqual(U.chunks[0].shape, (3, 6))
         self.assertEqual(len(s.chunks), 1)
@@ -148,7 +157,9 @@ class Test(unittest.TestCase):
         self.assertEqual(s.shape, (6,))
         self.assertEqual(V.shape, (6, 6))
 
-        U.tiles()
+        U = U.tiles()
+        s, V = get_tiled(s), get_tiled(V)
+
         self.assertEqual(len(U.chunks), 1)
         self.assertEqual(U.chunks[0].shape, (9, 6))
         self.assertEqual(len(s.chunks), 1)
@@ -166,7 +177,9 @@ class Test(unittest.TestCase):
         self.assertEqual(s.shape, (6,))
         self.assertEqual(V.shape, (6, 20))
 
-        U.tiles()
+        U = U.tiles()
+        s, V = get_tiled(s), get_tiled(V)
+
         self.assertEqual(len(U.chunks), 1)
         self.assertEqual(U.chunks[0].shape, (6, 6))
         self.assertEqual(len(s.chunks), 1)
@@ -214,7 +227,9 @@ class Test(unittest.TestCase):
     def testLU(self):
         a = mt.random.randint(1, 10, (6, 6), chunk_size=3)
         p, l, u = mt.linalg.lu(a)
-        l.tiles()
+
+        l = l.tiles()
+        p, u = get_tiled(p), get_tiled(u)
 
         self.assertEqual(l.shape, (6, 6))
         self.assertEqual(u.shape, (6, 6))
@@ -222,7 +237,8 @@ class Test(unittest.TestCase):
 
         a = mt.random.randint(1, 10, (6, 6), chunk_size=(3, 2))
         p, l, u = mt.linalg.lu(a)
-        l.tiles()
+        l = l.tiles()
+        p, u = get_tiled(p), get_tiled(u)
 
         self.assertEqual(l.shape, (6, 6))
         self.assertEqual(u.shape, (6, 6))
@@ -234,7 +250,8 @@ class Test(unittest.TestCase):
 
         a = mt.random.randint(1, 10, (7, 7), chunk_size=4)
         p, l, u = mt.linalg.lu(a)
-        l.tiles()
+        l = l.tiles()
+        p, u = get_tiled(p), get_tiled(u)
 
         self.assertEqual(l.shape, (7, 7))
         self.assertEqual(u.shape, (7, 7))
@@ -246,7 +263,8 @@ class Test(unittest.TestCase):
 
         a = mt.random.randint(1, 10, (7, 5), chunk_size=4)
         p, l, u = mt.linalg.lu(a)
-        l.tiles()
+        l = l.tiles()
+        p, u = get_tiled(p), get_tiled(u)
 
         self.assertEqual(l.shape, (7, 5))
         self.assertEqual(u.shape, (5, 5))
@@ -254,7 +272,8 @@ class Test(unittest.TestCase):
 
         a = mt.random.randint(1, 10, (5, 7), chunk_size=4)
         p, l, u = mt.linalg.lu(a)
-        l.tiles()
+        l = l.tiles()
+        p, u = get_tiled(p), get_tiled(u)
 
         self.assertEqual(l.shape, (5, 5))
         self.assertEqual(u.shape, (5, 7))
@@ -277,7 +296,8 @@ class Test(unittest.TestCase):
         self.assertTrue(u.op.sparse)
         self.assertIsInstance(u, SparseTensor)
 
-        p.tiles()
+        p = p.tiles()
+        l, u = get_tiled(l), get_tiled(u)
         self.assertTrue(all(c.is_sparse() for c in p.chunks))
         self.assertTrue(all(c.is_sparse() for c in l.chunks))
         self.assertTrue(all(c.is_sparse() for c in u.chunks))
@@ -370,7 +390,7 @@ class Test(unittest.TestCase):
 
         self.assertEqual(t3.shape, (6, 5))
 
-        t3.tiles()
+        t3 = t3.tiles()
 
         self.assertEqual(t3.shape, (6, 5))
         self.assertEqual(len(t3.chunks), 9)
@@ -385,27 +405,27 @@ class Test(unittest.TestCase):
         b = ones((10, 20), chunk_size=2)
         c = dot(a, b)
         self.assertEqual(c.shape, (20,))
-        c.tiles()
+        c = c.tiles()
         self.assertEqual(c.shape, tuple(sum(s) for s in c.nsplits))
 
         a = ones((10, 20), chunk_size=2)
         b = ones(20, chunk_size=2)
         c = dot(a, b)
         self.assertEqual(c.shape, (10,))
-        c.tiles()
+        c = c.tiles()
         self.assertEqual(c.shape, tuple(sum(s) for s in c.nsplits))
 
         v = ones((100, 100), chunk_size=10)
         tv = v.dot(v)
         self.assertEqual(tv.shape, (100, 100))
-        tv.tiles()
+        tv = tv.tiles()
         self.assertEqual(tv.shape, tuple(sum(s) for s in tv.nsplits))
 
         a = ones((10, 20), chunk_size=2)
         b = ones((30, 20), chunk_size=2)
         c = inner(a, b)
         self.assertEqual(c.shape, (10, 30))
-        c.tiles()
+        c = c.tiles()
         self.assertEqual(c.shape, tuple(sum(s) for s in c.nsplits))
 
     def testDot(self):

--- a/mars/tensor/merge/tests/test_merge.py
+++ b/mars/tensor/merge/tests/test_merge.py
@@ -18,6 +18,7 @@ import unittest
 
 import numpy as np
 
+from mars.tiles import get_tiled
 from mars.tensor.datasource import ones, empty
 from mars.tensor.merge import concatenate, stack
 
@@ -52,6 +53,7 @@ class Test(unittest.TestCase):
         b = ones((20, 20, 30), chunk_size=10)
 
         c = concatenate([a, b]).tiles()
+        a = get_tiled(a)
         self.assertEqual(c.chunk_shape[0], 4)
         self.assertEqual(c.chunk_shape[1], 4)
         self.assertEqual(c.chunk_shape[2], 6)
@@ -65,21 +67,21 @@ class Test(unittest.TestCase):
 
         self.assertEqual(arr2.shape, (10, 3, 4))
 
-        arr2.tiles()
+        arr2 = arr2.tiles()
         self.assertEqual(arr2.nsplits, ((1,) * 10, (2, 1), (2, 2)))
 
         arr3 = stack(raw_arrs, axis=1)
 
         self.assertEqual(arr3.shape, (3, 10, 4))
 
-        arr3.tiles()
+        arr3 = arr3.tiles()
         self.assertEqual(arr3.nsplits, ((2, 1), (1,) * 10, (2, 2)))
 
         arr4 = stack(raw_arrs, axis=2)
 
         self.assertEqual(arr4.shape, (3, 4, 10))
 
-        arr4.tiles()
+        arr4 = arr4.tiles()
         self.assertEqual(arr4.nsplits, ((2, 1), (2, 2), (1,) * 10))
 
         with self.assertRaises(ValueError):

--- a/mars/tensor/random/core.py
+++ b/mars/tensor/random/core.py
@@ -113,7 +113,7 @@ class TensorRandomOperandMixin(TensorOperandMixin):
                 t_nsplits = t.shape  # into 1 chunk
             rechunked = t.rechunk(t_nsplits)
             if rechunked is not t:
-                rechunked.single_tiles()
+                rechunked._inplace_tile()
                 changed = True
                 new_inputs.append(rechunked)
             else:
@@ -153,7 +153,7 @@ class TensorRandomOperandMixin(TensorOperandMixin):
 
         new_op = op.copy()
         return new_op.new_tensors(op.inputs, tensor.shape, order=tensor.order,
-                                  chunks=out_chunks, nsplits=nsplits)
+                                  chunks=out_chunks, nsplits=nsplits, **tensor.extra_params)
 
     @classmethod
     def execute(cls, ctx, op):
@@ -206,7 +206,7 @@ class TensorRandomOperandMixin(TensorOperandMixin):
                 else:
                     raise
 
-    def _get_shape(self, shapes):
+    def _calc_shape(self, shapes):
         shapes = list(shapes)
         if getattr(self, '_size', None) is not None:
             shapes.append(getattr(self, '_size'))
@@ -248,7 +248,7 @@ class TensorRandomOperandMixin(TensorOperandMixin):
 
         if tensor:
             if shape is None:
-                shape = self._get_shape(to_broadcast_shapes)
+                shape = self._calc_shape(to_broadcast_shapes)
 
             for field, inp in field_to_obj.items():
                 if field not in to_one_chunk_fields:
@@ -261,15 +261,22 @@ class TensorRandomOperandMixin(TensorOperandMixin):
             if field in field_to_obj:
                 setattr(self, field, next(inputs_iter))
 
+    @classmethod
+    def _get_shape(cls, kws, kw):
+        if kw.get('shape') is not None:
+            return kw.get('shape')
+        elif kws is not None and len(kws) > 0:
+            return kws[0].get('shape')
+
     def _new_tileables(self, inputs, kws=None, **kw):
         raw_chunk_size = kw.get('chunk_size', None)
-        shape = kw.get('shape', None)
+        shape = self._get_shape(kws, kw)
         with self._get_inputs_shape_by_given_fields(inputs, shape, raw_chunk_size, True) as (inputs, shape):
             kw['shape'] = shape
             return super(TensorRandomOperandMixin, self)._new_tileables(inputs, kws=kws, **kw)
 
     def _new_chunks(self, inputs, kws=None, **kw):
-        shape = kw.get('shape', None)
+        shape = self._get_shape(kws, kw)
         with self._get_inputs_shape_by_given_fields(inputs, shape, None, False) as (inputs, shape):
             kw['shape'] = shape
             return super(TensorRandomOperandMixin, self)._new_chunks(inputs, kws=kws, **kw)

--- a/mars/tensor/random/dirichlet.py
+++ b/mars/tensor/random/dirichlet.py
@@ -43,8 +43,8 @@ class TensorDirichlet(TensorDistribution, TensorRandomOperandMixin):
     def alpha(self):
         return self._alpha
 
-    def _get_shape(self, shapes):
-        shape = super(TensorDirichlet, self)._get_shape(shapes)
+    def _calc_shape(self, shapes):
+        shape = super(TensorDirichlet, self)._calc_shape(shapes)
         return shape + (len(self._alpha),)
 
     def __call__(self, chunk_size=None):

--- a/mars/tensor/random/tests/test_random.py
+++ b/mars/tensor/random/tests/test_random.py
@@ -20,6 +20,7 @@ from mars.tensor.random import RandomState, beta, rand, choice, multivariate_nor
     randint, randn, permutation, TensorPermutation, shuffle
 from mars.tensor.datasource import tensor as from_ndarray
 from mars.tests.core import TestBase
+from mars.tiles import get_tiled
 
 
 class Test(TestBase):
@@ -66,13 +67,13 @@ class Test(TestBase):
     def testChoice(self):
         t = choice(5, chunk_size=1)
         self.assertEqual(t.shape, ())
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(t.nsplits, ())
         self.assertEqual(len(t.chunks), 1)
 
         t = choice(5, 3, chunk_size=1)
         self.assertEqual(t.shape, (3,))
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(t.nsplits, ((1, 1, 1),))
 
         t = choice(5, 3, replace=False)
@@ -86,7 +87,7 @@ class Test(TestBase):
         self.assertEqual(t.shape, (5000, 2))
         self.assertEqual(t.op.size, (5000,))
 
-        t.tiles()
+        t = t.tiles()
         self.assertEqual(t.nsplits, ((500,) * 10, (2,)))
         self.assertEqual(len(t.chunks), 10)
         c = t.chunks[0]
@@ -117,7 +118,7 @@ class Test(TestBase):
         self.assertEqual(x.shape, (10,))
         self.assertIsInstance(x.op, TensorPermutation)
 
-        x.tiles()
+        x = x.tiles()
 
         self.assertEqual(len(x.chunks), 1)
         self.assertIsInstance(x.chunks[0].op, TensorPermutation)
@@ -128,7 +129,8 @@ class Test(TestBase):
         self.assertEqual(x.shape, (5,))
         self.assertIsInstance(x.op, TensorPermutation)
 
-        x.tiles()
+        x = x.tiles()
+        arr = get_tiled(arr)
 
         self.assertEqual(len(x.chunks), 3)
         self.assertTrue(np.isnan(x.chunks[0].shape[0]))
@@ -140,7 +142,8 @@ class Test(TestBase):
         self.assertEqual(x.shape, (3, 3))
         self.assertIsInstance(x.op, TensorPermutation)
 
-        x.tiles()
+        x = x.tiles()
+        arr = get_tiled(arr)
 
         self.assertEqual(len(x.chunks), 4)
         self.assertTrue(np.isnan(x.chunks[0].shape[0]))

--- a/mars/tensor/rechunk/rechunk.py
+++ b/mars/tensor/rechunk/rechunk.py
@@ -18,7 +18,7 @@ from ...compat import izip, lzip
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, AnyField, Int32Field, Int64Field
 from ...utils import check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..utils import calc_sliced_size
 from ..operands import TensorHasInput, TensorOperandMixin
 from .core import plan_rechunks, get_nsplits, compute_rechunk_slices
@@ -57,7 +57,7 @@ class TensorRechunk(TensorHasInput, TensorOperandMixin):
 
     @classmethod
     def tile(cls, op):
-        check_chunks_unknown_shape(op.inputs, TilesFail)
+        check_chunks_unknown_shape(op.inputs, TilesError)
         new_chunk_size = op.chunk_size
         steps = plan_rechunks(op.inputs[0], new_chunk_size, op.inputs[0].dtype.itemsize,
                               threshold=op.threshold,

--- a/mars/tensor/rechunk/rechunk.py
+++ b/mars/tensor/rechunk/rechunk.py
@@ -17,6 +17,8 @@ import itertools
 from ...compat import izip, lzip
 from ... import opcodes as OperandDef
 from ...serialize import KeyField, AnyField, Int32Field, Int64Field
+from ...utils import check_chunks_unknown_shape
+from ...tiles import TilesFail
 from ..utils import calc_sliced_size
 from ..operands import TensorHasInput, TensorOperandMixin
 from .core import plan_rechunks, get_nsplits, compute_rechunk_slices
@@ -55,6 +57,7 @@ class TensorRechunk(TensorHasInput, TensorOperandMixin):
 
     @classmethod
     def tile(cls, op):
+        check_chunks_unknown_shape(op.inputs, TilesFail)
         new_chunk_size = op.chunk_size
         steps = plan_rechunks(op.inputs[0], new_chunk_size, op.inputs[0].dtype.itemsize,
                               threshold=op.threshold,

--- a/mars/tensor/rechunk/tests/test_rechunk.py
+++ b/mars/tensor/rechunk/tests/test_rechunk.py
@@ -16,6 +16,7 @@
 
 import unittest
 
+from mars.tiles import get_tiled
 from mars.tensor.datasource import ones
 from mars.tensor.indexing.slice import TensorSlice
 from mars.tensor.rechunk.rechunk import compute_rechunk
@@ -24,7 +25,7 @@ from mars.tensor.rechunk.rechunk import compute_rechunk
 class Test(unittest.TestCase):
     def testComputeRechunk(self):
         tensor = ones((12, 8), chunk_size=((4, 4, 3, 1), (3, 3, 2)))
-        tensor.tiles()
+        tensor = tensor.tiles()
         new_tensor = compute_rechunk(tensor, ((9, 2, 1), (2, 1, 4, 1)))
 
         self.assertEqual(len(new_tensor.chunks), 12)
@@ -46,10 +47,10 @@ class Test(unittest.TestCase):
     def testRechunk(self):
         tensor = ones((12, 9), chunk_size=4)
         new_tensor = tensor.rechunk(3)
-        new_tensor.tiles()
+        new_tensor = new_tensor.tiles()
 
         self.assertEqual(len(new_tensor.chunks), 12)
-        self.assertEqual(new_tensor.chunks[0].inputs[0], tensor.chunks[0].data)
+        self.assertEqual(new_tensor.chunks[0].inputs[0], get_tiled(tensor).chunks[0].data)
         self.assertEqual(len(new_tensor.chunks[1].inputs), 2)
         self.assertEqual(new_tensor.chunks[1].inputs[0].op.slices,
                          (slice(None, 3, None), slice(3, None, None)))
@@ -64,7 +65,7 @@ class Test(unittest.TestCase):
     def testSparse(self):
         tensor = ones((7, 12), chunk_size=4).tosparse()
         new_tensor = tensor.rechunk(5)
-        new_tensor.tiles()
+        new_tensor = new_tensor.tiles()
 
         self.assertTrue(new_tensor.issparse())
         self.assertTrue(all(c.issparse() for c in new_tensor.chunks))

--- a/mars/tensor/reshape/reshape.py
+++ b/mars/tensor/reshape/reshape.py
@@ -23,7 +23,7 @@ from ... import opcodes as OperandDef
 from ...compat import six, izip
 from ...serialize import KeyField, TupleField, StringField, ValueType
 from ...utils import get_shuffle_input_keys_idxes, check_chunks_unknown_shape
-from ...tiles import TilesFail
+from ...tiles import TilesError
 from ..datasource import tensor as astensor
 from ..operands import TensorOperandMixin, TensorHasInput, TensorShuffleProxy, \
     TensorShuffleMap, TensorShuffleReduce
@@ -218,7 +218,7 @@ class TensorReshape(TensorHasInput, TensorOperandMixin):
             result = result.transpose()
             return [recursive_tile(result)]
 
-        check_chunks_unknown_shape(op.inputs, TilesFail)
+        check_chunks_unknown_shape(op.inputs, TilesError)
         try:
             rechunk_nsplits, reshape_nsplits = cls._gen_reshape_rechunk_nsplits(
                 in_tensor.shape, tensor.shape, in_tensor.nsplits)

--- a/mars/tensor/reshape/tests/test_reshape.py
+++ b/mars/tensor/reshape/tests/test_reshape.py
@@ -25,21 +25,21 @@ class Test(unittest.TestCase):
         a = ones((10, 20, 30), chunk_size=5)
         b = a.reshape(10, 600)
 
-        b.tiles()
+        b = b.tiles()
 
         self.assertEqual(tuple(sum(s) for s in b.nsplits), (10, 600))
 
         a = ones((10, 600), chunk_size=5)
         b = a.reshape(10, 30, 20)
 
-        b.tiles()
+        b = b.tiles()
 
         self.assertEqual(tuple(sum(s) for s in b.nsplits), (10, 30, 20))
 
         a = ones((10, 600), chunk_size=5)
         a.shape = [10, 30, 20]
 
-        a.tiles()
+        a = a.tiles()
 
         self.assertEqual(tuple(sum(s) for s in a.nsplits), (10, 30, 20))
 
@@ -51,7 +51,7 @@ class Test(unittest.TestCase):
         b = a.reshape(27, 31)
         b.op.extra_params['_reshape_with_shuffle'] = True
 
-        b.tiles()
+        b = b.tiles()
 
         self.assertEqual(tuple(sum(s) for s in b.nsplits), (27, 31))
         self.assertIsInstance(b.chunks[0].op, TensorReshapeReduce)

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -18,6 +18,7 @@ import unittest
 import numpy as np
 
 from mars.tensor import tensor
+from mars.tiles import get_tiled
 
 try:
     import scipy
@@ -41,7 +42,8 @@ class Test(unittest.TestCase):
         self.assertEqual(r.shape, raw.shape)
         self.assertEqual(r.dtype, expect.dtype)
 
-        r.tiles()
+        r = r.tiles()
+        t = get_tiled(t)
 
         self.assertEqual(r.nsplits, t.nsplits)
         for c in r.chunks:
@@ -59,7 +61,8 @@ class Test(unittest.TestCase):
         self.assertEqual(r.shape, raw.shape)
         self.assertEqual(r.dtype, expect.dtype)
 
-        r.tiles()
+        r = r.tiles()
+        t = get_tiled(t)
 
         self.assertEqual(r.nsplits, t.nsplits)
         for c in r.chunks:

--- a/mars/tensor/utils.py
+++ b/mars/tensor/utils.py
@@ -377,7 +377,7 @@ def unify_nsplits(*tensor_axes):
     for t, axes in tensor_axes:
         new_chunk = dict((i, axes_unified_splits[ax]) for ax, i in zip(axes, range(t.ndim))
                          if ax in axes_unified_splits)
-        res.append(rechunk(t, new_chunk).single_tiles())
+        res.append(rechunk(t, new_chunk)._inplace_tile())
 
     return tuple(res)
 
@@ -419,7 +419,7 @@ def recursive_tile(tensor):
         if cs:
             q.extend(cs)
             continue
-        t.single_tiles()
+        t._inplace_tile()
         q.pop()
 
     return tensor

--- a/mars/tests/test_executor.py
+++ b/mars/tests/test_executor.py
@@ -23,6 +23,7 @@ from mars.serialize import Int64Field
 from mars.tensor.operands import TensorOperand, TensorOperandMixin
 from mars.graph import DirectedGraph
 from mars.actors import Distributor, Actor
+from mars.tiles import get_tiled
 from mars.tests.core import create_actor_pool
 
 
@@ -176,6 +177,7 @@ class Test(unittest.TestCase):
         assigner = GraphDeviceAssigner(graph, list(n.op for n in graph.iter_indep()), devices=[0, 1])
         assigner.assign()
 
+        a = get_tiled(a)
         self.assertEqual(a.cix[0, 0].device, a.cix[0, 1].device)
         self.assertEqual(a.cix[1, 0].device, a.cix[1, 1].device)
         self.assertNotEqual(a.cix[0, 0].device, a.cix[1, 0].device)

--- a/mars/tests/test_mutable.py
+++ b/mars/tests/test_mutable.py
@@ -20,12 +20,15 @@ import unittest
 import numpy as np
 
 from mars.deploy.local.core import new_cluster
-from mars.session import new_session, LocalSession
+from mars.session import new_session, LocalSession, Session
 from mars.tests.core import mock
 
 
 @unittest.skipIf(sys.platform == 'win32', 'does not run in windows')
 class Test(unittest.TestCase):
+
+    def tearDown(self):
+        Session._default_session = None
 
     @mock.patch('webbrowser.open_new_tab', new=lambda *_, **__: True)
     def testMutableTensorCreateAndGet(self):
@@ -305,9 +308,6 @@ class Test(unittest.TestCase):
 
             # The arr should be executed after seal
             self.assertIn(arr.key, session._sess.executed_tileables)
-
-            # The arr should has chunks
-            self.assertNotEqual(arr.chunks, None)
 
             expected = np.zeros((4, 5), dtype='int32')
             expected[1:4, 2] = 8

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -29,7 +29,7 @@ from ..errors import ResponseMalformed, ExecutionInterrupted, ExecutionFailed, \
     ExecutionStateUnknown, ExecutionNotStopped
 from ..serialize import dataserializer
 from ..tensor.core import Indexes
-from ..utils import build_graph, sort_dataframe_result, numpy_dtype_from_descr_json
+from ..utils import build_tileable_graph, sort_dataframe_result, numpy_dtype_from_descr_json
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +142,7 @@ class Session(object):
         # those executed tileables should fetch data directly, submit the others
         run_tileables = [t for t in tileables if t.key not in self._executed_tileables]
 
-        graph = build_graph(run_tileables, executed_keys=list(self._executed_tileables.keys()))
+        graph = build_tileable_graph(run_tileables, set(self._executed_tileables.keys()))
         targets = [t.key for t in run_tileables]
 
         targets_join = ','.join(targets)

--- a/mars/worker/tests/test_main.py
+++ b/mars/worker/tests/test_main.py
@@ -25,6 +25,7 @@ import gevent
 
 from mars.compat import TimeoutError  # pylint: disable=W0622
 from mars.config import options
+from mars.tiles import get_tiled
 from mars.promise import PromiseActor
 from mars.utils import get_next_port, serialize_graph
 from mars.scheduler import ResourceActor, ChunkMetaActor
@@ -50,6 +51,7 @@ class WorkerProcessTestActor(PromiseActor):
         result = a.dot(b)
 
         graph = result.build_graph(tiled=True)
+        result = get_tiled(result)
 
         executor_ref = self.promise_ref(ExecutionActor.default_uid(), address=worker)
         io_meta = dict(chunks=[c.key for c in result.chunks])


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR aims to support iterative tiling. 

This is a situation which happens frequently. When an input tensor has chunks with unknown shape, the upcoming tile would fail. Previously, the entire execution would fail. With the support of iterative tiling, when the tile failed due to unknown shape, we will allow to execute the tile-unfinished graph first, then tile the rest part, if failure happens, execute first, then tile, and so forth.

This task would include:

- [x] Iterative tiling for local executor.
- [x] Iterative tiling for distributed executor.
- [x] Scan operands to find out those whose op cannot process chunk with unknown shape.
- [x] Make `tileable.tiles()` create a new object instead of modifying itself, unittests need to be modified as well.

An example is:

### Before iterative tiling implemented:

```
In [1]: import mars.tensor as mt                                                

In [2]: a = mt.random.rand(100, chunk_size=10)                                  

In [3]: a.sort()   # after sort, a's chunks will have unknown shape                                                             

In [5]: c = a[:10]    # no error happens                                                          

In [6]: c.execute()  # fails                                                           
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/Workspace/mars/mars/tiles.py in _dispatch(self, op)
    110         try:
--> 111             handler = self._handlers[op_cls]
    112             return handler(op)

KeyError: <class 'mars.tensor.indexing.getitem.TensorIndex'>

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
<ipython-input-6-c0ea283d147c> in <module>
----> 1 c.execute()

~/Workspace/mars/mars/tensor/core.py in execute(self, session, **kw)
    513 
    514     def execute(self, session=None, **kw):
--> 515         return self._data.execute(session, **kw)
    516 
    517 

~/Workspace/mars/mars/core.py in execute(self, session, **kw)
    582         if session is None:
    583             session = Session.default_or_local()
--> 584         return session.run(self, **kw)
    585 
    586     def fetch(self, session=None, **kw):

~/Workspace/mars/mars/session.py in run(self, *tileables, **kw)
    177         tileables = tuple(mt.tensor(t) if not isinstance(t, (Entity, Base)) else t
    178                           for t in tileables)
--> 179         result = self._sess.run(*tileables, **kw)
    180 
    181         for t in tileables:

~/Workspace/mars/mars/session.py in run(self, *tileables, **kw)
     88             # set number of running cores
     89             self.context.set_ncores(kw['n_parallel'])
---> 90             res = self._executor.execute_tileables(tileables, **kw)
     91             return res
     92 

~/Workspace/mars/mars/utils.py in _wrapped(*args, **kwargs)
    394                 _kernel_mode.eager = False
    395             _kernel_mode.eager_count = enter_eager_count + 1
--> 396             return func(*args, **kwargs)
    397         finally:
    398             _kernel_mode.eager_count -= 1

~/Workspace/mars/mars/executor.py in execute_tileables(self, tileables, fetch, n_parallel, n_thread, print_progress, mock, compose)
    648         concat_keys = []
    649         for tileable in tileables:
--> 650             tileable.tiles()
    651             chunk_keys = [c.key for c in tileable.chunks]
    652             result_keys.extend(chunk_keys)

~/Workspace/mars/mars/core.py in tiles(self)
    490 
    491     def tiles(self):
--> 492         return handler.tiles(self)
    493 
    494     def single_tiles(self):

~/Workspace/mars/mars/tiles.py in tiles(self, tiles_obj)
    155         for node in graph.topological_iter():
    156             if node.is_coarse() and node.op:
--> 157                 tiled = self._dispatch(node.op)
    158                 self._assign_to([t.data for t in tiled], node.op.outputs)
    159 

~/Workspace/mars/mars/utils.py in _wrapped(*args, **kwargs)
    394                 _kernel_mode.eager = False
    395             _kernel_mode.eager_count = enter_eager_count + 1
--> 396             return func(*args, **kwargs)
    397         finally:
    398             _kernel_mode.eager_count -= 1

~/Workspace/mars/mars/tiles.py in _dispatch(self, op)
    114             if hasattr(op_cls, 'tile'):
    115                 # has tile implementation
--> 116                 return op_cls.tile(op)
    117             for op_clz in self._handlers.keys():
    118                 if issubclass(op_cls, op_clz):

~/Workspace/mars/mars/tensor/indexing/getitem.py in tile(cls, op)
     78     def tile(cls, op):
     79         tile_handler = TensorIndexTilesHandler(op)
---> 80         return tile_handler()
     81 
     82     @classmethod

~/Workspace/mars/mars/tensor/indexing/getitem.py in __call__(self)
    489 
    490     def __call__(self):
--> 491         self._extract_indexes_info()
    492         self._preprocess_fancy_indexes()
    493         self._process_fancy_indexes()

~/Workspace/mars/mars/tensor/indexing/getitem.py in _extract_indexes_info(self)
    201             elif isinstance(raw_index_obj, slice):
    202                 reverse = (raw_index_obj.step or 0) < 0
--> 203                 idx_to_slices = sorted(slice_split(raw_index_obj, self._in_tensor.nsplits[in_axis]).items(),
    204                                        key=operator.itemgetter(0), reverse=reverse)
    205                 index_obj = OrderedDict()

~/Workspace/mars/mars/tensor/utils.py in slice_split(index, sizes)
    223 
    224     assert isinstance(index, slice)
--> 225     start, stop, step = index.indices(size)
    226 
    227     slice_all = slice(None)

TypeError: 'float' object cannot be interpreted as an integer
```

### After iterative tiling implemented

```
In [1]: import mars.tensor as mt                                                

In [2]: a = mt.random.rand(100, chunk_size=10)                                  

In [3]: a.sort()                                                                

In [4]: c = a[:10]                                                              

In [5]: c.execute()                                                             
Out[5]: 
array([0.02463543, 0.03005659, 0.03532287, 0.05244983, 0.06474972,
       0.06655057, 0.07276051, 0.0789955 , 0.07981996, 0.08654   ])
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #184 
