### PR TITLE
Assign enqueued operands immediately when no descendants are ready

### DIFF
--- a/mars/_utils.pxd
+++ b/mars/_utils.pxd
@@ -15,5 +15,6 @@
 cpdef str to_str(s, encoding=*)
 cpdef bytes to_binary(s, encoding=*)
 cpdef unicode to_text(s, encoding=*)
-cpdef register(cls, handler)
+cpdef register_tokenizer(cls, handler)
+cpdef tuple insert_reversed_tuple(tuple a, object x)
 

--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -221,7 +221,32 @@ tokenize_handler.register(pd.Index, tokenize_pandas_index)
 tokenize_handler.register(pd.Series, tokenize_pandas_series)
 tokenize_handler.register(pd.DataFrame, tokenize_pandas_dataframe)
 
-cpdef register(cls, handler):
+cpdef register_tokenizer(cls, handler):
     tokenize_handler.register(cls, handler)
 
-__all__ = ['to_str', 'to_binary', 'to_text', 'tokenize', 'tokenize_int', 'register']
+
+cpdef tuple insert_reversed_tuple(tuple a, object x):
+    cdef int mid, lo = 0, hi = len(a), len_a = hi
+    cdef object el
+
+    if len_a == 0:
+        return x,
+
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if a[mid] > x: lo = mid + 1
+        else: hi = mid
+
+    if lo == len_a:
+        return a + (x,)
+    el = a[lo]
+    if el == x:
+        return a
+    elif lo == 0 and el < x:
+        return (x,) + a
+    else:
+        return a[:lo] + (x,) + a[lo:]
+
+
+__all__ = ['to_str', 'to_binary', 'to_text', 'tokenize', 'tokenize_int', 'register_tokenizer',
+           'insert_reversed_tuple']

--- a/mars/config.py
+++ b/mars/config.py
@@ -342,6 +342,7 @@ default_options.register_option('worker.max_spill_size', '95%', validator=(is_st
 default_options.register_option('worker.callback_preserve_time', 3600 * 24, validator=is_integer)
 default_options.register_option('worker.event_preserve_time', 3600 * 24, validator=(is_integer, is_float))
 default_options.register_option('worker.copy_block_size', 64 * 1024, validator=is_integer)
+default_options.register_option('worker.cuda_thread_num', 2, validator=is_integer)
 default_options.register_option('worker.transfer_block_size', 1 * 1024 ** 2, validator=is_integer)
 default_options.register_option('worker.transfer_compression', 'lz4', validator=is_string, serialize=True)
 default_options.register_option('worker.prepare_data_timeout', 600, validator=is_integer)

--- a/mars/config.py
+++ b/mars/config.py
@@ -318,7 +318,7 @@ default_options.register_option('scheduler.enable_active_push', True, validator=
 default_options.register_option('scheduler.enable_chunk_relocation', False, validator=is_bool, serialize=True)
 default_options.register_option('scheduler.check_interval', 1, validator=is_integer, serialize=True)
 default_options.register_option('scheduler.default_cpu_usage', 1, validator=(is_integer, is_float), serialize=True)
-default_options.register_option('scheduler.default_cuda_usage', 1, validator=(is_integer, is_float), serialize=True)
+default_options.register_option('scheduler.default_cuda_usage', 0.5, validator=(is_integer, is_float), serialize=True)
 default_options.register_option('scheduler.execution_timeout', 600, validator=is_integer, serialize=True)
 default_options.register_option('scheduler.retry_num', 4, validator=is_integer, serialize=True)
 default_options.register_option('scheduler.fetch_limit', 10 * 1024 ** 2, validator=is_integer, serialize=True)
@@ -329,6 +329,11 @@ default_options.register_option('scheduler.dump_graph_data', False, validator=is
 default_options.register_option('scheduler.enable_failover', True, validator=is_bool, serialize=True)
 default_options.register_option('scheduler.status_timeout', 60, validator=is_numeric, serialize=True)
 default_options.register_option('scheduler.worker_blacklist_time', 3600, validator=is_numeric, serialize=True)
+
+# enqueue operands in a batch when creating OperandActors
+default_options.register_option('scheduler.batch_enqueue_initials', True, validator=is_bool, serialize=True)
+# invoke assigning when where there is no ready descendants
+default_options.register_option('scheduler.aggressive_assign', False, validator=is_bool, serialize=True)
 
 # Worker
 default_options.register_option('worker.spill_directory', None, validator=(is_null, is_string, is_list))

--- a/mars/config.py
+++ b/mars/config.py
@@ -24,10 +24,6 @@ from copy import deepcopy
 from .compat import six
 
 
-DEFAULT_CHUNK_SIZE = 1496
-DEFAULT_CONNECT_RETRY_TIMES = 4
-DEFAULT_CONNECT_TIMEOUT = 5
-DEFAULT_READ_TIMEOUT = 120
 _DEFAULT_REDIRECT_WARN = 'Option {source} has been replaced by {target} and might be removed in a future release.'
 
 

--- a/mars/scheduler/assigner.py
+++ b/mars/scheduler/assigner.py
@@ -272,7 +272,7 @@ class AssignEvaluationActor(SchedulerActor):
 
     def periodical_allocate(self):
         self.allocate_top_resources()
-        self.ref().periodical_allocate(_tell=True, _delay=2)
+        self.ref().periodical_allocate(_tell=True, _delay=0.5)
 
     def allocate_top_resources(self, fetch_requests=False):
         """

--- a/mars/scheduler/assigner.py
+++ b/mars/scheduler/assigner.py
@@ -272,7 +272,7 @@ class AssignEvaluationActor(SchedulerActor):
 
     def periodical_allocate(self):
         self.allocate_top_resources()
-        self.ref().periodical_allocate(_tell=True, _delay=0.5)
+        self.ref().periodical_allocate(_tell=True, _delay=2)
 
     def allocate_top_resources(self, fetch_requests=False):
         """

--- a/mars/scheduler/chunkmeta.py
+++ b/mars/scheduler/chunkmeta.py
@@ -390,12 +390,12 @@ class ChunkMetaClient(object):
     """
     Actor dispatches chunk meta requests to different scheduler hosts
     """
-    def __init__(self, ctx, cluster_info_ref):
+    def __init__(self, ctx, cluster_info_ref, has_local_cache=True):
         self._cluster_info = cluster_info_ref
         self.ctx = ctx
         self._local_meta_store_ref = ctx.actor_ref(
             ChunkMetaActor.default_uid(), address=cluster_info_ref.address)
-        if not ctx.has_actor(self._local_meta_store_ref):
+        if not has_local_cache or not ctx.has_actor(self._local_meta_store_ref):
             self._local_meta_store_ref = None
 
     def get_scheduler(self, key):

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -838,7 +838,8 @@ class GraphActor(SchedulerActor):
             scheduler_addr = self.get_scheduler(op_uid)
             kw = {}
             # for the **real** initial chunks, we do batch submitting
-            if chunk_graph.count_predecessors(chunks[0]) == 0:
+            if options.scheduler.batch_enqueue_initials \
+                    and chunk_graph.count_predecessors(chunks[0]) == 0:
                 kw['allocated'] = True
                 to_allocate_op_keys.add(op_key)
 

--- a/mars/scheduler/operands/base.py
+++ b/mars/scheduler/operands/base.py
@@ -108,13 +108,11 @@ class BaseOperandActor(SchedulerActor):
                          self._last_state, value)
         self._state = value
         self._info['state'] = value.name
-        futures = []
         for graph_ref in self._graph_refs:
-            futures.append(graph_ref.set_operand_state(self._op_key, value, _tell=True, _wait=False))
+            graph_ref.set_operand_state(self._op_key, value, _tell=True, _wait=False)
         if self._kv_store_ref is not None:
-            futures.append(self._kv_store_ref.write(
-                '%s/state' % self._op_path, value.name, _tell=True, _wait=False))
-        [f.result() for f in futures]
+            self._kv_store_ref.write(
+                '%s/state' % self._op_path, value.name, _tell=True, _wait=False)
 
     @property
     def worker(self):

--- a/mars/scheduler/operands/base.py
+++ b/mars/scheduler/operands/base.py
@@ -49,6 +49,8 @@ class BaseOperandActor(SchedulerActor):
 
         self._executable_dag = op_info.pop('executable_dag', None)
 
+        # set of running predecessors, used to broadcast priority changes
+        self._running_preds = set()
         # set of finished predecessors, used to decide whether we should move the operand to ready
         self._finish_preds = set()
         # set of finished successors, used to detect whether we can do clean up
@@ -212,6 +214,9 @@ class BaseOperandActor(SchedulerActor):
             return
         if self.state != state:
             self.start_operand(state)
+
+    def add_running_predecessor(self, op_key, worker):
+        self._running_preds.add(op_key)
 
     def add_finished_predecessor(self, op_key, worker, output_sizes=None):
         self._finish_preds.add(op_key)

--- a/mars/scheduler/operands/common.py
+++ b/mars/scheduler/operands/common.py
@@ -397,7 +397,8 @@ class OperandActor(BaseOperandActor):
             self._allocated = False
             if not self._is_worker_alive():
                 return
-            self._resource_ref.deallocate_resource(self._session_id, self._op_key, self.worker, _tell=True)
+            self._resource_ref.deallocate_resource(
+                self._session_id, self._op_key, self.worker, _tell=True, _wait=False)
 
             self._data_sizes = data_sizes
             self._io_meta['data_targets'] = list(data_sizes)
@@ -408,7 +409,8 @@ class OperandActor(BaseOperandActor):
             self._allocated = False
             # handling exception occurrence of operand execution
             exc_type = exc[0]
-            self._resource_ref.deallocate_resource(self._session_id, self._op_key, self.worker, _tell=True)
+            self._resource_ref.deallocate_resource(
+                self._session_id, self._op_key, self.worker, _tell=True, _wait=False)
 
             if self.state == OperandState.CANCELLING:
                 logger.warning('Execution of operand %s cancelled.', self._op_key)

--- a/mars/scheduler/operands/common.py
+++ b/mars/scheduler/operands/common.py
@@ -457,6 +457,8 @@ class OperandActor(BaseOperandActor):
             self.start_operand(OperandState.CANCELLING)
             return
 
+        use_aggressive_assign = options.scheduler.aggressive_assign
+
         succ_futures = []
         # update pred & succ finish records to trigger further actions
         # record if successors can be executed
@@ -474,7 +476,7 @@ class OperandActor(BaseOperandActor):
             pred_futures.extend(self._add_finished_terminal())
         [f.result() for f in pred_futures]
 
-        if not any(f.result() for f in succ_futures):
+        if use_aggressive_assign and not any(f.result() for f in succ_futures):
             self._assigner_ref.allocate_top_resources(1, _tell=True)
 
     @log_unhandled

--- a/mars/scheduler/tests/integrated/base.py
+++ b/mars/scheduler/tests/integrated/base.py
@@ -131,7 +131,8 @@ class SchedulerIntegratedTest(unittest.TestCase):
         return fn
 
     def start_processes(self, n_schedulers=2, n_workers=2, etcd=False, cuda=False, modules=None,
-                        log_scheduler=True, log_worker=True, env=None):
+                        log_scheduler=True, log_worker=True, env=None, scheduler_args=None,
+                        worker_args=None):
         old_not_errors = gevent.hub.Hub.NOT_ERROR
         gevent.hub.Hub.NOT_ERROR = (Exception,)
 
@@ -139,8 +140,8 @@ class SchedulerIntegratedTest(unittest.TestCase):
         self.scheduler_endpoints = ['127.0.0.1:' + p for p in scheduler_ports]
 
         append_args = []
-        append_args_scheduler = []
-        append_args_worker = []
+        append_args_scheduler = scheduler_args or []
+        append_args_worker = worker_args or []
         if modules:
             append_args.extend(['--load-modules', ','.join(modules)])
 

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -180,7 +180,7 @@ class Test(SchedulerIntegratedTest):
         from mars.dataframe.datasource.series import from_pandas as from_pandas_series
         from mars.dataframe.arithmetic import add
 
-        self.start_processes(etcd=False)
+        self.start_processes(etcd=False, scheduler_args=['-Dscheduler.aggressive_assign=true'])
 
         session_id = uuid.uuid1()
         actor_client = new_client()

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -317,3 +317,10 @@ class Test(unittest.TestCase):
             mt.random.shuffle(a)
             a = a.tiles()
             utils.check_chunks_unknown_shape([a], ValueError)
+
+    def testInsertReversedTuple(self):
+        self.assertTupleEqual(utils.insert_reversed_tuple((), 9), (9,))
+        self.assertTupleEqual(utils.insert_reversed_tuple((7, 4, 3, 1), 9), (9, 7, 4, 3, 1))
+        self.assertTupleEqual(utils.insert_reversed_tuple((7, 4, 3, 1), 6), (7, 6, 4, 3, 1))
+        self.assertTupleEqual(utils.insert_reversed_tuple((7, 4, 3, 1), 4), (7, 4, 3, 1))
+        self.assertTupleEqual(utils.insert_reversed_tuple((7, 4, 3, 1), 0), (7, 4, 3, 1, 0))

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -36,7 +36,8 @@ import numpy as np
 import pandas as pd
 
 from .compat import irange, functools32, getargspec
-from ._utils import to_binary, to_str, to_text, tokenize, tokenize_int, register as register_tokenizer
+from ._utils import to_binary, to_str, to_text, tokenize, tokenize_int, register_tokenizer,\
+    insert_reversed_tuple
 from .config import options
 from .lib.tblib import Traceback
 
@@ -44,8 +45,10 @@ logger = logging.getLogger(__name__)
 random.seed(int(time.time()) * os.getpid())
 
 
+# make flake8 happy by referencing these imports
 tokenize = tokenize
 register_tokenizer = register_tokenizer
+insert_reversed_tuple = insert_reversed_tuple
 
 
 # fix encoding conversion problem under windows

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -270,6 +270,9 @@ class BaseCalcActor(WorkerActor):
         storage_client = self.storage_client
         store_keys, store_metas = [], []
 
+        if data_attrs is None:
+            data_attrs = storage_client.get_data_attrs(session_id, keys_to_store)
+
         for k, attr in zip(keys_to_store, data_attrs):
             if attr is None or isinstance(k, tuple):
                 continue

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -235,12 +235,13 @@ class BaseCalcActor(WorkerActor):
 
         def _finalize(keys, exc_info):
             self._dispatch_ref.register_free_slot(self.uid, self._slot_name, _tell=True, _wait=False)
+            keys_to_delete = []
             keys_to_release = []
 
             for k in keys_to_fetch:
                 if get_chunk_key(k) not in chunk_targets:
                     if self._remove_intermediate:
-                        self.storage_client.delete(session_id, [k], [self._calc_intermediate_device])
+                        keys_to_delete.append(k)
                     keys_to_release.append(k)
 
             if not exc_info:
@@ -248,10 +249,12 @@ class BaseCalcActor(WorkerActor):
             else:
                 for k in chunk_targets:
                     if self._remove_intermediate:
-                        self.storage_client.delete(session_id, [k], [self._calc_intermediate_device])
+                        keys_to_delete.append(k)
                     keys_to_release.append(k)
                 self.tell_promise(callback, *exc_info, **dict(_accept=False))
 
+            if keys_to_delete:
+                self.storage_client.delete(session_id, keys_to_delete, [self._calc_intermediate_device])
             self._release_local_quotas(session_id, keys_to_release)
 
         return self._fetch_keys_to_process(session_id, keys_to_fetch) \
@@ -260,25 +263,23 @@ class BaseCalcActor(WorkerActor):
 
     @promise.reject_on_exception
     @log_unhandled
-    def store_results(self, session_id, keys_to_store, callback):
+    def store_results(self, session_id, graph_key, keys_to_store, data_attrs, callback):
+        logger.debug('Start dumping keys for graph %s', graph_key)
         from ..scheduler.chunkmeta import WorkerMeta
 
         storage_client = self.storage_client
-
-        sizes = storage_client.get_data_sizes(session_id, keys_to_store)
-        shapes = storage_client.get_data_shapes(session_id, keys_to_store)
-
         store_keys, store_metas = [], []
 
-        for k, size, shape in zip(keys_to_store, sizes, shapes):
-            if size is None or isinstance(k, tuple):
+        for k, attr in zip(keys_to_store, data_attrs):
+            if attr is None or isinstance(k, tuple):
                 continue
             store_keys.append(k)
-            store_metas.append(WorkerMeta(size, shape, (self.address,)))
+            store_metas.append(WorkerMeta(attr.size, attr.shape, (self.address,)))
         meta_future = self.get_meta_client().batch_set_chunk_meta(
             session_id, store_keys, store_metas, _wait=False)
 
         def _delete_keys(*_):
+            logger.debug('Finish dumping keys for graph %s', graph_key)
             if self._remove_intermediate:
                 storage_client.delete(
                     session_id, keys_to_store, [self._calc_intermediate_device], _tell=True)

--- a/mars/worker/daemon.py
+++ b/mars/worker/daemon.py
@@ -97,12 +97,7 @@ class WorkerDaemonActor(WorkerActor):
         pid = self._proc_pids[proc_idx]
         if pid in self._killed_pids:
             return False
-        try:
-            psutil.Process(pid)
-        except psutil.NoSuchProcess:
-            return False
-        else:
-            return True
+        return psutil.pid_exists(pid)
 
     def handle_process_down(self, proc_indices):
         """

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -247,7 +247,8 @@ class WorkerService(object):
             self._cuda_calc_actors.append(actor)
 
             uid = 'w:%d:mars-cuda-holder-%d-%d' % (start_pid + cuda_id, os.getpid(), cuda_id)
-            actor = actor_holder.create_actor(CudaHolderActor, device_id=stat.index, uid=uid)
+            actor = actor_holder.create_actor(
+                CudaHolderActor, stat.fb_mem_info.total, device_id=stat.index, uid=uid)
             self._cuda_holder_actors.append(actor)
 
             actor = actor_holder.create_actor(

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -242,9 +242,10 @@ class WorkerService(object):
 
         stats = resource.cuda_card_stats() if self._n_cuda_process else []
         for cuda_id, stat in enumerate(stats):
-            uid = 'w:%d:mars-cuda-calc-%d-%d' % (start_pid + cuda_id, os.getpid(), cuda_id)
-            actor = actor_holder.create_actor(CudaCalcActor, uid=uid)
-            self._cuda_calc_actors.append(actor)
+            for thread_no in range(options.worker.cuda_thread_num):
+                uid = 'w:%d:mars-cuda-calc-%d-%d-%d' % (start_pid + cuda_id, os.getpid(), cuda_id, thread_no)
+                actor = actor_holder.create_actor(CudaCalcActor, uid=uid)
+                self._cuda_calc_actors.append(actor)
 
             uid = 'w:%d:mars-cuda-holder-%d-%d' % (start_pid + cuda_id, os.getpid(), cuda_id)
             actor = actor_holder.create_actor(

--- a/mars/worker/status.py
+++ b/mars/worker/status.py
@@ -18,7 +18,7 @@ import time
 import logging
 from collections import defaultdict
 
-from .utils import WorkerActor, ExpMeanHolder, ExecutionState
+from .utils import WorkerActor, ExpMeanHolder
 from .. import resource
 from ..config import options
 from ..compat import six

--- a/mars/worker/status.py
+++ b/mars/worker/status.py
@@ -18,7 +18,7 @@ import time
 import logging
 from collections import defaultdict
 
-from .utils import WorkerActor, ExpMeanHolder
+from .utils import WorkerActor, ExpMeanHolder, ExecutionState
 from .. import resource
 from ..config import options
 from ..compat import six
@@ -201,13 +201,13 @@ class StatusActor(WorkerActor):
     def get_progress(self):
         return copy.deepcopy(self._progress)
 
-    def update_progress(self, session_id, graph_key, ops, stage):
+    def update_progress(self, session_id, graph_key, op_name, state):
         """
         Update statuses of operands
         :param session_id: session id
         :param graph_key: graph key
-        :param ops: operand name
-        :param stage: operand stage
+        :param op_name: operand name
+        :param state: operand execution state
         """
         session_id = str(session_id)
         graph_key = str(graph_key)
@@ -220,7 +220,7 @@ class StatusActor(WorkerActor):
             graph_dict = session_dict[graph_key]
         except KeyError:
             graph_dict = session_dict[graph_key] = dict()
-        graph_dict.update(dict(operands=ops, stage=stage))
+        graph_dict.update(dict(operands=op_name, stage=state.name))
 
     def remove_progress(self, session_id, graph_key):
         try:

--- a/mars/worker/storage/client.py
+++ b/mars/worker/storage/client.py
@@ -277,7 +277,12 @@ class StorageClient(object):
         return promise.all_(promises)
 
     def delete(self, session_id, data_keys, devices=None, _tell=False):
-        devices = devices or reduce(operator.or_, self._manager_ref.get_data_locations(session_id, data_keys))
+        if not devices:
+            devices = reduce(operator.ior,
+                             self._manager_ref.get_data_locations(session_id, data_keys), set())
+        else:
+            devices = self._normalize_devices(devices)
+
         devices = self._normalize_devices(devices)
         for dev_type in devices:
             handler = self.get_storage_handler(dev_type)
@@ -288,7 +293,12 @@ class StorageClient(object):
         return self.manager_ref.filter_exist_keys(session_id, data_keys, devices)
 
     def pin_data_keys(self, session_id, data_keys, token, devices=None):
-        devices = self._normalize_devices(devices or DataStorageDevice.__members__.values())
+        if not devices:
+            devices = reduce(operator.ior,
+                             self._manager_ref.get_data_locations(session_id, data_keys), set())
+        else:
+            devices = self._normalize_devices(devices)
+
         pinned = set()
         for dev in devices:
             handler = self.get_storage_handler(dev)
@@ -299,7 +309,12 @@ class StorageClient(object):
         return list(pinned)
 
     def unpin_data_keys(self, session_id, data_keys, token, devices=None):
-        devices = self._normalize_devices(devices or DataStorageDevice.__members__.values())
+        if not devices:
+            devices = reduce(operator.ior,
+                             self._manager_ref.get_data_locations(session_id, data_keys), set())
+        else:
+            devices = self._normalize_devices(devices)
+
         for dev in devices:
             handler = self.get_storage_handler(dev)
             if not getattr(handler, '_spillable', False):

--- a/mars/worker/storage/manager.py
+++ b/mars/worker/storage/manager.py
@@ -25,6 +25,14 @@ class DataAttrs(object):
         self.size = size
         self.shape = shape
 
+    def __reduce__(self):
+        return DataAttrs, (self.size, self.shape)
+
+    def __repr__(self):  # pragma: no cover
+        cls = type(self)
+        return '<%s.%s size=%r shape=%r at 0x%x>' \
+               % (cls.__module__, cls.__name__, self.size, self.shape, id(self))
+
 
 class StorageManagerActor(WorkerActor):
     def __init__(self):
@@ -89,19 +97,18 @@ class StorageManagerActor(WorkerActor):
         return [self._data_to_locations.get((session_id, key)) or set() for key in data_keys]
 
     def get_data_sizes(self, session_id, data_keys):
-        res = [None] * len(data_keys)
-        for idx, k in enumerate(data_keys):
-            try:
-                res[idx] = self._data_attrs[(session_id, k)].size
-            except KeyError:
-                pass
-        return res
+        return [a.size if a is not None else None
+                for a in self.get_data_attrs(session_id, data_keys)]
 
     def get_data_shapes(self, session_id, data_keys):
+        return [a.shape if a is not None else None
+                for a in self.get_data_attrs(session_id, data_keys)]
+
+    def get_data_attrs(self, session_id, data_keys):
         res = [None] * len(data_keys)
         for idx, k in enumerate(data_keys):
             try:
-                res[idx] = self._data_attrs[(session_id, k)].shape
+                res[idx] = self._data_attrs[(session_id, k)]
             except KeyError:
                 pass
         return res

--- a/mars/worker/storage/objectholder.py
+++ b/mars/worker/storage/objectholder.py
@@ -322,3 +322,18 @@ class CudaHolderActor(SimpleObjectHolderActor):
         super(CudaHolderActor, self).__init__(size_limit=size_limit)
         if device_id is not None:
             os.environ['CUDA_VISIBLE_DEVICES'] = str(device_id)
+
+        # warm up cupy
+        try:
+            import cupy
+            cupy.zeros((10, 10)).sum()
+        except ImportError:
+            pass
+        # warm up cudf
+        try:
+            import cudf
+            import numpy as np
+            import pandas as pd
+            cudf.from_pandas(pd.DataFrame(np.zeros((10, 10))))
+        except ImportError:
+            pass

--- a/mars/worker/storage/objectholder.py
+++ b/mars/worker/storage/objectholder.py
@@ -80,6 +80,9 @@ class ObjectHolderActor(WorkerActor):
     def post_delete(self, session_id, data_keys):
         raise NotImplementedError
 
+    def get_size_limit(self):
+        return self._size_limit
+
     @promise.reject_on_exception
     @log_unhandled
     def spill_size(self, size, multiplier=1, callback=None):

--- a/mars/worker/storage/objectholder.py
+++ b/mars/worker/storage/objectholder.py
@@ -316,6 +316,7 @@ class InProcHolderActor(SimpleObjectHolderActor):
 
 class CudaHolderActor(SimpleObjectHolderActor):
     _storage_device = DataStorageDevice.CUDA
+    _spill_devices = [DataStorageDevice.SHARED_MEMORY, DataStorageDevice.DISK]
 
     def __init__(self, size_limit=0, device_id=None):
         super(CudaHolderActor, self).__init__(size_limit=size_limit)

--- a/mars/worker/storage/sharedhandler.py
+++ b/mars/worker/storage/sharedhandler.py
@@ -145,7 +145,7 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
     @wrap_promised
     def put_objects(self, session_id, data_keys, objs, sizes=None, serialize=False,
                     pin_token=None, _promise=False):
-        keys, shapes = [], []
+        succ_keys, succ_shapes = [], []
         obj_refs = []
         affected_keys = []
         request_size, capacity = 0, 0
@@ -157,15 +157,15 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
 
                 try:
                     obj_refs.append(self._shared_store.put(session_id, key, obj))
-                    keys.append(key)
-                    shapes.append(shape)
+                    succ_keys.append(key)
+                    succ_shapes.append(shape)
                 except StorageFull as ex:
                     affected_keys.extend(ex.affected_keys)
                     request_size += ex.request_size
                     capacity = ex.capacity
                 finally:
                     del obj
-            self._holder_ref.put_objects_by_keys(session_id, keys, shapes=shapes, pin_token=pin_token)
+            self._holder_ref.put_objects_by_keys(session_id, succ_keys, shapes=succ_shapes, pin_token=pin_token)
             if affected_keys:
                 raise StorageFull(request_size=request_size, capacity=capacity,
                                   affected_keys=affected_keys)

--- a/mars/worker/tests/test_calc.py
+++ b/mars/worker/tests/test_calc.py
@@ -143,7 +143,8 @@ class Test(WorkerCase):
                     calc_ref.calc(session_id, add_chunk.op.key, serialize_graph(exec_graph),
                                   [add_chunk.key], _promise=True)
                         .then(_extract_value_ref)
-                        .then(lambda *_: calc_ref.store_results(session_id, [add_chunk.key], _promise=True))
+                        .then(lambda *_: calc_ref.store_results(
+                            session_id, add_chunk.op.key, [add_chunk.key], None, _promise=True))
                 )
 
             self.assertIsNone(ref_store[-1]())
@@ -187,5 +188,6 @@ class Test(WorkerCase):
                 self.waitp(
                     calc_ref.calc(session_id, add_chunk.op.key, serialize_graph(exec_graph),
                                   [add_chunk.key], _promise=True)
-                        .then(lambda *_: calc_ref.store_results(session_id, [add_chunk.key], _promise=True))
+                        .then(lambda *_: calc_ref.store_results(
+                            session_id, add_chunk.op.key, [add_chunk.key], None, _promise=True))
                 )

--- a/mars/worker/utils.py
+++ b/mars/worker/utils.py
@@ -20,13 +20,20 @@ from collections import OrderedDict
 
 from ..actors import ActorNotExist
 from ..cluster_info import ClusterInfoActor, HasClusterInfoActor
-from ..compat import OrderedDict3
+from ..compat import Enum, OrderedDict3
 from ..config import options
 from ..errors import WorkerProcessStopped
 from ..promise import PromiseActor
 from ..utils import build_exc_info
 
 logger = logging.getLogger(__name__)
+
+
+class ExecutionState(Enum):
+    ALLOCATING = 'allocating'
+    PREPARING_INPUTS = 'preparing_inputs'
+    CALCULATING = 'calculating'
+    STORING = 'storing'
 
 
 class WorkerClusterInfoActor(ClusterInfoActor):

--- a/mars/worker/utils.py
+++ b/mars/worker/utils.py
@@ -95,7 +95,7 @@ class WorkerActor(WorkerHasClusterInfoActor, PromiseActor):
 
     def get_meta_client(self):
         from ..scheduler.chunkmeta import ChunkMetaClient
-        return ChunkMetaClient(self.ctx, self._cluster_info_ref)
+        return ChunkMetaClient(self.ctx, self._cluster_info_ref, has_local_cache=False)
 
     def handle_actors_down(self, halt_refs):
         """


### PR DESCRIPTION
## What do these changes do?

Assign enqueued operands immediately when no descendants are ready. This behavior is disabled by default, and can be enabled with ``options.scheduler.aggressive_assign``.

## Related issue number

Fixes #853 
