### PR TITLE
Add `sort_range_index` parameter in `read_csv`

### DIFF
--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -23,7 +23,7 @@ from pyarrow import HdfsFile
 from ... import opcodes as OperandDef
 from ...config import options
 from ...utils import parse_readable_size, lazy_import
-from ...serialize import StringField, DictField, ListField, Int32Field, Int64Field, AnyField
+from ...serialize import StringField, DictField, ListField, Int32Field, Int64Field, BoolField, AnyField
 from ...filesystem import open_file, file_size, glob
 from ..core import IndexValue
 from ..utils import parse_index, build_empty_df, standardize_range_index
@@ -86,13 +86,17 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
     _usecols = ListField('usecols')
     _offset = Int64Field('offset')
     _size = Int64Field('size')
+    _sort_range_index = BoolField('sort_range_index')
 
     _storage_options = DictField('storage_options')
 
-    def __init__(self, path=None, names=None, sep=None, header=None, index_col=None, compression=None,
-                 usecols=None, offset=None, size=None, gpu=None, storage_options=None, **kw):
-        super().__init__(_path=path, _names=names, _sep=sep, _header=header, _index_col=index_col,
-                         _compression=compression, _usecols=usecols, _offset=offset, _size=size, _gpu=gpu,
+    def __init__(self, path=None, names=None, sep=None, header=None, index_col=None,
+                 compression=None, usecols=None, offset=None, size=None, gpu=None,
+                 sort_range_index=None, storage_options=None, **kw):
+        super().__init__(_path=path, _names=names, _sep=sep, _header=header,
+                         _index_col=index_col, _compression=compression,
+                         _usecols=usecols, _offset=offset, _size=size,
+                         _gpu=gpu, _sort_range_index=sort_range_index,
                          _storage_options=storage_options, _object_type=ObjectType.dataframe, **kw)
 
     @property
@@ -130,6 +134,10 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
     @property
     def size(self):
         return self._size
+
+    @property
+    def sort_range_index(self):
+        return self._sort_range_index
 
     @property
     def storage_options(self):
@@ -189,7 +197,8 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                 index_num += 1
                 offset += chunk_bytes
 
-        if len(out_chunks) > 1 and isinstance(df.index_value._index_value, IndexValue.RangeIndex):
+        if op.sort_range_index and len(out_chunks) > 1 and \
+                isinstance(df.index_value._index_value, IndexValue.RangeIndex):
             out_chunks = standardize_range_index(out_chunks)
         new_op = op.copy()
         nsplits = ((np.nan,) * len(out_chunks), (df.shape[1],))
@@ -252,8 +261,9 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                                   columns_value=columns_value, chunk_bytes=chunk_bytes)
 
 
-def read_csv(path, names=None, sep=',', index_col=None, compression=None, header='infer', dtype=None, usecols=None,
-             chunk_bytes=None, gpu=None, head_bytes='100k', head_lines=None, storage_options=None, **kwargs):
+def read_csv(path, names=None, sep=',', index_col=None, compression=None, header='infer',
+             dtype=None, usecols=None, chunk_bytes=None, gpu=None, head_bytes='100k',
+             head_lines=None, sort_range_index=False, storage_options=None, **kwargs):
     """
     Read comma-separated values (csv) file(s) into DataFrame.
     :param path: file path(s).
@@ -270,6 +280,7 @@ def read_csv(path, names=None, sep=',', index_col=None, compression=None, header
     :param gpu: If read into cudf DataFrame.
     :param head_bytes: Number of bytes to use in the head of file, mainly for data inference.
     :param head_lines: Number of lines to use in the head of file, mainly for data inference.
+    :param sort_range_index: Sort RangeIndex if csv doesn't contain index columns.
     :param storage_options: Options for storage connection.
     :param kwargs:
     :return: Mars DataFrame.
@@ -297,8 +308,9 @@ def read_csv(path, names=None, sep=',', index_col=None, compression=None, header
     if index_col and not isinstance(index_col, int):
         index_col = list(mini_df.columns).index(index_col)
     names = list(mini_df.columns)
-    op = DataFrameReadCSV(path=path, names=names, sep=sep, header=header, index_col=index_col, usecols=usecols,
-                          compression=compression, gpu=gpu, storage_options=storage_options, **kwargs)
+    op = DataFrameReadCSV(path=path, names=names, sep=sep, header=header, index_col=index_col,
+                          usecols=usecols, compression=compression, gpu=gpu,
+                          sort_range_index=sort_range_index, storage_options=storage_options, **kwargs)
     chunk_bytes = chunk_bytes or options.chunk_store_limit
     return op(index_value=index_value, columns_value=columns_value,
               dtypes=mini_df.dtypes, chunk_bytes=chunk_bytes)

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -351,10 +351,10 @@ class Test(TestBase):
             df.to_csv(file_path, index=False)
 
             pdf = pd.read_csv(file_path)
-            mdf = sess.run(md.read_csv(file_path))
+            mdf = sess.run(md.read_csv(file_path, sort_range_index=True))
             pd.testing.assert_frame_equal(pdf, mdf)
 
-            mdf2 = sess.run(md.read_csv(file_path, chunk_bytes=10))
+            mdf2 = sess.run(md.read_csv(file_path, sort_range_index=True, chunk_bytes=10))
             pd.testing.assert_frame_equal(pdf, mdf2)
         finally:
             shutil.rmtree(tempdir)

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -306,11 +306,15 @@ class DataFrameShuffleMerge(_DataFrameMergeBase):
         left, right = ctx[op.inputs[0].key], ctx[op.inputs[1].key]
 
         def execute_merge(x, y):
+            if not op.gpu:
+                kwargs = dict(copy=op.copy, validate=op.validate, indicator=op.indicator)
+            else:  # pragma: no cover
+                # cudf doesn't support 'validate' and 'copy'
+                kwargs = dict(indicator=op.indicator)
             return x.merge(y, how=op.how, on=op.on,
                            left_on=op.left_on, right_on=op.right_on,
                            left_index=op.left_index, right_index=op.right_index,
-                           sort=op.sort, suffixes=op.suffixes,
-                           copy=op.copy, indicator=op.indicator, validate=op.validate)
+                           sort=op.sort, suffixes=op.suffixes, **kwargs)
 
         # workaround for: https://github.com/pandas-dev/pandas/issues/27943
         try:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

We introduce `standardize_range_index` in #930 to fix wrong index when read csv files, it will cost  much time, so we add `sort_range_index` parameter in `read_csv` and set False as default, users can set `sort_range_index=True` if care about the index.