### PR TITLE
Fix wrong result of count_nonzero

### DIFF
--- a/mars/tensor/reduction/core.py
+++ b/mars/tensor/reduction/core.py
@@ -271,6 +271,21 @@ class TensorReductionMixin(TensorOperandMixin):
 
             ctx[out.key] = ret.astype(ret.dtype, order=out.order.value, copy=False)
 
+    @classmethod
+    def execute_one_chunk(cls, ctx, op):
+        cls.execute_agg(ctx, op)
+
+    @classmethod
+    def execute(cls, ctx, op):
+        if op.stage == OperandStage.map:
+            return cls.execute_map(ctx, op)
+        elif op.stage == OperandStage.combine:
+            return cls.execute_combine(ctx, op)
+        elif op.stage == OperandStage.agg:
+            return cls.execute_agg(ctx, op)
+        else:
+            return cls.execute_one_chunk(ctx, op)
+
 
 class TensorArgReductionMixin(TensorReductionMixin):
     __slots__ = ()
@@ -521,15 +536,6 @@ class TensorReduction(TensorHasInput):
         elif stage == OperandStage.combine and not hasattr(self, 'execute_combine'):
             return OperandStage.agg
         return stage
-
-    @classmethod
-    def execute(cls, ctx, op):
-        if op.stage == OperandStage.map:
-            return cls.execute_map(ctx, op)
-        elif op.stage == OperandStage.combine:
-            return cls.execute_combine(ctx, op)
-        else:
-            return cls.execute_agg(ctx, op)
 
 
 class TensorCumReduction(TensorHasInput):

--- a/mars/tensor/reduction/count_nonzero.py
+++ b/mars/tensor/reduction/count_nonzero.py
@@ -51,6 +51,14 @@ class TensorCountNonzero(TensorReduction, TensorReductionMixin):
     def execute_agg(cls, ctx, op):
         return TensorSum.execute_agg(ctx, op)
 
+    @classmethod
+    def execute_one_chunk(cls, ctx, op):
+        a = ctx[op.inputs[0].key]
+        (inp,), device_id, xp = as_same_device(
+            [a], device=op.device, ret_extra=True)
+        with device(device_id):
+            ctx[op.outputs[0].key] = xp.count_nonzero(inp, axis=op.axis)
+
 
 def count_nonzero(a, axis=None, combine_size=None):
     """

--- a/mars/tensor/reduction/tests/test_reduction_execute.py
+++ b/mars/tensor/reduction/tests/test_reduction_execute.py
@@ -173,6 +173,12 @@ class Test(unittest.TestCase):
         raw1 = np.random.random((20, 25))
         raw2 = np.random.randint(10, size=(20, 25))
 
+        arr0 = tensor(raw1)
+
+        res1 = self.executor.execute_tensor(arr0.var())
+        expected1 = raw1.var()
+        self.assertTrue(np.allclose(res1[0], expected1))
+
         arr1 = tensor(raw1, chunk_size=3)
 
         res1 = self.executor.execute_tensor(arr1.var())
@@ -464,6 +470,13 @@ class Test(unittest.TestCase):
 
     def testCountNonzeroExecution(self):
         raw = [[0, 1, 7, 0, 0], [3, 0, 0, 2, 19]]
+
+        arr = tensor(raw)
+        t = count_nonzero(arr)
+
+        res = self.executor.execute_tensor(t)[0]
+        expected = np.count_nonzero(raw)
+        np.testing.assert_equal(res, expected)
 
         arr = tensor(raw, chunk_size=2)
         t = count_nonzero(arr)

--- a/mars/tensor/reduction/tests/test_reduction_execute.py
+++ b/mars/tensor/reduction/tests/test_reduction_execute.py
@@ -173,7 +173,7 @@ class Test(unittest.TestCase):
         raw1 = np.random.random((20, 25))
         raw2 = np.random.randint(10, size=(20, 25))
 
-        arr0 = tensor(raw1)
+        arr0 = tensor(raw1, chunk_size=25)
 
         res1 = self.executor.execute_tensor(arr0.var())
         expected1 = raw1.var()
@@ -471,7 +471,7 @@ class Test(unittest.TestCase):
     def testCountNonzeroExecution(self):
         raw = [[0, 1, 7, 0, 0], [3, 0, 0, 2, 19]]
 
-        arr = tensor(raw)
+        arr = tensor(raw, chunk_size=5)
         t = count_nonzero(arr)
 
         res = self.executor.execute_tensor(t)[0]


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
`count_nonzero` produces wrong result when tensor has only one chunk, this PR will fix this issue.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #999 