### PR TITLE
Add comparison functions for DataFrame

### DIFF
--- a/mars/core.py
+++ b/mars/core.py
@@ -510,6 +510,9 @@ class HasShapeTileableData(TileableData):
             'shape': self.shape
         }
 
+    def _equals(self, o):
+        return self is o
+
 
 class ObjectData(TileableData):
     __slots__ = ()

--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -21,7 +21,6 @@ from pandas.core.dtypes.cast import find_common_type
 
 from ...tensor.datasource import tensor as astensor
 from ...serialize import AnyField, Float64Field
-
 from ...tensor.core import TENSOR_TYPE, ChunkData, Chunk
 from ...utils import classproperty
 from ..align import align_series_series, align_dataframe_series, align_dataframe_dataframe
@@ -38,9 +37,10 @@ class DataFrameBinOp(DataFrameOperand):
     _lhs = AnyField('lhs')
     _rhs = AnyField('rhs')
 
-    def __init__(self, axis=None, level=None, fill_value=None, object_type=None, lhs=None, rhs=None, **kw):
-        super().__init__(_axis=axis, _level=level, _fill_value=fill_value, _object_type=object_type,
-                         _lhs=lhs, _rhs=rhs, **kw)
+    def __init__(self, axis=None, level=None, fill_value=None,
+                 object_type=None, lhs=None, rhs=None, **kw):
+        super().__init__(_axis=axis, _level=level, _fill_value=fill_value,
+                         _object_type=object_type, _lhs=lhs, _rhs=rhs, **kw)
 
     @property
     def axis(self):
@@ -186,8 +186,8 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
         for chunk in tileable.chunks:
             out_op = op.copy().reset_key()
             if isinstance(chunk, DATAFRAME_CHUNK_TYPE):
-                out_chunk = out_op.new_chunk([chunk], shape=chunk.shape, index=chunk.index, dtypes=chunk.dtypes,
-                                             index_value=chunk.index_value,
+                out_chunk = out_op.new_chunk([chunk], shape=chunk.shape, index=chunk.index,
+                                             dtypes=chunk.dtypes, index_value=chunk.index_value,
                                              columns_value=getattr(chunk, 'columns_value'))
             else:
                 out_chunk = out_op.new_chunk([chunk], shape=chunk.shape, index=chunk.index, dtype=chunk.dtype,
@@ -200,7 +200,8 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
                                       index_value=df.index_value, name=df.name, chunks=out_chunks)
         else:
             return new_op.new_dataframes(op.inputs, df.shape, nsplits=tileable.nsplits, dtypes=df.dtypes,
-                                         index_value=df.index_value, columns_value=df.columns_value, chunks=out_chunks)
+                                         index_value=df.index_value, columns_value=df.columns_value,
+                                         chunks=out_chunks)
 
     @classmethod
     def _tile_with_tensor(cls, op):
@@ -259,7 +260,8 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
     def execute(cls, ctx, op):
         if len(op.inputs) == 2:
             df, other = ctx[op.inputs[0].key], ctx[op.inputs[1].key]
-            if isinstance(op.inputs[0], SERIES_CHUNK_TYPE) and isinstance(op.inputs[1], DATAFRAME_CHUNK_TYPE):
+            if isinstance(op.inputs[0], SERIES_CHUNK_TYPE) and \
+                    isinstance(op.inputs[1], DATAFRAME_CHUNK_TYPE):
                 df, other = other, df
                 func_name = getattr(cls, '_rfunc_name')
             else:
@@ -276,7 +278,11 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
             kw = dict({'axis': op.axis})
         else:
             kw = dict()
-        ctx[op.outputs[0].key] = getattr(df, func_name)(other, level=op.level, fill_value=op.fill_value, **kw)
+        if op.fill_value is not None:
+            # comparison function like eq does not have `fill_value`
+            kw['fill_value'] = op.fill_value
+        ctx[op.outputs[0].key] = getattr(df, func_name)(
+            other, level=op.level, **kw)
 
     @classproperty
     def _operator(self):
@@ -325,7 +331,8 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
             return {'shape': (index_shape, column_shape), 'dtypes': dtypes,
                     'columns_value': columns, 'index_value': index}
 
-        if isinstance(x1, (DATAFRAME_TYPE, DATAFRAME_CHUNK_TYPE)) and isinstance(x2, (SERIES_TYPE, SERIES_CHUNK_TYPE)):
+        if isinstance(x1, (DATAFRAME_TYPE, DATAFRAME_CHUNK_TYPE)) and \
+                isinstance(x2, (SERIES_TYPE, SERIES_CHUNK_TYPE)):
             if axis == 'columns' or axis == 1:
                 index_shape = x1.shape[0]
                 index = x1.index_value
@@ -359,7 +366,8 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
             return {'shape': (index_shape, column_shape), 'dtypes': dtypes,
                     'columns_value': columns, 'index_value': index}
 
-        if isinstance(x1, (SERIES_TYPE, SERIES_CHUNK_TYPE)) and isinstance(x2, (SERIES_TYPE, SERIES_CHUNK_TYPE)):
+        if isinstance(x1, (SERIES_TYPE, SERIES_CHUNK_TYPE)) and \
+                isinstance(x2, (SERIES_TYPE, SERIES_CHUNK_TYPE)):
             index_shape, dtype, index = np.nan, None, None
 
             dtype = find_common_type([x1.dtype, x2.dtype])
@@ -424,16 +432,19 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
                     other_shape = other.shape
                 if tensor.ndim == 2 and tensor.shape != other_shape:
                     raise ValueError(
-                        'Unable to coerce to DataFrame, shape must be {}: given {}'.format(other_shape, tensor.shape))
+                        'Unable to coerce to DataFrame, shape must be {}: '
+                        'given {}'.format(other_shape, tensor.shape))
                 elif tensor.ndim == 1 and tensor.shape[0] != other_shape[1]:
                     raise ValueError(
-                        'Unable to coerce to Series, length must be {}: given {}'.format(other_shape[1], tensor.shape[0]))
+                        'Unable to coerce to Series, length must be {}: given {}'.format(
+                            other_shape[1], tensor.shape[0]))
                 elif tensor.ndim > 2:
                     raise ValueError('Unable to coerce to Series/DataFrame, dim must be <= 2')
             if isinstance(other, SERIES_TYPE):
                 if tensor.ndim == 1 and (tensor.shape[0] != other.shape[0]):
                     raise ValueError(
-                        'Unable to coerce to Series, length must be {}: given {}'.format(other.shape[0], tensor.shape[0]))
+                        'Unable to coerce to Series, length must be {}: given {}'.format(
+                            other.shape[0], tensor.shape[0]))
                 elif tensor.ndim > 1:
                     raise ValueError('Unable to coerce to Series, dim must be 1')
 
@@ -486,7 +497,8 @@ class DataFrameUnaryOpMixin(DataFrameOperandMixin):
         for in_chunk in in_df.chunks:
             out_op = op.copy().reset_key()
             out_chunk = out_op.new_chunk([in_chunk], shape=in_chunk.shape, index=in_chunk.index,
-                                         index_value=in_chunk.index_value, columns_value=in_chunk.columns_value)
+                                         index_value=in_chunk.index_value,
+                                         columns_value=in_chunk.columns_value)
             out_chunks.append(out_chunk)
 
         new_op = op.copy()

--- a/mars/dataframe/arithmetic/equal.py
+++ b/mars/dataframe/arithmetic/equal.py
@@ -1,0 +1,33 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameBinOpMixin, DataFrameBinOp
+
+
+class DataFrameEqual(DataFrameBinOp, DataFrameBinOpMixin):
+    _op_type_ = OperandDef.EQ
+
+    _func_name = 'eq'
+    _rfunc_name = 'eq'
+
+    @classproperty
+    def _operator(self):
+        return lambda lhs, rhs: lhs.eq(rhs)
+
+
+def eq(df, other, axis='columns', level=None):
+    op = DataFrameEqual(axis=axis, level=level, lhs=df, rhs=other)
+    return op(df, other)

--- a/mars/dataframe/arithmetic/greater.py
+++ b/mars/dataframe/arithmetic/greater.py
@@ -1,0 +1,33 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameBinOpMixin, DataFrameBinOp
+
+
+class DataFrameGreater(DataFrameBinOp, DataFrameBinOpMixin):
+    _op_type_ = OperandDef.GT
+
+    _func_name = 'gt'
+    _rfunc_name = 'lt'
+
+    @classproperty
+    def _operator(self):
+        return lambda lhs, rhs: lhs.gt(rhs)
+
+
+def gt(df, other, axis='columns', level=None):
+    op = DataFrameGreater(axis=axis, level=level, lhs=df, rhs=other)
+    return op(df, other)

--- a/mars/dataframe/arithmetic/greater_equal.py
+++ b/mars/dataframe/arithmetic/greater_equal.py
@@ -1,0 +1,33 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameBinOpMixin, DataFrameBinOp
+
+
+class DataFrameGreaterEqual(DataFrameBinOp, DataFrameBinOpMixin):
+    _op_type_ = OperandDef.GE
+
+    _func_name = 'ge'
+    _rfunc_name = 'le'
+
+    @classproperty
+    def _operator(self):
+        return lambda lhs, rhs: lhs.ge(rhs)
+
+
+def ge(df, other, axis='columns', level=None):
+    op = DataFrameGreaterEqual(axis=axis, level=level, lhs=df, rhs=other)
+    return op(df, other)

--- a/mars/dataframe/arithmetic/less.py
+++ b/mars/dataframe/arithmetic/less.py
@@ -1,0 +1,34 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameBinOpMixin, DataFrameBinOp
+
+
+class DataFrameLess(DataFrameBinOp, DataFrameBinOpMixin):
+    _op_type_ = OperandDef.LT
+
+    _func_name = 'lt'
+    _rfunc_name = 'gt'
+
+    @classproperty
+    def _operator(self):
+        return lambda lhs, rhs: lhs.lt(rhs)
+
+
+def lt(df, other, axis='columns', level=None):
+    op = DataFrameLess(axis=axis, level=level, lhs=df, rhs=other)
+    return op(df, other)

--- a/mars/dataframe/arithmetic/less_equal.py
+++ b/mars/dataframe/arithmetic/less_equal.py
@@ -1,0 +1,33 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameBinOpMixin, DataFrameBinOp
+
+
+class DataFrameLessEqual(DataFrameBinOp, DataFrameBinOpMixin):
+    _op_type_ = OperandDef.LE
+
+    _func_name = 'le'
+    _rfunc_name = 'ge'
+
+    @classproperty
+    def _operator(self):
+        return lambda lhs, rhs: lhs.le(rhs)
+
+
+def le(df, other, axis='columns', level=None):
+    op = DataFrameLessEqual(axis=axis, level=level, lhs=df, rhs=other)
+    return op(df, other)

--- a/mars/dataframe/arithmetic/not_equal.py
+++ b/mars/dataframe/arithmetic/not_equal.py
@@ -1,0 +1,33 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameBinOpMixin, DataFrameBinOp
+
+
+class DataFrameNotEqual(DataFrameBinOp, DataFrameBinOpMixin):
+    _op_type_ = OperandDef.NE
+
+    _func_name = 'ne'
+    _rfunc_name = 'ne'
+
+    @classproperty
+    def _operator(self):
+        return lambda lhs, rhs: lhs.ne(rhs)
+
+
+def ne(df, other, axis='columns', level=None):
+    op = DataFrameNotEqual(axis=axis, level=level, lhs=df, rhs=other)
+    return op(df, other)

--- a/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
@@ -23,13 +23,22 @@ from mars.tensor.datasource import array as from_array
 from mars.dataframe.datasource.dataframe import from_pandas
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
 from mars.dataframe.arithmetic import abs
+from mars.dataframe.arithmetic.tests.test_arithmetic import comp_func
 
 
 binary_functions = dict(
-    add=dict(func=operator.add, func_name='add'),
-    subtract=dict(func=operator.sub, func_name='sub'),
-    floordiv=dict(func=operator.floordiv, func_name='floordiv'),
-    truediv=dict(func=operator.truediv, func_name='truediv')
+    add=dict(func=operator.add, func_name='add', rfunc_name='radd'),
+    subtract=dict(func=operator.sub, func_name='sub', rfunc_name='rsub'),
+    floordiv=dict(func=operator.floordiv, func_name='floordiv',
+                  rfunc_name='rfloordiv'),
+    truediv=dict(func=operator.truediv, func_name='truediv',
+                 rfunc_name='rtruediv'),
+    equal=dict(func=comp_func('eq', 'eq'), func_name='eq', rfunc_name='eq'),
+    not_equal=dict(func=comp_func('ne', 'ne'), func_name='ne', rfunc_name='ne'),
+    greater=dict(func=comp_func('gt', 'lt'), func_name='gt', rfunc_name='lt'),
+    less=dict(func=comp_func('lt', 'gt'), func_name='lt', rfunc_name='gt'),
+    greater_equal=dict(func=comp_func('ge', 'le'), func_name='ge', rfunc_name='le'),
+    less_equal=dict(func=comp_func('le', 'ge'), func_name='le', rfunc_name='ge'),
 )
 
 
@@ -37,10 +46,6 @@ binary_functions = dict(
 class TestBinary(TestBase):
     def setUp(self):
         self.executor = ExecutorForTest()
-
-    @property
-    def rfunc_name(self):
-        return 'r' + self.func_name
 
     def testWithoutShuffleExecution(self):
         # all the axes are monotonic

--- a/mars/dataframe/arithmetic/tests/test_comparison.py
+++ b/mars/dataframe/arithmetic/tests/test_comparison.py
@@ -1,0 +1,50 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import operator
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from mars.core import build_mode
+from mars.dataframe.initializer import DataFrame
+
+
+class Test(unittest.TestCase):
+    def testComp(self):
+        df1 = DataFrame(pd.DataFrame(np.random.rand(4, 3)))
+        df2 = DataFrame(pd.DataFrame(np.random.rand(4, 3)))
+
+        with build_mode():
+            self.assertFalse(df1.data == df2.data)
+            self.assertTrue(df1.data == df1.data)
+
+        for op in [operator.eq, operator.ne, operator.lt, operator.gt,
+                   operator.le, operator.ge]:
+            eq_df = op(df1, df2)
+            pd.testing.assert_index_equal(eq_df.index_value.to_pandas(),
+                                          df1.index_value.to_pandas())
+
+            # index not identical
+            df3 = DataFrame(pd.DataFrame(np.random.rand(4, 3),
+                                         index=[1, 2, 3, 4]))
+            with self.assertRaises(ValueError):
+                op(df1, df3)
+
+            # columns not identical
+            df4 = DataFrame(pd.DataFrame(np.random.rand(4, 3),
+                                         columns=['a', 'b', 'c']))
+            with self.assertRaises(ValueError):
+                op(df1, df4)

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -516,13 +516,6 @@ class SeriesData(HasShapeTileableData):
     def index_value(self):
         return self._index_value
 
-    def _equal(self, o):
-        # FIXME We need to implemented a true `==` operator for Series
-        if build_mode().is_build_mode:
-            return self is o
-        else:
-            return self == o
-
     def to_tensor(self, dtype=None):
         from ..tensor.datasource.from_dataframe import from_series
         return from_series(self, dtype=dtype)
@@ -536,13 +529,6 @@ class SeriesData(HasShapeTileableData):
 class Series(TileableEntity):
     __slots__ = ()
     _allow_data_type_ = (SeriesData,)
-
-    def __eq__(self, other):
-        return self._equal(other)
-
-    def __hash__(self):
-        # NB: we have customized __eq__ explicitly, thus we need define __hash__ explicitly as well.
-        return super().__hash__()
 
     def to_tensor(self, dtype=None):
         return self._data.to_tensor(dtype=dtype)
@@ -688,14 +674,6 @@ class DataFrameData(HasShapeTileableData):
     def columns_value(self):
         return self._columns_value
 
-    def _equal(self, o):
-        # FIXME We need to implemented a true `==` operator for DataFrame, current we just need
-        # to do `self is o` under build mode to make the `iloc.__setitem__` happy.
-        if build_mode().is_build_mode:
-            return self is o
-        else:
-            return self == o
-
     def to_tensor(self, dtype=None):
         from ..tensor.datasource.from_dataframe import from_dataframe
         return from_dataframe(self, dtype=dtype)
@@ -714,13 +692,6 @@ class DataFrameData(HasShapeTileableData):
 class DataFrame(TileableEntity):
     __slots__ = ()
     _allow_data_type_ = (DataFrameData,)
-
-    def __eq__(self, other):
-        return self._equal(other)
-
-    def __hash__(self):
-        # NB: we have customized __eq__ explicitly, thus we need define __hash__ explicitly as well.
-        return super().__hash__()
 
     def __len__(self):
         return len(self._data)

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -240,9 +240,6 @@ class TensorData(HasShapeTileableData):
 
         return reshape(self, shape, order=order)
 
-    def _equals(self, o):
-        return self is o
-
     def totiledb(self, uri, ctx=None, key=None, timestamp=None):
         from .datastore import totiledb
 

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -437,6 +437,7 @@ class BuildMode(object):
             self._old_mode = self.is_build_mode
             self.is_build_mode = True
         self._enter_times += 1
+        return self
 
     def __exit__(self, *_):
         self._enter_times -= 1


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR added comparison functions including `eq`, `ne`, `gt`, `ge`, `lt`, `le`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #837 .