### PR TITLE
Further remove py27-related imports

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
-PYTEST_CONFIG="--log-level=DEBUG --cov-report= --cov=mars --timeout=1500 -W ignore::PendingDeprecationWarning
---ignore mars/lib/functools32 --ignore mars/lib/futures"
+PYTEST_CONFIG="--log-level=DEBUG --cov-report= --cov=mars --timeout=1500 -W ignore::PendingDeprecationWarning"
 if [ -n "$WITH_HDFS" ]; then
   pytest $PYTEST_CONFIG --cov-config .coveragerc-threaded mars/dataframe/datasource/tests/test_hdfs.py
   coverage report

--- a/LICENSE
+++ b/LICENSE
@@ -218,6 +218,7 @@ Apache Software Foundation License 2.0
 - tornado:5.1.1
 - Cython:0.29
 - requests:2.19.1
+- cudf:0.6.0
 
 
 BSD 3-Clause
@@ -252,19 +253,11 @@ MIT License
 - gevent:1.3.7
 - gipc:0.6.0
 - etcd-gevent:0.1.1.1
-- six:1.10.0
 - bootstrap:3.3.7
 - bootstrap-table:1.15.4
 - font-awesome:4.7.0 (CSS)
 - startbootstrap-sb-admin-2:3.3.7
 - moment.js:2.3.1
-
-
-Python Software Foundation License
-----------------------------------
-
-- python-functools32
-- futures
 
 
 SIL OFL 1.1 license

--- a/mars/actors/core.pyx
+++ b/mars/actors/core.pyx
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import multiprocessing
 
 from .cluster cimport ClusterInfo

--- a/mars/actors/distributor.pyx
+++ b/mars/actors/distributor.pyx
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 from ..lib.mmh3 import hash as mmh_hash
 
 

--- a/mars/actors/pool/gevent_pool.pyx
+++ b/mars/actors/pool/gevent_pool.pyx
@@ -14,14 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import weakref
 import sys
 import pickle
 import random
-import errno
-import socket
 import struct
 import itertools
 from collections import OrderedDict

--- a/mars/actors/pool/messages.pyx
+++ b/mars/actors/pool/messages.pyx
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
-import errno
-import socket
 from pickle import dumps, loads
 
 import numpy as np

--- a/mars/actors/pool/utils.pyx
+++ b/mars/actors/pool/utils.pyx
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import numpy as np
 
 from ..._utils cimport to_str

--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import atexit
 import multiprocessing
 import os

--- a/mars/learn/contrib/pytorch/tests/integrated/test_distributed_pytorch.py
+++ b/mars/learn/contrib/pytorch/tests/integrated/test_distributed_pytorch.py
@@ -18,14 +18,12 @@ import os
 from mars.learn.tests.integrated.base import LearnIntegrationTestBase
 from mars.learn.contrib.pytorch import run_pytorch_script
 from mars.session import new_session
+from mars.utils import lazy_import
 
-try:
-    import torch
-except ImportError:
-    torch = None
+torch_installed = lazy_import('torch', globals=globals()) is not None
 
 
-@unittest.skipIf(torch is None, 'pytorch not installed')
+@unittest.skipIf(not torch_installed, 'pytorch not installed')
 class Test(LearnIntegrationTestBase):
     def testDistributedRunPyTorchScript(self):
         service_ep = 'http://127.0.0.1:' + self.web_port

--- a/mars/learn/contrib/pytorch/tests/pytorch_sample.py
+++ b/mars/learn/contrib/pytorch/tests/pytorch_sample.py
@@ -14,14 +14,9 @@
 
 import sys
 
-import torch
-import torch.nn as nn
-import torch.distributed as dist
-import torch.optim as optim
-import torch.utils.data
-
 
 def get_model():
+    import torch.nn as nn
     return nn.Sequential(
         nn.Linear(32, 64),
         nn.ReLU(),
@@ -32,11 +27,12 @@ def get_model():
     )
 
 
-assert len(sys.argv) == 2
-assert sys.argv[1] == 'multiple'
-
-
 def main():
+    import torch.nn as nn
+    import torch.distributed as dist
+    import torch.optim as optim
+    import torch.utils.data
+
     dist.init_process_group(backend='gloo')
     torch.manual_seed(42)
 
@@ -66,4 +62,6 @@ def main():
 
 
 if __name__ == "__main__":
+    assert len(sys.argv) == 2
+    assert sys.argv[1] == 'multiple'
     main()

--- a/mars/learn/contrib/pytorch/tests/test_run_script.py
+++ b/mars/learn/contrib/pytorch/tests/test_run_script.py
@@ -16,14 +16,12 @@ import os
 import unittest
 
 from mars.learn.contrib.pytorch import run_pytorch_script
+from mars.utils import lazy_import
 
-try:
-    import torch
-except ImportError:
-    torch = None
+torch_installed = lazy_import('torch', globals=globals()) is not None
 
 
-@unittest.skipIf(torch is None, 'pytorch not installed')
+@unittest.skipIf(not torch_installed, 'pytorch not installed')
 class Test(unittest.TestCase):
     def testLocalRunPyTorchScript(self):
         path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pytorch_sample.py')

--- a/mars/learn/contrib/xgboost/tracker.py
+++ b/mars/learn/contrib/xgboost/tracker.py
@@ -19,8 +19,6 @@ which is a specialized version for xgboost tasks.
 
 # pylint: disable=invalid-name, missing-docstring, too-many-arguments, too-many-locals
 # pylint: disable=too-many-branches, too-many-statements, too-many-instance-attributes
-from __future__ import absolute_import
-
 import socket
 import struct
 import time

--- a/mars/learn/datasets/samples_generator.py
+++ b/mars/learn/datasets/samples_generator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import numbers
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 

--- a/mars/learn/datasets/tests/test_samples_generator.py
+++ b/mars/learn/datasets/tests/test_samples_generator.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import division
 import unittest
 from functools import partial
 from collections import defaultdict

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import itertools
-from collections import defaultdict, Iterable
+from collections import defaultdict
+from collections.abc import Iterable
 from functools import reduce
 
 import numpy as np

--- a/mars/lib/gipc.pyx
+++ b/mars/lib/gipc.pyx
@@ -64,12 +64,8 @@ import codecs
 import logging
 import multiprocessing
 import multiprocessing.process
+import pickle
 from itertools import chain
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
 
 try:
     from pytest_cov.embed import cleanup_on_sigterm

--- a/mars/lib/sparse/__init__.py
+++ b/mars/lib/sparse/__init__.py
@@ -17,10 +17,7 @@
 import builtins
 import operator
 from functools import reduce
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 from .array import SparseNDArray
 from .matrix import SparseMatrix

--- a/mars/lib/sparse/matrix.py
+++ b/mars/lib/sparse/matrix.py
@@ -15,10 +15,7 @@
 # limitations under the License.
 
 import numpy as np
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 from .core import issparse, get_array_module, cp, cps, \
     get_sparse_module, naked, sps, splinalg

--- a/mars/serialize/core.pyx
+++ b/mars/serialize/core.pyx
@@ -17,7 +17,8 @@
 import importlib
 import inspect
 import copy
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable
 
 
 cdef class Identity:

--- a/mars/tensor/base/roll.py
+++ b/mars/tensor/base/roll.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.'
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 

--- a/mars/tensor/base/squeeze.py
+++ b/mars/tensor/base/squeeze.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import Iterable
+from collections.abc import Iterable
 
 from ...serialize import ValueType, KeyField, TupleField
 from ... import opcodes as OperandDef

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 
-from collections import Iterable, defaultdict
+from collections import defaultdict
+from collections.abc import Iterable
 from datetime import datetime
 from enum import Enum
 from operator import attrgetter

--- a/mars/tensor/datasource/indices.py
+++ b/mars/tensor/datasource/indices.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 

--- a/mars/tensor/fft/core.py
+++ b/mars/tensor/fft/core.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import Iterable
+from collections.abc import Iterable
 
 from ...serialize import ValueType, KeyField, StringField, Int32Field, \
     Int64Field, ListField

--- a/mars/tensor/indexing/unravel_index.py
+++ b/mars/tensor/indexing/unravel_index.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 

--- a/mars/tensor/linalg/norm.py
+++ b/mars/tensor/linalg/norm.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import itertools
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 

--- a/mars/tensor/linalg/tensordot.py
+++ b/mars/tensor/linalg/tensordot.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import itertools
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 

--- a/mars/tensor/merge/concatenate.py
+++ b/mars/tensor/merge/concatenate.py
@@ -14,7 +14,7 @@
 
 import itertools
 import operator
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 

--- a/mars/tensor/operands.py
+++ b/mars/tensor/operands.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from __future__ import absolute_import
-
 from ..serialize import DataTypeField
 from ..operands import Operand, TileableOperandMixin, HasInput, ShuffleProxy, \
     ShuffleMap, ShuffleReduce, Fuse

--- a/mars/tensor/random/core.py
+++ b/mars/tensor/random/core.py
@@ -14,7 +14,7 @@
 
 
 import itertools
-from collections import Iterable
+from collections.abc import Iterable
 from contextlib import contextmanager
 
 import numpy as np

--- a/mars/tensor/random/dirichlet.py
+++ b/mars/tensor/random/dirichlet.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import itertools
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 

--- a/mars/tensor/reduction/core.py
+++ b/mars/tensor/reduction/core.py
@@ -19,12 +19,9 @@ import copy
 import inspect
 import itertools
 import operator
+from collections.abc import Iterable
 from functools import reduce
 from math import ceil, log
-try:
-    from collections.abc import Iterable
-except ImportError:  # pragma: no cover
-    from collections import Iterable
 
 import numpy as np
 

--- a/mars/tensor/utils.py
+++ b/mars/tensor/utils.py
@@ -18,7 +18,8 @@ import inspect
 import itertools
 import operator
 import uuid
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable
 from functools import lru_cache, reduce, wraps
 from math import ceil
 from numbers import Integral

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -22,7 +22,7 @@ import tempfile
 import time
 import itertools
 import unittest
-from collections import Iterable
+from collections.abc import Iterable
 from weakref import ReferenceType
 
 import numpy as np


### PR DESCRIPTION
## What do these changes do?

Remove ``from __future__ import xxx`` and import ``Iterable`` from ``collections.abc``

## Related issue number

#419
