### PR TITLE
Fix distribute error under Py38

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           - { os: ubuntu-16.04, python-version: 3.5, python-abis: "cp35-cp35m", cython-trace: 1 }
           - { os: ubuntu-16.04, python-version: 3.6, python-abis: "cp36-cp36m" }
           - { os: ubuntu-16.04, python-version: 3.7, python-abis: "cp37-cp37m" }
-          - { os: ubuntu-16.04, python-version: 3.8, python-abis: "cp38-cp38m" }
+          - { os: ubuntu-16.04, python-version: 3.8, python-abis: "cp38-cp38" }
           - { os: ubuntu-16.04, python-version: 3.8-kubernetes, no-common-tests: 1,
               no-deploy: 1, with-kubernetes: "with Kubernetes" }
           - { os: ubuntu-16.04, python-version: 3.8-hdfs, no-common-tests: 1,

--- a/requirements-wheel.txt
+++ b/requirements-wheel.txt
@@ -2,4 +2,3 @@ numpy==1.14.5
 pandas==0.24.2
 cython==0.29.3
 requests>=2.4.0
-pyarrow>=0.11.0


### PR DESCRIPTION
## What do these changes do?

Python 3.8 uses new abi called ``cp38-cp38``, hence we need to change the definition in ci.yml. Build logs can be seen at https://github.com/wjsi/mars/commit/66e8581c0c81a1d506419e7a41174788482f2a0d/checks?check_suite_id=359196592.

## Related issue number

NA
