### PR TITLE
[BACKPORT] Make sure all kwargs are numpy types when inferring dtypes (#987)

### DIFF
--- a/conda-spec.txt
+++ b/conda-spec.txt
@@ -1,6 +1,7 @@
 numpy
 requests
 pyarrow
+cloudpickle
 cython
 mock
 pytest

--- a/mars/tensor/arithmetic/tests/test_arithmetic.py
+++ b/mars/tensor/arithmetic/tests/test_arithmetic.py
@@ -261,7 +261,7 @@ class Test(unittest.TestCase):
         t3 = isfinite(x, y)
         self.assertEqual(t3.dtype, y.dtype)
 
-    def testLogWithOutWhere(self):
+    def testLogWithoutWhere(self):
         t1 = ones((3, 4), chunk_size=2)
 
         t2 = log(t1, out=t1)

--- a/mars/tensor/utils.py
+++ b/mars/tensor/utils.py
@@ -230,7 +230,8 @@ def infer_dtype(np_func, empty=True, reverse=False, check=True):
             args = [make_arg(t) if is_arg(t) else t for t in tensors]
             if reverse:
                 args = args[::-1]
-            np_kw = dict((k, v) for k, v in six.iteritems(kw) if is_arg(v) and k != 'out')
+            np_kw = dict((k, make_arg(v) if hasattr(v, 'op') else v) for k, v in six.iteritems(kw)
+                         if is_arg(v) and k != 'out')
 
             dtype = None
             if not any(hasattr(arg, tensor_ufunc)


### PR DESCRIPTION
## What do these changes do?

Backport of #987

## Related issue number

NA