### PR TITLE
Support ufunc for Mars DataFrame

### DIFF
--- a/mars/dataframe/__init__.py
+++ b/mars/dataframe/__init__.py
@@ -28,8 +28,9 @@ from . import merge
 from . import reduction
 from . import statistics
 from . import groupby
+from . import ufunc
 
-del reduction, statistics, arithmetic, indexing, merge, base, groupby
+del reduction, statistics, arithmetic, indexing, merge, base, groupby, ufunc
 del DataFrameFetch, DataFrameFetchShuffle
 
 # noinspection PyUnresolvedReferences

--- a/mars/dataframe/arithmetic/__init__.py
+++ b/mars/dataframe/arithmetic/__init__.py
@@ -42,6 +42,14 @@ from .arctan import DataFrameArctan
 from .arcsinh import DataFrameArcsinh
 from .arccosh import DataFrameArccosh
 from .arctanh import DataFrameArctanh
+from .radians import DataFrameRadians
+from .degrees import DataFrameDegrees
+from .ceil import DataFrameCeil
+from .floor import DataFrameFloor
+from .around import DataFrameAround, round
+from .exp import DataFrameExp
+from .exp2 import DataFrameExp2
+from .expm1 import DataFrameExpm1
 
 
 def _wrap_eq():
@@ -80,12 +88,16 @@ def _install():
         DataFrameSinh, DataFrameCosh, DataFrameTanh,
         DataFrameArcsin, DataFrameArccos, DataFrameArctan,
         DataFrameArcsinh, DataFrameArccosh, DataFrameArctanh,
+        DataFrameRadians, DataFrameDegrees,
+        DataFrameCeil, DataFrameFloor, DataFrameAround,
+        DataFrameExp, DataFrameExp2, DataFrameExpm1,
     ]
     for unary_op in unary_ops:
         register_tensor_unary_ufunc(unary_op)
 
     for entity in DATAFRAME_TYPE + SERIES_TYPE:
         setattr(entity, 'abs', abs)
+        setattr(entity, 'round', round)
 
         setattr(entity, '__add__', wrap_notimplemented_exception(add))
         setattr(entity, '__radd__', wrap_notimplemented_exception(radd))

--- a/mars/dataframe/arithmetic/__init__.py
+++ b/mars/dataframe/arithmetic/__init__.py
@@ -28,6 +28,20 @@ from .greater import gt, DataFrameGreater
 from .less_equal import le, DataFrameLessEqual
 from .greater_equal import ge, DataFrameGreaterEqual
 from .log import DataFrameLog
+from .log2 import DataFrameLog2
+from .log10 import DataFrameLog10
+from .sin import DataFrameSin
+from .cos import DataFrameCos
+from .tan import DataFrameTan
+from .sinh import DataFrameSinh
+from .cosh import DataFrameCosh
+from .tanh import DataFrameTanh
+from .arcsin import DataFrameArcsin
+from .arccos import DataFrameArccos
+from .arctan import DataFrameArctan
+from .arcsinh import DataFrameArcsinh
+from .arccosh import DataFrameArccosh
+from .arctanh import DataFrameArctanh
 
 
 def _wrap_eq():
@@ -60,8 +74,15 @@ def _install():
     from ..core import DATAFRAME_TYPE, SERIES_TYPE
 
     # register mars unary ufuncs
-    register_tensor_unary_ufunc(DataFrameAbs)
-    register_tensor_unary_ufunc(DataFrameLog)
+    unary_ops = [
+        DataFrameAbs, DataFrameLog, DataFrameLog2, DataFrameLog10,
+        DataFrameSin, DataFrameCos, DataFrameTan,
+        DataFrameSinh, DataFrameCosh, DataFrameTanh,
+        DataFrameArcsin, DataFrameArccos, DataFrameArctan,
+        DataFrameArcsinh, DataFrameArccosh, DataFrameArctanh,
+    ]
+    for unary_op in unary_ops:
+        register_tensor_unary_ufunc(unary_op)
 
     for entity in DATAFRAME_TYPE + SERIES_TYPE:
         setattr(entity, 'abs', abs)

--- a/mars/dataframe/arithmetic/__init__.py
+++ b/mars/dataframe/arithmetic/__init__.py
@@ -16,7 +16,7 @@ from ...core import build_mode
 from ..core import DATAFRAME_TYPE
 from ..utils import wrap_notimplemented_exception
 from ..ufunc.tensor import register_tensor_unary_ufunc
-from .abs import abs, DataFrameAbs
+from .abs import abs_, DataFrameAbs
 from .add import add, radd, DataFrameAdd
 from .subtract import subtract, rsubtract, DataFrameSubtract
 from .floordiv import floordiv, rfloordiv, DataFrameFloorDiv
@@ -46,7 +46,7 @@ from .radians import DataFrameRadians
 from .degrees import DataFrameDegrees
 from .ceil import DataFrameCeil
 from .floor import DataFrameFloor
-from .around import DataFrameAround, round
+from .around import DataFrameAround, around
 from .exp import DataFrameExp
 from .exp2 import DataFrameExp2
 from .expm1 import DataFrameExpm1
@@ -96,8 +96,9 @@ def _install():
         register_tensor_unary_ufunc(unary_op)
 
     for entity in DATAFRAME_TYPE + SERIES_TYPE:
-        setattr(entity, 'abs', abs)
-        setattr(entity, 'round', round)
+        setattr(entity, '__abs__', abs_)
+        setattr(entity, 'abs', abs_)
+        setattr(entity, 'round', around)
 
         setattr(entity, '__add__', wrap_notimplemented_exception(add))
         setattr(entity, '__radd__', wrap_notimplemented_exception(radd))

--- a/mars/dataframe/arithmetic/__init__.py
+++ b/mars/dataframe/arithmetic/__init__.py
@@ -15,6 +15,7 @@
 from ...core import build_mode
 from ..core import DATAFRAME_TYPE
 from ..utils import wrap_notimplemented_exception
+from ..ufunc.tensor import register_tensor_unary_ufunc
 from .abs import abs, DataFrameAbs
 from .add import add, radd, DataFrameAdd
 from .subtract import subtract, rsubtract, DataFrameSubtract
@@ -26,6 +27,7 @@ from .less import lt, DataFrameLess
 from .greater import gt, DataFrameGreater
 from .less_equal import le, DataFrameLessEqual
 from .greater_equal import ge, DataFrameGreaterEqual
+from .log import DataFrameLog
 
 
 def _wrap_eq():
@@ -56,6 +58,10 @@ def _wrap_comparison(func):
 
 def _install():
     from ..core import DATAFRAME_TYPE, SERIES_TYPE
+
+    # register mars unary ufuncs
+    register_tensor_unary_ufunc(DataFrameAbs)
+    register_tensor_unary_ufunc(DataFrameLog)
 
     for entity in DATAFRAME_TYPE + SERIES_TYPE:
         setattr(entity, 'abs', abs)

--- a/mars/dataframe/arithmetic/abs.py
+++ b/mars/dataframe/arithmetic/abs.py
@@ -27,6 +27,6 @@ class DataFrameAbs(DataFrameUnaryUfunc):
         return TensorAbsolute
 
 
-def abs(df):
+def abs_(df):
     op = DataFrameAbs()
     return op(df)

--- a/mars/dataframe/arithmetic/arccos.py
+++ b/mars/dataframe/arithmetic/arccos.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameArccos(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.ARCCOS
+    _func_name = 'arccos'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorArccos
+        return TensorArccos

--- a/mars/dataframe/arithmetic/arccosh.py
+++ b/mars/dataframe/arithmetic/arccosh.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameArccosh(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.ARCCOSH
+    _func_name = 'arccosh'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorArccosh
+        return TensorArccosh

--- a/mars/dataframe/arithmetic/arcsin.py
+++ b/mars/dataframe/arithmetic/arcsin.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameArcsin(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.ARCSIN
+    _func_name = 'arcsin'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorArcsin
+        return TensorArcsin

--- a/mars/dataframe/arithmetic/arcsinh.py
+++ b/mars/dataframe/arithmetic/arcsinh.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameArcsinh(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.ARCSINH
+    _func_name = 'arcsinh'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorArcsinh
+        return TensorArcsinh

--- a/mars/dataframe/arithmetic/arctan.py
+++ b/mars/dataframe/arithmetic/arctan.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameArctan(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.ARCTAN
+    _func_name = 'arctan'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorArctan
+        return TensorArctan

--- a/mars/dataframe/arithmetic/arctanh.py
+++ b/mars/dataframe/arithmetic/arctanh.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameArctanh(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.ARCTANH
+    _func_name = 'arctanh'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorArctanh
+        return TensorArctanh

--- a/mars/dataframe/arithmetic/around.py
+++ b/mars/dataframe/arithmetic/around.py
@@ -1,0 +1,56 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from ... import opcodes as OperandDef
+from ...serialize import Int32Field
+from ...utils import classproperty
+from .core import DataFrameUnaryUfunc
+
+
+class DataFrameAround(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.AROUND
+    _func_name = 'around'
+
+    _decimals = Int32Field('decimals')
+
+    def __init__(self, decimals=None, object_type=None, **kw):
+        super().__init__(_decimals=decimals, object_type=object_type, **kw)
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorAround
+        return TensorAround
+
+    @property
+    def decimals(self):
+        return self._decimals
+
+    @classmethod
+    def execute(cls, ctx, op):
+        df = ctx[op.inputs[0].key]
+        func_name = getattr(cls, '_func_name')
+        if hasattr(df, func_name):
+            ctx[op.outputs[0].key] = getattr(df, func_name)(decimals=op.decimals)
+        else:
+            ctx[op.outputs[0].key] = getattr(np, func_name)(df, decimals=op.decimals)
+
+
+def round(df, decimals=0, *args, **kwargs):
+    if len(args) > 0:
+        raise TypeError('round() takes 0 positional arguments '
+                        'but {} was given'.format(len(args)))
+    op = DataFrameAround(decimals=decimals, **kwargs)
+    return op(df)

--- a/mars/dataframe/arithmetic/around.py
+++ b/mars/dataframe/arithmetic/around.py
@@ -48,7 +48,7 @@ class DataFrameAround(DataFrameUnaryUfunc):
             ctx[op.outputs[0].key] = getattr(np, func_name)(df, decimals=op.decimals)
 
 
-def round(df, decimals=0, *args, **kwargs):
+def around(df, decimals=0, *args, **kwargs):
     if len(args) > 0:
         raise TypeError('round() takes 0 positional arguments '
                         'but {} was given'.format(len(args)))

--- a/mars/dataframe/arithmetic/ceil.py
+++ b/mars/dataframe/arithmetic/ceil.py
@@ -1,0 +1,27 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameUnaryUfunc
+
+
+class DataFrameCeil(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.CEIL
+    _func_name = 'ceil'
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorCeil
+        return TensorCeil

--- a/mars/dataframe/arithmetic/cos.py
+++ b/mars/dataframe/arithmetic/cos.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameCos(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.COS
+    _func_name = 'cos'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorCos
+        return TensorCos

--- a/mars/dataframe/arithmetic/cosh.py
+++ b/mars/dataframe/arithmetic/cosh.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameCosh(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.COSH
+    _func_name = 'cosh'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorCosh
+        return TensorCosh

--- a/mars/dataframe/arithmetic/degrees.py
+++ b/mars/dataframe/arithmetic/degrees.py
@@ -1,0 +1,27 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameUnaryUfunc
+
+
+class DataFrameDegrees(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.DEGREES
+    _func_name = 'degrees'
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorDegrees
+        return TensorDegrees

--- a/mars/dataframe/arithmetic/exp.py
+++ b/mars/dataframe/arithmetic/exp.py
@@ -1,0 +1,27 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameUnaryUfunc
+
+
+class DataFrameExp(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.EXP
+    _func_name = 'exp'
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorExp
+        return TensorExp

--- a/mars/dataframe/arithmetic/exp2.py
+++ b/mars/dataframe/arithmetic/exp2.py
@@ -1,0 +1,27 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameUnaryUfunc
+
+
+class DataFrameExp2(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.EXP2
+    _func_name = 'exp2'
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorExp2
+        return TensorExp2

--- a/mars/dataframe/arithmetic/expm1.py
+++ b/mars/dataframe/arithmetic/expm1.py
@@ -1,0 +1,27 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameUnaryUfunc
+
+
+class DataFrameExpm1(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.EXPM1
+    _func_name = 'expm1'
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorExpm1
+        return TensorExpm1

--- a/mars/dataframe/arithmetic/floor.py
+++ b/mars/dataframe/arithmetic/floor.py
@@ -1,0 +1,27 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameUnaryUfunc
+
+
+class DataFrameFloor(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.FLOOR
+    _func_name = 'floor'
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorFloor
+        return TensorFloor

--- a/mars/dataframe/arithmetic/log.py
+++ b/mars/dataframe/arithmetic/log.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameLog(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.LOG
+    _func_name = 'log'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbs
-        return TensorAbs
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorLog
+        return TensorLog

--- a/mars/dataframe/arithmetic/log10.py
+++ b/mars/dataframe/arithmetic/log10.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameLog10(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.LOG10
+    _func_name = 'log10'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorLog10
+        return TensorLog10

--- a/mars/dataframe/arithmetic/log2.py
+++ b/mars/dataframe/arithmetic/log2.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameLog2(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.LOG2
+    _func_name = 'log2'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorLog2
+        return TensorLog2

--- a/mars/dataframe/arithmetic/radians.py
+++ b/mars/dataframe/arithmetic/radians.py
@@ -1,0 +1,27 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameUnaryUfunc
+
+
+class DataFrameRadians(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.RADIANS
+    _func_name = 'radians'
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorRadians
+        return TensorRadians

--- a/mars/dataframe/arithmetic/sin.py
+++ b/mars/dataframe/arithmetic/sin.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameSin(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.SIN
+    _func_name = 'sin'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorSin
+        return TensorSin

--- a/mars/dataframe/arithmetic/sinh.py
+++ b/mars/dataframe/arithmetic/sinh.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameSinh(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.SINH
+    _func_name = 'sinh'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorSinh
+        return TensorSinh

--- a/mars/dataframe/arithmetic/tan.py
+++ b/mars/dataframe/arithmetic/tan.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameTan(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.TAN
+    _func_name = 'tan'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorTan
+        return TensorTan

--- a/mars/dataframe/arithmetic/tanh.py
+++ b/mars/dataframe/arithmetic/tanh.py
@@ -17,16 +17,11 @@ from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
+class DataFrameTanh(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.TANH
+    _func_name = 'tanh'
 
     @classproperty
     def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbsolute
-        return TensorAbsolute
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+        from ...tensor.arithmetic import TensorTanh
+        return TensorTanh

--- a/mars/dataframe/arithmetic/tests/test_arithmetic.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic.py
@@ -27,7 +27,7 @@ from mars.dataframe.utils import split_monotonic_index_min_max, \
     build_split_idx_to_origin_idx, filter_index_value
 from mars.dataframe.datasource.dataframe import from_pandas, DataFrameDataSource
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series, SeriesDataSource
-from mars.dataframe.arithmetic import abs, DataFrameAbs, DataFrameAdd, DataFrameSubtract, \
+from mars.dataframe.arithmetic import DataFrameAbs, DataFrameAdd, DataFrameSubtract, \
     DataFrameFloorDiv, DataFrameTrueDiv, DataFrameEqual, DataFrameNotEqual, \
     DataFrameGreater, DataFrameLess, DataFrameGreaterEqual, DataFrameLessEqual
 from mars.dataframe.align import DataFrameIndexAlign, DataFrameShuffleProxy
@@ -1106,7 +1106,7 @@ class TestUnary(TestBase):
                              columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
         df1 = from_pandas(data1, chunk_size=(5, 10))
 
-        df2 = abs(df1)
+        df2 = df1.abs()
 
         # test df2's index and columns
         pd.testing.assert_index_equal(df2.columns_value.to_pandas(), df1.columns_value.to_pandas())

--- a/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
@@ -24,7 +24,6 @@ from mars import tensor as mt
 from mars.tensor.datasource import array as from_array
 from mars.dataframe.datasource.dataframe import from_pandas
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
-from mars.dataframe.arithmetic import abs
 from mars.dataframe.arithmetic.tests.test_arithmetic import comp_func
 
 
@@ -540,8 +539,11 @@ class TestUnary(TestBase):
         data1 = pd.DataFrame(np.random.uniform(low=-1, high=1, size=(10, 10)))
         df1 = from_pandas(data1, chunk_size=5)
 
-        result = self.executor.execute_dataframe(abs(df1), concat=True)[0]
+        result = self.executor.execute_dataframe(df1.abs(), concat=True)[0]
         expected = data1.abs()
+        pd.testing.assert_frame_equal(expected, result)
+
+        result = self.executor.execute_dataframe(abs(df1), concat=True)[0]
         pd.testing.assert_frame_equal(expected, result)
 
     def testUfunc(self):

--- a/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
@@ -14,6 +14,7 @@
 
 import operator
 import unittest
+from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -569,6 +570,14 @@ class TestUnary(TestBase):
             [np.arcsinh, mt.arcsinh],
             [np.arccosh, mt.arccosh],
             [np.arctanh, mt.arctanh],
+            [np.radians, mt.radians],
+            [np.degrees, mt.degrees],
+            [np.ceil, mt.ceil],
+            [np.floor, mt.floor],
+            [partial(np.around, decimals=2), partial(mt.around, decimals=2)],
+            [np.exp, mt.exp],
+            [np.exp2, mt.exp2],
+            [np.expm1, mt.expm1],
         ]
 
         for raw, data in [(df_raw, df), (series_raw, series)]:

--- a/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
@@ -544,7 +544,7 @@ class TestUnary(TestBase):
         pd.testing.assert_frame_equal(expected, result)
 
     def testUfunc(self):
-        df_raw = pd.DataFrame(np.random.uniform(low=-1, high=1, size=(10, 10)),
+        df_raw = pd.DataFrame(np.random.uniform(size=(10, 10)),
                               index=pd.RangeIndex(9, -1, -1))
         df = from_pandas(df_raw, chunk_size=5)
 
@@ -553,7 +553,22 @@ class TestUnary(TestBase):
         series = from_pandas_series(series_raw, chunk_size=5)
 
         ufuncs = [
-            [np.log, mt.log]
+            [np.abs, mt.abs],
+            [np.log, mt.log],
+            [np.log2, mt.log2],
+            [np.log10, mt.log10],
+            [np.sin, mt.sin],
+            [np.cos, mt.cos],
+            [np.tan, mt.tan],
+            [np.sinh, mt.sinh],
+            [np.cosh, mt.cosh],
+            [np.tanh, mt.tanh],
+            [np.arcsin, mt.arcsin],
+            [np.arccos, mt.arccos],
+            [np.arctan, mt.arctan],
+            [np.arcsinh, mt.arcsinh],
+            [np.arccosh, mt.arccosh],
+            [np.arctanh, mt.arctanh],
         ]
 
         for raw, data in [(df_raw, df), (series_raw, series)]:

--- a/mars/dataframe/ufunc/__init__.py
+++ b/mars/dataframe/ufunc/__init__.py
@@ -12,21 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ... import opcodes as OperandDef
-from ...utils import classproperty
-from .core import DataFrameUnaryUfunc
+
+def _install():
+    from ..core import DataFrame, Series
+    from .ufunc import _array_ufunc
+    from .tensor import _tensor_ufunc
+
+    for Entity in (DataFrame, Series):
+        Entity.__array_ufunc__ = _array_ufunc
+        Entity.__tensor_ufunc__ = _tensor_ufunc
 
 
-class DataFrameAbs(DataFrameUnaryUfunc):
-    _op_type_ = OperandDef.ABS
-    _func_name = 'abs'
-
-    @classproperty
-    def tensor_op_type(self):
-        from ...tensor.arithmetic import TensorAbs
-        return TensorAbs
-
-
-def abs(df):
-    op = DataFrameAbs()
-    return op(df)
+_install()
+del _install

--- a/mars/dataframe/ufunc/tensor.py
+++ b/mars/dataframe/ufunc/tensor.py
@@ -1,0 +1,53 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ...utils import classproperty
+
+
+_tensor_op_to_df_op = dict()
+
+
+def register_tensor_unary_ufunc(op):
+    _tensor_op_to_df_op[op.tensor_op_type] = op
+
+
+def get_tensor_ufunc_implementation(tensor_op):
+    if tensor_op in _tensor_op_to_df_op:
+        return _tensor_op_to_df_op[tensor_op]
+
+
+class TensorUfuncMixin:
+    __slots__ = ()
+
+    @classproperty
+    def tensor_op_type(self):
+        raise NotImplementedError
+
+    @classmethod
+    def ufunc_call(cls, tensor_op, inputs, out, **kw):
+        if out is not None:
+            return NotImplemented
+
+        try:
+            op = _tensor_op_to_df_op[tensor_op](**kw)
+            return op(*inputs)
+        except (KeyError, TypeError):
+            return NotImplemented
+
+
+def _tensor_ufunc(_, tensor_op, inputs, out, **kw):
+    op = get_tensor_ufunc_implementation(tensor_op)
+    if op is not None:
+        return op.ufunc_call(tensor_op, inputs, out, **kw)
+    return NotImplemented

--- a/mars/dataframe/ufunc/tensor.py
+++ b/mars/dataframe/ufunc/tensor.py
@@ -35,9 +35,11 @@ class TensorUfuncMixin:
         raise NotImplementedError
 
     @classmethod
-    def ufunc_call(cls, tensor_op, inputs, out, **kw):
+    def ufunc_call(cls, tensor_op, inputs, out, where, **kw):
         if out is not None:
             return NotImplemented
+        if where is not None:
+            raise NotImplementedError
 
         try:
             op = _tensor_op_to_df_op[tensor_op](**kw)
@@ -46,8 +48,8 @@ class TensorUfuncMixin:
             return NotImplemented
 
 
-def _tensor_ufunc(_, tensor_op, inputs, out, **kw):
+def _tensor_ufunc(_, tensor_op, inputs, out, where, **kw):
     op = get_tensor_ufunc_implementation(tensor_op)
     if op is not None:
-        return op.ufunc_call(tensor_op, inputs, out, **kw)
+        return op.ufunc_call(tensor_op, inputs, out, where, **kw)
     return NotImplemented

--- a/mars/dataframe/ufunc/ufunc.py
+++ b/mars/dataframe/ufunc/ufunc.py
@@ -1,0 +1,53 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from numbers import Number
+
+from ...tensor import tensor as astensor
+from ...tensor.ufunc.ufunc import UFUNC_TO_TENSOR_FUNC
+from ..core import DATAFRAME_TYPE, SERIES_TYPE
+
+
+def _check_arg(arg):
+    if isinstance(arg, Number):
+        return True
+
+    if isinstance(arg, (DATAFRAME_TYPE, SERIES_TYPE)):
+        return True
+
+    try:
+        astensor(arg)
+        return True
+    except ValueError:
+        return False
+
+
+def _array_ufunc(_, ufunc, method, *inputs, **kwargs):
+    out = kwargs.get('out', tuple())
+    for x in inputs + out:
+        if not _check_arg(x):
+            return NotImplemented
+
+    if method == '__call__':
+        if ufunc.signature is not None:
+            return NotImplemented
+        if ufunc not in UFUNC_TO_TENSOR_FUNC:
+            return NotImplemented
+
+        # we delegate numpy ufunc to tensor ufunc,
+        # tensor ufunc will handle Mars DataFrame properly.
+        tensor_func = UFUNC_TO_TENSOR_FUNC[ufunc]
+        return tensor_func(*inputs, **kwargs)
+
+    return NotImplemented

--- a/mars/tensor/arithmetic/around.py
+++ b/mars/tensor/arithmetic/around.py
@@ -40,6 +40,10 @@ class TensorAround(TensorUnaryOp):
         super().__init__(_decimals=decimals, _casting=casting, _err=err, _dtype=dtype,
                          _sparse=sparse, **kw)
 
+    @property
+    def ufunc_extra_params(self):
+        return {'decimals': self._decimals}
+
     @classmethod
     def execute(cls, ctx, op):
         (a,), device_id, xp = as_same_device(

--- a/mars/tensor/arithmetic/core.py
+++ b/mars/tensor/arithmetic/core.py
@@ -402,9 +402,14 @@ class TensorUnaryOp(TensorOperand, TensorUnaryOpMixin):
         else:
             return TensorOrder.F_ORDER
 
+    @property
+    def ufunc_extra_params(self):
+        return dict()
+
     def _call_tensor_ufunc(self, x, out=None, where=None):
         if hasattr(x, '__tensor_ufunc__'):
-            ret = x.__tensor_ufunc__(type(self), [x], out, where=where)
+            ret = x.__tensor_ufunc__(type(self), [x], out, where,
+                                     **self.ufunc_extra_params)
             if ret is NotImplemented:
                 return
             return ret

--- a/mars/tensor/utils.py
+++ b/mars/tensor/utils.py
@@ -443,8 +443,6 @@ def decide_unify_split(*splits):
 
 
 def unify_nsplits(*tensor_axes):
-    from .rechunk import rechunk
-
     tensor_splits = [dict((a, split) for a, split in zip(axes, t.nsplits) if split != (1,))
                      for t, axes in tensor_axes if t.nsplits]
     common_axes = reduce(operator.and_, [set(ts.keys()) for ts in tensor_splits]) if tensor_splits else set()
@@ -458,7 +456,7 @@ def unify_nsplits(*tensor_axes):
     for t, axes in tensor_axes:
         new_chunk = dict((i, axes_unified_splits[ax]) for ax, i in zip(axes, range(t.ndim))
                          if ax in axes_unified_splits)
-        res.append(rechunk(t, new_chunk)._inplace_tile())
+        res.append(t.rechunk(new_chunk)._inplace_tile())
 
     return tuple(res)
 

--- a/mars/tensor/utils.py
+++ b/mars/tensor/utils.py
@@ -215,21 +215,32 @@ def infer_dtype(np_func, empty=True, reverse=False, check=True):
                 arg = arg.op.data
             return arg[(0,) * max(1, arg.ndim)]
 
+    tensor_ufunc = '__tensor_ufunc__'
+
+    def is_arg(arg):
+        if hasattr(arg, tensor_ufunc):
+            return False
+        return hasattr(arg, 'ndim') and hasattr(arg, 'dtype')
+
     def inner(func):
         @wraps(func)
         def h(*tensors, **kw):
             usr_dtype = np.dtype(kw.pop('dtype')) if 'dtype' in kw else None
-            args = [make_arg(t) if hasattr(t, 'ndim') and hasattr(t, 'dtype') else t
-                    for t in tensors]
+            args = [make_arg(t) if is_arg(t) else t for t in tensors]
             if reverse:
                 args = args[::-1]
-            np_kw = dict((k, make_arg(v) if hasattr(v, 'ndim') and hasattr(v, 'dtype') else v)
-                         for k, v in kw.items() if k != 'out')
-            try:
-                with np.errstate(all='ignore'):
-                    dtype = np_func(*args, **np_kw).dtype
-            except:  # noqa: E722
-                dtype = None
+            np_kw = dict((k, v) for k, v in kw.items() if is_arg(v) and k != 'out')
+
+            dtype = None
+            if not any(hasattr(arg, tensor_ufunc)
+                       for arg in itertools.chain(args, np_kw.values())):
+                # skip infer if encounter mars DataFrame etc
+                # that implements __tensor_ufunc__
+                try:
+                    with np.errstate(all='ignore'):
+                        dtype = np_func(*args, **np_kw).dtype
+                except:  # noqa: E722
+                    dtype = None
 
             if usr_dtype and dtype:
                 can_cast_kwargs = {}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR introduces ufunc support for Mars DataFrame.

```
In[3]: import mars.dataframe as md

In[4]: import mars.tensor as mt

In[5]: df = md.DataFrame(mt.random.rand(4, 3))

In[6]: mt.log(df).execute()
Out[6]: 
          0         1         2
0 -0.063738 -0.651971 -0.607466
1 -3.262621 -0.167953 -3.122273
2 -2.715058 -4.306482 -0.030491
3 -1.339124 -0.573078 -4.276256
```

Tasks:

- [x] Support ufunc mechanism
- [x] Support more unary opeartions

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA
