### PR TITLE
Implements `describe` for DataFrame

### DIFF
--- a/mars/dataframe/base/__init__.py
+++ b/mars/dataframe/base/__init__.py
@@ -17,6 +17,7 @@ from .to_gpu import to_gpu
 from .to_cpu import to_cpu
 from .rechunk import rechunk
 from .reset_index import df_reset_index, series_reset_index
+from .describe import describe
 
 
 def _install():
@@ -27,12 +28,14 @@ def _install():
         setattr(t, 'to_cpu', to_cpu)
         setattr(t, 'rechunk', rechunk)
         setattr(t, 'reset_index', df_reset_index)
+        setattr(t, 'describe', describe)
     for t in SERIES_TYPE:
         setattr(t, 'to_gpu', to_gpu)
         setattr(t, 'to_cpu', to_cpu)
         setattr(t, 'rechunk', rechunk)
         setattr(t, 'reset_index', series_reset_index)
         setattr(t, 'map', map_)
+        setattr(t, 'describe', describe)
 
 
 _install()

--- a/mars/dataframe/base/describe.py
+++ b/mars/dataframe/base/describe.py
@@ -1,0 +1,152 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+
+from ... import opcodes as OperandDef
+from ... import tensor as mt
+from ...serialize import ValueType, KeyField, ListField
+from ...tensor.utils import recursive_tile
+from ..core import SERIES_TYPE
+from ..initializer import Series
+from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..utils import parse_index, build_empty_df
+
+
+class DataFrameDescribe(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = OperandDef.DESCRIBE
+
+    _input = KeyField('input')
+    _percentiles = ListField('percentiles', ValueType.float64)
+    _include = ListField('include')
+    _exclude = ListField('exclude')
+
+    def __init__(self, percentiles=None, include=None, exclude=None,
+                 object_type=None, **kw):
+        super().__init__(_percentiles=percentiles, _include=include,
+                         _exclude=exclude, _object_type=object_type, **kw)
+
+    @property
+    def input(self):
+        return self._input
+
+    @property
+    def percentiles(self):
+        return self._percentiles
+
+    @property
+    def include(self):
+        return self._include
+
+    @property
+    def exclude(self):
+        return self._exclude
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        self._input = self._inputs[0]
+
+    def __call__(self, df_or_series):
+        if isinstance(df_or_series, SERIES_TYPE):
+            self._object_type = ObjectType.series
+            if not np.issubdtype(df_or_series.dtype, np.number):
+                raise NotImplementedError('non-numeric type is not supported for now')
+            test_series = pd.Series([], dtype=df_or_series.dtype).describe(
+                percentiles=self._percentiles, include=self._include, exclude=self._exclude)
+            return self.new_series([df_or_series], shape=(len(test_series),),
+                                   dtype=test_series.dtype,
+                                   index_value=parse_index(test_series.index, store_data=True))
+        else:
+            self._object_type = ObjectType.dataframe
+            test_inp_df = build_empty_df(df_or_series.dtypes)
+            test_df = test_inp_df.describe(
+                percentiles=self._percentiles, include=self._include, exclude=self._exclude)
+            for dtype in test_df.dtypes:
+                if not np.issubdtype(dtype, np.number):
+                    raise NotImplementedError('non-numeric type is not supported for now')
+            return self.new_dataframe([df_or_series], shape=test_df.shape, dtypes=test_df.dtypes,
+                                      index_value=parse_index(test_df.index, store_data=True),
+                                      columns_value=parse_index(test_df.columns, store_data=True))
+
+    @classmethod
+    def tile(cls, op):
+        inp = op.input
+
+        if len(inp.chunks) == 1:
+            return cls._tile_one_chunk(op)
+
+        if isinstance(inp, SERIES_TYPE):
+            return cls._tile_series(op)
+        else:
+            return cls._tile_dataframe(op)
+
+    @classmethod
+    def _tile_one_chunk(cls, op):
+        out = op.outputs[0]
+
+        chunk_op = op.copy().reset_key()
+        chunk_params = out.params.copy()
+        chunk_params['index'] = (0,) * out.ndim
+        out_chunk = chunk_op.new_chunk([op.input.chunks[0]], kws=[chunk_params])
+
+        new_op = op.copy()
+        params = out.params.copy()
+        params['chunks'] = [out_chunk]
+        params['nsplits'] = tuple((s,) for s in out.shape)
+        return new_op.new_tileables(op.inputs, kws=[params])
+
+    @classmethod
+    def _tile_series(cls, op):
+        series = Series(op.input)
+        out = op.outputs[0]
+        index = out.index_value.to_pandas()
+        # ['count', 'mean', 'std', 'min', {percentiles}, 'max']
+        names = index.tolist()
+
+        values = [None] * 6
+        for i, agg in enumerate(names[:4]):
+            values[i] = mt.atleast_1d(getattr(series, agg)())
+        values[-1] = mt.atleast_1d(getattr(series, names[-1])())
+        values[4] = series.quantile(op.percentiles).to_tensor()
+
+        t = mt.concatenate(values).rechunk(len(names))
+        ret = Series(t, index=index, name=series.name)
+        return [recursive_tile(ret)]
+
+    @classmethod
+    def _tile_dataframe(cls, op):
+        pass
+
+    @classmethod
+    def execute(cls, ctx, op):
+        df_or_series = ctx[op.input.key]
+
+        ctx[op.outputs[0].key] = df_or_series.describe(
+            percentiles=op.percentiles, include=op.include, exclude=op.exclude)
+
+
+def describe(df_or_series, percentiles=None, include=None, exclude=None):
+    if percentiles is not None:
+        for p in percentiles:
+            if p < 0 or p > 1:
+                raise ValueError('percentiles should all be in the interval [0, 1]. '
+                                 'Try [{0:.3f}] instead.'.format(p / 100))
+    if percentiles is None:
+        percentiles = [0.25, 0.5, 0.75]
+    if not percentiles:
+        percentiles = [0.5]
+
+    op = DataFrameDescribe(percentiles=percentiles, include=include, exclude=exclude)
+    return op(df_or_series)

--- a/mars/dataframe/base/describe.py
+++ b/mars/dataframe/base/describe.py
@@ -136,12 +136,13 @@ class DataFrameDescribe(DataFrameOperand, DataFrameOperandMixin):
         names = index.tolist()
 
         df = df.rechunk({1: df.shape[1]})
+        df = df[columns]
 
         values = [None] * 6
         for i, agg in enumerate(names[:4]):
-            values[i] = getattr(df[columns], agg)().to_tensor()[None, :]
-        values[-1] = getattr(df[columns], names[-1])().to_tensor()[None, :]
-        values[4] = df[columns].quantile(op.percentiles).to_tensor()
+            values[i] = getattr(df, agg)().to_tensor()[None, :]
+        values[-1] = getattr(df, names[-1])().to_tensor()[None, :]
+        values[4] = df.quantile(op.percentiles).to_tensor()
 
         t = mt.concatenate(values).rechunk((len(index), len(columns)))
         ret = DataFrame(t, index=index, columns=columns)

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -257,3 +257,32 @@ class Test(TestBase):
         result = self.executor.execute_dataframe(r, concat=True)[0]
         expected = raw.map({'c': 'e'})
         pd.testing.assert_series_equal(result, expected)
+
+    def testDescribeExecution(self):
+        s_raw = pd.Series(np.random.rand(10))
+
+        # test one chunk
+        series = from_pandas_series(s_raw, chunk_size=10)
+
+        r = series.describe()
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s_raw.describe()
+        pd.testing.assert_series_equal(result, expected)
+
+        r = series.describe(percentiles=[])
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s_raw.describe(percentiles=[])
+        pd.testing.assert_series_equal(result, expected)
+
+        # test multi chunks
+        series = from_pandas_series(s_raw, chunk_size=3)
+
+        r = series.describe()
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s_raw.describe()
+        pd.testing.assert_series_equal(result, expected)
+
+        r = series.describe(percentiles=[])
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s_raw.describe(percentiles=[])
+        pd.testing.assert_series_equal(result, expected)

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -286,3 +286,35 @@ class Test(TestBase):
         result = self.executor.execute_dataframe(r, concat=True)[0]
         expected = s_raw.describe(percentiles=[])
         pd.testing.assert_series_equal(result, expected)
+
+        df_raw = pd.DataFrame(np.random.rand(10, 4), columns=list('abcd'))
+        df_raw['e'] = np.random.randint(100, size=10)
+
+        # test one chunk
+        df = from_pandas_df(df_raw, chunk_size=10)
+
+        r = df.describe()
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = df_raw.describe()
+        pd.testing.assert_frame_equal(result, expected)
+
+        r = series.describe(percentiles=[], include=np.float64)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s_raw.describe(percentiles=[], include=np.float64)
+        pd.testing.assert_series_equal(result, expected)
+
+        # test multi chunks
+        df = from_pandas_df(df_raw, chunk_size=3)
+
+        r = df.describe()
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = df_raw.describe()
+        pd.testing.assert_frame_equal(result, expected)
+
+        r = df.describe(percentiles=[], include=np.float64)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = df_raw.describe(percentiles=[], include=np.float64)
+        pd.testing.assert_frame_equal(result, expected)
+
+        with self.assertRaises(ValueError):
+            df.describe(percentiles=[1.1])

--- a/mars/dataframe/initializer.py
+++ b/mars/dataframe/initializer.py
@@ -32,7 +32,11 @@ class DataFrame(_Frame):
                 data = data.rechunk(chunk_size)
             df = dataframe_from_tensor(data, index=index, columns=columns, gpu=gpu, sparse=sparse)
         elif isinstance(data, DATAFRAME_TYPE):
-            df = data
+            if not hasattr(data, 'data'):
+                # DataFrameData
+                df = _Frame(data)
+            else:
+                df = data
         elif isinstance(data, dict) and any(isinstance(v, (Base, Entity)) for v in data.values()):
             # data is a dict and some value is tensor
             columns = list(data.keys()) if columns is None else columns

--- a/mars/dataframe/initializer.py
+++ b/mars/dataframe/initializer.py
@@ -56,7 +56,11 @@ class Series(_Series):
                 data = data.rechunk(chunk_size)
             series = series_from_tensor(data, index=index, name=name, gpu=gpu, sparse=sparse)
         elif isinstance(data, SERIES_TYPE):
-            series = data
+            if not hasattr(data, 'data'):
+                # SeriesData
+                series = _Series(data)
+            else:
+                series = data
         else:
             pd_series = pd.Series(data, index=index, dtype=dtype, name=name, copy=copy)
             series = from_pandas_series(pd_series, chunk_size=chunk_size, gpu=gpu, sparse=sparse)

--- a/mars/dataframe/reduction/count.py
+++ b/mars/dataframe/reduction/count.py
@@ -46,7 +46,7 @@ class DataFrameCount(DataFrameReductionOperand, DataFrameReductionMixin):
 
 
 def count_series(series, level=None, combine_size=None):
-    op = DataFrameCount(level=level, combine_size=combine_size, object_type=ObjectType.series)
+    op = DataFrameCount(level=level, combine_size=combine_size, object_type=ObjectType.scalar)
     return op(series)
 
 

--- a/mars/dataframe/reduction/max.py
+++ b/mars/dataframe/reduction/max.py
@@ -23,7 +23,7 @@ class DataFrameMax(DataFrameReductionOperand, DataFrameReductionMixin):
 
 def max_series(df, axis=None, skipna=None, level=None, combine_size=None):
     op = DataFrameMax(axis=axis, skipna=skipna, level=level, combine_size=combine_size,
-                      object_type=ObjectType.series)
+                      object_type=ObjectType.scalar)
     return op(df)
 
 

--- a/mars/dataframe/reduction/mean.py
+++ b/mars/dataframe/reduction/mean.py
@@ -41,7 +41,7 @@ class DataFrameMean(DataFrameReductionOperand, DataFrameReductionMixin):
 
 def mean_series(df, axis=None, skipna=None, level=None, combine_size=None):
     op = DataFrameMean(axis=axis, skipna=skipna, level=level, combine_size=combine_size,
-                       object_type=ObjectType.series)
+                       object_type=ObjectType.scalar)
     return op(df)
 
 

--- a/mars/dataframe/reduction/min.py
+++ b/mars/dataframe/reduction/min.py
@@ -23,7 +23,7 @@ class DataFrameMin(DataFrameReductionOperand, DataFrameReductionMixin):
 
 def min_series(df, axis=None, skipna=None, level=None, combine_size=None):
     op = DataFrameMin(axis=axis, skipna=skipna, level=level, combine_size=combine_size,
-                      object_type=ObjectType.series)
+                      object_type=ObjectType.scalar)
     return op(df)
 
 

--- a/mars/dataframe/reduction/prod.py
+++ b/mars/dataframe/reduction/prod.py
@@ -23,7 +23,7 @@ class DataFrameProd(DataFrameReductionOperand, DataFrameReductionMixin):
 
 def prod_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):
     op = DataFrameProd(axis=axis, skipna=skipna, level=level, min_count=min_count, combine_size=combine_size,
-                       object_type=ObjectType.series)
+                       object_type=ObjectType.scalar)
     return op(df)
 
 

--- a/mars/dataframe/reduction/sum.py
+++ b/mars/dataframe/reduction/sum.py
@@ -23,7 +23,7 @@ class DataFrameSum(DataFrameReductionOperand, DataFrameReductionMixin):
 
 def sum_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):
     op = DataFrameSum(axis=axis, skipna=skipna, level=level, min_count=min_count, combine_size=combine_size,
-                      object_type=ObjectType.series)
+                      object_type=ObjectType.scalar)
     return op(df)
 
 

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -18,6 +18,7 @@ import unittest
 
 from mars import opcodes as OperandDef
 from mars.tests.core import TestBase, parameterized
+from mars.tensor import Tensor
 from mars.dataframe.core import IndexValue, Series
 from mars.dataframe.reduction import DataFrameSum, DataFrameProd, DataFrameMin, DataFrameMax, \
     DataFrameCount, DataFrameMean, DataFrameVar
@@ -66,10 +67,8 @@ class Test(TestBase):
         self.assertEqual(chunk.index, chunk2.index)
         self.assertEqual(chunk.key, chunk2.key)
         self.assertEqual(chunk.shape, chunk2.shape)
-        self.assertEqual(chunk.name, chunk2.name)
         self.assertEqual(chunk.op.skipna, chunk2.op.skipna)
         self.assertEqual(chunk.op.axis, chunk2.op.axis)
-        pd.testing.assert_index_equal(chunk2.index_value.to_pandas(), chunk.index_value.to_pandas())
 
         # json
         chunk = reduction_df.chunks[0]
@@ -80,18 +79,14 @@ class Test(TestBase):
         self.assertEqual(chunk.index, chunk2.index)
         self.assertEqual(chunk.key, chunk2.key)
         self.assertEqual(chunk.shape, chunk2.shape)
-        self.assertEqual(chunk2.name, chunk.name)
         self.assertEqual(chunk.op.skipna, chunk2.op.skipna)
         self.assertEqual(chunk.op.axis, chunk2.op.axis)
-        pd.testing.assert_index_equal(chunk2.index_value.to_pandas(), chunk.index_value.to_pandas())
 
     def testSeriesReduction(self):
         data = pd.Series({'a': list(range(20))}, index=[str(i) for i in range(20)])
         series = getattr(from_pandas_series(data, chunk_size=3), self.func_name)()
 
-        self.assertIsInstance(series, Series)
-        self.assertEqual(series.name, data.name)
-        self.assertIsInstance(series.index_value._index_value, IndexValue.RangeIndex)
+        self.assertIsInstance(series, Tensor)
         self.assertEqual(series.shape, ())
 
         series = series.tiles()
@@ -108,9 +103,7 @@ class Test(TestBase):
             kwargs = dict()
         series = getattr(from_pandas_series(data, chunk_size=7), self.func_name)(**kwargs)
 
-        self.assertIsInstance(series, Series)
-        self.assertEqual(series.name, data.name)
-        self.assertIsInstance(series.index_value._index_value, IndexValue.RangeIndex)
+        self.assertIsInstance(series, Tensor)
         self.assertEqual(series.shape, ())
 
         series = series.tiles()

--- a/mars/dataframe/reduction/var.py
+++ b/mars/dataframe/reduction/var.py
@@ -103,7 +103,7 @@ class DataFrameVar(DataFrameReductionOperand, DataFrameReductionMixin):
 def var_series(series, axis=None, skipna=None, level=None, ddof=1, combine_size=None):
     op = DataFrameVar(axis=axis, skipna=skipna, level=level, ddof=ddof,
                       combine_size=combine_size,
-                      object_type=ObjectType.series)
+                      object_type=ObjectType.scalar)
     return op(series)
 
 

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -325,9 +325,10 @@ message OperandDef {
         DENSE_TO_SPARSE = 702;
         SPARSE_TO_DENSE = 703;
 
-        // Functions
+        // DataFrame
         MAP = 710;
         APPLY = 711;
+        DESCRIBE = 712;
 
         FUSE = 801;
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR adds support for `DataFrame.describe` and `Series.describe` when describing on numeric data.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA