### PR TITLE
Add support for {DataFrame,Series}.agg

### DIFF
--- a/mars/core.py
+++ b/mars/core.py
@@ -17,6 +17,7 @@
 import builtins
 import itertools
 from operator import attrgetter
+from typing import List
 from weakref import WeakKeyDictionary, WeakSet, ref
 
 import numpy as np
@@ -376,7 +377,7 @@ class TileableData(EntityData, Tileable):
             return tuple(map(len, self._nsplits))
 
     @property
-    def chunks(self):
+    def chunks(self) -> List["Chunk"]:
         return getattr(self, '_chunks', None)
 
     @property
@@ -388,7 +389,7 @@ class TileableData(EntityData, Tileable):
         self._nsplits = new_nsplits
 
     @property
-    def params(self):
+    def params(self) -> dict:
         # params return the properties which useful to rebuild a new tileable object
         return dict()
 
@@ -599,7 +600,7 @@ class ChunksIndexer(object):
             else:
                 return [self._tileable._chunks[idx] for idx in flat_index]
 
-        raise ValueError('Cannot get tensor chunk by {0}'.format(item))
+        raise ValueError('Cannot get {0} chunk by {1}'.format(type(self._tileable).__name__, item))
 
 
 class ExecutableTuple(tuple):

--- a/mars/dataframe/base/apply.py
+++ b/mars/dataframe/base/apply.py
@@ -22,7 +22,7 @@ from ...config import options
 from ...serialize import StringField, AnyField, BoolField, \
     TupleField, DictField, FunctionField
 from ..operands import DataFrameOperandMixin, DataFrameOperand, ObjectType
-from ..utils import build_empty_df, build_empty_series, parse_index
+from ..utils import build_empty_df, build_empty_series, parse_index, validate_axis
 
 
 class DataFrameApplyTransform(DataFrameOperand, DataFrameOperandMixin):
@@ -176,11 +176,7 @@ class DataFrameApplyTransform(DataFrameOperand, DataFrameOperandMixin):
 
     def __call__(self, df, dtypes=None, index=None):
         axis = getattr(self, 'axis', None) or 0
-        if axis == 'index':
-            axis = 0
-        elif axis == 'columns':
-            axis = 1
-        self._axis = axis
+        self._axis = axis = validate_axis(axis, df)
 
         dtypes, index_value = self._infer_df_func_returns(df.dtypes, dtypes, index)
         for arg, desc in zip((self._object_type, dtypes, index_value),

--- a/mars/dataframe/base/fillna.py
+++ b/mars/dataframe/base/fillna.py
@@ -25,6 +25,7 @@ from ...serialize import StringField, AnyField, BoolField, Int64Field
 from ..align import align_dataframe_dataframe, align_dataframe_series, align_series_series
 from ..core import DATAFRAME_TYPE
 from ..operands import DataFrameOperandMixin, DataFrameOperand, ObjectType
+from ..utils import validate_axis
 
 
 class FillNA(DataFrameOperand, DataFrameOperandMixin):
@@ -348,11 +349,7 @@ class FillNA(DataFrameOperand, DataFrameOperandMixin):
             method = 'ffill'
         self._method = method
         axis = getattr(self, 'axis', None) or 0
-        if axis == 'index':
-            axis = 0
-        elif axis == 'columns':
-            axis = 1
-        self._axis = axis
+        self._axis = validate_axis(axis, a)
 
         inputs = [a]
         if value_df is not None:

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -29,7 +29,7 @@ from ..merge import DataFrameConcat
 from ..operands import DataFrameOperand, DataFrameOperandMixin, \
     DataFrameShuffleProxy, ObjectType
 from ..core import GROUPBY_TYPE
-from ..utils import build_empty_df, parse_index, \
+from ..utils import build_empty_df, build_empty_series, parse_index, \
     build_concatenated_rows_frame, tokenize
 from .core import DataFrameGroupByOperand
 
@@ -41,6 +41,8 @@ _stage_infos = namedtuple('stage_infos', ('intermediate_cols', 'agg_cols',
                                           'map_func', 'map_output_column_to_func',
                                           'combine_func', 'combine_output_column_to_func',
                                           'agg_func', 'agg_output_column_to_func'))
+
+_series_col_name = 'col_name'
 
 
 class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
@@ -57,12 +59,16 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
     _agg_columns = ListField('agg_columns', ValueType.string)
     # store output columns -> function to apply on DataFrameGroupBy
     _output_column_to_func = DictField('output_column_to_func')
+    # store original name of the series
+    _series_name = StringField('series_name')
 
-    def __init__(self, func=None, by=None, as_index=None, sort=None, method=None,
-                 raw_func=None, agg_columns=None, output_column_to_func=None, stage=None, **kw):
+    def __init__(self, func=None, by=None, as_index=None, sort=None, method=None, raw_func=None,
+                 agg_columns=None, output_column_to_func=None, series_name=None, stage=None,
+                 object_type=None, **kw):
         super().__init__(_func=func, _by=by, _as_index=as_index, _sort=sort, _method=method,
                          _agg_columns=agg_columns, _output_column_to_func=output_column_to_func,
-                         _raw_func=raw_func, _stage=stage, _object_type=ObjectType.dataframe, **kw)
+                         _raw_func=raw_func, _series_name=series_name, _stage=stage,
+                         _object_type=object_type, **kw)
 
     @property
     def func(self):
@@ -97,8 +103,8 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
         return self._output_column_to_func
 
     @property
-    def stage(self):
-        return self._stage
+    def series_name(self):
+        return self._series_name
 
     def _normalize_keyword_aggregations(self, empty_df):
         raw_func = self._raw_func
@@ -114,18 +120,26 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
             # force as_index=True
             agg_df = empty_df.groupby(self.by, as_index=True).aggregate(self.func)
 
-            if not isinstance(agg_df.columns, pd.MultiIndex):
-                # 1 func, the columns of agg_df is the columns to aggregate
-                self._func = OrderedDict((c, [raw_func]) for c in agg_df.columns)
+            if isinstance(agg_df, pd.Series):
+                self._func = OrderedDict([(_series_col_name, [raw_func])])
             else:
-                func = OrderedDict()
-                for c, f in agg_df.columns:
-                    self._safe_append(func, c, f)
-                self._func = func
+                if isinstance(empty_df, pd.Series):
+                    func = OrderedDict()
+                    for f in agg_df.columns:
+                        self._safe_append(func, _series_col_name, f)
+                    self._func = func
+                elif not isinstance(agg_df.columns, pd.MultiIndex):
+                    # 1 func, the columns of agg_df is the columns to aggregate
+                    self._func = OrderedDict((c, [raw_func]) for c in agg_df.columns)
+                else:
+                    func = OrderedDict()
+                    for c, f in agg_df.columns:
+                        self._safe_append(func, c, f)
+                    self._func = func
 
-    def __call__(self, df):
+    def _call_dataframe(self, df):
         empty_df = build_empty_df(df.dtypes)
-        agg_df = empty_df.groupby(self.by, as_index=self._as_index).aggregate(self.func)
+        agg_df = empty_df.groupby(self.by, as_index=self.as_index).aggregate(self.func)
 
         shape = (np.nan, agg_df.shape[1])
         index_value = parse_index(agg_df.index, df.key)
@@ -147,6 +161,34 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
         return self.new_dataframe([df], shape=shape, dtypes=agg_df.dtypes,
                                   index_value=index_value,
                                   columns_value=parse_index(agg_df.columns, store_data=True))
+
+    def _call_series(self, series):
+        empty_series = build_empty_series(series.dtype)
+        agg_result = empty_series.groupby(self.by, as_index=self.as_index).aggregate(self.func)
+
+        index_value = parse_index(agg_result.index, series.key)
+        index_value.value.should_be_monotonic = True
+
+        # convert func to dict always
+        self._normalize_keyword_aggregations(empty_series)
+
+        self._series_name = series.name
+        # update value type
+        if isinstance(agg_result, pd.DataFrame):
+            self._object_type = ObjectType.dataframe
+            return self.new_dataframe([series], shape=(np.nan, len(agg_result.columns)),
+                                      dtypes=agg_result.dtypes, index_value=index_value,
+                                      columns_value=parse_index(agg_result.columns, store_data=True))
+        else:
+            self._object_type = ObjectType.series
+            return self.new_series([series], shape=(np.nan,), dtype=agg_result.dtype,
+                                   index_value=index_value)
+
+    def __call__(self, df):
+        if df.op.object_type == ObjectType.dataframe:
+            return self._call_dataframe(df)
+        else:
+            return self._call_series(df)
 
     @staticmethod
     def _safe_append(d, key, val):
@@ -241,7 +283,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
                         cls._safe_append(agg_func, new_col, None)
                         fun = _reduce_var if f == 'var' else _reduce_std
                         agg_output_column_to_func[new_col] = \
-                           partial(fun, columns=[sum_col, count_col, var_col])
+                            partial(fun, columns=[sum_col, count_col, var_col])
                 else:  # pragma: no cover
                     raise NotImplementedError
 
@@ -261,7 +303,8 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
         for chunk in chunks:
             # no longer consider as_index=False for the intermediate phases,
             # will do reset_index at last if so
-            map_op = DataFrameGroupByOperand(stage=OperandStage.map, shuffle_size=chunk_shape[0])
+            map_op = DataFrameGroupByOperand(stage=OperandStage.map, shuffle_size=chunk_shape[0],
+                                             object_type=ObjectType.dataframe_groupby)
             map_chunks.append(map_op.new_chunk([chunk], shape=(np.nan, np.nan), index=chunk.index,
                                                index_value=op.outputs[0].index_value))
 
@@ -284,20 +327,28 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
         for chunk in in_df.chunks:
             agg_op = op.copy().reset_key()
             # force as_index=True for map phase
+            agg_op._object_type = ObjectType.dataframe
             agg_op._as_index = True
             agg_op._stage = OperandStage.map
             agg_op._func = stage_infos.map_func
             agg_op._output_column_to_func = stage_infos.map_output_column_to_func
             columns_value = parse_index(pd.Index(stage_infos.intermediate_cols), store_data=True)
-            agg_chunk = agg_op.new_chunk([chunk], shape=out_df.shape, index=chunk.index,
-                                         index_value=out_df.index_value,
-                                         columns_value=columns_value)
+            new_index = chunk.index if len(chunk.index) == 2 else (chunk.index[0], 0)
+            if op.object_type == ObjectType.dataframe:
+                agg_chunk = agg_op.new_chunk([chunk], shape=out_df.shape, index=new_index,
+                                             index_value=out_df.index_value,
+                                             columns_value=columns_value)
+            else:
+                agg_chunk = agg_op.new_chunk([chunk], shape=(out_df.shape[0], 1), index=new_index,
+                                             index_value=out_df.index_value, columns_value=columns_value)
             agg_chunks.append(agg_chunk)
         return agg_chunks
 
     @classmethod
     def _tile_with_shuffle(cls, op):
-        in_df = build_concatenated_rows_frame(op.inputs[0])
+        in_df = op.inputs[0]
+        if len(in_df.shape) > 1:
+            in_df = build_concatenated_rows_frame(in_df)
         out_df = op.outputs[0]
 
         stage_infos = cls._gen_stages_columns_and_funcs(op.func)
@@ -316,19 +367,30 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
             agg_op._func = stage_infos.agg_func
             agg_op._output_column_to_func = stage_infos.agg_output_column_to_func
             agg_op._agg_columns = stage_infos.agg_cols
-            agg_chunk = agg_op.new_chunk([chunk], shape=out_df.shape, index=chunk.index,
-                                         index_value=out_df.index_value,
-                                         columns_value=out_df.columns_value)
+            if op.object_type == ObjectType.dataframe:
+                agg_chunk = agg_op.new_chunk([chunk], shape=out_df.shape, index=chunk.index,
+                                             index_value=out_df.index_value,
+                                             columns_value=out_df.columns_value)
+            else:
+                agg_chunk = agg_op.new_chunk([chunk], shape=out_df.shape, index=chunk.index,
+                                             index_value=out_df.index_value)
             agg_chunks.append(agg_chunk)
 
         new_op = op.copy()
-        return new_op.new_dataframes([in_df], shape=out_df.shape, index_value=out_df.index_value,
-                                     columns_value=out_df.columns_value, chunks=agg_chunks,
-                                     nsplits=((np.nan,) * len(agg_chunks), (out_df.shape[1],)))
+        if op.object_type == ObjectType.dataframe:
+            return new_op.new_dataframes([in_df], shape=out_df.shape, index_value=out_df.index_value,
+                                         columns_value=out_df.columns_value, chunks=agg_chunks,
+                                         nsplits=((np.nan,) * len(agg_chunks), (out_df.shape[1],)))
+        else:
+            return new_op.new_seriess([in_df], dtype=out_df.dtype, shape=out_df.shape,
+                                      index_value=out_df.index_value,
+                                      chunks=agg_chunks, nsplits=((np.nan,) * len(agg_chunks),))
 
     @classmethod
     def _tile_with_tree(cls, op):
-        in_df = build_concatenated_rows_frame(op.inputs[0])
+        in_df = op.inputs[0]
+        if len(in_df.shape) > 1:
+            in_df = build_concatenated_rows_frame(in_df)
         out_df = op.outputs[0]
 
         stage_infos = cls._gen_stages_columns_and_funcs(op.func)
@@ -347,6 +409,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
                         c._index = (j, 0)
                     chk = concat_op.new_chunk(chks, dtypes=chks[0].dtypes)
                 chunk_op = op.copy().reset_key()
+                chunk_op._object_type = ObjectType.dataframe
                 chunk_op._stage = OperandStage.combine
                 chunk_op._func = stage_infos.combine_func
                 chunk_op._output_column_to_func = stage_infos.combine_output_column_to_func
@@ -363,14 +426,19 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
         chunk_op._func = stage_infos.agg_func
         chunk_op._output_column_to_func = stage_infos.agg_output_column_to_func
         chunk_op._agg_columns = stage_infos.agg_cols
-        chunk = chunk_op.new_chunk([chk], index=(0, 0), shape=out_df.shape, index_value=out_df.index_value,
-                                   columns_value=out_df.columns_value, dtypes=out_df.dtypes)
+        kw = out_df.params.copy()
+        kw['index'] = (0, 0) if op.object_type == ObjectType.dataframe else (0,)
+        chunk = chunk_op.new_chunk([chk], **kw)
         new_op = op.copy()
-        nsplits = ((out_df.shape[0],), (out_df.shape[1],))
-        return new_op.new_tileables(op.inputs, chunks=[chunk], nsplits=nsplits,
-                                    dtypes=out_df.dtypes, shape=out_df.shape,
-                                    index_value=out_df.index_value,
-                                    columns_value=out_df.columns_value)
+        if op.object_type == ObjectType.dataframe:
+            nsplits = ((out_df.shape[0],), (out_df.shape[1],))
+            return new_op.new_tileables(op.inputs, chunks=[chunk], nsplits=nsplits, dtypes=out_df.dtypes,
+                                        shape=out_df.shape, index_value=out_df.index_value,
+                                        columns_value=out_df.columns_value)
+        else:
+            nsplits = ((out_df.shape[0],),)
+            return new_op.new_tileables(op.inputs, chunks=[chunk], nsplits=nsplits, dtype=out_df.dtype,
+                                        shape=out_df.shape, index_value=out_df.index_value)
 
     @classmethod
     def tile(cls, op):
@@ -382,7 +450,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
             raise NotImplementedError
 
     @classmethod
-    def _get_grouped(cls, op, df, copy=False):
+    def _get_grouped(cls, op: "DataFrameGroupByAgg", df, copy=False):
         if copy:
             df = df.copy()
         if op.stage == OperandStage.agg:
@@ -408,6 +476,9 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
         df = ctx[op.inputs[0].key]
         out = op.outputs[0]
 
+        if isinstance(df, pd.Series) and op.object_type == ObjectType.dataframe:
+            df = pd.DataFrame(df, columns=[_series_col_name])
+
         grouped = cls._get_grouped(op, df)
         if op.stage == OperandStage.agg:
             # use intermediate columns
@@ -428,9 +499,14 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
         if cls._is_raw_one_func(op):
             # do some optimization if the raw func is a str or list whose length is 1
             func = next(iter(func.values()))[0]
-            result = grouped.agg(func)
-            if result.empty and not df.empty:
-                # fix for py35, due to buffer read-only
+            try:
+                result = grouped.agg(func)
+                if result.empty and not df.empty:
+                    # fix for py35, due to buffer read-only
+                    raise ValueError
+            except ValueError:
+                # fail due to buffer read-only
+                # force to get grouped again by copy
                 grouped = cls._get_grouped(op, df, copy=True)
                 result = grouped.agg(func)
         else:
@@ -459,11 +535,14 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
             # empty data, set index manually
             result.index = out.index_value.to_pandas()
 
-        if op.stage == OperandStage.agg:
-            if not op.as_index:
-                result.reset_index(inplace=True)
-            result.columns = out.columns_value.to_pandas()
-
+        if op.object_type == ObjectType.series:
+            result = result.iloc[:, 0]
+            result.name = op.series_name
+        else:
+            if op.stage == OperandStage.agg:
+                if not op.as_index:
+                    result.reset_index(inplace=True)
+                result.columns = out.columns_value.to_pandas()
         ctx[out.key] = result
 
 
@@ -511,5 +590,6 @@ def agg(groupby, func, method='tree'):
 
     in_df = groupby.inputs[0]
     agg_op = DataFrameGroupByAgg(func=func, by=groupby.op.by, method=method, raw_func=func,
-                                 as_index=groupby.op.as_index, sort=groupby.op.sort)
+                                 as_index=groupby.op.as_index, sort=groupby.op.sort,
+                                 object_type=in_df.op.object_type)
     return agg_op(in_df)

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -65,7 +65,7 @@ class Test(TestBase):
         for key, group in r:
             pd.testing.assert_series_equal(group, expected.get_group(key))
 
-    def testGroupByAgg(self):
+    def testDataFrameGroupByAgg(self):
         rs = np.random.RandomState(0)
         df1 = pd.DataFrame({'a': rs.choice([2, 3, 4], size=(100,)),
                             'b': rs.choice([2, 3, 4], size=(100,))})
@@ -165,6 +165,75 @@ class Test(TestBase):
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(r13, concat=True)[0],
                                       df2.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count']))
         self.assertTrue(r13.op.as_index)
+
+    def testSeriesGroupByAgg(self):
+        rs = np.random.RandomState(0)
+        series1 = pd.Series(rs.rand(10))
+        ms1 = md.Series(series1, chunk_size=3)
+
+        for method in ['tree', 'shuffle']:
+            r1 = ms1.groupby(lambda x: x % 2).agg('sum', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r1, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('sum'))
+            r2 = ms1.groupby(lambda x: x % 2).agg('min', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r2, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('min'))
+
+            r1 = ms1.groupby(lambda x: x % 2).agg('prod', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r1, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('prod'))
+            r2 = ms1.groupby(lambda x: x % 2).agg('max', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r2, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('max'))
+            r3 = ms1.groupby(lambda x: x % 2).agg('count', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('count'))
+            r4 = ms1.groupby(lambda x: x % 2).agg('mean', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('mean'))
+            r5 = ms1.groupby(lambda x: x % 2).agg('var', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r5, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('var'))
+            r6 = ms1.groupby(lambda x: x % 2).agg('std', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r6, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('std'))
+
+            agg = ['std', 'mean', 'var', 'max', 'count']
+            r3 = ms1.groupby(lambda x: x % 2).agg(agg, method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                          series1.groupby(lambda x: x % 2).agg(agg))
+
+        r4 = ms1.groupby(lambda x: x % 2).sum()
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).sum())
+
+        r5 = ms1.groupby(lambda x: x % 2).prod()
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r5, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).prod())
+
+        r6 = ms1.groupby(lambda x: x % 2).min()
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r6, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).min())
+
+        r7 = ms1.groupby(lambda x: x % 2).max()
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r7, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).max())
+
+        r8 = ms1.groupby(lambda x: x % 2).count()
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r8, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).count())
+
+        r9 = ms1.groupby(lambda x: x % 2).mean()
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r9, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).mean())
+
+        r10 = ms1.groupby(lambda x: x % 2).var()
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r10, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).var())
+
+        r11 = ms1.groupby(lambda x: x % 2).std()
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r11, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).std())
 
     def testGroupByApplyTransform(self):
         df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],

--- a/mars/dataframe/merge/concat.py
+++ b/mars/dataframe/merge/concat.py
@@ -18,7 +18,7 @@ import numpy as np
 from ...serialize import ListField, StringField, BoolField, AnyField
 from ... import opcodes as OperandDef
 from ...utils import lazy_import
-from ..utils import parse_index, build_empty_df, standardize_range_index
+from ..utils import parse_index, build_empty_df, standardize_range_index, validate_axis
 from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType, SERIES_TYPE
 
 cudf = lazy_import('cudf', globals=globals())
@@ -353,10 +353,7 @@ def concat(objs, axis=0, join='outer', ignore_index=False, keys=None, levels=Non
            verify_integrity=False, sort=False, copy=True):
     if not isinstance(objs, (list, tuple)):  # pragma: no cover
         raise TypeError('first argument must be an iterable of dataframe or series objects')
-    if axis == 'index':
-        axis = 0
-    if axis == 'columns':
-        axis = 1
+    axis = validate_axis(axis)
     if isinstance(objs, dict):  # pragma: no cover
         keys = objs.keys()
         objs = objs.values()

--- a/mars/dataframe/reduction/__init__.py
+++ b/mars/dataframe/reduction/__init__.py
@@ -28,6 +28,7 @@ from .cumsum import DataFrameCumsum
 
 def _install():
     from ..core import DATAFRAME_TYPE, SERIES_TYPE
+    from .aggregation import aggregate
     from .sum import sum_series, sum_dataframe
     from .prod import prod_series, prod_dataframe
     from .max import max_series, max_dataframe
@@ -42,13 +43,14 @@ def _install():
     from .cumsum import cumsum
 
     func_names = ['sum', 'prod', 'max', 'min', 'count', 'mean', 'var',
-                  'std', 'cummax', 'cummin', 'cumprod', 'cumsum']
+                  'std', 'cummax', 'cummin', 'cumprod', 'cumsum',
+                  'agg', 'aggregate']
     series_funcs = [sum_series, prod_series, max_series, min_series,
                     count_series, mean_series, var_series, std_series,
-                    cummax, cummin, cumprod, cumsum]
+                    cummax, cummin, cumprod, cumsum, aggregate, aggregate]
     df_funcs = [sum_dataframe, prod_dataframe, max_dataframe, min_dataframe,
                 count_dataframe, mean_dataframe, var_dataframe, std_dataframe,
-                cummax, cummin, cumprod, cumsum]
+                cummax, cummin, cumprod, cumsum, aggregate, aggregate]
     for func_name, series_func, df_func in zip(func_names, series_funcs, df_funcs):
         for t in DATAFRAME_TYPE:
             setattr(t, func_name, df_func)

--- a/mars/dataframe/reduction/aggregation.py
+++ b/mars/dataframe/reduction/aggregation.py
@@ -1,0 +1,553 @@
+from collections import namedtuple, OrderedDict
+from collections.abc import Iterable
+from typing import Union, List, Dict
+
+import cloudpickle
+import numpy as np
+import pandas as pd
+
+from ... import opcodes
+from ...config import options
+from ...operands import OperandStage
+from ...serialize import BytesField, AnyField, DictField
+from ...utils import tokenize, ceildiv
+from ..merge import DataFrameConcat
+from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..utils import build_empty_df, build_empty_series, parse_index, validate_axis
+
+_stage_info = namedtuple('_stage_info', ('map_groups', 'map_sources', 'combine_groups', 'combine_sources',
+                                         'agg_sources', 'agg_columns', 'agg_funcs', 'key_to_funcs',
+                                         'valid_columns'))
+_series_col_name = 'col_name'
+
+
+class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = opcodes.AGGREGATE
+
+    _func = AnyField('func')
+    _axis = AnyField('axis')
+
+    _map_groups = DictField('map_groups')
+    _map_sources = DictField('map_sources')
+    _combine_groups = DictField('combine_groups')
+    _combine_sources = DictField('combine_sources')
+    _agg_sources = DictField('agg_sources')
+    _agg_columns = DictField('agg_columns')
+    _agg_funcs = DictField('agg_funcs')
+    _key_to_funcs = BytesField('keys_to_funcs', on_serialize=cloudpickle.dumps,
+                               on_deserialize=cloudpickle.loads)
+
+    def __init__(self, func=None, axis=None, map_groups=None, map_sources=None, combine_groups=None,
+                 combine_sources=None, agg_sources=None, agg_columns=None, agg_funcs=None,
+                 key_to_funcs=None, object_type=None, stage=None, **kw):
+        super().__init__(_func=func, _axis=axis, _map_groups=map_groups, _map_sources=map_sources,
+                         _combine_groups=combine_groups, _combine_sources=combine_sources,
+                         _agg_sources=agg_sources, _agg_columns=agg_columns, _agg_funcs=agg_funcs,
+                         _key_to_funcs=key_to_funcs, _stage=stage, _object_type=object_type, **kw)
+
+    @property
+    def func(self):
+        return self._func
+
+    @property
+    def axis(self) -> int:
+        return self._axis
+
+    @property
+    def map_groups(self) -> Dict:
+        return self._map_groups
+
+    @property
+    def map_sources(self) -> Dict:
+        return self._map_sources
+
+    @property
+    def combine_groups(self) -> Dict:
+        return self._combine_groups
+
+    @property
+    def combine_sources(self) -> Dict:
+        return self._combine_sources
+
+    @property
+    def agg_sources(self) -> Dict:
+        return self._agg_sources
+
+    @property
+    def agg_columns(self) -> Dict:
+        return self._agg_columns
+
+    @property
+    def agg_funcs(self) -> Dict:
+        return self._agg_funcs
+
+    @property
+    def key_to_funcs(self) -> Dict:
+        return self._key_to_funcs
+
+    def _calc_result_shape(self, df):
+        if self.object_type == ObjectType.dataframe:
+            empty_obj = build_empty_df(df.dtypes, index=pd.RangeIndex(0, 10))
+        else:
+            empty_obj = build_empty_series(df.dtype, index=pd.RangeIndex(0, 10), name=df.name)
+
+        result_df = empty_obj.agg(self.func, axis=self.axis)
+
+        if isinstance(result_df, pd.DataFrame):
+            self._object_type = ObjectType.dataframe
+            return result_df.dtypes, result_df.index
+        elif isinstance(result_df, pd.Series):
+            self._object_type = ObjectType.series
+            return pd.Series([result_df.dtype], index=[result_df.name]), result_df.index
+        else:
+            self._object_type = ObjectType.scalar
+            return np.array(result_df).dtype, None
+
+    def _normalize_funcs(self):
+        if isinstance(self._func, dict):
+            new_func = OrderedDict()
+            for k, v in self._func.items():
+                if isinstance(v, str) or callable(v):
+                    new_func[k] = [v]
+                else:
+                    new_func[k] = v
+            self._func = new_func
+        elif isinstance(self._func, Iterable) and not isinstance(self._func, str):
+            self._func = list(self._func)
+        else:
+            self._func = [self._func]
+
+    def __call__(self, df):
+        dtypes, index = self._calc_result_shape(df)
+        self._normalize_funcs()
+        if self._object_type == ObjectType.dataframe:
+            if self.axis == 0:
+                new_shape = (len(index), len(dtypes))
+                new_index = parse_index(index, store_data=True)
+            else:
+                new_shape = (df.shape[0], len(dtypes))
+                new_index = df.index_value
+            return self.new_dataframe([df], shape=new_shape, dtypes=dtypes, index_value=new_index,
+                                      columns_value=parse_index(dtypes.index, store_data=True))
+        elif self._object_type == ObjectType.series:
+            if df.op.object_type == ObjectType.series:
+                new_shape = (len(index),)
+                new_index = parse_index(index, store_data=True)
+            else:
+                new_shape = (df.shape[1 - self.axis],)
+                new_index = [df.columns_value, df.index_value][self.axis]
+            return self.new_series([df], shape=new_shape, dtype=dtypes[0], name=dtypes.index[0],
+                                   index_value=new_index)
+        else:
+            return self.new_scalar([df], dtype=dtypes)
+
+    @staticmethod
+    def _safe_append(d, key, val):
+        if key not in d:
+            d[key] = []
+        if val not in d[key]:
+            d[key].append(val)
+
+    @classmethod
+    def _gen_chunk_stage_info(cls, op_func: Union[List, Dict], chunk_cols=None):
+        map_groups = OrderedDict()
+        map_sources = OrderedDict()
+        combine_groups = OrderedDict()
+        combine_sources = OrderedDict()
+        agg_sources = OrderedDict()
+        agg_columns = OrderedDict()
+        agg_funcs = OrderedDict()
+        key_to_funcs = OrderedDict()
+        valid_columns = []
+
+        def _clean_dict(d):
+            return OrderedDict((k, sorted(v) if v != [None] else None) for k, v in d.items())
+
+        def _fun_to_str(fun):
+            if isinstance(fun, str):
+                return fun
+            fun_str = tokenize(fun)
+            key_to_funcs[fun_str] = fun
+            return fun if isinstance(fun, str) else tokenize(fun)
+
+        def _add_column_to_functions(col, fun_name, mappers, combiners, aggregator):
+            sources = []
+            for mapper, combiner in zip(mappers, combiners):
+                mapper_str, combiner_str = _fun_to_str(mapper), _fun_to_str(combiner)
+                cls._safe_append(map_groups, mapper_str, col)
+                cls._safe_append(combine_groups, (mapper_str, combiner_str), col)
+                sources.append((mapper_str, combiner_str))
+
+            for mapper, combiner in zip(mappers, combiners):
+                if callable(combiner):
+                    combine_sources[(_fun_to_str(mapper), _fun_to_str(combiner))] = sources
+
+            agg_sources[fun_name] = sources
+            cls._safe_append(agg_columns, fun_name, col)
+            agg_funcs[fun_name] = _fun_to_str(aggregator)
+
+        chunk_cols = set(chunk_cols) if chunk_cols is not None else None
+        if isinstance(op_func, list):
+            op_func = {None: op_func}
+        for col, funcs in op_func.items():
+            if col is not None:
+                if chunk_cols is not None and col not in chunk_cols:
+                    continue
+                valid_columns.append(col)
+            for func in funcs:
+                if func in {'sum', 'prod', 'min', 'max'}:
+                    _add_column_to_functions(col, func, [func], [func], func)
+                elif func == 'count':
+                    _add_column_to_functions(col, func, [func], ['sum'], 'sum')
+                elif func == 'mean':
+                    def _mean(sum_data, count_data, axis=0):
+                        return sum_data.sum(axis=axis) / count_data.sum(axis=axis)
+
+                    _add_column_to_functions(col, func, ['sum', 'count'], ['sum', 'sum'], _mean)
+                elif func in {'var', 'std'}:
+                    def _reduce_var(sum_data, count_data, var_data, axis=0):
+                        reduced_cnt = count_data.sum(axis=axis)
+                        var_square = var_data * (count_data - 1)
+                        avg = sum_data.sum(axis=axis) / reduced_cnt
+                        avg_diff = (sum_data / count_data).subtract(avg, axis=1 - axis)
+                        var_square = var_square.sum(axis=axis) + (count_data * avg_diff ** 2).sum(axis=axis)
+                        return var_square / (reduced_cnt - 1)
+
+                    def _reduce_std(*args, **kwargs):
+                        return np.sqrt(_reduce_var(*args, **kwargs))
+
+                    _add_column_to_functions(col, func, ['sum', 'count', 'var'],
+                                             ['sum', 'sum', _reduce_var],
+                                             _reduce_var if func == 'var' else _reduce_std)
+                else:  # pragma: no cover
+                    raise NotImplementedError
+
+        return _stage_info(map_groups=_clean_dict(map_groups), map_sources=map_sources,
+                           combine_groups=_clean_dict(combine_groups), combine_sources=combine_sources,
+                           agg_sources=agg_sources, agg_columns=_clean_dict(agg_columns),
+                           agg_funcs=agg_funcs, key_to_funcs=key_to_funcs, valid_columns=valid_columns or None)
+
+    @classmethod
+    def _gen_map_chunks(cls, op, in_df, out_df, stage_infos: List[_stage_info],
+                        input_index_to_output: Dict[int, int]):
+        axis = op.axis
+
+        if axis == 0:
+            agg_chunks_shape = (in_df.chunk_shape[0], len(stage_infos)) \
+                               if len(in_df.chunk_shape) == 2 else (in_df.chunk_shape[0], 1)
+        else:
+            agg_chunks_shape = (len(stage_infos), in_df.chunk_shape[1])
+
+        agg_chunks = np.empty(agg_chunks_shape, dtype=np.object)
+        for chunk in in_df.chunks:
+            input_index = chunk.index[1 - axis] if len(chunk.index) > 1 else 0
+            if input_index not in input_index_to_output:
+                continue
+            map_op = op.copy().reset_key()
+            new_axis_index = input_index_to_output[input_index]
+            stage_info = stage_infos[new_axis_index]
+            # force as_index=True for map phase
+            map_op._object_type = ObjectType.dataframe
+            map_op._stage = OperandStage.map
+            map_op._map_groups = stage_info.map_groups
+            map_op._map_sources = stage_info.map_sources
+            map_op._combine_groups = stage_info.combine_groups
+            map_op._key_to_funcs = stage_info.key_to_funcs
+
+            if axis == 0:
+                new_index = (chunk.index[0], new_axis_index) if len(chunk.index) == 2 else (chunk.index[0], 0)
+            else:
+                new_index = (new_axis_index, chunk.index[1])
+
+            if op.object_type == ObjectType.dataframe:
+                if axis == 0:
+                    new_shape = (1, chunk.shape[1] if len(chunk.shape) > 1 else 1)
+                else:
+                    new_shape = (chunk.shape[1] if len(chunk.shape) > 1 else 1, 1)
+                agg_chunk = map_op.new_chunk(
+                    [chunk], shape=new_shape, index=new_index, index_value=chunk.index_value,
+                    columns_value=chunk.columns_value)
+            elif op.object_type == ObjectType.series:
+                agg_chunk = map_op.new_chunk([chunk], shape=(out_df.shape[0], 1), index=new_index,
+                                             index_value=out_df.index_value)
+            else:  # scalar target
+                agg_chunk = map_op.new_chunk([chunk], shape=(1, 1), index=new_index)
+            agg_chunks[agg_chunk.index] = agg_chunk
+        return agg_chunks
+
+    @classmethod
+    def _tile_single_chunk(cls, op: "DataFrameAggregate"):
+        in_df = op.inputs[0]
+        out_df = op.outputs[0]
+
+        chunk_op = op.copy().reset_key()
+        if op.object_type == ObjectType.dataframe:
+            chunk = chunk_op.new_chunk(in_df.chunks, index=(0, 0), shape=out_df.shape,
+                                       index_value=out_df.index_value, columns_value=out_df.columns_value)
+        else:
+            chunk = chunk_op.new_chunk(in_df.chunks, index=(0,), shape=out_df.shape,
+                                       index_value=out_df.index_value)
+
+        tileable_op = op.copy().reset_key()
+        kw = out_df.params.copy()
+        kw.update(dict(chunks=[chunk], nsplits=((x,) for x in out_df.shape)))
+        return tileable_op.new_tileables([in_df], **kw)
+
+    @classmethod
+    def _tile_tree(cls, op: "DataFrameAggregate"):
+        in_df = op.inputs[0]
+        out_df = op.outputs[0]
+        combine_size = options.combine_size
+        axis = op.axis
+
+        input_index_to_output = dict()
+        output_index_to_input = []
+        axis_stage_infos = []
+        if len(in_df.chunk_shape) > 1:
+            for col_idx in range(in_df.chunk_shape[1 - axis]):
+                idx_chunk = in_df.cix[0, col_idx] if axis == 0 else in_df.cix[col_idx, 0]
+                stage_info = cls._gen_chunk_stage_info(
+                    op.func, idx_chunk.dtypes.index if axis == 0 else None)
+                if not stage_info.map_groups:
+                    continue
+                input_index_to_output[col_idx] = len(axis_stage_infos)
+                output_index_to_input.append(col_idx)
+                axis_stage_infos.append(stage_info)
+        else:
+            stage_info = cls._gen_chunk_stage_info(op.func, [_series_col_name])
+            input_index_to_output[0] = 0
+            axis_stage_infos.append(stage_info)
+
+        chunks = cls._gen_map_chunks(op, in_df, out_df, axis_stage_infos, input_index_to_output)
+        while chunks.shape[axis] > combine_size:
+            if axis == 0:
+                new_chunks_shape = (ceildiv(chunks.shape[0], combine_size), chunks.shape[1])
+            else:
+                new_chunks_shape = (chunks.shape[0], ceildiv(chunks.shape[1], combine_size))
+
+            new_chunks = np.empty(new_chunks_shape, dtype=np.object)
+            for idx0, i in enumerate(range(0, chunks.shape[axis], combine_size)):
+                for idx1 in range(chunks.shape[1 - axis]):
+                    stage_info = axis_stage_infos[idx1]
+                    if axis == 0:
+                        chks = chunks[i: i + combine_size, idx1]
+                        chunk_index = (idx0, idx1)
+                    else:
+                        chks = chunks[idx1, i: i + combine_size]
+                        chunk_index = (idx1, idx0)
+
+                    chks = chks.reshape((chks.shape[0],)).tolist()
+                    if len(chks) == 1:
+                        chk = chks[0]
+                    else:
+                        concat_op = DataFrameConcat(object_type=ObjectType.dataframe, axis=axis)
+                        # Change index for concatenate
+                        for j, c in enumerate(chks):
+                            c._index = (j, 0) if axis == 0 else (0, j)
+                        chk = concat_op.new_chunk(chks, dtypes=chks[0].dtypes)
+                    chunk_op = op.copy().reset_key()
+                    chunk_op._object_type = ObjectType.dataframe
+                    chunk_op._stage = OperandStage.combine
+                    chunk_op._combine_groups = stage_info.combine_groups
+                    chunk_op._combine_sources = stage_info.combine_sources
+                    chunk_op._key_to_funcs = stage_info.key_to_funcs
+
+                    if axis == 0:
+                        new_chunks[chunk_index] = chunk_op.new_chunk(
+                            [chk], index=chunk_index, shape=(np.nan, chks[0].shape[1]),
+                            index_value=chks[0].index_value)
+                    else:
+                        new_chunks[chunk_index] = chunk_op.new_chunk(
+                            [chk], index=chunk_index, shape=(chks[0].shape[0], np.nan),
+                            index_value=chks[0].columns_value)
+            chunks = new_chunks
+
+        agg_chunks = []
+        for idx in range(chunks.shape[1 - axis]):
+            stage_info = axis_stage_infos[idx]
+
+            concat_op = DataFrameConcat(object_type=ObjectType.dataframe, axis=axis)
+            if axis == 0:
+                chks = chunks[:, idx]
+            else:
+                chks = chunks[idx, :]
+            chks = chks.reshape((chks.shape[0],)).tolist()
+            chk = concat_op.new_chunk(chks, dtypes=chks[0].dtypes)
+            chunk_op = op.copy().reset_key()
+            chunk_op._stage = OperandStage.agg
+            chunk_op._combine_groups = stage_info.combine_groups
+            chunk_op._agg_columns = stage_info.agg_columns
+            chunk_op._agg_funcs = stage_info.agg_funcs
+            chunk_op._agg_sources = stage_info.agg_sources
+            chunk_op._key_to_funcs = stage_info.key_to_funcs
+
+            kw = out_df.params.copy()
+            if op.object_type == ObjectType.dataframe:
+                if axis == 0:
+                    kw['index'] = (0, idx)
+                    src_col_chunk = in_df.cix[0, output_index_to_input[idx]]
+                    if axis_stage_infos[idx].valid_columns is None:
+                        kw['columns_value'] = src_col_chunk.columns_value
+                        shape_len = src_col_chunk.shape[1]
+                    else:
+                        kw['columns_value'] = parse_index(
+                            pd.Index(axis_stage_infos[idx].valid_columns), store_data=True)
+                        shape_len = len(axis_stage_infos[idx].valid_columns)
+                    kw['shape'] = (out_df.shape[0], shape_len)
+                else:
+                    kw['index'] = (idx, 0)
+                    src_col_chunk = in_df.cix[output_index_to_input[idx], 0]
+                    kw['index_value'] = src_col_chunk.index_value
+                    kw['shape'] = (src_col_chunk.shape[0], out_df.shape[1])
+            else:
+                src_col_chunk = in_df.chunks[output_index_to_input[idx] if output_index_to_input else 0]
+                kw['index'] = (0,)
+                if op.object_type == ObjectType.series:
+                    kw['name'] = out_df.name
+                    if in_df.op.object_type == ObjectType.series:
+                        kw['index_value'] = out_df.index_value
+                        kw['shape'] = out_df.shape
+                    elif axis == 0:
+                        kw['index_value'] = src_col_chunk.index_value
+                        kw['shape'] = (src_col_chunk.shape[0],)
+                    else:
+                        kw['index_value'] = src_col_chunk.columns_value
+                        kw['shape'] = (src_col_chunk.shape[1],)
+                else:
+                    kw['shape'] = ()
+            agg_chunks.append(chunk_op.new_chunk([chk], **kw))
+
+        new_op = op.copy()
+        if op.object_type == ObjectType.dataframe:
+            if axis == 0:
+                nsplits = ((out_df.shape[0],), tuple(c.shape[1] for c in agg_chunks))
+            else:
+                nsplits = (tuple(c.shape[0] for c in agg_chunks), (out_df.shape[1],))
+            return new_op.new_tileables(op.inputs, chunks=agg_chunks, nsplits=nsplits, dtypes=out_df.dtypes,
+                                        shape=out_df.shape, index_value=out_df.index_value,
+                                        columns_value=out_df.columns_value)
+        elif op.object_type == ObjectType.series:
+            nsplits = (tuple(c.shape[0] for c in agg_chunks),)
+            return new_op.new_tileables(op.inputs, chunks=agg_chunks, nsplits=nsplits, dtype=out_df.dtype,
+                                        shape=out_df.shape, index_value=out_df.index_value, name=out_df.name)
+        else:  # scalar
+            return new_op.new_tileables(op.inputs, chunks=agg_chunks, dtype=out_df.dtype,
+                                        shape=())
+
+    @classmethod
+    def tile(cls, op: "DataFrameAggregate"):
+        if len(op.inputs[0].chunks) == 1:
+            return cls._tile_single_chunk(op)
+        else:
+            return cls._tile_tree(op)
+
+    @staticmethod
+    def _wrap_df(value, columns=None, transform=False):
+        if isinstance(value, np.generic):
+            value = pd.DataFrame([value], columns=columns)
+        else:
+            value = pd.DataFrame(value, columns=columns)
+        return value.T if transform else value
+
+    @classmethod
+    def _execute_map(cls, ctx, op: "DataFrameAggregate"):
+        in_data = ctx[op.inputs[0].key]
+        axis = op.axis
+        axis_index = op.outputs[0].index[axis]
+
+        # map according to map groups
+        ret_map_dfs = dict()
+        for map_func_str, cols in op.map_groups.items():
+            if cols is None:
+                src_df = in_data
+            else:
+                src_df = in_data[cols]
+            ret_map_dfs[map_func_str] = cls._wrap_df(src_df.agg(map_func_str, axis=axis),
+                                                     columns=[axis_index], transform=axis == 0)
+
+        ret_combine_dfs = OrderedDict()
+        for func_strs, cols in op.combine_groups.items():
+            if cols is None:
+                ret_combine_dfs[func_strs] = ret_map_dfs[func_strs[0]]
+            else:
+                ret_combine_dfs[func_strs] = ret_map_dfs[func_strs[0]][cols]
+        ctx[op.outputs[0].key] = tuple(ret_combine_dfs.values())
+
+    @classmethod
+    def _execute_combine(cls, ctx, op: "DataFrameAggregate"):
+        in_data = ctx[op.inputs[0].key]
+        in_data_dict = dict(zip(op.combine_groups.keys(), in_data))
+        axis = op.axis
+        axis_index = op.outputs[0].index[axis]
+
+        combines = []
+        for fun_strs, df in zip(op.combine_groups.keys(), in_data):
+            if fun_strs[-1] in op.key_to_funcs:
+                func = op.key_to_funcs[fun_strs[-1]]
+                sources = [in_data_dict[fs] for fs in op.combine_sources[fun_strs]]
+                result = cls._wrap_df(func(*sources, axis=axis), columns=[axis_index],
+                                      transform=axis == 0)
+            else:
+                result = cls._wrap_df(df.agg(fun_strs[-1], axis=axis), columns=[axis_index],
+                                      transform=axis == 0)
+            combines.append(result)
+        ctx[op.outputs[0].key] = tuple(combines)
+
+    @classmethod
+    def _execute_agg(cls, ctx, op: "DataFrameAggregate"):
+        in_data = ctx[op.inputs[0].key]
+        in_data_dict = dict(zip(op.combine_groups.keys(), in_data))
+        axis = op.axis
+
+        aggs = []
+        for func_name, func_sources in op.agg_sources.items():
+            func_str = op.agg_funcs[func_name]
+            func_cols = op.agg_columns[func_name]
+            if func_cols is None:
+                func_inputs = [in_data_dict[src] for src in func_sources]
+            else:
+                func_inputs = [in_data_dict[src][func_cols] for src in func_sources]
+
+            if func_str in op.key_to_funcs:
+                func = op.key_to_funcs[func_str]
+                agg_series = func(*func_inputs, axis=axis)
+            else:
+                agg_series = func_inputs[0].agg(func_str, axis=axis)
+
+            agg_series.name = func_name
+            aggs.append(cls._wrap_df(agg_series, transform=axis == 0))
+
+        concat_df = pd.concat(aggs, axis=axis)
+        if op.object_type == ObjectType.series:
+            if concat_df.shape[0] == 1:
+                concat_df = concat_df.iloc[0, :]
+            else:
+                concat_df = concat_df.iloc[:, 0]
+            concat_df.name = op.outputs[0].name
+        elif op.object_type == ObjectType.scalar:
+            concat_df = concat_df.iloc[0, 0]
+        else:
+            if axis == 0:
+                concat_df = concat_df.reindex(op.outputs[0].index_value.to_pandas())
+            else:
+                concat_df = concat_df[op.outputs[0].columns_value.to_pandas()]
+        ctx[op.outputs[0].key] = concat_df
+
+    @classmethod
+    def execute(cls, ctx, op: "DataFrameAggregate"):
+        if op.stage == OperandStage.map:
+            cls._execute_map(ctx, op)
+        elif op.stage == OperandStage.combine:
+            cls._execute_combine(ctx, op)
+        elif op.stage == OperandStage.agg:
+            cls._execute_agg(ctx, op)
+        else:
+            ctx[op.outputs[0].key] = ctx[op.inputs[0].key].agg(op.func, axis=op.axis)
+
+
+def aggregate(df, func, axis=0):
+    axis = validate_axis(axis, df)
+    if (df.op.object_type == ObjectType.series or axis == 1) and isinstance(func, dict):
+        raise NotImplementedError('Currently cannot aggregate dicts over axis=1 on %s' % type(df).__name__)
+    op = DataFrameAggregate(func=func, axis=axis, object_type=df.op.object_type)
+    return op(df)

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import operator
+import unittest
+from functools import reduce
+
 import pandas as pd
 import numpy as np
-import unittest
 
 from mars import opcodes as OperandDef
 from mars.operands import OperandStage
@@ -27,6 +30,7 @@ from mars.dataframe.reduction import DataFrameSum, DataFrameProd, DataFrameMin, 
 from mars.dataframe.merge import DataFrameConcat
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
 from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df
+from mars.dataframe.operands import ObjectType
 
 
 reduction_functions = dict(
@@ -364,6 +368,134 @@ class TestCumReduction(TestBase):
         self.assertIsInstance(reduction_df.chunks[-1].inputs[-1].op, self.op)
         self.assertEqual(reduction_df.chunks[-1].inputs[-1].op.stage, OperandStage.map)
         self.assertEqual(len(reduction_df.chunks[-1].inputs), 7)
+
+
+class TestAggregate(TestBase):
+    def testDataFrameAggregate(self):
+        data = pd.DataFrame(np.random.rand(20, 19))
+        agg_funcs = ['sum', 'min', 'max', 'mean', 'var', 'std']
+
+        df = from_pandas_df(data)
+        result = df.agg(agg_funcs).tiles()
+        self.assertEqual(len(result.chunks), 1)
+        self.assertEqual(result.shape, (6, data.shape[1]))
+        self.assertListEqual(list(result.columns_value.to_pandas()), list(range(19)))
+        self.assertListEqual(list(result.index_value.to_pandas()), agg_funcs)
+        self.assertEqual(result.op.object_type, ObjectType.dataframe)
+        self.assertListEqual(result.op.func, agg_funcs)
+
+        df = from_pandas_df(data, chunk_size=(3, 4))
+
+        result = df.agg('sum').tiles()
+        self.assertEqual(len(result.chunks), 5)
+        self.assertEqual(result.shape, (data.shape[1],))
+        self.assertListEqual(list(result.index_value.to_pandas()), list(range(data.shape[1])))
+        self.assertEqual(result.op.object_type, ObjectType.series)
+        self.assertListEqual(result.op.func, ['sum'])
+        agg_chunk = result.chunks[0]
+        self.assertEqual(agg_chunk.shape, (3,))
+        self.assertListEqual(list(agg_chunk.index_value.to_pandas()), list(range(3)))
+        self.assertEqual(agg_chunk.op.stage, OperandStage.agg)
+
+        result = df.agg('sum', axis=1).tiles()
+        self.assertEqual(len(result.chunks), 7)
+        self.assertEqual(result.shape, (data.shape[0],))
+        self.assertListEqual(list(result.index_value.to_pandas()), list(range(data.shape[0])))
+        self.assertEqual(result.op.object_type, ObjectType.series)
+        agg_chunk = result.chunks[0]
+        self.assertEqual(agg_chunk.shape, (4,))
+        self.assertListEqual(list(agg_chunk.index_value.to_pandas()), list(range(4)))
+        self.assertEqual(agg_chunk.op.stage, OperandStage.agg)
+
+        result = df.agg('var', axis=1).tiles()
+        self.assertEqual(len(result.chunks), 7)
+        self.assertEqual(result.shape, (data.shape[0],))
+        self.assertListEqual(list(result.index_value.to_pandas()), list(range(data.shape[0])))
+        self.assertEqual(result.op.object_type, ObjectType.series)
+        self.assertListEqual(result.op.func, ['var'])
+        agg_chunk = result.chunks[0]
+        self.assertEqual(agg_chunk.shape, (4,))
+        self.assertListEqual(list(agg_chunk.index_value.to_pandas()), list(range(4)))
+        self.assertEqual(agg_chunk.op.stage, OperandStage.agg)
+
+        result = df.agg(['sum', 'min', 'max', 'mean', 'var', 'std']).tiles()
+        self.assertEqual(len(result.chunks), 5)
+        self.assertEqual(result.shape, (len(agg_funcs), data.shape[1]))
+        self.assertListEqual(list(result.columns_value.to_pandas()), list(range(data.shape[1])))
+        self.assertListEqual(list(result.index_value.to_pandas()), agg_funcs)
+        self.assertEqual(result.op.object_type, ObjectType.dataframe)
+        self.assertListEqual(result.op.func, agg_funcs)
+        agg_chunk = result.chunks[0]
+        self.assertEqual(agg_chunk.shape, (len(agg_funcs), 4))
+        self.assertListEqual(list(agg_chunk.columns_value.to_pandas()), list(range(4)))
+        self.assertListEqual(list(agg_chunk.index_value.to_pandas()), agg_funcs)
+        self.assertEqual(agg_chunk.op.stage, OperandStage.agg)
+
+        result = df.agg(['sum', 'min', 'max', 'mean', 'var', 'std'], axis=1).tiles()
+        self.assertEqual(len(result.chunks), 7)
+        self.assertEqual(result.shape, (data.shape[0], len(agg_funcs)))
+        self.assertListEqual(list(result.columns_value.to_pandas()), agg_funcs)
+        self.assertListEqual(list(result.index_value.to_pandas()), list(range(data.shape[0])))
+        self.assertEqual(result.op.object_type, ObjectType.dataframe)
+        self.assertListEqual(result.op.func, agg_funcs)
+        agg_chunk = result.chunks[0]
+        self.assertEqual(agg_chunk.shape, (3, len(agg_funcs)))
+        self.assertListEqual(list(agg_chunk.columns_value.to_pandas()), agg_funcs)
+        self.assertListEqual(list(agg_chunk.index_value.to_pandas()), list(range(3)))
+        self.assertEqual(agg_chunk.op.stage, OperandStage.agg)
+
+        dict_fun = {0: 'sum', 2: ['var', 'max'], 9: ['mean', 'var', 'std']}
+        all_cols = set(reduce(operator.add, [[v] if isinstance(v, str) else v for v in dict_fun.values()]))
+        result = df.agg(dict_fun).tiles()
+        self.assertEqual(len(result.chunks), 2)
+        self.assertEqual(result.shape, (len(all_cols), len(dict_fun)))
+        self.assertSetEqual(set(result.columns_value.to_pandas()), set(dict_fun.keys()))
+        self.assertSetEqual(set(result.index_value.to_pandas()), all_cols)
+        self.assertEqual(result.op.object_type, ObjectType.dataframe)
+        self.assertListEqual(result.op.func[0], [dict_fun[0]])
+        self.assertListEqual(result.op.func[2], dict_fun[2])
+        agg_chunk = result.chunks[0]
+        self.assertEqual(agg_chunk.shape, (len(all_cols), 2))
+        self.assertListEqual(list(agg_chunk.columns_value.to_pandas()), [0, 2])
+        self.assertSetEqual(set(agg_chunk.index_value.to_pandas()), all_cols)
+        self.assertEqual(agg_chunk.op.stage, OperandStage.agg)
+
+        with self.assertRaises(NotImplementedError):
+            df.agg({0: ['sum', 'min', 'var'], 9: ['mean', 'var', 'std']}, axis=1)
+
+    def testSeriesAggregate(self):
+        data = pd.Series(np.random.rand(20), index=[str(i) for i in range(20)], name='a')
+        agg_funcs = ['sum', 'min', 'max', 'mean', 'var', 'std']
+
+        series = from_pandas_series(data)
+
+        result = series.agg(agg_funcs).tiles()
+        self.assertEqual(len(result.chunks), 1)
+        self.assertEqual(result.shape, (6,))
+        self.assertListEqual(list(result.index_value.to_pandas()), agg_funcs)
+        self.assertEqual(result.op.object_type, ObjectType.series)
+        self.assertListEqual(result.op.func, agg_funcs)
+
+        series = from_pandas_series(data, chunk_size=3)
+
+        result = series.agg('sum').tiles()
+        self.assertEqual(len(result.chunks), 1)
+        self.assertEqual(result.shape, ())
+        self.assertEqual(result.op.object_type, ObjectType.scalar)
+        agg_chunk = result.chunks[0]
+        self.assertEqual(agg_chunk.shape, ())
+        self.assertEqual(agg_chunk.op.stage, OperandStage.agg)
+
+        result = series.agg(['sum', 'min', 'max', 'mean', 'var', 'std']).tiles()
+        self.assertEqual(len(result.chunks), 1)
+        self.assertEqual(result.shape, (len(agg_funcs),))
+        self.assertListEqual(list(result.index_value.to_pandas()), agg_funcs)
+        self.assertEqual(result.op.object_type, ObjectType.series)
+        self.assertListEqual(result.op.func, agg_funcs)
+        agg_chunk = result.chunks[0]
+        self.assertEqual(agg_chunk.shape, (len(agg_funcs),))
+        self.assertListEqual(list(agg_chunk.index_value.to_pandas()), agg_funcs)
+        self.assertEqual(agg_chunk.op.stage, OperandStage.agg)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/mars/dataframe/reduction/tests/test_reduction_execute.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execute.py
@@ -326,16 +326,17 @@ class TestAggregate(TestBase):
         self.executor = ExecutorForTest()
 
     def testDataFrameAggregate(self):
+        all_aggs = ['sum', 'prod', 'min', 'max', 'count', 'mean', 'var', 'std']
         data = pd.DataFrame(np.random.rand(20, 20))
 
         df = from_pandas_df(data)
-        result = df.agg(['sum', 'min', 'max', 'mean', 'var', 'std'])
+        result = df.agg(all_aggs)
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(result, concat=True)[0],
-                                      data.agg(['sum', 'min', 'max', 'mean', 'var', 'std']))
+                                      data.agg(all_aggs))
 
         df = from_pandas_df(data, chunk_size=3)
 
-        for func in ['sum', 'min', 'max', 'mean', 'var', 'std']:
+        for func in all_aggs:
             result = df.agg(func)
             pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
                                            data.agg(func))
@@ -344,36 +345,41 @@ class TestAggregate(TestBase):
             pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
                                            data.agg(func, axis=1))
 
-        result = df.agg(['sum', 'min', 'max', 'mean', 'var', 'std'])
+        result = df.agg(['sum'])
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(result, concat=True)[0],
-                                      data.agg(['sum', 'min', 'max', 'mean', 'var', 'std']))
+                                      data.agg(['sum']))
 
-        result = df.agg(['sum', 'min', 'max', 'mean', 'var', 'std'], axis=1)
+        result = df.agg(all_aggs)
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(result, concat=True)[0],
-                                      data.agg(['sum', 'min', 'max', 'mean', 'var', 'std'], axis=1))
+                                      data.agg(all_aggs))
+
+        result = df.agg(all_aggs, axis=1)
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(result, concat=True)[0],
+                                      data.agg(all_aggs, axis=1))
 
         result = df.agg({0: ['sum', 'min', 'var'], 9: ['mean', 'var', 'std']})
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(result, concat=True)[0],
                                       data.agg({0: ['sum', 'min', 'var'], 9: ['mean', 'var', 'std']}))
 
     def testSeriesAggregate(self):
+        all_aggs = ['sum', 'prod', 'min', 'max', 'count', 'mean', 'var', 'std']
         data = pd.Series(np.random.rand(20), index=[str(i) for i in range(20)], name='a')
 
         series = from_pandas_series(data)
-        result = series.agg(['sum', 'min', 'max', 'mean', 'var', 'std'])
+        result = series.agg(all_aggs)
         pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
-                                       data.agg(['sum', 'min', 'max', 'mean', 'var', 'std']))
+                                       data.agg(all_aggs))
 
         series = from_pandas_series(data, chunk_size=3)
 
-        for func in ['sum', 'min', 'max', 'mean', 'var', 'std']:
+        for func in all_aggs:
             result = series.agg(func)
             self.assertAlmostEqual(self.executor.execute_dataframe(result, concat=True)[0],
                                    data.agg(func))
 
-        result = series.agg(['sum', 'min', 'max', 'mean', 'var', 'std'])
+        result = series.agg(all_aggs)
         pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
-                                       data.agg(['sum', 'min', 'max', 'mean', 'var', 'std']))
+                                       data.agg(all_aggs))
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/mars/dataframe/reduction/tests/test_reduction_execute.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execute.py
@@ -321,5 +321,60 @@ class TestCumReduction(TestBase):
             self.executor.execute_dataframe(reduction_df3, concat=True)[0])
 
 
+class TestAggregate(TestBase):
+    def setUp(self):
+        self.executor = ExecutorForTest()
+
+    def testDataFrameAggregate(self):
+        data = pd.DataFrame(np.random.rand(20, 20))
+
+        df = from_pandas_df(data)
+        result = df.agg(['sum', 'min', 'max', 'mean', 'var', 'std'])
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(result, concat=True)[0],
+                                      data.agg(['sum', 'min', 'max', 'mean', 'var', 'std']))
+
+        df = from_pandas_df(data, chunk_size=3)
+
+        for func in ['sum', 'min', 'max', 'mean', 'var', 'std']:
+            result = df.agg(func)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
+                                           data.agg(func))
+
+            result = df.agg(func, axis=1)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
+                                           data.agg(func, axis=1))
+
+        result = df.agg(['sum', 'min', 'max', 'mean', 'var', 'std'])
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(result, concat=True)[0],
+                                      data.agg(['sum', 'min', 'max', 'mean', 'var', 'std']))
+
+        result = df.agg(['sum', 'min', 'max', 'mean', 'var', 'std'], axis=1)
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(result, concat=True)[0],
+                                      data.agg(['sum', 'min', 'max', 'mean', 'var', 'std'], axis=1))
+
+        result = df.agg({0: ['sum', 'min', 'var'], 9: ['mean', 'var', 'std']})
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(result, concat=True)[0],
+                                      data.agg({0: ['sum', 'min', 'var'], 9: ['mean', 'var', 'std']}))
+
+    def testSeriesAggregate(self):
+        data = pd.Series(np.random.rand(20), index=[str(i) for i in range(20)], name='a')
+
+        series = from_pandas_series(data)
+        result = series.agg(['sum', 'min', 'max', 'mean', 'var', 'std'])
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
+                                       data.agg(['sum', 'min', 'max', 'mean', 'var', 'std']))
+
+        series = from_pandas_series(data, chunk_size=3)
+
+        for func in ['sum', 'min', 'max', 'mean', 'var', 'std']:
+            result = series.agg(func)
+            self.assertAlmostEqual(self.executor.execute_dataframe(result, concat=True)[0],
+                                   data.agg(func))
+
+        result = series.agg(['sum', 'min', 'max', 'mean', 'var', 'std'])
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
+                                       data.agg(['sum', 'min', 'max', 'mean', 'var', 'std']))
+
+
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/mars/dataframe/reduction/var.py
+++ b/mars/dataframe/reduction/var.py
@@ -93,7 +93,7 @@ class DataFrameVar(DataFrameReductionOperand, DataFrameReductionMixin):
         count = concat_count.sum(axis=op.axis)
         r = cls._execute_reduction(data, op, reduction_func='sum')
         avg = cls._keep_dim(r / count, op)
-        avg_diff = data / concat_count - avg
+        avg_diff = (data / concat_count).subtract(avg, axis=op.axis)
 
         kwargs = dict(axis=op.axis, skipna=op.skipna)
         reduced_var_square = var_square.sum(**kwargs) + (concat_count * avg_diff ** 2).sum(**kwargs)

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -573,7 +573,7 @@ def wrap_notimplemented_exception(func):
     return wrapper
 
 
-def validate_axis(axis, tileable):
+def validate_axis(axis, tileable=None):
     if axis == 'index':
         axis = 0
     elif axis == 'columns':
@@ -582,7 +582,7 @@ def validate_axis(axis, tileable):
     illegal = False
     try:
         axis = operator.index(axis)
-        if axis < 0 or axis >= tileable.ndim:
+        if axis < 0 or (tileable and axis >= tileable.ndim):
             illegal = True
     except TypeError:
         illegal = True

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -331,7 +331,7 @@ message OperandDef {
         MAP = 710;
         DESCRIBE = 712;
         FILL_NA = 713;
-        TRANSFORM = 714;
+        AGGREGATE = 714;
 
         FUSE = 801;
 

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -26,7 +26,6 @@ import time
 import traceback
 import uuid
 
-import gevent
 import numpy as np
 from numpy.testing import assert_array_equal
 
@@ -57,9 +56,28 @@ class Test(unittest.TestCase):
         if os.path.exists(options.worker.spill_directory):
             shutil.rmtree(options.worker.spill_directory)
 
-    def wait_scheduler_worker_start(self):
-        old_not_errors = gevent.hub.Hub.NOT_ERROR
-        gevent.hub.Hub.NOT_ERROR = (Exception,)
+    def _start_service(self):
+        worker_port = self.worker_port = str(get_next_port())
+        scheduler_port = self.scheduler_port = str(get_next_port())
+        proc_worker = subprocess.Popen([sys.executable, '-m', 'mars.worker',
+                                        '-a', '127.0.0.1',
+                                        '-p', worker_port,
+                                        '--cpu-procs', '2',
+                                        '--cache-mem', '10m',
+                                        '--schedulers', '127.0.0.1:' + scheduler_port,
+                                        '--log-level', 'debug',
+                                        '--log-format', 'WOR %(asctime)-15s %(message)s',
+                                        '--ignore-avail-mem'])
+        proc_scheduler = subprocess.Popen([sys.executable, '-m', 'mars.scheduler',
+                                           '--nproc', '1',
+                                           '-H', '127.0.0.1',
+                                           '-p', scheduler_port,
+                                           '-Dscheduler.default_cpu_usage=0',
+                                           '--log-level', 'debug',
+                                           '--log-format', 'SCH %(asctime)-15s %(message)s'])
+
+        self.proc_worker = proc_worker
+        self.proc_scheduler = proc_scheduler
 
         actor_client = new_client()
         time.sleep(1)
@@ -83,41 +101,14 @@ class Test(unittest.TestCase):
                 raise SystemError('Scheduler not started. exit code %s' % self.proc_scheduler.poll())
             if self.proc_worker.poll() is not None:
                 raise SystemError('Worker not started. exit code %s' % self.proc_worker.poll())
-            if time.time() - check_time > 20:
+            if time.time() - check_time > 30:
                 raise SystemError('Check meta_timestamp timeout')
 
             time.sleep(0.1)
 
-        gevent.hub.Hub.NOT_ERROR = old_not_errors
-
-    def setUp(self):
-        worker_port = self.worker_port = str(get_next_port())
-        scheduler_port = self.scheduler_port = str(get_next_port())
-        proc_worker = subprocess.Popen([sys.executable, '-m', 'mars.worker',
-                                        '-a', '127.0.0.1',
-                                        '-p', worker_port,
-                                        '--cpu-procs', '2',
-                                        '--cache-mem', '10m',
-                                        '--schedulers', '127.0.0.1:' + scheduler_port,
-                                        '--log-level', 'debug',
-                                        '--log-format', 'WOR %(asctime)-15s %(message)s',
-                                        '--ignore-avail-mem'])
-        proc_scheduler = subprocess.Popen([sys.executable, '-m', 'mars.scheduler',
-                                           '--nproc', '1',
-                                           '-H', '127.0.0.1',
-                                           '-p', scheduler_port,
-                                           '-Dscheduler.default_cpu_usage=0',
-                                           '--log-level', 'debug',
-                                           '--log-format', 'SCH %(asctime)-15s %(message)s'])
-
-        self.proc_worker = proc_worker
-        self.proc_scheduler = proc_scheduler
-
-        self.wait_scheduler_worker_start()
-
         web_port = self.web_port = str(get_next_port())
         proc_web = subprocess.Popen([sys.executable, '-m', 'mars.web',
-                                    '-H', '127.0.0.1',
+                                     '-H', '127.0.0.1',
                                      '--log-level', 'debug',
                                      '--log-format', 'WEB %(asctime)-15s %(message)s',
                                      '-p', web_port,
@@ -139,11 +130,9 @@ class Test(unittest.TestCase):
                 continue
             break
 
-        self.exceptions = gevent.hub.Hub.NOT_ERROR
-        gevent.hub.Hub.NOT_ERROR = (Exception,)
-
-    def tearDown(self):
-        procs = (self.proc_web, self.proc_worker, self.proc_scheduler)
+    def _stop_service(self):
+        procs = [p for p in (self.proc_web, self.proc_worker, self.proc_scheduler)
+                 if p is not None]
         for p in procs:
             p.send_signal(signal.SIGINT)
 
@@ -157,7 +146,19 @@ class Test(unittest.TestCase):
             if p.poll() is None:
                 p.kill()
 
-        gevent.hub.Hub.NOT_ERROR = self.exceptions
+    def setUp(self):
+        self.proc_scheduler = self.proc_worker = self.proc_web = None
+        for attempt in range(3):
+            try:
+                self._start_service()
+                break
+            except:  # noqa: E722
+                self._stop_service()
+                if attempt == 2:
+                    raise
+
+    def tearDown(self):
+        self._stop_service()
 
     def testWebApi(self):
         service_ep = 'http://127.0.0.1:' + self.web_port

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.14.0
 pandas>=0.20.0
 requests>=2.4.0
-pyarrow>=0.11.0,<0.16.0
+pyarrow>=0.11.0
 cloudpickle>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.14.0
 pandas>=0.20.0
 requests>=2.4.0
-pyarrow>=0.11.0
+pyarrow>=0.11.0,<0.16.0
 cloudpickle>=1.0.0


### PR DESCRIPTION
## What do these changes do?

This PR adds support for aggregation on data frames and series. We describe the method we use below.
Given that every aggregation function used in tree reduction can be put in three stages: map, combine and agg, which can be illustrated below:

```
map1 - combine1
map2 - combine2  > agg
...
mapx - combinex
```

We first group data by functions used in the map stage and create u separated map groups, one for every distinct map function. Then for every map group, we divide then further by combine functions accepting the results of the map group into map-combine groups. Therefore every map-combine group has one corresponding map group, but the reversed conclusion does not hold. Then all related columns in map-combine groups for every aggregation is collected, and aggregation result is computed.

For instance, if the line below is entered:

```
df.agg({'c1': 'sum', 'c2': ['sum', 'count'], 'c3': ['var']})
```

Map groups below are created:

```
'sum': {'c1', 'c2', 'c3'}, 'count': {'c2', 'c3'}, 'var': {'c3'}
```

From these map groups, map-combine groups are created:

```
'sum-sum': {'c1', 'c2', 'c3'}, 'count-sum': {'c2', 'c3'}, 'var-reduce_var': {'c3'}
```

And then aggregation results can be computed as

```
sum: sum of 'sum-sum' {'c1', 'c2'}
count: sum of 'count-sum' {'c2'}
var: reduce_var of ('sum-sum': {'c3'}, 'count-sum': {'c3'}, 'var-reduce_var': {'c3'})
```

And the final result is a concatenation of results above.

If column labels are absent, columns will be None, and the whole data frame ios then treated as data to process.

Due to current implementation, aggregating on row indexes is not supported.

## Related issue number

Fixes #1035