### PR TITLE
Fix `validate_axis` when input tileable has unknown shape

### DIFF
--- a/mars/dataframe/tests/test_utils.py
+++ b/mars/dataframe/tests/test_utils.py
@@ -376,3 +376,6 @@ class Test(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             validate_axis(2, df)
+
+        df2 = df[df[0] < 0.5]  # create unknown shape
+        self.assertEqual(validate_axis(0, df2), 0)

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -613,7 +613,7 @@ def validate_axis(axis, tileable=None):
     illegal = False
     try:
         axis = operator.index(axis)
-        if axis < 0 or (tileable and axis >= tileable.ndim):
+        if axis < 0 or (tileable is not None and axis >= tileable.ndim):
             illegal = True
     except TypeError:
         illegal = True

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -456,9 +456,10 @@ class PSRSConcatPivot(TensorOperand, TensorOperandMixin):
                 kth = xp.arange(p - 1, (p - 1) ** 2 + 1, p - 1)
                 a.partition(kth, axis=op.axis)
 
-            select = slice(p - 1, (p - 1) ** 2 + 1, p - 1)
+            select = slice(p, p ** 2 + 1, p)
             slc = (slice(None),) * op.axis + (select,)
-            ctx[op.outputs[0].key] = a[slc]
+            ctx[op.outputs[0].key] = result = a[slc]
+            assert result.shape[op.axis] == p - 1
 
 
 class PSRSShuffle(TensorMapReduceOperand, TensorOperandMixin):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

When input tileable e.g. DataFrame has unknown shape, `validate_axis` would fail which illustrated in #1090 .

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1090 .
