### PR TITLE
Fix `read_csv` execution on GPU

### DIFF
--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -149,6 +149,14 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                                      chunks=[new_chunk], nsplits=nsplits)
 
     @classmethod
+    def _validate_dtypes(cls, dtypes, is_gpu):
+        dtypes = dtypes.to_dict()
+        # CuDF doesn't support object type, turn it to 'str'.
+        if is_gpu:
+            dtypes = dict((n, dt.name if dt != np.dtype('object') else 'str') for n, dt in dtypes.items())
+        return dtypes
+
+    @classmethod
     def tile(cls, op):
         if op.compression:
             return cls._tile_compressed(op)
@@ -184,6 +192,31 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                                      chunks=out_chunks, nsplits=nsplits)
 
     @classmethod
+    def _pandas_read_csv(cls, f, op):
+        csv_kwargs = op.extra_params.copy()
+        out_df = op.outputs[0]
+        start, end = _find_chunk_start_end(f, op.offset, op.size)
+        f.seek(start)
+        b = BytesIO(f.read(end - start))
+        if end == start:
+            # the last chunk may be empty
+            df = build_empty_df(out_df.dtypes)
+        else:
+            if start == 0:
+                # The first chunk contains header
+                # As we specify names and dtype, we need to skip header rows
+                csv_kwargs['skiprows'] = 1 if op.header == 'infer' else op.header
+            df = pd.read_csv(b, sep=op.sep, names=op.names, index_col=op.index_col,
+                             dtype=out_df.dtypes.to_dict(), **csv_kwargs)
+        return df
+
+    @classmethod
+    def _cudf_read_csv(cls, op):
+        df = cudf.read_csv(op.path, byte_range=(op.offset, op.size), sep=op.sep, names=op.names,
+                           dtype=cls._validate_dtypes(op.outputs[0].dtypes, op.gpu))
+        return df
+
+    @classmethod
     def execute(cls, ctx, op):
         xdf = cudf if op.gpu else pd
         out_df = op.outputs[0]
@@ -194,21 +227,10 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                 # As we specify names and dtype, we need to skip header rows
                 csv_kwargs['skiprows'] = 1 if op.header == 'infer' else op.header
                 df = xdf.read_csv(BytesIO(f.read()), sep=op.sep, names=op.names, index_col=op.index_col,
-                                  dtype=out_df.dtypes.to_dict(), **csv_kwargs)
+                                  dtype=cls._validate_dtypes(op.outputs[0].dtypes, op.gpu), **csv_kwargs)
             else:
-                start, end = _find_chunk_start_end(f, op.offset, op.size)
-                f.seek(start)
-                b = BytesIO(f.read(end - start))
-                if end == start:
-                    # the last chunk may be empty
-                    df = build_empty_df(out_df.dtypes)
-                else:
-                    if start == 0:
-                        # The first chunk contains header
-                        # As we specify names and dtype, we need to skip header rows
-                        csv_kwargs['skiprows'] = 1 if op.header == 'infer' else op.header
-                    df = xdf.read_csv(b, sep=op.sep, names=op.names, index_col=op.index_col,
-                                      dtype=out_df.dtypes.to_dict(), **csv_kwargs)
+                df = cls._cudf_read_csv(op) if op.gpu else cls._pandas_read_csv(f, op)
+
         ctx[out_df.key] = df
 
     def __call__(self, index_value=None, columns_value=None, dtypes=None, chunk_bytes=None):

--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -213,8 +213,11 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
     @classmethod
     def _cudf_read_csv(cls, op):
         csv_kwargs = op.extra_params
-        df = cudf.read_csv(op.path, byte_range=(op.offset, op.size), sep=op.sep, names=op.names,
-                           dtype=cls._validate_dtypes(op.outputs[0].dtypes, op.gpu), **csv_kwargs)
+        if op.offset == 0:
+            df = cudf.read_csv(op.path, byte_range=(op.offset, op.size), sep=op.sep, **csv_kwargs)
+        else:
+            df = cudf.read_csv(op.path, byte_range=(op.offset, op.size), sep=op.sep, names=op.names,
+                               dtype=cls._validate_dtypes(op.outputs[0].dtypes, op.gpu), **csv_kwargs)
         return df
 
     @classmethod

--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -212,8 +212,9 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def _cudf_read_csv(cls, op):
+        csv_kwargs = op.extra_params
         df = cudf.read_csv(op.path, byte_range=(op.offset, op.size), sep=op.sep, names=op.names,
-                           dtype=cls._validate_dtypes(op.outputs[0].dtypes, op.gpu))
+                           dtype=cls._validate_dtypes(op.outputs[0].dtypes, op.gpu), **csv_kwargs)
         return df
 
     @classmethod

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -283,14 +283,18 @@ class Test(TestBase):
         tempdir = tempfile.mkdtemp()
         file_path = os.path.join(tempdir, 'test.csv')
         try:
-            df = pd.DataFrame([[1, 2.0, 'v1'], [4, 5.0, 'v2'], [7, 8.0, 'v3']], columns=['a', 'b', 'c'])
+            df = pd.DataFrame({
+                'col1': np.random.rand(100),
+                'col2': np.random.choice(['a', 'b', 'c'], (100,)),
+                'col3': np.arange(100)
+            })
             df.to_csv(file_path, index=False)
 
             pdf = pd.read_csv(file_path)
             mdf = self.executor.execute_dataframe(md.read_csv(file_path, gpu=True), concat=True)[0]
             pd.testing.assert_frame_equal(pdf.reset_index(drop=True), mdf.to_pandas().reset_index(drop=True))
 
-            mdf2 = self.executor.execute_dataframe(md.read_csv(file_path, gpu=True, chunk_bytes=10),
+            mdf2 = self.executor.execute_dataframe(md.read_csv(file_path, gpu=True, chunk_bytes=200),
                                                    concat=True)[0]
             pd.testing.assert_frame_equal(pdf.reset_index(drop=True), mdf2.to_pandas().reset_index(drop=True))
 

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -94,9 +94,10 @@ class DataFrameGroupByOperand(DataFrameOperand, DataFrameOperandMixin):
 
     _by = AnyField('by')
     _as_index = BoolField('as_index')
+    _sort = BoolField('sort')
 
-    def __init__(self, by=None, as_index=None, object_type=ObjectType.groupby, **kw):
-        super(DataFrameGroupByOperand, self).__init__(_by=by, _as_index=as_index,
+    def __init__(self, by=None, as_index=None, sort=None, object_type=ObjectType.groupby, **kw):
+        super(DataFrameGroupByOperand, self).__init__(_by=by, _as_index=as_index, _sort=sort,
                                                       _object_type=object_type, **kw)
 
     @property
@@ -106,6 +107,10 @@ class DataFrameGroupByOperand(DataFrameOperand, DataFrameOperandMixin):
     @property
     def as_index(self):
         return self._as_index
+
+    @property
+    def sort(self):
+        return self._sort
 
     def __call__(self, df):
         return self.new_tileable([df])
@@ -147,8 +152,8 @@ class DataFrameGroupByOperand(DataFrameOperand, DataFrameOperandMixin):
         ctx[op.outputs[0].key] = list(df.groupby(op.by))
 
 
-def dataframe_groupby(df, by, as_index=True):
+def dataframe_groupby(df, by, as_index=True, sort=True):
     if isinstance(by, six.string_types):
         by = [by]
-    op = DataFrameGroupByOperand(by=by, as_index=as_index)
+    op = DataFrameGroupByOperand(by=by, as_index=as_index, sort=sort)
     return op(df)

--- a/mars/dataframe/merge/concat.py
+++ b/mars/dataframe/merge/concat.py
@@ -121,6 +121,8 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
                 ret = xdf.concat(concats, sort=False)
             else:
                 ret = xdf.concat(concats)
+                # cuDF will lost index name when concat two seriess.
+                ret.index.name = concats[0].index.name
             if getattr(chunk.index_value, 'should_be_monotonic', False):
                 ret.sort_index(inplace=True)
             if getattr(chunk.columns_value, 'should_be_monotonic', False):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
We passed specific dtypes when call `cudf.read_csv`, as object type is unsupported in cuDF, we treat it as string type as default.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #852 
