### PR TITLE
Support transferring multiple chunks at one time

### DIFF
--- a/.github/workflows/install-hdfs.sh
+++ b/.github/workflows/install-hdfs.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 set -e
 
-sudo apt-get remove -y yarn || true
-sudo apt-get update
+sudo apt-get remove -yq yarn || true
 
 # Installing CDH 5 with YARN on a Single Linux Node in Pseudo-distributed mode.
 curl -fsSL https://archive.cloudera.com/cdh5/ubuntu/xenial/amd64/cdh/archive.key | sudo apt-key add -
 echo 'deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/xenial/amd64/cdh xenial-cdh5 contrib' | sudo tee /etc/apt/sources.list.d/cloudera.list
 echo 'deb-src http://archive.cloudera.com/cdh5/ubuntu/xenial/amd64/cdh xenial-cdh5 contrib' | sudo tee -a /etc/apt/sources.list.d/cloudera.list
-sudo apt-get update
-sudo apt-get -y install hadoop-conf-pseudo libhdfs0
+sudo apt-get -q update || true
+sudo apt-get -yq install hadoop-conf-pseudo libhdfs0
 
 # start a pseudo-distributed Hadoop.
 sudo -u hdfs hdfs namenode -format

--- a/.github/workflows/install-minikube.sh
+++ b/.github/workflows/install-minikube.sh
@@ -5,8 +5,8 @@ export CHANGE_MINIKUBE_NONE_USER=true
 sudo apt-get remove -y docker.io || true
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-sudo apt-get update
-sudo apt-get install -y docker-ce
+sudo apt-get -q update || true
+sudo apt-get install -yq docker-ce
 
 K8S_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 

--- a/mars/errors.py
+++ b/mars/errors.py
@@ -68,10 +68,6 @@ class StorageDataExists(MarsError):
     pass
 
 
-class ChecksumMismatch(MarsError):
-    pass
-
-
 class ExecutionInterrupted(MarsError):
     pass
 

--- a/mars/promise.py
+++ b/mars/promise.py
@@ -247,6 +247,7 @@ class Promise(object):
         if self._accepted is not None:
             args_and_kwargs = [self._args, self._kwargs]
             args_and_kwargs[1]['_accept'] = self._accepted
+            _promise_pool.pop(self.id, None)
             self._clear_result_cache()
             self.step_next(args_and_kwargs)
         return promise
@@ -557,6 +558,8 @@ def all_(promises):
         def _then(*_, **__):
             finish_set.add(promise.id)
             if all(p.id in finish_set for p in promises):
+                for p in promises:
+                    _promise_pool.pop(p.id, None)
                 new_promise.step_next()
         return _then
 

--- a/mars/promise.py
+++ b/mars/promise.py
@@ -279,7 +279,7 @@ class PromiseRefWrapper(object):
     Promise wrapper that enables promise call by adding _promise=True
     """
     def __init__(self, ref, caller):
-        self._ref = ref
+        self._ref = caller.ctx.actor_ref(ref)
         self._caller = caller  # type: PromiseActor
 
     def send(self, message):
@@ -298,6 +298,10 @@ class PromiseRefWrapper(object):
     @property
     def address(self):
         return self._ref.address
+
+    def __reduce__(self):
+        # when pickled, return original ActorRef
+        return ActorRef, (self._caller.address, self._ref.uid)
 
     def __getattr__(self, item):
         if item.startswith('_'):

--- a/mars/web/static/js/mars.js
+++ b/mars/web/static/js/mars.js
@@ -44,9 +44,9 @@ $(function() {
                 $('#' + refInfo.id + ' table').bootstrapTable();
             });
         }, 'text');
-        window.setTimeout(refresh_tables, 10000);
+        window.setTimeout(refresh_tables, 5000);
     };
     if ($('.auto-refresh').length > 0) {
-        window.setTimeout(refresh_tables, 10000);
+        window.setTimeout(refresh_tables, 5000);
     }
 });

--- a/mars/worker/__init__.py
+++ b/mars/worker/__init__.py
@@ -21,4 +21,4 @@ from .prochelper import ProcessHelperActor
 from .quota import QuotaActor, MemQuotaActor
 from .storage import *
 from .status import StatusActor
-from .transfer import SenderActor, ReceiverActor
+from .transfer import SenderActor, ReceiverManagerActor, ReceiverWorkerActor

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -104,6 +104,9 @@ class BaseCalcActor(WorkerActor):
         context_dict = dict()
         storage_client = self.storage_client
 
+        if not keys_to_fetch:
+            return promise.finished(context_dict)
+
         def _handle_loaded(objs):
             data_locations = storage_client.get_data_locations(session_id, keys_to_fetch)
             shared_quota_keys = []

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -530,7 +530,6 @@ class ExecutionActor(WorkerActor):
                 .then(lambda *_: self._mem_quota_ref.request_batch_quota(
                     quota_request, _promise=True) if quota_request else None) \
                 .then(lambda *_: self._prepare_graph_inputs(session_id, graph_key)) \
-                .then(lambda *_: self._prepare_graph_inputs(session_id, graph_key)) \
                 .then(lambda *_: self._dispatch_ref.get_free_slot(calc_device, _promise=True)) \
                 .then(lambda uid: self._send_calc_request(session_id, graph_key, uid)) \
                 .then(lambda saved_keys: self._store_results(session_id, graph_key, saved_keys)) \

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -758,7 +758,7 @@ class ExecutionActor(WorkerActor):
 
         for target, keys in address_to_data_keys.items():
             self.ctx.actor_ref(ReceiverManagerActor.default_uid(), address=target) \
-                .register_keys(session_id, keys, _tell=True, _wait=False)
+                .register_pending_keys(session_id, keys, _tell=True, _wait=False)
 
         return promise.all_(promises)
 

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -176,7 +176,7 @@ class ExecutionActor(WorkerActor):
                 self._dump_execution_states()
         self.ref().periodical_dump(_tell=True, _delay=10)
 
-    def _pin_data_keys(self, session_id, graph_key, data_keys):
+    def _pin_shared_data_keys(self, session_id, graph_key, data_keys):
         if not data_keys:
             return []
         try:
@@ -258,7 +258,7 @@ class ExecutionActor(WorkerActor):
 
         keys_to_pin = list(input_chunk_keys.keys())
         graph_record.pinned_keys = set()
-        self._pin_data_keys(session_id, graph_key, keys_to_pin)
+        self._pin_shared_data_keys(session_id, graph_key, keys_to_pin)
 
         load_chunk_sizes = dict((k, v) for k, v in input_chunk_keys.items()
                                 if k not in graph_record.pinned_keys)
@@ -266,7 +266,6 @@ class ExecutionActor(WorkerActor):
                                for k, v in load_chunk_sizes.items()
                                if k not in graph_record.shared_input_chunks)
         if alloc_cache_batch:
-            # todo change when compute with gpu
             storage_client.spill_size(sum(alloc_cache_batch.values()), [graph_record.preferred_data_device])
 
         graph_record.mem_request = alloc_mem_batch or dict()
@@ -296,12 +295,12 @@ class ExecutionActor(WorkerActor):
 
         @log_unhandled
         def _finish_fetch(*_):
-            locations = storage_client.get_data_locations(session_id, [chunk_key])[0]
-            if (0, DataStorageDevice.SHARED_MEMORY) in locations:
-                self._pin_data_keys(session_id, graph_key, [chunk_key])
+            locations = set(l[1] for l in storage_client.get_data_locations(session_id, [chunk_key])[0])
+            if DataStorageDevice.PROC_MEMORY not in locations:
+                self._pin_shared_data_keys(session_id, graph_key, [chunk_key])
                 self._mem_quota_ref.release_quotas(
                     [build_quota_key(session_id, chunk_key, owner=graph_key)], _tell=True, _wait=False)
-                if (0, graph_record.preferred_data_device) not in locations:
+                if graph_record.preferred_data_device not in locations:
                     return storage_client.copy_to(session_id, [chunk_key], [graph_record.preferred_data_device])
 
         @log_unhandled
@@ -340,7 +339,7 @@ class ExecutionActor(WorkerActor):
 
             return sender_ref.send_data(
                 session_id, [chunk_key], [self.address], ensure_cached=ensure_cached,
-                timeout=timeout, _timeout=timeout, _promise=True
+                pin_token=graph_key, timeout=timeout, _timeout=timeout, _promise=True
             ).then(_finish_fetch)
 
         return promise.finished() \
@@ -531,6 +530,7 @@ class ExecutionActor(WorkerActor):
                 .then(lambda *_: self._mem_quota_ref.request_batch_quota(
                     quota_request, _promise=True) if quota_request else None) \
                 .then(lambda *_: self._prepare_graph_inputs(session_id, graph_key)) \
+                .then(lambda *_: self._prepare_graph_inputs(session_id, graph_key)) \
                 .then(lambda *_: self._dispatch_ref.get_free_slot(calc_device, _promise=True)) \
                 .then(lambda uid: self._send_calc_request(session_id, graph_key, uid)) \
                 .then(lambda saved_keys: self._store_results(session_id, graph_key, saved_keys)) \
@@ -598,26 +598,26 @@ class ExecutionActor(WorkerActor):
         better_shared_keys = [k for k in copy_keys if k not in graph_record.shared_input_chunks]
 
         def _release_copied_keys(keys):
-            actual_moved_keys = self._pin_data_keys(session_id, graph_key, keys)
+            actual_moved_keys = self._pin_shared_data_keys(session_id, graph_key, keys)
             self._mem_quota_ref.release_quotas(
                 [build_quota_key(session_id, k, owner=graph_key) for k in actual_moved_keys],
                 _tell=True)
 
         if ensure_shared_keys:
-            self._mem_quota_ref.release_quotas(
-                [build_quota_key(session_id, k, owner=graph_key) for k in ensure_shared_keys],
-                _tell=True)
             promises.append(
                 self.storage_client.copy_to(
                     session_id, ensure_shared_keys, [graph_record.preferred_data_device],
                     ensure=True, pin_token=graph_key)
+                .then(lambda *_: _release_copied_keys(better_shared_keys),
+                      lambda *_: _release_copied_keys(better_shared_keys))
             )
         if better_shared_keys:
             promises.append(
                 self.storage_client.copy_to(
                     session_id, better_shared_keys, [graph_record.preferred_data_device],
                     ensure=False, pin_token=graph_key)
-                .then(lambda *_: _release_copied_keys(better_shared_keys))
+                .then(lambda *_: _release_copied_keys(better_shared_keys),
+                      lambda *_: _release_copied_keys(better_shared_keys))
             )
         return promises
 

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -31,7 +31,7 @@ from .dispatcher import DispatchActor
 from .events import EventsActor
 from .execution import ExecutionActor
 from .calc import CpuCalcActor, CudaCalcActor
-from .transfer import ReceiverActor, SenderActor, ReceiverManagerActor, ResultSenderActor
+from .transfer import SenderActor, ReceiverManagerActor, ReceiverWorkerActor, ResultSenderActor
 from .prochelper import ProcessHelperActor
 from .storage import IORunnerActor, StorageManagerActor, SharedHolderActor, \
     InProcHolderActor, CudaHolderActor
@@ -268,7 +268,7 @@ class WorkerService(object):
         # Mutable requires ReceiverActor (with LocalClusterSession)
         for receiver_id in range(2 * self._n_net_process):
             uid = 'w:%d:mars-receiver-%d-%d' % (start_pid + receiver_id // 2, os.getpid(), receiver_id)
-            actor = actor_holder.create_actor(ReceiverActor, uid=uid)
+            actor = actor_holder.create_actor(ReceiverWorkerActor, uid=uid)
             self._receiver_actors.append(actor)
 
         # create ProcessHelperActor

--- a/mars/worker/storage/client.py
+++ b/mars/worker/storage/client.py
@@ -145,8 +145,8 @@ class StorageClient(object):
         device_order = self._normalize_devices(device_order)
 
         def _action(handler, _keys, _promise=True):
-            logger.debug('Creating %s writer for (%s, %s) on %s', 'packed' if packed else 'bytes',
-                         session_id, data_key, handler.storage_type)
+            logger.debug('Creating %s writer for (%s, %s) with size %s on %s', 'packed' if packed else 'bytes',
+                         session_id, data_key, total_bytes, handler.storage_type)
             return handler.create_bytes_writer(
                 session_id, data_key, total_bytes, packed=packed,
                 packed_compression=packed_compression, _promise=_promise)
@@ -175,6 +175,8 @@ class StorageClient(object):
         source_devices = self._normalize_devices(source_devices)
         stored_dev_lists = self._manager_ref.get_data_locations(session_id, data_keys)
         dev_to_keys = defaultdict(list)
+        if any(not loc for loc in stored_dev_lists):
+            raise KeyError(next(k for k, loc in zip(data_keys, stored_dev_lists)))
         for key, devs in zip(data_keys, stored_dev_lists):
             first_dev = next((stored_dev for stored_dev in source_devices if stored_dev in devs),
                              None) or sorted(devs)[0]

--- a/mars/worker/storage/client.py
+++ b/mars/worker/storage/client.py
@@ -261,7 +261,7 @@ class StorageClient(object):
             sizes_dict = dict((k, calc_data_size(obj)) for k, obj in zip(data_keys, objs))
 
         data_dict = dict(zip(data_keys, objs))
-        objs[:] = []
+        del objs
 
         def _action(h, keys):
             objects = [data_dict[k] for k in keys]
@@ -294,10 +294,6 @@ class StorageClient(object):
         device_total_size = defaultdict(lambda: 0)
         lift_reqs = defaultdict(list)
         for k, devices, size in zip(data_keys, existing_devs, data_sizes):
-            # currently copy across non-zero processes is not allowed.
-            if self.proc_id != 0:
-                devices = [d for d in devices if d[0] in (0, self.proc_id)]
-
             if not devices or not size:
                 return promise.finished(
                     *build_exc_info(KeyError, 'Data key (%s, %s) not exist, proc_id=%s' % (session_id, k, self.proc_id)),

--- a/mars/worker/storage/client.py
+++ b/mars/worker/storage/client.py
@@ -83,14 +83,19 @@ class StorageClient(object):
                 for d in devices] if devices is not None else None
 
     def _do_with_spill(self, action, data_keys, total_bytes, device_order,
-                       device_pos=0, spill_multiplier=1.0, ensure=True):
+                       device_pos=0, spill_multiplier=1.0, ensure=True, data_cleaner=None):
         def _handle_err(*exc_info):
             if issubclass(exc_info[0], StorageFull):
                 req_bytes = max(total_bytes, exc_info[1].request_size)
+
+                if data_cleaner and exc_info[1].affected_keys:
+                    affected_keys = set(exc_info[1].affected_keys)
+                    data_cleaner([k for k in data_keys if k not in affected_keys])
+
                 if device_pos < len(device_order) - 1:
                     return self._do_with_spill(
                         action, exc_info[1].affected_keys, req_bytes, device_order,
-                        device_pos=device_pos + 1, spill_multiplier=1.0, ensure=ensure,
+                        device_pos=device_pos + 1, spill_multiplier=1.0, ensure=ensure
                     )
                 elif ensure:
                     new_multiplier = min(spill_multiplier + 0.1, 10)
@@ -99,6 +104,8 @@ class StorageClient(object):
                             action, exc_info[1].affected_keys, req_bytes, device_order,
                             device_pos=device_pos, spill_multiplier=new_multiplier, ensure=ensure,
                         ))
+            elif data_cleaner:
+                data_cleaner(data_keys)
             six.reraise(*exc_info)
 
         cur_device = device_order[device_pos]
@@ -141,15 +148,15 @@ class StorageClient(object):
             raise IOError('Cannot return a non-promise result')
 
     def create_writer(self, session_id, data_key, total_bytes, device_order, packed=False,
-                      packed_compression=None, _promise=True):
+                      packed_compression=None, pin_token=None, _promise=True):
         device_order = self._normalize_devices(device_order)
 
         def _action(handler, _keys, _promise=True):
             logger.debug('Creating %s writer for (%s, %s) with size %s on %s', 'packed' if packed else 'bytes',
                          session_id, data_key, total_bytes, handler.storage_type)
             return handler.create_bytes_writer(
-                session_id, data_key, total_bytes, packed=packed,
-                packed_compression=packed_compression, _promise=_promise)
+                session_id, data_key, total_bytes, packed=packed, packed_compression=packed_compression,
+                pin_token=pin_token, _promise=_promise)
 
         if _promise:
             return self._do_with_spill(_action, [data_key], total_bytes, device_order)
@@ -164,12 +171,18 @@ class StorageClient(object):
             raise exc
 
     def get_object(self, session_id, data_key, source_devices, serialize=False, _promise=True):
+        def _extract_obj(objs):
+            try:
+                return objs[0]
+            finally:
+                objs[:] = []
+
         if _promise:
             return self.get_objects(session_id, [data_key], source_devices, serialize=serialize,
-                                    _promise=True).then(lambda objs: objs[0])
+                                    _promise=True).then(_extract_obj)
         else:
-            return self.get_objects(session_id, [data_key], source_devices, serialize=serialize,
-                                    _promise=False)[0]
+            return _extract_obj(self.get_objects(session_id, [data_key], source_devices, serialize=serialize,
+                                                 _promise=False))
 
     def get_objects(self, session_id, data_keys, source_devices, serialize=False, _promise=True):
         source_devices = self._normalize_devices(source_devices)
@@ -182,31 +195,63 @@ class StorageClient(object):
                              None) or sorted(devs)[0]
             dev_to_keys[first_dev].append(key)
 
+        is_success = [True]
         data_dict = dict()
         if not _promise:
-            if any(dev not in source_devices for dev in dev_to_keys.keys()):
-                raise IOError('Getting objects without promise not supported')
-            for stored_dev, keys in dev_to_keys.items():
-                handler = self.get_storage_handler(stored_dev)
-                data_dict.update(zip(keys, handler.get_objects(
-                    session_id, data_keys, serialize=serialize, _promise=False)))
-            return [data_dict[k] for k in data_keys]
+            try:
+                if any(dev not in source_devices for dev in dev_to_keys.keys()):
+                    raise IOError('Getting objects without promise not supported')
+                for stored_dev, keys in dev_to_keys.items():
+                    handler = self.get_storage_handler(stored_dev)
+                    data_dict.update(zip(keys, handler.get_objects(
+                        session_id, data_keys, serialize=serialize, _promise=False)))
+                return [data_dict.pop(k) for k in data_keys]
+            finally:
+                data_dict.clear()
         else:
-            promises = []
-            for stored_dev, keys in dev_to_keys.items():
-                handler = self.get_storage_handler(stored_dev)
-                loc_getter = functools.partial(
-                    lambda keys, *_: self.get_objects(
-                        session_id, keys, source_devices, serialize=serialize, _promise=True), keys)
-                updater = functools.partial(lambda keys, objs: data_dict.update(zip(keys, objs)),
-                                            keys)
-                if stored_dev in source_devices:
-                    promises.append(handler.get_objects(
-                        session_id, keys, serialize=serialize, _promise=True).then(updater))
-                else:
-                    promises.append(self.copy_to(session_id, keys, source_devices)
-                        .then(loc_getter).then(updater))
-            return promise.all_(promises).then(lambda *_: [data_dict[k] for k in data_keys])
+            def _update_key_items(keys, objs):
+                try:
+                    if is_success[0]:
+                        data_dict.update(zip(keys, objs))
+                finally:
+                    objs[:] = []
+
+            def _handle_key_error(*exc):
+                is_success[0] = False
+                data_dict.clear()
+                six.reraise(*exc)
+
+            def _finalize(*exc):
+                try:
+                    if not exc:
+                        return [data_dict.pop(k) for k in data_keys]
+                    else:
+                        six.reraise(*exc)
+                finally:
+                    data_dict.clear()
+
+            try:
+                promises = []
+                for stored_dev, keys in dev_to_keys.items():
+                    handler = self.get_storage_handler(stored_dev)
+                    loc_getter = functools.partial(
+                        lambda keys, *_: self.get_objects(
+                            session_id, keys, source_devices, serialize=serialize, _promise=True), keys)
+                    updater = functools.partial(_update_key_items, keys)
+                    if stored_dev in source_devices:
+                        promises.append(
+                            handler.get_objects(session_id, keys, serialize=serialize, _promise=True)
+                                .then(updater, _handle_key_error)
+                        )
+                    else:
+                        promises.append(
+                            self.copy_to(session_id, keys, source_devices).then(loc_getter)
+                                .then(updater, _handle_key_error)
+                        )
+                return promise.all_(promises).then(lambda *_: _finalize(), _finalize)
+            except:  # noqa: E722
+                data_dict.clear()
+                raise
 
     def put_objects(self, session_id, data_keys, objs, device_order, sizes=None, serialize=False):
         device_order = self._normalize_devices(device_order)
@@ -216,6 +261,7 @@ class StorageClient(object):
             sizes_dict = dict((k, calc_data_size(obj)) for k, obj in zip(data_keys, objs))
 
         data_dict = dict(zip(data_keys, objs))
+        objs[:] = []
 
         def _action(h, keys):
             objects = [data_dict[k] for k in keys]
@@ -224,9 +270,20 @@ class StorageClient(object):
                 return h.put_objects(session_id, keys, objects, sizes=data_sizes, serialize=serialize,
                                      _promise=True)
             finally:
-                objects[:] = []
+                del objects
 
-        return self._do_with_spill(_action, data_keys, sum(sizes_dict.values()), device_order)
+        def _clean_succeeded(keys):
+            for k in keys:
+                data_dict.pop(k, None)
+
+        def _clean_all(*exc):
+            data_dict.clear()
+            if exc:
+                six.reraise(*exc)
+
+        return self._do_with_spill(_action, data_keys, sum(sizes_dict.values()), device_order,
+                                   data_cleaner=_clean_succeeded) \
+            .then(lambda *_: _clean_all(), _clean_all)
 
     def copy_to(self, session_id, data_keys, device_order, ensure=True, pin_token=None):
         device_order = self._normalize_devices(device_order)
@@ -237,9 +294,13 @@ class StorageClient(object):
         device_total_size = defaultdict(lambda: 0)
         lift_reqs = defaultdict(list)
         for k, devices, size in zip(data_keys, existing_devs, data_sizes):
+            # currently copy across non-zero processes is not allowed.
+            if self.proc_id != 0:
+                devices = [d for d in devices if d[0] in (0, self.proc_id)]
+
             if not devices or not size:
                 return promise.finished(
-                    *build_exc_info(KeyError, 'Data key (%s, %s) does not exist.' % (session_id, k)),
+                    *build_exc_info(KeyError, 'Data key (%s, %s) not exist, proc_id=%s' % (session_id, k, self.proc_id)),
                     **dict(_accept=False)
                 )
 

--- a/mars/worker/storage/core.py
+++ b/mars/worker/storage/core.py
@@ -245,8 +245,7 @@ class StorageHandler(object):
             else:
                 return promise.finished()
         else:
-            raise NotImplementedError('Copying from %r to %r not supported now' %
-                                      (src_handler.storage_type, self.storage_type))
+            return fallback() if fallback is not None else promise.finished()
 
     def unregister_data(self, session_id, data_keys, _tell=False):
         self._storage_ctx.manager_ref \

--- a/mars/worker/storage/cudahandler.py
+++ b/mars/worker/storage/cudahandler.py
@@ -121,7 +121,8 @@ class CudaHandler(StorageHandler, ObjectStorageMixin, SpillableStorageMixin):
     def load_from_object_io(self, session_id, data_keys, src_handler, pin_token=None):
         return self._batch_load_objects(
             session_id, data_keys,
-            lambda k: src_handler.get_objects(session_id, k, _promise=True), pin_token=pin_token, batch_get=True)
+            lambda keys: src_handler.get_objects(session_id, keys, _promise=True),
+            pin_token=pin_token, batch_get=True)
 
     def load_from_bytes_io(self, session_id, data_keys, src_handler, pin_token=None):
         def _read_serialized(reader):

--- a/mars/worker/storage/iorunner.py
+++ b/mars/worker/storage/iorunner.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 import logging
 from collections import deque
 
@@ -91,7 +90,7 @@ class IORunnerActor(WorkerActor):
             return
 
         @log_unhandled
-        def _finalize(exc, *_):
+        def _finalize(*exc):
             del self._cur_work_items[work_item_id]
             if not exc:
                 self.tell_promise(cb)
@@ -104,4 +103,4 @@ class IORunnerActor(WorkerActor):
         src_handler = self.storage_client.get_storage_handler(src_device)
         dest_handler = self.storage_client.get_storage_handler(dest_device)
         dest_handler.load_from(session_id, data_keys, src_handler) \
-            .then(functools.partial(_finalize, None), lambda *exc: _finalize(exc))
+            .then(lambda *_: _finalize(), _finalize)

--- a/mars/worker/storage/manager.py
+++ b/mars/worker/storage/manager.py
@@ -94,7 +94,7 @@ class StorageManagerActor(WorkerActor):
                 pass
 
     def get_data_locations(self, session_id, data_keys):
-        return [self._data_to_locations.get((session_id, key)) or set() for key in data_keys]
+        return [set(self._data_to_locations.get((session_id, key)) or ()) for key in data_keys]
 
     def get_data_sizes(self, session_id, data_keys):
         return [a.size if a is not None else None

--- a/mars/worker/storage/objectholder.py
+++ b/mars/worker/storage/objectholder.py
@@ -272,7 +272,7 @@ class SimpleObjectHolderActor(ObjectHolderActor):
                 self.pin_data_keys(session_id, data_keys, pin_token)
             self._finish_put_objects(session_id, data_keys)
         finally:
-            data_objs[:] = []
+            del data_objs
 
     def get_object(self, session_id, data_key):
         return self._data_holder[(session_id, data_key)]

--- a/mars/worker/storage/procmemhandler.py
+++ b/mars/worker/storage/procmemhandler.py
@@ -43,11 +43,18 @@ class ProcMemHandler(StorageHandler, ObjectStorageMixin):
     @wrap_promised
     def put_objects(self, session_id, data_keys, objs, sizes=None, serialize=False,
                     pin_token=None, _promise=False):
+        raw_objs = objs
         objs = [self._deserial(obj) if serialize else obj for obj in objs]
-        sizes = sizes or [calc_data_size(obj) for obj in objs]
-        shapes = [getattr(obj, 'shape', None) for obj in objs]
-        self._inproc_store_ref.put_objects(session_id, data_keys, objs, sizes, pin_token=pin_token)
-        self.register_data(session_id, data_keys, sizes, shapes)
+        obj = None
+        try:
+            sizes = sizes or [calc_data_size(obj) for obj in objs]
+            shapes = [getattr(obj, 'shape', None) for obj in objs]
+            self._inproc_store_ref.put_objects(session_id, data_keys, objs, sizes, pin_token=pin_token)
+            self.register_data(session_id, data_keys, sizes, shapes)
+        finally:
+            raw_objs[:] = []
+            objs[:] = []
+            del obj
 
     def load_from_bytes_io(self, session_id, data_keys, src_handler, pin_token=None):
         def _read_serialized(reader):

--- a/mars/worker/storage/procmemhandler.py
+++ b/mars/worker/storage/procmemhandler.py
@@ -43,7 +43,6 @@ class ProcMemHandler(StorageHandler, ObjectStorageMixin):
     @wrap_promised
     def put_objects(self, session_id, data_keys, objs, sizes=None, serialize=False,
                     pin_token=None, _promise=False):
-        raw_objs = objs
         objs = [self._deserial(obj) if serialize else obj for obj in objs]
         obj = None
         try:
@@ -52,7 +51,6 @@ class ProcMemHandler(StorageHandler, ObjectStorageMixin):
             self._inproc_store_ref.put_objects(session_id, data_keys, objs, sizes, pin_token=pin_token)
             self.register_data(session_id, data_keys, sizes, shapes)
         finally:
-            raw_objs[:] = []
             objs[:] = []
             del obj
 

--- a/mars/worker/storage/sharedhandler.py
+++ b/mars/worker/storage/sharedhandler.py
@@ -150,7 +150,6 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
         affected_keys = []
         request_size, capacity = 0, 0
 
-        raw_objs = objs
         objs = [self._deserial(obj) if serialize else obj for obj in objs]
         obj_refs = []
         obj = None
@@ -177,7 +176,6 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
                                   affected_keys=affected_keys)
         finally:
             del obj
-            raw_objs[:] = []
             objs[:] = []
             obj_refs[:] = []
 

--- a/mars/worker/storage/sharedhandler.py
+++ b/mars/worker/storage/sharedhandler.py
@@ -17,8 +17,9 @@ import functools
 import pyarrow
 
 from ... import promise
+from ...compat import six
 from ...config import options
-from ...errors import StorageFull
+from ...errors import StorageFull, StorageDataExists
 from ...serialize import dataserializer
 from ..dataio import ArrowBufferIO
 from .core import StorageHandler, BytesStorageMixin, ObjectStorageMixin, \
@@ -146,15 +147,16 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
     def put_objects(self, session_id, data_keys, objs, sizes=None, serialize=False,
                     pin_token=None, _promise=False):
         succ_keys, succ_shapes = [], []
-        obj_refs = []
         affected_keys = []
         request_size, capacity = 0, 0
 
+        raw_objs = objs
+        objs = [self._deserial(obj) if serialize else obj for obj in objs]
+        obj_refs = []
+        obj = None
         try:
             for key, obj in zip(data_keys, objs):
-                obj = self._deserial(obj) if serialize else obj
                 shape = getattr(obj, 'shape', None)
-
                 try:
                     obj_refs.append(self._shared_store.put(session_id, key, obj))
                     succ_keys.append(key)
@@ -163,17 +165,24 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
                     affected_keys.extend(ex.affected_keys)
                     request_size += ex.request_size
                     capacity = ex.capacity
-                finally:
-                    del obj
+                except StorageDataExists:
+                    if self.location in self.storage_ctx.get_data_locations(session_id, [key])[0]:
+                        succ_keys.append(key)
+                        succ_shapes.append(shape)
+                    else:
+                        raise
             self._holder_ref.put_objects_by_keys(session_id, succ_keys, shapes=succ_shapes, pin_token=pin_token)
             if affected_keys:
                 raise StorageFull(request_size=request_size, capacity=capacity,
                                   affected_keys=affected_keys)
         finally:
+            del obj
+            raw_objs[:] = []
+            objs[:] = []
             obj_refs[:] = []
-            del objs
 
     def load_from_bytes_io(self, session_id, data_keys, src_handler, pin_token=None):
+        is_success = [True]
         shared_bufs = []
         failed_keys = set()
         storage_full_sizes = [0, 0]
@@ -186,19 +195,24 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
                 storage_full_sizes[0] += exc.request_size
                 storage_full_sizes[1] = exc.capacity
             else:
+                is_success[0] = False
+                shared_bufs[:] = []
                 self.pass_on_exc(reader.close, exc_info)
 
         def _on_file_close(key, _reader, writer, finished):
             if finished:
-                shared_bufs.append(writer.get_shared_buffer())
+                if is_success[0]:
+                    shared_bufs.append(writer.get_shared_buffer())
             else:
                 failed_keys.add(key)
 
-        def _finalize_load(*_):
+        def _finalize_load(*exc):
             try:
                 success_keys = [k for k in data_keys if k not in failed_keys]
                 if success_keys:
                     self._holder_ref.put_objects_by_keys(session_id, success_keys, pin_token=pin_token)
+                if exc:
+                    six.reraise(*exc)
                 if failed_keys:
                     raise StorageFull(request_size=storage_full_sizes[0], capacity=storage_full_sizes[1],
                                       affected_keys=list(failed_keys))
@@ -215,7 +229,8 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
                               lambda *exc: handle_worker_create_fail(reader, exc)))
 
         def _fallback(*_):
-            return promise.all_(_load_single_key(k) for k in data_keys).then(_finalize_load)
+            return promise.all_(_load_single_key(k) for k in data_keys) \
+                .then(lambda *_: _finalize_load(), _finalize_load)
 
         return self.transfer_in_runner(session_id, data_keys, src_handler, _fallback)
 

--- a/mars/worker/storage/tests/test_client.py
+++ b/mars/worker/storage/tests/test_client.py
@@ -58,50 +58,27 @@ class OtherProcessTestActor(WorkerActor):
         else:
             six.reraise(*self._result)
 
-    def run_copy_global_to_proc_test(self):
+    def run_copy_test(self, src_location, dest_location):
         self._accept, self._result = None, None
 
         session_id = str(uuid.uuid4())
         data1 = np.random.randint(0, 32767, (655360,), np.int16)
         key1 = str(uuid.uuid4())
 
-        shared_handler = self.storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
-        proc_handler = self.storage_client.get_storage_handler((1, DataStorageDevice.PROC_MEMORY))
+        src_handler = self.storage_client.get_storage_handler(src_location)
+        proc_handler = self.storage_client.get_storage_handler(dest_location)
 
         def _verify_result(*_):
             result = proc_handler.get_objects(session_id, [key1])[0]
             assert_allclose(result, data1)
 
             devices = self._manager_ref.get_data_locations(session_id, [key1])[0]
-            if devices != {(0, DataStorageDevice.SHARED_MEMORY), (1, DataStorageDevice.PROC_MEMORY)}:
+            self.storage_client.delete(session_id, [key1])
+            if devices != {src_location, dest_location}:
                 raise AssertionError
 
-        shared_handler.put_objects(session_id, [key1], [data1])
-        self.storage_client.copy_to(session_id, [key1], [(1, DataStorageDevice.PROC_MEMORY)]) \
-            .then(_verify_result) \
-            .then(lambda *_: self.set_result(1),
-                  lambda *exc: self.set_result(exc, accept=False))
-
-    def run_copy_proc_to_global_test(self):
-        self._accept, self._result = None, None
-
-        session_id = str(uuid.uuid4())
-        data1 = np.random.randint(0, 32767, (655360,), np.int16)
-        key1 = str(uuid.uuid4())
-
-        shared_handler = self.storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
-        proc_handler = self.storage_client.get_storage_handler((1, DataStorageDevice.PROC_MEMORY))
-
-        def _verify_result(*_):
-            result = shared_handler.get_objects(session_id, [key1])[0]
-            assert_allclose(result, data1)
-
-            devices = self._manager_ref.get_data_locations(session_id, [key1])[0]
-            if devices != {(0, DataStorageDevice.SHARED_MEMORY), (1, DataStorageDevice.PROC_MEMORY)}:
-                raise AssertionError
-
-        proc_handler.put_objects(session_id, [key1], [data1])
-        self.storage_client.copy_to(session_id, [key1], [DataStorageDevice.SHARED_MEMORY]) \
+        src_handler.put_objects(session_id, [key1], [data1])
+        self.storage_client.copy_to(session_id, [key1], [dest_location]) \
             .then(_verify_result) \
             .then(lambda *_: self.set_result(1),
                   lambda *exc: self.set_result(exc, accept=False))
@@ -257,12 +234,13 @@ class Test(WorkerCase):
                 ref = weakref.ref(data_dict[data_keys[0]])
                 storage_client.put_objects(session_id, data_keys[:1], [ref()],
                                            [DataStorageDevice.SHARED_MEMORY])
+                data_list[:] = []
                 data_dict.clear()
                 self.assertIsNone(ref())
 
     def testLoadStoreInOtherProcess(self):
         test_addr = '127.0.0.1:%d' % get_next_port()
-        with self.create_pool(n_process=2, address=test_addr, distributor=MarsDistributor(2)) as pool:
+        with self.create_pool(n_process=3, address=test_addr, distributor=MarsDistributor(3)) as pool:
             pool.create_actor(WorkerDaemonActor, uid=WorkerDaemonActor.default_uid())
             pool.create_actor(StorageManagerActor, uid=StorageManagerActor.default_uid())
 
@@ -274,26 +252,30 @@ class Test(WorkerCase):
             pool.create_actor(SharedHolderActor, self.plasma_storage_size,
                               uid=SharedHolderActor.default_uid())
 
-            pool.create_actor(InProcHolderActor, uid='w:1:InProcHolderActor')
+            pool.create_actor(InProcHolderActor, uid='w:1:InProcHolderActor1')
+            pool.create_actor(InProcHolderActor, uid='w:2:InProcHolderActor2')
             pool.create_actor(IORunnerActor, lock_free=True, dispatched=False, uid=IORunnerActor.gen_uid(1))
 
             test_ref = pool.create_actor(OtherProcessTestActor, uid='w:0:OtherProcTest')
 
-            test_ref.run_copy_global_to_proc_test(_tell=True)
+            def _get_result():
+                start_time = time.time()
+                while test_ref.get_result() is None:
+                    pool.sleep(0.5)
+                    if time.time() - start_time > 10:
+                        raise TimeoutError
 
-            start_time = time.time()
-            while test_ref.get_result() is None:
-                pool.sleep(0.5)
-                if time.time() - start_time > 10:
-                    raise TimeoutError
+            test_ref.run_copy_test((0, DataStorageDevice.SHARED_MEMORY),
+                                   (1, DataStorageDevice.PROC_MEMORY), _tell=True)
+            _get_result()
 
-            test_ref.run_copy_proc_to_global_test(_tell=True)
+            test_ref.run_copy_test((1, DataStorageDevice.PROC_MEMORY),
+                                   (0, DataStorageDevice.SHARED_MEMORY), _tell=True)
+            _get_result()
 
-            start_time = time.time()
-            while test_ref.get_result() is None:
-                pool.sleep(0.5)
-                if time.time() - start_time > 10:
-                    raise TimeoutError
+            test_ref.run_copy_test((1, DataStorageDevice.PROC_MEMORY),
+                                   (2, DataStorageDevice.PROC_MEMORY), _tell=True)
+            _get_result()
 
     def testClientSpill(self, *_):
         test_addr = '127.0.0.1:%d' % get_next_port()

--- a/mars/worker/storage/tests/test_client.py
+++ b/mars/worker/storage/tests/test_client.py
@@ -252,6 +252,14 @@ class Test(WorkerCase):
                           lambda *exc: test_actor.set_result(exc, accept=False))
                 assert_allclose(self.get_result(5), data_dict[first_shared_key])
 
+                storage_client.delete(session_id, data_keys)
+                time.sleep(0.5)
+                ref = weakref.ref(data_dict[data_keys[0]])
+                storage_client.put_objects(session_id, data_keys[:1], [ref()],
+                                           [DataStorageDevice.SHARED_MEMORY])
+                data_dict.clear()
+                self.assertIsNone(ref())
+
     def testLoadStoreInOtherProcess(self):
         test_addr = '127.0.0.1:%d' % get_next_port()
         with self.create_pool(n_process=2, address=test_addr, distributor=MarsDistributor(2)) as pool:

--- a/mars/worker/tests/base.py
+++ b/mars/worker/tests/base.py
@@ -139,7 +139,7 @@ class WorkerCase(unittest.TestCase):
             p = promises[0]
         p.then(lambda *s: self._test_actor_ref.set_result(s, _tell=True),
                lambda *exc: self._test_actor_ref.set_result(exc, accept=False, _tell=True))
-        self.get_result(timeout)
+        return self.get_result(timeout)
 
     def get_result(self, timeout=None):
         if not self._result_event.wait(timeout):

--- a/mars/worker/tests/test_calc.py
+++ b/mars/worker/tests/test_calc.py
@@ -158,7 +158,7 @@ class Test(WorkerCase):
             self.assertEqual(sorted(storage_client.get_data_locations(session_id, [fetch_chunks[0].key])[0]),
                              [(0, DataStorageDevice.SHARED_MEMORY)])
             self.assertEqual(sorted(storage_client.get_data_locations(session_id, [fetch_chunks[1].key])[0]),
-                             [(0, DataStorageDevice.SHARED_MEMORY), (0, DataStorageDevice.DISK)])
+                             [(0, DataStorageDevice.DISK)])
             self.assertEqual(sorted(storage_client.get_data_locations(session_id, [fetch_chunks[2].key])[0]),
                              [(0, DataStorageDevice.DISK)])
             self.assertEqual(sorted(storage_client.get_data_locations(session_id, [add_chunk.key])[0]),

--- a/mars/worker/tests/test_execution.py
+++ b/mars/worker/tests/test_execution.py
@@ -73,7 +73,8 @@ class MockSenderActor(WorkerActor):
 
     @promise.reject_on_exception
     def send_data(self, session_id, chunk_keys, target_endpoints, target_slots=None,
-                  ensure_cached=True, compression=None, timeout=None, callback=None):
+                  ensure_cached=True, compression=None, pin_token=None, timeout=None,
+                  callback=None):
         if self._mode == 'in':
             self._dispatch_ref.register_free_slot(self.uid, 'sender')
             self.storage_client.put_objects(

--- a/mars/worker/tests/test_transfer.py
+++ b/mars/worker/tests/test_transfer.py
@@ -92,7 +92,8 @@ class MockReceiverWorkerActor(WorkerActor):
             return ReceiveStatus.NOT_STARTED
 
     def create_data_writers(self, session_id, chunk_keys, data_sizes, sender_ref,
-                            ensure_cached=True, timeout=0, use_promise=True, callback=None):
+                            ensure_cached=True, pin_token=None, timeout=0,
+                            use_promise=True, callback=None):
         from mars.compat import BytesIO
         for chunk_key, data_size in zip(chunk_keys, data_sizes):
             query_key = (session_id, chunk_key)

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -13,19 +13,18 @@
 # limitations under the License.
 
 import functools
+import operator
 import logging
 import sys
 import time
-import zlib
 from collections import defaultdict
-
-import pandas as pd
 
 from .. import promise
 from ..compat import six, Enum, TimeoutError  # pylint: disable=W0622
 from ..config import options
 from ..errors import *
 from ..serialize import dataserializer
+from ..scheduler.chunkmeta import WorkerMeta
 from ..utils import log_unhandled, build_exc_info
 from .events import EventContext, EventCategory, EventLevel, ProcedureEventType
 from .storage import DataStorageDevice
@@ -36,9 +35,24 @@ logger = logging.getLogger(__name__)
 
 class ReceiveStatus(Enum):
     NOT_STARTED = 0
-    RECEIVING = 1
-    RECEIVED = 2
-    ERROR = 3
+    PENDING = 1
+    RECEIVING = 2
+    RECEIVED = 3
+    ERROR = 4
+
+
+class TransferEndpointStatus(object):
+    __slots__ = 'parts', 'total_size', 'keys', 'end_marks', 'send_future'
+
+    def __init__(self):
+        self.reset()
+        self.send_future = None
+
+    def reset(self):
+        self.parts = []
+        self.total_size = 0
+        self.keys = []
+        self.end_marks = []
 
 
 class SenderActor(WorkerActor):
@@ -75,98 +89,97 @@ class SenderActor(WorkerActor):
             raise DependencyMissing('Dependency %s not met on sending.' % chunk_key)
         return nbytes
 
-    def _collect_receiver_refs(self, chunk_key, target_endpoints, target_slots, timeout):
-        from .dispatcher import DispatchActor
-
-        if isinstance(target_endpoints, six.string_types):
-            target_endpoints, target_slots = [target_endpoints], [target_slots]
-        if target_slots is None:
-            target_slots = [None] * len(target_endpoints)
-
-        refs, slot_futures = [], []
-        for ep, slot in zip(target_endpoints, target_slots):
-            if slot is None:
-                dispatch_ref = self.ctx.actor_ref(DispatchActor.default_uid(), address=ep)
-                slot_futures.append((ep, dispatch_ref.get_hash_slot('receiver', chunk_key, _wait=False)))
-            else:
-                refs.append(self.promise_ref(slot, address=ep))
-        refs.extend([self.promise_ref(f.result(timeout), address=ep)
-                     for ep, f in slot_futures])
-        return refs
-
     @promise.reject_on_exception
     @log_unhandled
-    def send_data(self, session_id, chunk_key, target_endpoints, target_slots=None,
-                  ensure_cached=True, compression=None, timeout=None, callback=None):
+    def send_data(self, session_id, chunk_keys, target_endpoints, ensure_cached=True,
+                  compression=None, timeout=None, callback=None):
         """
         Send data to other workers
         :param session_id: session id
-        :param chunk_key: chunk to be sent
+        :param chunk_keys: chunks to be sent
         :param target_endpoints: endpoints to receive this chunk
-        :param target_slots: slots for receivers, None if not fixed
         :param ensure_cached: if True, make sure the data is in the shared storage of the target worker
         :param compression: compression type when transfer in network
         :param timeout: timeout of data sending
         :param callback: promise callback
         """
-        already_started = set()
-        data_size_bin = [self._read_data_size(session_id, chunk_key)]
-        wait_refs = []
+        chunk_keys = list(chunk_keys)
+        if isinstance(target_endpoints, six.string_types):
+            target_endpoints = [target_endpoints]
+
+        data_sizes_bin = [self.storage_client.get_data_sizes(session_id, chunk_keys)]
+        if any(s is None for s in data_sizes_bin[0]):
+            raise DependencyMissing('Dependencies %r not met when sending.'
+                                    % [k for k, s in zip(chunk_keys, data_sizes_bin[0]) if s is None])
         compression = compression or dataserializer.CompressType(options.worker.transfer_compression)
 
-        try:
-            receiver_refs = self._collect_receiver_refs(
-                chunk_key, target_endpoints, target_slots, timeout)
-        except:  # noqa: E722
-            self._dispatch_ref.register_free_slot(self.uid, 'sender', _tell=True)
-            raise
+        wait_refs = []
+        addrs_to_chunks = dict()
+        receiver_refs = []
+        receiver_manager_ref_dict = dict(
+            (ep, self.promise_ref(ReceiverManagerActor.default_uid(), address=ep))
+            for ep in target_endpoints)
 
         @log_unhandled
-        def _create_writers(reader):
+        def _create_local_readers():
+            promises = []
+            keys_to_readers = dict()
+            for k in chunk_keys:
+                promises.append(self.storage_client.create_reader(
+                    session_id, k, source_devices, packed=True, packed_compression=compression)
+                    .then(functools.partial(operator.setitem, keys_to_readers, k)))
+            return promise.all_(promises).then(lambda *_: keys_to_readers)
+
+        @log_unhandled
+        def _create_remote_writers(keys_to_readers):
             create_write_promises = []
-            data_size = data_size_bin[0] = self._read_data_size(session_id, chunk_key)
-            for ref in receiver_refs:
+            data_sizes = data_sizes_bin[0] = self.storage_client.get_data_sizes(session_id, chunk_keys)
+            for ref in receiver_manager_ref_dict.values():
                 # register transfer actions
                 create_write_promises.append(
-                    ref.create_data_writer(
-                        session_id, chunk_key, data_size, self.ref(), ensure_cached=ensure_cached,
+                    ref.create_data_writers(
+                        session_id, chunk_keys, data_sizes, self.ref(), ensure_cached=ensure_cached,
                         timeout=timeout, _timeout=timeout, _promise=True
-                    ).then(functools.partial(_handle_created, ref))
+                    ).then(_handle_created)
                 )
-            return promise.all_(create_write_promises).then(lambda *_: reader)
+            return promise.all_(create_write_promises).then(lambda *_: keys_to_readers)
 
         @log_unhandled
-        def _handle_created(ref, address, status):
+        def _handle_created(ref, statuses):
+            manager_ref = receiver_manager_ref_dict[ref.address]
             # filter out endpoints already transferred or already started transfer
-            if status == ReceiveStatus.RECEIVED:
-                already_started.add(address)
-            elif status == ReceiveStatus.RECEIVING:
-                already_started.add(address)
-                wait_refs.append(ref.register_finish_callback(
-                    session_id, chunk_key, _timeout=timeout, _promise=True))
+            keys_receiving, keys_to_receive = [], []
+            for k, status in zip(chunk_keys, statuses):
+                if status == ReceiveStatus.RECEIVING:
+                    keys_receiving.append(k)
+                elif status is None:
+                    keys_to_receive.append(k)
+
+            if keys_to_receive:
+                addrs_to_chunks[ref.address] = keys_to_receive
+                receiver_refs.append(self.promise_ref(ref))
+            if keys_receiving:
+                wait_refs.append(manager_ref.add_keys_callback(
+                    session_id, keys_receiving, _timeout=timeout, _promise=True))
 
         @log_unhandled
         def _finalize(*_):
             self._dispatch_ref.register_free_slot(self.uid, 'sender', _tell=True)
-            self.tell_promise(callback, data_size_bin[0])
+            self.tell_promise(callback, data_sizes_bin[0])
 
         @log_unhandled
         def _handle_rejection(*exc):
-            logger.exception('Transfer chunk %s to %r failed', chunk_key, target_endpoints, exc_info=exc)
+            logger.exception('Transfer chunks %r to %r failed', chunk_keys, target_endpoints, exc_info=exc)
             self._dispatch_ref.register_free_slot(self.uid, 'sender', _tell=True)
             for ref in receiver_refs:
-                ref.cancel_receive(session_id, chunk_key, _tell=True, _wait=False)
+                ref.cancel_receive(session_id, addrs_to_chunks[ref.address], _tell=True, _wait=False)
             self.tell_promise(callback, *exc, **dict(_accept=False))
 
         try:
             source_devices = [DataStorageDevice.SHARED_MEMORY, DataStorageDevice.DISK]
-            self.storage_client.create_reader(
-                session_id, chunk_key, source_devices, packed=True, packed_compression=compression) \
-                .then(_create_writers) \
-                .then(lambda reader: self._compress_and_send(
-                    session_id, chunk_key,
-                    [ref for ref in receiver_refs if ref.address not in already_started],
-                    reader, timeout=timeout,
+            _create_local_readers().then(_create_remote_writers) \
+                .then(lambda keys_to_readers: self._compress_and_send(
+                    session_id, addrs_to_chunks, receiver_refs, keys_to_readers, timeout=timeout,
                 )) \
                 .then(lambda *_: promise.all_(wait_refs)) \
                 .then(_finalize, _handle_rejection)
@@ -175,122 +188,278 @@ class SenderActor(WorkerActor):
             return
 
     @log_unhandled
-    def _compress_and_send(self, session_id, chunk_key, target_refs, reader, timeout=None):
+    def _compress_and_send(self, session_id, addrs_to_chunks, receiver_refs, keys_to_readers, timeout=None):
         """
         Compress and send data to receivers in chunked manner
         :param session_id: session id
         :param chunk_key: chunk key
-        :param target_refs: refs to send data to
+        :param receiver_refs: refs to send data to
         """
+        # collect data targets
+        chunks_to_addrs = defaultdict(set)
+        for addr, chunks in addrs_to_chunks.items():
+            for key in chunks:
+                chunks_to_addrs[key].add(addr)
+        all_chunk_keys = sorted(chunks_to_addrs.keys(), key=lambda k: len(chunks_to_addrs[k]))
+        addr_statuses = dict((k, TransferEndpointStatus()) for k in addrs_to_chunks.keys())
+        addr_to_refs = dict((ref.address, ref) for ref in receiver_refs)
+
         # start compress and send data into targets
-        logger.debug('Data writer for chunk %s allocated at targets, start transmission', chunk_key)
+        logger.debug('Data writer for chunks %r allocated at targets, start transmission', all_chunk_keys)
         block_size = options.worker.transfer_block_size
 
         # filter out endpoints we need to send to
         try:
-            if not target_refs:
+            if not receiver_refs:
                 self._dispatch_ref.register_free_slot(self.uid, 'sender', _tell=True, _wait=False)
                 return
-
-            futures = []
-            checksum = 0
+            cur_key_id = 0
+            cur_key = all_chunk_keys[cur_key_id]
+            cur_reader = keys_to_readers[cur_key]
             with EventContext(self._events_ref, EventCategory.PROCEDURE, EventLevel.NORMAL,
                               ProcedureEventType.NETWORK, self.uid):
-                while True:
+                while cur_key_id < len(all_chunk_keys):
                     # read a data part from reader we defined above
-                    pool = reader.get_io_pool()
-                    next_chunk = pool.submit(reader.read, block_size).result()
-                    is_last = not next_chunk or len(next_chunk) < block_size
-                    # make sure all previous transfers finished
-                    [f.result(timeout=timeout) for f in futures]
-                    checksum = zlib.crc32(next_chunk, checksum)
-                    futures = []
-                    for ref in target_refs:
-                        # we perform async transfer and wait after next part is loaded and compressed
-                        futures.append(ref.receive_data_part(
-                            session_id, chunk_key, next_chunk, checksum, is_last=is_last, _wait=False))
-                    if is_last:
-                        [f.result(timeout=timeout) for f in futures]
-                        break
+                    pool = cur_reader.get_io_pool()
+                    next_part = pool.submit(cur_reader.read, block_size).result()
+                    file_eof = len(next_part) < block_size
+
+                    for addr in chunks_to_addrs[cur_key]:
+                        addr_status = addr_statuses[addr]
+                        addr_status.parts.append(next_part)
+                        addr_status.keys.append(cur_key)
+                        addr_status.total_size += len(next_part)
+                        addr_status.end_marks.append(file_eof)
+
+                        if addr_status.total_size >= block_size:
+                            if addr_status.send_future:
+                                addr_status.send_future.result(timeout=timeout)
+                            addr_status.send_future = addr_to_refs[addr].receive_data_part(
+                                session_id, addr_status.keys, addr_status.end_marks,
+                                *addr_status.parts, _wait=False)
+                            addr_status.reset()
+
+                    # when some part goes to end, move to the next chunk
+                    if file_eof:
+                        cur_reader.close()
+                        cur_key_id += 1
+                        if cur_key_id < len(all_chunk_keys):
+                            cur_key = all_chunk_keys[cur_key_id]
+                            cur_reader = keys_to_readers[cur_key]
+                        else:
+                            for addr, addr_status in addr_statuses.items():
+                                if addr_status.send_future:
+                                    addr_status.send_future.result()
+                                if addr_status.parts:
+                                    # mark the final chunk as finished
+                                    addr_status.end_marks[-1] = True
+                                    addr_status.send_future = addr_to_refs[addr].receive_data_part(
+                                        session_id, addr_status.keys, addr_status.end_marks,
+                                        *addr_status.parts, _wait=False)
+                                addr_status.reset()
+                            for addr_status in addr_statuses.values():
+                                if addr_status.send_future:
+                                    addr_status.send_future.result()
+                                addr_status.reset()
+
         except:  # noqa: E722
-            for ref in target_refs:
-                ref.cancel_receive(session_id, chunk_key, _tell=True, _wait=False)
+            for ref in receiver_refs:
+                ref.cancel_receive(session_id, addrs_to_chunks[ref.address], _tell=True, _wait=False)
             raise
         finally:
-            reader.close()
+            for reader in keys_to_readers.values():
+                reader.close()
 
 
 class ReceiverDataMeta(object):
-    __slots__ = 'start_time', 'chunk_size', 'checksum', 'source_address', \
-                'transfer_event_id', 'status', 'callback_args', 'callback_kwargs'
+    __slots__ = 'start_time', 'chunk_size', 'source_address',\
+                'status', 'transfer_event_id', 'receiver_worker_uid', \
+                'callback_ids', 'callback_args', 'callback_kwargs'
 
-    def __init__(self, start_time=None, chunk_size=None, checksum=0,
-                 source_address=None, transfer_event_id=None, status=None,
-                 callback_args=None, callback_kwargs=None):
-        self.start_time = start_time or time.time()
+    def __init__(self, start_time=None, chunk_size=None, source_address=None,
+                 transfer_event_id=None, receiver_worker_uid=None, status=None,
+                 callback_ids=None, callback_args=None, callback_kwargs=None):
+        self.start_time = start_time
         self.chunk_size = chunk_size
-        self.checksum = checksum
         self.source_address = source_address
         self.status = status
         self.transfer_event_id = transfer_event_id
+        self.receiver_worker_uid = receiver_worker_uid
+        self.callback_ids = callback_ids or []
         self.callback_args = callback_args or ()
         self.callback_kwargs = callback_kwargs or {}
+
+    def update(self, **kwargs):
+        kwargs['callback_ids'] = list(set(self.callback_ids) | set(kwargs.get('callback_ids') or ()))
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
 
 class ReceiverManagerActor(WorkerActor):
     def __init__(self):
         super(ReceiverManagerActor, self).__init__()
-        self._receiver_callback_ids = dict()
+        self._data_meta_cache = ExpiringCache()
         self._max_callback_id = 0
         self._callback_id_to_callbacks = dict()
         self._callback_id_to_keys = dict()
 
+        self._dispatch_ref = None
+
+    def post_create(self):
+        super(ReceiverManagerActor, self).post_create()
+
+        from .dispatcher import DispatchActor
+        self._dispatch_ref = self.promise_ref(DispatchActor.default_uid())
+
+    def _update_data_meta(self, session_id, data_key, **kwargs):
+        try:
+            self._data_meta_cache[(session_id, data_key)].update(**kwargs)
+        except KeyError:
+            self._data_meta_cache[(session_id, data_key)] = ReceiverDataMeta(**kwargs)
+
+    @promise.reject_on_exception
+    @log_unhandled
+    def create_data_writers(self, session_id, data_keys, data_sizes, sender_ref,
+                            ensure_cached=True, timeout=0, use_promise=True, callback=None):
+        sender_address = None if sender_ref is None else sender_ref.address
+        logger.debug('Begin creating transmission data writer for chunks %r from %s',
+                     data_keys, sender_address)
+        data_locations = dict(zip(
+            data_keys, self.storage_client.get_data_locations(session_id, data_keys)))
+        keys_to_fetch = []
+        sizes_to_fetch = []
+        statuses = []
+
+        slot_ref = self.promise_ref(self._dispatch_ref.get_hash_slot('receiver', repr(data_keys)))
+        for chunk_key, data_size in zip(data_keys, data_sizes):
+            session_chunk_key = (session_id, chunk_key)
+            try:
+                data_meta = self._data_meta_cache[session_chunk_key]
+            except KeyError:
+                data_meta = self._data_meta_cache[session_chunk_key] = \
+                    ReceiverDataMeta(chunk_size=data_size, source_address=sender_address,
+                                     status=ReceiveStatus.NOT_STARTED)
+
+            if data_locations.get(chunk_key):
+                data_meta.status = ReceiveStatus.RECEIVED
+                statuses.append(ReceiveStatus.RECEIVED)
+                continue
+            if data_meta.status == ReceiveStatus.RECEIVING:
+                # data transfer already started
+                logger.debug('Chunk %s already started transmission', chunk_key)
+                statuses.append(ReceiveStatus.RECEIVING)
+                continue
+
+            data_meta.start_time = time.time()
+            data_meta.receiver_worker_uid = slot_ref.uid
+            data_meta.source_address = sender_address
+            data_meta.status = ReceiveStatus.RECEIVING
+
+            self._update_data_meta(session_id, chunk_key, chunk_size=data_size,
+                                   source_address=sender_address, status=ReceiveStatus.RECEIVING)
+            keys_to_fetch.append(chunk_key)
+            sizes_to_fetch.append(data_size)
+            statuses.append(None)  # this notifies the sender to transmit data
+
+        if use_promise:
+            if keys_to_fetch:
+                slot_ref.create_data_writers(
+                    session_id, keys_to_fetch, sizes_to_fetch, sender_ref, ensure_cached=ensure_cached,
+                    timeout=timeout, use_promise=use_promise, _promise=True) \
+                    .then(lambda *_: self.tell_promise(callback, slot_ref, statuses))
+            else:
+                self.tell_promise(callback, slot_ref, statuses)
+        else:
+            slot_ref.create_data_writers(
+                session_id, keys_to_fetch, sizes_to_fetch, sender_ref, ensure_cached=ensure_cached,
+                timeout=timeout, use_promise=use_promise)
+            return slot_ref, statuses
+
     def register_keys(self, session_id, data_keys):
         for key in data_keys:
-            self._receiver_callback_ids[(session_id, key)] = []
+            session_data_key = (session_id, key)
+            if session_data_key not in self._data_meta_cache:
+                self._data_meta_cache[session_data_key] = ReceiverDataMeta(status=ReceiveStatus.PENDING)
 
-    def filter_registered_keys(self, session_id, data_keys):
-        return [k for k in data_keys if (session_id, k) in self._receiver_callback_ids]
+    def filter_receiving_keys(self, session_id, data_keys):
+        keys = []
+        receiving_status = (ReceiveStatus.PENDING, ReceiveStatus.RECEIVING)
+        for k in data_keys:
+            try:
+                if self._data_meta_cache[(session_id, k)].status in receiving_status:
+                    keys.append(k)
+            except KeyError:
+                pass
+        return keys
 
     def add_keys_callback(self, session_id, data_keys, callback):
         cb_id = self._max_callback_id
         self._max_callback_id += 1
 
-        self._callback_id_to_callbacks[cb_id] = callback
-        self._callback_id_to_keys[cb_id] = set((session_id, k) for k in data_keys)
-
+        receiving_status = (ReceiveStatus.PENDING, ReceiveStatus.RECEIVING)
+        registered_session_keys = []
+        args, kwargs = (), {}
         for k in data_keys:
-            self._receiver_callback_ids[(session_id, k)].append(cb_id)
+            session_data_key = (session_id, k)
+            data_meta = self._data_meta_cache[session_data_key]  # type: ReceiverDataMeta
+            if data_meta.status in receiving_status:
+                registered_session_keys.append(session_data_key)
+                data_meta.callback_ids.append(cb_id)
+            else:
+                args, kwargs = data_meta.callback_args, data_meta.callback_kwargs
 
-    def notify_key_finish(self, session_id, data_key, *args, **kwargs):
-        session_data_key = (session_id, data_key)
-        cb_ids = self._receiver_callback_ids.pop(session_data_key, [])
-        if not cb_ids:
-            return
+        if registered_session_keys:
+            self._callback_id_to_callbacks[cb_id] = callback
+            self._callback_id_to_keys[cb_id] = set(registered_session_keys)
+            logger.debug('Callback for transferring %r registered', registered_session_keys)
+        else:
+            self._max_callback_id = cb_id
+            self.tell_promise(callback, *args, **kwargs)
 
-        kwargs['_wait'] = False
-        for cb_id in cb_ids:
-            cb_keys = self._callback_id_to_keys[cb_id]
-            cb_keys.remove(session_data_key)
-            if not cb_keys:
-                del self._callback_id_to_keys[cb_id]
-                cb = self._callback_id_to_callbacks.pop(cb_id)
-                self.tell_promise(cb, *args, **kwargs)
+    def notify_keys_finish(self, session_id, data_keys, *args, **kwargs):
+        for data_key in data_keys:
+            session_data_key = (session_id, data_key)
+            try:
+                data_meta = self._data_meta_cache[session_data_key]  # type: ReceiverDataMeta
+            except KeyError:
+                logger.debug('Record of %s not found.', data_key)
+                continue
+
+            if kwargs.get('_accept', True):
+                data_meta.status = ReceiveStatus.RECEIVED
+            else:
+                data_meta.status = ReceiveStatus.ERROR
+
+            cb_ids = data_meta.callback_ids
+            data_meta.callback_ids = []
+            if not cb_ids:
+                continue
+
+            kwargs['_wait'] = False
+            notified = 0
+            for cb_id in cb_ids:
+                cb_keys = self._callback_id_to_keys[cb_id]
+                cb_keys.remove(session_data_key)
+                if not cb_keys:
+                    del self._callback_id_to_keys[cb_id]
+                    cb = self._callback_id_to_callbacks.pop(cb_id)
+                    notified += 1
+                    self.tell_promise(cb, *args, **kwargs)
+            logger.debug('%d transfer listeners of %s notified.', notified, data_key)
 
 
-class ReceiverActor(WorkerActor):
+class ReceiverWorkerActor(WorkerActor):
     """
     Actor handling receiving data from a SenderActor
     """
     def __init__(self):
-        super(ReceiverActor, self).__init__()
+        super(ReceiverWorkerActor, self).__init__()
         self._chunk_holder_ref = None
         self._dispatch_ref = None
         self._receiver_manager_ref = None
         self._events_ref = None
         self._status_ref = None
 
-        self._finish_callbacks = defaultdict(list)
         self._data_writers = dict()
         self._writing_futures = dict()
         self._data_meta_cache = ExpiringCache()
@@ -300,7 +469,7 @@ class ReceiverActor(WorkerActor):
         from .status import StatusActor
         from .dispatcher import DispatchActor
 
-        super(ReceiverActor, self).post_create()
+        super(ReceiverWorkerActor, self).post_create()
 
         self._events_ref = self.ctx.actor_ref(EventsActor.default_uid())
         if not self.ctx.has_actor(self._events_ref):
@@ -335,113 +504,72 @@ class ReceiverActor(WorkerActor):
 
     @promise.reject_on_exception
     @log_unhandled
-    def register_finish_callback(self, session_id, chunk_key, callback):
-        """
-        Register a promise callback to handle transfer termination.
-        If the chunk has already been transferred or error occurred,
-        the existing results are sent.
-        :param session_id: session id
-        :param chunk_key: chunk key
-        :param callback: promise callback
-        """
-        session_chunk_key = (session_id, chunk_key)
-        if session_chunk_key not in self._data_meta_cache:
-            self._finish_callbacks[session_chunk_key].append(callback)
-            return
-        data_meta = self._data_meta_cache[session_chunk_key]  # type: ReceiverDataMeta
-        if data_meta.status in (ReceiveStatus.RECEIVED, ReceiveStatus.ERROR):
-            # invoke callback directly when transfer finishes
-            self.tell_promise(callback, *data_meta.callback_args, **data_meta.callback_kwargs)
-        else:
-            self._finish_callbacks[session_chunk_key].append(callback)
-
-    @promise.reject_on_exception
-    @log_unhandled
-    def create_data_writer(self, session_id, chunk_key, data_size, sender_ref,
-                           ensure_cached=True, timeout=0, use_promise=True, callback=None):
+    def create_data_writers(self, session_id, chunk_keys, data_sizes, sender_ref,
+                            ensure_cached=True, timeout=0, use_promise=True, callback=None):
         """
         Create a data writer for subsequent data transfer. The writer can either work on
         shared storage or spill.
+
         :param session_id: session id
-        :param chunk_key: chunk key
-        :param data_size: uncompressed data size
+        :param chunk_keys: chunk keys
+        :param data_sizes: uncompressed data sizes
         :param sender_ref: ActorRef of SenderActor
-        :param ensure_cached: if True, the data should be stored in shared memory, otherwise spill is acceptable
+        :param ensure_cached: if True, the data should be stored in shared memory,
+                              otherwise spill is acceptable
         :param timeout: timeout if the chunk receiver does not close
-        :param use_promise: if True, we use promise callback to notify accomplishment of writer creation,
-            otherwise the function returns directly and when sill is needed, a StorageFull will be raised instead.
+        :param use_promise: if True, we use promise callback to notify accomplishment
+                            of writer creation, otherwise the function returns directly
+                            and when sill is needed, a StorageFull will be raised instead.
         :param callback: promise callback
         """
-        sender_address = None if sender_ref is None else sender_ref.address
-
-        logger.debug('Begin creating transmission data writer for chunk %s from %s',
-                     chunk_key, sender_address)
-        session_chunk_key = (session_id, chunk_key)
-
-        data_status = self.check_status(session_id, chunk_key)
-
-        if data_status == ReceiveStatus.RECEIVING:
-            # data transfer already started
-            logger.debug('Chunk %s already started transmission', chunk_key)
-            if callback:
-                self.tell_promise(callback, self.address, ReceiveStatus.RECEIVING)
-            return self.address, ReceiveStatus.RECEIVING
-
-        # build meta data for data transfer
-        if session_chunk_key in self._data_meta_cache:
-            if data_status == ReceiveStatus.RECEIVED:
-                # already received: callback directly
-                logger.debug('Chunk %s already received', chunk_key)
-                if callback:
-                    self.tell_promise(callback, self.address, ReceiveStatus.RECEIVED)
-                self._invoke_finish_callbacks(session_id, chunk_key)
-                return self.address, ReceiveStatus.RECEIVED
-            else:
-                del self._data_meta_cache[session_chunk_key]
-
-        self._data_meta_cache[session_chunk_key] = ReceiverDataMeta(
-            chunk_size=data_size, source_address=sender_address,
-            status=ReceiveStatus.RECEIVING)
-
-        # configure timeout callback
-        if timeout:
-            self.ref().handle_receive_timeout(session_id, chunk_key, _delay=timeout, _tell=True)
-
+        promises = []
+        failed_container = [False]
         device_order = [DataStorageDevice.SHARED_MEMORY]
+        source_address = sender_ref.address if sender_ref is not None else None
         if not ensure_cached:
             device_order += [DataStorageDevice.DISK]
 
-        def _handle_accept(writer):
-            self._data_writers[session_chunk_key] = writer
-            if callback is not None:
-                self.tell_promise(callback, self.address, None)
+        def _handle_accept(key, writer):
+            if failed_container[0]:
+                writer.close(finished=False)
+            else:
+                self._data_writers[(session_id, key)] = writer
 
         @log_unhandled
-        def _handle_reject(*exc):
-            if self.check_status(session_id, chunk_key) == ReceiveStatus.RECEIVED:
-                logger.debug('Chunk %s already received', chunk_key)
-                self._invoke_finish_callbacks(session_id, chunk_key)
-                if callback is not None:
-                    self.tell_promise(callback, self.address, ReceiveStatus.RECEIVED)
+        def _handle_reject(key, *exc):
+            if self.check_status(session_id, key) == ReceiveStatus.RECEIVED:
+                logger.debug('Chunk %s already received', key)
+                self._invoke_finish_callbacks(session_id, key)
             else:
-                logger.debug('Rejecting %s from putting into plasma.', chunk_key)
-                self._stop_transfer_with_exc(session_id, chunk_key, exc)
+                logger.debug('Rejecting %s from putting into plasma.', key)
+                failed_container[0] = True
+                self._stop_transfer_with_exc(session_id, key, exc)
                 if callback is not None:
                     self.tell_promise(callback, *exc, **dict(_accept=False))
 
-        if use_promise:
-            self.storage_client.create_writer(
-                session_id, chunk_key, data_size, device_order, packed=True) \
-                .then(_handle_accept, _handle_reject)
-        else:
-            try:
-                writer = self.storage_client.create_writer(
-                    session_id, chunk_key, data_size, device_order, packed=True, _promise=False)
-                _handle_accept(writer)
-                return self.address, None
-            except:  # noqa: E722
-                _handle_reject(*sys.exc_info())
-                raise
+        # configure timeout callback
+        if timeout:
+            self.ref().handle_receive_timeout(session_id, chunk_keys, _delay=timeout, _tell=True)
+
+        for chunk_key, data_size in zip(chunk_keys, data_sizes):
+            self._data_meta_cache[(session_id, chunk_key)] = ReceiverDataMeta(
+                start_time=time.time(), chunk_size=data_size, source_address=source_address)
+            if use_promise:
+                promises.append(self.storage_client.create_writer(
+                    session_id, chunk_key, data_size, device_order, packed=True, _promise=True)
+                    .then(functools.partial(_handle_accept, chunk_key),
+                          functools.partial(_handle_reject, chunk_key)))
+            else:
+                try:
+                    _writer = self.storage_client.create_writer(
+                        session_id, chunk_key, data_size, device_order, packed=True, _promise=False)
+                    _handle_accept(chunk_key, _writer)
+                    return self.address, None
+                except:  # noqa: E722
+                    _handle_reject(*sys.exc_info())
+                    raise
+
+        promise.all_(promises).then(lambda *_: self.tell_promise(callback))
 
     def _wait_unfinished_writing(self, session_id, data_key):
         try:
@@ -451,28 +579,20 @@ class ReceiverActor(WorkerActor):
             pass
 
     @log_unhandled
-    def receive_data_part(self, session_id, chunk_key, data_part, checksum, is_last=False):
+    def receive_data_part(self, session_id, chunk_keys, end_marks, *data_parts):
         """
         Receive data part from sender
         :param session_id: session id
-        :param chunk_key: chunk key
-        :param data_part: data to be written
-        :param checksum: checksum up to now
-        :param is_last: if True, after writing this chunk, a
+        :param chunk_keys: chunk keys
+        :param chunk_ends: if not None, positions (last_byte + 1) of chunk ends
+        :param data_parts: data parts to be written
         """
-        self._wait_unfinished_writing(session_id, chunk_key)
-
-        session_chunk_key = (session_id, chunk_key)
-        try:
-            data_meta = self._data_meta_cache[session_chunk_key]  # type: ReceiverDataMeta
-            meta_future = None
-
-            if data_part:
-                # check if checksum matches
-                local_checksum = zlib.crc32(data_part, data_meta.checksum)
-                if local_checksum != checksum:
-                    raise ChecksumMismatch
-                data_meta.checksum = local_checksum
+        finished_keys, finished_meta_keys, finished_metas = [], [], []
+        for chunk_key, data_part, end_mark in zip(chunk_keys, data_parts, end_marks):
+            self._wait_unfinished_writing(session_id, chunk_key)
+            session_chunk_key = (session_id, chunk_key)
+            try:
+                data_meta = self._data_meta_cache[session_chunk_key]  # type: ReceiverDataMeta
 
                 # if error occurred, interrupts
                 if data_meta.status == ReceiveStatus.ERROR:
@@ -480,59 +600,74 @@ class ReceiverActor(WorkerActor):
                     return  # pragma: no cover
                 writer = self._data_writers[session_chunk_key]
                 pool = writer.get_io_pool()
-                self._writing_futures[session_chunk_key] = pool.submit(writer.write, data_part)
-                if meta_future:
-                    meta_future.result()
+                self._writing_futures[session_chunk_key] = pool.submit(
+                    writer.write, data_part)
 
-            if is_last:
-                self._wait_unfinished_writing(session_id, chunk_key)
+                if end_mark:
+                    finished_keys.append(chunk_key)
+                    if not isinstance(chunk_key, tuple):
+                        finished_meta_keys.append(chunk_key)
+                        finished_metas.append(WorkerMeta(chunk_size=data_meta.chunk_size,
+                                                         workers=(self.address,)))
+            except:  # noqa: E722
+                self._stop_transfer_with_exc(session_id, chunk_keys, sys.exc_info())
+                return
+
+        if finished_keys:
+            for chunk_key in finished_keys:
+                session_chunk_key = (session_id, chunk_key)
+                data_meta = self._data_meta_cache[session_chunk_key]  # type: ReceiverDataMeta
+
+                import pyarrow.lib
+                try:
+                    self._wait_unfinished_writing(session_id, chunk_key)
+                except pyarrow.lib.ArrowIOError:
+                    raise
                 # update transfer speed stats
                 if self._status_ref:
                     time_delta = time.time() - data_meta.start_time
                     self._status_ref.update_mean_stats(
                         'net_transfer_speed', data_meta.chunk_size * 1.0 / time_delta,
                         _tell=True, _wait=False)
-
                 self._data_writers[session_chunk_key].close()
+                data_meta.status = ReceiveStatus.RECEIVED
+                logger.debug('Transfer for data %s finished.', chunk_key)
                 del self._data_writers[session_chunk_key]
 
-                if not isinstance(chunk_key, tuple):
-                    self.get_meta_client().set_chunk_meta(
-                        session_id, chunk_key, size=data_meta.chunk_size, workers=(self.address,))
-
-                data_meta.status = ReceiveStatus.RECEIVED
-                self._invoke_finish_callbacks(session_id, chunk_key)
-                logger.debug('Transfer for data %s finished.', chunk_key)
-        except:  # noqa: E722
-            self._stop_transfer_with_exc(session_id, chunk_key, sys.exc_info())
+            self._invoke_finish_callbacks(session_id, finished_keys)
+        if finished_meta_keys:
+            self.get_meta_client().batch_set_chunk_meta(session_id, finished_meta_keys, finished_metas)
 
     def _is_receive_running(self, session_id, chunk_key):
-        session_chunk_key = (session_id, chunk_key)
-        if session_chunk_key not in self._data_meta_cache:
+        receive_done_statuses = (ReceiveStatus.ERROR, ReceiveStatus.RECEIVED)
+        try:
+            if self._data_meta_cache[(session_id, chunk_key)].status in receive_done_statuses:
+                # already terminated, we do nothing
+                return False
+            return True
+        except KeyError:
             return False
-        if self._data_meta_cache[session_chunk_key].status in (ReceiveStatus.ERROR, ReceiveStatus.RECEIVED):
-            # already terminated, we do nothing
-            return False
-        return True
 
     @log_unhandled
-    def cancel_receive(self, session_id, chunk_key, exc_info=None):
+    def cancel_receive(self, session_id, chunk_keys, exc_info=None):
         """
         Cancel data receive by returning an ExecutionInterrupted
         :param session_id: session id
-        :param chunk_key: chunk key
+        :param chunk_keys: chunk keys
         :param exc_info: exception to raise
         """
-        self._wait_unfinished_writing(session_id, chunk_key)
+        receiving_keys = []
+        for k in chunk_keys:
+            if self._is_receive_running(session_id, k):
+                receiving_keys.append(k)
+            self._wait_unfinished_writing(session_id, k)
 
-        logger.debug('Transfer for %s cancelled.', chunk_key)
-        if not self._is_receive_running(session_id, chunk_key):
-            return
+        logger.debug('Transfer for %r cancelled.', chunk_keys)
 
         if exc_info is None:
             exc_info = build_exc_info(ExecutionInterrupted)
 
-        self._stop_transfer_with_exc(session_id, chunk_key, exc_info)
+        self._stop_transfer_with_exc(session_id, receiving_keys, exc_info)
 
     @log_unhandled
     def notify_dead_senders(self, dead_workers):
@@ -547,52 +682,48 @@ class ReceiverActor(WorkerActor):
                 self.ref().cancel_receive(*session_chunk_key, **dict(exc_info=exc_info, _tell=True))
 
     @log_unhandled
-    def handle_receive_timeout(self, session_id, chunk_key):
-        if not self._is_receive_running(session_id, chunk_key):
+    def handle_receive_timeout(self, session_id, chunk_keys):
+        if not any(self._is_receive_running(session_id, k) for k in chunk_keys):
             # if transfer already finishes, no needs to report timeout
             return
-        logger.debug('Transfer for %s timed out, cancelling.', chunk_key)
-        self._stop_transfer_with_exc(session_id, chunk_key, build_exc_info(TimeoutError))
+        logger.debug('Transfer for %r timed out, cancelling.', chunk_keys)
+        self._stop_transfer_with_exc(session_id, chunk_keys, build_exc_info(TimeoutError))
 
-    def _stop_transfer_with_exc(self, session_id, chunk_key, exc):
-        self._wait_unfinished_writing(session_id, chunk_key)
+    def _stop_transfer_with_exc(self, session_id, chunk_keys, exc):
+        for chunk_key in chunk_keys:
+            self._wait_unfinished_writing(session_id, chunk_key)
 
         if not isinstance(exc[1], ExecutionInterrupted):
-            logger.exception('Error occurred in receiving %s. Cancelling transfer.',
-                             chunk_key, exc_info=exc)
+            logger.exception('Error occurred in receiving %r. Cancelling transfer.',
+                             chunk_keys, exc_info=exc)
 
-        session_chunk_key = (session_id, chunk_key)
+        for chunk_key in chunk_keys:
+            session_chunk_key = (session_id, chunk_key)
 
-        # stop and close data writer
-        try:
-            # transfer is not finished yet, we need to clean up unfinished stuffs
-            self._data_writers[session_chunk_key].close(finished=False)
-            del self._data_writers[session_chunk_key]
-        except KeyError:
-            # transfer finished and writer cleaned, no need to clean up
-            pass
+            # stop and close data writer
+            try:
+                # transfer is not finished yet, we need to clean up unfinished stuffs
+                self._data_writers[session_chunk_key].close(finished=False)
+                del self._data_writers[session_chunk_key]
+            except KeyError:
+                # transfer finished and writer cleaned, no need to clean up
+                pass
 
-        data_meta = self._data_meta_cache[session_chunk_key]  # type: ReceiverDataMeta
-        data_meta.status = ReceiveStatus.ERROR
-        self._invoke_finish_callbacks(session_id, chunk_key, *exc, **dict(_accept=False))
+            data_meta = self._data_meta_cache[session_chunk_key]  # type: ReceiverDataMeta
+            data_meta.status = ReceiveStatus.ERROR
 
-    def _invoke_finish_callbacks(self, session_id, chunk_key, *args, **kwargs):
+        self._invoke_finish_callbacks(session_id, chunk_keys, *exc, **dict(_accept=False))
+
+    def _invoke_finish_callbacks(self, session_id, chunk_keys, *args, **kwargs):
         # invoke registered callbacks for chunk
-        session_chunk_key = (session_id, chunk_key)
-        data_meta = self._data_meta_cache[session_chunk_key]  # type: ReceiverDataMeta
-        data_meta.callback_args = args
-        data_meta.callback_kwargs = kwargs
-
+        if not chunk_keys:
+            return
+        data_meta = self._data_meta_cache[(session_id, chunk_keys[0])]  # type: ReceiverDataMeta
         if data_meta.transfer_event_id is not None and self._events_ref is not None:
-            self._events_ref.close_event(data_meta.transfer_event_id, _tell=True)
-
-        for cb in self._finish_callbacks[session_chunk_key]:
-            kwargs['_wait'] = False
-            self.tell_promise(cb, *args, **kwargs)
+            self._events_ref.close_event(data_meta.transfer_event_id, _tell=True, _wait=False)
+        kwargs['_tell'] = True
         if self._receiver_manager_ref:
-            self._receiver_manager_ref.notify_key_finish(session_id, chunk_key, *args, **kwargs)
-        if session_chunk_key in self._finish_callbacks:
-            del self._finish_callbacks[session_chunk_key]
+            self._receiver_manager_ref.notify_keys_finish(session_id, chunk_keys, *args, **kwargs)
 
 
 class ResultCopyActor(WorkerActor):
@@ -650,37 +781,36 @@ class ResultSenderActor(WorkerActor):
                     pool = reader.get_io_pool()
                     value = dataserializer.deserialize(pool.submit(reader.read).result())
 
-            if isinstance(value, (pd.DataFrame, pd.Series)):
+            try:
                 sliced_value = value.iloc[index_obj]
-            else:
+            except AttributeError:
                 sliced_value = value[index_obj]
 
             return self._serialize_pool.submit(
                 dataserializer.dumps, sliced_value, compression_type).result()
 
 
-def put_remote_chunk(session_id, chunk_key, data, receiver_ref):
+def put_remote_chunk(session_id, chunk_key, data, receiver_manager_ref):
     """
     Put a chunk to target machine using given receiver_ref
     """
     from .dataio import ArrowBufferIO
     buf = dataserializer.serialize(data).to_buffer()
-    receiver_ref.create_data_writer(session_id, chunk_key, buf.size, None,
-                                    ensure_cached=False, use_promise=False)
+    receiver_ref, _ = receiver_manager_ref.create_data_writers(
+        session_id, [chunk_key], [buf.size], None, ensure_cached=False, use_promise=False)
+    receiver_ref = receiver_manager_ref.ctx.actor_ref(receiver_ref)
     block_size = options.worker.transfer_block_size
 
     reader = None
     try:
         reader = ArrowBufferIO(buf, 'r', block_size=block_size)
-        checksum = 0
         futures = []
         while True:
-            next_chunk = reader.read(block_size)
-            is_last = not next_chunk or len(next_chunk) < block_size
+            next_part = reader.read(block_size)
+            is_last = not next_part or len(next_part) < block_size
             [f.result() for f in futures]
-            checksum = zlib.crc32(next_chunk, checksum)
             futures.append(receiver_ref.receive_data_part(
-                session_id, chunk_key, next_chunk, checksum, is_last=is_last, _wait=False))
+                session_id, [chunk_key], [is_last], next_part, _wait=False))
             if is_last:
                 [f.result() for f in futures]
                 break


### PR DESCRIPTION
## What do these changes do?

In this PR, several designs in transfer.py is changed.

1. Receiver meta is now shared by both ``ReceiverManagerActor`` and ``ReceiverWorkerActor`` (previously ``ReceiverActor``) to make sure that transfer meta does not conflict between different worker actors.
2. ``create_data_writers`` now accepts batch interface.
3. ``receive_data_part`` now supports transferring multiple data chunks at one time. whether the part of data is a terminating data piece of a chunk is determined by argument ``end_marks``.
4. ``send_data`` now accepts multiple chunk keys. data pieces are dispatched to different receivers.

## Related issue number

Fixes #832