### PR TITLE
Support string and datetime methods via `Series.str` and `Series.dt` accessor

### DIFF
--- a/mars/dataframe/base/__init__.py
+++ b/mars/dataframe/base/__init__.py
@@ -21,6 +21,7 @@ from .describe import describe
 from .apply import df_apply, df_transform, series_apply, series_transform
 from .fillna import fillna, ffill, bfill
 from .string_ import SeriesStringMethod
+from .datetimes import SeriesDatetimeMethod
 
 
 def _install():
@@ -54,3 +55,4 @@ def _install():
 _install()
 del _install
 del SeriesStringMethod
+del SeriesDatetimeMethod

--- a/mars/dataframe/base/__init__.py
+++ b/mars/dataframe/base/__init__.py
@@ -20,6 +20,7 @@ from .reset_index import df_reset_index, series_reset_index
 from .describe import describe
 from .apply import df_apply, df_transform, series_apply, series_transform
 from .fillna import fillna, ffill, bfill
+from .string_ import SeriesStringMethod
 
 
 def _install():
@@ -52,3 +53,4 @@ def _install():
 
 _install()
 del _install
+del SeriesStringMethod

--- a/mars/dataframe/base/accessor.py
+++ b/mars/dataframe/base/accessor.py
@@ -1,0 +1,50 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import wraps
+
+import pandas as pd
+
+from .string_ import _string_method_to_handlers, SeriesStringMethod
+
+
+class StringAccessor:
+    def __init__(self, series):
+        self._series = series
+
+    def _gen_func(self, method):
+        @wraps(getattr(pd.Series.str, method))
+        def _inner(*args, **kwargs):
+            op = SeriesStringMethod(method=method, method_args=args,
+                                    method_kwargs=kwargs)
+            return op(self._series)
+        return _inner
+
+    def __getitem__(self, item):
+        return self._gen_func('__getitem__')(item)
+
+    def __getattr__(self, item):
+        if item in _string_method_to_handlers:
+            return self._gen_func(item)
+        return super().__getattribute__(item)
+
+    def split(self, pat=None, n=-1, expand=False):
+        return self._gen_func('split')(pat=pat, n=n, expand=expand)
+
+    def rsplit(self, pat=None, n=-1, expand=False):
+        return self._gen_func('rsplit')(pat=pat, n=n, expand=expand)
+
+    def cat(self, others=None, sep=None, na_rep=None, join='left'):
+        return self._gen_func('cat')(others=others, sep=sep,
+                                     na_rep=na_rep, join=join)

--- a/mars/dataframe/base/datetimes.py
+++ b/mars/dataframe/base/datetimes.py
@@ -1,0 +1,121 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+
+from ... import opcodes as OperandDef
+from ...serialize import KeyField, StringField, TupleField, DictField, BoolField
+from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..utils import build_empty_series
+
+
+class SeriesDatetimeMethod(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = OperandDef.DATETIME_METHOD
+
+    _input = KeyField('input')
+    _method = StringField('method')
+    _method_args = TupleField('method_args')
+    _method_kwargs = DictField('method_kwargs')
+    _is_property = BoolField('is_property')
+
+    def __init__(self, method=None, method_args=None, method_kwargs=None,
+                 is_property=None, stage=None, object_type=None, **kw):
+        super().__init__(_method=method, _method_args=method_args,
+                         _method_kwargs=method_kwargs, _is_property=is_property,
+                         _stage=stage, _object_type=object_type, **kw)
+        if self._object_type is None:
+            self._object_type = ObjectType.series
+
+    @property
+    def input(self):
+        return self._input
+
+    @property
+    def method(self):
+        return self._method
+
+    @property
+    def method_args(self):
+        return self._method_args
+
+    @property
+    def method_kwargs(self):
+        return self._method_kwargs
+
+    @property
+    def is_property(self):
+        return self._is_property
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        self._input = self._inputs[0]
+
+    def __call__(self, inp):
+        return _datetime_method_to_handlers[self._method].call(self, inp)
+
+    @classmethod
+    def tile(cls, op):
+        return _datetime_method_to_handlers[op.method].tile(op)
+
+    @classmethod
+    def execute(cls, ctx, op):
+        return _datetime_method_to_handlers[op.method].execute(ctx, op)
+
+
+class SeriesDatetimeMethodBaseHandler:
+    @classmethod
+    def call(cls, op, inp):
+        empty_series = build_empty_series(inp.dtype)
+        if op.is_property:
+            test_obj = getattr(empty_series.dt, op.method)
+        else:
+            test_obj = getattr(empty_series.dt, op.method)(
+                *op.method_args, **op.method_kwargs)
+        dtype = test_obj.dtype
+        return op.new_series([inp], shape=inp.shape,
+                             dtype=dtype, index_value=inp.index_value,
+                             name=inp.name)
+
+    @classmethod
+    def tile(cls, op):
+        out = op.outputs[0]
+
+        out_chunks = []
+        for series_chunk in op.input.chunks:
+            chunk_op = op.copy().reset_key()
+            out_chunks.append(chunk_op.new_chunk(
+                [series_chunk], shape=series_chunk.shape,
+                dtype=out.dtype, index=series_chunk.index,
+                index_value=series_chunk.index_value,
+                name=series_chunk.name))
+
+        params = out.params
+        params['chunks'] = out_chunks
+        params['nsplits'] = op.input.nsplits
+        new_op = op.copy()
+        return new_op.new_tileables([op.input], kws=[params])
+
+    @classmethod
+    def execute(cls, ctx, op):
+        inp = ctx[op.input.key]
+        out = getattr(inp.dt, op.method)
+        if not op.is_property:
+            out = out(*op.method_args, **op.method_kwargs)
+        ctx[op.outputs[0].key] = out
+
+
+_datetime_method_to_handlers = {}
+for method in dir(pd.Series.dt):
+    if not method.startswith('_'):
+        _datetime_method_to_handlers[method] = SeriesDatetimeMethodBaseHandler

--- a/mars/dataframe/base/datetimes.py
+++ b/mars/dataframe/base/datetimes.py
@@ -109,7 +109,11 @@ class SeriesDatetimeMethodBaseHandler:
     @classmethod
     def execute(cls, ctx, op):
         inp = ctx[op.input.key]
-        out = getattr(inp.dt, op.method)
+        try:
+            out = getattr(inp.dt, op.method)
+        except ValueError:
+            # fail due to buffer read-only
+            out = getattr(inp.copy().dt, op.method)
         if not op.is_property:
             out = out(*op.method_args, **op.method_kwargs)
         ctx[op.outputs[0].key] = out

--- a/mars/dataframe/base/string_.py
+++ b/mars/dataframe/base/string_.py
@@ -81,9 +81,6 @@ class SeriesStringMethod(DataFrameOperand, DataFrameOperandMixin):
         return _string_method_to_handlers[op.method].execute(ctx, op)
 
 
-_string_method_to_handlers = {}
-
-
 class SeriesStringMethodBaseHandler:
     @classmethod
     def call(cls, op, inp):
@@ -108,7 +105,6 @@ class SeriesStringMethodBaseHandler:
                 name=series_chunk.name)
             out_chunks.append(out_chunk)
 
-        out = op.outputs[0]
         params = out.params
         params['chunks'] = out_chunks
         params['nsplits'] = op.input.nsplits
@@ -381,6 +377,7 @@ class SeriesStringExtractHandler(SeriesStringMethodBaseHandler):
         return new_op.new_tileables([op.input], kws=[params])
 
 
+_string_method_to_handlers = {}
 _not_implements = ['get_dummies']
 # start to register handlers for string methods
 # register special methods first

--- a/mars/dataframe/base/string_.py
+++ b/mars/dataframe/base/string_.py
@@ -1,0 +1,400 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+
+from ... import opcodes as OperandDef
+from ...config import options
+from ...operands import OperandStage
+from ...serialize import KeyField, StringField, TupleField, DictField
+from ...tensor import tensor as astensor
+from ...tensor.core import TENSOR_TYPE
+from ...tiles import TilesError
+from ...utils import ceildiv, check_chunks_unknown_shape
+from ..align import align_series_series
+from ..core import SERIES_TYPE
+from ..initializer import Series as asseries
+from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..utils import build_empty_series, parse_index, infer_index_value
+
+
+class SeriesStringMethod(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = OperandDef.STRING_METHOD
+
+    _input = KeyField('input')
+    _method = StringField('method')
+    _method_args = TupleField('method_args')
+    _method_kwargs = DictField('method_kwargs')
+
+    def __init__(self, method=None, method_args=None, method_kwargs=None,
+                 stage=None, object_type=None, **kw):
+        super().__init__(_method=method, _method_args=method_args,
+                         _method_kwargs=method_kwargs, _stage=stage,
+                         _object_type=object_type, **kw)
+        if self._object_type is None:
+            self._object_type = ObjectType.series
+
+    @property
+    def input(self):
+        return self._input
+
+    @property
+    def method(self):
+        return self._method
+
+    @property
+    def method_args(self):
+        return self._method_args
+
+    @property
+    def method_kwargs(self):
+        return self._method_kwargs
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        self._input = self._inputs[0]
+        if len(self._inputs) == 2:
+            # for method cat
+            self._method_kwargs['others'] = self._inputs[1]
+
+    def __call__(self, inp):
+        return _string_method_to_handlers[self._method].call(self, inp)
+
+    @classmethod
+    def tile(cls, op):
+        return _string_method_to_handlers[op.method].tile(op)
+
+    @classmethod
+    def execute(cls, ctx, op):
+        return _string_method_to_handlers[op.method].execute(ctx, op)
+
+
+_string_method_to_handlers = {}
+
+
+class SeriesStringMethodBaseHandler:
+    @classmethod
+    def call(cls, op, inp):
+        empty_series = build_empty_series(inp.dtype)
+        dtype = getattr(empty_series.str, op.method)(
+            *op.method_args, **op.method_kwargs).dtype
+        return op.new_series([inp], shape=inp.shape,
+                             dtype=dtype,
+                             index_value=inp.index_value,
+                             name=inp.name)
+
+    @classmethod
+    def tile(cls, op):
+        out = op.outputs[0]
+        out_chunks = []
+        for series_chunk in op.input.chunks:
+            chunk_op = op.copy().reset_key()
+            out_chunk = chunk_op.new_chunk(
+                [series_chunk], shape=series_chunk.shape,
+                dtype=out.dtype, index=series_chunk.index,
+                index_value=series_chunk.index_value,
+                name=series_chunk.name)
+            out_chunks.append(out_chunk)
+
+        out = op.outputs[0]
+        params = out.params
+        params['chunks'] = out_chunks
+        params['nsplits'] = op.input.nsplits
+        new_op = op.copy()
+        return new_op.new_tileables([op.input], kws=[params])
+
+    @classmethod
+    def execute(cls, ctx, op):
+        inp = ctx[op.input.key]
+        ctx[op.outputs[0].key] = getattr(inp.str, op.method)(
+            *op.method_args, **op.method_kwargs)
+
+
+class SeriesStringSplitHandler(SeriesStringMethodBaseHandler):
+    @classmethod
+    def call(cls, op, inp):
+        method_kwargs = op.method_kwargs
+        if method_kwargs.get('expand', False) is False:
+            return super().call(op, inp)
+        n = method_kwargs.get('n', -1)
+        # does not support if expand and n == -1
+        if n == -1:  # pragma: no cover
+            raise NotImplementedError('`n` needs to be specified when expand=True')
+
+        op._object_type = ObjectType.dataframe
+        columns = pd.RangeIndex(n + 1)
+        columns_value = parse_index(columns, store_data=True)
+        dtypes = pd.Series([inp.dtype] * len(columns), index=columns)
+        return op.new_dataframe([inp], shape=(inp.shape[0], len(columns)),
+                                dtypes=dtypes, columns_value=columns_value,
+                                index_value=inp.index_value)
+
+    @classmethod
+    def tile(cls, op):
+        out = op.outputs[0]
+
+        if out.op.object_type == ObjectType.series:
+            return super().tile(op)
+
+        out_chunks = []
+        columns = out.columns_value.to_pandas()
+        for series_chunk in op.input.chunks:
+            chunk_op = op.copy().reset_key()
+            out_chunk = chunk_op.new_chunk(
+                [series_chunk], shape=(series_chunk.shape[0], len(columns)),
+                index=(series_chunk.index[0], 0),
+                dtypes=out.dtypes, index_value=series_chunk.index_value,
+                columns_value=out.columns_value
+            )
+            out_chunks.append(out_chunk)
+
+        params = out.params
+        params['chunks'] = out_chunks
+        params['nsplits'] = (op.input.nsplits[0], (len(columns),))
+        new_op = op.copy()
+        return new_op.new_tileables([op.input], kws=[params])
+
+    @classmethod
+    def execute(cls, ctx, op):
+        inp = ctx[op.input.key]
+        out = op.outputs[0]
+        result = getattr(inp.str, op.method)(
+            *op.method_args, **op.method_kwargs)
+        if result.ndim == 2 and result.shape[1] < out.shape[1]:
+            for i in range(result.shape[1], out.shape[1]):
+                result[i] = None
+        ctx[op.outputs[0].key] = result
+
+
+class SeriesStringCatHandler(SeriesStringMethodBaseHandler):
+    CAT_TYPE_ERROR = "others must be Series, Index, DataFrame, " \
+                     "Tensor, np.ndarrary or list-like " \
+                     "(either containing only strings or " \
+                     "containing only objects of " \
+                     "type Series/Index/Tensor/np.ndarray[1-dim])"
+    CAT_LEN_ERROR = "If `others` contains arrays or lists (or other list-likes without an index), " \
+                    "these must all be of the same length as the calling Series/Index."
+
+    @classmethod
+    def call(cls, op, inp):
+        method_kwargs = op.method_kwargs
+        others = method_kwargs.get('others')
+
+        if others is None:
+            op._object_type = ObjectType.scalar
+            return op.new_scalar([inp], dtype=inp.dtype)
+        elif isinstance(others, (tuple, list, np.ndarray, TENSOR_TYPE)):
+            others = astensor(others, dtype=object)
+            if others.ndim != 1:
+                raise TypeError(cls.CAT_TYPE_ERROR)
+            if not np.isnan(inp.shape[0]) and not np.isnan(others.shape[0]) and \
+                    inp.shape[0] != others.shape[0]:
+                raise ValueError(cls.CAT_LEN_ERROR)
+            inputs = [inp]
+            if isinstance(others, TENSOR_TYPE):
+                inputs.append(others)
+            return op.new_series(inputs, shape=inp.shape,
+                                 dtype=inp.dtype,
+                                 index_value=inp.index_value,
+                                 name=inp.name)
+        elif isinstance(others, (pd.Series, SERIES_TYPE)):
+            others = asseries(others)
+            if op.method_kwargs.get('join') != 'outer':  # pragma: no cover
+                raise NotImplementedError('only outer join supported for now')
+            return op.new_series([inp, others], shape=inp.shape,
+                                 dtype=inp.dtype,
+                                 index_value=infer_index_value(inp.index_value,
+                                                               others.index_value),
+                                 name=inp.name)
+        elif isinstance(others, str) and op.method_kwargs.get('sep') is None:
+            raise ValueError('Did you mean to supply a `sep` keyword?')
+        else:
+            raise TypeError(cls.CAT_TYPE_ERROR)
+
+    @classmethod
+    def _tile_aggregate_cat(cls, op, inp, out):
+        from ..merge.concat import DataFrameConcat
+
+        # scalar
+        combine_size = options.combine_size
+        out_chunks = inp.chunks
+        out_chunk_size = len(out_chunks)
+        while out_chunk_size > 1:
+            out_chunk_size = ceildiv(len(out_chunks), combine_size)
+            is_terminate = out_chunk_size == 1
+            new_out_chunks = []
+            for i in range(out_chunk_size):
+                chunk_inputs = out_chunks[i * combine_size: (i + 1) * combine_size]
+                index_value = parse_index(chunk_inputs[0].index_value.to_pandas(), chunk_inputs)
+                # concat inputs
+                concat_chunk = DataFrameConcat(object_type=ObjectType.series).new_chunk(
+                    chunk_inputs, index=(i,), dtype=chunk_inputs[0].dtype,
+                    index_value=index_value, name=chunk_inputs[0].name)
+                chunk_op = op.copy().reset_key()
+                if not is_terminate:
+                    chunk_op._object_type = ObjectType.series
+                    chunk_op._stage = OperandStage.map if not is_terminate else OperandStage.agg
+                    index_value = parse_index(index_value.to_pandas()[:0], concat_chunk)
+                    out_chunk = chunk_op.new_chunk([concat_chunk], dtype=concat_chunk.dtype,
+                                                   index=(i,), index_value=index_value,
+                                                   name=concat_chunk.name)
+                else:
+                    out_chunk = chunk_op.new_chunk([concat_chunk], dtype=concat_chunk.dtype)
+                new_out_chunks.append(out_chunk)
+            out_chunks = new_out_chunks
+
+        new_op = op.copy()
+        params = out.params
+        params['nsplits'] = ()
+        params['chunks'] = out_chunks
+        return new_op.new_tileables(op.inputs, kws=[params])
+
+    @classmethod
+    def tile(cls, op):
+        inp = op.input
+        out = op.outputs[0]
+
+        if out.ndim == 0:
+            return cls._tile_aggregate_cat(op, inp, out)
+        elif isinstance(op.inputs[1], TENSOR_TYPE):
+            check_chunks_unknown_shape(op.inputs, TilesError)
+            # rechunk others as input
+            others = op.inputs[1].rechunk(op.input.nsplits)._inplace_tile()
+            out_chunks = []
+            for c in op.input.chunks:
+                chunk_op = op.copy().reset_key()
+                chunk_op._method_kwargs = op.method_kwargs.copy()
+                out_chunk = chunk_op.new_chunk([c, others.cix[c.index]],
+                                               dtype=c.dtype,
+                                               index=c.index,
+                                               index_value=c.index_value,
+                                               name=c.name)
+                out_chunks.append(out_chunk)
+            new_op = op.copy()
+            params = out.params
+            params['nsplits'] = inp.nsplits
+            params['chunks'] = out_chunks
+            return new_op.new_tileables(op.inputs, kws=[params])
+        elif isinstance(op.inputs[1], SERIES_TYPE):
+            # both series
+            out_chunks = []
+            nsplits, _, left_chunks, right_chunks = align_series_series(*op.inputs)
+            for left_chunk, right_chunk in zip(left_chunks, right_chunks):
+                chunk_op = op.copy().reset_key()
+                chunk_op._method_kwargs = op.method_kwargs.copy()
+                out_chunk = chunk_op.new_chunk([left_chunk, right_chunk],
+                                               dtype=left_chunk.dtype,
+                                               index=left_chunk.index,
+                                               index_value=left_chunk.index_value,
+                                               name=out.name)
+                out_chunks.append(out_chunk)
+            new_op = op.copy()
+            params = out.params
+            params['nsplits'] = nsplits
+            params['chunks'] = out_chunks
+            return new_op.new_tileables(op.inputs, kws=[params])
+
+    @classmethod
+    def execute(cls, ctx, op):
+        inputs = [ctx[inp.key] for inp in op.inputs]
+        method_kwargs = op.method_kwargs
+        if len(inputs) == 1:
+            cat = inputs[0].str.cat(**method_kwargs)
+            if op.stage == OperandStage.map:
+                # keep series
+                cat = type(inputs[0])([cat])
+            ctx[op.outputs[0].key] = cat
+        else:
+            method_kwargs['others'] = inputs[1]
+            ctx[op.outputs[0].key] = inputs[0].str.cat(**method_kwargs)
+
+
+class SeriesStringExtractHandler(SeriesStringMethodBaseHandler):
+    @classmethod
+    def call(cls, op, inp):
+        empty_series = build_empty_series(
+            inp.dtype, index=inp.index_value.to_pandas()[:0])
+        test_df = getattr(empty_series.str, op.method)(
+            *op.method_args, **op.method_kwargs)
+        if test_df.ndim == 1:
+            return op.new_series([inp], shape=inp.shape,
+                                 dtype=test_df.dtype,
+                                 index_value=inp.index_value,
+                                 name=inp.name)
+        else:
+            op._object_type = ObjectType.dataframe
+            if op.method == 'extractall':
+                index_value = parse_index(test_df.index, inp)
+            else:
+                index_value = inp.index_value
+            return op.new_dataframe([inp], shape=(inp.shape[0], test_df.shape[1]),
+                                    dtypes=test_df.dtypes,
+                                    index_value=index_value,
+                                    columns_value=parse_index(test_df.columns,
+                                                              store_data=True))
+
+    @classmethod
+    def tile(cls, op):
+        out = op.outputs[0]
+        out_chunks = []
+        for series_chunk in op.input.chunks:
+            chunk_op = op.copy().reset_key()
+            if out.ndim == 1:
+                out_chunk = chunk_op.new_chunk(
+                    [series_chunk], shape=series_chunk.shape,
+                    index=series_chunk.index,
+                    dtype=out.dtype, index_value=series_chunk.index_value,
+                    name=out.name)
+            else:
+                if op.method == 'extract':
+                    index_value = series_chunk.index_value
+                else:
+                    index_value = parse_index(out.index_value.to_pandas()[:0],
+                                              series_chunk)
+                out_chunk = chunk_op.new_chunk(
+                    [series_chunk], shape=(series_chunk.shape[0], out.shape[1]),
+                    index=(series_chunk.index[0], 0),
+                    dtypes=out.dtypes, index_value=index_value,
+                    columns_value=out.columns_value)
+            out_chunks.append(out_chunk)
+
+        out = op.outputs[0]
+        params = out.params
+        params['chunks'] = out_chunks
+        if out.ndim == 1:
+            params['nsplits'] = op.input.nsplits
+        else:
+            params['nsplits'] = (op.input.nsplits[0], (out.shape[1],))
+        new_op = op.copy()
+        return new_op.new_tileables([op.input], kws=[params])
+
+
+_not_implements = ['get_dummies']
+# start to register handlers for string methods
+# register special methods first
+_string_method_to_handlers['split'] = SeriesStringSplitHandler
+_string_method_to_handlers['rsplit'] = SeriesStringSplitHandler
+_string_method_to_handlers['cat'] = SeriesStringCatHandler
+_string_method_to_handlers['extract'] = SeriesStringExtractHandler
+_string_method_to_handlers['extractall'] = SeriesStringExtractHandler
+# then come to the normal methods
+for method in dir(pd.Series.str):
+    if method.startswith('_') and method != '__getitem__':
+        continue
+    if method in _not_implements:
+        continue
+    if method in _string_method_to_handlers:
+        continue
+    _string_method_to_handlers[method] = SeriesStringMethodBaseHandler

--- a/mars/dataframe/base/tests/test_base.py
+++ b/mars/dataframe/base/tests/test_base.py
@@ -520,3 +520,34 @@ class Test(TestBase):
                                           s.index[i * 2: (i + 1) * 2])
             pd.testing.assert_index_equal(c.columns_value.to_pandas(), pd.RangeIndex(1))
             self.assertEqual(c.shape, (2, 1) if i == 0 else (1, 1))
+
+        self.assertIn('lstrip', dir(series.str))
+
+    def testDatetimeMethod(self):
+        s = pd.Series([pd.Timestamp('2020-1-1'),
+                       pd.Timestamp('2020-2-1'),
+                       pd.Timestamp('2020-3-1')],
+                      name='ss')
+        series = from_pandas_series(s, chunk_size=2)
+
+        r = series.dt.year
+        self.assertEqual(r.dtype, s.dt.year.dtype)
+        pd.testing.assert_index_equal(r.index_value.to_pandas(), s.index)
+        self.assertEqual(r.shape, s.shape)
+        self.assertEqual(r.op.object_type, ObjectType.series)
+        self.assertEqual(r.name, s.dt.year.name)
+
+        r = r.tiles()
+        for i, c in enumerate(r.chunks):
+            self.assertEqual(c.index, (i,))
+            self.assertEqual(c.dtype, s.dt.year.dtype)
+            self.assertEqual(c.op.object_type, ObjectType.series)
+            self.assertEqual(r.name, s.dt.year.name)
+            pd.testing.assert_index_equal(c.index_value.to_pandas(),
+                                          s.index[i * 2: (i + 1) * 2])
+            self.assertEqual(c.shape, (2,) if i == 0 else (1,))
+
+        with self.assertRaises(AttributeError):
+            _ = series.dt.non_exist
+
+        self.assertIn('ceil', dir(series.dt))

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -562,3 +562,70 @@ class Test(TestBase):
         result = self.executor.execute_dataframe(r, concat=True)[0]
         expected = s_raw.transform(lambda x: x + 1)
         pd.testing.assert_series_equal(result, expected)
+
+    def testStringMethodExecution(self):
+        s = pd.Series(['s1,s2', 'ef,', 'dd', np.nan])
+        s2 = pd.concat([s, s, s])
+
+        series = from_pandas_series(s, chunk_size=2)
+        series2 = from_pandas_series(s2, chunk_size=2)
+
+        # test getitem
+        r = series.str[:3]
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.str[:3]
+        pd.testing.assert_series_equal(result, expected)
+
+        # test split, expand=False
+        r = series.str.split(',', n=2)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.str.split(',', n=2)
+        pd.testing.assert_series_equal(result, expected)
+
+        # test split, expand=True
+        r = series.str.split(',', expand=True, n=1)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.str.split(',', expand=True, n=1)
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test rsplit
+        r = series.str.rsplit(',', expand=True, n=1)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.str.rsplit(',', expand=True, n=1)
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test cat all data
+        r = series2.str.cat(sep='/', na_rep='e')
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s2.str.cat(sep='/', na_rep='e')
+        self.assertEqual(result, expected)
+
+        # test cat list
+        r = series.str.cat(['a', 'b', np.nan, 'c'])
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.str.cat(['a', 'b', np.nan, 'c'])
+        pd.testing.assert_series_equal(result, expected)
+
+        # test cat series
+        r = series.str.cat(series.str.capitalize(), join='outer')
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.str.cat(s.str.capitalize(), join='outer')
+        pd.testing.assert_series_equal(result, expected)
+
+        # test extractall
+        r = series.str.extractall(r"(?P<letter>[ab])(?P<digit>\d)")
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.str.extractall(r"(?P<letter>[ab])(?P<digit>\d)")
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test extract, expand=False
+        r = series.str.extract(r'[ab](\d)', expand=False)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.str.extract(r'[ab](\d)', expand=False)
+        pd.testing.assert_series_equal(result, expected)
+
+        # test extract, expand=True
+        r = series.str.extract(r'[ab](\d)', expand=True)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.str.extract(r'[ab](\d)', expand=True)
+        pd.testing.assert_frame_equal(result, expected)

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -629,3 +629,31 @@ class Test(TestBase):
         result = self.executor.execute_dataframe(r, concat=True)[0]
         expected = s.str.extract(r'[ab](\d)', expand=True)
         pd.testing.assert_frame_equal(result, expected)
+
+    def testDatetimeMethodExecution(self):
+        # test datetime
+        s = pd.Series([pd.Timestamp('2020-1-1'),
+                       pd.Timestamp('2020-2-1'),
+                       np.nan])
+        series = from_pandas_series(s, chunk_size=2)
+
+        r = series.dt.year
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.dt.year
+        pd.testing.assert_series_equal(result, expected)
+
+        r = series.dt.strftime('%m-%d-%Y')
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.dt.strftime('%m-%d-%Y')
+        pd.testing.assert_series_equal(result, expected)
+
+        # test timedelta
+        s = pd.Series([pd.Timedelta('1 days'),
+                       pd.Timedelta('3 days'),
+                       np.nan])
+        series = from_pandas_series(s, chunk_size=2)
+
+        r = series.dt.days
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.dt.days
+        pd.testing.assert_series_equal(result, expected)

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -16,10 +16,8 @@
 
 import numpy as np
 
-try:
-    import pandas as pd
-except ImportError:  # pragma: no cover
-    pass
+import pandas as pd
+from pandas.util import cache_readonly
 
 from ..utils import on_serialize_shape, on_deserialize_shape, on_serialize_numpy_type, \
     is_eager_mode, build_mode
@@ -467,7 +465,7 @@ class SeriesChunk(Chunk):
 
 
 class SeriesData(HasShapeTileableData):
-    __slots__ = ()
+    __slots__ = '_cache',
 
     # optional field
     _dtype = DataTypeField('dtype')
@@ -527,6 +525,12 @@ class SeriesData(HasShapeTileableData):
     def index_value(self):
         return self._index_value
 
+    @cache_readonly
+    def str(self):
+        from .base.accessor import StringAccessor
+
+        return StringAccessor(self)
+
     def to_tensor(self, dtype=None):
         from ..tensor.datasource.from_dataframe import from_series
         return from_series(self, dtype=dtype)
@@ -538,7 +542,7 @@ class SeriesData(HasShapeTileableData):
 
 
 class Series(TileableEntity):
-    __slots__ = ()
+    __slots__ = '_cache',
     _allow_data_type_ = (SeriesData,)
 
     def to_tensor(self, dtype=None):
@@ -546,6 +550,10 @@ class Series(TileableEntity):
 
     def from_tensor(self, in_tensor, index=None, name=None):
         return self._data.from_tensor(in_tensor, index=index, name=name)
+
+    @cache_readonly
+    def str(self):
+        return self._data.str
 
     def __mars_tensor__(self, dtype=None, order='K'):
         tensor = self._data.to_tensor()

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -531,6 +531,12 @@ class SeriesData(HasShapeTileableData):
 
         return StringAccessor(self)
 
+    @cache_readonly
+    def dt(self):
+        from .base.accessor import DatetimeAccessor
+
+        return DatetimeAccessor(self)
+
     def to_tensor(self, dtype=None):
         from ..tensor.datasource.from_dataframe import from_series
         return from_series(self, dtype=dtype)

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -332,6 +332,8 @@ message OperandDef {
         DESCRIBE = 712;
         FILL_NA = 713;
         AGGREGATE = 714;
+        STRING_METHOD = 715;
+        DATETIME_METHOD = 716;
 
         FUSE = 801;
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR implements string and datetime methods via `Series.str` and `Series.dt` accessor.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1051 .
Resolves #1052 .