### PR TITLE
[BACKPORT] Add `dtype` property for `TensorImread` (#1004)

### DIFF
--- a/mars/tensor/__init__.py
+++ b/mars/tensor/__init__.py
@@ -55,6 +55,7 @@ from .indexing import take, compress, extract, choose, unravel_index, \
     nonzero, flatnonzero, fill_diagonal
 from .rechunk import rechunk
 from .einsum import einsum
+from .images import imread
 # noinspection PyUnresolvedReferences
 from .lib.index_tricks import mgrid, ogrid, ndindex
 from .core import mutable_tensor

--- a/mars/tensor/einsum/core.py
+++ b/mars/tensor/einsum/core.py
@@ -37,8 +37,8 @@ class TensorEinsum(TensorOperand, TensorOperandMixin):
     _order = StringField('order')
     _casting = StringField('casting')
 
-    def __init__(self, subscripts=None, optimize=None, order=None, casting=None, **kw):
-        super(TensorEinsum, self).__init__(_subscripts=subscripts, _optimize=optimize,
+    def __init__(self, subscripts=None, optimize=None, dtype=None, order=None, casting=None, **kw):
+        super(TensorEinsum, self).__init__(_subscripts=subscripts, _optimize=optimize, _dtype=dtype,
                                            _order=order, _casting=casting, **kw)
 
     @property

--- a/mars/tensor/images/imread.py
+++ b/mars/tensor/images/imread.py
@@ -35,8 +35,8 @@ class TensorImread(TensorOperand, TensorOperandMixin):
 
     _filepath = AnyField('filepath')
 
-    def __init__(self, filepath=None, **kwargs):
-        super(TensorImread, self).__init__(_filepath=filepath, **kwargs)
+    def __init__(self, filepath=None, dtype=None, **kwargs):
+        super(TensorImread, self).__init__(_filepath=filepath, _dtype=dtype, **kwargs)
 
     @property
     def filepath(self):
@@ -95,5 +95,5 @@ def imread(path, chunk_size=None):
         shape = img_shape
     if chunk_size is None:
         chunk_size = int(options.chunk_store_limit / img_size)
-    op = TensorImread(filepath=path, chunk_size=chunk_size)
+    op = TensorImread(filepath=path, chunk_size=chunk_size, dtype=sample_data.dtype)
     return op(shape=shape, chunk_size=chunk_size)

--- a/mars/tensor/images/tests/test_images.py
+++ b/mars/tensor/images/tests/test_images.py
@@ -41,10 +41,12 @@ class Test(TestBase):
 
             t = imread(os.path.join(tempdir, 'random_0.png'))
             self.assertEqual(t.shape, (50, 50, 3))
+            self.assertEqual(t.dtype, np.dtype('uint8'))
 
             tiled = t.tiles()
             self.assertEqual(len(tiled.chunks), 1)
             self.assertEqual(tiled.chunks[0].shape, (50, 50, 3))
+            self.assertEqual(tiled.chunks[0].dtype, np.dtype('uint8'))
 
             t = imread(os.path.join(tempdir, 'random_*.png'), chunk_size=3)
             self.assertEqual(t.shape, (10, 50, 50, 3))
@@ -52,6 +54,7 @@ class Test(TestBase):
             tiled = t.tiles()
             self.assertEqual(len(tiled.chunks), 4)
             self.assertEqual(tiled.nsplits, ((3, 3, 3, 1), (50,), (50,), (3,)))
+            self.assertEqual(tiled.chunks[0].dtype, np.dtype('uint8'))
             self.assertEqual(tiled.chunks[0].index, (0, 0, 0, 0))
             self.assertEqual(tiled.chunks[0].shape, (3, 50, 50, 3))
             self.assertEqual(tiled.chunks[1].index, (1, 0, 0, 0))


### PR DESCRIPTION
Backport of #1004.