### PR TITLE
[BACKPORT] Fix tile in nonzero that tensor instead of tensor data should be used during the process (#954)

### DIFF
--- a/mars/tensor/indexing/nonzero.py
+++ b/mars/tensor/indexing/nonzero.py
@@ -47,7 +47,7 @@ class TensorNonzero(TensorHasInput, TensorOperandMixin):
     def tile(cls, op):
         from ..datasource import arange
 
-        in_tensor = op.input
+        in_tensor = astensor(op.input)
 
         flattened = in_tensor.astype(bool).flatten()
         recursive_tile(flattened)

--- a/mars/tensor/indexing/tests/test_indexing_execute.py
+++ b/mars/tensor/indexing/tests/test_indexing_execute.py
@@ -526,6 +526,13 @@ class Test(unittest.TestCase):
 
         np.testing.assert_array_equal(res, expected)
 
+        t = hstack((x > 1).nonzero())
+
+        res = self.executor.execute_tensor(t, concat=True)[0]
+        expected = np.hstack(np.nonzero(data > 1))
+
+        np.testing.assert_array_equal(res, expected)
+
     def testFlatnonzeroExecution(self):
         x = arange(-2, 3, chunk_size=2)
 


### PR DESCRIPTION
## What do these changes do?

Backport of #954

## Related issue number

NA