### PR TITLE
Fix the wrong `RangeIndex` in read_csv

### DIFF
--- a/mars/dataframe/base/standardize_range_index.py
+++ b/mars/dataframe/base/standardize_range_index.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+
+from ... import opcodes as OperandDef
+from ...utils import lazy_import
+from ..operands import DataFrameOperandMixin, DataFrameOperand
+
+
+cudf = lazy_import('cudf', globals=globals())
+
+
+class ChunkStandardizeRangeIndex(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = OperandDef.STANDARDIZE_RANGE_INDEX
+
+    def __init__(self, prepare_inputs=None, object_type=None, **kwargs):
+        super().__init__(__prepare_inputs=prepare_inputs, _object_type=object_type, **kwargs)
+
+    @classmethod
+    def execute(cls, ctx, op):
+        xdf = cudf if op.gpu else pd
+        in_data = ctx[op.inputs[-1].key]
+        input_keys = [c.key for c in op.inputs[:-1]]
+        metas = ctx.get_chunk_metas(input_keys)
+        index_start = sum([m.chunk_shape[0] for m in metas])
+        ctx[op.outputs[0].key] = in_data.set_index(xdf.RangeIndex(index_start, index_start + len(in_data)))

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -18,6 +18,7 @@ import pandas as pd
 from mars.dataframe.base import to_gpu, to_cpu, df_reset_index, series_reset_index
 from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
+from mars.session import new_session
 from mars.tests.core import TestBase, require_cudf, ExecutorForTest
 from mars.utils import lazy_import
 
@@ -160,14 +161,27 @@ class Test(TestBase):
         pd.testing.assert_series_equal(result, expected)
 
         # Test Unknown shape
+        sess = new_session()
         data1 = pd.DataFrame(np.random.rand(10, 3), index=[0, 10, 2, 3, 4, 5, 6, 7, 8, 9])
         df1 = from_pandas_df(data1, chunk_size=5)
         data2 = pd.DataFrame(np.random.rand(10, 3), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3])
         df2 = from_pandas_df(data2, chunk_size=6)
         df = (df1 + df2).reset_index()
-        result = self.executor.execute_dataframe(df, concat=True)[0]
+        result = sess.run(df)
+        pd.testing.assert_index_equal(result.index, pd.RangeIndex(12))
         # Inconsistent with Pandas when input dataframe's shape is unknown.
         result = result.sort_values(by=result.columns[0])
+        expected = (data1 + data2).reset_index()
+        np.testing.assert_array_equal(result.to_numpy(), expected.to_numpy())
 
+        data1 = pd.Series(np.random.rand(10,), index=[0, 10, 2, 3, 4, 5, 6, 7, 8, 9])
+        series1 = from_pandas_series(data1, chunk_size=3)
+        data2 = pd.Series(np.random.rand(10,), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3])
+        series2 = from_pandas_series(data2, chunk_size=3)
+        df = (series1 + series2).reset_index()
+        result = sess.run(df)
+        pd.testing.assert_index_equal(result.index, pd.RangeIndex(12))
+        # Inconsistent with Pandas when input dataframe's shape is unknown.
+        result = result.sort_values(by=result.columns[0])
         expected = (data1 + data2).reset_index()
         np.testing.assert_array_equal(result.to_numpy(), expected.to_numpy())

--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -25,7 +25,8 @@ from ...config import options
 from ...utils import parse_readable_size, lazy_import
 from ...serialize import StringField, DictField, ListField, Int32Field, Int64Field, AnyField
 from ...filesystem import open_file, file_size, glob
-from ..utils import parse_index, build_empty_df
+from ..core import IndexValue
+from ..utils import parse_index, build_empty_df, standardize_range_index
 from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
 
 
@@ -187,6 +188,8 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                 index_num += 1
                 offset += chunk_bytes
 
+        if len(out_chunks) > 1 and isinstance(df.index_value._index_value, IndexValue.RangeIndex):
+            out_chunks = standardize_range_index(out_chunks)
         new_op = op.copy()
         nsplits = ((np.nan,) * len(out_chunks), (df.shape[1],))
         return new_op.new_dataframes(None, df.shape, dtypes=df.dtypes,

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -579,3 +579,18 @@ def validate_axis(axis, tileable):
         raise ValueError('No axis named {} for '
                          'object type {}'.format(axis, type(tileable)))
     return axis
+
+
+def standardize_range_index(chunks):
+    from .base.standardize_range_index import ChunkStandardizeRangeIndex
+
+    row_chunks = dict((k, next(v)) for k, v in itertools.groupby(chunks, key=lambda x: x.index[0]))
+    row_chunks = [row_chunks[i] for i in range(len(row_chunks))]
+
+    out_chunks = []
+    for c in chunks:
+        inputs = row_chunks[:c.index[0]] + [c]
+        op = ChunkStandardizeRangeIndex(prepare_inputs=[False] * len(inputs), object_type=c.op.object_type)
+        out_chunks.append(op.new_chunk(inputs, **c.params.copy()))
+
+    return out_chunks

--- a/mars/scheduler/tests/integrated/no_prepare_op.py
+++ b/mars/scheduler/tests/integrated/no_prepare_op.py
@@ -1,0 +1,29 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from mars.tensor.arithmetic import TensorAdd
+
+
+class NoPrepareOperand(TensorAdd):
+    _op_type_ = 9870104312
+
+    @classmethod
+    def execute(cls, ctx, op):
+        input_keys = [c.key for c in op.inputs]
+        has_all_data = all(k in ctx for k in input_keys)
+        if has_all_data:
+            raise ValueError('Unexpected behavior')
+        ctx[op.outputs[0].key] = np.array((len(op.inputs), 1))

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -375,6 +375,9 @@ message OperandDef {
         // store
         READ_CSV = 2100;
 
+        // standardize range index
+        STANDARDIZE_RANGE_INDEX = 2102;
+
         // successors exclusive
         SUCCESSORS_EXCLUSIVE = 2002;
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Provides a util `standardize_range_index` to set correct `RangeIndex` to each chunk for operands like `read_csv`, their chunk shape is unknown before execution, we need this util to calculate the right start position and end position of `RangeIndex`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #928.