### PR TITLE
Implements `Series.map`

### DIFF
--- a/mars/dataframe/base/__init__.py
+++ b/mars/dataframe/base/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .map import map_
 from .to_gpu import to_gpu
 from .to_cpu import to_cpu
 from .rechunk import rechunk
@@ -31,6 +32,7 @@ def _install():
         setattr(t, 'to_cpu', to_cpu)
         setattr(t, 'rechunk', rechunk)
         setattr(t, 'reset_index', series_reset_index)
+        setattr(t, 'map', map_)
 
 
 _install()

--- a/mars/dataframe/base/map.py
+++ b/mars/dataframe/base/map.py
@@ -1,0 +1,157 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+from collections.abc import MutableMapping
+
+import cloudpickle
+import numpy as np
+import pandas as pd
+
+from ... import opcodes as OperandDef
+from ...serialize import KeyField, AnyField, BytesField, StringField
+from ...tiles import TilesError
+from ...utils import check_chunks_unknown_shape
+from ..core import SERIES_TYPE
+from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+
+
+class DataFrameMap(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = OperandDef.MAP
+
+    _input = KeyField('input')
+    _arg = AnyField('arg')
+    _arg_func = BytesField('arg_func', on_serialize=cloudpickle.dumps,
+                           on_deserialize=cloudpickle.loads)
+    _na_action = StringField('na_action')
+
+    def __init__(self, arg=None, arg_func=None, na_action=None,
+                 object_type=None, **kw):
+        super().__init__(_arg=arg, _arg_func=arg_func, _na_action=na_action,
+                         _object_type=object_type, **kw)
+        if self._object_type is None:
+            self._object_type = ObjectType.series
+
+    @property
+    def input(self):
+        return self._input
+
+    @property
+    def arg(self):
+        return self._arg
+
+    @property
+    def arg_func(self):
+        return self._arg_func
+
+    @property
+    def na_action(self):
+        return self._na_action
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        self._input = self._inputs[0]
+        if len(inputs) == 2:
+            self._arg = self._inputs[1]
+
+    def __call__(self, series, dtype, test_size=3):
+        if dtype is None:
+            if self._arg_func is not None:
+                # arg is a function, try to inspect the signature
+                sig = inspect.signature(self._arg_func)
+                return_type = sig.return_annotation
+                if return_type is not inspect._empty:
+                    dtype = np.dtype(return_type)
+            else:
+                if isinstance(self._arg, MutableMapping):
+                    inferred_dtype = pd.Series(self._arg).dtype
+                else:
+                    inferred_dtype = self._arg.dtype
+                if np.issubdtype(inferred_dtype, np.number):
+                    if np.issubdtype(inferred_dtype, np.inexact):
+                        # for the inexact e.g. float
+                        # we can make the decision,
+                        # but for int, due to the nan which may occur,
+                        # we cannot infer the dtype
+                        dtype = inferred_dtype
+                else:
+                    dtype = inferred_dtype
+
+        if dtype is None:
+            raise ValueError('cannot infer dtype, '
+                             'it needs to be specified manually for `map`')
+        else:
+            dtype = np.dtype(dtype)
+
+        inputs = [series]
+        if isinstance(self._arg, SERIES_TYPE):
+            inputs.append(self._arg)
+        return self.new_series(inputs, shape=series.shape, dtype=dtype,
+                               index_value=series.index_value, name=series.name)
+
+    @classmethod
+    def tile(cls, op):
+        in_series = op.input
+        out_series = op.outputs[0]
+
+        arg = op.arg
+        if len(op.inputs) == 2:
+            # make sure arg has known shape when it's a md.Series
+            check_chunks_unknown_shape([op.arg], TilesError)
+            arg = op.arg.rechunk(op.arg.shape)._inplace_tile()
+
+        out_chunks = []
+        for chunk in in_series.chunks:
+            chunk_op = op.copy().reset_key()
+            chunk_inputs = [chunk]
+            if len(op.inputs) == 2:
+                chunk_inputs.append(arg.chunks[0])
+            out_chunk = chunk_op.new_chunk(chunk_inputs, shape=chunk.shape,
+                                           dtype=out_series.dtype,
+                                           index_value=chunk.index_value,
+                                           name=out_series.name,
+                                           index=chunk.index)
+            out_chunks.append(out_chunk)
+
+        new_op = op.copy()
+        params = out_series.params
+        params['chunks'] = out_chunks
+        params['nsplits'] = in_series.nsplits
+        return new_op.new_seriess(op.inputs, kws=[params])
+
+    @classmethod
+    def execute(cls, ctx, op):
+        series = ctx[op.inputs[0].key]
+        out = op.outputs[0]
+        if len(op.inputs) == 2:
+            arg = ctx[op.inputs[1].key]
+        elif op.arg is not None:
+            arg = op.arg
+        else:
+            arg = op.arg_func
+
+        ret = series.map(arg, na_action=op.na_action)
+        if ret.dtype != out.dtype:
+            ret = ret.astype(out.dtype)
+        ctx[out.key] = ret
+
+
+def map_(series, arg, na_action=None, dtype=None, test_size=3):
+    if callable(arg):
+        arg_func, arg = arg, None
+    else:
+        arg_func = None
+
+    op = DataFrameMap(arg=arg, arg_func=arg_func, na_action=na_action)
+    return op(series, dtype=dtype, test_size=test_size)

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -222,13 +222,13 @@ class Test(TestBase):
         expected = raw.map(lambda x: x + 1)
         pd.testing.assert_series_equal(result, expected)
 
-        def f(x: int) -> int:
-            return x + 1
+        def f(x: int) -> float:
+            return x + 1.
 
         # dtype can be inferred for function
         r = s.map(f)
         result = self.executor.execute_dataframe(r, concat=True)[0]
-        expected = raw.map(lambda x: x + 1)
+        expected = raw.map(lambda x: x + 1.)
         pd.testing.assert_series_equal(result, expected)
 
         # test arg is a md.Series

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -325,6 +325,10 @@ message OperandDef {
         DENSE_TO_SPARSE = 702;
         SPARSE_TO_DENSE = 703;
 
+        // Functions
+        MAP = 710;
+        APPLY = 711;
+
         FUSE = 801;
 
         // control

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 numpy>=1.14.0
 pandas>=0.20.0
 requests>=2.4.0
-pyarrow>=0.11.0
+pyarrow>=0.11.0,<0.16.0
 cython>=0.29
 pytest>=3.5.0
 pytest-cov>=2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.14.0
 pandas>=0.20.0
 requests>=2.4.0
-pyarrow>=0.11.0
+pyarrow>=0.11.0,<0.16.0
 cloudpickle>=1.0.0


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR added support for `Series.map()`.

The key issue is how to infer the dtype given the arg which could be a dict, Series(both pd and md), or a function. Below is what has been done in this PR:

1. If arg is a function, try to get the return type which given in type hint.
2. If arg is a dict or Series, convert to Series always, and get the dtype of it, if it's a number as well as np.inexact, for instance, np.float, it's legal; if it's int for instance, we cannot make sure if it's legal, because np.nan may exist always, and the real dtype could be float instead of int.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA
