### PR TITLE
Support `mars.learn.neighbors.NearestNeighbors`

### DIFF
--- a/mars/learn/metrics/pairwise/__init__.py
+++ b/mars/learn/metrics/pairwise/__init__.py
@@ -16,4 +16,4 @@ from .euclidean import euclidean_distances
 from .haversine import haversine_distances
 from .manhattan import manhattan_distances
 from .cosine import cosine_distances, cosine_similarity
-from .pairwise import pairwise_distances
+from .pairwise import pairwise_distances, PAIRWISE_DISTANCE_FUNCTIONS

--- a/mars/learn/neighbors/__init__.py
+++ b/mars/learn/neighbors/__init__.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# register operands
-from .utils.shuffle import shuffle
-from .contrib import xgboost, tensorflow, pytorch
-from .metrics import pairwise
-from . import preprocessing
-from . import neighbors
+try:
+    from .unsupervised import NearestNeighbors
+except ImportError:  # pragma: no cover
+    pass
 
-for _mod in [xgboost, tensorflow, pytorch, neighbors]:
-    _mod.register_op()
 
-del _mod, shuffle, pairwise, preprocessing
+def register_op():
+    from .ball_tree import BallTree, BallTreeQuery
+    from .kd_tree import KDTree, KDTreeQuery
+
+    del BallTree, BallTreeQuery, KDTree, KDTreeQuery

--- a/mars/learn/neighbors/ball_tree.py
+++ b/mars/learn/neighbors/ball_tree.py
@@ -18,26 +18,20 @@ except ImportError:  # pragma: no cover
     SkBallTree = None
 
 from ... import opcodes as OperandDef
-from ...utils import classproperty, require_not_none
+from ...utils import require_not_none
 from .tree import TreeBase, TreeQueryBase
 
 
 @require_not_none(SkBallTree)
 class _BallTree(TreeBase):
     _op_type_ = OperandDef.BALL_TREE_TRAIN
-
-    @classproperty
-    def _tree_type(self):
-        return SkBallTree
+    _tree_type = SkBallTree
 
 
 @require_not_none(SkBallTree)
 class BallTreeQuery(TreeQueryBase):
     _op_type_ = OperandDef.BALL_TREE_QUERY
-
-    @classproperty
-    def _tree_type(self):
-        return SkBallTree
+    _tree_type = SkBallTree
 
 
 @require_not_none(SkBallTree)

--- a/mars/learn/neighbors/ball_tree.py
+++ b/mars/learn/neighbors/ball_tree.py
@@ -1,0 +1,60 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    from sklearn.neighbors.ball_tree import BallTree as SkBallTree
+except ImportError:  # pragma: no cover
+    SkBallTree = None
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty, require_not_none
+from .tree import TreeBase, TreeQueryBase
+
+
+@require_not_none(SkBallTree)
+class _BallTree(TreeBase):
+    _op_type_ = OperandDef.BALL_TREE_TRAIN
+
+    @classproperty
+    def _tree_type(self):
+        return SkBallTree
+
+
+@require_not_none(SkBallTree)
+class BallTreeQuery(TreeQueryBase):
+    _op_type_ = OperandDef.BALL_TREE_QUERY
+
+    @classproperty
+    def _tree_type(self):
+        return SkBallTree
+
+
+@require_not_none(SkBallTree)
+def ball_tree_query(tree, data, n_neighbors, return_distance):
+    op = BallTreeQuery(tree=tree, n_neighbors=n_neighbors,
+                       return_distance=return_distance)
+    ret = op(data)
+    if not return_distance:
+        return ret[0]
+    return ret
+
+
+@require_not_none(SkBallTree)
+def BallTree(X, leaf_size, metric=None, **metric_params):
+    metric_func = None
+    if callable(metric):
+        metric_func, metric = metric, None
+    op = _BallTree(leaf_size=leaf_size, metric=metric, metric_func=metric_func,
+                   **metric_params)
+    return op(X)

--- a/mars/learn/neighbors/base.py
+++ b/mars/learn/neighbors/base.py
@@ -1,0 +1,354 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pickle
+import warnings
+from abc import ABCMeta, abstractmethod
+
+import numpy as np
+from sklearn.base import BaseEstimator, MultiOutputMixin
+from sklearn.neighbors.ball_tree import BallTree as SklearnBallTree
+from sklearn.neighbors.kd_tree import KDTree as SklearnKDTree
+
+from ... import tensor as mt
+from ..metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
+from ..metrics import pairwise_distances
+from ..utils import check_array
+from ..utils.validation import check_is_fitted
+from .ball_tree import BallTree, ball_tree_query
+from .kd_tree import KDTree, kd_tree_query
+
+
+VALID_METRICS = dict(ball_tree=SklearnBallTree.valid_metrics,
+                     kd_tree=SklearnKDTree.valid_metrics,
+                     # The following list comes from the
+                     # sklearn.metrics.pairwise doc string
+                     brute=(list(PAIRWISE_DISTANCE_FUNCTIONS.keys()) +
+                            ['braycurtis', 'canberra', 'chebyshev',
+                             'correlation', 'cosine', 'dice', 'hamming',
+                             'jaccard', 'kulsinski', 'mahalanobis',
+                             'matching', 'minkowski', 'rogerstanimoto',
+                             'russellrao', 'seuclidean', 'sokalmichener',
+                             'sokalsneath', 'sqeuclidean',
+                             'yule', 'wminkowski']))
+
+
+VALID_METRICS_SPARSE = dict(ball_tree=[],
+                            kd_tree=[],
+                            brute=(PAIRWISE_DISTANCE_FUNCTIONS.keys() -
+                                   {'haversine'}))
+
+
+class NeighborsBase(BaseEstimator, MultiOutputMixin, metaclass=ABCMeta):
+    """Base class for nearest neighbors estimators."""
+
+    @abstractmethod
+    def __init__(self, n_neighbors=None, radius=None,
+                 algorithm='auto', leaf_size=30, metric='minkowski',
+                 p=2, metric_params=None, n_jobs=None):
+
+        self.n_neighbors = n_neighbors
+        self.radius = radius
+        self.algorithm = algorithm
+        self.leaf_size = leaf_size
+        self.metric = metric
+        self.metric_params = metric_params
+        self.p = p
+        self.n_jobs = n_jobs
+        self._check_algorithm_metric()
+
+    def _check_algorithm_metric(self):
+        if self.algorithm not in ['auto', 'brute',
+                                  'kd_tree', 'ball_tree']:
+            raise ValueError("unrecognized algorithm: '%s'" % self.algorithm)
+
+        if self.algorithm == 'auto':
+            if self.metric == 'precomputed':
+                alg_check = 'brute'
+            elif (callable(self.metric) or
+                  self.metric in VALID_METRICS['ball_tree']):
+                alg_check = 'ball_tree'
+            else:
+                alg_check = 'brute'
+        else:
+            alg_check = self.algorithm
+
+        if callable(self.metric):
+            if self.algorithm == 'kd_tree':
+                # callable metric is only valid for brute force and ball_tree
+                raise ValueError(
+                    "kd_tree algorithm does not support callable metric '%s'"
+                    % self.metric)
+        elif self.metric not in VALID_METRICS[alg_check]:
+            raise ValueError("Metric '%s' not valid. Use "
+                             "sorted(sklearn.neighbors.VALID_METRICS['%s']) "
+                             "to get valid options. "
+                             "Metric can also be a callable function."
+                             % (self.metric, alg_check))
+
+        if self.metric_params is not None and 'p' in self.metric_params:
+            warnings.warn("Parameter p is found in metric_params. "
+                          "The corresponding parameter from __init__ "
+                          "is ignored.", SyntaxWarning, stacklevel=3)
+            effective_p = self.metric_params['p']
+        else:
+            effective_p = self.p
+
+        if self.metric in ['wminkowski', 'minkowski'] and effective_p < 1:
+            raise ValueError("p must be greater than one for minkowski metric")
+
+    def _fit(self, X, session=None, run_kwargs=None):
+        self._check_algorithm_metric()
+        if self.metric_params is None:
+            self.effective_metric_params_ = {}
+        else:
+            self.effective_metric_params_ = self.metric_params.copy()
+
+        effective_p = self.effective_metric_params_.get('p', self.p)
+        if self.metric in ['wminkowski', 'minkowski']:
+            self.effective_metric_params_['p'] = effective_p
+
+        self.effective_metric_ = self.metric
+        # For minkowski distance, use more efficient methods where available
+        if self.metric == 'minkowski':
+            p = self.effective_metric_params_.pop('p', 2)
+            if p < 1:
+                raise ValueError("p must be greater than one "
+                                 "for minkowski metric")
+            elif p == 1:
+                self.effective_metric_ = 'manhattan'
+            elif p == 2:
+                self.effective_metric_ = 'euclidean'
+            elif p == np.inf:
+                self.effective_metric_ = 'chebyshev'
+            else:
+                self.effective_metric_params_['p'] = p
+
+        if isinstance(X, NeighborsBase):
+            self._fit_X = X._fit_X
+            self._tree = X._tree
+            self._fit_method = X._fit_method
+            return self
+
+        elif isinstance(X, SklearnBallTree):
+            self._fit_X = X.data
+            self._tree = X
+            self._fit_method = 'ball_tree'
+            return self
+
+        elif isinstance(X, SklearnKDTree):
+            self._fit_X = X.data
+            self._tree = X
+            self._fit_method = 'kd_tree'
+            return self
+
+        X = check_array(X, accept_sparse=True)
+
+        n_samples = X.shape[0]
+        if n_samples == 0:
+            raise ValueError("n_samples must be greater than 0")
+
+        if X.issparse():
+            if self.algorithm not in ('auto', 'brute'):
+                warnings.warn("cannot use tree with sparse input: "
+                              "using brute force")
+            if self.effective_metric_ not in VALID_METRICS_SPARSE['brute'] \
+                    and not callable(self.effective_metric_):
+                raise ValueError("Metric '%s' not valid for sparse input. "
+                                 "Use sorted(sklearn.neighbors."
+                                 "VALID_METRICS_SPARSE['brute']) "
+                                 "to get valid options. "
+                                 "Metric can also be a callable function."
+                                 % (self.effective_metric_))
+            self._fit_X = X.copy()
+            self._tree = None
+            self._fit_method = 'brute'
+            return self
+
+        self._fit_method = self.algorithm
+        self._fit_X = X
+
+        if self._fit_method == 'auto':
+            # A tree approach is better for small number of neighbors,
+            # and KDTree is generally faster when available
+            if ((self.n_neighbors is None or
+                 self.n_neighbors < self._fit_X.shape[0] // 2) and
+                    self.metric != 'precomputed'):
+                if self.effective_metric_ in VALID_METRICS['kd_tree']:
+                    self._fit_method = 'kd_tree'
+                elif (callable(self.effective_metric_) or
+                      self.effective_metric_ in VALID_METRICS['ball_tree']):
+                    self._fit_method = 'ball_tree'
+                else:
+                    self._fit_method = 'brute'
+            else:
+                self._fit_method = 'brute'
+
+        if self._fit_method == 'ball_tree':
+            tree = BallTree(X, self.leaf_size,
+                            metric=self.effective_metric_,
+                            **self.effective_metric_params_)
+            self._tree = pickle.loads(
+                tree.execute(session=session, **(run_kwargs or dict())))
+        elif self._fit_method == 'kd_tree':
+            tree = KDTree(X, self.leaf_size,
+                          metric=self.effective_metric_,
+                          **self.effective_metric_params_)
+            self._tree = pickle.loads(
+                tree.execute(session=session, **(run_kwargs or dict())))
+        elif self._fit_method == 'brute':
+            self._tree = None
+        else:
+            raise ValueError("algorithm = '%s' not recognized"
+                             % self.algorithm)
+
+        if self.n_neighbors is not None:
+            if self.n_neighbors <= 0:
+                raise ValueError(
+                    "Expected n_neighbors > 0. Got %d" %
+                    self.n_neighbors
+                )
+            else:
+                if not np.issubdtype(type(self.n_neighbors), np.integer):
+                    raise TypeError(
+                        "n_neighbors does not take %s value, "
+                        "enter integer value" %
+                        type(self.n_neighbors))
+
+        return self
+
+    @property
+    def _pairwise(self):
+        # For cross-validation routines to split data correctly
+        return self.metric == 'precomputed'
+
+
+class KNeighborsMixin:
+    """Mixin for k-neighbors searches"""
+
+    def kneighbors(self, X=None, n_neighbors=None, return_distance=True,
+                   session=None, run_kwargs=None):
+        check_is_fitted(self, ["_fit_method", "_fit_X"], all_or_any=any)
+
+        if n_neighbors is None:
+            n_neighbors = self.n_neighbors
+        elif n_neighbors <= 0:
+            raise ValueError(
+                "Expected n_neighbors > 0. Got %d" %
+                n_neighbors
+            )
+        else:
+            if not np.issubdtype(type(n_neighbors), np.integer):
+                raise TypeError(
+                    "n_neighbors does not take %s value, "
+                    "enter integer value" %
+                    type(n_neighbors))
+
+        if X is not None:
+            query_is_train = False
+            X = check_array(X, accept_sparse=True)
+        else:
+            query_is_train = True
+            X = self._fit_X
+            # Include an extra neighbor to account for the sample itself being
+            # returned, which is removed later
+            n_neighbors += 1
+
+        train_size = self._fit_X.shape[0]
+        if n_neighbors > train_size:
+            raise ValueError(
+                "Expected n_neighbors <= n_samples, "
+                " but n_samples = %d, n_neighbors = %d" %
+                (train_size, n_neighbors)
+            )
+        n_samples, _ = X.shape
+        sample_range = mt.arange(n_samples)[:, None]
+
+        if self._fit_method == 'brute':
+            # for efficiency, use squared euclidean distances
+            kwds = ({'squared': True} if self.effective_metric_ == 'euclidean'
+                    else self.effective_metric_params_)
+
+            dist = pairwise_distances(X, self._fit_X, metric=self.effective_metric_,
+                                      **kwds)
+            neigh_dist, neigh_ind = mt.topk(dist, n_neighbors, largest=False, sorted=True,
+                                            return_index=True)
+            if return_distance:
+                if self.effective_metric_ == 'euclidean':
+                    result = mt.sqrt(neigh_dist), neigh_ind
+                else:
+                    result = neigh_dist, neigh_ind
+            else:
+                result = neigh_ind
+        elif self._fit_method in ['ball_tree', 'kd_tree']:
+            if X.issparse():
+                raise ValueError(
+                    "%s does not work with sparse matrices. Densify the data, "
+                    "or set algorithm='brute'" % self._fit_method)
+
+            query = ball_tree_query if self._fit_method == 'ball_tree' else kd_tree_query
+            result = query(self._tree, X, n_neighbors, return_distance)
+        else:
+            raise ValueError("internal: _fit_method not recognized")
+
+        if not query_is_train:
+            if isinstance(result, (tuple, list)):
+                result = mt.ExecutableTuple(result)
+            result.execute(session=session, fetch=False,
+                           **(run_kwargs or dict()))
+            return result
+        else:
+            # If the query data is the same as the indexed data, we would like
+            # to ignore the first nearest neighbor of every sample, i.e
+            # the sample itself.
+            if return_distance:
+                dist, neigh_ind = result
+            else:
+                neigh_ind = result
+
+            sample_mask = neigh_ind != sample_range
+
+            # Corner case: When the number of duplicates are more
+            # than the number of neighbors, the first NN will not
+            # be the sample, but a duplicate.
+            # In that case mask the first duplicate.
+            dup_gr_nbrs = mt.all(sample_mask, axis=1)
+            sample_mask[:, 0] = mt.where(dup_gr_nbrs, False, sample_mask[:, 0])
+
+            neigh_ind = mt.reshape(
+                neigh_ind[sample_mask], (n_samples, n_neighbors - 1))
+
+            if return_distance:
+                dist = mt.reshape(
+                    dist[sample_mask], (n_samples, n_neighbors))
+                ret = mt.ExecutableTuple([dist, neigh_ind])
+                ret.execute(session=session, fetch=False,
+                            **(run_kwargs or dict()))
+                return ret
+            neigh_ind.execute(session=session, fetch=False,
+                              **(run_kwargs or dict()))
+            return neigh_ind
+
+
+class UnsupervisedMixin:
+    def fit(self, X, y=None, session=None, run_kwargs=None):
+        """Fit the model using X as training data
+
+        Parameters
+        ----------
+        X : {array-like, tensor, BallTree, KDTree}
+            Training data. If tensor, shape [n_samples, n_features],
+            or [n_samples, n_samples] if metric='precomputed'.
+        """
+        return self._fit(X, session=session, run_kwargs=run_kwargs)

--- a/mars/learn/neighbors/kd_tree.py
+++ b/mars/learn/neighbors/kd_tree.py
@@ -52,9 +52,8 @@ def kd_tree_query(tree, data, n_neighbors, return_distance):
 
 @require_not_none(SkKDTree)
 def KDTree(X, leaf_size, metric=None, **metric_params):
-    metric_func = None
-    if callable(metric):
-        metric_func, metric = metric, None
-    op = _KDTree(leaf_size=leaf_size, metric=metric, metric_func=metric_func,
+    # kd_tree cannot accept callable metric
+    assert not callable(metric)
+    op = _KDTree(leaf_size=leaf_size, metric=metric,
                  **metric_params)
     return op(X)

--- a/mars/learn/neighbors/kd_tree.py
+++ b/mars/learn/neighbors/kd_tree.py
@@ -18,26 +18,20 @@ except ImportError:  # pragma: no cover
     SkKDTree = None
 
 from ... import opcodes as OperandDef
-from ...utils import classproperty, require_not_none
+from ...utils import require_not_none
 from .tree import TreeBase, TreeQueryBase
 
 
 @require_not_none(SkKDTree)
 class _KDTree(TreeBase):
     _op_type_ = OperandDef.KD_TREE_TRAIN
-
-    @classproperty
-    def _tree_type(self):
-        return SkKDTree
+    _tree_type = SkKDTree
 
 
 @require_not_none(SkKDTree)
 class KDTreeQuery(TreeQueryBase):
     _op_type_ = OperandDef.KD_TREE_QUERY
-
-    @classproperty
-    def _tree_type(self):
-        return SkKDTree
+    _tree_type = SkKDTree
 
 
 @require_not_none(SkKDTree)

--- a/mars/learn/neighbors/kd_tree.py
+++ b/mars/learn/neighbors/kd_tree.py
@@ -1,0 +1,60 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    from sklearn.neighbors.kd_tree import KDTree as SkKDTree
+except ImportError:  # pragma: no cover
+    SkKDTree = None
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty, require_not_none
+from .tree import TreeBase, TreeQueryBase
+
+
+@require_not_none(SkKDTree)
+class _KDTree(TreeBase):
+    _op_type_ = OperandDef.KD_TREE_TRAIN
+
+    @classproperty
+    def _tree_type(self):
+        return SkKDTree
+
+
+@require_not_none(SkKDTree)
+class KDTreeQuery(TreeQueryBase):
+    _op_type_ = OperandDef.KD_TREE_QUERY
+
+    @classproperty
+    def _tree_type(self):
+        return SkKDTree
+
+
+@require_not_none(SkKDTree)
+def kd_tree_query(tree, data, n_neighbors, return_distance):
+    op = KDTreeQuery(tree=tree, n_neighbors=n_neighbors,
+                     return_distance=return_distance)
+    ret = op(data)
+    if not return_distance:
+        return ret[0]
+    return ret
+
+
+@require_not_none(SkKDTree)
+def KDTree(X, leaf_size, metric=None, **metric_params):
+    metric_func = None
+    if callable(metric):
+        metric_func, metric = metric, None
+    op = _KDTree(leaf_size=leaf_size, metric=metric, metric_func=metric_func,
+                 **metric_params)
+    return op(X)

--- a/mars/learn/neighbors/tests/__init__.py
+++ b/mars/learn/neighbors/tests/__init__.py
@@ -11,15 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# register operands
-from .utils.shuffle import shuffle
-from .contrib import xgboost, tensorflow, pytorch
-from .metrics import pairwise
-from . import preprocessing
-from . import neighbors
-
-for _mod in [xgboost, tensorflow, pytorch, neighbors]:
-    _mod.register_op()
-
-del _mod, shuffle, pairwise, preprocessing

--- a/mars/learn/neighbors/tests/test_nearest_neighbors.py
+++ b/mars/learn/neighbors/tests/test_nearest_neighbors.py
@@ -15,8 +15,12 @@
 import unittest
 
 import numpy as np
+import scipy.sparse as sps
 try:
     from sklearn.neighbors import NearestNeighbors as SkNearestNeighbors
+    from sklearn.neighbors.ball_tree import BallTree as SkBallTree
+    from sklearn.neighbors.kd_tree import KDTree as SkKDTree
+    from sklearn.utils.testing import assert_warns
 except ImportError:  # pragma: no cover
     SkNearestNeighbors = None
 
@@ -26,13 +30,115 @@ from mars.learn.neighbors import NearestNeighbors
 
 @unittest.skipIf(SkNearestNeighbors is None, 'scikit-learn not installed')
 class Test(unittest.TestCase):
+    def testNearestNeighbors(self):
+        rs = np.random.RandomState(0)
+        raw_X = rs.rand(10, 5)
+        raw_Y = rs.rand(8, 5)
+
+        X = mt.tensor(raw_X)
+        Y = mt.tensor(raw_Y)
+
+        raw_sparse_x = sps.random(10, 5, density=0.5, format='csr', random_state=rs)
+        raw_sparse_y = sps.random(8, 5, density=0.4, format='csr', random_state=rs)
+
+        X_sparse = mt.tensor(raw_sparse_x)
+        Y_sparse = mt.tensor(raw_sparse_y)
+
+        metric_func = lambda u, v: np.sqrt(((u-v)**2).sum())
+
+        _ = NearestNeighbors(algorithm='auto', metric='precomputed', metric_params={})
+
+        with self.assertRaises(ValueError):
+            _ = NearestNeighbors(algorithm='unknown')
+
+        with self.assertRaises(ValueError):
+            _ = NearestNeighbors(algorithm='kd_tree', metric=metric_func)
+
+        with self.assertRaises(ValueError):
+            _ = NearestNeighbors(algorithm='auto', metric='unknown')
+
+        assert_warns(SyntaxWarning, NearestNeighbors, metric_params={'p': 1})
+
+        with self.assertRaises(ValueError):
+            _ = NearestNeighbors(metric='wminkowski', p=0)
+
+        with self.assertRaises(ValueError):
+            _ = NearestNeighbors(algorithm='auto', metric='minkowski', p=0)
+
+        nn = NearestNeighbors(algorithm='auto', metric='minkowski', p=1)
+        nn.fit(X)
+        self.assertEqual(nn.effective_metric_, 'manhattan')
+
+        nn = NearestNeighbors(algorithm='auto', metric='minkowski', p=2)
+        nn.fit(X)
+        self.assertEqual(nn.effective_metric_, 'euclidean')
+
+        nn = NearestNeighbors(algorithm='auto', metric='minkowski', p=np.inf)
+        nn.fit(X)
+        self.assertEqual(nn.effective_metric_, 'chebyshev')
+
+        nn2 = NearestNeighbors(algorithm='auto', metric='minkowski')
+        nn2.fit(nn)
+        self.assertEqual(nn2._fit_method, nn._fit_method)
+
+        nn = NearestNeighbors(algorithm='auto', metric='minkowski')
+        ball_tree = SkBallTree(raw_X)
+        nn.fit(ball_tree)
+        self.assertEqual(nn._fit_method, 'ball_tree')
+
+        nn = NearestNeighbors(algorithm='auto', metric='minkowski')
+        kd_tree = SkKDTree(raw_X)
+        nn.fit(kd_tree)
+        self.assertEqual(nn._fit_method, 'kd_tree')
+
+        with self.assertRaises(ValueError):
+            nn = NearestNeighbors()
+            nn.fit(np.random.rand(0, 10))
+
+        nn = NearestNeighbors(algorithm='ball_tree')
+        assert_warns(UserWarning, nn.fit, X_sparse)
+
+        nn = NearestNeighbors(metric='haversine')
+        with self.assertRaises(ValueError):
+            nn.fit(X_sparse)
+
+        nn = NearestNeighbors(metric=metric_func, n_neighbors=1)
+        nn.fit(X)
+        self.assertEqual(nn._fit_method, 'ball_tree')
+
+        nn = NearestNeighbors(metric='sqeuclidean', n_neighbors=1)
+        nn.fit(X)
+        self.assertEqual(nn._fit_method, 'brute')
+
+        with self.assertRaises(ValueError):
+            nn = NearestNeighbors(n_neighbors=-1)
+            nn.fit(X)
+
+        with self.assertRaises(TypeError):
+            nn = NearestNeighbors(n_neighbors=1.3)
+            nn.fit(X)
+
+        nn = NearestNeighbors()
+        nn.fit(X)
+        with self.assertRaises(ValueError):
+            nn.kneighbors(Y, n_neighbors=-1)
+        with self.assertRaises(TypeError):
+            nn.kneighbors(Y, n_neighbors=1.3)
+        with self.assertRaises(ValueError):
+            nn.kneighbors(Y, n_neighbors=11)
+
+        nn = NearestNeighbors(algorithm='ball_tree')
+        nn.fit(X)
+        with self.assertRaises(ValueError):
+            nn.kneighbors(Y_sparse)
+
     def testNearestNeighborsExecution(self):
         rs = np.random.RandomState(0)
         raw_X = rs.rand(10, 5)
         raw_Y = rs.rand(8, 5)
 
         X = mt.tensor(raw_X, chunk_size=7)
-        Y = mt.tensor(raw_Y, chunk_size=5)
+        Y = mt.tensor(raw_Y, chunk_size=(5, 3))
 
         for algo in ['brute', 'ball_tree', 'kd_tree', 'auto']:
             for metric in ['minkowski', 'manhattan']:
@@ -52,3 +158,64 @@ class Test(unittest.TestCase):
                 result = [r.fetch() for r in ret]
                 np.testing.assert_almost_equal(result[0], expected[0])
                 np.testing.assert_almost_equal(result[1], expected[1])
+
+                # test return_distance=False
+                ret = nn.kneighbors(Y, return_distance=False)
+
+                result = ret.fetch()
+                np.testing.assert_almost_equal(result, expected[1])
+
+                # test y is x
+                ret = nn.kneighbors()
+
+                expected = snn.kneighbors()
+
+                result = [r.fetch() for r in ret]
+                np.testing.assert_almost_equal(result[0], expected[0])
+                np.testing.assert_almost_equal(result[1], expected[1])
+
+                # test y is x, and return_distance=False
+                ret = nn.kneighbors(return_distance=False)
+
+                result = ret.fetch()
+                np.testing.assert_almost_equal(result, expected[1])
+
+        # test callable metric
+        metric = lambda u, v: np.sqrt(((u-v)**2).sum())
+        for algo in ['brute', 'ball_tree']:
+            nn = NearestNeighbors(n_neighbors=3,
+                                  algorithm=algo,
+                                  metric=metric)
+            nn.fit(X)
+
+            ret = nn.kneighbors(Y)
+
+            snn = SkNearestNeighbors(n_neighbors=3,
+                                     algorithm=algo,
+                                     metric=metric)
+            snn.fit(raw_X)
+            expected = snn.kneighbors(raw_Y)
+
+            result = [r.fetch() for r in ret]
+            np.testing.assert_almost_equal(result[0], expected[0])
+            np.testing.assert_almost_equal(result[1], expected[1])
+
+        # test sparse
+        raw_sparse_x = sps.random(10, 5, density=0.5, format='csr', random_state=rs)
+        raw_sparse_y = sps.random(8, 5, density=0.4, format='csr', random_state=rs)
+
+        X = mt.tensor(raw_sparse_x, chunk_size=7)
+        Y = mt.tensor(raw_sparse_y, chunk_size=5)
+
+        nn = NearestNeighbors(n_neighbors=3)
+        nn.fit(X)
+
+        ret = nn.kneighbors(Y)
+
+        snn = SkNearestNeighbors(n_neighbors=3)
+        snn.fit(raw_sparse_x)
+        expected = snn.kneighbors(raw_sparse_y)
+
+        result = [r.fetch() for r in ret]
+        np.testing.assert_almost_equal(result[0], expected[0])
+        np.testing.assert_almost_equal(result[1], expected[1])

--- a/mars/learn/neighbors/tests/test_nearest_neighbors.py
+++ b/mars/learn/neighbors/tests/test_nearest_neighbors.py
@@ -1,0 +1,54 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+try:
+    from sklearn.neighbors import NearestNeighbors as SkNearestNeighbors
+except ImportError:  # pragma: no cover
+    SkNearestNeighbors = None
+
+import mars.tensor as mt
+from mars.learn.neighbors import NearestNeighbors
+
+
+@unittest.skipIf(SkNearestNeighbors is None, 'scikit-learn not installed')
+class Test(unittest.TestCase):
+    def testNearestNeighborsExecution(self):
+        rs = np.random.RandomState(0)
+        raw_X = rs.rand(10, 5)
+        raw_Y = rs.rand(8, 5)
+
+        X = mt.tensor(raw_X, chunk_size=7)
+        Y = mt.tensor(raw_Y, chunk_size=5)
+
+        for algo in ['brute', 'ball_tree', 'kd_tree', 'auto']:
+            for metric in ['minkowski', 'manhattan']:
+                nn = NearestNeighbors(n_neighbors=3,
+                                      algorithm=algo,
+                                      metric=metric)
+                nn.fit(X)
+
+                ret = nn.kneighbors(Y)
+
+                snn = SkNearestNeighbors(n_neighbors=3,
+                                         algorithm=algo,
+                                         metric=metric)
+                snn.fit(raw_X)
+                expected = snn.kneighbors(raw_Y)
+
+                result = [r.fetch() for r in ret]
+                np.testing.assert_almost_equal(result[0], expected[0])
+                np.testing.assert_almost_equal(result[1], expected[1])

--- a/mars/learn/neighbors/tree.py
+++ b/mars/learn/neighbors/tree.py
@@ -1,0 +1,231 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pickle
+
+import cloudpickle
+import numpy as np
+
+from ...serialize import KeyField, Int32Field, DictField, StringField, BytesField, BoolField
+from ...tiles import TilesError
+from ...tensor.core import TensorOrder
+from ...utils import check_chunks_unknown_shape, classproperty, tokenize
+from ..operands import LearnOperand, LearnOperandMixin, OutputType
+
+
+class TreeBase(LearnOperand, LearnOperandMixin):
+    _input = KeyField('input')
+    _leaf_size = Int32Field('leaf_size')
+    _metric = StringField('metric')
+    _metric_func = BytesField('metric_func', on_serialize=cloudpickle.dumps,
+                              on_deserialize=cloudpickle.loads)
+
+    _metric_params = DictField('metric_params')
+
+    def __init__(self, leaf_size=None, metric=None, metric_func=None,
+                 metric_params=None, output_types=None, **kw):
+        super().__init__(_leaf_size=leaf_size, _metric=metric,
+                         _metric_func=metric_func, _metric_params=metric_params,
+                         _output_types=output_types, **kw)
+        if self._output_types is None:
+            self._output_types = [OutputType.object]
+
+    @property
+    def input(self):
+        return self._input
+
+    @property
+    def leaf_size(self):
+        return self._leaf_size
+
+    @property
+    def metric(self):
+        return self._metric
+
+    @property
+    def metric_func(self):
+        return self._metric_func
+
+    @property
+    def metric_params(self):
+        return self._metric_params
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        self._input = self._inputs[0]
+
+    def __call__(self, a):
+        return self.new_tileable([a])
+
+    @classmethod
+    def tile(cls, op):
+        check_chunks_unknown_shape(op.inputs, TilesError)
+
+        # ball tree and kd tree requires the full data,
+        # thus rechunk input tensor into 1 chunk
+        inp = op.input.rechunk({ax: s for ax, s in enumerate(op.input.shape)})
+        inp = inp._inplace_tile()
+        out = op.outputs[0]
+
+        chunk_op = op.copy().reset_key()
+        kw = out.params
+        kw['index'] = inp.chunks[0].index
+        chunk = chunk_op.new_chunk([inp.chunks[0]], kws=[kw])
+
+        new_op = op.copy()
+        tileable_kw = out.params
+        tileable_kw['nsplits'] = ((1,),)
+        tileable_kw['chunks'] = [chunk]
+        return new_op.new_tileables(op.inputs, kws=[tileable_kw])
+
+    @classproperty
+    def _tree_type(self):
+        raise NotImplementedError
+
+    @classmethod
+    def execute(cls, ctx, op):
+        if op.gpu:  # pragma: no cover
+            raise NotImplementedError('Does not support tree-based '
+                                      'nearest neighbors on GPU')
+
+        a = ctx[op.input.key]
+        metric = op.metric or op.metric_func
+        tree = cls._tree_type(
+            a, op.leaf_size, metric=metric,
+            **(op.metric_params or dict()))
+        ctx[op.outputs[0].key] = pickle.dumps(tree)
+
+
+class TreeQueryBase(LearnOperand, LearnOperandMixin):
+    _input = KeyField('input')
+    _tree = BytesField('tree', on_serialize=pickle.dumps,
+                       on_deserialize=pickle.loads)
+    _n_neighbors = Int32Field('n_neighbors')
+    _return_distance = BoolField('return_distance')
+
+    def __init__(self, tree=None, n_neighbors=None, return_distance=None,
+                 output_types=None, **kw):
+        super().__init__(_tree=tree, _n_neighbors=n_neighbors,
+                         _return_distance=return_distance,
+                         _output_types=output_types, **kw)
+        if self._output_types is None:
+            self._output_types = [OutputType.tensor] * self.output_limit
+
+    @property
+    def input(self):
+        return self._input
+
+    @property
+    def tree(self):
+        return self._tree
+
+    @property
+    def n_neighbors(self):
+        return self._n_neighbors
+
+    @property
+    def return_distance(self):
+        return self._return_distance
+
+    @property
+    def output_limit(self):
+        return 2 if self._return_distance else 1
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        self._input = self._inputs[0]
+
+    def _update_key(self):
+        values = []
+        for value in self._values_:
+            if isinstance(value, self._tree_type):
+                values.append(pickle.dumps(value))
+            else:
+                values.append(value)
+        self._obj_set('_key', tokenize(type(self).__name__, *values))
+        return self
+
+    def __call__(self, x):
+        kws = []
+        if self._return_distance:
+            kws.append({'shape': (x.shape[0], self._n_neighbors),
+                        'dtype': np.dtype(np.float64),
+                        'order': x.order,
+                        'type': 'distance'})
+        kws.append({
+            'shape': (x.shape[0], self._n_neighbors),
+            'dtype': np.dtype(np.int64),
+            'order': TensorOrder.C_ORDER,
+            'type': 'indices'
+        })
+        return self.new_tileables([x], kws=kws, output_limit=len(kws))
+
+    @classmethod
+    def tile(cls, op):
+        inp = op.input
+        if inp.chunk_shape[1] != 1:
+            check_chunks_unknown_shape([inp], TilesError)
+            inp = inp.rechunk({1: inp.shape[1]})._inplace_tile()
+
+        out_chunks = [[] for _ in range(len(op.outputs))]
+        for chunk in inp.chunks:
+            chunk_op = op.copy().reset_key()
+            chunk_kws = []
+            if op.return_distance:
+                chunk_kws.append({
+                    'shape': (chunk.shape[0], op.n_neighbors),
+                    'dtype': np.dtype(np.float64),
+                    'order': chunk.order,
+                    'index': chunk.index,
+                    'type': 'distance'
+                })
+            chunk_kws.append({
+                'shape': (chunk.shape[0], op.n_neighbors),
+                'dtype': np.dtype(np.int64),
+                'order': TensorOrder.C_ORDER,
+                'index': chunk.index,
+                'type': 'indices'
+            })
+            chunks = chunk_op.new_chunks([chunk], kws=chunk_kws, output_limit=len(chunk_kws))
+            for cs, c in zip(out_chunks, chunks):
+                cs.append(c)
+
+        kws = [o.params for o in op.outputs]
+        nsplits = list(inp.nsplits)
+        nsplits[1] = (op.n_neighbors,)
+        if op.return_distance:
+            kws[0]['chunks'] = out_chunks[0]
+            kws[0]['nsplits'] = tuple(nsplits)
+        kws[-1]['chunks'] = out_chunks[-1]
+        kws[-1]['nsplits'] = tuple(nsplits)
+        new_op = op.copy()
+        return new_op.new_tileables(op.inputs, kws=kws, output_limit=len(kws))
+
+    @classproperty
+    def _tree_type(self):
+        raise NotImplementedError
+
+    @classmethod
+    def execute(cls, ctx, op):
+        if op.gpu:  # pragma: no cover
+            raise NotImplementedError('Does not support tree-based '
+                                      'nearest neighbors on GPU')
+
+        x = ctx[op.input.key]
+        ret = op.tree.query(x, op.n_neighbors, op.return_distance)
+        if op.return_distance:
+            ctx[op.outputs[0].key] = ret[0]
+            ctx[op.outputs[1].key] = ret[1]
+        else:
+            ctx[op.outputs[0].key] = ret

--- a/mars/learn/neighbors/unsupervised.py
+++ b/mars/learn/neighbors/unsupervised.py
@@ -12,14 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# register operands
-from .utils.shuffle import shuffle
-from .contrib import xgboost, tensorflow, pytorch
-from .metrics import pairwise
-from . import preprocessing
-from . import neighbors
+from .base import NeighborsBase
+from .base import KNeighborsMixin
+from .base import UnsupervisedMixin
 
-for _mod in [xgboost, tensorflow, pytorch, neighbors]:
-    _mod.register_op()
 
-del _mod, shuffle, pairwise, preprocessing
+class NearestNeighbors(NeighborsBase, KNeighborsMixin,
+                       UnsupervisedMixin):
+    def __init__(self, n_neighbors=5, radius=1.0,
+                 algorithm='auto', leaf_size=30, metric='minkowski',
+                 p=2, metric_params=None, **kwargs):
+        super().__init__(
+            n_neighbors=n_neighbors,
+            radius=radius,
+            algorithm=algorithm,
+            leaf_size=leaf_size, metric=metric, p=p,
+            metric_params=metric_params, **kwargs)

--- a/mars/learn/utils/validation.py
+++ b/mars/learn/utils/validation.py
@@ -20,7 +20,7 @@ from numpy.core.numeric import ComplexWarning
 try:
     from sklearn.utils.validation import check_is_fitted
 except ImportError:  # pragma: no cover:
-    pass
+    check_is_fitted = None
 
 from ... import tensor as mt
 from ...lib.sparse import issparse
@@ -380,3 +380,6 @@ def check_non_negative(X, whom):
         Who passed X to this function.
     """
     return check_non_negative_then_return_value(X, X, whom)
+
+
+check_is_fitted = check_is_fitted

--- a/mars/learn/utils/validation.py
+++ b/mars/learn/utils/validation.py
@@ -17,6 +17,10 @@ import numbers
 
 import numpy as np
 from numpy.core.numeric import ComplexWarning
+try:
+    from sklearn.utils.validation import check_is_fitted
+except ImportError:  # pragma: no cover:
+    pass
 
 from ... import tensor as mt
 from ...lib.sparse import issparse

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -384,6 +384,14 @@ message OperandDef {
         PAIRWISE_COSINE_DISTANCES = 2202;
         PAIRWISE_HAVERSINE_DISTANCES = 2203;
 
+        // nearest neighbors
+        KD_TREE_TRAIN = 2230;
+        KD_TREE_QUERY = 2231;
+        BALL_TREE_TRAIN = 2232;
+        BALL_TREE_QUERY = 2233;
+        FAISS_TRAIN = 2234;
+        FAISS_QUERY = 2235;
+
         // XGBoost
         XGBOOST_TRAIN = 3001;
         XGBOOST_PREDICT = 3002;

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -288,7 +288,7 @@ def _sort(a, op, xp, axis=None, kind=None, order=None, inplace=False):
     if xp is np:
         method = a.sort if inplace else partial(np.sort, a)
         return method(axis=axis, kind=kind, order=order)
-    else:
+    else:  # pragma: no cover
         # cupy does not support structure type
         assert xp is cp
         assert order is not None
@@ -303,7 +303,7 @@ def _argsort(a, op, xp, axis=None, kind=None, order=None):
     order = order if order is not None else op.order
     if xp is np:
         return np.argsort(a, axis=axis, kind=kind, order=order)
-    else:
+    else:  # pragma: no cover
         # cupy does not support structure type
         assert xp is cp
         assert order is not None

--- a/mars/tensor/base/sort.py
+++ b/mars/tensor/base/sort.py
@@ -241,25 +241,7 @@ class TensorSort(TensorOperand, PSRSOperandMixin):
 _AVAILABLE_KINDS = {'QUICKSORT', 'MERGESORT', 'HEAPSORT', 'STABLE'}
 
 
-def _validate_sort_arguments(a, axis, kind, parallel_kind, psrs_kinds, order):
-    a = astensor(a)
-    if axis is None:
-        a = a.flatten()
-        axis = 0
-    else:
-        axis = validate_axis(a.ndim, axis)
-    if kind is not None:
-        raw_kind = kind
-        kind = kind.upper()
-        if kind not in _AVAILABLE_KINDS:
-            # check kind
-            raise ValueError('{} is an unrecognized kind of sort'.format(raw_kind))
-    if parallel_kind is not None:
-        raw_parallel_kind = parallel_kind
-        parallel_kind = parallel_kind.upper()
-        if parallel_kind not in {'PSRS'}:
-            raise ValueError('{} is an unrecognized kind of '
-                             'parallel sort'.format(raw_parallel_kind))
+def _validate_sort_psrs_kinds(psrs_kinds):
     if psrs_kinds is not None:
         if isinstance(psrs_kinds, (list, tuple)):
             psrs_kinds = list(psrs_kinds)
@@ -280,8 +262,31 @@ def _validate_sort_arguments(a, axis, kind, parallel_kind, psrs_kinds, order):
             raise TypeError('psrs_kinds should be list or tuple')
     else:
         psrs_kinds = ['quicksort', 'mergesort', 'mergesort']
-    order = validate_order(a.dtype, order)
+    return psrs_kinds
 
+
+def _validate_sort_arguments(a, axis, kind, parallel_kind, psrs_kinds, order):
+    a = astensor(a)
+    if axis is None:
+        a = a.flatten()
+        axis = 0
+    else:
+        axis = validate_axis(a.ndim, axis)
+    if kind is not None:
+        raw_kind = kind
+        kind = kind.upper()
+        if kind not in _AVAILABLE_KINDS:
+            # check kind
+            raise ValueError('{} is an unrecognized kind of sort'.format(raw_kind))
+    if parallel_kind is not None:
+        raw_parallel_kind = parallel_kind
+        parallel_kind = parallel_kind.upper()
+        if parallel_kind not in {'PSRS'}:
+            raise ValueError('{} is an unrecognized kind of '
+                             'parallel sort'.format(raw_parallel_kind))
+
+    order = validate_order(a.dtype, order)
+    psrs_kinds = _validate_sort_psrs_kinds(psrs_kinds)
     return a, axis, kind, parallel_kind, psrs_kinds, order
 
 

--- a/mars/tensor/base/sort.py
+++ b/mars/tensor/base/sort.py
@@ -185,7 +185,7 @@ class TensorSort(TensorOperand, PSRSOperandMixin):
                         'shape': chunk.shape,
                         'index': chunk.index,
                         'order': chunk.order,
-                        'dtyep': chunk.dtype,
+                        'dtype': chunk.dtype,
                         'type': 'sorted'
                     })
                 if return_indices:

--- a/mars/tensor/base/tests/test_base.py
+++ b/mars/tensor/base/tests/test_base.py
@@ -805,6 +805,14 @@ class Test(unittest.TestCase):
         t = t.tiles()
         self.assertEqual(t.op.parallel_kind, 'tree')
 
-        # t = topk(a, 3)
-        # t = t.tiles()
-        # self.assertEqual(t.op.parallel_kind, 'psrs')
+        t = topk(a, 3)
+        t = t.tiles()
+        self.assertEqual(t.op.parallel_kind, 'psrs')
+
+        t = topk(sort(a), 3)
+        t = t.tiles()
+        # k is less than 100
+        self.assertEqual(t.op.parallel_kind, 'tree')
+
+        with self.assertRaises(ValueError):
+            topk(a, 3, parallel_kind='unknown')

--- a/mars/tensor/reshape/reshape.py
+++ b/mars/tensor/reshape/reshape.py
@@ -512,7 +512,12 @@ def reshape(a, newshape, order='C'):
     if a.shape == newshape and tensor_order == a.order:
         # does not need to reshape
         return a
+    return _reshape(a, newshape, order=order, tensor_order=tensor_order)
 
+
+def _reshape(a, newshape, order='C', tensor_order=None):
+    if tensor_order is None:
+        tensor_order = get_order(order, a.order, available_options='CFA')
     op = TensorReshape(newshape, order, dtype=a.dtype,
                        create_view=tensor_order == a.order)
     return op(a, tensor_order)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR adds support for `mars.learn.neighbors.NearestNeighbors` which is the counterpart of `sklearn.neighbors.NearestNeighbors`.

sklearn provides three algorithms including `brute`, `ball_tree` and `kd_tree`, the next PR'd like to introduce [faiss](https://github.com/facebookresearch/faiss) as well. Faiss is quite friendly for large dataset and distributed setting.

Tasks:

- [x] #960 and #946 got merged.
- [x] Algo: brute
- [x] Algo: ball_tree
- [x] Algo: kd_tree

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #949 .
