### PR TITLE
Support sort_index for DataFrame and Series

### DIFF
--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 4, 0, 'a2')
+version_info = (0, 4, 0, 'a3')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 4, 0, 'a3')
+version_info = (0, 4, 0, 'b1')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/dataframe/sort/__init__.py
+++ b/mars/dataframe/sort/__init__.py
@@ -13,14 +13,21 @@
 # limitations under the License.
 
 from .sort_values import DataFrameSortValues
+from .sort_index import DataFrameSortIndex
 
 
 def _install():
-    from ..core import DATAFRAME_TYPE
-    from .sort_values import sort_values
+    from ..core import DATAFRAME_TYPE, SERIES_TYPE
+    from .sort_values import dataframe_sort_values, series_sort_values
+    from .sort_index import sort_index
 
     for cls in DATAFRAME_TYPE:
-        setattr(cls, 'sort_values', sort_values)
+        setattr(cls, 'sort_values', dataframe_sort_values)
+        setattr(cls, 'sort_index', sort_index)
+
+    for cls in SERIES_TYPE:
+        setattr(cls, 'sort_values', series_sort_values)
+        setattr(cls, 'sort_index', sort_index)
 
 
 _install()

--- a/mars/dataframe/sort/core.py
+++ b/mars/dataframe/sort/core.py
@@ -1,0 +1,69 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from ...serialize import Int32Field, StringField, ListField, BoolField, ValueType
+from ..operands import DataFrameOperand
+
+
+class DataFrameSortOperand(DataFrameOperand):
+    _axis = Int32Field('axis')
+    _ascending = BoolField('ascending')
+    _inplace = BoolField('inplace')
+    _kind = StringField('kind')
+    _na_position = StringField('na_position')
+    _ignore_index = BoolField('ignore_index')
+    _parallel_kind = StringField('parallel_kind')
+    _psrs_kinds = ListField('psrs_kinds', ValueType.string)
+
+    def __init__(self, axis=None, ascending=None, inplace=None, kind=None,
+                 na_position=None, ignore_index=None, parallel_kind=None, psrs_kinds=None, **kw):
+        super(DataFrameSortOperand, self).__init__(_axis=axis, _ascending=ascending,
+                                                   _inplace=inplace, _kind=kind,
+                                                   _na_position=na_position,
+                                                   _ignore_index=ignore_index,
+                                                   _parallel_kind=parallel_kind,
+                                                   _psrs_kinds=psrs_kinds, **kw)
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @property
+    def ascending(self):
+        return self._ascending
+
+    @property
+    def inplace(self):
+        return self._inplace
+
+    @property
+    def kind(self):
+        return self._kind
+
+    @property
+    def na_position(self):
+        return self._na_position
+
+    @property
+    def ignore_index(self):
+        return self._ignore_index
+
+    @property
+    def parallel_kind(self):
+        return self._parallel_kind
+
+    @property
+    def psrs_kinds(self):
+        return self._psrs_kinds

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -506,7 +506,7 @@ class DataFramePSRSShuffle(DataFrameMapReduceOperand, DataFrameOperandMixin):
 
     @classmethod
     def _execute_map(cls, ctx, op):
-        a, pivots = [ctx[c.key] for c in op.inputs]
+        a = [ctx[c.key] for c in op.inputs][0]
         if op.sort_type == 'sort_values':
             if len(a.shape) == 2:
                 # DataFrame type

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -20,8 +20,8 @@ from ...utils import lazy_import, get_shuffle_input_keys_idxes
 from ...operands import OperandStage
 from ...serialize import ValueType, Int32Field, ListField, StringField, BoolField
 from ...tensor.base.psrs import PSRSOperandMixin
-from ..utils import parse_index
-from ..operands import DataFrameOperandMixin, DataFrameOperand,\
+from ..utils import standardize_range_index
+from ..operands import DataFrameOperandMixin, DataFrameOperand, DataFrameShuffleProxy, \
     ObjectType, DataFrameMapReduceOperand
 
 
@@ -30,30 +30,48 @@ cudf = lazy_import('cudf', globals=globals())
 
 class DataFramePSRSOperandMixin(DataFrameOperandMixin, PSRSOperandMixin):
     @classmethod
+    def _collect_op_properties(cls, op):
+        from .sort_values import DataFrameSortValues
+        if isinstance(op, DataFrameSortValues):
+            properties = dict(sort_type='sort_values', axis=op.axis, by=op.by, ascending=op.ascending,
+                              inplace=op.inplace, na_position=op.na_position)
+        else:
+            properties = dict(sort_type='sort_index', axis=op.axis, level=op.level, ascending=op.ascending,
+                              inplace=op.inplace, na_position=op.na_position, sort_remaining=op.sort_remaining)
+        return properties
+
+    @classmethod
     def local_sort_and_regular_sample(cls, op, in_data, axis_chunk_shape, axis_offsets, out_idx):
         # stage 1: local sort and regular samples collected
         sorted_chunks, indices_chunks, sampled_chunks = [], [], []
         for i in range(axis_chunk_shape):
             in_chunk = in_data.chunks[i]
             kind = None if op.psrs_kinds is None else op.psrs_kinds[0]
-            chunk_op = DataFramePSRSSortRegularSample(
-                axis=op.axis, by=op.by, ascending=op.ascending,
-                inplace=op.inplace, kind=kind, na_position=op.na_position,
-                n_partition=axis_chunk_shape)
+            chunk_op = DataFramePSRSSortRegularSample(kind=kind, n_partition=axis_chunk_shape,
+                                                      object_type=op.object_type,
+                                                      **cls._collect_op_properties(op))
             kws = []
             sort_shape = in_chunk.shape
             kws.append({'shape': sort_shape,
                         'index_value': in_chunk.index_value,
-                        'columns_value': in_chunk.columns_value,
-                        'index': in_chunk.index,
-                        'dtypes': in_chunk.dtypes})
-            sampled_shape = (axis_chunk_shape, len(op.by))
+                        'index': in_chunk.index})
+            if chunk_op.sort_type == 'sort_values':
+                sampled_shape = (axis_chunk_shape, len(op.by)) if \
+                    op.by else (axis_chunk_shape,)
+            else:
+                sampled_shape = (axis_chunk_shape, sort_shape[1]) if\
+                    len(sort_shape) == 2 else (axis_chunk_shape,)
             kws.append({'shape': sampled_shape,
                         'index_value': in_chunk.index_value,
-                        'columns_value': parse_index(pd.Index(op.by), store_data=True),
-                        'dtypes': in_chunk.dtypes,
                         'index': (i,),
                         'type': 'regular_sampled'})
+            if op.object_type == ObjectType.dataframe:
+                kws[0].update({'columns_value': in_chunk.columns_value, 'dtypes': in_chunk.dtypes})
+                kws[1].update({'columns_value': in_chunk.columns_value, 'dtypes': in_chunk.dtypes})
+            else:
+                kws[0].update(({'dtype': in_chunk.dtype, 'name': in_chunk.name}))
+                kws[1].update({'dtype': in_chunk.dtype})
+
             chunks = chunk_op.new_chunks([in_chunk], kws=kws, output_limit=len(kws))
             sort_chunk, sampled_chunk = chunks
             sorted_chunks.append(sort_chunk)
@@ -63,16 +81,18 @@ class DataFramePSRSOperandMixin(DataFrameOperandMixin, PSRSOperandMixin):
     @classmethod
     def concat_and_pivot(cls, op, axis_chunk_shape, out_idx, sorted_chunks, sampled_chunks):
         # stage 2: gather and merge samples, choose and broadcast p-1 pivots
-        concat_pivot_op = DataFramePSRSConcatPivot(
-            by=op.by, axis=op.axis, ascending=op.ascending, na_position=op.na_position,
-            kind=None if op.psrs_kinds is None else op.psrs_kinds[1])
+        kind = None if op.psrs_kinds is None else op.psrs_kinds[1]
+        concat_pivot_op = DataFramePSRSConcatPivot(kind=kind, n_partition=axis_chunk_shape,
+                                                   object_type=op.object_type,
+                                                   **cls._collect_op_properties(op))
         concat_pivot_shape = \
             sorted_chunks[0].shape[:op.axis] + (axis_chunk_shape - 1,) + \
             sorted_chunks[0].shape[op.axis + 1:]
         concat_pivot_index = out_idx[:op.axis] + (0,) + out_idx[op.axis:]
         concat_pivot_chunk = concat_pivot_op.new_chunk(sampled_chunks,
                                                        shape=concat_pivot_shape,
-                                                       index=concat_pivot_index)
+                                                       index=concat_pivot_index,
+                                                       object_type=op.object_type)
         return concat_pivot_chunk
 
     @classmethod
@@ -83,15 +103,19 @@ class DataFramePSRSOperandMixin(DataFrameOperandMixin, PSRSOperandMixin):
         length = len(sorted_chunks)
         for i in range(length):
             chunk_inputs = [sorted_chunks[i], concat_pivot_chunk]
-            partition_shuffle_map = DataFramePSRSShuffle(
-                by=op.by, stage=OperandStage.map, axis=op.axis, ascending=op.ascending,
-                na_position=op.na_position, n_partition=axis_chunk_shape)
-            partition_chunk = partition_shuffle_map.new_chunk(chunk_inputs,
-                                                              shape=chunk_inputs[0].shape,
-                                                              index=chunk_inputs[0].index,
-                                                              index_value=chunk_inputs[0].index_value,
-                                                              columns_value=chunk_inputs[0].columns_value,
-                                                              dtypes=chunk_inputs[0].dtypes)
+            partition_shuffle_map = DataFramePSRSShuffle(n_partition=axis_chunk_shape,
+                                                         stage=OperandStage.map,
+                                                         object_type=op.object_type,
+                                                         **cls._collect_op_properties(op))
+            kw = dict(shape=chunk_inputs[0].shape,
+                      index=chunk_inputs[0].index,
+                      index_value=chunk_inputs[0].index_value)
+            if op.object_type == ObjectType.dataframe:
+                kw.update(dict(columns_value=chunk_inputs[0].columns_value,
+                               dtypes=chunk_inputs[0].dtypes))
+            else:
+                kw.update(dict(dtype=chunk_inputs[0].dtype, name=chunk_inputs[0].name))
+            partition_chunk = partition_shuffle_map.new_chunk(chunk_inputs, **kw)
             partition_chunks.append(partition_chunk)
         return partition_chunks
 
@@ -102,50 +126,132 @@ class DataFramePSRSOperandMixin(DataFrameOperandMixin, PSRSOperandMixin):
         for i, partition_chunk in enumerate(partition_chunks):
             kind = None if op.psrs_kinds is None else op.psrs_kinds[2]
             partition_shuffle_reduce = DataFramePSRSShuffle(
-                stage=OperandStage.reduce, axis=op.axis, by=op.by, ascending=op.ascending,
-                inplace=op.inplace, na_position=op.na_position, kind=kind, shuffle_key=str(i))
+                stage=OperandStage.reduce, kind=kind, shuffle_key=str(i),
+                object_type=op.object_type, **cls._collect_op_properties(op))
             chunk_shape = list(partition_chunk.shape)
             chunk_shape[op.axis] = np.nan
 
-            cs = partition_shuffle_reduce.new_chunks(
-                [proxy_chunk], shape=tuple(chunk_shape), index=partition_chunk.index,
-                index_value=partition_chunk.index_value, columns_value=partition_chunk.columns_value,
-                dtypes=partition_chunk.dtypes)
+            kw = dict(shape=tuple(chunk_shape), index=partition_chunk.index,
+                      index_value=partition_chunk.index_value)
+            if op.object_type == ObjectType.dataframe:
+                kw.update(dict(columns_value=partition_chunk.columns_value,
+                               dtypes=partition_chunk.dtypes))
+            else:
+                kw.update(dict(dtype=partition_chunk.dtype, name=partition_chunk.name))
+            cs = partition_shuffle_reduce.new_chunks([proxy_chunk], **kw)
 
             partition_sort_chunks.append(cs[0])
         return partition_sort_chunks, partition_indices_chunks, sort_info_chunks
 
+    @classmethod
+    def _tile_psrs(cls, op, in_data):
+        out = op.outputs[0]
+        in_df, axis_chunk_shape, _, _ = cls.preprocess(op, in_data=in_data)
 
-def sort_dataframe(df, op, inplace=None):
+        # stage 1: local sort and regular samples collected
+        sorted_chunks, _, sampled_chunks = cls.local_sort_and_regular_sample(
+            op, in_df, axis_chunk_shape, None, None)
+
+        # stage 2: gather and merge samples, choose and broadcast p-1 pivots
+        concat_pivot_chunk = cls.concat_and_pivot(
+            op, axis_chunk_shape, (), sorted_chunks, sampled_chunks)
+
+        # stage 3: Local data is partitioned
+        partition_chunks = cls.partition_local_data(
+            op, axis_chunk_shape, sorted_chunks, None, concat_pivot_chunk)
+
+        proxy_chunk = DataFrameShuffleProxy(object_type=op.object_type).new_chunk(
+            partition_chunks, shape=())
+
+        # stage 4: all *ith* classes are gathered and merged
+        partition_sort_chunks = cls.partition_merge_data(
+            op, False, None, partition_chunks, proxy_chunk)[0]
+
+        if op.ignore_index:
+            chunks = standardize_range_index(partition_sort_chunks, axis=op.axis)
+        else:
+            chunks = partition_sort_chunks
+
+        if op.object_type == ObjectType.dataframe:
+            nsplits = ((np.nan,) * len(chunks), (out.shape[1],))
+            new_op = op.copy()
+            return new_op.new_dataframes(op.inputs, shape=out.shape, chunks=chunks,
+                                         nsplits=nsplits, index_value=out.index_value,
+                                         columns_value=out.columns_value, dtypes=out.dtypes)
+        else:
+            nsplits = ((np.nan,) * len(chunks), )
+            new_op = op.copy()
+            return new_op.new_seriess(op.inputs, shape=out.shape, chunks=chunks,
+                                      nsplits=nsplits, index_value=out.index_value,
+                                      dtype=out.dtype, name=out.name)
+
+
+def execute_sort_values(data, op, inplace=None):
     if inplace is None:
         inplace = op.inplace
     # ignore_index is new in Pandas version 1.0.0.
     ignore_index = getattr(op, 'ignore_index', False)
-    if isinstance(df, pd.DataFrame):
+    if isinstance(data, (pd.DataFrame, pd.Series)):
+        kwargs = dict(axis=op.axis, ascending=op.ascending, ignore_index=ignore_index,
+                      na_position=op.na_position, kind=op.kind)
+        if isinstance(data, pd.DataFrame):
+            kwargs['by'] = op.by
         if inplace:
+            kwargs['inplace'] = True
             try:
-                df.sort_values(op.by, axis=op.axis, ascending=op.ascending, ignore_index=ignore_index,
-                               inplace=True, na_position=op.na_position, kind=op.kind)
+                data.sort_values(**kwargs)
             except TypeError:  # pragma: no cover
-                df.sort_values(op.by, axis=op.axis, ascending=op.ascending, inplace=True,
-                               na_position=op.na_position, kind=op.kind)
-            return df
+                kwargs.pop('ignore_index', None)
+                data.sort_values(**kwargs)
+            return data
         else:
             try:
-                return df.sort_values(op.by, axis=op.axis, ascending=op.ascending, ignore_index=ignore_index,
-                                      inplace=False, na_position=op.na_position, kind=op.kind)
+                return data.sort_values(**kwargs)
             except TypeError:  # pragma: no cover
-                return df.sort_values(op.by, axis=op.axis, ascending=op.ascending,
-                                      inplace=False, na_position=op.na_position, kind=op.kind)
+                kwargs.pop('ignore_index', None)
+                return data.sort_values(**kwargs)
 
     else:  # pragma: no cover
         # cudf doesn't support axis and kind
-        return df.sort_values(
-            op.by, ascending=op.ascending, na_position=op.na_position)
+        if isinstance(data, cudf.DataFrame):
+            return data.sort_values(
+                op.by, ascending=op.ascending, na_position=op.na_position)
+        else:
+            return data.sort_values(
+                ascending=op.ascending, na_position=op.na_position)
 
 
-class DataFramePSRSSortRegularSample(DataFrameOperand, DataFrameOperandMixin):
-    _op_type_ = OperandDef.PSRS_SORT_REGULAR_SMAPLE
+def execute_sort_index(data, op, inplace=None):
+    if inplace is None:
+        inplace = op.inplace
+    # ignore_index is new in Pandas version 1.0.0.
+    ignore_index = getattr(op, 'ignore_index', False)
+    if isinstance(data, (pd.DataFrame, pd.Series)):
+        kwargs = dict(level=op.level, ascending=op.ascending, ignore_index=ignore_index,
+                      na_position=op.na_position, kind=op.kind, sort_remaining=op.sort_remaining)
+        if inplace:
+            kwargs['inplace'] = True
+            try:
+                data.sort_index(**kwargs)
+            except TypeError:  # pragma: no cover
+                kwargs.pop('ignore_index', None)
+                data.sort_index(**kwargs)
+            return data
+        else:
+            try:
+                return data.sort_index(**kwargs)
+            except TypeError:  # pragma: no cover
+                kwargs.pop('ignore_index', None)
+                return data.sort_index(**kwargs)
+
+    else:  # pragma: no cover
+        # cudf only support ascending
+        return data.sort_index(ascending=op.ascending)
+
+
+class DataFramePSRSChunkOperand(DataFrameOperand):
+    # sort type could be 'sort_values' or 'sort_index'
+    _sort_type = StringField('sort_type')
 
     _axis = Int32Field('axis')
     _by = ListField('by', ValueType.string)
@@ -153,13 +259,23 @@ class DataFramePSRSSortRegularSample(DataFrameOperand, DataFrameOperandMixin):
     _inplace = BoolField('inplace')
     _kind = StringField('kind')
     _na_position = StringField('na_position')
+
+    # for sort_index
+    _level = ListField('level')
+    _sort_remaining = BoolField('sort_remaining')
+
     _n_partition = Int32Field('n_partition')
 
-    def __init__(self, by=None, axis=None, ascending=None, inplace=None, kind=None,
-                 na_position=None,  n_partition=None, **kw):
-        super().__init__(_by=by, _axis=axis, _ascending=ascending, _inplace=inplace,
-                         _kind=kind, _na_position=na_position, _n_partition=n_partition,
-                         _object_type=ObjectType.dataframe, **kw)
+    def __init__(self, sort_type=None, by=None, axis=None, ascending=None, inplace=None, kind=None,
+                 na_position=None, level=None, sort_remaining=None, n_partition=None, object_type=None, **kw):
+        super().__init__(_sort_type=sort_type, _by=by, _axis=axis, _ascending=ascending,
+                         _inplace=inplace, _kind=kind, _na_position=na_position,
+                         _level=level, _sort_remaining=sort_remaining, _n_partition=n_partition,
+                         _object_type=object_type, **kw)
+
+    @property
+    def sort_type(self):
+        return self._sort_type
 
     @property
     def axis(self):
@@ -186,8 +302,20 @@ class DataFramePSRSSortRegularSample(DataFrameOperand, DataFrameOperandMixin):
         return self._na_position
 
     @property
+    def level(self):
+        return self._level
+
+    @property
+    def sort_remaining(self):
+        return self._sort_remaining
+
+    @property
     def n_partition(self):
         return self._n_partition
+
+
+class DataFramePSRSSortRegularSample(DataFramePSRSChunkOperand, DataFrameOperandMixin):
+    _op_type_ = OperandDef.PSRS_SORT_REGULAR_SMAPLE
 
     @property
     def output_limit(self):
@@ -200,45 +328,26 @@ class DataFramePSRSSortRegularSample(DataFrameOperand, DataFrameOperandMixin):
         n = op.n_partition
         w = int(a.shape[op.axis] // n)
 
-        ctx[op.outputs[0].key] = res = sort_dataframe(a, op)
-        # do regular sample
         slc = (slice(None),) * op.axis + (slice(0, n * w, w),)
-        ctx[op.outputs[-1].key] = res[op.by].iloc[slc]
+        if op.sort_type == 'sort_values':
+            ctx[op.outputs[0].key] = res = execute_sort_values(a, op)
+            # do regular sample
+            if op.by is not None:
+                ctx[op.outputs[-1].key] = res[op.by].iloc[slc]
+            else:
+                ctx[op.outputs[-1].key] = res.iloc[slc]
+        else:
+            ctx[op.outputs[0].key] = res = execute_sort_index(a, op)
+            # do regular sample
+            ctx[op.outputs[-1].key] = res.iloc[slc]
 
 
-class DataFramePSRSConcatPivot(DataFrameOperand, DataFrameOperandMixin):
+class DataFramePSRSConcatPivot(DataFramePSRSChunkOperand, DataFrameOperandMixin):
     _op_type_ = OperandDef.PSRS_CONCAT_PIVOT
 
-    _by = ListField('by', ValueType.string)
-    _axis = Int32Field('axis')
-    _ascending = BoolField('ascending')
-    _na_position = StringField('na_position')
-    _kind = StringField('kind')
-
-    def __init__(self, by=None, axis=None, ascending=None, na_position=None, kind=None, **kw):
-        super().__init__(_by=by, _axis=axis, _ascending=ascending,
-                         _na_position=na_position, _kind=kind,
-                         _object_type=ObjectType.dataframe, **kw)
-
     @property
-    def by(self):
-        return self._by
-
-    @property
-    def axis(self):
-        return self._axis
-
-    @property
-    def ascending(self):
-        return self._ascending
-
-    @property
-    def na_position(self):
-        return self._na_position
-
-    @property
-    def kind(self):
-        return self._kind
+    def output_limit(self):
+        return 1
 
     @classmethod
     def execute(cls, ctx, op):
@@ -249,15 +358,20 @@ class DataFramePSRSConcatPivot(DataFrameOperand, DataFrameOperandMixin):
         p = len(inputs)
         assert a.shape[op.axis] == p ** 2
 
-        a = sort_dataframe(a, op, inplace=False)
-
         select = slice(p - 1, (p - 1) ** 2 + 1, p - 1)
         slc = (slice(None),) * op.axis + (select,)
-        ctx[op.outputs[-1].key] = a.iloc[slc]
+        if op.sort_type == 'sort_values':
+            a = execute_sort_values(a, op, inplace=False)
+            ctx[op.outputs[-1].key] = a.iloc[slc]
+        else:
+            a = execute_sort_index(a, op, inplace=False)
+            ctx[op.outputs[-1].key] = a.index[slc]
 
 
 class DataFramePSRSShuffle(DataFrameMapReduceOperand, DataFrameOperandMixin):
     _op_type_ = OperandDef.PSRS_SHUFFLE
+
+    _sort_type = StringField('sort_type')
 
     # for shuffle map
     _axis = Int32Field('axis')
@@ -267,14 +381,24 @@ class DataFramePSRSShuffle(DataFrameMapReduceOperand, DataFrameOperandMixin):
     _na_position = StringField('na_position')
     _n_partition = Int32Field('n_partition')
 
+    # for sort_index
+    _level = ListField('level')
+    _sort_remaining = BoolField('sort_remaining')
+
     # for shuffle reduce
     _kind = StringField('kind')
 
-    def __init__(self, by=None, axis=None, ascending=None, n_partition=None, na_position=None,
-                 inplace=None, kind=None, stage=None, shuffle_key=None, **kw):
-        super().__init__(_by=by, _axis=axis, _ascending=ascending, _n_partition=n_partition,
-                         _na_position=na_position, _inplace=inplace, _kind=kind, _stage=stage,
-                         _shuffle_key=shuffle_key, _object_type=ObjectType.dataframe, **kw)
+    def __init__(self, sort_type=None, by=None, axis=None, ascending=None, n_partition=None,
+                 na_position=None, inplace=None, kind=None, level=None, sort_remaining=None,
+                 stage=None, shuffle_key=None, object_type=None, **kw):
+        super().__init__(_sort_type=sort_type, _by=by, _axis=axis, _ascending=ascending,
+                         _n_partition=n_partition, _na_position=na_position, _inplace=inplace,
+                         _kind=kind, _level=level, _sort_remaining=sort_remaining, _stage=stage,
+                         _shuffle_key=shuffle_key, _object_type=object_type, **kw)
+
+    @property
+    def sort_type(self):
+        return self._sort_type
 
     @property
     def by(self):
@@ -295,6 +419,14 @@ class DataFramePSRSShuffle(DataFrameMapReduceOperand, DataFrameOperandMixin):
     @property
     def na_position(self):
         return self._na_position
+
+    @property
+    def level(self):
+        return self._level
+
+    @property
+    def sort_remaining(self):
+        return self._sort_remaining
 
     @property
     def n_partition(self):
@@ -309,7 +441,7 @@ class DataFramePSRSShuffle(DataFrameMapReduceOperand, DataFrameOperandMixin):
         return 1
 
     @classmethod
-    def _execute_map(cls, ctx, op):
+    def _execute_dataframe_map(cls, ctx, op):
         a, pivots = [ctx[c.key] for c in op.inputs]
         out = op.outputs[0]
 
@@ -344,12 +476,57 @@ class DataFramePSRSShuffle(DataFrameMapReduceOperand, DataFrameOperandMixin):
                     ctx[(out.key, str(i))] = selected
 
     @classmethod
+    def _execute_series_map(cls, ctx, op):
+        a, pivots = [ctx[c.key] for c in op.inputs]
+        out = op.outputs[0]
+
+        if isinstance(a, pd.Series):
+            if op.ascending:
+                poses = a.searchsorted(pivots, side='right')
+            else:
+                poses = len(a) - a.iloc[::-1].searchsorted(pivots, side='right')
+            poses = (None,) + tuple(poses) + (None,)
+            for i in range(op.n_partition):
+                values = a.iloc[poses[i]: poses[i + 1]]
+                ctx[(out.key, str(i))] = values
+
+    @classmethod
+    def _execute_sort_index_map(cls, ctx, op):
+        a, pivots = [ctx[c.key] for c in op.inputs]
+        out = op.outputs[0]
+
+        if op.ascending:
+            poses = a.index.searchsorted(list(pivots), side='right')
+        else:
+            poses = len(a) - a.index[::-1].searchsorted(list(pivots), side='right')
+        poses = (None,) + tuple(poses) + (None,)
+        for i in range(op.n_partition):
+            values = a.iloc[poses[i]: poses[i + 1]]
+            ctx[(out.key, str(i))] = values
+
+    @classmethod
+    def _execute_map(cls, ctx, op):
+        a, pivots = [ctx[c.key] for c in op.inputs]
+        if op.sort_type == 'sort_values':
+            if len(a.shape) == 2:
+                # DataFrame type
+                cls._execute_dataframe_map(ctx, op)
+            else:
+                # Series type
+                cls._execute_series_map(ctx, op)
+        else:
+            cls._execute_sort_index_map(ctx, op)
+
+    @classmethod
     def _execute_reduce(cls, ctx, op):
         input_keys, _ = get_shuffle_input_keys_idxes(op.inputs[0])
         raw_inputs = [ctx[(input_key, op.shuffle_key)] for input_key in input_keys]
-        xdf = pd if isinstance(raw_inputs[0], pd.DataFrame) else cudf
+        xdf = pd if isinstance(raw_inputs[0], (pd.DataFrame, pd.Series)) else cudf
         concat_values = xdf.concat(raw_inputs, axis=op.axis)
-        ctx[op.outputs[0].key] = sort_dataframe(concat_values, op)
+        if op.sort_type == 'sort_values':
+            ctx[op.outputs[0].key] = execute_sort_values(concat_values, op)
+        else:
+            ctx[op.outputs[0].key] = execute_sort_index(concat_values, op)
 
     @classmethod
     def execute(cls, ctx, op):

--- a/mars/dataframe/sort/sort_index.py
+++ b/mars/dataframe/sort/sort_index.py
@@ -1,0 +1,167 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+
+from ...serialize import ListField, BoolField
+from ... import opcodes as OperandDef
+from ...tensor.base.sort import _validate_sort_psrs_kinds
+from ..utils import parse_index, validate_axis, build_concatenated_rows_frame
+from ..operands import DATAFRAME_TYPE, ObjectType
+from .core import DataFrameSortOperand
+from .psrs import DataFramePSRSOperandMixin, execute_sort_index
+
+
+class DataFrameSortIndex(DataFrameSortOperand, DataFramePSRSOperandMixin):
+    _op_type_ = OperandDef.SORT_INDEX
+
+    _level = ListField('level')
+    _sort_remaining = BoolField('sort_remaining')
+
+    def __init__(self, level=None, sort_remaining=None, **kw):
+        super(DataFrameSortIndex, self).__init__(_level=level, _sort_remaining=sort_remaining, **kw)
+
+    @property
+    def level(self):
+        return self._level
+
+    @property
+    def sort_remaining(self):
+        return self._sort_remaining
+
+    @classmethod
+    def tile(cls, op):
+        df = op.inputs[0]
+
+        if op.axis == 0:
+            df = build_concatenated_rows_frame(df)
+
+            if df.chunk_shape[op.axis] == 1:
+                out_chunks = []
+                for chunk in df.chunks:
+                    chunk_op = op.copy().reset_key()
+                    out_chunks.append(chunk_op.new_chunk(
+                        [chunk], shape=chunk.shape, index=chunk.index, index_value=chunk.index_value,
+                        columns_value=chunk.columns_value, dtypes=chunk.dtypes))
+                new_op = op.copy()
+                kws = op.outputs[0].params.copy()
+                kws['nsplits'] = df.nsplits
+                kws['chunks'] = out_chunks
+                return new_op.new_dataframes(op.inputs, **kws)
+            else:
+                if op.na_position != 'last':  # pragma: no cover
+                    raise NotImplementedError('Only support puts NaNs at the end.')
+                # use parallel sorting by regular sampling
+                return cls._tile_psrs(op, df)
+
+    def _call_dataframe(self, df):
+        if self.axis == 0:
+            if self.ignore_index:
+                index_value = parse_index(pd.RangeIndex(df.shape[0]))
+            else:
+                index_value = df.index_value
+            return self.new_dataframe([df], shape=df.shape, dtypes=df.dtypes,
+                                      index_value=index_value,
+                                      columns_value=df.columns_value)
+        else:
+            if self.ignore_index:
+                dtypes = df.dtypes.reset_index(drop=True)
+                columns_value = parse_index(pd.RangeIndex(df.shape[1]), store_data=True)
+            else:
+                dtypes = df.dtypes.sort_values()
+                columns_value = parse_index(dtypes.index, store_data=True)
+            return self.new_dataframe([df], shape=df.shape, dtypes=dtypes,
+                                      index_value=df.index_value,
+                                      columns_value=columns_value)
+
+    @classmethod
+    def execute(cls, ctx, op):
+        in_data = ctx[op.inputs[0].key]
+        ctx[op.outputs[0].key] = execute_sort_index(in_data, op)
+
+    def _call_series(self, series):
+        if self.axis != 0:
+            raise TypeError('Invalid axis: {}'.format(self.axis))
+        if self.ignore_index:
+            index_value = parse_index(pd.RangeIndex(series.shape[0]))
+        else:
+            index_value = series.index_value
+
+        return self.new_series([series], shape=series.shape, dtype=series.dtype,
+                               index_value=index_value, name=series.name)
+
+    def __call__(self, a):
+        if isinstance(a, DATAFRAME_TYPE):
+            self._object_type = ObjectType.dataframe
+            return self._call_dataframe(a)
+        else:
+            self._object_type = ObjectType.series
+            return self._call_series(a)
+
+
+def sort_index(a, axis=0, level=None, ascending=True, inplace=False, kind='quicksort',
+               na_position='last', sort_remaining=True, ignore_index: bool = False,
+               parallel_kind='PSRS', psrs_kinds=None):
+    """
+    Sort object by labels (along an axis).
+
+    Parameters
+    ----------
+    a : Input DataFrame or Series.
+    axis : {0 or 'index', 1 or 'columns'}, default 0
+        The axis along which to sort.  The value 0 identifies the rows,
+        and 1 identifies the columns.
+    level : int or level name or list of ints or list of level names
+        If not None, sort on values in specified index level(s).
+    ascending : bool, default True
+        Sort ascending vs. descending.
+    inplace : bool, default False
+        If True, perform operation in-place.
+    kind : {'quicksort', 'mergesort', 'heapsort'}, default 'quicksort'
+        Choice of sorting algorithm. See also ndarray.np.sort for more
+        information.  `mergesort` is the only stable algorithm. For
+        DataFrames, this option is only applied when sorting on a single
+        column or label.
+    na_position : {'first', 'last'}, default 'last'
+        Puts NaNs at the beginning if `first`; `last` puts NaNs at the end.
+        Not implemented for MultiIndex.
+    sort_remaining : bool, default True
+        If True and sorting by level and index is multilevel, sort by other
+        levels too (in order) after sorting by specified level.
+    ignore_index : bool, default False
+        If True, the resulting axis will be labeled 0, 1, …, n - 1.
+    parallel_kind: {'PSRS'}, optional.
+        Parallel sorting algorithm, for the details, refer to:
+        http://csweb.cs.wfu.edu/bigiron/LittleFE-PSRS/build/html/PSRSalgorithm.html
+    psrs_kinds: Sorting algorithms during PSRS algorithm.
+
+    Returns
+    -------
+    sorted_obj : DataFrame or None
+        DataFrame with sorted index if inplace=False, None otherwise.
+    """
+    if na_position not in ['last', 'first']:  # pragma: no cover
+        raise TypeError('Invalid na_position: {}'.format(na_position))
+    psrs_kinds = _validate_sort_psrs_kinds(psrs_kinds)
+    axis = validate_axis(axis, a)
+    level = level if isinstance(level, (list, tuple)) else [level]
+    op = DataFrameSortIndex(level=level, axis=axis, ascending=ascending, inplace=inplace,
+                            kind=kind, na_position=na_position, sort_remaining=sort_remaining,
+                            ignore_index=ignore_index, parallel_kind=parallel_kind,
+                            psrs_kinds=psrs_kinds)
+    sorted_a = op(a)
+    if inplace:
+        a.data = sorted_a.data
+    else:
+        return sorted_a

--- a/mars/dataframe/sort/sort_values.py
+++ b/mars/dataframe/sort/sort_values.py
@@ -12,119 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import pandas as pd
 
-from ...serialize import Int32Field, StringField, ListField, BoolField, ValueType
+from ...serialize import ListField, ValueType
 from ... import opcodes as OperandDef
 from ...tensor.base.sort import _validate_sort_psrs_kinds
-from ..utils import parse_index, standardize_range_index, validate_axis, build_concatenated_rows_frame
-from ..operands import DataFrameOperand, DataFrameShuffleProxy, ObjectType
-from .psrs import DataFramePSRSOperandMixin, sort_dataframe
+from ..utils import parse_index, validate_axis, build_concatenated_rows_frame
+from ..operands import ObjectType
+from .core import DataFrameSortOperand
+from .psrs import DataFramePSRSOperandMixin, execute_sort_values
 
 
-class DataFrameSortValues(DataFrameOperand, DataFramePSRSOperandMixin):
+class DataFrameSortValues(DataFrameSortOperand, DataFramePSRSOperandMixin):
     _op_type_ = OperandDef.SORT_VALUES
 
     _by = ListField('by', ValueType.string)
-    _axis = Int32Field('axis')
-    _ascending = BoolField('ascending')
-    _inplace = BoolField('inplace')
-    _kind = StringField('kind')
-    _na_position = StringField('na_position')
-    _ignore_index = BoolField('ignore_index')
-    _parallel_kind = StringField('parallel_kind')
-    _psrs_kinds = ListField('psrs_kinds', ValueType.string)
 
-    def __init__(self, by=None, axis=None, ascending=None, inplace=None, kind=None,
-                 na_position=None, ignore_index=None, parallel_kind=None, psrs_kinds=None, **kw):
-        super(DataFrameSortValues, self).__init__(_by=by, _axis=axis, _ascending=ascending,
-                                                  _inplace=inplace, _kind=kind,
-                                                  _na_position=na_position,
-                                                  _ignore_index=ignore_index,
-                                                  _parallel_kind=parallel_kind,
-                                                  _psrs_kinds=psrs_kinds,
-                                                  _object_type=ObjectType.dataframe, **kw)
+    def __init__(self, by=None, object_type=None, **kw):
+        super(DataFrameSortValues, self).__init__(_by=by, _object_type=object_type, **kw)
 
     @property
     def by(self):
         return self._by
 
-    @property
-    def axis(self):
-        return self._axis
-
-    @property
-    def ascending(self):
-        return self._ascending
-
-    @property
-    def inplace(self):
-        return self._inplace
-
-    @property
-    def kind(self):
-        return self._kind
-
-    @property
-    def na_position(self):
-        return self._na_position
-
-    @property
-    def ignore_index(self):
-        return self._ignore_index
-
-    @property
-    def parallel_kind(self):
-        return self._parallel_kind
-
-    @property
-    def psrs_kinds(self):
-        return self._psrs_kinds
-
     @classmethod
-    def _tile_psrs(cls, op, in_data):
-        out = op.outputs[0]
-        in_df, axis_chunk_shape, _, _ = cls.preprocess(op, in_data=in_data)
-
-        # stage 1: local sort and regular samples collected
-        sorted_chunks, _, sampled_chunks = cls.local_sort_and_regular_sample(
-            op, in_df, axis_chunk_shape, None, None)
-
-        # stage 2: gather and merge samples, choose and broadcast p-1 pivots
-        concat_pivot_chunk = cls.concat_and_pivot(
-            op, axis_chunk_shape, (), sorted_chunks, sampled_chunks)
-
-        # stage 3: Local data is partitioned
-        partition_chunks = cls.partition_local_data(
-            op, axis_chunk_shape, sorted_chunks, None, concat_pivot_chunk)
-
-        proxy_chunk = DataFrameShuffleProxy(object_type=ObjectType.dataframe).new_chunk(
-            partition_chunks, shape=())
-
-        # stage 4: all *ith* classes are gathered and merged
-        partition_sort_chunks = cls.partition_merge_data(
-            op, False, None, partition_chunks, proxy_chunk)[0]
-
-        if op.ignore_index:
-            chunks = standardize_range_index(partition_sort_chunks, axis=op.axis)
-        else:
-            chunks = partition_sort_chunks
-
-        if op.axis == 0:
-            nsplits = ((np.nan,) * len(chunks), (out.shape[1],))
-        else:
-            nsplits = ((out.shape[0],), (np.nan,) * len(chunks))
-        new_op = op.copy()
-        return new_op.new_dataframes(op.inputs, shape=out.shape, chunks=chunks,
-                                     nsplits=nsplits, index_value=out.index_value,
-                                     columns_value=out.columns_value, dtypes=out.dtypes)
-
-    @classmethod
-    def tile(cls, op):
-        df = op.inputs[0]
-
-        df = build_concatenated_rows_frame(df)
+    def _tile_dataframe(cls, op):
+        df = build_concatenated_rows_frame(op.inputs[0])
 
         if df.chunk_shape[op.axis] == 1:
             out_chunks = []
@@ -145,26 +58,57 @@ class DataFrameSortValues(DataFrameOperand, DataFramePSRSOperandMixin):
             return cls._tile_psrs(op, df)
 
     @classmethod
+    def _tile_series(cls, op):
+        series = op.inputs[0]
+        if len(series.chunks) == 1:
+            chunk = series.chunks[0]
+            chunk_op = op.copy().reset_key()
+            out_chunks = [chunk_op.new_chunk(series.chunks, shape=chunk.shape, index=chunk.index,
+                                             index_value=chunk.index_value, dtype=chunk.dtype,
+                                             name=chunk.name)]
+            new_op = op.copy()
+            kws = op.outputs[0].params.copy()
+            kws['nsplits'] = series.nsplits
+            kws['chunks'] = out_chunks
+            return new_op.new_seriess(op.inputs, **kws)
+        else:
+            if op.na_position != 'last':  # pragma: no cover
+                raise NotImplementedError('Only support puts NaNs at the end.')
+            # use parallel sorting by regular sampling
+            return cls._tile_psrs(op, series)
+
+    @classmethod
+    def tile(cls, op):
+        if op.object_type == ObjectType.dataframe:
+            return cls._tile_dataframe(op)
+        else:
+            return cls._tile_series(op)
+
+    @classmethod
     def execute(cls, ctx, op):
         in_data = ctx[op.inputs[0].key]
-        ctx[op.outputs[0].key] = sort_dataframe(in_data, op)
+        ctx[op.outputs[0].key] = execute_sort_values(in_data, op)
 
-    def __call__(self, df):
+    def __call__(self, a):
         assert self.axis == 0
         if self.ignore_index:
-            index_value = parse_index(pd.RangeIndex(df.shape[0]))
+            index_value = parse_index(pd.RangeIndex(a.shape[0]))
         else:
-            index_value = df.index_value
-        return self.new_dataframe([df], shape=df.shape, dtypes=df.dtypes,
-                                  index_value=index_value,
-                                  columns_value=df.columns_value)
+            index_value = a.index_value
+        if a.op.object_type == ObjectType.dataframe:
+            return self.new_dataframe([a], shape=a.shape, dtypes=a.dtypes,
+                                      index_value=index_value,
+                                      columns_value=a.columns_value)
+        else:
+            return self.new_series([a], shape=a.shape, dtype=a.dtype,
+                                   index_value=index_value, name=a.name)
 
 
-def sort_values(df, by, axis=0, ascending=True, inplace=False, kind='quicksort',
-                na_position='last', ignore_index=False, parallel_kind='PSRS', psrs_kinds=None):
+def dataframe_sort_values(df, by, axis=0, ascending=True, inplace=False, kind='quicksort',
+                          na_position='last', ignore_index=False, parallel_kind='PSRS', psrs_kinds=None):
     """
     Sort by the values along either axis.
-    :param df: input data.
+    :param df: input DataFrame.
     :param by: Name or list of names to sort by.
     :param axis: Axis to be sorted.
     :param ascending: Sort ascending vs. descending. Specify list for multiple sort orders.
@@ -241,9 +185,104 @@ def sort_values(df, by, axis=0, ascending=True, inplace=False, kind='quicksort',
     by = by if isinstance(by, (list, tuple)) else [by]
     op = DataFrameSortValues(by=by, axis=axis, ascending=ascending, inplace=inplace, kind=kind,
                              na_position=na_position, ignore_index=ignore_index, parallel_kind=parallel_kind,
-                             psrs_kinds=psrs_kinds)
+                             psrs_kinds=psrs_kinds, object_type=ObjectType.dataframe)
     sorted_df = op(df)
     if inplace:
         df.data = sorted_df.data
     else:
         return sorted_df
+
+
+def series_sort_values(series, axis=0, ascending=True, inplace=False, kind='quicksort',
+                       na_position='last', ignore_index=False, parallel_kind='PSRS', psrs_kinds=None):
+    """
+    Sort by the values.
+
+    Sort a Series in ascending or descending order by some
+    criterion.
+
+    Parameters
+    ----------
+    series : input Series.
+    axis : {0 or 'index'}, default 0
+        Axis to direct sorting. The value 'index' is accepted for
+        compatibility with DataFrame.sort_values.
+    ascending : bool, default True
+        If True, sort values in ascending order, otherwise descending.
+    inplace : bool, default False
+        If True, perform operation in-place.
+    kind : {'quicksort', 'mergesort' or 'heapsort'}, default 'quicksort'
+        Choice of sorting algorithm. See also :func:`numpy.sort` for more
+        information. 'mergesort' is the only stable  algorithm.
+    na_position : {'first' or 'last'}, default 'last'
+        Argument 'first' puts NaNs at the beginning, 'last' puts NaNs at
+        the end.
+    ignore_index : bool, default False
+         If True, the resulting axis will be labeled 0, 1, …, n - 1.
+
+    Returns
+    -------
+    Series
+        Series ordered by values.
+
+    Examples
+    --------
+    >>> import mars.dataframe as md
+    >>> raw = pd.Series([np.nan, 1, 3, 10, 5])
+    >>> s = md.Series(raw)
+    >>> s.execute()
+    0     NaN
+    1     1.0
+    2     3.0
+    3     10.0
+    4     5.0
+    dtype: float64
+
+    Sort values ascending order (default behaviour)
+
+    >>> s.sort_values(ascending=True).execute()
+    1     1.0
+    2     3.0
+    4     5.0
+    3    10.0
+    0     NaN
+    dtype: float64
+
+    Sort values descending order
+
+    >>> s.sort_values(ascending=False).execute()
+    3    10.0
+    4     5.0
+    2     3.0
+    1     1.0
+    0     NaN
+    dtype: float64
+
+    Sort values inplace
+
+    >>> s.sort_values(ascending=False, inplace=True)
+    >>> s.execute()
+    3    10.0
+    4     5.0
+    2     3.0
+    1     1.0
+    0     NaN
+    dtype: float64
+
+    Sort values putting NAs first
+    """
+    if na_position not in ['last', 'first']:  # pragma: no cover
+        raise TypeError('invalid na_position: {}'.format(na_position))
+    axis = validate_axis(axis, series)
+    if axis != 0:
+        raise NotImplementedError('Only support sort on axis 0')
+    psrs_kinds = _validate_sort_psrs_kinds(psrs_kinds)
+    op = DataFrameSortValues(axis=axis, ascending=ascending, inplace=inplace, kind=kind,
+                             na_position=na_position, ignore_index=ignore_index,
+                             parallel_kind=parallel_kind, psrs_kinds=psrs_kinds,
+                             object_type=ObjectType.series)
+    sorted_series = op(series)
+    if inplace:
+        series.data = sorted_series.data
+    else:
+        return sorted_series

--- a/mars/dataframe/sort/tests/test_sort.py
+++ b/mars/dataframe/sort/tests/test_sort.py
@@ -118,5 +118,4 @@ class Test(unittest.TestCase):
 
         tiled = sorted_df.tiles()
 
-        self.assertEqual(len(tiled.chunks), 18)
         self.assertTrue(all(isinstance(c.op, DataFrameIndex) for c in tiled.chunks))

--- a/mars/dataframe/sort/tests/test_sort.py
+++ b/mars/dataframe/sort/tests/test_sort.py
@@ -19,7 +19,7 @@ import pandas as pd
 
 from mars.operands import OperandStage
 from mars.dataframe.initializer import DataFrame
-from mars.dataframe.sort.sort_values import sort_values, DataFrameSortValues
+from mars.dataframe.sort.sort_values import dataframe_sort_values, DataFrameSortValues
 
 
 class Test(unittest.TestCase):
@@ -32,7 +32,7 @@ class Test(unittest.TestCase):
                             'f': [pd.Timedelta('{} days'.format(i)) for i in range(10)]
                             },)
         df = DataFrame(raw)
-        sorted_df = sort_values(df, by='c')
+        sorted_df = dataframe_sort_values(df, by='c')
 
         self.assertEqual(sorted_df.shape, raw.shape)
         self.assertIsInstance(sorted_df.op, DataFrameSortValues)
@@ -43,7 +43,7 @@ class Test(unittest.TestCase):
         self.assertIsInstance(tiled.chunks[0].op, DataFrameSortValues)
 
         df = DataFrame(raw, chunk_size=6)
-        sorted_df = sort_values(df, by='c')
+        sorted_df = dataframe_sort_values(df, by='c')
 
         self.assertEqual(sorted_df.shape, raw.shape)
         self.assertIsInstance(sorted_df.op, DataFrameSortValues)
@@ -55,7 +55,7 @@ class Test(unittest.TestCase):
 
         # test ignore index
         df = DataFrame(raw, chunk_size=3)
-        sorted_df = sort_values(df, by=['a', 'c'])
+        sorted_df = dataframe_sort_values(df, by=['a', 'c'])
 
         self.assertEqual(sorted_df.shape, raw.shape)
         self.assertIsInstance(sorted_df.op, DataFrameSortValues)

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -218,7 +218,7 @@ class Test(unittest.TestCase):
         try:  # for python3.5
             expected = raw.sort_index(axis=1, ignore_index=True)
         except TypeError:
-            expected = raw.sort_index(axis=1, ignore_index=True)
+            expected = raw.sort_index(axis=1)
             expected.index = pd.RangeIndex(len(expected))
         pd.testing.assert_frame_equal(result, expected)
 

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 
 from mars.tests.core import ExecutorForTest
-from mars.dataframe import DataFrame
+from mars.dataframe import DataFrame, Series
 from mars.session import new_session
 
 
@@ -139,3 +139,42 @@ class Test(unittest.TestCase):
         df.sort_values('a0', inplace=True)
 
         pd.testing.assert_frame_equal(result, df)
+
+        # test Sereis.sort_values
+        raw = pd.Series(np.random.rand(10))
+        series = Series(raw)
+        result = self.executor.execute_dataframe(series.sort_values(), concat=True)[0]
+        expected = raw.sort_values()
+
+        pd.testing.assert_series_equal(result, expected)
+
+        series = Series(raw, chunk_size=3)
+        result = self.executor.execute_dataframe(series.sort_values(), concat=True)[0]
+        expected = raw.sort_values()
+
+        pd.testing.assert_series_equal(result, expected)
+
+        series = Series(raw, chunk_size=2)
+        result = self.executor.execute_dataframe(series.sort_values(ascending=False), concat=True)[0]
+        expected = raw.sort_values(ascending=False)
+
+        pd.testing.assert_series_equal(result, expected)
+
+    def testSortIndexExecution(self):
+        raw = pd.DataFrame(np.random.rand(100, 10), index=np.random.rand(100))
+
+        mdf = DataFrame(raw)
+        result = self.executor.execute_dataframe(mdf.sort_index(), concat=True)[0]
+        expected = raw.sort_index()
+        pd.testing.assert_frame_equal(result, expected)
+
+        mdf = DataFrame(raw, chunk_size=30)
+        result = self.executor.execute_dataframe(mdf.sort_index(), concat=True)[0]
+        expected = raw.sort_index()
+        pd.testing.assert_frame_equal(result, expected)
+
+        mdf = DataFrame(raw, chunk_size=20)
+        result = self.executor.execute_dataframe(mdf.sort_index(ascending=False), concat=True)[0]
+        expected = raw.sort_index(ascending=False)
+        pd.testing.assert_frame_equal(result, expected)
+

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -188,7 +188,11 @@ class Test(unittest.TestCase):
 
         mdf = DataFrame(raw, chunk_size=10)
         result = executor.execute_dataframe(mdf.sort_index(ignore_index=True), concat=True)[0]
-        expected = raw.sort_index(ignore_index=True)
+        try:  # for python3.5
+            expected = raw.sort_index(ignore_index=True)
+        except TypeError:
+            expected = raw.sort_index()
+            expected.index = pd.RangeIndex(len(expected))
         pd.testing.assert_frame_equal(result, expected)
 
         # test axis=1
@@ -211,7 +215,11 @@ class Test(unittest.TestCase):
 
         mdf = DataFrame(raw, chunk_size=4)
         result = self.executor.execute_dataframe(mdf.sort_index(axis=1, ignore_index=True), concat=True)[0]
-        expected = raw.sort_index(axis=1, ignore_index=True)
+        try:  # for python3.5
+            expected = raw.sort_index(axis=1, ignore_index=True)
+        except TypeError:
+            expected = raw.sort_index(axis=1, ignore_index=True)
+            expected.index = pd.RangeIndex(len(expected))
         pd.testing.assert_frame_equal(result, expected)
 
         # test series

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -161,10 +161,16 @@ class Test(unittest.TestCase):
         pd.testing.assert_series_equal(result, expected)
 
     def testSortIndexExecution(self):
-        raw = pd.DataFrame(np.random.rand(100, 10), index=np.random.rand(100))
+        raw = pd.DataFrame(np.random.rand(100, 20), index=np.random.rand(100))
 
         mdf = DataFrame(raw)
         result = self.executor.execute_dataframe(mdf.sort_index(), concat=True)[0]
+        expected = raw.sort_index()
+        pd.testing.assert_frame_equal(result, expected)
+
+        mdf = DataFrame(raw)
+        mdf.sort_index(inplace=True)
+        result = self.executor.execute_dataframe(mdf, concat=True)[0]
         expected = raw.sort_index()
         pd.testing.assert_frame_equal(result, expected)
 
@@ -178,3 +184,50 @@ class Test(unittest.TestCase):
         expected = raw.sort_index(ascending=False)
         pd.testing.assert_frame_equal(result, expected)
 
+        executor = ExecutorForTest(storage=new_session().context)
+
+        mdf = DataFrame(raw, chunk_size=10)
+        result = executor.execute_dataframe(mdf.sort_index(ignore_index=True), concat=True)[0]
+        expected = raw.sort_index(ignore_index=True)
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test axis=1
+        raw = pd.DataFrame(np.random.rand(10, 10), columns=np.random.rand(10))
+
+        mdf = DataFrame(raw)
+        result = self.executor.execute_dataframe(mdf.sort_index(axis=1), concat=True)[0]
+        expected = raw.sort_index(axis=1)
+        pd.testing.assert_frame_equal(result, expected)
+
+        mdf = DataFrame(raw, chunk_size=3)
+        result = self.executor.execute_dataframe(mdf.sort_index(axis=1), concat=True)[0]
+        expected = raw.sort_index(axis=1)
+        pd.testing.assert_frame_equal(result, expected)
+
+        mdf = DataFrame(raw, chunk_size=4)
+        result = self.executor.execute_dataframe(mdf.sort_index(axis=1, ascending=False), concat=True)[0]
+        expected = raw.sort_index(axis=1, ascending=False)
+        pd.testing.assert_frame_equal(result, expected)
+
+        mdf = DataFrame(raw, chunk_size=4)
+        result = self.executor.execute_dataframe(mdf.sort_index(axis=1, ignore_index=True), concat=True)[0]
+        expected = raw.sort_index(axis=1, ignore_index=True)
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test series
+        raw = pd.Series(np.random.rand(10, ), index=np.random.rand(10))
+
+        series = Series(raw)
+        result = self.executor.execute_dataframe(series.sort_index(), concat=True)[0]
+        expected = raw.sort_index()
+        pd.testing.assert_series_equal(result, expected)
+
+        series = Series(raw, chunk_size=2)
+        result = self.executor.execute_dataframe(series.sort_index(), concat=True)[0]
+        expected = raw.sort_index()
+        pd.testing.assert_series_equal(result, expected)
+
+        series = Series(raw, chunk_size=3)
+        result = self.executor.execute_dataframe(series.sort_index(ascending=False), concat=True)[0]
+        expected = raw.sort_index(ascending=False)
+        pd.testing.assert_series_equal(result, expected)

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -140,7 +140,7 @@ def decide_dataframe_chunk_sizes(shape, chunk_size, memory_usage):
             cs = min(col_left_size, dim_size)
             col_chunk_size.append(cs)
             start = int(np.sum(col_chunk_size[:-1]))
-            col_chunk_store.append(average_memory_usage[start: start + cs].sum())
+            col_chunk_store.append(average_memory_usage.iloc[start: start + cs].sum())
             col_left_size -= cs
         if row_left_size > 0:
             max_col_chunk_store = max(col_chunk_store)

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -393,6 +393,7 @@ message OperandDef {
 
         // dataframe sort
         SORT_VALUES = 2050;
+        SORT_INDEX = 2051;
 
         // store
         READ_CSV = 2100;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Add support for `sort_index`.

- [x] Support Series.sort_values.

- [x] Support DataFrame.sort_index and Series.sort_index on axis 0.

- [x] Support DataFrame.sort_index and Series.sort_index on axis 1.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #1037.