### PR TITLE
Fix error when chunk_size not provided for `md.read_sql_table`

### DIFF
--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 4, 0, 'a1')
+version_info = (0, 4, 0, 'a2')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/dataframe/datasource/read_sql_table.py
+++ b/mars/dataframe/datasource/read_sql_table.py
@@ -104,7 +104,7 @@ class DataFrameReadSQLTable(DataFrameOperand, DataFrameOperandMixin):
         from sqlalchemy import sql
 
         # fetch test DataFrame
-        query = sql.select(columns).limit(test_rows).select_from(table)
+        query = sql.select(columns).limit(test_rows)
         test_df = pd.read_sql(query, engine_or_conn, index_col=self._index_col,
                               coerce_float=self._coerce_float,
                               parse_dates=self._parse_dates)
@@ -275,7 +275,6 @@ class DataFrameReadSQLTable(DataFrameOperand, DataFrameOperandMixin):
             query = query.limit(out.shape[0])
             if op.offset > 0:
                 query = query.offset(op.offset)
-            query = query.select_from(table)
 
             df = pd.read_sql(query, engine, index_col=op.index_col,
                              coerce_float=op.coerce_float,


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This PR fixes error when chunk_size not provided for `md.read_sql_table`. And for the execution of `read_sql_table`, explicit `order_by` is specified.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #989 .