### PR TITLE
Mark resource as processing once allocated

### DIFF
--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -713,7 +713,7 @@ class ExecutionActor(WorkerActor):
 
         # make sure that memory suffices before actually run execution
         logger.debug('Ensuring resource %r for graph %s', target_allocs, graph_key)
-        return self._mem_quota_ref.request_batch_quota(target_allocs, _promise=True) \
+        return self._mem_quota_ref.request_batch_quota(target_allocs, process_quota=True, _promise=True) \
             .then(lambda *_: self._deallocate_scheduler_resource(session_id, graph_key, delay=2)) \
             .then(_start_calc)
 

--- a/mars/worker/tests/test_quota.py
+++ b/mars/worker/tests/test_quota.py
@@ -36,6 +36,7 @@ class Test(WorkerCase):
 
             quota_ref = pool.create_actor(QuotaActor, 300, uid=QuotaActor.default_uid())
 
+            # test quota options with non-existing keys
             quota_ref.process_quotas(['non_exist'])
             quota_ref.hold_quotas(['non_exist'])
             quota_ref.release_quotas(['non_exist'])
@@ -43,13 +44,15 @@ class Test(WorkerCase):
             with self.assertRaises(ValueError):
                 quota_ref.request_quota('ERROR', 1000)
 
+            # test quota request with immediate return
             self.assertTrue(quota_ref.request_quota('0', 100))
             self.assertTrue(quota_ref.request_quota('0', 50))
             self.assertTrue(quota_ref.request_quota('0', 200))
 
-            quota_ref.process_quotas(['0'])
+            # test request with process_quota=True
+            quota_ref.request_quota('0', 200, process_quota=True)
             self.assertIn('0', quota_ref.dump_data().proc_sizes)
-            quota_ref.alter_allocation('0', 190, new_key=('0', 0))
+            quota_ref.alter_allocation('0', 190, new_key=('0', 0), process_quota=True)
             self.assertEqual(quota_ref.dump_data().allocations[('0', 0)], 190)
 
             quota_ref.hold_quotas([('0', 0)])
@@ -89,9 +92,9 @@ class Test(WorkerCase):
                     with self.assertRaises(ValueError):
                         self.get_result(5)
 
-            self.assertNotIn('1', quota_ref.dump_data().requests)
-            self.assertIn('2', quota_ref.dump_data().allocations)
-            self.assertNotIn('3', quota_ref.dump_data().allocations)
+                self.assertNotIn('1', quota_ref.dump_data().requests)
+                self.assertIn('2', quota_ref.dump_data().allocations)
+                self.assertNotIn('3', quota_ref.dump_data().allocations)
 
             quota_ref.release_quotas([('0', 1)])
             self.assertIn('3', quota_ref.dump_data().allocations)
@@ -147,22 +150,28 @@ class Test(WorkerCase):
             quota_ref = pool.create_actor(QuotaActor, 300, uid=QuotaActor.default_uid())
 
             end_time = []
-            for idx in range(2):
-                x = str(idx)
-                with self.run_actor_test(pool) as test_actor:
+
+            with self.run_actor_test(pool) as test_actor:
+                for idx in (0, 1):
+                    x = str(idx)
                     ref = test_actor.promise_ref(QuotaActor.default_uid())
 
-                    def actual_exec(keys):
-                        for k in keys:
-                            ref.release_quotas([k])
+                    def actual_exec(b, set_result):
+                        self.assertTrue(ref.request_batch_quota(b, process_quota=True))
+                        self.assertEqual(set(b.keys()), set(quota_ref.dump_data().proc_sizes.keys()))
+                        ref.release_quotas(list(b.keys()))
                         end_time.append(time.time())
-                        test_actor.set_result(None)
+                        if set_result:
+                            test_actor.set_result(None)
 
                     keys = [x + '_0', x + '_1']
                     batch = dict((k, 100) for k in keys)
                     ref.request_batch_quota(batch, _promise=True) \
-                        .then(functools.partial(test_actor.run_later, actual_exec, keys, _delay=0.5))
-                    self.get_result(10)
+                        .then(functools.partial(test_actor.run_later, actual_exec, batch,
+                                                set_result=(idx == 1), _delay=0.5),
+                              lambda *exc: test_actor.set_result(exc, accept=False))
+
+                self.get_result(10)
 
             self.assertGreater(abs(end_time[0] - end_time[1]), 0.4)
             self.assertEqual(quota_ref.get_allocated_size(), 0)


### PR DESCRIPTION
## What do these changes do?

Add an option ``process_quota`` to resource requests. Once the request is allocated and ``process_quota`` is True, the resource will be marked as processing.

## Related issue number

Fixes #847 