### PR TITLE
Fix sparse behavior for tensor.min and tensor.max

### DIFF
--- a/mars/lib/sparse/__init__.py
+++ b/mars/lib/sparse/__init__.py
@@ -689,7 +689,7 @@ def isreal(x, **kw):
 
 
 def where(cond, x, y):
-    if any([i.ndim != 2 for i in (cond, x, y)]):
+    if any([i.ndim not in (0, 2) for i in (cond, x, y)]):
         raise NotImplementedError
 
     from .matrix import where as matrix_where

--- a/mars/lib/sparse/matrix.py
+++ b/mars/lib/sparse/matrix.py
@@ -191,14 +191,14 @@ class SparseMatrix(SparseArray):
             x = getattr(get_array_module(x), method_name)(x, axis=axis, **kw)
         else:
             x = getattr(self.spmatrix, method_name)(axis=axis, **kw)
-        if issparse(x):
-            return SparseMatrix(x)
         if not isinstance(axis, Iterable):
             axis = (axis,)
         axis = list(range(len(self.shape))) if axis is None else axis
         shape = tuple(s if i not in axis else 1 for i, s in enumerate(self.shape)
                       if keepdims or i not in axis)
         m = get_array_module(x)
+        if issparse(x):
+            return SparseNDArray(x, shape=shape)
         if m.isscalar(x):
             if keepdims:
                 return m.array([x])[0].reshape((1,) * self.ndim)

--- a/mars/tensor/reduction/core.py
+++ b/mars/tensor/reduction/core.py
@@ -58,6 +58,10 @@ class TensorReductionMixin(TensorOperandMixin):
     def _calc_order(cls, a, out):
         return out.order if out is not None else a.order
 
+    @classmethod
+    def _is_sparse(cls, input_sparse, shape):
+        return False
+
     def _call(self, a, out):
         a = astensor(a)
         if out is not None and not isinstance(out, Tensor):
@@ -81,6 +85,7 @@ class TensorReductionMixin(TensorOperandMixin):
             shape = tuple(s if i not in axis else 1 for i, s in enumerate(a.shape)
                           if keepdims or i not in axis)
 
+        self._sparse = self._is_sparse(a.issparse(), shape)
         t = self.new_tensor([a], shape, order=order)
 
         if out is None:

--- a/mars/tensor/reduction/max.py
+++ b/mars/tensor/reduction/max.py
@@ -29,6 +29,12 @@ class TensorMax(TensorReduction, TensorReductionMixin):
         super(TensorMax, self).__init__(_axis=axis, _dtype=dtype, _keepdims=keepdims, _stage=stage,
                                         _combine_size=combine_size, **kw)
 
+    @classmethod
+    def _is_sparse(cls, input_sparse, shape):
+        if input_sparse and len(shape) > 0:
+            return True
+        return False
+
 
 def max(a, axis=None, out=None, keepdims=None, combine_size=None):
     """

--- a/mars/tensor/reduction/min.py
+++ b/mars/tensor/reduction/min.py
@@ -29,6 +29,12 @@ class TensorMin(TensorReduction, TensorReductionMixin):
         super(TensorMin, self).__init__(_axis=axis, _dtype=dtype, _keepdims=keepdims, _stage=stage,
                                         _combine_size=combine_size, **kw)
 
+    @classmethod
+    def _is_sparse(cls, input_sparse, shape):
+        if input_sparse and len(shape) > 0:
+            return True
+        return False
+
 
 def min(a, axis=None, out=None, keepdims=None, combine_size=None):
     """

--- a/mars/tensor/reduction/tests/test_reduction_execute.py
+++ b/mars/tensor/reduction/tests/test_reduction_execute.py
@@ -68,8 +68,10 @@ class Test(unittest.TestCase):
 
         np.testing.assert_array_equal(
             raw.max(axis=0), self.executor.execute_tensor(arr.max(axis=0), concat=True)[0])
+        self.assertFalse(arr.max(axis=0).issparse())
         np.testing.assert_array_equal(
             raw.min(axis=0), self.executor.execute_tensor(arr.min(axis=0), concat=True)[0])
+        self.assertFalse(arr.min(axis=0).issparse())
 
         np.testing.assert_array_equal(
             raw.max(axis=(1, 2)), self.executor.execute_tensor(arr.max(axis=(1, 2)), concat=True)[0])
@@ -82,6 +84,15 @@ class Test(unittest.TestCase):
 
         self.assertEqual([raw.max()], self.executor.execute_tensor(arr.max()))
         self.assertEqual([raw.min()], self.executor.execute_tensor(arr.min()))
+
+        np.testing.assert_almost_equal(
+            raw.max(axis=1).A.ravel(),
+            self.executor.execute_tensor(arr.max(axis=1), concat=True)[0].toarray())
+        self.assertTrue(arr.max(axis=1).issparse())
+        np.testing.assert_almost_equal(
+            raw.min(axis=1).A.ravel(),
+            self.executor.execute_tensor(arr.min(axis=1), concat=True)[0].toarray())
+        self.assertTrue(arr.min(axis=1).issparse())
 
     def testAllAnyExecution(self):
         raw1 = np.zeros((10, 15))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

If a tensor(ndim > 1) is sparse, tensor.min(axis=0) and tensor.max(axis=0) would be sparse as well. The past behavior is wrong, fix it in this PR.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA
