### PR TITLE
Implement `mean` operator for DataFrame and Series

### DIFF
--- a/mars/dataframe/reduction/__init__.py
+++ b/mars/dataframe/reduction/__init__.py
@@ -17,26 +17,26 @@ from .prod import DataFrameProd
 from .max import DataFrameMax
 from .min import DataFrameMin
 from .count import DataFrameCount
+from .mean import DataFrameMean
 
 
 def _install():
-    from ..core import DataFrame, Series
+    from ..core import DATAFRAME_TYPE, SERIES_TYPE
     from .sum import sum_series, sum_dataframe
     from .prod import prod_series, prod_dataframe
     from .max import max_series, max_dataframe
     from .min import min_series, min_dataframe
     from .count import count_series, count_dataframe
+    from .mean import mean_series, mean_dataframe
 
-    setattr(DataFrame, 'sum', sum_dataframe)
-    setattr(Series, 'sum', sum_series)
-    setattr(DataFrame, 'prod', prod_dataframe)
-    setattr(Series, 'prod', prod_series)
-    setattr(DataFrame, 'max', max_dataframe)
-    setattr(Series, 'max', max_series)
-    setattr(DataFrame, 'min', min_dataframe)
-    setattr(Series, 'min', min_series)
-    setattr(DataFrame, 'count', count_dataframe)
-    setattr(Series, 'count', count_series)
+    func_names = ['sum', 'prod', 'max', 'min', 'count', 'mean']
+    series_funcs = [sum_series, prod_series, max_series, min_series, count_series, mean_series]
+    df_funcs = [sum_dataframe, prod_dataframe, max_dataframe, min_dataframe, count_dataframe, mean_dataframe]
+    for func_name, series_func, df_func in zip(func_names, series_funcs, df_funcs):
+        for t in DATAFRAME_TYPE:
+            setattr(t, func_name, df_func)
+        for t in SERIES_TYPE:
+            setattr(t, func_name, series_func)
 
 
 _install()

--- a/mars/dataframe/reduction/mean.py
+++ b/mars/dataframe/reduction/mean.py
@@ -1,0 +1,51 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import lazy_import
+from .core import DataFrameReductionOperand, DataFrameReductionMixin, ObjectType
+
+cudf = lazy_import('cudf', globals=globals())
+
+
+class DataFrameMean(DataFrameReductionOperand, DataFrameReductionMixin):
+    _op_type_ = OperandDef.MEAN
+    _func_name = 'mean'
+
+    @classmethod
+    def _execute_map(cls, ctx, op):
+        cls._execute_map_with_count(ctx, op, reduction_func='sum')
+
+    @classmethod
+    def _execute_combine(cls, ctx, op):
+        cls._execute_combine_with_count(ctx, op, reduction_func='sum')
+
+    @classmethod
+    def _execute_agg(cls, ctx, op):
+        in_data, concat_count = ctx[op.inputs[0].key]
+        count = concat_count.sum(axis=op.axis)
+        r = cls._execute_reduction(in_data, op, reduction_func='sum')
+        ctx[op.outputs[0].key] = r / count
+
+
+def mean_series(df, axis=None, skipna=None, level=None, combine_size=None):
+    op = DataFrameMean(axis=axis, skipna=skipna, level=level, combine_size=combine_size,
+                       object_type=ObjectType.series)
+    return op(df)
+
+
+def mean_dataframe(df, axis=None, skipna=None, level=None, numeric_only=None, combine_size=None):
+    op = DataFrameMean(axis=axis, skipna=skipna, level=level, numeric_only=numeric_only,
+                       combine_size=combine_size, object_type=ObjectType.series)
+    return op(df)

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -19,7 +19,8 @@ import unittest
 from mars import opcodes as OperandDef
 from mars.tests.core import TestBase, parameterized
 from mars.dataframe.core import IndexValue, Series
-from mars.dataframe.reduction import DataFrameSum, DataFrameProd, DataFrameMin, DataFrameMax, DataFrameCount
+from mars.dataframe.reduction import DataFrameSum, DataFrameProd, DataFrameMin, DataFrameMax, \
+    DataFrameCount, DataFrameMean
 from mars.dataframe.merge import DataFrameConcat
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
 from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df
@@ -31,6 +32,7 @@ reduction_functions = dict(
     min=dict(func_name='min', op=DataFrameMin, has_skipna=True),
     max=dict(func_name='max', op=DataFrameMax, has_skipna=True),
     count=dict(func_name='count', op=DataFrameCount, has_skipna=False),
+    mean=dict(func_name='mean', op=DataFrameMean, has_skipna=True)
 )
 
 

--- a/mars/dataframe/reduction/tests/test_reduction_execute.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execute.py
@@ -27,6 +27,7 @@ reduction_functions = dict(
     prod=dict(func_name='prod', has_min_count=True),
     min=dict(func_name='min', has_min_count=False),
     max=dict(func_name='max', has_min_count=False),
+    mean=dict(func_name='mean', has_min_count=False)
 )
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Add `Mean` implementation in DataFrame reduction module.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #883.