### PR TITLE
[BACKPORT] Implements head/tail based on iloc, and fixes bug in `getitem`. (#1057)

### DIFF
--- a/mars/dataframe/indexing/__init__.py
+++ b/mars/dataframe/indexing/__init__.py
@@ -14,20 +14,22 @@
 
 
 def _install():
-    from .iloc import iloc
+    from .iloc import iloc, head, tail
     from .loc import loc
     from .set_index import set_index
     from .getitem import dataframe_getitem, series_getitem
     from ..operands import DATAFRAME_TYPE, SERIES_TYPE
 
-    for cls in DATAFRAME_TYPE:
+    for cls in DATAFRAME_TYPE + SERIES_TYPE:
         setattr(cls, 'iloc', property(iloc))
         setattr(cls, 'loc', property(loc))
+        setattr(cls, 'head', head)
+        setattr(cls, 'tail', tail)
+
+    for cls in DATAFRAME_TYPE:
         setattr(cls, 'set_index', set_index)
         setattr(cls, '__getitem__', dataframe_getitem)
     for cls in SERIES_TYPE:
-        setattr(cls, 'iloc', property(iloc))
-        setattr(cls, 'loc', property(loc))
         setattr(cls, '__getitem__', series_getitem)
 
 

--- a/mars/dataframe/indexing/iloc.py
+++ b/mars/dataframe/indexing/iloc.py
@@ -449,3 +449,11 @@ class SeriesIlocSetItem(DataFrameOperand, DataFrameOperandMixin):
 
 def iloc(a):
     return DataFrameIloc(a)
+
+
+def head(a, n=5):
+    return DataFrameIloc(a)[0:n]
+
+
+def tail(a, n=5):
+    return DataFrameIloc(a)[-n:]

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -456,3 +456,41 @@ class Test(TestBase):
         series5 = series[selected]
         pd.testing.assert_series_equal(
             self.executor.execute_dataframe(series5, concat=True)[0], data[selected])
+
+    def testHead(self):
+        data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'c3', 'c4', 'c5'])
+        df = md.DataFrame(data, chunk_size=2)
+
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.head(), concat=True)[0], data.head())
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.head(3), concat=True)[0], data.head(3))
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.head(-3), concat=True)[0], data.head(-3))
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.head(8), concat=True)[0], data.head(8))
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.head(-8), concat=True)[0], data.head(-8))
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.head(13), concat=True)[0], data.head(13))
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.head(-13), concat=True)[0], data.head(-13))
+
+    def testTail(self):
+        data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'c3', 'c4', 'c5'])
+        df = md.DataFrame(data, chunk_size=2)
+
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.tail(), concat=True)[0], data.tail())
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.tail(3), concat=True)[0], data.tail(3))
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.tail(-3), concat=True)[0], data.tail(-3))
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.tail(8), concat=True)[0], data.tail(8))
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.tail(-8), concat=True)[0], data.tail(-8))
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.tail(13), concat=True)[0], data.tail(13))
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df.tail(-13), concat=True)[0], data.tail(-13))


### PR DESCRIPTION
Backport of #1057.