### PR TITLE
Fix possible failure of `testIterativeTilingWithoutEtcd` for Python 3.5 in CI

### DIFF
--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -294,7 +294,7 @@ class Test(SchedulerIntegratedTest):
         expected = np.sort(raw)[:5]
         assert_allclose(loads(result), expected)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(KeyError):
             session_ref.fetch_result(graph_key, a.key, check=False)
 
         raw1 = rs.rand(20)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR tries to fix possible failure of `testIterativeTilingWithoutEtcd` for Python 3.5 in CI.

The reason is that some value stored in a dict value is bind into a weakref.WeakKeyDIctionary, and the same key may be overwritten and gc may collect the old value, thus it's gone in the weak key dict either.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #895 .
