### PR TITLE
Support serializing `pd.Timestamp` and `pd.Timedelta`

### DIFF
--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -25,7 +25,7 @@ from ..utils import on_serialize_shape, on_deserialize_shape, on_serialize_numpy
     is_eager_mode, build_mode
 from ..core import ChunkData, Chunk, TileableEntity, TileableData, HasShapeTileableData
 from ..serialize import Serializable, ValueType, ProviderType, DataTypeField, AnyField, \
-    SeriesField, BoolField, Int64Field, Int32Field, StringField, ListField, SliceField, \
+    SeriesField, BoolField, Int32Field, StringField, ListField, SliceField, \
     TupleField, OneOfField, ReferenceField, NDArrayField
 
 
@@ -126,7 +126,7 @@ class IndexValue(Serializable):
         _data = NDArrayField('data')
         _freq = AnyField('freq')
         _start = AnyField('start')
-        _periods = Int64Field('periods')
+        _periods = AnyField('periods')
         _end = AnyField('end')
         _closed = AnyField('closed')
         _tz = AnyField('tz')
@@ -140,7 +140,7 @@ class IndexValue(Serializable):
         _unit = AnyField('unit')
         _freq = AnyField('freq')
         _start = AnyField('start')
-        _periods = Int64Field('periods')
+        _periods = AnyField('periods')
         _end = AnyField('end')
         _closed = AnyField('closed')
 
@@ -149,7 +149,7 @@ class IndexValue(Serializable):
         _data = NDArrayField('data')
         _freq = AnyField('freq')
         _start = AnyField('start')
-        _periods = Int64Field('periods')
+        _periods = AnyField('periods')
         _end = AnyField('end')
         _year = AnyField('year')
         _month = AnyField('month')

--- a/mars/dataframe/datasource/tests/test_datasource.py
+++ b/mars/dataframe/datasource/tests/test_datasource.py
@@ -72,7 +72,8 @@ class Test(TestBase):
 
     def testDataFrameGraphSerialize(self):
         df = from_pandas_df(pd.DataFrame(np.random.rand(10, 10),
-                                         columns=[np.random.bytes(10) for _ in range(10)]))
+                                         columns=pd.timedelta_range(start='1 day', periods=10),
+                                         index=pd.date_range('2020-1-1', periods=10)))
         graph = df.build_graph(tiled=False)
 
         pb = graph.to_pb()

--- a/mars/serialize/jsonserializer.pyx
+++ b/mars/serialize/jsonserializer.pyx
@@ -300,12 +300,18 @@ cdef class JsonSerializeProvider(Provider):
         return None
 
     cdef inline dict _serialize_datetime64(self, value):
+        if isinstance(value, pd.Timestamp):
+            # convert to np.datetime64
+            value = value.to_datetime64()
         return self._serialize_datetime64_timedelta64(value, ValueType.datetime64)
 
     cdef inline _deserialize_datetime64(self, obj, list callbacks):
         return self._deserialize_datetime64_timedelta64(obj, callbacks)
 
     cdef inline dict _serialize_timedelta64(self, value):
+        if isinstance(value, pd.Timedelta):
+            # convert to np.timedelta64
+            value = value.to_timedelta64()
         return self._serialize_datetime64_timedelta64(value, ValueType.timedelta64)
 
     cdef inline _deserialize_timedelta64(self, obj, list callbacks):
@@ -430,14 +436,10 @@ cdef class JsonSerializeProvider(Provider):
             return self._serialize_tuple(value, tp=None, weak_ref=weak_ref)
         elif isinstance(value, dict):
             return self._serialize_dict(value, tp=None, weak_ref=weak_ref)
-        elif isinstance(value, np.datetime64):
+        elif isinstance(value, (np.datetime64, pd.Timestamp)):
             return self._serialize_datetime64(value)
-        elif isinstance(value, pd.Timestamp):
-            return self._serialize_datetime64(value.to_datetime64())
-        elif isinstance(value, np.timedelta64):
+        elif isinstance(value, (np.timedelta64, pd.Timedelta)):
             return self._serialize_timedelta64(value)
-        elif isinstance(value, pd.Timedelta):
-            return self._serialize_timedelta64(value.to_timedelta64())
         elif isinstance(value, np.number):
             return self._serialize_untyped_value(value.item())
         elif callable(value):

--- a/mars/serialize/pbserializer.pyx
+++ b/mars/serialize/pbserializer.pyx
@@ -157,6 +157,9 @@ cdef class ProtobufSerializeProvider(Provider):
         return KeyPlaceholder(obj.key.key, obj.key.id)
 
     cdef inline void _set_datetime64(self, value, obj, tp=None):
+        if isinstance(value, pd.Timestamp):
+            # convert to np.datetime64
+            value = value.to_datetime64()
         bio = BytesIO()
         np.save(bio, value)
         obj.datetime64 = bio.getvalue()
@@ -173,6 +176,9 @@ cdef class ProtobufSerializeProvider(Provider):
             return None
 
     cdef inline void _set_timedelta64(self, value, obj, tp=None):
+        if isinstance(value, pd.Timedelta):
+            # convert to np.timedelta64
+            value = value.to_timedelta64()
         bio = BytesIO()
         np.save(bio, value)
         obj.timedelta64 = bio.getvalue()
@@ -458,9 +464,9 @@ cdef class ProtobufSerializeProvider(Provider):
             self._set_tuple(value, obj, tp=None, weak_ref=weak_ref)
         elif isinstance(value, dict):
             self._set_dict(value, obj, tp=None, weak_ref=weak_ref)
-        elif isinstance(value, np.datetime64):
+        elif isinstance(value, (np.datetime64, pd.Timestamp)):
             self._set_datetime64(value, obj)
-        elif isinstance(value, np.timedelta64):
+        elif isinstance(value, (np.timedelta64, pd.Timedelta)):
             self._set_timedelta64(value, obj)
         elif isinstance(value, np.number):
             self._set_untyped_value(value.item(), obj)

--- a/mars/serialize/protos/indexvalue.proto
+++ b/mars/serialize/protos/indexvalue.proto
@@ -77,7 +77,7 @@ message IndexValue {
         Value data = 2;
         Value freq = 3;
         Value start = 4;
-        int64 periods = 5;
+        Value periods = 5;
         Value end = 6;
         Value closed = 7;
         Value tz = 8;
@@ -103,7 +103,7 @@ message IndexValue {
         Value unit = 3;
         Value freq = 4;
         Value start = 5;
-        int64 periods = 6;
+        Value periods = 6;
         Value end = 7;
         Value closed = 8;
         // public fields
@@ -124,7 +124,7 @@ message IndexValue {
         Value data = 2;
         Value freq = 3;
         Value start = 4;
-        int64 periods = 5;
+        Value periods = 5;
         Value end = 6;
         Value year = 7;
         Value month = 8;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR adds support for serializing `pd.Timestamp` and `pd.Timedelta`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1064 .
