### PR TITLE
Add CI/CD for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,23 +9,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-16.04, macOS-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.7-kubernetes, 3.7-hdfs]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.8-kubernetes, 3.8-hdfs]
         include:
           - { os: ubuntu-16.04, python-version: 2.7, python-abis: "cp27-cp27m:cp27-cp27mu" }
           - { os: ubuntu-16.04, python-version: 3.5, python-abis: "cp35-cp35m", cython-trace: 1 }
           - { os: ubuntu-16.04, python-version: 3.6, python-abis: "cp36-cp36m" }
           - { os: ubuntu-16.04, python-version: 3.7, python-abis: "cp37-cp37m" }
-          - { os: ubuntu-16.04, python-version: 3.7-kubernetes, no-common-tests: 1,
+          - { os: ubuntu-16.04, python-version: 3.8, python-abis: "cp38-cp38m" }
+          - { os: ubuntu-16.04, python-version: 3.8-kubernetes, no-common-tests: 1,
               no-deploy: 1, with-kubernetes: "with Kubernetes" }
-          - { os: ubuntu-16.04, python-version: 3.7-hdfs, no-common-tests: 1,
+          - { os: ubuntu-16.04, python-version: 3.8-hdfs, no-common-tests: 1,
               no-deploy: 1, with-hdfs: "with hdfs" }
-          - { os: windows-latest, python-version: 3.7, build-static: 1 }
+          - { os: windows-latest, python-version: 3.8, build-static: 1 }
         exclude:
-          - { os: macOS-latest, python-version: 3.7-kubernetes }
-          - { os: macOS-latest, python-version: 3.7-hdfs }
+          - { os: macOS-latest, python-version: 3.8-kubernetes }
+          - { os: macOS-latest, python-version: 3.8-hdfs }
           - { os: windows-latest, python-version: 2.7 }
-          - { os: windows-latest, python-version: 3.7-kubernetes }
-          - { os: windows-latest, python-version: 3.7-hdfs }
+          - { os: windows-latest, python-version: 3.8-kubernetes }
+          - { os: windows-latest, python-version: 3.8-hdfs }
 
     steps:
     - name: Check out code
@@ -52,6 +53,13 @@ jobs:
       run: |
         source ./.github/workflows/reload-env.sh
         export DEFAULT_VENV=$VIRTUAL_ENV
+        if [[ "$PYTHON" =~ "3.8" ]]; then
+          conda install -n test --quiet --yes python=$PYTHON numpy pyarrow
+          # remove three lines below once gevent 1.5 is released
+          # resolve compatibility issue in tblib inside gevent
+          GEVENT_TBLIB_FILE=$(python -c "from gevent import _tblib; print(_tblib.__file__)")
+          curl https://raw.githubusercontent.com/gevent/gevent/1.5a2/src/gevent/_tblib.py -o "$GEVENT_TBLIB_FILE"
+        fi
         pip install -r requirements-dev.txt
         pip install -r requirements-extra.txt
         pip install git+https://github.com/wjsi/coveralls-python.git
@@ -61,32 +69,33 @@ jobs:
           pip install virtualenv flake8 etcd-gevent
           if [ -z "$NO_COMMON_TESTS" ]; then
             if [[ $UNAME == "linux" ]] && [[ ! "$PYTHON" =~ "3.5" ]]; then
-              conda install -n test --quiet --yes -c conda-forge python=$PYTHON "tiledb-py>=0.4.3" || true;
-              conda install -n test --quiet --yes -c pkgs/main python=$PYTHON certifi;
+              conda install -n test --quiet --yes -c conda-forge python=$PYTHON "tiledb-py>=0.4.3" || true
+              conda install -n test --quiet --yes -c pkgs/main python=$PYTHON certifi
             fi
             if [[ $UNAME == "linux" ]] && [[ ! "$PYTHON" =~ "3.5" ]] && [[ ! "$PYTHON" =~ "2.7" ]]; then
-              conda install --quiet --yes -n test -c conda-forge --no-deps python=$PYTHON libxgboost py-xgboost xgboost;
+              conda install --quiet --yes -n test -c conda-forge --no-deps python=$PYTHON libxgboost py-xgboost xgboost
             fi
-            if [[ $UNAME == "linux" ]] && [[ ! "$PYTHON" =~ "2.7" ]]; then
-              pip install tensorflow;
+            if [[ $UNAME == "linux" ]] && [[ ! "$PYTHON" =~ "2.7" ]] && [[ ! "$PYTHON" =~ "3.8" ]]; then
+              pip install tensorflow
             fi
-            virtualenv testenv && source testenv/bin/activate;
-            pip install -r requirements.txt && pip install pytest pytest-timeout;
+            virtualenv testenv && source testenv/bin/activate
+            pip install -r requirements.txt && pip install pytest pytest-timeout
             if [ -z "$DEFAULT_VENV" ]; then
-              deactivate;
+              deactivate
             else
-              source $DEFAULT_VENV/bin/activate;
+              source $DEFAULT_VENV/bin/activate
             fi
           fi
           source ./.github/workflows/download-etcd.sh
           if [ -n "$WITH_KUBERNETES" ]; then
-            ./.github/workflows/install-minikube.sh;
-            pip install kubernetes;
+            ./.github/workflows/install-minikube.sh
+            pip install kubernetes
           fi
           if [ -n "$WITH_HDFS" ]; then
-            ./.github/workflows/install-hdfs.sh;
+            ./.github/workflows/install-hdfs.sh
           fi
         fi
+        conda list
 
     - name: Build cython extensions
       env:

--- a/.github/workflows/reload-env.sh
+++ b/.github/workflows/reload-env.sh
@@ -10,7 +10,8 @@ fi
 
 if [[ $UNAME == "mingw"* ]]; then
   CONDA=$(echo "/$CONDA" | sed -e 's/\\/\//g' -e 's/://')
-  export PATH="$CONDA/envs/test/Scripts:$CONDA/envs/test:$CONDA/Scripts:$CONDA:$PATH"
+  export PATH="$CONDA/Library:$CONDA/Library/bin:$CONDA/Scripts:$CONDA:$PATH"
+  export PATH="$CONDA/envs/test/Library:$CONDA/envs/test/Library/bin:$CONDA/envs/test/Scripts:$CONDA/envs/test:$PATH"
 else
   export PATH="$HOME/miniconda/envs/test/bin:$HOME/miniconda/bin:$PATH"
 fi

--- a/mars/actors/pool/messages.pyx
+++ b/mars/actors/pool/messages.pyx
@@ -837,7 +837,7 @@ cdef inline bytes _wrap_read_func(object read_func, size_t size):
     except ConnectionResetError:
         raise BrokenPipeError('The remote server is closed')
     except socket.error as ex:
-        if ex.errno == errno.EPIPE:
+        if ex.errno in (errno.EPIPE, errno.ECONNRESET):
             raise BrokenPipeError('The remote server is closed')
         else:
             raise
@@ -892,7 +892,7 @@ if PY_MAJOR_VERSION < 3:  # pragma: no cover
         try:
             return _write_remote_message(*args, **kwargs)
         except socket.error as ex:
-            if ex.errno == errno.EPIPE:
+            if ex.errno in (errno.ECONNRESET, errno.EPIPE):
                 raise BrokenPipeError
             else:
                 raise

--- a/mars/deploy/kubernetes/tests/Dockerfile.test
+++ b/mars/deploy/kubernetes/tests/Dockerfile.test
@@ -1,7 +1,7 @@
 ARG BASE_CONTAINER=marsproject/mars-base
 FROM ${BASE_CONTAINER}
 
-RUN /srv/retry.sh 3 /opt/conda/bin/conda install -c anaconda \
+RUN /srv/retry.sh 3 /opt/conda/bin/conda install -c pkgs/main \
     coverage \
   && conda clean --all -f -y
 

--- a/mars/lib/gipc.pyx
+++ b/mars/lib/gipc.pyx
@@ -435,7 +435,13 @@ def _child(target, args, kwargs):
             pass
 
 
-class _GProcess(multiprocessing.Process):
+try:
+    from multiprocessing.context import ForkProcess
+except ImportError:
+    ForkProcess = multiprocessing.Process
+
+
+class _GProcess(ForkProcess):
     """
     Compatible with the ``multiprocessing.Process`` API.
 

--- a/mars/lib/tblib/__init__.py
+++ b/mars/lib/tblib/__init__.py
@@ -15,7 +15,7 @@ except ImportError:
 if not tb_set_next and not tproxy:
     raise ImportError("Cannot use tblib. Runtime not supported.")
 
-__version__ = '1.3.2'
+__version__ = '1.6.0'
 __all__ = 'Traceback',
 
 PY3 = sys.version_info[0] == 3
@@ -37,6 +37,9 @@ class TracebackParseError(Exception):
 
 
 class Code(object):
+
+    co_code = None
+
     def __init__(self, code):
         self.co_filename = code.co_filename
         self.co_name = code.co_name
@@ -92,7 +95,12 @@ class Traceback(object):
         while current:
             f_code = current.tb_frame.f_code
             code = compile('\n' * (current.tb_lineno - 1) + 'raise __traceback_maker', current.tb_frame.f_code.co_filename, 'exec')
-            if PY3:
+            if hasattr(code, "replace"):
+                # Python 3.8 and newer
+                code = code.replace(co_argcount=0,
+                                    co_filename=f_code.co_filename, co_name=f_code.co_name,
+                                    co_freevars=(), co_cellvars=())
+            elif PY3:
                 code = CodeType(
                     0, code.co_kwonlyargcount,
                     code.co_nlocals, code.co_stacksize, code.co_flags,

--- a/mars/lib/tblib/pickling_support.py
+++ b/mars/lib/tblib/pickling_support.py
@@ -1,11 +1,13 @@
-try:
-    import copy_reg
-except ImportError:
-    import copyreg as copy_reg
+import sys
 from types import TracebackType
 
 from . import Frame
 from . import Traceback
+
+if sys.version_info.major >= 3:
+    import copyreg
+else:
+    import copy_reg as copyreg
 
 
 def unpickle_traceback(tb_frame, tb_lineno, tb_next):
@@ -20,5 +22,66 @@ def pickle_traceback(tb):
     return unpickle_traceback, (Frame(tb.tb_frame), tb.tb_lineno, tb.tb_next and Traceback(tb.tb_next))
 
 
-def install():
-    copy_reg.pickle(TracebackType, pickle_traceback)
+def unpickle_exception(func, args, cause, tb):
+    inst = func(*args)
+    inst.__cause__ = cause
+    inst.__traceback__ = tb
+    return inst
+
+
+def pickle_exception(obj):
+    # All exceptions, unlike generic Python objects, define __reduce_ex__
+    # __reduce_ex__(4) should be no different from __reduce_ex__(3).
+    # __reduce_ex__(5) could bring benefits in the unlikely case the exception
+    # directly contains buffers, but PickleBuffer objects will cause a crash when
+    # running on protocol=4, and there's no clean way to figure out the current
+    # protocol from here. Note that any object returned by __reduce_ex__(3) will
+    # still be pickled with protocol 5 if pickle.dump() is running with it.
+    rv = obj.__reduce_ex__(3)
+    if isinstance(rv, str):
+        raise TypeError("str __reduce__ output is not supported")
+    assert isinstance(rv, tuple) and len(rv) >= 2
+
+    return (unpickle_exception, rv[:2] + (obj.__cause__, obj.__traceback__)) + rv[2:]
+
+
+def _get_subclasses(cls):
+    # Depth-first traversal of all direct and indirect subclasses of cls
+    to_visit = [cls]
+    while to_visit:
+        this = to_visit.pop()
+        yield this
+        to_visit += list(this.__subclasses__())
+
+
+def install(*exc_classes_or_instances):
+    copyreg.pickle(TracebackType, pickle_traceback)
+
+    if sys.version_info.major < 3:
+        # Dummy decorator?
+        if len(exc_classes_or_instances) == 1:
+            exc = exc_classes_or_instances[0]
+            if isinstance(exc, type) and issubclass(exc, BaseException):
+                return exc
+        return
+
+    if not exc_classes_or_instances:
+        for exception_cls in _get_subclasses(BaseException):
+            copyreg.pickle(exception_cls, pickle_exception)
+        return
+
+    for exc in exc_classes_or_instances:
+        if isinstance(exc, BaseException):
+            while exc is not None:
+                copyreg.pickle(type(exc), pickle_exception)
+                exc = exc.__cause__
+        elif isinstance(exc, type) and issubclass(exc, BaseException):
+            copyreg.pickle(exc, pickle_exception)
+            # Allow using @install as a decorator for Exception classes
+            if len(exc_classes_or_instances) == 1:
+                return exc
+        else:
+            raise TypeError(
+                "Expected subclasses or instances of BaseException, got %s"
+                % (type(exc))
+            )

--- a/mars/tensor/base/sort.py
+++ b/mars/tensor/base/sort.py
@@ -134,7 +134,7 @@ class PSRSSorter(object):
         # another shuffle would be required to make sure each axis except to sort
         # has elements with identical size
         extra_shape = [s for i, s in enumerate(in_tensor.shape) if i != op.axis]
-        need_align = np.prod(extra_shape, dtype=int) != 1
+        need_align = bool(np.prod(extra_shape, dtype=int) != 1)
 
         out_chunks = []
         for out_idx in out_idxes:


### PR DESCRIPTION
## What do these changes do?

Add CI/CD for Python 3.8. Several points to notice:
1. As TensorFlow wheels are not supported yet in Python 3.8, we ignore TensorFlow in tests for Python 3.8.
2. tblib will add compatibility for Python 3.8 in 1.5, and gevent will embed this version in the next release, we have to patch gevent package to make sure cases run correctly.

Code changes, not CI/CD configurations. are to be backported to make sure v0.2.x works correctly in Python 3.8 with source code.

## Related issue number

NA
