### PR TITLE
Check metadata consistency for output chunks and tileables

### DIFF
--- a/mars/dataframe/arithmetic/dot.py
+++ b/mars/dataframe/arithmetic/dot.py
@@ -64,8 +64,19 @@ class DataFrameDot(DataFrameOperand, DataFrameOperandMixin):
             return self.new_scalar([lhs, rhs], dtype=test_ret.dtype)
         elif test_ret.ndim == 1:
             self._object_type = ObjectType.series
+            if lhs.ndim == 1:
+                if hasattr(rhs, 'columns_value'):
+                    index_value = rhs.columns_value
+                else:
+                    # tensor
+                    length = -1 if np.isnan(rhs.shape[1]) else rhs.shape[1]
+                    pd_index = pd.RangeIndex(length)
+                    index_value = parse_index(pd_index, store_data=True)
+            else:
+                assert rhs.ndim == 1
+                index_value = lhs.index_value
             return self.new_series([lhs, rhs], shape=test_ret.shape,
-                                   dtype=test_ret.dtype, index_value=lhs.index_value)
+                                   dtype=test_ret.dtype, index_value=index_value)
         else:
             self._object_type = ObjectType.dataframe
             if isinstance(rhs, TENSOR_TYPE):

--- a/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
@@ -339,7 +339,9 @@ class TestBinary(TestBase):
         data3 = self.to_boolean_if_needed(data3)
         df4 = from_pandas(data3, chunk_size=5)
         df5 = getattr(df4, self.rfunc_name)(1)
-        result = self.executor.execute_dataframe(df5, concat=True)[0]
+        # todo check dtypes when pandas reverts its behavior on broadcasting
+        check_dtypes = self.func_name not in ('__and__', '__or__', '__xor__')
+        result = self.executor.execute_dataframe(df5, concat=True, check_dtypes=check_dtypes)[0]
         expected2 = self.func(1, data3)
         pd.testing.assert_frame_equal(expected2, result)
 

--- a/mars/dataframe/base/apply.py
+++ b/mars/dataframe/base/apply.py
@@ -200,10 +200,10 @@ class DataFrameApplyTransform(DataFrameOperand, DataFrameOperandMixin):
         if self._object_type == ObjectType.dataframe:
             if axis == 0:
                 return self.new_dataframe([df], shape=shape, dtypes=dtypes, index_value=index_value,
-                                          columns_value=df.columns_value)
+                                          columns_value=parse_index(dtypes.index))
             else:
                 return self.new_dataframe([df], shape=shape, dtypes=dtypes, index_value=df.index_value,
-                                          columns_value=index_value)
+                                          columns_value=parse_index(dtypes.index))
         else:
             return self.new_series([df], shape=shape, dtype=dtypes, index_value=index_value)
 

--- a/mars/dataframe/base/reset_index.py
+++ b/mars/dataframe/base/reset_index.py
@@ -82,7 +82,8 @@ class DataFrameResetIndex(DataFrameOperand, DataFrameOperandMixin):
         new_op = op.copy()
         if op.drop:
             return new_op.new_seriess(op.inputs, op.inputs[0].shape, nsplits=op.inputs[0].nsplits,
-                                      chunks=out_chunks, dtype=out.dtype, index_value=out.index_value)
+                                      name=out.name, chunks=out_chunks, dtype=out.dtype,
+                                      index_value=out.index_value)
         else:
             nsplits = (op.inputs[0].nsplits[0], (out.shape[1],))
             return new_op.new_dataframes(op.inputs, out.shape, nsplits=nsplits, chunks=out_chunks,

--- a/mars/dataframe/base/standardize_range_index.py
+++ b/mars/dataframe/base/standardize_range_index.py
@@ -47,5 +47,5 @@ class ChunkStandardizeRangeIndex(DataFrameOperand, DataFrameOperandMixin):
         if op.axis == 0:
             in_data.index = xdf.RangeIndex(index_start, index_start + len(in_data))
         else:
-            in_data.columns = xdf.RangeIndex(index_start, index_start + len(in_data))
+            in_data.columns = xdf.RangeIndex(index_start, index_start + in_data.shape[1])
         ctx[op.outputs[0].key] = in_data

--- a/mars/dataframe/base/string_.py
+++ b/mars/dataframe/base/string_.py
@@ -247,7 +247,8 @@ class SeriesStringCatHandler(SeriesStringMethodBaseHandler):
                                                    index=(i,), index_value=index_value,
                                                    name=concat_chunk.name)
                 else:
-                    out_chunk = chunk_op.new_chunk([concat_chunk], dtype=concat_chunk.dtype)
+                    out_chunk = chunk_op.new_chunk([concat_chunk], dtype=concat_chunk.dtype,
+                                                   shape=out.shape)
                 new_out_chunks.append(out_chunk)
             out_chunks = new_out_chunks
 

--- a/mars/dataframe/base/string_.py
+++ b/mars/dataframe/base/string_.py
@@ -333,9 +333,11 @@ class SeriesStringExtractHandler(SeriesStringMethodBaseHandler):
             op._object_type = ObjectType.dataframe
             if op.method == 'extractall':
                 index_value = parse_index(test_df.index, inp)
+                shape = (np.nan, test_df.shape[1])
             else:
                 index_value = inp.index_value
-            return op.new_dataframe([inp], shape=(inp.shape[0], test_df.shape[1]),
+                shape=(inp.shape[0], test_df.shape[1])
+            return op.new_dataframe([inp], shape=shape,
                                     dtypes=test_df.dtypes,
                                     index_value=index_value,
                                     columns_value=parse_index(test_df.columns,

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -151,9 +151,9 @@ class Test(TestBase):
         pd.testing.assert_frame_equal(result, expected)
 
         columns = pd.MultiIndex.from_tuples([('speed', 'max'), ('species', 'type')])
+        data.columns = columns
         df = from_pandas_df(data, chunk_size=2)
         df2 = df_reset_index(df, level='class', col_level=1, col_fill='species')
-        data.columns = columns
         result = self.executor.execute_dataframe(df2, concat=True)[0]
         expected = data.reset_index(level='class', col_level=1, col_fill='species')
         pd.testing.assert_frame_equal(result, expected)

--- a/mars/dataframe/datasource/date_range.py
+++ b/mars/dataframe/datasource/date_range.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import time
+from datetime import datetime, date, time
 
 import numpy as np
 import pandas as pd
 from pandas.tseries.frequencies import to_offset
 from pandas.tseries.offsets import Tick
-from pandas._libs.tslibs import timezones, normalize_date
+from pandas._libs.tslibs import timezones
 
 from ... import opcodes as OperandDef
 from ...config import options
@@ -26,6 +26,21 @@ from ...serialize import AnyField, Int64Field, BoolField, StringField
 from ...tensor.utils import decide_chunk_sizes
 from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
 from ..utils import parse_index
+
+try:
+    from pandas._libs.tslib import normalize_date
+except ImportError:  # pragma: no cover
+    def normalize_date(dt):  # from pandas/_libs/tslibs/conversion.pyx
+        if isinstance(dt, datetime):
+            if isinstance(dt, pd.Timestamp):
+                return dt.replace(hour=0, minute=0, second=0, microsecond=0,
+                                  nanosecond=0)
+            else:
+                return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        elif isinstance(dt, date):
+            return datetime(dt.year, dt.month, dt.day)
+        else:
+            raise TypeError('Unrecognized type: %r' % type(dt))
 
 
 class DataFrameDateRange(DataFrameOperand, DataFrameOperandMixin):

--- a/mars/dataframe/datasource/from_tensor.py
+++ b/mars/dataframe/datasource/from_tensor.py
@@ -237,6 +237,7 @@ class DataFrameFromTensor(DataFrameOperand, DataFrameOperandMixin):
                 dtypes = out_df.dtypes
                 columns_value = parse_index(out_df.columns_value.to_pandas()[0:1],
                                             store_data=True)
+                chunk_shape = (in_chunk.shape[0], 1)
             else:
                 i, j = in_chunk.index
                 column_stop = cum_size[1][j]
@@ -245,6 +246,7 @@ class DataFrameFromTensor(DataFrameOperand, DataFrameOperandMixin):
                 pd_columns = out_df.columns_value.to_pandas()
                 chunk_pd_columns = pd_columns[column_stop - in_chunk.shape[1]:column_stop]
                 columns_value = parse_index(chunk_pd_columns, store_data=True)
+                chunk_shape = in_chunk.shape
 
             index_stop = cum_size[0][i]
             if isinstance(op.index, INDEX_TYPE):
@@ -264,7 +266,7 @@ class DataFrameFromTensor(DataFrameOperand, DataFrameOperandMixin):
 
             out_op.extra_params['index_stop'] = index_stop
             out_op.extra_params['column_stop'] = column_stop
-            out_chunk = out_op.new_chunk(chunk_inputs, shape=in_chunk.shape,
+            out_chunk = out_op.new_chunk(chunk_inputs, shape=chunk_shape,
                                          index=chunk_index, dtypes=dtypes,
                                          index_value=index_value,
                                          columns_value=columns_value)

--- a/mars/dataframe/groupby/tests/test_groupby.py
+++ b/mars/dataframe/groupby/tests/test_groupby.py
@@ -137,14 +137,14 @@ class Test(TestBase):
         self.assertEqual(applied.chunks[0].dtype, df1.a.dtype)
 
         applied = mdf.groupby('b').transform(apply_df).tiles()
-        pd.testing.assert_series_equal(applied.dtypes, df1.dtypes)
-        self.assertEqual(applied.shape, (9, 3))
+        pd.testing.assert_series_equal(applied.dtypes, df1.dtypes.loc[['a', 'c']])
+        self.assertEqual(applied.shape, (9, 2))
         self.assertEqual(applied.op._op_type_, opcodes.GROUPBY_TRANSFORM)
         self.assertTrue(applied.op.is_transform)
         self.assertEqual(applied.op.object_type, ObjectType.dataframe)
         self.assertEqual(len(applied.chunks), 3)
-        self.assertEqual(applied.chunks[0].shape, (np.nan, 3))
-        pd.testing.assert_series_equal(applied.chunks[0].dtypes, df1.dtypes)
+        self.assertEqual(applied.chunks[0].shape, (np.nan, 2))
+        pd.testing.assert_series_equal(applied.chunks[0].dtypes, df1.dtypes.loc[['a', 'c']])
 
         series1 = pd.Series([3, 4, 5, 3, 5, 4, 1, 2, 3])
 

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -57,8 +57,8 @@ class SeriesIndex(DataFrameOperand, DataFrameOperandMixin):
     def is_intermediate(self):
         return self._is_intermediate
 
-    def __call__(self, series):
-        return self.new_tileable([series], dtype=series.dtype)
+    def __call__(self, series, name=None):
+        return self.new_tileable([series], dtype=series.dtype, name=name)
 
     def _new_tileables(self, inputs, kws=None, **kw):
         # Override this method to automatically decide the output type,
@@ -113,7 +113,8 @@ class SeriesIndex(DataFrameOperand, DataFrameOperandMixin):
         out_series = op.outputs[0]
 
         index_op = SeriesIndex(labels=op.labels)
-        index_chunk = index_op.new_chunk(in_series.chunks, dtype=out_series.dtype)
+        kw = {'name': out_series.name} if hasattr(out_series, 'name') else {}
+        index_chunk = index_op.new_chunk(in_series.chunks, dtype=out_series.dtype, **kw)
         new_op = op.copy()
         nsplits = ((len(op.labels),),) if isinstance(op.labels, list) else ()
         return new_op.new_tileables(op.inputs, chunks=[index_chunk], nsplits=nsplits,
@@ -138,18 +139,23 @@ class SeriesIndex(DataFrameOperand, DataFrameOperandMixin):
                     concat_op = DataFrameConcat(object_type=ObjectType.series)
                     chk = concat_op.new_chunk(chks, dtype=chks[0].dtype)
                 chk_op = SeriesIndex(labels=op.labels, is_intermediate=True)
+                kw = {'name': out_series.name} if hasattr(out_series, 'name') else {}
                 chk = chk_op.new_chunk([chk], shape=(np.nan,), dtype=chk.dtype,
-                                       index_value=parse_index(pd.RangeIndex(-1)))
+                                       index_value=parse_index(pd.RangeIndex(-1)), **kw)
                 new_chunks.append(chk)
             chunks = new_chunks
 
         concat_op = DataFrameConcat(object_type=ObjectType.series)
-        chk = concat_op.new_chunk(chunks, dtype=chunks[0].dtype)
+        kw = {'name': out_series.name} if hasattr(out_series, 'name') else {}
+        chk = concat_op.new_chunk(chunks, dtype=chunks[0].dtype, **kw)
         index_op = SeriesIndex(labels=op.labels)
-        chunk = index_op.new_chunk([chk], dtype=chk.dtype)
+        chunk = index_op.new_chunk([chk], dtype=chk.dtype, **kw)
         new_op = op.copy()
         nsplits = ((len(op.labels),),) if isinstance(op.labels, list) else ()
-        return new_op.new_tileables(op.inputs, dtype=out_series.dtype, chunks=[chunk], nsplits=nsplits)
+        kw = out_series.params
+        kw['nsplits'] = nsplits
+        kw['chunks'] = [chunk]
+        return new_op.new_tileables(op.inputs, kws=[kw])
 
     @classmethod
     def tile(cls, op):
@@ -183,13 +189,15 @@ class SeriesIndex(DataFrameOperand, DataFrameOperandMixin):
                 index_op = SeriesIndex(labels=list(labels))
                 c = in_series.chunks[idx[0]]
                 nsplits.append(len(labels))
+                index_value = parse_index(pd.Index([], dtype=c.index_value.to_pandas().dtype),
+                                          c, labels)
                 out_chunks.append(index_op.new_chunk([c], shape=(len(labels),), dtype=c.dtype,
-                                                     index_value=parse_index(pd.RangeIndex(len(labels))),
+                                                     index_value=index_value,
                                                      name=c.name, index=(i,)))
             new_op = op.copy()
             return new_op.new_seriess(op.inputs, shape=out_series.shape, dtype=out_series.dtype,
                                       index_value=out_series.index_value, nsplits=(tuple(nsplits),),
-                                      chunks=out_chunks)
+                                      chunks=out_chunks, name=out_series.name)
 
     @classmethod
     def execute(cls, ctx, op):
@@ -398,7 +406,7 @@ def dataframe_getitem(df, item):
 def series_getitem(series, labels, combine_size=None):
     if isinstance(labels, list) or np.isscalar(labels):
         op = SeriesIndex(labels=labels, combine_size=combine_size)
-        return op(series)
+        return op(series, name=series.name)
     elif isinstance(labels, _list_like_types) and astensor(labels).dtype == np.bool:
         return series.loc[labels]
     else:

--- a/mars/dataframe/indexing/iloc.py
+++ b/mars/dataframe/indexing/iloc.py
@@ -181,7 +181,9 @@ class DataFrameIlocGetItem(DataFrameOperand, DataFrameOperandMixin):
                 return self.new_scalar(inputs, dtype=dtype)
             else:
                 self._object_type = ObjectType.series
-                return self.new_series(inputs, shape=shape, dtype=dtype, index_value=index_value)
+                return self.new_series(inputs, shape=shape, dtype=dtype,
+                                       index_value=index_value,
+                                       name=df.dtypes.index[self.indexes[1]])
         elif isinstance(self.indexes[0], Integral):
             shape = shape1
             dtype = find_common_type(df.dtypes.iloc[self.indexes[1]].values)
@@ -365,10 +367,14 @@ class SeriesIlocGetItem(DataFrameOperand, DataFrameOperandMixin):
             ctx[chunk.key] = series[indexes]
 
     def __call__(self, series):
-        shape = tuple(calc_shape(series.shape, self.indexes))
-        index_value = indexing_index_value(series.index_value, self.indexes[0])
-        inputs = [series] + [index for index in self._indexes if isinstance(index, (Base, Entity))]
-        return self.new_series(inputs, shape=shape, dtype=series.dtype, index_value=index_value)
+        if isinstance(self._indexes[0], Integral):
+            self._object_type = ObjectType.scalar
+            return self.new_scalar([series], dtype=series.dtype)
+        else:
+            shape = tuple(calc_shape(series.shape, self.indexes))
+            index_value = indexing_index_value(series.index_value, self.indexes[0])
+            inputs = [series] + [index for index in self._indexes if isinstance(index, (Base, Entity))]
+            return self.new_series(inputs, shape=shape, dtype=series.dtype, index_value=index_value)
 
 
 class SeriesIlocSetItem(DataFrameOperand, DataFrameOperandMixin):

--- a/mars/dataframe/indexing/index_lib.py
+++ b/mars/dataframe/indexing/index_lib.py
@@ -453,10 +453,36 @@ class DataFrameIndexHandler:
         chunk_index_info.set(info)
 
 
-class NDArrayBoolIndexHandler(DataFrameIndexHandler, NDArrayBoolIndexHandlerBase):
-    @classproperty
-    def kind(self):  # pylint: disable=no-self-use
-        return 'iloc'
+class NDArrayBoolIndexHandler(NDArrayBoolIndexHandlerBase):
+    @classmethod
+    def set_chunk_index_info(cls,
+                             context: IndexHandlerContext,
+                             index_info: IndexInfo,
+                             chunk_index: Tuple[int],
+                             chunk_index_info: ChunkIndexInfo,
+                             output_axis_index: int,
+                             index,
+                             output_shape: int):
+        tileable = context.tileable
+        chunk_input = tileable.cix[chunk_index]
+
+        if index_info.input_axis == 0:
+            dtype = chunk_input.index_value.to_pandas().dtype
+            index_value = parse_index(pd.Index([], dtype=dtype),
+                                      chunk_input, index, store_data=False)
+            dtypes = None
+        else:
+            pd_index = chunk_input.columns_value.to_pandas()
+            filtered_index = pd_index[index]
+            index_value = parse_index(filtered_index, store_data=True)
+            dtypes = chunk_input.dtypes[index]
+
+        info = ChunkIndexAxisInfo(output_axis_index=output_axis_index,
+                                  processed_index=index,
+                                  output_shape=output_shape,
+                                  index_value=index_value,
+                                  dtypes=dtypes)
+        chunk_index_info.set(info)
 
 
 class TensorBoolIndexHandler(TensorBoolIndexHandlerBase):

--- a/mars/dataframe/indexing/set_index.py
+++ b/mars/dataframe/indexing/set_index.py
@@ -53,7 +53,7 @@ class DataFrameSetIndex(DataFrameOperand, DataFrameOperandMixin):
     def __call__(self, df):
         new_df = build_empty_df(df.dtypes).set_index(keys=self.keys, drop=self.drop, append=self.append,
                                                      verify_integrity=self.verify_integrity)
-        return self.new_dataframe([df], shape=new_df.shape, dtypes=new_df.dtypes,
+        return self.new_dataframe([df], shape=(df.shape[0], new_df.shape[1]), dtypes=new_df.dtypes,
                                   index_value=parse_index(new_df.index),
                                   columns_value=parse_index(new_df.columns, store_data=True))
 

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -104,6 +104,12 @@ class Test(TestBase):
         pd.testing.assert_frame_equal(
             expected, self.executor.execute_dataframe(df12, concat=True)[0])
 
+        # bool index array on axis 1
+        expected = df1.iloc[[2, 1], [True, False, True]]
+        df14 = df2.iloc[[2, 1], [True, False, True]]
+        pd.testing.assert_frame_equal(
+            expected, self.executor.execute_dataframe(df14, concat=True)[0])
+
         # bool index
         expected = df1.iloc[[True, False, True], [2, 1]]
         df13 = df2.iloc[md.Series([True, False, True], chunk_size=1), [2, 1]]
@@ -229,7 +235,7 @@ class Test(TestBase):
         self.assertEqual(result, expected)
 
         df = df1.loc['a3', 'b']
-        result = self.executor.execute_tensor(df, concat=True)[0]
+        result = self.executor.execute_tensor(df, concat=True, check_shape=False)[0]
         expected = raw1.loc['a3', 'b']
         self.assertEqual(result, expected)
 

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -48,7 +48,7 @@ class Test(TestBase):
         expected = df1.iloc[1]
         df3 = df2.iloc[1]
         pd.testing.assert_series_equal(
-            expected, self.executor.execute_dataframe(df3, concat=True)[0])
+            expected, self.executor.execute_dataframe(df3, concat=True, check_series_name=False)[0])
 
         # plain index on axis 1
         expected = df1.iloc[:2, 1]

--- a/mars/dataframe/merge/concat.py
+++ b/mars/dataframe/merge/concat.py
@@ -275,11 +275,17 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
             col_length = 0
             columns = []
             dtypes = dict()
+            undefined_name = 0
             for series in objs:
-                dtypes[series.name] = series.dtype
-                columns.append(series.name)
+                if series.name is None:
+                    dtypes[undefined_name] = series.dtype
+                    undefined_name += 1
+                    columns.append(undefined_name)
+                else:
+                    dtypes[series.name] = series.dtype
+                    columns.append(series.name)
                 col_length += 1
-            if self.ignore_index:
+            if self.ignore_index or undefined_name == len(objs):
                 columns_value = parse_index(pd.RangeIndex(col_length))
             else:
                 columns_value = parse_index(pd.Index(columns), store_data=True)
@@ -321,7 +327,7 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
                 col_length += df.shape[1]
                 empty_dfs.append(build_empty_df(df.dtypes))
 
-            emtpy_result = pd.concat(empty_dfs, join=self.join, axis=0, sort=True)
+            emtpy_result = pd.concat(empty_dfs, join=self.join, axis=1, sort=True)
             if self.ignore_index:
                 columns_value = parse_index(pd.RangeIndex(col_length))
             else:

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -163,9 +163,11 @@ class _DataFrameMergeBase(DataFrameOperand, DataFrameOperandMixin):
         empty_left, empty_right = build_empty_df(left.dtypes), build_empty_df(right.dtypes)
         # left should have values to keep columns order.
         gen_left_data = [np.random.rand(1).astype(dt)[0] for dt in left.dtypes]
-        empty_left = empty_left.append(pd.DataFrame([gen_left_data], columns=list(empty_left.columns)))
+        empty_left = empty_left.append(pd.DataFrame([gen_left_data], columns=list(empty_left.columns))
+                                       .astype(left.dtypes))
         gen_right_data = [np.random.rand(1).astype(dt)[0] for dt in right.dtypes]
-        empty_right = empty_right.append(pd.DataFrame([gen_right_data], columns=list(empty_right.columns)))
+        empty_right = empty_right.append(pd.DataFrame([gen_right_data], columns=list(empty_right.columns))
+                                         .astype(right.dtypes))
         # this `merge` will check whether the combination of those arguments is valid
         merged = empty_left.merge(empty_right, how=self.how, on=self.on,
                                   left_on=self.left_on, right_on=self.right_on,

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -161,6 +161,11 @@ class _DataFrameMergeBase(DataFrameOperand, DataFrameOperandMixin):
 
     def __call__(self, left, right):
         empty_left, empty_right = build_empty_df(left.dtypes), build_empty_df(right.dtypes)
+        # left should have values to keep columns order.
+        gen_left_data = [np.random.rand(1).astype(dt)[0] for dt in left.dtypes]
+        empty_left = empty_left.append(pd.DataFrame([gen_left_data], columns=list(empty_left.columns)))
+        gen_right_data = [np.random.rand(1).astype(dt)[0] for dt in right.dtypes]
+        empty_right = empty_right.append(pd.DataFrame([gen_right_data], columns=list(empty_right.columns)))
         # this `merge` will check whether the combination of those arguments is valid
         merged = empty_left.merge(empty_right, how=self.how, on=self.on,
                                   left_on=self.left_on, right_on=self.right_on,
@@ -216,6 +221,7 @@ class DataFrameShuffleMerge(_DataFrameMergeBase):
                                            shape=df.shape,
                                            index=left.chunks[0].index,
                                            index_value=df.index_value,
+                                           dtypes=df.dtypes,
                                            columns_value=df.columns_value)
             out_chunks = [out_chunk]
             nsplits = ((np.nan,), (df.shape[1],))
@@ -229,6 +235,7 @@ class DataFrameShuffleMerge(_DataFrameMergeBase):
                                                index=c.index,
                                                index_value=infer_index_value(left_chunk.index_value,
                                                                              c.index_value),
+                                               dtypes=df.dtypes,
                                                columns_value=df.columns_value)
                 out_chunks.append(out_chunk)
             nsplits = ((np.nan,) * len(right.chunks), (df.shape[1],))
@@ -242,6 +249,7 @@ class DataFrameShuffleMerge(_DataFrameMergeBase):
                                                index=c.index,
                                                index_value=infer_index_value(right_chunk.index_value,
                                                                              c.index_value),
+                                               dtypes=df.dtypes,
                                                columns_value=df.columns_value)
                 out_chunks.append(out_chunk)
             nsplits = ((np.nan,) * len(left.chunks), (df.shape[1],))
@@ -312,6 +320,10 @@ class DataFrameShuffleMerge(_DataFrameMergeBase):
             r = execute_merge(left, right)
         except ValueError:
             r = execute_merge(left.copy(deep=True), right.copy(deep=True))
+
+        # make sure column's order
+        if not all(n1 == n2 for n1, n2 in zip(chunk.columns_value.to_pandas(), r.columns)):
+            r = r[list(chunk.columns_value.to_pandas())]
         ctx[chunk.key] = r
 
 

--- a/mars/dataframe/merge/tests/test_merge.py
+++ b/mars/dataframe/merge/tests/test_merge.py
@@ -252,7 +252,8 @@ class Test(TestBase):
         r = concat([mdf1, mdf2], axis='columns')
 
         self.assertEqual(r.shape, (10, 8))
-        pd.testing.assert_series_equal(r.dtypes, df1.dtypes)
+        expected_dtypes = pd.concat([df1, df2], axis='columns').dtypes
+        pd.testing.assert_series_equal(r.dtypes, expected_dtypes)
 
         tiled = r.tiles()
         self.assertEqual(tiled.nsplits, ((3, 3, 3, 1), (3, 1, 4)))

--- a/mars/dataframe/sort/tests/test_sort.py
+++ b/mars/dataframe/sort/tests/test_sort.py
@@ -60,7 +60,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(sorted_df.shape, raw.shape)
         self.assertIsInstance(sorted_df.op, DataFrameSortValues)
-        pd.testing.assert_index_equal(sorted_df.index_value.to_pandas(), pd.RangeIndex(10))
 
         tiled = sorted_df.tiles()
 

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -214,7 +214,9 @@ class Test(unittest.TestCase):
         pd.testing.assert_frame_equal(result, expected)
 
         mdf = DataFrame(raw, chunk_size=4)
-        result = self.executor.execute_dataframe(mdf.sort_index(axis=1, ignore_index=True), concat=True)[0]
+        executor = ExecutorForTest(storage=new_session().context)
+
+        result = executor.execute_dataframe(mdf.sort_index(axis=1, ignore_index=True), concat=True)[0]
         try:  # for python3.5
             expected = raw.sort_index(axis=1, ignore_index=True)
         except TypeError:

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -230,6 +230,17 @@ def parse_index(index_value, *args, store_data=False, key=None):
         kw['_sortorder'] = index.sortorder
         return IndexValue.MultiIndex(_names=index.names, **kw)
 
+    if index_value is None:
+        return IndexValue(_index_value=IndexValue.Index(
+            _is_monotonic_increasing=False,
+            _is_monotonic_decreasing=False,
+            _is_unique=False,
+            _min_val=None,
+            _max_val=None,
+            _min_val_close=True,
+            _max_val_close=True,
+            _key=key or tokenize(*args),
+        ))
     if isinstance(index_value, pd.RangeIndex):
         return IndexValue(_index_value=_serialize_range_index(index_value))
     elif isinstance(index_value, pd.MultiIndex):

--- a/mars/tensor/base/searchsorted.py
+++ b/mars/tensor/base/searchsorted.py
@@ -210,7 +210,7 @@ class TensorSearchsorted(TensorOperand, TensorOperandMixin):
                 ind -= 1
             return inp_indices[ind], inp_data[ind]
         else:
-            ret_indices = np.empty(v.shape, dtype=int)
+            ret_indices = np.empty(v.shape, dtype=np.intp)
             ret_data = np.empty(v.shape, dtype=inp_data.dtype)
             for idx in itertools.product(*(range(s) for s in v.shape)):
                 ind = xp.searchsorted(inp_data[(slice(None),) + idx], v[idx], side=op.side)
@@ -229,7 +229,7 @@ class TensorSearchsorted(TensorOperand, TensorOperandMixin):
                 ind -= 1
             return inp_indices[ind]
         else:
-            indices = np.empty(v.shape, dtype=int)
+            indices = np.empty(v.shape, dtype=np.intp)
             for idx in itertools.product(*(range(s) for s in v.shape)):
                 ind = xp.searchsorted(inp_data[(slice(None),) + idx], v[idx], side=op.side)
                 if ind >= len(inp_indices):
@@ -357,6 +357,6 @@ def searchsorted(a, v, side='left', sorter=None, combine_size=None):
     if not np.isscalar(v):
         v = astensor(v)
 
-    op = TensorSearchsorted(values=v, side=side, dtype=np.dtype(np.int64),
+    op = TensorSearchsorted(values=v, side=side, dtype=np.dtype(np.intp),
                             combine_size=combine_size)
     return op(a, v)

--- a/mars/tensor/base/tests/test_base.py
+++ b/mars/tensor/base/tests/test_base.py
@@ -652,11 +652,11 @@ class Test(unittest.TestCase):
         self.assertEqual(x.shape, (10, np.nan))
         self.assertEqual(x.dtype, np.dtype(np.int64))
         self.assertEqual(indices.shape, (np.nan,))
-        self.assertEqual(indices.dtype, np.dtype(np.int64))
+        self.assertEqual(indices.dtype, np.dtype(np.intp))
         self.assertEqual(inverse.shape, (20,))
-        self.assertEqual(inverse.dtype, np.dtype(np.int64))
+        self.assertEqual(inverse.dtype, np.dtype(np.intp))
         self.assertEqual(counts.shape, (np.nan,))
-        self.assertEqual(counts.dtype, np.dtype(np.int64))
+        self.assertEqual(counts.dtype, np.dtype(np.int_))
 
         x = x.tiles()
         indices, inverse, counts = \
@@ -687,7 +687,7 @@ class Test(unittest.TestCase):
         self.assertEqual(counts.nsplits, ((np.nan, np.nan),))
         for i in range(2):
             self.assertEqual(counts.chunks[i].shape, (np.nan,))
-            self.assertEqual(counts.chunks[i].dtype, raw.dtype)
+            self.assertEqual(counts.chunks[i].dtype, np.dtype(np.int_))
             self.assertEqual(counts.chunks[i].index, (i,))
 
     def testSort(self):

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -122,7 +122,7 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
         # unique counts tensor
         if op.return_counts:
             kw = {'shape': (np.nan,),
-                  'dtype': np.dtype(np.intp),
+                  'dtype': np.dtype(np.int_),
                   'gpu': input_obj.op.gpu,
                   'type': 'counts'}
             if chunk:

--- a/mars/tensor/reduction/core.py
+++ b/mars/tensor/reduction/core.py
@@ -272,7 +272,7 @@ class TensorReductionMixin(TensorOperandMixin):
                 ret = reduce_func(input_chunk, axis=axis,
                                   keepdims=bool(op.keepdims))
 
-            ctx[out.key] = ret.astype(ret.dtype, order=out.order.value, copy=False)
+            ctx[out.key] = ret.astype(op.dtype, order=out.order.value, copy=False)
 
     @classmethod
     def execute_one_chunk(cls, ctx, op):

--- a/mars/tensor/reduction/count_nonzero.py
+++ b/mars/tensor/reduction/count_nonzero.py
@@ -110,6 +110,6 @@ def count_nonzero(a, axis=None, combine_size=None):
     array([2, 3])
 
     """
-    op = TensorCountNonzero(axis=axis, dtype=np.dtype(np.intp),
+    op = TensorCountNonzero(axis=axis, dtype=np.dtype(np.int_),
                             keepdims=None, combine_size=combine_size)
     return op(a)

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -346,7 +346,7 @@ def create_actor_pool(*args, **kwargs):
 
 
 _check_options = dict()
-_check_args = ['check_series_name', 'check_dtypes', 'check_dtype']
+_check_args = ['check_series_name', 'check_dtypes', 'check_dtype', 'check_shape']
 
 
 class MarsObjectCheckMixin:
@@ -383,7 +383,8 @@ class MarsObjectCheckMixin:
         if not hasattr(expected, 'dtype'):
             return
         cls.assert_dtype_consistent(expected.dtype, real.dtype)
-        cls.assert_shape_consistent(expected.shape, real.shape)
+        if _check_options['check_shape']:
+            cls.assert_shape_consistent(expected.shape, real.shape)
 
     @classmethod
     def assert_index_consistent(cls, expected_index_value, real_index):

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -381,7 +381,12 @@ class MarsObjectCheckMixin:
     @classmethod
     def assert_index_consistent(cls, expected_index_value, real_index):
         if expected_index_value.has_value():
-            pd.testing.assert_index_equal(expected_index_value.to_pandas(), real_index)
+            expected_index = expected_index_value.to_pandas()
+            try:
+                pd.testing.assert_index_equal(expected_index, real_index)
+            except AssertionError as e:
+                raise AssertionError('Index of real value (%r) not equal to (%r)' %
+                                     (expected_index, real_index)) from e
 
     @classmethod
     def assert_dataframe_consistent(cls, expected, real):

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -348,7 +348,9 @@ def create_actor_pool(*args, **kwargs):
 class MarsObjectCheckMixin:
     @staticmethod
     def assert_shape_consistent(expected_shape, real_shape):
-        assert len(expected_shape) == len(real_shape)
+        if len(expected_shape) != len(real_shape):
+            raise AssertionError('ndim in metadata %r is not consistent with real ndim %r'
+                                 % (len(expected_shape), len(real_shape)))
         for e, r in zip(expected_shape, real_shape):
             if not np.isnan(e) and e != r:
                 raise AssertionError('shape in metadata %r is not consistent with real shape %r'
@@ -371,6 +373,8 @@ class MarsObjectCheckMixin:
         if not isinstance(real, (np.generic, np.ndarray, SparseNDArray)):
             raise AssertionError('Type of real value (%r) not one of '
                                  '(np.generic, np.array, SparseNDArray)' % type(real))
+        if not hasattr(expected, 'dtype'):
+            return
         cls.assert_dtype_consistent(expected.dtype, real.dtype)
         cls.assert_shape_consistent(expected.shape, real.shape)
 

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -393,14 +393,15 @@ class MarsObjectCheckMixin:
         if not isinstance(real, pd.DataFrame):
             raise AssertionError('Type of real value (%r) not DataFrame' % type(real))
         cls.assert_shape_consistent(expected.shape, real.shape)
-        pd.testing.assert_index_equal(expected.dtypes.index, real.dtypes.index)
+        if not np.isnan(expected.shape[1]):  # ignore when columns length is nan
+            pd.testing.assert_index_equal(expected.dtypes.index, real.dtypes.index)
 
-        try:
-            for expected_dtype, real_dtype in zip(expected.dtypes, real.dtypes):
-                cls.assert_dtype_consistent(expected_dtype, real_dtype)
-        except AssertionError:
-            raise AssertionError('dtypes in metadata %r cannot cast to real dtype %r'
-                                 % (expected.dtypes, real.dtypes))
+            try:
+                for expected_dtype, real_dtype in zip(expected.dtypes, real.dtypes):
+                    cls.assert_dtype_consistent(expected_dtype, real_dtype)
+            except AssertionError:
+                raise AssertionError('dtypes in metadata %r cannot cast to real dtype %r'
+                                     % (expected.dtypes, real.dtypes))
 
         cls.assert_index_consistent(expected.columns_value, real.columns)
         cls.assert_index_consistent(expected.index_value, real.index)

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -26,11 +26,12 @@ from collections.abc import Iterable
 from weakref import ReferenceType
 
 import numpy as np
+import pandas as pd
 
 from mars.serialize import serializes, deserializes, \
     ProtobufSerializeProvider, JsonSerializeProvider
 from mars.utils import lazy_import
-from mars.executor import Executor
+from mars.executor import Executor, GraphExecution
 
 try:
     import pytest
@@ -344,15 +345,96 @@ def create_actor_pool(*args, **kwargs):
     raise OSError("Failed to create actor pool")
 
 
-class ExecutorForTest(Executor):
+class MarsObjectCheckMixin:
+    @staticmethod
+    def assert_shape_consistent(expected_shape, real_shape):
+        assert len(expected_shape) == len(real_shape)
+        for e, r in zip(expected_shape, real_shape):
+            assert np.isnan(e) or e == r
+
+    @staticmethod
+    def assert_dtype_consistent(expected_dtype, real_dtype):
+        if expected_dtype != real_dtype:
+            assert np.can_cast(expected_dtype, real_dtype)
+
+    @classmethod
+    def assert_tensor_consistent(cls, expected, real):
+        from mars.lib.sparse import SparseNDArray
+        assert isinstance(real, (np.generic, np.ndarray, SparseNDArray))
+        cls.assert_dtype_consistent(expected.dtype, real.dtype)
+        cls.assert_shape_consistent(expected.shape, real.shape)
+
+    @classmethod
+    def assert_index_consistent(cls, expected_index_value, real_index):
+        if expected_index_value.has_value():
+            pd.testing.assert_index_equal(expected_index_value.to_pandas(), real_index)
+
+    @classmethod
+    def assert_dataframe_consistent(cls, expected, real):
+        assert isinstance(real, pd.DataFrame)
+        cls.assert_shape_consistent(expected.shape, real.shape)
+        pd.testing.assert_index_equal(expected.dtypes.index, real.dtypes.index)
+        for expected_dtype, real_dtype in zip(expected.dtypes, real.dtypes):
+            cls.assert_dtype_consistent(expected_dtype, real_dtype)
+        cls.assert_index_consistent(expected.columns_value, real.columns)
+        cls.assert_index_consistent(expected.index_value, real.index)
+
+    @classmethod
+    def assert_series_consistent(cls, expected, real):
+        assert isinstance(real, pd.Series)
+        cls.assert_shape_consistent(expected.shape, real.shape)
+        assert expected.name == real.name
+        cls.assert_dtype_consistent(expected.dtype, real.dtype)
+        cls.assert_index_consistent(expected.index_value, real.index)
+
+    @classmethod
+    def assert_object_consistent(cls, expected, real):
+        from mars.tensor.core import TENSOR_TYPE
+        from mars.dataframe.core import DATAFRAME_TYPE, SERIES_TYPE
+
+        from mars.tensor.core import CHUNK_TYPE as TENSOR_CHUNK_TYPE
+        from mars.dataframe.core import DATAFRAME_CHUNK_TYPE, SERIES_CHUNK_TYPE
+
+        if isinstance(expected, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
+            cls.assert_tensor_consistent(expected, real)
+        elif isinstance(expected, (DATAFRAME_TYPE, DATAFRAME_CHUNK_TYPE)):
+            cls.assert_dataframe_consistent(expected, real)
+        elif isinstance(expected, (SERIES_TYPE, SERIES_CHUNK_TYPE)):
+            cls.assert_series_consistent(expected, real)
+
+
+class GraphExecutionWithChunkCheck(MarsObjectCheckMixin, GraphExecution):
+    def _execute_operand(self, op):
+        super()._execute_operand(op)
+        if self._mock:
+            return
+        for o in op.outputs:
+            if o.key not in self._key_set:
+                continue
+            self.assert_object_consistent(o, self._chunk_results[o.key])
+
+
+class ExecutorForTest(MarsObjectCheckMixin, Executor):
     """
     Mostly identical to normal executor, difference is that when executing graph,
     graph will be serialized then deserialized by Protocol Buffers and JSON both.
     """
     __test__ = False
+    _graph_execution_cls = GraphExecutionWithChunkCheck
 
     def execute_graph(self, graph, keys, **kw):
         if 'NO_SERIALIZE_IN_TEST_EXECUTOR' not in os.environ:
             graph = type(graph).from_json(graph.to_json())
             graph = type(graph).from_pb(graph.to_pb())
         return super().execute_graph(graph, keys, **kw)
+
+    def execute_tileable(self, tileable, *args, **kwargs):
+        result = super().execute_tileable(tileable, *args, **kwargs)
+        self.assert_object_consistent(tileable, result)
+        return result
+
+    def execute_tileables(self, tileables, *args, **kwargs):
+        results = super().execute_tileables(tileables, *args, **kwargs)
+        for tileable, result in zip(tileables, results):
+            self.assert_object_consistent(tileable, result)
+        return results

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -359,6 +359,9 @@ class MarsObjectCheckMixin:
     @staticmethod
     def assert_dtype_consistent(expected_dtype, real_dtype):
         if expected_dtype != real_dtype:
+            if expected_dtype == np.dtype('O') and real_dtype.type is np.str_:
+                # real dtype is string, this matches expectation
+                return
             if expected_dtype is None:
                 raise AssertionError('Expected dtype cannot be None')
             if not np.can_cast(expected_dtype, real_dtype):
@@ -390,6 +393,10 @@ class MarsObjectCheckMixin:
 
     @classmethod
     def assert_dataframe_consistent(cls, expected, real):
+        # fixme with ISSUE:1036
+        if 'GroupBy' in type(real).__name__:
+            return
+
         if not isinstance(real, pd.DataFrame):
             raise AssertionError('Type of real value (%r) not DataFrame' % type(real))
         cls.assert_shape_consistent(expected.shape, real.shape)
@@ -408,6 +415,10 @@ class MarsObjectCheckMixin:
 
     @classmethod
     def assert_series_consistent(cls, expected, real):
+        # fixme with ISSUE:1036
+        if 'GroupBy' in type(real).__name__:
+            return
+
         if not isinstance(real, pd.Series):
             raise AssertionError('Type of real value (%r) not Series' % type(real))
         cls.assert_shape_consistent(expected.shape, real.shape)

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -456,11 +456,18 @@ class ExecutorForTest(MarsObjectCheckMixin, Executor):
 
     def execute_tileable(self, tileable, *args, **kwargs):
         result = super().execute_tileable(tileable, *args, **kwargs)
-        self.assert_object_consistent(tileable, result)
+        if kwargs.get('concat', False):
+            self.assert_object_consistent(tileable, result[0])
         return result
+
+    execute_tensor = execute_tileable
+    execute_dataframe = execute_tileable
 
     def execute_tileables(self, tileables, *args, **kwargs):
         results = super().execute_tileables(tileables, *args, **kwargs)
         for tileable, result in zip(tileables, results):
             self.assert_object_consistent(tileable, result)
         return results
+
+    execute_tensors = execute_tileables
+    execute_dataframes = execute_tileables

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -350,17 +350,27 @@ class MarsObjectCheckMixin:
     def assert_shape_consistent(expected_shape, real_shape):
         assert len(expected_shape) == len(real_shape)
         for e, r in zip(expected_shape, real_shape):
-            assert np.isnan(e) or e == r
+            if not np.isnan(e) and e != r:
+                raise AssertionError('shape in metadata %r is not consistent with real shape %r'
+                                     % (expected_shape, real_shape))
 
     @staticmethod
     def assert_dtype_consistent(expected_dtype, real_dtype):
         if expected_dtype != real_dtype:
-            assert np.can_cast(expected_dtype, real_dtype)
+            if expected_dtype is None:
+                raise AssertionError('Expected dtype cannot be None')
+            if not np.can_cast(expected_dtype, real_dtype):
+                raise AssertionError('dtype in metadata %r cannot cast to real dtype %r'
+                                     % (expected_dtype, real_dtype))
 
     @classmethod
     def assert_tensor_consistent(cls, expected, real):
         from mars.lib.sparse import SparseNDArray
-        assert isinstance(real, (np.generic, np.ndarray, SparseNDArray))
+        if isinstance(real, (str, int, bool, float, complex)):
+            real = np.array([real])[0]
+        if not isinstance(real, (np.generic, np.ndarray, SparseNDArray)):
+            raise AssertionError('Type of real value (%r) not one of '
+                                 '(np.generic, np.array, SparseNDArray)' % type(real))
         cls.assert_dtype_consistent(expected.dtype, real.dtype)
         cls.assert_shape_consistent(expected.shape, real.shape)
 
@@ -371,19 +381,31 @@ class MarsObjectCheckMixin:
 
     @classmethod
     def assert_dataframe_consistent(cls, expected, real):
-        assert isinstance(real, pd.DataFrame)
+        if not isinstance(real, pd.DataFrame):
+            raise AssertionError('Type of real value (%r) not DataFrame' % type(real))
         cls.assert_shape_consistent(expected.shape, real.shape)
         pd.testing.assert_index_equal(expected.dtypes.index, real.dtypes.index)
-        for expected_dtype, real_dtype in zip(expected.dtypes, real.dtypes):
-            cls.assert_dtype_consistent(expected_dtype, real_dtype)
+
+        try:
+            for expected_dtype, real_dtype in zip(expected.dtypes, real.dtypes):
+                cls.assert_dtype_consistent(expected_dtype, real_dtype)
+        except AssertionError:
+            raise AssertionError('dtypes in metadata %r cannot cast to real dtype %r'
+                                 % (expected.dtypes, real.dtypes))
+
         cls.assert_index_consistent(expected.columns_value, real.columns)
         cls.assert_index_consistent(expected.index_value, real.index)
 
     @classmethod
     def assert_series_consistent(cls, expected, real):
-        assert isinstance(real, pd.Series)
+        if not isinstance(real, pd.Series):
+            raise AssertionError('Type of real value (%r) not Series' % type(real))
         cls.assert_shape_consistent(expected.shape, real.shape)
-        assert expected.name == real.name
+
+        if expected.name != real.name:
+            raise AssertionError('series name in metadata %r is not equal to real name %r'
+                                 % (expected.name, real.name))
+
         cls.assert_dtype_consistent(expected.dtype, real.dtype)
         cls.assert_index_consistent(expected.index_value, real.index)
 


### PR DESCRIPTION
## What do these changes do?

Add check on tensor / dataframe tests to check metadata consistency for outputs.

Members are welcome to push into this PR to fix test failures.

Known failures:

* [x] mars/tensor/base/tests/test_base_execute.py::Test::testArgpartitionExecution
* [x] mars/tensor/base/tests/test_base_execute.py::Test::testArgsort - Asser...
* [x] mars/tensor/base/tests/test_base_execute.py::Test::testPartitionIndicesExecution
* [x] mars/tensor/base/tests/test_base_execute.py::Test::testSortIndicesExecution
* [x] mars/tensor/datastore/tests/test_datastore_execute.py::Test::testStoreTileDBExecution
* [x] mars/tensor/fft/tests/test_fft_execute.py::Test::testIRFFTExecution - ...
* [x] mars/tensor/indexing/tests/test_indexing_execute.py::Test::testFancyIndexingNumpyExecution
* [x] mars/tensor/indexing/tests/test_indexing_execute.py::Test::testFancyIndexingTensorExecution
* [x] mars/tensor/reduction/tests/test_reduction_execute.py::Test::testAllAnyExecution
* [x] mars/tensor/reduction/tests/test_reduction_execute.py::Test::testNanReduction
* [x] mars/tensor/statistics/tests/test_statistics_execute.py::Test::testHistogramBinEdgesExecution
* [x] mars/tensor/statistics/tests/test_statistics_execute.py::Test::testQuantileExecution
* [x] mars/dataframe/arithmetic/tests/test_arithmetic_execution.py::TestBinary::testChained
* [x] mars/dataframe/arithmetic/tests/test_arithmetic_execution.py::TestBinary::testDataframeAndScalar
* [x] mars/dataframe/arithmetic/tests/test_arithmetic_execution.py::TestBinary::testDataframeAndSeries
* [x] mars/dataframe/arithmetic/tests/test_arithmetic_execution.py::TestBinary::testRfunc
* [x] mars/dataframe/arithmetic/tests/test_arithmetic_execution.py::TestBinary::testSameIndex
* [x] mars/dataframe/arithmetic/tests/test_arithmetic_execution.py::TestBinary::testWithMultiForms
* [x] mars/dataframe/arithmetic/tests/test_arithmetic_execution.py::TestBinary::testWithPlainValue
* [x] mars/dataframe/arithmetic/tests/test_dot.py::Test::testDotExecution - ...
* [x] mars/dataframe/base/tests/test_base_execution.py::Test::testDataFrameApplyExecute
* [x] mars/dataframe/base/tests/test_base_execution.py::Test::testResetIndexExecution
* [x] mars/dataframe/base/tests/test_base_execution.py::Test::testStringMethodExecution
* [x] mars/dataframe/datasource/tests/test_datasource_execution.py::Test::testFromTensorExecution
* [x] mars/dataframe/datastore/tests/test_datastore_execute.py::Test::testToCSVExecution
* [x] mars/dataframe/groupby/tests/test_groupby_execution.py::Test::testGroupBy
* [x] mars/dataframe/groupby/tests/test_groupby_execution.py::Test::testGroupByApplyTransform
* [x] mars/dataframe/indexing/tests/test_indexing_execution.py::Test::testILocGetItem
* [x] mars/dataframe/indexing/tests/test_indexing_execution.py::Test::testLocGetItem
* [x] mars/dataframe/indexing/tests/test_indexing_execution.py::Test::testSeriesGetitem
* [x] mars/dataframe/indexing/tests/test_indexing_execution.py::Test::testSetIndex
* [x] mars/dataframe/merge/tests/test_merge_execution.py::Test::testConcat
* [x] mars/dataframe/merge/tests/test_merge_execution.py::Test::testJoinOn
* [x] mars/dataframe/merge/tests/test_merge_execution.py::Test::testMerge - ...
* [x] mars/dataframe/merge/tests/test_merge_execution.py::Test::testMergeOneChunk
* [x] mars/dataframe/reduction/tests/test_reduction_execute.py::TestCount::testSeriesCount
* [x] mars/dataframe/sort/tests/test_sort_execute.py::Test::testSortIndexExecution
* [x] mars/dataframe/sort/tests/test_sort_execute.py::Test::testSortValuesExecution
* [x] mars/dataframe/statistics/tests/test_statistics_execute.py::Test::testDataFrameQuantileExecution
* [x] mars/dataframe/statistics/tests/test_statistics_execute.py::Test::testSeriesQuantileExecution
* [x] mars/dataframe/window/rolling/tests/test_rolling_execute.py::Test::testRollingAggExecution
* [x] mars/learn/utils/tests/test_checks.py::Test::testCheckNonNegativeThenReturnValueExecution

Windows-specific failures:

* [x] mars/dataframe/base/tests/test_base_execution.py::Test::testStringMethodExecution
* [x] mars/dataframe/merge/tests/test_merge_execution.py::Test::testMerge - ...
* [x] mars/tensor/base/tests/test_base_execute.py::Test::testSearchsortedExecution
* [x] mars/tensor/base/tests/test_base_execute.py::Test::testUniqueExecution
* [x] mars/tensor/reduction/tests/test_reduction_execute.py::Test::testCountNonzeroExecution
* [x] mars/tensor/reduction/tests/test_reduction_execute.py::Test::testOutReductionExecution

## Related issue number

Fixes #1070