### PR TITLE
Add support for DataFrame.sort_values

### DIFF
--- a/mars/dataframe/__init__.py
+++ b/mars/dataframe/__init__.py
@@ -29,12 +29,13 @@ from . import indexing
 from . import merge
 from . import reduction
 from . import statistics
+from . import sort
 from . import groupby
 from . import ufunc
 from . import datastore
 
 del reduction, statistics, arithmetic, indexing, merge, base, \
-    groupby, ufunc, datastore
+    groupby, ufunc, datastore, sort
 del DataFrameFetch, DataFrameFetchShuffle
 
 # noinspection PyUnresolvedReferences

--- a/mars/dataframe/sort/__init__.py
+++ b/mars/dataframe/sort/__init__.py
@@ -1,0 +1,35 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .sort_values import DataFrameSortValues
+
+
+def _install():
+    from ..core import DATAFRAME_TYPE
+    from .sort_values import sort_values
+
+    def handle_inplace(sort_func):
+        def inner(*args, **kwargs):
+            if not kwargs.get('inplace'):
+                return sort_func(*args, **kwargs)
+            else:
+                args[0].data = sort_func(*args, **kwargs).data
+        return inner
+
+    for cls in DATAFRAME_TYPE:
+        setattr(cls, 'sort_values', handle_inplace(sort_values))
+
+
+_install()
+del _install

--- a/mars/dataframe/sort/__init__.py
+++ b/mars/dataframe/sort/__init__.py
@@ -19,16 +19,8 @@ def _install():
     from ..core import DATAFRAME_TYPE
     from .sort_values import sort_values
 
-    def handle_inplace(sort_func):
-        def inner(*args, **kwargs):
-            if not kwargs.get('inplace'):
-                return sort_func(*args, **kwargs)
-            else:
-                args[0].data = sort_func(*args, **kwargs).data
-        return inner
-
     for cls in DATAFRAME_TYPE:
-        setattr(cls, 'sort_values', handle_inplace(sort_values))
+        setattr(cls, 'sort_values', sort_values)
 
 
 _install()

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -1,0 +1,373 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+
+from ... import opcodes as OperandDef
+from ...utils import lazy_import, get_shuffle_input_keys_idxes
+from ...operands import OperandStage
+from ...serialize import ValueType, Int32Field, ListField, StringField, BoolField
+from ...tensor.base.psrs import PSRSOperandMixin
+from ..utils import parse_index
+from ..operands import DataFrameOperandMixin, DataFrameOperand,\
+    ObjectType, DataFrameMapReduceOperand
+
+
+cudf = lazy_import('cudf', globals=globals())
+
+
+class DataFramePSRSOperandMixin(DataFrameOperandMixin, PSRSOperandMixin):
+    @classmethod
+    def local_sort_and_regular_sample(cls, op, in_tensor, axis_chunk_shape, axis_offsets, out_idx):
+        # stage 1: local sort and regular samples collected
+        sorted_chunks, indices_chunks, sampled_chunks = [], [], []
+        for i in range(axis_chunk_shape):
+            in_chunk = in_tensor.chunks[i]
+            kind = None if op.psrs_kinds is None else op.psrs_kinds[0]
+            chunk_op = DataFramePSRSSortRegularSample(
+                axis=op.axis, by=op.by, ascending=op.ascending,
+                inplace=op.inplace, kind=kind, na_position=op.na_position,
+                n_partition=axis_chunk_shape)
+            kws = []
+            sort_shape = in_chunk.shape
+            kws.append({'shape': sort_shape,
+                        'index_value': in_chunk.index_value,
+                        'columns_value': in_chunk.columns_value,
+                        'index': in_chunk.index,
+                        'dtypes': in_chunk.dtypes})
+            sampled_shape = (axis_chunk_shape, len(op.by))
+            kws.append({'shape': sampled_shape,
+                        'index_value': in_chunk.index_value,
+                        'columns_value': parse_index(pd.Index(op.by), store_data=True),
+                        'dtypes': in_chunk.dtypes,
+                        'index': (i,),
+                        'type': 'regular_sampled'})
+            chunks = chunk_op.new_chunks([in_chunk], kws=kws, output_limit=len(kws))
+            sort_chunk, sampled_chunk = chunks
+            sorted_chunks.append(sort_chunk)
+            sampled_chunks.append(sampled_chunk)
+        return sorted_chunks, indices_chunks, sampled_chunks
+
+    @classmethod
+    def concat_and_pivot(cls, op, axis_chunk_shape, out_idx, sorted_chunks, sampled_chunks):
+        # stage 2: gather and merge samples, choose and broadcast p-1 pivots
+        concat_pivot_op = DataFramePSRSConcatPivot(
+            by=op.by, axis=op.axis, ascending=op.ascending, na_position=op.na_position,
+            kind=None if op.psrs_kinds is None else op.psrs_kinds[1])
+        concat_pivot_shape = \
+            sorted_chunks[0].shape[:op.axis] + (axis_chunk_shape - 1,) + \
+            sorted_chunks[0].shape[op.axis + 1:]
+        concat_pivot_index = out_idx[:op.axis] + (0,) + out_idx[op.axis:]
+        concat_pivot_chunk = concat_pivot_op.new_chunk(sampled_chunks,
+                                                       shape=concat_pivot_shape,
+                                                       index=concat_pivot_index)
+        return concat_pivot_chunk
+
+    @classmethod
+    def partition_local_data(cls, op, axis_chunk_shape, sorted_chunks,
+                             indices_chunks, concat_pivot_chunk):
+        # stage 3: Local data is partitioned
+        partition_chunks = []
+        length = len(sorted_chunks)
+        for i in range(length):
+            chunk_inputs = [sorted_chunks[i], concat_pivot_chunk]
+            partition_shuffle_map = DataFramePSRSShuffle(
+                by=op.by, stage=OperandStage.map, axis=op.axis, ascending=op.ascending,
+                na_position=op.na_position, n_partition=axis_chunk_shape)
+            partition_chunk = partition_shuffle_map.new_chunk(chunk_inputs,
+                                                              shape=chunk_inputs[0].shape,
+                                                              index=chunk_inputs[0].index,
+                                                              index_value=chunk_inputs[0].index_value,
+                                                              columns_value=chunk_inputs[0].columns_value,
+                                                              dtypes=chunk_inputs[0].dtypes)
+            partition_chunks.append(partition_chunk)
+        return partition_chunks
+
+    @classmethod
+    def partition_merge_data(cls, op, need_align, return_value, partition_chunks, proxy_chunk):
+        # stage 4: all *ith* classes are gathered and merged
+        partition_sort_chunks, partition_indices_chunks, sort_info_chunks = [], [], []
+        for i, partition_chunk in enumerate(partition_chunks):
+            kind = None if op.psrs_kinds is None else op.psrs_kinds[2]
+            partition_shuffle_reduce = DataFramePSRSShuffle(
+                stage=OperandStage.reduce, axis=op.axis, by=op.by, ascending=op.ascending,
+                inplace=op.inplace, na_position=op.na_position, kind=kind, shuffle_key=str(i))
+            chunk_shape = list(partition_chunk.shape)
+            chunk_shape[op.axis] = np.nan
+
+            cs = partition_shuffle_reduce.new_chunks(
+                [proxy_chunk], shape=tuple(chunk_shape), index=partition_chunk.index,
+                index_value=partition_chunk.index_value, columns_value=partition_chunk.columns_value,
+                dtypes=partition_chunk.dtypes)
+
+            partition_sort_chunks.append(cs[0])
+        return partition_sort_chunks, partition_indices_chunks, sort_info_chunks
+
+
+def sort_dataframe(df, op, inplace=None):
+    if inplace is None:
+        inplace = op.inplace
+    # ignore_index is new in Pandas version 1.0.0.
+    ignore_index = getattr(op, 'ignore_index', False)
+    if isinstance(df, pd.DataFrame):
+        if inplace:
+            try:
+                df.sort_values(op.by, axis=op.axis, ascending=op.ascending, ignore_index=ignore_index,
+                               inplace=True, na_position=op.na_position, kind=op.kind)
+            except TypeError:  # pragma: no cover
+                df.sort_values(op.by, axis=op.axis, ascending=op.ascending, inplace=True,
+                               na_position=op.na_position, kind=op.kind)
+            return df
+        else:
+            try:
+                return df.sort_values(op.by, axis=op.axis, ascending=op.ascending, ignore_index=ignore_index,
+                                      inplace=False, na_position=op.na_position, kind=op.kind)
+            except TypeError:  # pragma: no cover
+                return df.sort_values(op.by, axis=op.axis, ascending=op.ascending,
+                                      inplace=False, na_position=op.na_position, kind=op.kind)
+
+    else:  # pragma: no cover
+        # cudf doesn't support axis and kind
+        return df.sort_values(
+            op.by, ascending=op.ascending, na_position=op.na_position)
+
+
+class DataFramePSRSSortRegularSample(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = OperandDef.PSRS_SORT_REGULAR_SMAPLE
+
+    _axis = Int32Field('axis')
+    _by = ListField('by', ValueType.string)
+    _ascending = BoolField('ascending')
+    _inplace = BoolField('inplace')
+    _kind = StringField('kind')
+    _na_position = StringField('na_position')
+    _n_partition = Int32Field('n_partition')
+
+    def __init__(self, by=None, axis=None, ascending=None, inplace=None, kind=None,
+                 na_position=None,  n_partition=None, **kw):
+        super().__init__(_by=by, _axis=axis, _ascending=ascending, _inplace=inplace,
+                         _kind=kind, _na_position=na_position, _n_partition=n_partition,
+                         _object_type=ObjectType.dataframe, **kw)
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @property
+    def by(self):
+        return self._by
+
+    @property
+    def ascending(self):
+        return self._ascending
+
+    @property
+    def inplace(self):
+        return self._inplace
+
+    @property
+    def kind(self):
+        return self._kind
+
+    @property
+    def na_position(self):
+        return self._na_position
+
+    @property
+    def n_partition(self):
+        return self._n_partition
+
+    @property
+    def output_limit(self):
+        return 2
+
+    @classmethod
+    def execute(cls, ctx, op):
+        a = ctx[op.inputs[0].key]
+
+        n = op.n_partition
+        w = int(a.shape[op.axis] // n)
+
+        ctx[op.outputs[0].key] = res = sort_dataframe(a, op)
+        # do regular sample
+        slc = (slice(None),) * op.axis + (slice(0, n * w, w),)
+        if op.axis == 0:
+            ctx[op.outputs[-1].key] = res[op.by].iloc[slc]
+        else:
+            ctx[op.outputs[-1].key] = res.loc[op.by].iloc[slc]
+
+
+class DataFramePSRSConcatPivot(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = OperandDef.PSRS_CONCAT_PIVOT
+
+    _by = ListField('by', ValueType.string)
+    _axis = Int32Field('axis')
+    _ascending = BoolField('ascending')
+    _na_position = StringField('na_position')
+    _kind = StringField('kind')
+
+    def __init__(self, by=None, axis=None, ascending=None, na_position=None, kind=None, **kw):
+        super().__init__(_by=by, _axis=axis, _ascending=ascending,
+                         _na_position=na_position, _kind=kind,
+                         _object_type=ObjectType.dataframe, **kw)
+
+    @property
+    def by(self):
+        return self._by
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @property
+    def ascending(self):
+        return self._ascending
+
+    @property
+    def na_position(self):
+        return self._na_position
+
+    @property
+    def kind(self):
+        return self._kind
+
+    @classmethod
+    def execute(cls, ctx, op):
+        inputs = [ctx[c.key] for c in op.inputs]
+        xdf = pd if isinstance(inputs[0], (pd.DataFrame, pd.Series)) else cudf
+
+        a = xdf.concat(inputs, axis=op.axis)
+        p = len(inputs)
+        assert a.shape[op.axis] == p ** 2
+
+        a = sort_dataframe(a, op, inplace=False)
+
+        select = slice(p - 1, (p - 1) ** 2 + 1, p - 1)
+        slc = (slice(None),) * op.axis + (select,)
+        ctx[op.outputs[-1].key] = a.iloc[slc]
+
+
+class DataFramePSRSShuffle(DataFrameMapReduceOperand, DataFrameOperandMixin):
+    _op_type_ = OperandDef.PSRS_SHUFFLE
+
+    # for shuffle map
+    _axis = Int32Field('axis')
+    _by = ListField('by', ValueType.string)
+    _ascending = BoolField('ascending')
+    _inplace = BoolField('inplace')
+    _na_position = StringField('na_position')
+    _n_partition = Int32Field('n_partition')
+
+    # for shuffle reduce
+    _kind = StringField('kind')
+
+    def __init__(self, by=None, axis=None, ascending=None, n_partition=None, na_position=None,
+                 inplace=None, kind=None, stage=None, shuffle_key=None, **kw):
+        super().__init__(_by=by, _axis=axis, _ascending=ascending, _n_partition=n_partition,
+                         _na_position=na_position, _inplace=inplace, _kind=kind, _stage=stage,
+                         _shuffle_key=shuffle_key, _object_type=ObjectType.dataframe, **kw)
+
+    @property
+    def by(self):
+        return self._by
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @property
+    def ascending(self):
+        return self._ascending
+
+    @property
+    def inplace(self):
+        return self._inplace
+
+    @property
+    def na_position(self):
+        return self._na_position
+
+    @property
+    def n_partition(self):
+        return self._n_partition
+
+    @property
+    def kind(self):
+        return self._kind
+
+    @property
+    def output_limit(self):
+        return 1
+
+    @classmethod
+    def _execute_map(cls, ctx, op):
+        a, pivots = [ctx[c.key] for c in op.inputs]
+        out = op.outputs[0]
+        if op.axis == 1:
+            a, pivots = a.transpose(), pivots.transpose()
+
+        if isinstance(a, pd.DataFrame):
+            # use numpy.searchsorted to find split positions.
+            records = a[op.by].to_records(index=False)
+            p_records = pivots.to_records(index=False)
+            if op.ascending:
+                poses = records.searchsorted(p_records, side='right')
+            else:
+                poses = len(records) - records[::-1].searchsorted(p_records, side='right')
+
+            poses = (None,) + tuple(poses) + (None,)
+            for i in range(op.n_partition):
+                values = a.iloc[poses[i]: poses[i + 1]]
+                if op.axis == 0:
+                    ctx[(out.key, str(i))] = values
+                else:
+                    ctx[(out.key, str(i))] = values.transpose()
+        else:  # pragma: no cover
+            # for cudf, find split positions in loops.
+            if op.ascending:
+                pivots.append(a.iloc[-1][op.by])
+                for i in range(op.n_partition):
+                    selected = a
+                    for label in op.by:
+                        selected = selected.loc[a[label] <= pivots.iloc[i][label]]
+                    if op.axis == 0:
+                        ctx[(out.key, str(i))] = selected
+                    else:
+                        ctx[(out.key, str(i))] = selected.transpose()
+            else:
+                pivots.append(a.iloc[-1][op.by])
+                for i in range(op.n_partition):
+                    selected = a
+                    for label in op.by:
+                        selected = selected.loc[a[label] >= pivots.iloc[i][label]]
+                    if op.axis == 0:
+                        ctx[(out.key, str(i))] = selected
+                    else:
+                        ctx[(out.key, str(i))] = selected.transpose()
+
+    @classmethod
+    def _execute_reduce(cls, ctx, op):
+        input_keys, _ = get_shuffle_input_keys_idxes(op.inputs[0])
+        raw_inputs = [ctx[(input_key, op.shuffle_key)] for input_key in input_keys]
+        xdf = pd if isinstance(raw_inputs[0], pd.DataFrame) else cudf
+        concat_values = xdf.concat(raw_inputs, axis=op.axis)
+        ctx[op.outputs[0].key] = sort_dataframe(concat_values, op)
+
+    @classmethod
+    def execute(cls, ctx, op):
+        if op.stage == OperandStage.map:
+            cls._execute_map(ctx, op)
+        else:
+            cls._execute_reduce(ctx, op)

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -30,11 +30,11 @@ cudf = lazy_import('cudf', globals=globals())
 
 class DataFramePSRSOperandMixin(DataFrameOperandMixin, PSRSOperandMixin):
     @classmethod
-    def local_sort_and_regular_sample(cls, op, in_tensor, axis_chunk_shape, axis_offsets, out_idx):
+    def local_sort_and_regular_sample(cls, op, in_data, axis_chunk_shape, axis_offsets, out_idx):
         # stage 1: local sort and regular samples collected
         sorted_chunks, indices_chunks, sampled_chunks = [], [], []
         for i in range(axis_chunk_shape):
-            in_chunk = in_tensor.chunks[i]
+            in_chunk = in_data.chunks[i]
             kind = None if op.psrs_kinds is None else op.psrs_kinds[0]
             chunk_op = DataFramePSRSSortRegularSample(
                 axis=op.axis, by=op.by, ascending=op.ascending,

--- a/mars/dataframe/sort/sort_values.py
+++ b/mars/dataframe/sort/sort_values.py
@@ -1,0 +1,184 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+
+from ...serialize import Int32Field, StringField, ListField, BoolField, ValueType
+from ... import opcodes as OperandDef
+from ...tensor.base.sort import _validate_sort_psrs_kinds
+from ..utils import parse_index, standardize_range_index, validate_axis, build_concated_rows_frame
+from ..operands import DataFrameOperand, DataFrameShuffleProxy, ObjectType
+from .psrs import DataFramePSRSOperandMixin, sort_dataframe
+
+
+class DataFrameSortValues(DataFrameOperand, DataFramePSRSOperandMixin):
+    _op_type_ = OperandDef.SORT_VALUES
+
+    _by = ListField('by', ValueType.string)
+    _axis = Int32Field('axis')
+    _ascending = BoolField('ascending')
+    _inplace = BoolField('inplace')
+    _kind = StringField('kind')
+    _na_position = StringField('na_position')
+    _ignore_index = BoolField('ignore_index')
+    _parallel_kind = StringField('parallel_kind')
+    _psrs_kinds = ListField('psrs_kinds', ValueType.string)
+
+    def __init__(self, by=None, axis=None, ascending=None, inplace=None, kind=None,
+                 na_position=None, ignore_index=None, parallel_kind=None, psrs_kinds=None, **kw):
+        super(DataFrameSortValues, self).__init__(_by=by, _axis=axis, _ascending=ascending,
+                                                  _inplace=inplace, _kind=kind,
+                                                  _na_position=na_position,
+                                                  _ignore_index=ignore_index,
+                                                  _parallel_kind=parallel_kind,
+                                                  _psrs_kinds=psrs_kinds,
+                                                  _object_type=ObjectType.dataframe, **kw)
+
+    @property
+    def by(self):
+        return self._by
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @property
+    def ascending(self):
+        return self._ascending
+
+    @property
+    def inplace(self):
+        return self._inplace
+
+    @property
+    def kind(self):
+        return self._kind
+
+    @property
+    def na_position(self):
+        return self._na_position
+
+    @property
+    def ignore_index(self):
+        return self._ignore_index
+
+    @property
+    def parallel_kind(self):
+        return self._parallel_kind
+
+    @property
+    def psrs_kinds(self):
+        return self._psrs_kinds
+
+    @classmethod
+    def _tile_psrs(cls, op, in_data):
+        out = op.outputs[0]
+        in_df, axis_chunk_shape, out_idxes, _ = cls.preprocess(op, in_data=in_data)
+
+        # stage 1: local sort and regular samples collected
+        sorted_chunks, _, sampled_chunks = cls.local_sort_and_regular_sample(
+            op, in_df, axis_chunk_shape, None, None)
+
+        # stage 2: gather and merge samples, choose and broadcast p-1 pivots
+        concat_pivot_chunk = cls.concat_and_pivot(
+            op, axis_chunk_shape, (), sorted_chunks, sampled_chunks)
+
+        # stage 3: Local data is partitioned
+        partition_chunks = cls.partition_local_data(
+            op, axis_chunk_shape, sorted_chunks, None, concat_pivot_chunk)
+
+        proxy_chunk = DataFrameShuffleProxy(object_type=ObjectType.dataframe).new_chunk(
+            partition_chunks, shape=())
+
+        # stage 4: all *ith* classes are gathered and merged
+        partition_sort_chunks = cls.partition_merge_data(
+            op, False, None, partition_chunks, proxy_chunk)[0]
+
+        if op.ignore_index:
+            chunks = standardize_range_index(partition_sort_chunks, axis=op.axis)
+        else:
+            chunks = partition_sort_chunks
+
+        if op.axis == 0:
+            nsplits = ((np.nan,) * len(chunks), (out.shape[1],))
+        else:
+            nsplits = ((out.shape[0],), (np.nan,) * len(chunks))
+        new_op = op.copy()
+        return new_op.new_dataframes(op.inputs, shape=out.shape, chunks=chunks,
+                                     nsplits=nsplits, index_value=out.index_value,
+                                     columns_value=out.columns_value, dtypes=out.dtypes)
+
+    @classmethod
+    def tile(cls, op):
+        df = op.inputs[0]
+
+        if op.axis == 0:
+            df = build_concated_rows_frame(df)
+        else:
+            df = df.rechunk({0: (df.shape[0],)})._inplace_tile()
+
+        if df.chunk_shape[op.axis] == 1:
+            out_chunks = []
+            for chunk in df.chunks:
+                chunk_op = op.copy().reset_key()
+                out_chunks.append(chunk_op.new_chunk(
+                    [chunk], shape=chunk.shape, index=chunk.index, index_value=chunk.index_value,
+                    columns_value=chunk.columns_value, dtypes=chunk.dtypes))
+            new_op = op.copy()
+            kws = op.outputs[0].params.copy()
+            kws['nsplits'] = df.nsplits
+            kws['chunks'] = out_chunks
+            return new_op.new_dataframes(op.inputs, **kws)
+        else:
+            if op.na_position != 'last':  # pragma: no cover
+                raise NotImplementedError('Only support puts NaNs at the end.')
+            # use parallel sorting by regular sampling
+            return cls._tile_psrs(op, df)
+
+    @classmethod
+    def execute(cls, ctx, op):
+        in_data = ctx[op.inputs[0].key]
+        ctx[op.outputs[0].key] = sort_dataframe(in_data, op)
+
+    def __call__(self, df):
+        if self.axis == 0:
+            if self.ignore_index:
+                index_value = parse_index(pd.RangeIndex(df.shape[0]))
+            else:
+                index_value = df.index_value
+            return self.new_dataframe([df], shape=df.shape, dtypes=df.dtypes,
+                                      index_value=index_value,
+                                      columns_value=df.columns_value)
+        else:
+            if self.ignore_index:
+                columns_value = parse_index(pd.RangeIndex(df.shape[1]), store_data=True)
+            else:
+                columns_value = df.columns_value
+            return self.new_dataframe([df], shape=df.shape, dtypes=df.dtypes,
+                                      index_value=df.columns_value,
+                                      columns_value=columns_value)
+
+
+def sort_values(df, by, axis=0, ascending=True, inplace=False, kind='quicksort',
+                na_position='last', ignore_index=False, parallel_kind='PSRS', psrs_kinds=None):
+    if na_position not in ['last', 'first']:  # pragma: no cover
+        raise TypeError('invalid na_position: {}'.format(na_position))
+    psrs_kinds = _validate_sort_psrs_kinds(psrs_kinds)
+    axis = validate_axis(axis, df)
+    by = by if isinstance(by, (list, tuple)) else [by]
+    op = DataFrameSortValues(by=by, axis=axis, ascending=ascending, inplace=inplace, kind=kind,
+                             na_position=na_position, ignore_index=ignore_index, parallel_kind=parallel_kind,
+                             psrs_kinds=psrs_kinds)
+    return op(df)

--- a/mars/dataframe/sort/tests/__init__.py
+++ b/mars/dataframe/sort/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mars/dataframe/sort/tests/test_sort.py
+++ b/mars/dataframe/sort/tests/test_sort.py
@@ -1,0 +1,72 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from mars.operands import OperandStage
+from mars.dataframe.initializer import DataFrame
+from mars.dataframe.sort.sort_values import sort_values, DataFrameSortValues
+
+
+class Test(unittest.TestCase):
+    def testSortValues(self):
+        raw = pd.DataFrame({'a': np.random.rand(10),
+                            'b': np.random.randint(1000, size=10),
+                            'c': np.random.rand(10),
+                            'd': [np.random.bytes(10) for _ in range(10)],
+                            'e': [pd.Timestamp('201{}'.format(i)) for i in range(10)],
+                            'f': [pd.Timedelta('{} days'.format(i)) for i in range(10)]
+                            },)
+        df = DataFrame(raw)
+        sorted_df = sort_values(df, by='c')
+
+        self.assertEqual(sorted_df.shape, raw.shape)
+        self.assertIsInstance(sorted_df.op, DataFrameSortValues)
+
+        tiled = sorted_df.tiles()
+
+        self.assertEqual(len(tiled.chunks), 1)
+        self.assertIsInstance(tiled.chunks[0].op, DataFrameSortValues)
+
+        df = DataFrame(raw, chunk_size=6)
+        sorted_df = sort_values(df, by='c')
+
+        self.assertEqual(sorted_df.shape, raw.shape)
+        self.assertIsInstance(sorted_df.op, DataFrameSortValues)
+
+        tiled = sorted_df.tiles()
+
+        self.assertEqual(len(tiled.chunks), 2)
+        self.assertEqual(tiled.chunks[0].op.stage, OperandStage.reduce)
+
+        # test ignore index
+        df = DataFrame(raw, chunk_size=3)
+        sorted_df = sort_values(df, by=['a', 'c'])
+
+        self.assertEqual(sorted_df.shape, raw.shape)
+        self.assertIsInstance(sorted_df.op, DataFrameSortValues)
+        pd.testing.assert_index_equal(sorted_df.index_value.to_pandas(), pd.RangeIndex(10))
+
+        tiled = sorted_df.tiles()
+
+        self.assertEqual(len(tiled.chunks), 3)
+        self.assertEqual(tiled.chunks[0].op.stage, OperandStage.reduce)
+        pd.testing.assert_index_equal(tiled.chunks[0].index_value.to_pandas(), pd.RangeIndex(3))
+        self.assertEqual(tiled.chunks[1].op.stage, OperandStage.reduce)
+        pd.testing.assert_index_equal(tiled.chunks[1].index_value.to_pandas(), pd.RangeIndex(3, 6))
+        self.assertEqual(tiled.chunks[2].op.stage, OperandStage.reduce)
+        pd.testing.assert_index_equal(tiled.chunks[2].index_value.to_pandas(), pd.RangeIndex(6, 10))

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -145,7 +145,11 @@ class Test(unittest.TestCase):
         mdf = DataFrame(df, chunk_size=3)
         result = executor.execute_dataframe(
             mdf.sort_values(['a0', 'a1'], ignore_index=True), concat=True)[0]
-        expected = df.sort_values(['a0', 'a1'], ignore_index=True)
+        try:  # for python3.5
+            expected = df.sort_values(['a0', 'a1'], ignore_index=True)
+        except TypeError:
+            expected = df.sort_values(['a0', 'a1'])
+            expected.index = pd.RangeIndex(len(expected))
 
         pd.testing.assert_frame_equal(result, expected)
 

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -98,27 +98,6 @@ class Test(unittest.TestCase):
 
         pd.testing.assert_frame_equal(result, expected)
 
-        # test axis 1
-        df = pd.DataFrame(np.random.rand(10, 100), index=['a' + str(i) for i in range(10)])
-
-        mdf = DataFrame(df)
-        result = self.executor.execute_dataframe(mdf.sort_values('a0', axis=1), concat=True)[0]
-        expected = df.sort_values('a0', axis=1)
-
-        pd.testing.assert_frame_equal(result, expected)
-
-        mdf = DataFrame(df, chunk_size=10)
-        result = self.executor.execute_dataframe(mdf.sort_values('a0', axis=1), concat=True)[0]
-        expected = df.sort_values('a0', axis=1)
-
-        pd.testing.assert_frame_equal(result, expected)
-
-        mdf = DataFrame(df, chunk_size=10)
-        result = self.executor.execute_dataframe(mdf.sort_values(['a2', 'a3'], axis=1), concat=True)[0]
-        expected = df.sort_values(['a2', 'a3'], axis=1)
-
-        pd.testing.assert_frame_equal(result, expected)
-
         # test nan
         df = pd.DataFrame({
             'col1': ['A', 'A', 'B', 'B', 'D', 'C'],
@@ -160,4 +139,3 @@ class Test(unittest.TestCase):
         df.sort_values('a0', inplace=True)
 
         pd.testing.assert_frame_equal(result, df)
-

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -1,0 +1,159 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from mars.tests.core import ExecutorForTest
+from mars.dataframe import DataFrame
+from mars.session import new_session
+
+
+class Test(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.executor = ExecutorForTest('numpy')
+
+    def testSortValuesExecution(self):
+        df = pd.DataFrame(np.random.rand(100, 10), columns=['a' + str(i) for i in range(10)])
+
+        # test one chunk
+        mdf = DataFrame(df)
+        result = self.executor.execute_dataframe(mdf.sort_values('a0'), concat=True)[0]
+        expected = df.sort_values('a0')
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        result = self.executor.execute_dataframe(mdf.sort_values(['a6', 'a7'], ascending=False), concat=True)[0]
+        expected = df.sort_values(['a6', 'a7'], ascending=False)
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test psrs
+        mdf = DataFrame(df, chunk_size=10)
+        result = self.executor.execute_dataframe(mdf.sort_values('a0'), concat=True)[0]
+        expected = df.sort_values('a0')
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        result = self.executor.execute_dataframe(mdf.sort_values(['a3', 'a4']), concat=True)[0]
+        expected = df.sort_values(['a3', 'a4'])
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test ascending=False
+        result = self.executor.execute_dataframe(mdf.sort_values(['a0', 'a1'], ascending=False), concat=True)[0]
+        expected = df.sort_values(['a0', 'a1'], ascending=False)
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        result = self.executor.execute_dataframe(mdf.sort_values(['a7'], ascending=False), concat=True)[0]
+        expected = df.sort_values(['a7'], ascending=False)
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test rechunk
+        mdf = DataFrame(df, chunk_size=3)
+        result = self.executor.execute_dataframe(mdf.sort_values('a0'), concat=True)[0]
+        expected = df.sort_values('a0')
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        result = self.executor.execute_dataframe(mdf.sort_values(['a3', 'a4']), concat=True)[0]
+        expected = df.sort_values(['a3', 'a4'])
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test other types
+        raw = pd.DataFrame({'a': np.random.rand(10),
+                            'b': np.random.randint(1000, size=10),
+                            'c': np.random.rand(10),
+                            'd': [np.random.bytes(10) for _ in range(10)],
+                            'e': [pd.Timestamp('201{}'.format(i)) for i in range(10)],
+                            'f': [pd.Timedelta('{} days'.format(i)) for i in range(10)]
+                            },)
+        mdf = DataFrame(raw, chunk_size=3)
+
+        for label in raw.columns:
+            result = self.executor.execute_dataframe(mdf.sort_values(label), concat=True)[0]
+            expected = raw.sort_values(label)
+            pd.testing.assert_frame_equal(result, expected)
+
+        result = self.executor.execute_dataframe(mdf.sort_values(['a', 'b', 'e'], ascending=False), concat=True)[0]
+        expected = raw.sort_values(['a', 'b', 'e'], ascending=False)
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test axis 1
+        df = pd.DataFrame(np.random.rand(10, 100), index=['a' + str(i) for i in range(10)])
+
+        mdf = DataFrame(df)
+        result = self.executor.execute_dataframe(mdf.sort_values('a0', axis=1), concat=True)[0]
+        expected = df.sort_values('a0', axis=1)
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        mdf = DataFrame(df, chunk_size=10)
+        result = self.executor.execute_dataframe(mdf.sort_values('a0', axis=1), concat=True)[0]
+        expected = df.sort_values('a0', axis=1)
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        mdf = DataFrame(df, chunk_size=10)
+        result = self.executor.execute_dataframe(mdf.sort_values(['a2', 'a3'], axis=1), concat=True)[0]
+        expected = df.sort_values(['a2', 'a3'], axis=1)
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test nan
+        df = pd.DataFrame({
+            'col1': ['A', 'A', 'B', 'B', 'D', 'C'],
+            'col2': [2, 1, 9, np.nan, 7, 4],
+            'col3': [0, 1, 9, 4, 2, 3],
+        })
+        mdf = DataFrame(df)
+        result = self.executor.execute_dataframe(mdf.sort_values(['col2']), concat=True)[0]
+        expected = df.sort_values(['col2'])
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        mdf = DataFrame(df, chunk_size=3)
+        result = self.executor.execute_dataframe(mdf.sort_values(['col2']), concat=True)[0]
+        expected = df.sort_values(['col2'])
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test ignore_index
+        executor = ExecutorForTest(storage=new_session().context)
+
+        df = pd.DataFrame(np.random.rand(10, 3), columns=['a' + str(i) for i in range(3)])
+
+        mdf = DataFrame(df, chunk_size=3)
+        result = executor.execute_dataframe(
+            mdf.sort_values(['a0', 'a1'], ignore_index=True), concat=True)[0]
+        expected = df.sort_values(['a0', 'a1'], ignore_index=True)
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test inplace
+        mdf = DataFrame(df)
+        mdf.sort_values('a0', inplace=True)
+        result = self.executor.execute_dataframe(mdf, concat=True)[0]
+        df.sort_values('a0', inplace=True)
+
+        pd.testing.assert_frame_equal(result, df)
+

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -593,16 +593,17 @@ def validate_axis(axis, tileable):
     return axis
 
 
-def standardize_range_index(chunks):
+def standardize_range_index(chunks, axis=0):
     from .base.standardize_range_index import ChunkStandardizeRangeIndex
 
-    row_chunks = dict((k, next(v)) for k, v in itertools.groupby(chunks, key=lambda x: x.index[0]))
+    row_chunks = dict((k, next(v)) for k, v in itertools.groupby(chunks, key=lambda x: x.index[axis]))
     row_chunks = [row_chunks[i] for i in range(len(row_chunks))]
 
     out_chunks = []
     for c in chunks:
-        inputs = row_chunks[:c.index[0]] + [c]
-        op = ChunkStandardizeRangeIndex(prepare_inputs=[False] * len(inputs), object_type=c.op.object_type)
+        inputs = row_chunks[:c.index[axis]] + [c]
+        op = ChunkStandardizeRangeIndex(
+            prepare_inputs=[False] * len(inputs), axis=axis, object_type=c.op.object_type)
         out_chunks.append(op.new_chunk(inputs, **c.params.copy()))
 
     return out_chunks

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -391,6 +391,9 @@ message OperandDef {
         CALC_PARTITIONS_INFO = 2046;
         PARTITION_MERGED = 2047;
 
+        // dataframe sort
+        SORT_VALUES = 2050;
+
         // store
         READ_CSV = 2100;
         TO_CSV = 2101;

--- a/mars/tensor/base/partition.py
+++ b/mars/tensor/base/partition.py
@@ -30,7 +30,7 @@ from ..utils import validate_axis, validate_order
 from .psrs import TensorPSRSOperandMixin
 
 
-class ParallelPartitionMixinTensor(TensorPSRSOperandMixin):
+class ParallelPartitionMixin(TensorPSRSOperandMixin):
     @classmethod
     def calc_paritions_info(cls, op, kth, size, sort_info_chunks):
         # stage5, collect sort infos and calculate partition info for each partitions
@@ -97,7 +97,7 @@ class ParallelPartitionMixinTensor(TensorPSRSOperandMixin):
         return partitioned_chunks, partitioned_indices_chunks
 
 
-class TensorPartition(TensorOperand, ParallelPartitionMixinTensor):
+class TensorPartition(TensorOperand, ParallelPartitionMixin):
     _op_type_ = OperandDef.PARTITION
 
     _input = KeyField('input')

--- a/mars/tensor/base/partition.py
+++ b/mars/tensor/base/partition.py
@@ -27,10 +27,10 @@ from ..core import TENSOR_TYPE, CHUNK_TYPE, TensorOrder
 from ..array_utils import as_same_device, device
 from ..datasource import tensor as astensor
 from ..utils import validate_axis, validate_order
-from .psrs import PSRSOperandMixin
+from .psrs import TensorPSRSOperandMixin
 
 
-class ParallelPartitionMixin(PSRSOperandMixin):
+class ParallelPartitionMixinTensor(TensorPSRSOperandMixin):
     @classmethod
     def calc_paritions_info(cls, op, kth, size, sort_info_chunks):
         # stage5, collect sort infos and calculate partition info for each partitions
@@ -97,7 +97,7 @@ class ParallelPartitionMixin(PSRSOperandMixin):
         return partitioned_chunks, partitioned_indices_chunks
 
 
-class TensorPartition(TensorOperand, ParallelPartitionMixin):
+class TensorPartition(TensorOperand, ParallelPartitionMixinTensor):
     _op_type_ = OperandDef.PARTITION
 
     _input = KeyField('input')
@@ -358,7 +358,7 @@ class TensorPartition(TensorOperand, ParallelPartitionMixin):
                 ctx[op.outputs[0].key] = xp.partition(a, kth, axis=op.axis, **kw)
 
 
-class CalcPartitionsInfo(TensorOperand, PSRSOperandMixin):
+class CalcPartitionsInfo(TensorOperand, TensorPSRSOperandMixin):
     _op_type_ = OperandDef.CALC_PARTITIONS_INFO
 
     _kth = AnyField('kth')
@@ -422,7 +422,7 @@ class CalcPartitionsInfo(TensorOperand, PSRSOperandMixin):
                 ctx[out.key] = partition_info
 
 
-class PartitionMerged(TensorOperand, PSRSOperandMixin):
+class PartitionMerged(TensorOperand, TensorPSRSOperandMixin):
     _op_type_ = OperandDef.PARTITION_MERGED
 
     _return_value = BoolField('return_value')

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -89,15 +89,15 @@ class PSRSOperandMixin:
 
 class TensorPSRSOperandMixin(TensorOperandMixin, PSRSOperandMixin):
     @classmethod
-    def local_sort_and_regular_sample(cls, op, in_tensor, axis_chunk_shape, axis_offsets, out_idx):
+    def local_sort_and_regular_sample(cls, op, in_data, axis_chunk_shape, axis_offsets, out_idx):
         # stage 1: local sort and regular samples collected
         sorted_chunks, indices_chunks, sampled_chunks = [], [], []
-        sampled_dtype = np.dtype([(o, in_tensor.dtype[o]) for o in op.order]) \
-            if op.order is not None else in_tensor.dtype
+        sampled_dtype = np.dtype([(o, in_data.dtype[o]) for o in op.order]) \
+            if op.order is not None else in_data.dtype
         for i in range(axis_chunk_shape):
             idx = list(out_idx)
             idx.insert(op.axis, i)
-            in_chunk = in_tensor.cix[tuple(idx)]
+            in_chunk = in_data.cix[tuple(idx)]
             kind = None if op.psrs_kinds is None else op.psrs_kinds[0]
             chunk_op = PSRSSortRegularSample(axis=op.axis, order=op.order, kind=kind,
                                              return_indices=op.return_indices,

--- a/mars/tensor/base/sort.py
+++ b/mars/tensor/base/sort.py
@@ -21,10 +21,10 @@ from ..operands import TensorOperand, TensorShuffleProxy, TensorOrder
 from ..array_utils import as_same_device, device
 from ..datasource import tensor as astensor
 from ..utils import validate_axis, validate_order
-from .psrs import PSRSOperandMixin
+from .psrs import TensorPSRSOperandMixin
 
 
-class TensorSort(TensorOperand, PSRSOperandMixin):
+class TensorSort(TensorOperand, TensorPSRSOperandMixin):
     _op_type_ = OperandDef.SORT
 
     _axis = Int32Field('axis')


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Support `DataFrame.sort_values` by a parallel sorting algorithm PSRS, the logic is similar to `mt.sort`.

## Related issue number
Solve part of #1037.

<!-- Are there any issues opened that will be resolved by merging this change? -->
