### PR TITLE
Fix tests under Python 3.6 as VS2015 is preinstalled

### DIFF
--- a/.github/workflows/install-conda.sh
+++ b/.github/workflows/install-conda.sh
@@ -13,12 +13,14 @@ elif [[ $UNAME == "mingw"* ]] || [[ $UNAME == "msys"* ]]; then
   CONDA_OS="Windows"
   FILE_EXT="exe"
   # VS2015 needed by Python 3.5
-  if [[ "$PYTHON" == "3.5" ]]; then
-    npm install --global --silent --vs2015 windows-build-tools
+  if [[ "$PYTHON" == "3.5" ]] || [[ "$PYTHON" == "3.6" ]]; then
+    vcbindir="/c/Program Files (x86)/Microsoft Visual Studio 14.0/VC/BIN/x86_amd64"
+    if [[ ! -d $vcbindir ]]; then
+      npm install --global --silent --vs2015 windows-build-tools
+    fi
     # Remove SDK of Windows Driver Framework to avoid confusion
     rm -rf "/c/Program Files (x86)/Windows Kits/10/include/wdf"
     # Locate and copy resource compiler into VC dir
-    vcbindir="/c/Program Files (x86)/Microsoft Visual Studio 14.0/VC/BIN/x86_amd64"
     for subdir in $(ls -r "/c/Program Files (x86)/Windows Kits/10/bin"); do
       bindir="/c/Program Files (x86)/Windows Kits/10/bin/$subdir/x64"
       if [ -f "$bindir/rc.exe" ] && [ -f "$bindir/rcdll.dll" ]; then

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -4,6 +4,6 @@ numexpr>=2.6.4
 psutil>=4.0.0
 lz4>=1.0.0
 protobuf>=3.6
-gevent>=1.3.0
+gevent>=1.2.0
 bokeh>=1.0.0
 jinja2>=2.0


### PR DESCRIPTION
## What do these changes do?

Detect installation of VS2015 and fix missing RC compiler.

## Related issue number

Fixes #1013 