### PR TITLE
Implements mt.{topk, argsort, argpartition, argtopk}

### DIFF
--- a/mars/learn/metrics/pairwise/euclidean.py
+++ b/mars/learn/metrics/pairwise/euclidean.py
@@ -145,7 +145,7 @@ class EuclideanDistances(PairwiseDistances):
         return [recursive_tile(distances)]
 
 
-def euclidean_distances(X, Y=None, Y_norm_squared=None, squred=False,
+def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
                         X_norm_squared=None):
     """
     Considering the rows of X (and Y=X) as vectors, compute the
@@ -213,7 +213,7 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squred=False,
     paired_distances : distances betweens pairs of elements of X and Y.
     """
     op = EuclideanDistances(x=X, y=Y, x_norm_squared=X_norm_squared,
-                            y_norm_squared=Y_norm_squared, squared=squred,
+                            y_norm_squared=Y_norm_squared, squared=squared,
                             dtype=np.dtype(np.float64))
     return op(X, Y=Y, Y_norm_squared=Y_norm_squared,
               X_norm_squared=X_norm_squared)

--- a/mars/learn/metrics/pairwise/tests/test_euclidean_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_euclidean_distances.py
@@ -91,7 +91,7 @@ class Test(unittest.TestCase):
             x_sq = (x ** 2).astype(np.float32)
             y_sq = (y ** 2).astype(np.float32)
 
-            distance = euclidean_distances(x_sq, y_sq, squred=True)
+            distance = euclidean_distances(x_sq, y_sq, squared=True)
 
             x_raw_sq = (raw_x ** 2).astype(np.float32)
             y_raw_sq = (raw_y ** 2).astype(np.float32)

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -272,6 +272,7 @@ message OperandDef {
         QUANTILE = 440;
         FILL_DIAGONAL = 441;
         NORMALIZE = 442;
+        TOPK = 443;
         // fancy index, distributed phase is a shuffle operation that
         // the fancy indexes will be distributed to the left chunks
         // the concat phase will concat back the indexed left chunks and index

--- a/mars/tensor/__init__.py
+++ b/mars/tensor/__init__.py
@@ -23,7 +23,8 @@ from .datastore import totiledb
 from .base import result_type, ndim, copyto, transpose, where, broadcast_to, broadcast_arrays, \
     expand_dims, rollaxis, swapaxes, moveaxis, ravel, atleast_1d, atleast_2d, atleast_3d, argwhere, \
     array_split, split, hsplit, vsplit, dsplit, roll, squeeze, diff, ediff1d, \
-    flip, flipud, fliplr, repeat, tile, isin, searchsorted, unique, sort, partition
+    flip, flipud, fliplr, repeat, tile, isin, searchsorted, unique, \
+    sort, argsort, partition, argpartition, topk, argtopk
 from .arithmetic import add, subtract, multiply, divide, truediv as true_divide, \
     floordiv as floor_divide, mod, power, float_power, fmod, sqrt, \
     around, round_, round_ as round, logaddexp, logaddexp2, negative, positive, \

--- a/mars/tensor/base/__init__.py
+++ b/mars/tensor/base/__init__.py
@@ -49,6 +49,7 @@ from .searchsorted import searchsorted, TensorSearchsorted
 from .unique import unique
 from .sort import sort
 from .partition import partition
+from .topk import topk
 from .to_gpu import to_gpu
 from .to_cpu import to_cpu
 

--- a/mars/tensor/base/__init__.py
+++ b/mars/tensor/base/__init__.py
@@ -48,7 +48,9 @@ from .isin import isin, TensorIsIn
 from .searchsorted import searchsorted, TensorSearchsorted
 from .unique import unique
 from .sort import sort
+from .argsort import argsort
 from .partition import partition
+from .argpartition import argpartition
 from .topk import topk
 from .to_gpu import to_gpu
 from .to_cpu import to_cpu

--- a/mars/tensor/base/__init__.py
+++ b/mars/tensor/base/__init__.py
@@ -52,6 +52,7 @@ from .argsort import argsort
 from .partition import partition
 from .argpartition import argpartition
 from .topk import topk
+from .argtopk import argtopk
 from .to_gpu import to_gpu
 from .to_cpu import to_cpu
 

--- a/mars/tensor/base/argpartition.py
+++ b/mars/tensor/base/argpartition.py
@@ -1,0 +1,24 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .partition import _validate_partition_arguments, TensorPartition
+
+
+def argpartition(a, kth, axis=-1, kind='introselect', order=None, **kw):
+    a, kth, axis, kind, order, need_align = _validate_partition_arguments(
+        a, kth, axis, kind, order, kw)
+    op = TensorPartition(kth=kth, axis=axis, kind=kind, order=order,
+                         need_align=need_align, return_value=False,
+                         return_indices=True, dtype=a.dtype, gpu=a.op.gpu)
+    return op(a, kth)

--- a/mars/tensor/base/argpartition.py
+++ b/mars/tensor/base/argpartition.py
@@ -16,6 +16,71 @@ from .partition import _validate_partition_arguments, TensorPartition
 
 
 def argpartition(a, kth, axis=-1, kind='introselect', order=None, **kw):
+    """
+    Perform an indirect partition along the given axis using the
+    algorithm specified by the `kind` keyword. It returns an array of
+    indices of the same shape as `a` that index data along the given
+    axis in partitioned order.
+
+    .. versionadded:: 1.8.0
+
+    Parameters
+    ----------
+    a : array_like
+        Tensor to sort.
+    kth : int or sequence of ints
+        Element index to partition by. The k-th element will be in its
+        final sorted position and all smaller elements will be moved
+        before it and all larger elements behind it. The order all
+        elements in the partitions is undefined. If provided with a
+        sequence of k-th it will partition all of them into their sorted
+        position at once.
+    axis : int or None, optional
+        Axis along which to sort. The default is -1 (the last axis). If
+        None, the flattened tensor is used.
+    kind : {'introselect'}, optional
+        Selection algorithm. Default is 'introselect'
+    order : str or list of str, optional
+        When `a` is a tensor with fields defined, this argument
+        specifies which fields to compare first, second, etc. A single
+        field can be specified as a string, and not all fields need be
+        specified, but unspecified fields will still be used, in the
+        order in which they come up in the dtype, to break ties.
+
+    Returns
+    -------
+    index_tensor : Tensor, int
+        Tensor of indices that partition `a` along the specified axis.
+        If `a` is one-dimensional, ``a[index_tensor]`` yields a partitioned `a`.
+        More generally, ``np.take_along_axis(a, index_tensor, axis=a)`` always
+        yields the partitioned `a`, irrespective of dimensionality.
+
+    See Also
+    --------
+    partition : Describes partition algorithms used.
+    Tensor.partition : Inplace partition.
+    argsort : Full indirect sort
+
+    Notes
+    -----
+    See `partition` for notes on the different selection algorithms.
+
+    Examples
+    --------
+    One dimensional tensor:
+
+    >>> import mars.tensor as mt
+    >>> x = mt.array([3, 4, 2, 1])
+    >>> x[mt.argpartition(x, 3)].execute()
+    array([2, 1, 3, 4])
+    >>> x[mt.argpartition(x, (1, 3))].execute()
+    array([1, 2, 3, 4])
+
+    >>> x = [3, 4, 2, 1]
+    >>> mt.array(x)[mt.argpartition(x, 3)].execute()
+    array([2, 1, 3, 4])
+
+    """
     a, kth, axis, kind, order, need_align = _validate_partition_arguments(
         a, kth, axis, kind, order, kw)
     op = TensorPartition(kth=kth, axis=axis, kind=kind, order=order,

--- a/mars/tensor/base/argsort.py
+++ b/mars/tensor/base/argsort.py
@@ -1,0 +1,26 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .sort import _validate_sort_arguments, TensorSort
+
+
+def argsort(a, axis=-1, kind=None, parallel_kind=None, psrs_kinds=None, order=None):
+    a, axis, kind, parallel_kind, psrs_kinds, order = _validate_sort_arguments(
+        a, axis, kind, parallel_kind, psrs_kinds, order)
+
+    op = TensorSort(axis=axis ,kind=kind, parallel_kind=parallel_kind,
+                    order=order, psrs_kinds=psrs_kinds,
+                    return_value=False, return_indices=True,
+                    dtype=a.dtype, gpu=a.op.gpu)
+    return op(a)

--- a/mars/tensor/base/argsort.py
+++ b/mars/tensor/base/argsort.py
@@ -16,6 +16,108 @@ from .sort import _validate_sort_arguments, TensorSort
 
 
 def argsort(a, axis=-1, kind=None, parallel_kind=None, psrs_kinds=None, order=None):
+    """
+    Returns the indices that would sort a tensor.
+
+    Perform an indirect sort along the given axis using the algorithm specified
+    by the `kind` keyword. It returns a tensor of indices of the same shape as
+    `a` that index data along the given axis in sorted order.
+
+    Parameters
+    ----------
+    a : array_like
+        Tensor to sort.
+    axis : int or None, optional
+        Axis along which to sort.  The default is -1 (the last axis). If None,
+        the flattened tensor is used.
+    kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, optional
+        Sorting algorithm. The default is 'quicksort'. Note that both 'stable'
+        and 'mergesort' use timsort under the covers and, in general, the
+        actual implementation will vary with data type. The 'mergesort' option
+        is retained for backwards compatibility.
+
+        .. versionchanged:: 1.15.0.
+           The 'stable' option was added.
+    order : str or list of str, optional
+        When `a` is a tensor with fields defined, this argument specifies
+        which fields to compare first, second, etc.  A single field can
+        be specified as a string, and not all fields need be specified,
+        but unspecified fields will still be used, in the order in which
+        they come up in the dtype, to break ties.
+
+    Returns
+    -------
+    index_tensor : Tensor, int
+        Tensor of indices that sort `a` along the specified `axis`.
+        If `a` is one-dimensional, ``a[index_tensor]`` yields a sorted `a`.
+        More generally, ``np.take_along_axis(a, index_tensor, axis=axis)``
+        always yields the sorted `a`, irrespective of dimensionality.
+
+    See Also
+    --------
+    sort : Describes sorting algorithms used.
+    lexsort : Indirect stable sort with multiple keys.
+    Tensor.sort : Inplace sort.
+    argpartition : Indirect partial sort.
+
+    Notes
+    -----
+    See `sort` for notes on the different sorting algorithms.
+
+    Examples
+    --------
+    One dimensional tensor:
+
+    >>> import mars.tensor as mt
+    >>> x = mt.array([3, 1, 2])
+    >>> mt.argsort(x).execute()
+    array([1, 2, 0])
+
+    Two-dimensional tensor:
+
+    >>> x = mt.array([[0, 3], [2, 2]])
+    >>> x.execute()
+    array([[0, 3],
+           [2, 2]])
+
+    >>> ind = mt.argsort(x, axis=0)  # sorts along first axis (down)
+    >>> ind.execute()
+    array([[0, 1],
+           [1, 0]])
+    #>>> mt.take_along_axis(x, ind, axis=0).execute()  # same as np.sort(x, axis=0)
+    #array([[0, 2],
+    #       [2, 3]])
+
+    >>> ind = mt.argsort(x, axis=1)  # sorts along last axis (across)
+    >>> ind.execute()
+    array([[0, 1],
+           [0, 1]])
+    #>>> mt.take_along_axis(x, ind, axis=1).execute()  # same as np.sort(x, axis=1)
+    #array([[0, 3],
+    #       [2, 2]])
+
+    Indices of the sorted elements of a N-dimensional array:
+
+    >>> ind = mt.unravel_index(mt.argsort(x, axis=None), x.shape)
+    >>> ind.execute9)
+    (array([0, 1, 1, 0]), array([0, 0, 1, 1]))
+    >>> x[ind].execute()  # same as np.sort(x, axis=None)
+    array([0, 2, 2, 3])
+
+    Sorting with keys:
+
+    >>> x = mt.array([(1, 0), (0, 1)], dtype=[('x', '<i4'), ('y', '<i4')])
+    >>> x.execute()
+    array([(1, 0), (0, 1)],
+          dtype=[('x', '<i4'), ('y', '<i4')])
+
+    >>> mt.argsort(x, order=('x','y')).execute()
+    array([1, 0])
+
+    >>> mt.argsort(x, order=('y','x')).execute()
+    array([0, 1])
+
+    """
     a, axis, kind, parallel_kind, psrs_kinds, order = _validate_sort_arguments(
         a, axis, kind, parallel_kind, psrs_kinds, order)
 

--- a/mars/tensor/base/argtopk.py
+++ b/mars/tensor/base/argtopk.py
@@ -16,10 +16,11 @@ from ...operands import OperandStage
 from .topk import _validate_topk_arguments, TensorTopk
 
 
-def argtopk(a, k, axis=-1, largest=True, sorted=True, parallel_kind='auto',
-            psrs_kinds=None):
-    a, k, axis, largest, sorted, parallel_kind, psrs_kinds = \
-        _validate_topk_arguments(a, k, axis, largest, sorted, parallel_kind, psrs_kinds)
+def argtopk(a, k, axis=-1, largest=True, sorted=True, order=None,
+            parallel_kind='auto', psrs_kinds=None):
+    a, k, axis, largest, sorted, order, parallel_kind, psrs_kinds = \
+        _validate_topk_arguments(a, k, axis, largest, sorted, order,
+                                 parallel_kind, psrs_kinds)
     op = TensorTopk(k=k, axis=axis, largest=largest, sorted=sorted,
                     parallel_kind=parallel_kind, psrs_kinds=psrs_kinds,
                     dtype=a.dtype, return_value=False, return_indices=True,

--- a/mars/tensor/base/argtopk.py
+++ b/mars/tensor/base/argtopk.py
@@ -1,0 +1,27 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ...operands import OperandStage
+from .topk import _validate_topk_arguments, TensorTopk
+
+
+def argtopk(a, k, axis=-1, largest=True, sorted=True, parallel_kind='auto',
+            psrs_kinds=None):
+    a, k, axis, largest, sorted, parallel_kind, psrs_kinds = \
+        _validate_topk_arguments(a, k, axis, largest, sorted, parallel_kind, psrs_kinds)
+    op = TensorTopk(k=k, axis=axis, largest=largest, sorted=sorted,
+                    parallel_kind=parallel_kind, psrs_kinds=psrs_kinds,
+                    dtype=a.dtype, return_value=False, return_indices=True,
+                    stage=OperandStage.agg)
+    return op(a)

--- a/mars/tensor/base/partition.py
+++ b/mars/tensor/base/partition.py
@@ -12,23 +12,92 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
+
 import numpy as np
 
 from ... import opcodes as OperandDef
 from ...serialize import ValueType, KeyField, Int32Field, \
     StringField, ListField, BoolField, AnyField
-from ...utils import check_chunks_unknown_shape
+from ...utils import check_chunks_unknown_shape, flatten, stack_back
 from ...tiles import TilesError
 from ...core import Base, Entity
-from ..operands import TensorOperand, TensorOperandMixin, TensorShuffleProxy
-from ..core import TENSOR_TYPE, CHUNK_TYPE
+from ..operands import TensorOperand, TensorShuffleProxy
+from ..core import TENSOR_TYPE, CHUNK_TYPE, TensorOrder
 from ..array_utils import as_same_device, device
 from ..datasource import tensor as astensor
 from ..utils import validate_axis, validate_order
-from .sort import PSRSSorter, PSRSOperandMixin
+from .psrs import PSRSOperandMixin
 
 
-class TensorPartition(TensorOperand, TensorOperandMixin):
+class ParallelPartitionMixin(PSRSOperandMixin):
+    @classmethod
+    def calc_paritions_info(cls, op, kth, size, sort_info_chunks):
+        # stage5, collect sort infos and calculate partition info for each partitions
+        if isinstance(kth, TENSOR_TYPE):
+            kth = kth.chunks[0]
+            is_kth_input = True
+        else:
+            is_kth_input = False
+        calc_op = CalcPartitionsInfo(kth=kth, size=size,
+                                     dtype=np.dtype(np.int32), gpu=op.gpu)
+        kws = []
+        for i, sort_info_chunk in enumerate(sort_info_chunks):
+            kws.append({
+                'shape': sort_info_chunk.shape + (len(op.kth),),
+                'order': sort_info_chunk.order,
+                'index': sort_info_chunk.index,
+                'pos': i
+            })
+        inputs = list(sort_info_chunks)
+        if is_kth_input:
+            inputs.insert(0, kth)
+        return calc_op.new_chunks(inputs, kws=kws, output_limit=len(kws))
+
+    @classmethod
+    def partition_on_merged(cls, op, need_align, partition_merged_chunks,
+                            partition_indices_chunks, partition_info_chunks):
+        # Stage 6: partition on each partitions
+        return_value, return_indices = op.return_value, op.return_indices
+        partitioned_chunks, partitioned_indices_chunks = [], []
+        for i, partition_merged_chunk, partition_info_chunk in \
+                zip(itertools.count(), partition_merged_chunks, partition_info_chunks):
+            partition_op = PartitionMerged(
+                return_value=return_value, return_indices=return_indices,
+                order=op.order, kind=op.kind, need_align=need_align,
+                dtype=partition_merged_chunk.dtype, gpu=op.gpu)
+            chunk_inputs = []
+            kws = []
+            if return_value:
+                chunk_inputs.append(partition_merged_chunk)
+                kws.append({
+                    'shape': partition_merged_chunk.shape,
+                    'order': partition_merged_chunk.order,
+                    'index': partition_merged_chunk.index,
+                    'type': 'partitioned'
+                })
+            if return_indices:
+                if not return_value:
+                    # value is required even it's not returned
+                    chunk_inputs.append(partition_merged_chunk)
+                chunk_inputs.append(partition_indices_chunks[i])
+                kws.append({
+                    'shape': partition_merged_chunk.shape,
+                    'order': TensorOrder.C_ORDER,
+                    'index': partition_merged_chunk.index,
+                    'type': 'argpartition'
+                })
+            chunk_inputs.append(partition_info_chunk)
+            partition_chunks = partition_op.new_chunks(chunk_inputs, kws=kws)
+            if return_value:
+                partitioned_chunks.append(partition_chunks[0])
+            if return_indices:
+                partitioned_indices_chunks.append(partition_chunks[-1])
+
+        return partitioned_chunks, partitioned_indices_chunks
+
+
+class TensorPartition(TensorOperand, ParallelPartitionMixin):
     _op_type_ = OperandDef.PARTITION
 
     _input = KeyField('input')
@@ -37,11 +106,15 @@ class TensorPartition(TensorOperand, TensorOperandMixin):
     _kind = StringField('kind')
     _order = ListField('order', ValueType.string)
     _need_align = BoolField('need_align')
+    _return_value = BoolField('return_value')
+    _return_indices = BoolField('return_indices')
 
     def __init__(self, kth=None, axis=None, kind=None, order=None,
-                 need_align=None, dtype=None, gpu=None, **kw):
+                 need_align=None, return_value=None, return_indices=None,
+                 dtype=None, gpu=None, **kw):
         super().__init__(_kth=kth, _axis=axis, _kind=kind, _order=order,
-                         _need_align=need_align, _dtype=dtype, _gpu=gpu, **kw)
+                         _need_align=need_align, _return_value=return_value,
+                         _return_indices=return_indices, _dtype=dtype, _gpu=gpu, **kw)
 
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
@@ -80,11 +153,127 @@ class TensorPartition(TensorOperand, TensorOperandMixin):
     def order(self):
         return self._order
 
+    @property
+    def return_value(self):
+        return self._return_value
+
+    @property
+    def return_indices(self):
+        return self._return_indices
+
+    @property
+    def output_limit(self):
+        return int(bool(self._return_value)) + int(bool(self._return_indices))
+
     def __call__(self, a, kth):
         inputs = [a]
         if isinstance(kth, TENSOR_TYPE):
             inputs.append(kth)
-        return self.new_tensor(inputs, shape=a.shape, order=a.order)
+        kws = []
+        if self._return_value:
+            kws.append({
+                'shape': a.shape,
+                'order': a.order,
+                'type': 'sorted'
+            })
+        if self._return_indices:
+            kws.append({
+                'shape': a.shape,
+                'order': TensorOrder.C_ORDER,
+                'type': 'argsort'
+            })
+        ret = self.new_tensors(inputs, kws=kws)
+        if len(kws) == 1:
+            return ret[0]
+        return ret
+
+    @classmethod
+    def _tile_psrs(cls, op, kth):
+        """
+        Approach here would be almost like PSRSSorter, but there are definitely some differences
+        Main processes are listed below:
+        Stage 1, local sort and regular samples collected
+        State 2, gather and merge samples, choose and broadcast p-1 pivots
+        Stage 3, Local data is partitioned
+        Stage 4: all *ith* classes are gathered and merged, sizes should be calculated as well
+        Stage 5: collect sizes from partitions, calculate how to partition given kth
+        Stage 6: partition on each partitions
+        Stage 7: align if axis is given, and more than 1 dimension
+        """
+        out_tensor = op.outputs[0]
+        return_value, return_indices = op.return_value, op.return_indices
+        # preprocess, to make sure chunk shape on axis are approximately same
+        in_tensor, axis_chunk_shape, out_idxes, need_align = cls.preprocess(op)
+        axis_offsets = [0] + np.cumsum(in_tensor.nsplits[op.axis]).tolist()[:-1]
+
+        out_chunks, out_indices_chunks = [], []
+        for out_idx in out_idxes:
+            # stage 1: local sort and regular samples collected
+            sorted_chunks, indices_chunks, sampled_chunks = \
+                cls.local_sort_and_regular_sample(op, in_tensor, axis_chunk_shape,
+                                                  axis_offsets, out_idx)
+
+            # stage 2: gather and merge samples, choose and broadcast p-1 pivots
+            concat_pivot_chunk = cls.concat_and_pivot(
+                op, axis_chunk_shape, out_idx, sorted_chunks, sampled_chunks)
+
+            # stage 3: Local data is partitioned
+            partition_chunks = cls.partition_local_data(
+                op, axis_chunk_shape, sorted_chunks, indices_chunks, concat_pivot_chunk)
+
+            proxy_chunk = TensorShuffleProxy(dtype=partition_chunks[0].dtype).new_chunk(
+                partition_chunks, shape=())
+
+            # stage 4: all *ith* classes are gathered and merged,
+            # note that we don't need sort here, op.psrs_kinds[2] is None
+            # force need_align=True to get sort info
+            partition_merged_chunks, partition_indices_chunks, sort_info_chunks = \
+                cls.partition_merge_data(op, True, True, partition_chunks, proxy_chunk)
+
+            # stage5, collect sort infos and calculate partition info for each partitions
+            partition_info_chunks = cls.calc_paritions_info(
+                op, kth, in_tensor.shape[op.axis], sort_info_chunks)
+
+            # Stage 6: partition on each partitions
+            partitioned_chunks, partitioned_indices_chunks = cls.partition_on_merged(
+                op, need_align, partition_merged_chunks, partition_indices_chunks, partition_info_chunks)
+
+            if not need_align:
+                if return_value:
+                    out_chunks.extend(partitioned_chunks)
+                if return_indices:
+                    out_indices_chunks.extend(partitioned_indices_chunks)
+            else:
+                align_reduce_chunks, align_reduce_indices_chunks = cls.align_partitions_data(
+                    op, out_idx, in_tensor, partitioned_chunks,
+                    partitioned_indices_chunks, sort_info_chunks)
+                if return_value:
+                    out_chunks.extend(align_reduce_chunks)
+                if return_indices:
+                    out_indices_chunks.extend(align_reduce_indices_chunks)
+
+        new_op = op.copy()
+        nsplits = list(in_tensor.nsplits)
+        if not need_align:
+            nsplits[op.axis] = (np.nan,) * axis_chunk_shape
+        kws = []
+        if return_value:
+            kws.append({
+                'shape': out_tensor.shape,
+                'order': out_tensor.order,
+                'chunks': out_chunks,
+                'nsplits': tuple(nsplits),
+                'type': 'partitioned'
+            })
+        if return_indices:
+            kws.append({
+                'shape': out_tensor.shape,
+                'order': TensorOrder.C_ORDER,
+                'chunks': out_indices_chunks,
+                'nsplits': tuple(nsplits),
+                'type': 'argpartition'
+            })
+        return new_op.new_tensors(op.inputs, kws=kws)
 
     @classmethod
     def tile(cls, op):
@@ -98,22 +287,49 @@ class TensorPartition(TensorOperand, TensorOperandMixin):
             check_chunks_unknown_shape([kth], TilesError)
             kth = kth.rechunk(kth.shape)._inplace_tile()
 
+        return_value, return_indices = op.return_value, op.return_indices
         if in_tensor.chunk_shape[op.axis] == 1:
-            out_chunks = []
+            out_chunks, out_indices_chunks = [], []
             for chunk in in_tensor.chunks:
                 chunk_op = op.copy().reset_key()
+                chunk_op = op.copy().reset_key()
+                kws = []
+                if return_value:
+                    kws.append({
+                        'shape': chunk.shape,
+                        'index': chunk.index,
+                        'order': chunk.order,
+                        'dtyep': chunk.dtype,
+                        'type': 'partitioned'
+                    })
+                if return_indices:
+                    kws.append({
+                        'shape': chunk.shape,
+                        'index': chunk.index,
+                        'order': TensorOrder.C_ORDER,
+                        'dtype': np.dtype(np.int64),
+                        'type': 'argpartition'
+                    })
                 chunk_inputs = [chunk]
                 if isinstance(kth, TENSOR_TYPE):
                     chunk_inputs.append(kth.chunks[0])
-                out_chunk = chunk_op.new_chunk(chunk_inputs, shape=chunk.shape,
-                                               index=chunk.index, order=chunk.order)
-                out_chunks.append(out_chunk)
+                chunks = chunk_op.new_chunks(chunk_inputs, kws=kws)
+                if return_value:
+                    out_chunks.append(chunks[0])
+                if return_indices:
+                    out_indices_chunks.append(chunks[-1])
 
             new_op = op.copy()
-            return new_op.new_tensors([in_tensor], shape=in_tensor.shape, order=in_tensor.order,
-                                      chunks=out_chunks, nsplits=in_tensor.nsplits)
+            kws = [out.params for out in op.outputs]
+            if return_value:
+                kws[0]['nsplits'] = in_tensor.nsplits
+                kws[0]['chunks'] = out_chunks
+            if return_indices:
+                kws[-1]['nsplits'] = in_tensor.nsplits
+                kws[-1]['chunks'] = out_indices_chunks
+            return new_op.new_tensors([in_tensor], kws=kws)
         else:
-            return ParallelPartition.tile(op, kth)
+            return cls._tile_psrs(op, kth)
 
     @classmethod
     def execute(cls, ctx, op):
@@ -124,115 +340,23 @@ class TensorPartition(TensorOperand, TensorOperandMixin):
             kth = inputs[1]
         else:
             kth = op.kth
+        return_value, return_indices = op.return_value, op.return_indices
 
         with device(device_id):
-            ctx[op.outputs[0].key] = xp.partition(
-                a, kth, axis=op.axis, kind=op.kind, order=op.order)
+            kw = {}
+            if op.kind is not None:
+                kw['kind'] = op.kind
+            if op.order is not None:
+                kw['order'] = op.order
 
-
-class ParallelPartition:
-    @classmethod
-    def calc_paritions_info(cls, op, kth, size, sort_info_chunks):
-        # stage5, collect sort infos and calculate partition info for each partitions
-        if isinstance(kth, TENSOR_TYPE):
-            kth = kth.chunks[0]
-            is_kth_input = True
-        else:
-            is_kth_input = False
-        calc_op = CalcPartitionsInfo(kth=kth, size=size,
-                                     dtype=np.dtype(np.int32), gpu=op.gpu)
-        kws = []
-        for i, sort_info_chunk in enumerate(sort_info_chunks):
-            kws.append({
-                'shape': sort_info_chunk.shape + (len(op.kth),),
-                'order': sort_info_chunk.order,
-                'index': sort_info_chunk.index,
-                'pos': i
-            })
-        inputs = list(sort_info_chunks)
-        if is_kth_input:
-            inputs.insert(0, kth)
-        return calc_op.new_chunks(inputs, kws=kws, output_limit=len(kws))
-
-    @classmethod
-    def partition_on_merged(cls, op, need_align, partition_merged_chunks, partition_info_chunks):
-        # Stage 6: partition on each partitions
-        partitioned_chunks = []
-        for partition_merged_chunk, partition_info_chunk in \
-                zip(partition_merged_chunks, partition_info_chunks):
-            partition_op = PartitionMerged(
-                order=op.order, kind=op.kind, need_align=need_align,
-                dtype=partition_merged_chunk.dtype, gpu=op.gpu)
-            partition_chunk = partition_op.new_chunk(
-                [partition_merged_chunk, partition_info_chunk],
-                shape=partition_merged_chunk.shape,
-                order=partition_merged_chunk.order,
-                index=partition_merged_chunk.index)
-            partitioned_chunks.append(partition_chunk)
-
-        return partitioned_chunks
-
-    @classmethod
-    def tile(cls, op, kth):
-        """
-        Approach here would be almost like PSRSSorter, but there are definitely some differences
-        Main processes are listed below:
-        Stage 1, local sort and regular samples collected
-        State 2, gather and merge samples, choose and broadcast p-1 pivots
-        Stage 3, Local data is partitioned
-        Stage 4: all *ith* classes are gathered and merged, sizes should be calculated as well
-        Stage 5: collect sizes from partitions, calculate how to partition given kth
-        Stage 6: partition on each partitions
-        Stage 7: align if axis is given, and more than 1 dimension
-        """
-        out_tensor = op.outputs[0]
-        # preprocess, to make sure chunk shape on axis are approximately same
-        in_tensor, axis_chunk_shape, out_idxes, need_align = PSRSSorter.preprocess(op)
-
-        out_chunks = []
-        for out_idx in out_idxes:
-            # stage 1: local sort and regular samples collected
-            sorted_chunks, sampled_chunks = PSRSSorter.local_sort_and_regular_sample(
-                op, in_tensor, axis_chunk_shape, out_idx)
-
-            # stage 2: gather and merge samples, choose and broadcast p-1 pivots
-            concat_pivot_chunk = PSRSSorter.concat_and_pivot(
-                op, axis_chunk_shape, out_idx, sorted_chunks, sampled_chunks)
-
-            # stage 3: Local data is partitioned
-            partition_chunks = PSRSSorter.partition_local_data(
-                op, axis_chunk_shape, sorted_chunks, concat_pivot_chunk)
-
-            proxy_chunk = TensorShuffleProxy(dtype=partition_chunks[0].dtype).new_chunk(
-                partition_chunks, shape=())
-
-            # stage 4: all *ith* classes are gathered and merged,
-            # note that we don't need sort here, op.psrs_kinds[2] is None
-            # force need_align=True to get sort info
-            partition_merged_chunks, sort_info_chunks = PSRSSorter.partition_merge_data(
-                op, True, partition_chunks, proxy_chunk)
-
-            # stage5, collect sort infos and calculate partition info for each partitions
-            partition_info_chunks = cls.calc_paritions_info(
-                op, kth, in_tensor.shape[op.axis], sort_info_chunks)
-
-            # Stage 6: partition on each partitions
-            partitioned_chunks = cls.partition_on_merged(
-                op, need_align, partition_merged_chunks, partition_info_chunks)
-
-            if not need_align:
-                out_chunks.extend(partitioned_chunks)
+            if return_indices:
+                if not return_value:
+                    ctx[op.outputs[0].key] = xp.argpartition(a, kth, axis=op.axis, **kw)
+                else:
+                    argparts = ctx[op.outputs[1].key] = xp.argpartition(a, kth, axis=op.axis, **kw)
+                    ctx[op.outputs[0].key] = xp.take_along_axis(a, argparts, op.axis)
             else:
-                align_reduce_chunks = PSRSSorter.align_partitions_data(
-                    op, out_idx, in_tensor, partitioned_chunks, sort_info_chunks)
-                out_chunks.extend(align_reduce_chunks)
-
-        new_op = op.copy()
-        nsplits = list(in_tensor.nsplits)
-        if not need_align:
-            nsplits[op.axis] = (np.nan,) * axis_chunk_shape
-        return new_op.new_tensors(op.inputs, shape=out_tensor.shape, order=out_tensor.order,
-                                  chunks=out_chunks, nsplits=tuple(nsplits))
+                ctx[op.outputs[0].key] = xp.partition(a, kth, axis=op.axis, **kw)
 
 
 class CalcPartitionsInfo(TensorOperand, PSRSOperandMixin):
@@ -302,13 +426,25 @@ class CalcPartitionsInfo(TensorOperand, PSRSOperandMixin):
 class PartitionMerged(TensorOperand, PSRSOperandMixin):
     _op_type_ = OperandDef.PARTITION_MERGED
 
+    _return_value = BoolField('return_value')
+    _return_indices = BoolField('return_indices')
     _order = ListField('order', ValueType.string)
     _kind = StringField('kind')
     _need_align = BoolField('need_align')
 
-    def __init__(self, order=None, kind=None, need_align=None, dtype=None, gpu=None, **kw):
-        super().__init__(_order=order, _kind=kind, _need_align=need_align,
+    def __init__(self, return_value=None, return_indices=None, order=None, kind=None,
+                 need_align=None, dtype=None, gpu=None, **kw):
+        super().__init__(_return_value=return_value, _return_indices=return_indices,
+                         _order=order, _kind=kind, _need_align=need_align,
                          _dtype=dtype, _gpu=gpu, **kw)
+
+    @property
+    def return_value(self):
+        return self._return_value
+
+    @property
+    def return_indices(self):
+        return self._return_indices
 
     @property
     def order(self):
@@ -322,30 +458,69 @@ class PartitionMerged(TensorOperand, PSRSOperandMixin):
     def need_align(self):
         return self._need_align
 
+    @property
+    def output_limit(self):
+        return int(bool(self._return_value)) + int(bool(self._return_indices))
+
     @classmethod
     def execute(cls, ctx, op):
-        merged_data = ctx[op.inputs[0].key]
-        partition_info = ctx[op.inputs[1].key]
-        inputs, device_id, xp = as_same_device(
-            merged_data + (partition_info,), device=op.device, ret_extra=True)
-        merged_data = inputs[:-1]
-        partition_info = inputs[-1]
+        return_value, return_indices = op.return_value, op.return_indices
 
-        outs = []
+        raw_inputs = [ctx[inp.key] for inp in op.inputs]
+        flatten_inputs = flatten(raw_inputs)
+        inputs, device_id, xp = as_same_device(flatten_inputs, device=op.device, ret_extra=True)
+        inputs = stack_back(inputs, raw_inputs)
+        partition_info = inputs[-1]
+        merged_data, merged_indices = None, None
+        if return_value:
+            merged_data = inputs[0]
+        if return_indices:
+            # if return indices, value should be returned
+            assert len(inputs) == 3
+            if not return_value:
+                merged_data = inputs[0]
+            merged_indices = inputs[1]
+
+        outs, out_indices = [], []
         with device(device_id):
+            kw = {}
+            if op.kind is not None:
+                kw['kind'] = op.kind
+            if op.order is not None:
+                kw['order'] = op.order
+
             ravel_partition_info = partition_info.reshape(-1, partition_info.shape[-1])
-            for merged_vec, kth in zip(merged_data, ravel_partition_info):
+            for i, merged_vec, kth in zip(itertools.count(), merged_data, ravel_partition_info):
                 kth = kth[kth > -1]
                 if kth.size == 0:
-                    outs.append(merged_vec)
+                    if return_value:
+                        outs.append(merged_vec)
+                    if return_indices:
+                        out_indices.append(merged_indices[i])
                 else:
-                    outs.append(xp.partition(merged_vec, kth, kind=op.kind, order=op.order))
+                    if return_indices:
+                        argparts = xp.argpartition(merged_vec, kth, **kw)
+                        if return_value:
+                            outs.append(xp.take(merged_vec, argparts))
+                        out_indices.append(xp.take(merged_indices[i], argparts))
+                    else:
+                        outs.append(xp.partition(merged_vec, kth, **kw))
 
         if not op.need_align:
-            assert len(outs) == 1
-            ctx[op.outputs[0].key] = outs[0]
+            assert len(outs or out_indices) == 1
+            i = 0
+            if return_value:
+                ctx[op.outputs[0].key] = outs[0]
+                i += 1
+            if return_indices:
+                ctx[op.outputs[i].key] = out_indices[0]
         else:
-            ctx[op.outputs[0].key] = tuple(outs)
+            i = 0
+            if return_value:
+                ctx[op.outputs[0].key] = tuple(outs)
+                i += 1
+            if return_indices:
+                ctx[op.outputs[i].key] = tuple(out_indices)
 
 
 def _check_kth_dtype(dtype):
@@ -360,6 +535,33 @@ def _validate_kth_value(kth, size):
         raise ValueError('kth(={}) out of bounds ({})'.format(
             invalid_kth, size))
     return kth
+
+
+def _validate_partition_arguments(a, kth, axis, kind, order, kw):
+    a = astensor(a)
+    if axis is None:
+        a = a.flatten()
+        axis = 0
+    else:
+        axis = validate_axis(a.ndim, axis)
+    if isinstance(kth, (Base, Entity)):
+        kth = astensor(kth)
+        _check_kth_dtype(kth.dtype)
+    else:
+        kth = np.atleast_1d(kth)
+        kth = _validate_kth_value(kth, a.shape[axis])
+    if kth.ndim > 1:
+        raise ValueError('object too deep for desired array')
+    if kind != 'introselect':
+        raise ValueError('{} is an unrecognized kind of select'.format(kind))
+    # if a is structure type and order is not None
+    order = validate_order(a.dtype, order)
+    need_align = kw.pop('need_align', None)
+    if len(kw) > 0:
+        raise TypeError('partition() got an unexpected keyword '
+                        'argument \'{}\''.format(next(iter(kw))))
+
+    return a, kth, axis, kind, order, need_align
 
 
 def partition(a, kth, axis=-1, kind='introselect', order=None, **kw):
@@ -441,29 +643,11 @@ def partition(a, kth, axis=-1, kind='introselect', order=None, **kw):
     >>> mt.partition(a, (1, 3)).execute()
     array([1, 2, 3, 4])
     """
-    a = astensor(a)
-    if axis is None:
-        a = a.flatten()
-        axis = 0
-    else:
-        axis = validate_axis(a.ndim, axis)
-    if isinstance(kth, (Base, Entity)):
-        kth = astensor(kth)
-        _check_kth_dtype(kth.dtype)
-    else:
-        kth = np.atleast_1d(kth)
-        kth = _validate_kth_value(kth, a.shape[axis])
-    if kth.ndim > 1:
-        raise ValueError('object too deep for desired array')
-    if kind != 'introselect':
-        raise ValueError('{} is an unrecognized kind of select'.format(kind))
-    # if a is structure type and order is not None
-    order = validate_order(a.dtype, order)
-    need_align = kw.pop('need_align', None)
-    if len(kw) > 0:
-        raise TypeError('partition() got an unexpected keyword '
-                        'argument \'{}\''.format(next(iter(kw))))
-
+    return_indices = kw.pop('return_index', False)
+    a, kth, axis, kind, order, need_align = \
+        _validate_partition_arguments(a, kth, axis, kind, order, kw)
     op = TensorPartition(kth=kth, axis=axis, kind=kind, order=order,
-                         need_align=need_align, dtype=a.dtype, gpu=a.op.gpu)
+                         need_align=need_align, return_value=True,
+                         return_indices=return_indices,
+                         dtype=a.dtype, gpu=a.op.gpu)
     return op(a, kth)

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -1,0 +1,792 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+from functools import partial
+
+import numpy as np
+
+from ... import opcodes as OperandDef
+from ...tiles import TilesError
+from ...serialize import ValueType, Int32Field, Int64Field, \
+    ListField, StringField, BoolField
+from ...operands import OperandStage
+from ...utils import get_shuffle_input_keys_idxes, flatten, stack_back
+from ..core import TensorOrder
+from ..operands import TensorOperand, TensorMapReduceOperand, \
+    TensorShuffleProxy, TensorOperandMixin
+from ..array_utils import as_same_device, device, cp
+
+
+class PSRSOperandMixin(TensorOperandMixin):
+    @classmethod
+    def preprocess(cls, op):
+        in_tensor = op.inputs[0]
+        axis_shape = in_tensor.shape[op.axis]
+        axis_chunk_shape = in_tensor.chunk_shape[op.axis]
+
+        # rechunk to ensure all chunks on axis have rough same size
+        axis_chunk_shape = min(axis_chunk_shape, int(np.sqrt(axis_shape)))
+        if np.isnan(axis_shape) or any(np.isnan(s) for s in in_tensor.nsplits[op.axis]):
+            raise TilesError('fail to tile because either the shape of '
+                             'input tensor on axis {} has unknown shape or chunk shape'.format(op.axis))
+        chunk_size = int(axis_shape / axis_chunk_shape)
+        chunk_sizes = [chunk_size for _ in range(int(axis_shape // chunk_size))]
+        if axis_shape % chunk_size > 0:
+            chunk_sizes[-1] += axis_shape % chunk_size
+        in_tensor = in_tensor.rechunk(
+            {op.axis: tuple(chunk_sizes)})._inplace_tile()
+        axis_chunk_shape = in_tensor.chunk_shape[op.axis]
+
+        left_chunk_shape = in_tensor.chunk_shape[:op.axis] + in_tensor.chunk_shape[op.axis + 1:]
+        if len(left_chunk_shape) > 0:
+            out_idxes = itertools.product(*(range(s) for s in left_chunk_shape))
+        else:
+            out_idxes = [()]
+        # if the size except axis has more than 1, the sorted values on each one may be different
+        # another shuffle would be required to make sure each axis except to sort
+        # has elements with identical size
+        extra_shape = [s for i, s in enumerate(in_tensor.shape) if i != op.axis]
+        if op.need_align is None:
+            need_align = bool(np.prod(extra_shape, dtype=int) != 1)
+        else:
+            need_align = op.need_align
+
+        return in_tensor, axis_chunk_shape, out_idxes, need_align
+
+    @classmethod
+    def local_sort_and_regular_sample(cls, op, in_tensor, axis_chunk_shape, axis_offsets, out_idx):
+        # stage 1: local sort and regular samples collected
+        sorted_chunks, indices_chunks, sampled_chunks = [], [], []
+        sampled_dtype = np.dtype([(o, in_tensor.dtype[o]) for o in op.order]) \
+            if op.order is not None else in_tensor.dtype
+        for i in range(axis_chunk_shape):
+            idx = list(out_idx)
+            idx.insert(op.axis, i)
+            in_chunk = in_tensor.cix[tuple(idx)]
+            kind = None if op.psrs_kinds is None else op.psrs_kinds[0]
+            chunk_op = PSRSSortRegularSample(axis=op.axis, order=op.order, kind=kind,
+                                             return_indices=op.return_indices,
+                                             n_partition=axis_chunk_shape,
+                                             axis_offset=axis_offsets[i],
+                                             gpu=op.gpu)
+            kws = []
+            sort_shape = in_chunk.shape
+            kws.append({'shape': sort_shape,
+                        'order': in_chunk.order,
+                        'dtype': in_chunk.dtype,
+                        'index': in_chunk.index,
+                        'type': 'sorted'})
+            if op.return_indices:
+                kws.append({'shape': sort_shape,
+                            'order': TensorOrder.C_ORDER,
+                            'dtype': np.dtype(np.int64),
+                            'index': in_chunk.index,
+                            'type': 'argsort'})
+            sampled_shape = (axis_chunk_shape,)
+            kws.append({'shape': sampled_shape,
+                        'order': in_chunk.order,
+                        'dtype': sampled_dtype,
+                        'index': (i,),
+                        'type': 'regular_sampled'})
+            chunks = chunk_op.new_chunks([in_chunk], kws=kws, output_limit=len(kws))
+            if len(chunks) == 2:
+                sort_chunk, sampled_chunk = chunks
+                sorted_chunks.append(sort_chunk)
+                sampled_chunks.append(sampled_chunk)
+            else:
+                sort_chunk, indices_chunk, sampled_chunk = chunks
+                sorted_chunks.append(sort_chunk)
+                indices_chunks.append(indices_chunk)
+                sampled_chunks.append(sampled_chunk)
+
+        return sorted_chunks, indices_chunks, sampled_chunks
+
+    @classmethod
+    def concat_and_pivot(cls, op, axis_chunk_shape, out_idx, sorted_chunks, sampled_chunks):
+        # stage 2: gather and merge samples, choose and broadcast p-1 pivots
+        concat_pivot_op = PSRSConcatPivot(axis=op.axis,
+                                          order=op.order,
+                                          kind=None if op.psrs_kinds is None else op.psrs_kinds[1],
+                                          dtype=sampled_chunks[0].dtype,
+                                          gpu=op.gpu)
+        concat_pivot_shape = \
+            sorted_chunks[0].shape[:op.axis] + (axis_chunk_shape - 1,) + \
+            sorted_chunks[0].shape[op.axis + 1:]
+        concat_pivot_index = out_idx[:op.axis] + (0,) + out_idx[op.axis:]
+        concat_pivot_chunk = concat_pivot_op.new_chunk(sampled_chunks,
+                                                       shape=concat_pivot_shape,
+                                                       index=concat_pivot_index)
+        return concat_pivot_chunk
+
+    @classmethod
+    def partition_local_data(cls, op, axis_chunk_shape, sorted_chunks,
+                             indices_chunks, concat_pivot_chunk):
+        # stage 3: Local data is partitioned
+        return_value = op.return_value
+        return_indices = op.return_indices
+        if return_indices:
+            # if return indices and psrs_kind[2] is not None
+            # value has to be output
+            map_return_value = True
+        else:
+            map_return_value = return_value
+        partition_chunks = []
+        length = len(sorted_chunks or indices_chunks)
+        for i in range(length):
+            chunk_inputs = []
+            if sorted_chunks:
+                chunk_inputs.append(sorted_chunks[i])
+            if indices_chunks:
+                chunk_inputs.append(indices_chunks[i])
+            chunk_inputs.append(concat_pivot_chunk)
+            partition_shuffle_map = PSRSShuffle(return_value=map_return_value,
+                                                return_indices=return_indices,
+                                                stage=OperandStage.map, axis=op.axis,
+                                                n_partition=axis_chunk_shape,
+                                                input_sorted=op.psrs_kinds[0] is not None,
+                                                order=op.order, dtype=chunk_inputs[0].dtype,
+                                                gpu=chunk_inputs[0].op.gpu)
+            partition_chunk = partition_shuffle_map.new_chunk(chunk_inputs,
+                                                              shape=chunk_inputs[0].shape,
+                                                              index=chunk_inputs[0].index,
+                                                              order=chunk_inputs[0].order)
+            partition_chunks.append(partition_chunk)
+        return partition_chunks
+
+    @classmethod
+    def partition_merge_data(cls, op, need_align, return_value, partition_chunks, proxy_chunk):
+        # stage 4: all *ith* classes are gathered and merged
+        return_value = return_value if return_value is not None else op.return_value
+        return_indices = op.return_indices
+        partition_sort_chunks, partition_indices_chunks, sort_info_chunks = [], [], []
+        for i, partition_chunk in enumerate(partition_chunks):
+            kind = None if op.psrs_kinds is None else op.psrs_kinds[2]
+            partition_shuffle_reduce = PSRSShuffle(return_value=return_value,
+                                                   return_indices=return_indices,
+                                                   stage=OperandStage.reduce,
+                                                   axis=op.axis, order=op.order,
+                                                   kind=kind,
+                                                   shuffle_key=str(i),
+                                                   dtype=partition_chunk.dtype,
+                                                   gpu=partition_chunk.op.gpu,
+                                                   need_align=need_align)
+            kws = []
+            chunk_shape = list(partition_chunk.shape)
+            chunk_shape[op.axis] = np.nan
+            if return_value:
+                kws.append({
+                    'shape': tuple(chunk_shape),
+                    'order': partition_chunk.order,
+                    'index': partition_chunk.index,
+                    'dtype': partition_chunk.dtype,
+                    'type': 'sorted',
+                })
+            if return_indices:
+                kws.append({
+                    'shape': tuple(chunk_shape),
+                    'order': TensorOrder.C_ORDER,
+                    'index': partition_chunk.index,
+                    'dtype': np.dtype(np.int64),
+                    'type': 'argsort'
+                })
+            if need_align:
+                s = list(chunk_shape)
+                s.pop(op.axis)
+                kws.append({
+                    'shape': tuple(s),
+                    'order': TensorOrder.C_ORDER,
+                    'index': partition_chunk.index,
+                    'dtype': np.dtype(np.int32),
+                    'type': 'sort_info',
+                })
+            cs = partition_shuffle_reduce.new_chunks([proxy_chunk], kws=kws)
+            i = 0
+            if return_value:
+                partition_sort_chunks.append(cs[0])
+                i += 1
+            if return_indices:
+                partition_indices_chunks.append(cs[i])
+            if need_align:
+                sort_info_chunks.append(cs[-1])
+
+        return partition_sort_chunks, partition_indices_chunks, sort_info_chunks
+
+    @classmethod
+    def align_partitions_data(cls, op, out_idx, in_tensor,
+                              partition_sort_chunks, partition_indices_chunks, sort_info_chunks):
+        return_value, return_indices = op.return_value, op.return_indices
+        align_map_chunks = []
+        length = len(partition_sort_chunks or partition_indices_chunks)
+        for i in range(length):
+            chunk_inputs = []
+            if return_value:
+                chunk_inputs.append(partition_sort_chunks[i])
+            if return_indices:
+                chunk_inputs.append(partition_indices_chunks[i])
+            chunk_inputs.extend(sort_info_chunks)
+            align_map_op = PSRSAlign(return_value=return_value, return_indices=return_indices,
+                                     stage=OperandStage.map, axis=op.axis,
+                                     output_sizes=list(in_tensor.nsplits[op.axis]),
+                                     dtype=chunk_inputs[0].dtype,
+                                     gpu=chunk_inputs[0].op.gpu)
+            align_map_chunk = align_map_op.new_chunk(chunk_inputs,
+                                                     shape=chunk_inputs[0].shape,
+                                                     index=chunk_inputs[0].index,
+                                                     order=TensorOrder.C_ORDER)
+            align_map_chunks.append(align_map_chunk)
+        proxy_chunk = TensorShuffleProxy(dtype=align_map_chunks[0].dtype).new_chunk(
+            align_map_chunks, shape=())
+        align_reduce_value_chunks, align_reduce_indices_chunks = [], []
+        for i, align_map_chunk in enumerate(align_map_chunks):
+            align_reduce_op = PSRSAlign(return_value=return_value, return_indices=return_indices,
+                                        stage=OperandStage.reduce, axis=op.axis,
+                                        shuffle_key=str(i), dtype=align_map_chunk.dtype,
+                                        gpu=align_map_chunk.op.gpu)
+            idx = list(out_idx)
+            idx.insert(op.axis, i)
+            in_chunk = in_tensor.cix[tuple(idx)]
+            kws = []
+            if return_value:
+                kws.append({
+                    'shape': in_chunk.shape,
+                    'index': in_chunk.index,
+                    'order': in_chunk.order,
+                    'type': 'sorted'
+                })
+            if return_indices:
+                kws.append({
+                    'shape': in_chunk.shape,
+                    'index': in_chunk.index,
+                    'order': TensorOrder.C_ORDER,
+                    'type': 'argsort'
+                })
+            align_reduce_chunks = align_reduce_op.new_chunks([proxy_chunk], kws=kws)
+            if return_value:
+                align_reduce_value_chunks.append(align_reduce_chunks[0])
+            if return_indices:
+                align_reduce_indices_chunks.append(align_reduce_chunks[-1])
+
+        return align_reduce_value_chunks, align_reduce_indices_chunks
+
+
+def _sort(a, op, xp, axis=None, kind=None, order=None, inplace=False):
+    axis = axis if axis is not None else op.axis
+    kind = kind if kind is not None else op.kind
+    order = order if order is not None else op.order
+    if xp is np:
+        method = a.sort if inplace else partial(np.sort, a)
+        return method(axis=axis, kind=kind, order=order)
+    else:
+        # cupy does not support structure type
+        assert xp is cp
+        assert order is not None
+        method = a.sort if inplace else partial(cp.sort, a)
+        # cupy does not support kind, thus just ignore it
+        return method(axis=axis)
+
+
+def _argsort(a, op, xp, axis=None, kind=None, order=None):
+    axis = axis if axis is not None else op.axis
+    kind = kind if kind is not None else op.kind
+    order = order if order is not None else op.order
+    if xp is np:
+        return np.argsort(a, axis=axis, kind=kind, order=order)
+    else:
+        # cupy does not support structure type
+        assert xp is cp
+        assert order is not None
+        return cp.argsort(a, axis=axis)
+
+
+class PSRSSortRegularSample(TensorOperand, TensorOperandMixin):
+    _op_type_ = OperandDef.PSRS_SORT_REGULAR_SMAPLE
+
+    _axis = Int32Field('axis')
+    _order = ListField('order', ValueType.string)
+    _kind = StringField('kind')
+    _return_indices = BoolField('return_indices')
+    _n_partition = Int32Field('n_partition')
+    _axis_offset = Int64Field('axis_offset')
+
+    def __init__(self, axis=None, order=None, kind=None, return_indices=None,
+                 n_partition=None, axis_offset=None, dtype=None, gpu=None, **kw):
+        super().__init__(_axis=axis, _order=order, _kind=kind, _return_indices=return_indices,
+                         _n_partition=n_partition, _axis_offset=axis_offset,
+                         _dtype=dtype, _gpu=gpu, **kw)
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @property
+    def order(self):
+        return self._order
+
+    @property
+    def kind(self):
+        return self._kind
+
+    @property
+    def return_indices(self):
+        return self._return_indices
+
+    @property
+    def n_partition(self):
+        return self._n_partition
+
+    @property
+    def axis_offset(self):
+        return self._axis_offset
+
+    @property
+    def output_limit(self):
+        # return sorted tensor, indices(optional) and regular sampled tensor
+        return 2 if not self._return_indices else 3
+
+    @classmethod
+    def execute(cls, ctx, op):
+        (a,), device_id, xp = as_same_device(
+            [ctx[c.key] for c in op.inputs], device=op.device, ret_extra=True)
+
+        with device(device_id):
+            n = op.n_partition
+            w = int(a.shape[op.axis] // n)
+            if not op.return_indices:
+                if op.kind is not None:
+                    # sort
+                    res = ctx[op.outputs[0].key] = _sort(a, op, xp)
+                else:
+                    # do not sort, prepare for sample by `xp.partition`
+                    kth = np.arange(0, n * w, w)
+                    ctx[op.outputs[0].key] = res = xp.partition(
+                        a, kth, axis=op.axis, order=op.order)
+            else:
+                if op.kind is not None:
+                    # argsort
+                    indices = _argsort(a, op, xp)
+                else:
+                    # do not sort, use `xp.argpartition`
+                    kth = np.arange(0, n * w, w)
+                    indices = xp.argpartition(
+                        a, kth, axis=op.axis, order=op.order)
+                ctx[op.outputs[0].key] = res = xp.take_along_axis(a, indices, op.axis)
+                ctx[op.outputs[1].key] = op.axis_offset + indices
+
+            # do regular sample
+            if op.order is not None:
+                res = res[op.order]
+            slc = (slice(None),) * op.axis + (slice(0, n * w, w),)
+            ctx[op.outputs[-1].key] = res[slc]
+
+
+class PSRSConcatPivot(TensorOperand, TensorOperandMixin):
+    _op_type_ = OperandDef.PSRS_CONCAT_PIVOT
+
+    _axis = Int32Field('axis')
+    _order = ListField('order', ValueType.string)
+    _kind = StringField('kind')
+
+    def __init__(self, axis=None, order=None, kind=None, dtype=None, gpu=None, **kw):
+        super().__init__(_axis=axis, _order=order, _kind=kind, _dtype=dtype, _gpu=gpu, **kw)
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @property
+    def order(self):
+        return self._order
+
+    @property
+    def kind(self):
+        return self._kind
+
+    @classmethod
+    def execute(cls, ctx, op):
+        inputs, device_id, xp = as_same_device(
+            [ctx[c.key] for c in op.inputs], device=op.device, ret_extra=True)
+
+        with device(device_id):
+            a = xp.concatenate(inputs, axis=op.axis)
+            p = len(inputs)
+            assert a.shape[op.axis] == p ** 2
+
+            if op.kind is not None:
+                # sort
+                _sort(a, op, xp, inplace=True)
+            else:
+                # prepare for sampling via `partition`
+                kth = xp.arange(p - 1, (p - 1) ** 2 + 1, p - 1)
+                a.partition(kth, axis=op.axis)
+
+            select = slice(p - 1, (p - 1) ** 2 + 1, p - 1)
+            slc = (slice(None),) * op.axis + (select,)
+            ctx[op.outputs[0].key] = a[slc]
+
+
+class PSRSShuffle(TensorMapReduceOperand, TensorOperandMixin):
+    _op_type_ = OperandDef.PSRS_SHUFFLE
+
+    # public
+    _return_value = BoolField('return_value')
+    _return_indices = BoolField('return_indices')
+
+    # for shuffle map
+    _axis = Int32Field('axis')
+    _order = ListField('order', ValueType.string)
+    _n_partition = Int32Field('n_partition')
+    _input_sorted = BoolField('input_sorted')
+
+    # for shuffle reduce
+    _kind = StringField('kind')
+    _need_align = BoolField('need_align')
+
+    def __init__(self, return_value=None, return_indices=None,
+                 axis=None, order=None, n_partition=None, input_sorted=None,
+                 kind=None, need_align=None, stage=None, shuffle_key=None,
+                 dtype=None, gpu=None, **kw):
+        super().__init__(_return_value=return_value, _return_indices=return_indices,
+                         _axis=axis, _order=order, _n_partition=n_partition,
+                         _input_sorted=input_sorted, _kind=kind, _need_align=need_align,
+                         _stage=stage, _shuffle_key=shuffle_key, _dtype=dtype, _gpu=gpu, **kw)
+
+    @property
+    def return_value(self):
+        return self._return_value
+
+    @property
+    def return_indices(self):
+        return self._return_indices
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @property
+    def order(self):
+        return self._order
+
+    @property
+    def n_partition(self):
+        return self._n_partition
+
+    @property
+    def input_sorted(self):
+        return self._input_sorted
+
+    @property
+    def kind(self):
+        return self._kind
+
+    @property
+    def need_align(self):
+        return self._need_align
+
+    @property
+    def output_limit(self):
+        if self._stage == OperandStage.map:
+            return 1
+        else:
+            limit = int(bool(self._return_value)) + \
+                    int(bool(self._return_indices))
+            if self._need_align:
+                limit += 1
+            return limit
+
+    @classmethod
+    def _execute_map(cls, ctx, op):
+        return_value = op.return_value
+        return_indices = op.return_indices
+
+        inputs, device_id, xp = as_same_device([ctx[c.key] for c in op.inputs],
+                                               device=op.device, ret_extra=True)
+        out = op.outputs[0]
+        a = inputs[0]
+        pivots = inputs[-1]
+        a_indices = None
+        if return_indices:
+            a_indices = inputs[-2]
+
+        with device(device_id):
+            shape = tuple(s for i, s in enumerate(a.shape) if i != op.axis)
+            reduce_outputs = [np.empty(shape, dtype=object) for _ in range(op.n_partition)]
+            for idx in itertools.product(*(range(s) for s in shape)):
+                slc = list(idx)
+                slc.insert(op.axis, slice(None))
+                slc = tuple(slc)
+                a_1d, pivots_1d = a[slc], pivots[slc]
+                a_indices_1d = a_indices[slc] if a_indices is not None else None
+                raw_a_1d = a_1d
+                if op.order is not None:
+                    a_1d = a_1d[op.order]
+                if op.input_sorted:
+                    # a is sorted already
+                    poses = xp.searchsorted(a_1d, pivots_1d, side='right')
+                    poses = (None,) + tuple(poses) + (None,)
+                    for i in range(op.n_partition):
+                        reduce_out = []
+                        if return_value:
+                            values = raw_a_1d[poses[i]: poses[i + 1]]
+                            reduce_out.append(values)
+                        if return_indices:
+                            indices = a_indices_1d[poses[i]: poses[i + 1]]
+                            reduce_out.append(indices)
+                        reduce_outputs[i][idx] = tuple(reduce_out)
+                else:
+                    # a is not sorted, search every element in pivots
+                    out_idxes = xp.searchsorted(pivots_1d, a_1d, side='right')
+                    for i in range(op.n_partition):
+                        cond = out_idxes == i
+                        reduce_out = []
+                        if return_value:
+                            values = raw_a_1d[cond]
+                            reduce_out.append(values)
+                        if return_indices:
+                            indices = a_indices_1d[cond]
+                            reduce_out.append(indices)
+                        reduce_outputs[i][idx] = tuple(reduce_out)
+            for i in range(op.n_partition):
+                ctx[(out.key, str(i))] = tuple(reduce_outputs[i].ravel())
+
+    @classmethod
+    def _execute_reduce(cls, ctx, op):
+        input_keys, _ = get_shuffle_input_keys_idxes(op.inputs[0])
+        raw_inputs = [ctx[(input_key, op.shuffle_key)] for input_key in input_keys]
+        # flatten inputs
+        flatten_inputs = flatten(raw_inputs)
+        inputs, device_id, xp = as_same_device(flatten_inputs, device=op.device, ret_extra=True)
+        # organize back inputs
+        inputs = stack_back(inputs, raw_inputs)
+
+        out = op.outputs[0]
+        extra_shape = list(out.shape)
+        extra_shape.pop(op.axis)
+
+        return_value = op.return_value
+        return_indices = op.return_indices
+
+        with device(device_id):
+            sort_res = np.empty(len(inputs[0]), dtype=object)
+            if extra_shape:
+                sort_res = sort_res.reshape(*extra_shape)
+            sort_info = np.empty(sort_res.shape, dtype=np.int32)
+            it = itertools.count(0)
+            for inps in zip(*inputs):
+                cur = itertools.count()
+                values, indices = None, None
+                ret = []
+                if return_value or len(inps[0]) == 2:
+                    i = next(cur)
+                    values = xp.concatenate([inp[i] for inp in inps])
+                    if return_value:
+                        ret.append(values)
+                if return_indices:
+                    i = next(cur)
+                    indices = xp.concatenate([inp[i] for inp in inps])
+                    ret.append(indices)
+
+                if op.kind is not None:
+                    # sort only if kind specified
+                    if return_indices:
+                        # if kind specified and return_indices
+                        # values cannot be None
+                        assert values is not None
+                        values_indices = _argsort(values, op, xp, axis=0)
+                        if return_value:
+                            xp.take(values, values_indices, out=values)
+                        xp.take(indices, values_indices, out=indices)
+                    else:
+                        _sort(values, op, xp, axis=0, inplace=True)
+
+                j = next(it)
+                sort_res.ravel()[j] = ret
+                sort_info.ravel()[j] = len(ret[0])
+
+            if not op.need_align:
+                assert len(sort_res) == 1
+                shape = list(extra_shape)
+                shape.insert(op.axis, len(sort_res[0]))
+                i = 0
+                if return_value:
+                    ctx[op.outputs[0].key] = sort_res[0][i]
+                    i += 1
+                if return_indices:
+                    ctx[op.outputs[i].key] = sort_res[0][i]
+            else:
+                i = 0
+                if return_value:
+                    ctx[op.outputs[0].key] = tuple(r[0] for r in sort_res.ravel())
+                    i += 1
+                if return_indices:
+                    ctx[op.outputs[i].key] = tuple(r[i] for r in sort_res.ravel())
+                ctx[op.outputs[-1].key] = sort_info
+
+    @classmethod
+    def execute(cls, ctx, op):
+        if op.stage == OperandStage.map:
+            cls._execute_map(ctx, op)
+        else:
+            cls._execute_reduce(ctx, op)
+
+
+class PSRSAlign(TensorMapReduceOperand, TensorOperandMixin):
+    _op_type_ = OperandDef.PSRS_ALIGN
+
+    _return_value = BoolField('return_value')
+    _return_indices = BoolField('return_indices')
+    _axis = Int32Field('axis')
+    _output_sizes = ListField('output_sizes', ValueType.int32)
+
+    def __init__(self, return_value=None, return_indices=None, axis=None,
+                 output_sizes=None, stage=None, shuffle_key=None,
+                 dtype=None, gpu=None, **kw):
+        super().__init__(_return_value=return_value, _return_indices=return_indices,
+                         _axis=axis, _output_sizes=output_sizes, _stage=stage,
+                         _shuffle_key=shuffle_key, _dtype=dtype, _gpu=gpu, **kw)
+
+    @property
+    def return_value(self):
+        return self._return_value
+
+    @property
+    def return_indices(self):
+        return self._return_indices
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @property
+    def output_sizes(self):
+        return self._output_sizes
+
+    @property
+    def output_limit(self):
+        if self._stage == OperandStage.map:
+            return 1
+        else:
+            return int(bool(self._return_value)) + int(bool(self._return_indices))
+
+    @classmethod
+    def _execute_map(cls, ctx, op):
+        inputs, device_id, xp = as_same_device(
+            [ctx[c.key] for c in op.inputs], device=op.device, ret_extra=True)
+        sort_res, sort_indices = None, None
+        i = 0
+        if op.return_value:
+            sort_res = inputs[0]
+            i += 1
+        if op.return_indices:
+            sort_indices = inputs[i]
+            i += 1
+        sort_infos = inputs[i:]
+        out = op.outputs[0]
+
+        with device(device_id):
+            length = len(sort_res or sort_indices)
+            outs = np.empty((len(op.output_sizes), length), dtype=object)
+            out_sizes = op.output_sizes
+            cum_out_sizes = (0,) + tuple(np.cumsum(out_sizes))
+            for i in range(length):
+                sort_1d = sort_res[i] if sort_res is not None else None
+                indices_1d = sort_indices[i] if sort_indices is not None else None
+                sort_lengths = [sort_info.flat[i] for sort_info in sort_infos]
+                cum_sort_lengths = (0,) + tuple(np.cumsum(sort_lengths))
+                j = out.index[op.axis]
+                start_pos = cum_sort_lengths[j]
+                end_pos = cum_sort_lengths[j + 1]
+                out_idx_start, out_idx_end = np.searchsorted(cum_out_sizes, [start_pos, end_pos])
+                out_idx_start = max(out_idx_start - 1, 0)
+                for out_idx in range(out_idx_start, out_idx_end):
+                    out_start_pos = cum_out_sizes[out_idx]
+                    out_end_pos = cum_out_sizes[out_idx + 1]
+                    s = max(start_pos, out_start_pos)
+                    size = max(min(end_pos, out_end_pos) - s, 0)
+                    s = max(0, s - start_pos)
+                    ret = []
+                    if sort_1d is not None:
+                        ret.append(sort_1d[s: s + size])
+                    if indices_1d is not None:
+                        ret.append(indices_1d[s: s + size])
+                    outs[out_idx, i] = tuple(ret)
+
+            for idx in range(len(op.output_sizes)):
+                ret = []
+                for ar in outs[idx]:
+                    if ar is None:
+                        item = []
+                        if sort_res is not None:
+                            item.append(xp.empty((0,), dtype=out.dtype))
+                        if sort_indices is not None:
+                            item.append(xp.empty((0,), dtype=np.dtype(np.int64)))
+                        ret.append(tuple(item))
+                    else:
+                        ret.append(ar)
+                ctx[(op.outputs[0].key, str(idx))] = tuple(ret)
+
+    @classmethod
+    def _execute_reduce(cls, ctx, op):
+        in_chunk = op.inputs[0]
+        axis = op.axis
+        input_keys, _ = get_shuffle_input_keys_idxes(in_chunk)
+        raw_inputs = [ctx[(input_key, op.shuffle_key)] for input_key in input_keys]
+        flatten_inputs = flatten(raw_inputs)
+        inputs, device_id, xp = as_same_device(flatten_inputs, device=op.device, ret_extra=True)
+        inputs = stack_back(flatten_inputs, raw_inputs)
+
+        out = op.outputs[0]
+        extra_shape = list(out.shape)
+        extra_shape.pop(axis)
+
+        return_value = op.return_value
+        return_indices = op.return_indices
+
+        with device(device_id):
+            if return_value:
+                values_res = xp.empty(out.shape, dtype=out.dtype)
+            else:
+                values_res = None
+            if return_indices:
+                indices_res = xp.empty(out.shape, dtype=np.dtype(np.int64))
+            else:
+                indices_res = None
+            it = itertools.product(*(range(s) for i, s in enumerate(out.shape) if i != axis))
+            for inps in zip(*inputs):
+                slc = list(next(it))
+                slc.insert(op.axis, slice(None))
+                i = 0
+                if return_value:
+                    value_concat_1d = xp.concatenate([inp[0] for inp in inps])
+                    values_res[tuple(slc)] = value_concat_1d
+                    i += 1
+                if return_indices:
+                    ind_concat_id = xp.concatenate([inp[i] for inp in inps])
+                    indices_res[tuple(slc)] = ind_concat_id
+
+            i = 0
+            if return_value:
+                ctx[op.outputs[0].key] = values_res.astype(values_res.dtype,
+                                                           order=op.outputs[0].order.value)
+                i += 1
+            if return_indices:
+                ctx[op.outputs[i].key] = indices_res.astype(indices_res.dtype,
+                                                            order=op.outputs[i].order.value)
+
+    @classmethod
+    def execute(cls, ctx, op):
+        if op.stage == OperandStage.map:
+            cls._execute_map(ctx, op)
+        else:
+            cls._execute_reduce(ctx, op)

--- a/mars/tensor/base/sort.py
+++ b/mars/tensor/base/sort.py
@@ -12,24 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import itertools
-from functools import partial
-
 import numpy as np
 
 from ... import opcodes as OperandDef
-from ...operands import OperandStage
 from ...serialize import ValueType, Int32Field, StringField, ListField, BoolField
-from ...tiles import NotSupportTile, TilesError
-from ...utils import get_shuffle_input_keys_idxes
-from ..operands import TensorOperand, TensorOperandMixin, TensorMapReduceOperand, \
-    TensorShuffleProxy, TensorOrder
-from ..array_utils import as_same_device, device, cp
+from ..operands import TensorOperand, TensorShuffleProxy, TensorOrder
+from ..array_utils import as_same_device, device
 from ..datasource import tensor as astensor
 from ..utils import validate_axis, validate_order
+from .psrs import PSRSOperandMixin
 
 
-class TensorSort(TensorOperand, TensorOperandMixin):
+class TensorSort(TensorOperand, PSRSOperandMixin):
     _op_type_ = OperandDef.SORT
 
     _axis = Int32Field('axis')
@@ -38,12 +32,17 @@ class TensorSort(TensorOperand, TensorOperandMixin):
     _order = ListField('order', ValueType.string)
     _psrs_kinds = ListField('psrs_kinds', ValueType.string)
     _need_align = BoolField('need_align')
+    _return_value = BoolField('return_value')
+    _return_indices = BoolField('return_indices')
 
     def __init__(self, axis=None, kind=None, parallel_kind=None, order=None,
-                 psrs_kinds=None, need_align=None, dtype=None, gpu=None, **kw):
+                 psrs_kinds=None, need_align=None, return_value=None,
+                 return_indices=None, dtype=None, gpu=None, **kw):
         super().__init__(_axis=axis, _kind=kind, _parallel_kind=parallel_kind,
                          _order=order, _psrs_kinds=psrs_kinds,
-                         _need_align=need_align, _dtype=dtype, _gpu=gpu, **kw)
+                         _need_align=need_align, _return_value=return_value,
+                         _return_indices=return_indices,
+                         _dtype=dtype, _gpu=gpu, **kw)
 
     @property
     def axis(self):
@@ -69,229 +68,55 @@ class TensorSort(TensorOperand, TensorOperandMixin):
     def need_align(self):
         return self._need_align
 
+    @property
+    def return_value(self):
+        return self._return_value
+
+    @property
+    def return_indices(self):
+        return self._return_indices
+
+    @property
+    def output_limit(self):
+        return int(bool(self._return_value)) + int(bool(self._return_indices))
+
     def __call__(self, a):
-        return self.new_tensor([a], shape=a.shape, order=a.order)
-
-    @classmethod
-    def tile(cls, op):
-        in_tensor = op.inputs[0]
-
-        if in_tensor.chunk_shape[op.axis] == 1:
-            out_chunks = []
-            for chunk in in_tensor.chunks:
-                chunk_op = op.copy().reset_key()
-                out_chunk = chunk_op.new_chunk([chunk], shape=chunk.shape,
-                                               index=chunk.index, order=chunk.order)
-                out_chunks.append(out_chunk)
-
-            new_op = op.copy()
-            return new_op.new_tensors([in_tensor], shape=in_tensor.shape, order=in_tensor.order,
-                                      chunks=out_chunks, nsplits=in_tensor.nsplits)
-        else:
-            # use parallel sorting by regular sampling
-            return PSRSSorter.tile(op)
-
-    @classmethod
-    def execute(cls, ctx, op):
-        (a,), device_id, xp = as_same_device([ctx[inp.key] for inp in op.inputs],
-                                             device=op.device, ret_extra=True)
-
-        with device(device_id):
-            kw = {}
-            if op.kind is not None:
-                kw['kind'] = op.kind
-            if op.order is not None:
-                kw['order'] = op.order
-            ctx[op.outputs[0].key] = xp.sort(a, axis=op.axis, **kw)
-
-
-class PSRSSorter(object):
-    @classmethod
-    def preprocess(cls, op):
-        in_tensor = op.inputs[0]
-        axis_shape = in_tensor.shape[op.axis]
-        axis_chunk_shape = in_tensor.chunk_shape[op.axis]
-
-        # rechunk to ensure all chunks on axis have rough same size
-        axis_chunk_shape = min(axis_chunk_shape, int(np.sqrt(axis_shape)))
-        if np.isnan(axis_shape) or any(np.isnan(s) for s in in_tensor.nsplits[op.axis]):
-            raise TilesError('fail to tile because either the shape of '
-                             'input tensor on axis {} has unknown shape or chunk shape'.format(op.axis))
-        chunk_size = int(axis_shape / axis_chunk_shape)
-        chunk_sizes = [chunk_size for _ in range(int(axis_shape // chunk_size))]
-        if axis_shape % chunk_size > 0:
-            chunk_sizes[-1] += axis_shape % chunk_size
-        in_tensor = in_tensor.rechunk(
-            {op.axis: tuple(chunk_sizes)})._inplace_tile()
-        axis_chunk_shape = in_tensor.chunk_shape[op.axis]
-
-        left_chunk_shape = in_tensor.chunk_shape[:op.axis] + in_tensor.chunk_shape[op.axis + 1:]
-        if len(left_chunk_shape) > 0:
-            out_idxes = itertools.product(*(range(s) for s in left_chunk_shape))
-        else:
-            out_idxes = [()]
-        # if the size except axis has more than 1, the sorted values on each one may be different
-        # another shuffle would be required to make sure each axis except to sort
-        # has elements with identical size
-        extra_shape = [s for i, s in enumerate(in_tensor.shape) if i != op.axis]
-        if op.need_align is None:
-            need_align = bool(np.prod(extra_shape, dtype=int) != 1)
-        else:
-            need_align = op.need_align
-
-        return in_tensor, axis_chunk_shape, out_idxes, need_align
-
-    @classmethod
-    def local_sort_and_regular_sample(cls, op, in_tensor, axis_chunk_shape, out_idx):
-        # stage 1: local sort and regular samples collected
-        sorted_chunks, sampled_chunks = [], []
-        sampled_dtype = np.dtype([(o, in_tensor.dtype[o]) for o in op.order]) \
-            if op.order is not None else in_tensor.dtype
-        for i in range(axis_chunk_shape):
-            idx = list(out_idx)
-            idx.insert(op.axis, i)
-            in_chunk = in_tensor.cix[tuple(idx)]
-            kind = None if op.psrs_kinds is None else op.psrs_kinds[0]
-            chunk_op = PSRSSortRegularSample(axis=op.axis, order=op.order, kind=kind,
-                                             n_partition=axis_chunk_shape, gpu=op.gpu)
-            kws = []
-            sort_shape = in_chunk.shape
-            kws.append({'shape': sort_shape,
-                        'order': in_chunk.order,
-                        'dtype': in_chunk.dtype,
-                        'index': in_chunk.index,
-                        'type': 'sorted'})
-            sampled_shape = (axis_chunk_shape,)
-            kws.append({'shape': sampled_shape,
-                        'order': in_chunk.order,
-                        'dtype': sampled_dtype,
-                        'index': (i,),
-                        'type': 'regular_sampled'})
-            sort_chunk, sampled_chunk = chunk_op.new_chunks([in_chunk], kws=kws)
-            sorted_chunks.append(sort_chunk)
-            sampled_chunks.append(sampled_chunk)
-
-        return sorted_chunks, sampled_chunks
-
-    @classmethod
-    def concat_and_pivot(cls, op, axis_chunk_shape, out_idx, sorted_chunks, sampled_chunks):
-        # stage 2: gather and merge samples, choose and broadcast p-1 pivots
-        concat_pivot_op = PSRSConcatPivot(axis=op.axis,
-                                          order=op.order,
-                                          kind=None if op.psrs_kinds is None else op.psrs_kinds[1],
-                                          dtype=sampled_chunks[0].dtype,
-                                          gpu=op.gpu)
-        concat_pivot_shape = \
-            sorted_chunks[0].shape[:op.axis] + (axis_chunk_shape - 1,) + \
-            sorted_chunks[0].shape[op.axis + 1:]
-        concat_pivot_index = out_idx[:op.axis] + (0,) + out_idx[op.axis:]
-        concat_pivot_chunk = concat_pivot_op.new_chunk(sampled_chunks,
-                                                       shape=concat_pivot_shape,
-                                                       index=concat_pivot_index)
-        return concat_pivot_chunk
-
-    @classmethod
-    def partition_local_data(cls, op, axis_chunk_shape, sorted_chunks, concat_pivot_chunk):
-        # stage 3: Local data is partitioned
-        partition_chunks = []
-        for sorted_chunk in sorted_chunks:
-            partition_shuffle_map = PSRSShuffle(stage=OperandStage.map, axis=op.axis,
-                                                n_partition=axis_chunk_shape,
-                                                input_sorted=op.psrs_kinds[0] is not None,
-                                                order=op.order, dtype=sorted_chunk.dtype,
-                                                gpu=sorted_chunk.op.gpu)
-            partition_chunk = partition_shuffle_map.new_chunk([sorted_chunk, concat_pivot_chunk],
-                                                              shape=sorted_chunk.shape,
-                                                              index=sorted_chunk.index,
-                                                              order=sorted_chunk.order)
-            partition_chunks.append(partition_chunk)
-        return partition_chunks
-
-    @classmethod
-    def partition_merge_data(cls, op, need_align, partition_chunks, proxy_chunk):
-        # stage 4: all *ith* classes are gathered and merged
-        partition_sort_chunks, sort_info_chunks = [], []
-        for i, partition_chunk in enumerate(partition_chunks):
-            kind = None if op.psrs_kinds is None else op.psrs_kinds[2]
-            partition_shuffle_reduce = PSRSShuffle(stage=OperandStage.reduce,
-                                                   axis=op.axis, order=op.order,
-                                                   kind=kind,
-                                                   shuffle_key=str(i),
-                                                   dtype=partition_chunk.dtype,
-                                                   gpu=partition_chunk.op.gpu,
-                                                   need_align=need_align)
-            kws = []
-            chunk_shape = list(partition_chunk.shape)
-            chunk_shape[op.axis] = np.nan
+        kws = []
+        if self._return_value:
             kws.append({
-                'shape': tuple(chunk_shape),
-                'order': partition_chunk.order,
-                'index': partition_chunk.index,
-                'dtype': partition_chunk.dtype,
-                'type': 'sorted',
+                'shape': a.shape,
+                'order': a.order,
+                'dtype': a.dtype,
+                'type': 'sorted'
             })
-            if need_align:
-                s = list(chunk_shape)
-                s.pop(op.axis)
-                kws.append({
-                    'shape': tuple(s),
-                    'order': TensorOrder.C_ORDER,
-                    'index': partition_chunk.index,
-                    'dtype': np.dtype(np.int32),
-                    'type': 'sort_info',
-                })
-            cs = partition_shuffle_reduce.new_chunks([proxy_chunk], kws=kws)
-            partition_sort_chunks.append(cs[0])
-            if need_align:
-                sort_info_chunks.append(cs[1])
-
-        return partition_sort_chunks, sort_info_chunks
+        if self._return_indices:
+            kws.append({
+                'shape': a.shape,
+                'order': TensorOrder.C_ORDER,
+                'dtype': np.dtype(np.int64),
+                'type': 'argsort'
+            })
+        ret = self.new_tensors([a], kws=kws)
+        if len(kws) == 1:
+            return ret[0]
+        return ret
 
     @classmethod
-    def align_partitions_data(cls, op, out_idx, in_tensor, partition_sort_chunks, sort_info_chunks):
-        align_map_chunks = []
-        for partition_sort_chunk in partition_sort_chunks:
-            align_map_op = PSRSAlign(stage=OperandStage.map, axis=op.axis,
-                                     output_sizes=list(in_tensor.nsplits[op.axis]),
-                                     dtype=partition_sort_chunk.dtype,
-                                     gpu=partition_sort_chunk.op.gpu)
-            align_map_chunk = align_map_op.new_chunk([partition_sort_chunk] + sort_info_chunks,
-                                                     shape=partition_sort_chunk.shape,
-                                                     index=partition_sort_chunk.index,
-                                                     order=TensorOrder.C_ORDER)
-            align_map_chunks.append(align_map_chunk)
-        proxy_chunk = TensorShuffleProxy(dtype=align_map_chunks[0].dtype).new_chunk(
-            align_map_chunks, shape=())
-        align_reduce_chunks = []
-        for i, align_map_chunk in enumerate(align_map_chunks):
-            align_reduce_op = PSRSAlign(stage=OperandStage.reduce, axis=op.axis,
-                                        shuffle_key=str(i), dtype=align_map_chunk.dtype,
-                                        gpu=align_map_chunk.op.gpu)
-            idx = list(out_idx)
-            idx.insert(op.axis, i)
-            in_chunk = in_tensor.cix[tuple(idx)]
-            align_reduce_chunk = align_reduce_op.new_chunk([proxy_chunk],
-                                                           shape=in_chunk.shape,
-                                                           index=in_chunk.index,
-                                                           order=in_chunk.order)
-            align_reduce_chunks.append(align_reduce_chunk)
-
-        return align_reduce_chunks
-
-    @classmethod
-    def tile(cls, op):
+    def _tile_psrs(cls, op):
         """
         Refer to http://csweb.cs.wfu.edu/bigiron/LittleFE-PSRS/build/html/PSRSalgorithm.html
         to see explanation of parallel sorting by regular sampling
         """
         out_tensor = op.outputs[0]
         in_tensor, axis_chunk_shape, out_idxes, need_align = cls.preprocess(op)
+        axis_offsets = [0] + np.cumsum(in_tensor.nsplits[op.axis]).tolist()[:-1]
+        return_value, return_indices = op.return_value, op.return_indices
 
-        out_chunks = []
+        out_value_chunks, out_indices_chunks = [], []
         for out_idx in out_idxes:
             # stage 1: local sort and regular samples collected
-            sorted_chunks, sampled_chunks = cls.local_sort_and_regular_sample(
-                op, in_tensor, axis_chunk_shape, out_idx)
+            sorted_chunks, indices_chunks, sampled_chunks = cls.local_sort_and_regular_sample(
+                op, in_tensor, axis_chunk_shape, axis_offsets, out_idx)
 
             # stage 2: gather and merge samples, choose and broadcast p-1 pivots
             concat_pivot_chunk = cls.concat_and_pivot(
@@ -299,369 +124,168 @@ class PSRSSorter(object):
 
             # stage 3: Local data is partitioned
             partition_chunks = cls.partition_local_data(
-                op, axis_chunk_shape, sorted_chunks, concat_pivot_chunk)
+                op, axis_chunk_shape, sorted_chunks, indices_chunks, concat_pivot_chunk)
 
             proxy_chunk = TensorShuffleProxy(dtype=partition_chunks[0].dtype).new_chunk(
                 partition_chunks, shape=())
 
             # stage 4: all *ith* classes are gathered and merged
-            partition_sort_chunks, sort_info_chunks = cls.partition_merge_data(
-                op, need_align, partition_chunks, proxy_chunk)
+            partition_sort_chunks, partition_indices_chunks, sort_info_chunks = \
+                cls.partition_merge_data(op, need_align, None, partition_chunks, proxy_chunk)
 
             if not need_align:
-                out_chunks.extend(partition_sort_chunks)
+                if return_value:
+                    out_value_chunks.extend(partition_sort_chunks)
+                if return_indices:
+                    out_indices_chunks.extend(partition_indices_chunks)
             else:
-                align_reduce_chunks = cls.align_partitions_data(
-                    op, out_idx, in_tensor, partition_sort_chunks, sort_info_chunks)
-                out_chunks.extend(align_reduce_chunks)
+                align_reduce_value_chunks, align_reduce_indices_chunks = \
+                    cls.align_partitions_data(
+                        op, out_idx, in_tensor, partition_sort_chunks,
+                        partition_indices_chunks, sort_info_chunks)
+                if return_value:
+                    out_value_chunks.extend(align_reduce_value_chunks)
+                if return_indices:
+                    out_indices_chunks.extend(align_reduce_indices_chunks)
 
         new_op = op.copy()
         nsplits = list(in_tensor.nsplits)
         if not need_align:
             nsplits[op.axis] = (np.nan,) * axis_chunk_shape
-        return new_op.new_tensors(op.inputs, shape=out_tensor.shape, order=out_tensor.order,
-                                  chunks=out_chunks, nsplits=tuple(nsplits))
+        kws = []
+        if return_value:
+            kws.append({
+                'shape': out_tensor.shape,
+                'order': out_tensor.order,
+                'chunks': out_value_chunks,
+                'nsplits': nsplits
+            })
+        if return_indices:
+            kws.append({
+                'shape': out_tensor.shape,
+                'order': TensorOrder.C_ORDER,
+                'chunks': out_indices_chunks,
+                'nsplits': nsplits
+            })
+        return new_op.new_tensors(op.inputs, kws=kws)
 
-
-class PSRSOperandMixin(TensorOperandMixin):
     @classmethod
     def tile(cls, op):
-        raise NotSupportTile('{} is a chunk op'.format(cls))
+        in_tensor = op.inputs[0]
+        return_value, return_indices = op.return_value, op.return_indices
 
+        if in_tensor.chunk_shape[op.axis] == 1:
+            out_chunks, out_indices_chunks = [], []
+            for chunk in in_tensor.chunks:
+                chunk_op = op.copy().reset_key()
+                kws = []
+                if return_value:
+                    kws.append({
+                        'shape': chunk.shape,
+                        'index': chunk.index,
+                        'order': chunk.order,
+                        'dtyep': chunk.dtype,
+                        'type': 'sorted'
+                    })
+                if return_indices:
+                    kws.append({
+                        'shape': chunk.shape,
+                        'index': chunk.index,
+                        'order': TensorOrder.C_ORDER,
+                        'dtype': np.dtype(np.int64),
+                        'type': 'argsort'
+                    })
+                chunks = chunk_op.new_chunks([chunk], kws=kws)
+                if return_value:
+                    out_chunks.append(chunks[0])
+                if return_indices:
+                    out_indices_chunks.append(chunks[-1])
 
-def _sort(a, op, xp, axis=None, kind=None, order=None, inplace=False):
-    axis = axis if axis is not None else op.axis
-    kind = kind if kind is not None else op.kind
-    order = order if order is not None else op.order
-    if xp is np:
-        method = a.sort if inplace else partial(np.sort, a)
-        return method(axis=axis, kind=kind, order=order)
-    else:
-        # cupy does not support structure type
-        assert xp is cp
-        assert order is not None
-        method = a.sort if inplace else partial(cp.sort, a)
-        # cupy does not support kind, thus just ignore it
-        return method(axis=axis)
-
-
-class PSRSSortRegularSample(TensorOperand, PSRSOperandMixin):
-    _op_type_ = OperandDef.PSRS_SORT_REGULAR_SMAPLE
-
-    _axis = Int32Field('axis')
-    _order = ListField('order', ValueType.string)
-    _kind = StringField('kind')
-    _n_partition = Int32Field('n_partition')
-
-    def __init__(self, axis=None, order=None, kind=None, n_partition=None,
-                 dtype=None, gpu=None, **kw):
-        super().__init__(_axis=axis, _order=order, _kind=kind, _n_partition=n_partition,
-                         _dtype=dtype, _gpu=gpu, **kw)
-
-    @property
-    def axis(self):
-        return self._axis
-
-    @property
-    def order(self):
-        return self._order
-
-    @property
-    def kind(self):
-        return self._kind
-
-    @property
-    def n_partition(self):
-        return self._n_partition
-
-    @property
-    def output_limit(self):
-        # return sorted tensor and regular sampled tensor
-        return 2
+            new_op = op.copy()
+            kws = [out.params for out in op.outputs]
+            if return_value:
+                kws[0]['nsplits'] = in_tensor.nsplits
+                kws[0]['chunks'] = out_chunks
+            if return_indices:
+                kws[-1]['nsplits'] = in_tensor.nsplits
+                kws[-1]['chunks'] = out_indices_chunks
+            return new_op.new_tensors([in_tensor], kws=kws)
+        else:
+            # use parallel sorting by regular sampling
+            return cls._tile_psrs(op)
 
     @classmethod
     def execute(cls, ctx, op):
-        (a,), device_id, xp = as_same_device(
-            [ctx[c.key] for c in op.inputs], device=op.device, ret_extra=True)
+        (a,), device_id, xp = as_same_device([ctx[inp.key] for inp in op.inputs],
+                                             device=op.device, ret_extra=True)
+        return_value, return_indices = op.return_value, op.return_indices
 
         with device(device_id):
-            n = op.n_partition
-            w = int(a.shape[op.axis] // n)
+            kw = {}
             if op.kind is not None:
-                # sort
-                res = ctx[op.outputs[0].key] = _sort(a, op, xp)
-            else:
-                # do not sort, prepare for sample by `xp.partition`
-                kth = np.arange(0, n * w, w)
-                ctx[op.outputs[0].key] = res = xp.partition(
-                    a, kth, axis=op.axis, order=op.order)
-            # do regular sample
+                kw['kind'] = op.kind
             if op.order is not None:
-                res = res[op.order]
-            slc = (slice(None),) * op.axis + (slice(0, n * w, w),)
-            ctx[op.outputs[1].key] = res[slc]
+                kw['order'] = op.order
 
-
-class PSRSConcatPivot(TensorOperand, PSRSOperandMixin):
-    _op_type_ = OperandDef.PSRS_CONCAT_PIVOT
-
-    _axis = Int32Field('axis')
-    _order = ListField('order', ValueType.string)
-    _kind = StringField('kind')
-
-    def __init__(self, axis=None, order=None, kind=None, dtype=None, gpu=None, **kw):
-        super().__init__(_axis=axis, _order=order, _kind=kind, _dtype=dtype, _gpu=gpu, **kw)
-
-    @property
-    def axis(self):
-        return self._axis
-
-    @property
-    def order(self):
-        return self._order
-
-    @property
-    def kind(self):
-        return self._kind
-
-    @classmethod
-    def execute(cls, ctx, op):
-        inputs, device_id, xp = as_same_device(
-            [ctx[c.key] for c in op.inputs], device=op.device, ret_extra=True)
-
-        with device(device_id):
-            a = xp.concatenate(inputs, axis=op.axis)
-            p = len(inputs)
-            assert a.shape[op.axis] == p ** 2
-
-            if op.kind is not None:
-                # sort
-                _sort(a, op, xp, inplace=True)
-            else:
-                # prepare for sampling via `partition`
-                kth = xp.arange(p - 1, (p - 1) ** 2 + 1, p - 1)
-                a.partition(kth, axis=op.axis)
-
-            select = slice(p - 1, (p - 1) ** 2 + 1, p - 1)
-            slc = (slice(None),) * op.axis + (select,)
-            ctx[op.outputs[0].key] = a[slc]
-
-
-class PSRSShuffle(TensorMapReduceOperand, PSRSOperandMixin):
-    _op_type_ = OperandDef.PSRS_SHUFFLE
-
-    _axis = Int32Field('axis')
-    _order = ListField('order', ValueType.string)
-    _n_partition = Int32Field('n_partition')
-    _input_sorted = BoolField('input_sorted')
-
-    _kind = StringField('kind')
-    _need_align = BoolField('need_align')
-
-    def __init__(self, axis=None, order=None, n_partition=None, input_sorted=None,
-                 kind=None, need_align=None, stage=None, shuffle_key=None,
-                 dtype=None, gpu=None, **kw):
-        super().__init__(_axis=axis, _order=order, _n_partition=n_partition,
-                         _input_sorted=input_sorted, _kind=kind, _need_align=need_align,
-                         _stage=stage, _shuffle_key=shuffle_key, _dtype=dtype, _gpu=gpu, **kw)
-
-    @property
-    def axis(self):
-        return self._axis
-
-    @property
-    def order(self):
-        return self._order
-
-    @property
-    def n_partition(self):
-        return self._n_partition
-
-    @property
-    def input_sorted(self):
-        return self._input_sorted
-
-    @property
-    def kind(self):
-        return self._kind
-
-    @property
-    def need_align(self):
-        return self._need_align
-
-    @property
-    def output_limit(self):
-        return 1 if not self._need_align else 2
-
-    @classmethod
-    def _execute_map(cls, ctx, op):
-        (a, pivots), device_id, xp = as_same_device([ctx[c.key] for c in op.inputs],
-                                                    device=op.device, ret_extra=True)
-        out = op.outputs[0]
-
-        with device(device_id):
-            shape = tuple(s for i, s in enumerate(a.shape) if i != op.axis)
-            reduce_outputs = [np.empty(shape, dtype=object) for _ in range(op.n_partition)]
-            for idx in itertools.product(*(range(s) for s in shape)):
-                slc = list(idx)
-                slc.insert(op.axis, slice(None))
-                slc = tuple(slc)
-                a_1d, pivots_1d = a[slc], pivots[slc]
-                raw_a_1d = a_1d
-                if op.order is not None:
-                    a_1d = a_1d[op.order]
-                if op.input_sorted:
-                    # a is sorted already
-                    poses = xp.searchsorted(a_1d, pivots_1d, side='right')
-                    poses = (None,) + tuple(poses) + (None,)
-                    for i in range(op.n_partition):
-                        reduce_outputs[i][idx] = raw_a_1d[poses[i]: poses[i + 1]]
+            if return_indices:
+                if not return_value:
+                    ctx[op.outputs[0].key] = xp.argsort(a, axis=op.axis, **kw)
                 else:
-                    # a is not sorted, search every element in pivots
-                    out_idxes = xp.searchsorted(pivots_1d, a_1d, side='right')
-                    for i in range(op.n_partition):
-                        reduce_outputs[i][idx] = raw_a_1d[out_idxes == i]
-            for i in range(op.n_partition):
-                ctx[(out.key, str(i))] = tuple(reduce_outputs[i].ravel())
-
-    @classmethod
-    def _execute_reduce(cls, ctx, op):
-        input_keys, _ = get_shuffle_input_keys_idxes(op.inputs[0])
-        raw_inputs = [ctx[(input_key, op.shuffle_key)] for input_key in input_keys]
-        flatten_inputs = []
-        for raw_input in raw_inputs:
-            flatten_inputs.extend(raw_input)
-        inputs, device_id, xp = as_same_device(flatten_inputs, device=op.device, ret_extra=True)
-        input_len = len(raw_inputs[0])
-        inputs = [inputs[i * input_len: (i + 1) * input_len]
-                  for i in range(len(raw_inputs))]
-        out = op.outputs[0]
-        extra_shape = list(out.shape)
-        extra_shape.pop(op.axis)
-
-        with device(device_id):
-            sort_res = np.empty(len(inputs[0]), dtype=object)
-            if extra_shape:
-                sort_res = sort_res.reshape(*extra_shape)
-            sort_info = np.empty(sort_res.shape, dtype=np.int32)
-            it = itertools.count(0)
-            for inps in zip(*inputs):
-                out = xp.concatenate(inps)
-                if op.kind is not None:
-                    # skip sort
-                    _sort(out, op, xp, axis=0, inplace=True)
-                j = next(it)
-                sort_res.ravel()[j] = out
-                sort_info.ravel()[j] = len(out)
-
-            if not op.need_align:
-                assert len(sort_res) == 1
-                shape = list(extra_shape)
-                shape.insert(op.axis, len(sort_res[0]))
-                ctx[op.outputs[0].key] = sort_res[0]
+                    indices = ctx[op.outputs[1].key] = xp.argsort(a, axis=op.axis, **kw)
+                    ctx[op.outputs[0].key] = xp.take_along_axis(a, indices, op.axis)
             else:
-                ctx[op.outputs[0].key] = tuple(sort_res.ravel())
-                ctx[op.outputs[1].key] = sort_info
-
-    @classmethod
-    def execute(cls, ctx, op):
-        if op.stage == OperandStage.map:
-            cls._execute_map(ctx, op)
-        else:
-            cls._execute_reduce(ctx, op)
-
-
-class PSRSAlign(TensorMapReduceOperand, PSRSOperandMixin):
-    _op_type_ = OperandDef.PSRS_ALIGN
-
-    _axis = Int32Field('axis')
-    _output_sizes = ListField('output_sizes', ValueType.int32)
-
-    def __init__(self, axis=None, output_sizes=None, stage=None, shuffle_key=None,
-                 dtype=None, gpu=None, **kw):
-        super().__init__(_axis=axis, _output_sizes=output_sizes, _stage=stage,
-                         _shuffle_key=shuffle_key, _dtype=dtype, _gpu=gpu, **kw)
-
-    @property
-    def axis(self):
-        return self._axis
-
-    @property
-    def output_sizes(self):
-        return self._output_sizes
-
-    @classmethod
-    def _execute_map(cls, ctx, op):
-        inputs, device_id, xp = as_same_device(
-            [ctx[c.key] for c in op.inputs], device=op.device, ret_extra=True)
-        sort_res, sort_infos = inputs[0], inputs[1:]
-        out = op.outputs[0]
-
-        with device(device_id):
-            length = len(sort_res)
-            outs = np.empty((len(op.output_sizes), length), dtype=object)
-            out_sizes = op.output_sizes
-            cum_out_sizes = (0,) + tuple(np.cumsum(out_sizes))
-            for i, sort_1d in enumerate(sort_res):
-                sort_lengths = [sort_info.flat[i] for sort_info in sort_infos]
-                cum_sort_lengths = (0,) + tuple(np.cumsum(sort_lengths))
-                j = out.index[op.axis]
-                start_pos = cum_sort_lengths[j]
-                end_pos = cum_sort_lengths[j + 1]
-                out_idx_start, out_idx_end = np.searchsorted(cum_out_sizes, [start_pos, end_pos])
-                out_idx_start = max(out_idx_start - 1, 0)
-                for out_idx in range(out_idx_start, out_idx_end):
-                    out_start_pos = cum_out_sizes[out_idx]
-                    out_end_pos = cum_out_sizes[out_idx + 1]
-                    s = max(start_pos, out_start_pos)
-                    size = max(min(end_pos, out_end_pos) - s, 0)
-                    s = max(0, s - start_pos)
-                    outs[out_idx, i] = sort_1d[s: s + size]
-
-            for idx in range(len(op.output_sizes)):
-                ctx[(op.outputs[0].key, str(idx))] = \
-                    tuple(ar if ar is not None else xp.empty((0,), dtype=out.dtype)
-                          for ar in outs[idx])
-
-    @classmethod
-    def _execute_reduce(cls, ctx, op):
-        in_chunk = op.inputs[0]
-        axis = op.axis
-        input_keys, _ = get_shuffle_input_keys_idxes(in_chunk)
-        raw_inputs = [ctx[(input_key, op.shuffle_key)] for input_key in input_keys]
-        flatten_inputs = []
-        for raw_input in raw_inputs:
-            flatten_inputs.extend(raw_input)
-        inputs, device_id, xp = as_same_device(flatten_inputs, device=op.device, ret_extra=True)
-        input_len = len(raw_inputs[0])
-        inputs = [inputs[i * input_len: (i + 1) * input_len]
-                  for i in range(len(raw_inputs))]
-        out = op.outputs[0]
-        extra_shape = list(out.shape)
-        extra_shape.pop(axis)
-
-        with device(device_id):
-            res = xp.empty(out.shape, dtype=out.dtype)
-            it = itertools.product(*(range(s) for i, s in enumerate(out.shape) if i != axis))
-            for inps in zip(*inputs):
-                slc = list(next(it))
-                slc.insert(op.axis, slice(None))
-                concat_1d = xp.concatenate(inps)
-                res[tuple(slc)] = concat_1d
-            ctx[out.key] = res.astype(res.dtype, order=out.order.value)
-
-    @classmethod
-    def execute(cls, ctx, op):
-        if op.stage == OperandStage.map:
-            cls._execute_map(ctx, op)
-        else:
-            cls._execute_reduce(ctx, op)
+                ctx[op.outputs[0].key] = xp.sort(a, axis=op.axis, **kw)
 
 
 _AVAILABLE_KINDS = {'QUICKSORT', 'MERGESORT', 'HEAPSORT', 'STABLE'}
 
 
-def sort(a, axis=-1, kind=None, parallel_kind=None, psrs_kinds=None, order=None):
+def _validate_sort_arguments(a, axis, kind, parallel_kind, psrs_kinds, order):
+    a = astensor(a)
+    if axis is None:
+        a = a.flatten()
+        axis = 0
+    else:
+        axis = validate_axis(a.ndim, axis)
+    if kind is not None:
+        raw_kind = kind
+        kind = kind.upper()
+        if kind not in _AVAILABLE_KINDS:
+            # check kind
+            raise ValueError('{} is an unrecognized kind of sort'.format(raw_kind))
+    if parallel_kind is not None:
+        raw_parallel_kind = parallel_kind
+        parallel_kind = parallel_kind.upper()
+        if parallel_kind not in {'PSRS'}:
+            raise ValueError('{} is an unrecognized kind of '
+                             'parallel sort'.format(raw_parallel_kind))
+    if psrs_kinds is not None:
+        if isinstance(psrs_kinds, (list, tuple)):
+            psrs_kinds = list(psrs_kinds)
+            if len(psrs_kinds) != 3:
+                raise ValueError('psrs_kinds should have 3 elements')
+            for i, psrs_kind in enumerate(psrs_kinds):
+                if psrs_kind is None:
+                    if i < 2:
+                        continue
+                    else:
+                        raise ValueError('3rd element of psrs_kinds '
+                                         'should be specified')
+                upper_psrs_kind = psrs_kind.upper()
+                if upper_psrs_kind not in _AVAILABLE_KINDS:
+                    raise ValueError('{} is an unrecognized kind '
+                                     'in psrs_kinds'.format(psrs_kind))
+        else:
+            raise TypeError('psrs_kinds should be list or tuple')
+    else:
+        psrs_kinds = ['quicksort', 'mergesort', 'mergesort']
+    order = validate_order(a.dtype, order)
+
+    return a, axis, kind, parallel_kind, psrs_kinds, order
+
+
+def sort(a, axis=-1, kind=None, parallel_kind=None, psrs_kinds=None,
+         order=None, return_index=False):
     r"""
     Return a sorted copy of a tensor.
 
@@ -690,6 +314,8 @@ def sort(a, axis=-1, kind=None, parallel_kind=None, psrs_kinds=None, order=None)
         be specified as a string, and not all fields need be specified,
         but unspecified fields will still be used, in the order in which
         they come up in the dtype, to break ties.
+    return_index: bool
+        Return indices as well if True.
 
     Returns
     -------
@@ -786,46 +412,10 @@ def sort(a, axis=-1, kind=None, parallel_kind=None, psrs_kinds=None, order=None)
            ('Arthur', 1.8, 41)],
           dtype=[('name', '|S10'), ('height', '<f8'), ('age', '<i4')])
     """
-    a = astensor(a)
-    if axis is None:
-        a = a.flatten()
-        axis = 0
-    else:
-        axis = validate_axis(a.ndim, axis)
-    if kind is not None:
-        raw_kind = kind
-        kind = kind.upper()
-        if kind not in _AVAILABLE_KINDS:
-            # check kind
-            raise ValueError('{} is an unrecognized kind of sort'.format(raw_kind))
-    if parallel_kind is not None:
-        raw_parallel_kind = parallel_kind
-        parallel_kind = parallel_kind.upper()
-        if parallel_kind not in {'PSRS'}:
-            raise ValueError('{} is an unrecognized kind of '
-                             'parallel sort'.format(raw_parallel_kind))
-    if psrs_kinds is not None:
-        if isinstance(psrs_kinds, (list, tuple)):
-            psrs_kinds = list(psrs_kinds)
-            if len(psrs_kinds) != 3:
-                raise ValueError('psrs_kinds should have 3 elements')
-            for i, psrs_kind in enumerate(psrs_kinds):
-                if psrs_kind is None:
-                    if i < 2:
-                        continue
-                    else:
-                        raise ValueError('3rd element of psrs_kinds '
-                                         'should be specified')
-                upper_psrs_kind = psrs_kind.upper()
-                if upper_psrs_kind not in _AVAILABLE_KINDS:
-                    raise ValueError('{} is an unrecognized kind '
-                                     'in psrs_kinds'.format(psrs_kind))
-        else:
-            raise TypeError('psrs_kinds should be list or tuple')
-    else:
-        psrs_kinds = ['quicksort', 'mergesort', 'mergesort']
-    order = validate_order(a.dtype, order)
-
-    op = TensorSort(axis=axis, kind=kind, parallel_kind=parallel_kind, order=order,
-                    psrs_kinds=psrs_kinds, dtype=a.dtype, gpu=a.op.gpu)
+    a, axis, kind, parallel_kind, psrs_kinds, order = \
+        _validate_sort_arguments(a, axis, kind, parallel_kind, psrs_kinds, order)
+    op = TensorSort(axis=axis, kind=kind, parallel_kind=parallel_kind,
+                    order=order, psrs_kinds=psrs_kinds,
+                    return_value=True, return_indices=return_index,
+                    dtype=a.dtype, gpu=a.op.gpu)
     return op(a)

--- a/mars/tensor/base/tests/test_base.py
+++ b/mars/tensor/base/tests/test_base.py
@@ -23,7 +23,7 @@ from mars.tensor.datasource import ones, tensor, arange, array, asarray, \
 from mars.tensor.base import transpose, broadcast_to, where, argwhere, array_split, \
     split, squeeze, result_type, repeat, copyto, isin, moveaxis, TensorCopyTo, \
     atleast_1d, atleast_2d, atleast_3d, ravel, searchsorted, unique, sort, \
-    partition, to_gpu, to_cpu
+    partition, topk, to_gpu, to_cpu
 from mars.operands import OperandStage
 from mars.tiles import get_tiled
 
@@ -796,3 +796,15 @@ class Test(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             partition(np.random.rand(10), [-11, 2])
+
+    def testTopk(self):
+        raw = np.random.rand(20)
+        a = tensor(raw, chunk_size=10)
+
+        t = topk(a, 2)
+        t = t.tiles()
+        self.assertEqual(t.op.parallel_kind, 'tree')
+
+        # t = topk(a, 3)
+        # t = t.tiles()
+        # self.assertEqual(t.op.parallel_kind, 'psrs')

--- a/mars/tensor/base/tests/test_base_execute.py
+++ b/mars/tensor/base/tests/test_base_execute.py
@@ -26,7 +26,7 @@ from mars.tensor.datasource import tensor, ones, zeros, arange
 from mars.tensor.base import copyto, transpose, moveaxis, broadcast_to, broadcast_arrays, where, \
     expand_dims, rollaxis, atleast_1d, atleast_2d, atleast_3d, argwhere, array_split, split, \
     hsplit, vsplit, dsplit, roll, squeeze, diff, ediff1d, flip, flipud, fliplr, repeat, tile, \
-    isin, searchsorted, unique, sort, argsort, partition, argpartition, topk, to_gpu, to_cpu
+    isin, searchsorted, unique, sort, argsort, partition, argpartition, topk, argtopk, to_gpu, to_cpu
 from mars.tests.core import require_cupy, ExecutorForTest
 
 
@@ -1437,27 +1437,70 @@ class Test(unittest.TestCase):
             a = a[(slice(None),) * axis + (slice(None, None, -1),)]
         return a[(slice(None),) * axis + (slice(k),)]
 
-    def testTopkExecution(self):
-        raw = np.random.rand(9, 10, 11)
+    @staticmethod
+    def _handle_result(result, axis, largest):
+        result = np.sort(result, axis=axis)
+        if largest:
+            ax = axis if axis is not None else 0
+            result = result[(slice(None),) * ax + (slice(None, None, -1),)]
+        return result
 
-        for chunk_size in [11, 4]:
+    def testTopkExecution(self):
+        raw = np.random.rand(5, 6, 7)
+
+        for chunk_size in [7, 2]:
             a = tensor(raw, chunk_size=chunk_size)
             for axis in [0, 1, 2, None]:
                 size = raw.shape[axis] if axis is not None else raw.size
                 for largest in [True, False]:
                     for to_sort in [True, False]:
                         for parallel_kind in ['tree']:
-                            for k in [2, size -2, size, size + 2]:
+                            for k in [2, size - 2, size, size + 2]:
                                 r = topk(a, k, axis=axis, largest=largest,
                                          sorted=to_sort, parallel_kind=parallel_kind)
 
                                 result = self.executor.execute_tensor(r, concat=True)[0]
 
                                 if not to_sort:
-                                    result = np.sort(result, axis=axis)
-                                    if largest:
-                                        ax = axis if axis is not None else 0
-                                        result = result[(slice(None),) * ax + (slice(None, None, -1),)]
-
+                                    result = self._handle_result(result, axis, largest)
                                 expected = self._topk_slow(raw, k, axis, largest)
                                 np.testing.assert_array_equal(result, expected)
+
+                                r = topk(a, k, axis=axis, largest=largest,
+                                         sorted=to_sort, parallel_kind=parallel_kind,
+                                         return_index=True)
+
+                                ta, ti = self.executor.execute_tensors(r)
+                                raw2 = raw
+                                if axis is None:
+                                    raw2 = raw.flatten()
+                                np.testing.assert_array_equal(ta, np.take_along_axis(raw2, ti, axis))
+                                if not to_sort:
+                                    ta = self._handle_result(ta, axis, largest)
+                                np.testing.assert_array_equal(ta, expected)
+
+    def testArgtopk(self):
+        # only 1 chunk when axis = -1
+        raw = np.random.rand(100, 10)
+        x = tensor(raw, chunk_size=10)
+
+        pa = argtopk(x, 3, parallel_kind='tree')
+
+        r = self.executor.execute_tensor(pa, concat=True)[0]
+        np.testing.assert_array_equal(np.sort(raw)[:, -1:-4:-1], np.take_along_axis(raw, r, axis=-1))
+
+        x = tensor(raw, chunk_size=(22, 4))
+
+        pa = argtopk(x, 3, parallel_kind='tree')
+
+        r = self.executor.execute_tensor(pa, concat=True)[0]
+        np.testing.assert_array_equal(np.sort(raw)[:, -1:-4:-1], np.take_along_axis(raw, r, axis=-1))
+
+        raw = np.random.rand(100)
+
+        x = tensor(raw, chunk_size=23)
+
+        pa = argtopk(x, 3, axis=0, parallel_kind='tree')
+
+        r = self.executor.execute_tensor(pa, concat=True)[0]
+        np.testing.assert_array_equal(np.sort(raw, axis=0)[-1:-4:-1], raw[r])

--- a/mars/tensor/base/topk.py
+++ b/mars/tensor/base/topk.py
@@ -1,0 +1,247 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+
+import numpy as np
+
+from ... import opcodes as OperandDef
+from ...config import options
+from ...serialize import ValueType, KeyField, Int64Field, Int32Field, \
+    BoolField, StringField, ListField
+from ...utils import ceildiv
+from ..operands import TensorOperand, TensorOperandMixin
+from ..datasource import tensor as astensor
+from ..array_utils import as_same_device, device
+from ..utils import validate_axis
+
+
+class TensorTopk(TensorOperand, TensorOperandMixin):
+    _op_type_ = OperandDef.TOPK
+
+    _input = KeyField('input')
+    _k = Int64Field('k')
+    _axis = Int32Field('axis')
+    _largest = BoolField('largest')
+    _sorted = BoolField('sorted')
+    _parallel_kind = StringField('parallel_kind')
+    _psrs_kinds = ListField('psrs_kinds', ValueType.string)
+
+    def __init__(self, k=None, axis=None, largest=None, sorted=None,
+                 parallel_kind=None, psrs_kinds=None, dtype=None,
+                 gpu=None, **kw):
+        super().__init__(_k=k, _axis=axis, _largest=largest, _sorted=sorted,
+                         _parallel_kind=parallel_kind, _psrs_kinds=psrs_kinds,
+                         _dtype=dtype, _gpu=gpu, **kw)
+
+    @property
+    def input(self):
+        return self._input
+
+    @property
+    def k(self):
+        return self._k
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @property
+    def largest(self):
+        return self._largest
+
+    @property
+    def sorted(self):
+        return self._sorted
+
+    @property
+    def parallel_kind(self):
+        return self._parallel_kind
+
+    @property
+    def psrs_kinds(self):
+        return self._psrs_kinds
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        self._input = self._inputs[0]
+
+    def __call__(self, a):
+        shape = list(a.shape)
+        shape[self._axis] = min(a.shape[self._axis], self._k)
+        return self.new_tensor([a], shape=tuple(shape), order=a.order)
+
+    @classmethod
+    def _tile_one_chunk(cls, op):
+        out = op.outputs[0]
+        chunk_op = op.copy().reset_key()
+        chunk = chunk_op.new_chunk([op.input.chunks[0]], shape=out.shape,
+                                   order=out.order)
+        new_op = op.copy()
+        return new_op.new_tensors(op.inputs, shape=out.shape, order=out.order,
+                                  chunks=[chunk], nsplits=tuple((s,) for s in out.shape))
+
+    @classmethod
+    def _tile_via_psrs(cls, op):
+        pass
+
+    @classmethod
+    def _gen_topk_chunk(cls, input_chunk, op, is_terminate_node, chunk_index=None):
+        chunk_op = op.copy().reset_key()
+        if not is_terminate_node:
+            # no need to sort if not the terminated node
+            chunk_op._sorted = False
+        shape = list(input_chunk.shape)
+        shape[op.axis] = min(op.k, input_chunk.shape[op.axis])
+        return chunk_op.new_chunk([input_chunk], shape=tuple(shape),
+                                  order=input_chunk.order,
+                                  index=chunk_index)
+
+    @classmethod
+    def _merge_chunks(cls, input_chunks, axis):
+        from ..merge import TensorConcatenate
+
+        if len(input_chunks) == 1:
+            return input_chunks[0]
+
+        shape = list(input_chunks[0].shape)
+        shape[axis] = sum(c.shape[axis] for c in input_chunks)
+
+        merge_op = TensorConcatenate(axis=axis, dtype=input_chunks[0].dtype)
+        return merge_op.new_chunk(input_chunks, shape=tuple(shape),
+                                  order=input_chunks[0].order)
+
+    @classmethod
+    def _tile_via_tree(cls, op):
+        a = op.input
+        axis = op.axis
+        out = op.outputs[0]
+        combine_size = options.combine_size
+
+        out_chunks = []
+        for other_idx in itertools.product(
+                *(range(s) for i, s in enumerate(a.chunk_shape) if i != axis)):
+            merge_chunks = []
+            for j in range(a.chunk_shape[axis]):
+                idx = list(other_idx)
+                idx.insert(axis, j)
+                input_chunk = a.cix[tuple(idx)]
+                merge_chunks.append(cls._gen_topk_chunk(input_chunk, op, False))
+            while len(merge_chunks) > combine_size:
+                new_size = ceildiv(len(merge_chunks), combine_size)
+                new_merge_chunks = []
+                for i in range(new_size):
+                    to_merge_chunks = merge_chunks[i * combine_size: (i + 1) * combine_size]
+                    merge_chunk = cls._merge_chunks(to_merge_chunks, axis)
+                    topk_chunk = cls._gen_topk_chunk(merge_chunk, op, False)
+                    new_merge_chunks.append(topk_chunk)
+                merge_chunks = new_merge_chunks
+
+            merge_chunk = cls._merge_chunks(merge_chunks, axis)
+            chunk_index = list(other_idx)
+            chunk_index.insert(axis, 0)
+            out_chunks.append(cls._gen_topk_chunk(merge_chunk, op, True,
+                                                  chunk_index=tuple(chunk_index)))
+
+        new_op = op.copy()
+        nsplits = list(a.nsplits)
+        nsplits[axis] = (op.k,)
+        return new_op.new_tensors(op.inputs, shape=out.shape, order=out.order,
+                                  chunks=out_chunks, nsplits=tuple(nsplits))
+
+    @classmethod
+    def tile(cls, op):
+        a = op.input
+        combine_size = options.combine_size
+        k = op.k
+        axis = op.axis
+
+        if len(a.chunks) == 1:
+            return cls._tile_one_chunk(op)
+
+        parallel_kind = op.parallel_kind.lower()
+
+        if parallel_kind == 'auto':
+            nsplit = a.nsplits[axis]
+            max_chunk_size = max(nsplit)
+            if np.isnan(max_chunk_size):
+                # has unknown chunk shape and k > 100 just choose 'psrs'
+                parallel_kind = 'psrs' if k > 100 else 'tree'
+            else:
+                if combine_size * k <= max_chunk_size:
+                    # each chunk will have k elements on specified axis,
+                    # if combined chunk which generated in the tree reduction
+                    # is less than max chunk size, parallel kind `tree` will be adopted
+                    parallel_kind = 'tree'
+                else:
+                    parallel_kind = 'psrs'
+
+        if parallel_kind == 'tree':
+            op._parallel_kind = 'tree'
+            return cls._tile_via_tree(op)
+        else:
+            assert parallel_kind == 'psrs'
+            op._parallel_kind = 'psrs'
+            return cls._tile_via_psrs(op)
+
+    @classmethod
+    def execute(cls, ctx, op):
+        (a,), device_id, xp = as_same_device(
+            [ctx[inp.key] for inp in op.inputs], device=op.device, ret_extra=True)
+        out = op.outputs[0]
+        k = op.k
+        axis = op.axis
+        to_sort = op.sorted
+        largest = op.largest
+
+        with device(device_id):
+            size = a.shape[axis]
+            base_slc = (slice(None),) * axis
+
+            if k >= size:
+                if to_sort:
+                    a = xp.sort(a, axis=axis)
+                if largest:
+                    a = a[base_slc + (slice(None, None, -1),)]
+                ctx[out.key] = a
+                return
+
+            if largest:
+                length = size - k
+                a = xp.partition(a, length, axis=axis)[base_slc + (slice(-k, None),)]
+                if to_sort:
+                    # sort then reverse
+                    a = xp.sort(a, axis=axis)[base_slc + (slice(None, None, -1),)]
+            else:
+                a = xp.partition(a, k, axis=axis)[base_slc + (slice(k),)]
+                if to_sort:
+                    a = xp.sort(a, axis=axis)
+
+            ctx[out.key] = a
+
+
+def topk(a, k, axis=-1, largest=True, sorted=True, parallel_kind='auto', psrs_kinds=None):
+    a = astensor(a)
+    if axis is None:
+        a = a.flatten()
+        axis = 0
+    else:
+        axis = validate_axis(a.ndim, axis)
+    if parallel_kind.lower() not in {'auto', 'tree', 'psrs'}:
+        raise ValueError('`parallel_kind` could only be `auto`, `tree`, or `psrs`')
+
+    op = TensorTopk(k=k, axis=axis, largest=largest, sorted=sorted,
+                    parallel_kind=parallel_kind, psrs_kinds=psrs_kinds,
+                    dtype=a.dtype)
+    return op(a)

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -787,9 +787,86 @@ def require_module(module: str):
             return
     return wrap
 
+
 def ignore_warning(func):
     def inner(*args, **kwargs):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
             return func(*args, **kwargs)
     return inner
+
+
+def flatten(nested_iterable):
+    """
+    Flatten a nested iterable into a list.
+
+    Parameters
+    ----------
+    nested_iterable : list or tuple
+        an iterable which can contain other iterables
+
+    Returns
+    -------
+    flattened : list
+
+    Examples
+    --------
+    >>> flatten([[0, 1], [2, 3]])
+    [0, 1, 2, 3]
+    >>> flatten([[0, 1], [[3], [4, 5]]])
+    [0, 1, 3, 4, 5]
+    """
+
+    flattened = []
+    stack = list(nested_iterable)[::-1]
+    while len(stack) > 0:
+        inp = stack.pop()
+        if isinstance(inp, (tuple, list)):
+            stack.extend(inp[::-1])
+        else:
+            flattened.append(inp)
+    return flattened
+
+
+def stack_back(flattened, raw):
+    """
+    Organize a new iterable from a flattened list according to raw iterable.
+
+    Parameters
+    ----------
+    flattened : list
+        flattened list
+    raw: list
+        raw iterable
+
+    Returns
+    -------
+    ret : list
+
+    Examples
+    --------
+    >>> raw = [[0, 1], [2, [3, 4]]]
+    >>> flattened = flatten(raw)
+    >>> flattened
+    [0, 1, 2, 3, 4]
+    >>> a = [f + 1 for f in flattened]
+    >>> a
+    [1, 2, 3, 4, 5]
+    >>> stack_back(a, raw)
+    [[1, 2], [3, [4, 5]]]
+    """
+    flattened_iter = iter(flattened)
+    result = list()
+
+    def _stack(container, items):
+        for item in items:
+            if not isinstance(item, (list, tuple)):
+                container.append(next(flattened_iter))
+            else:
+                new_container = list()
+                container.append(new_container)
+                _stack(new_container, item)
+
+        return container
+
+    return _stack(result, raw)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR introduces `topk` which described in #943 . 

PSRS has been refactored to support return indices, thus `argsort`, `argpartition`, `argtopk` are added as well.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #943 .
