### PR TITLE
[BACKPORT] Fix validate_axis when input tileable has unknown shape (#1091)

### DIFF
--- a/mars/dataframe/tests/test_utils.py
+++ b/mars/dataframe/tests/test_utils.py
@@ -376,3 +376,6 @@ class Test(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             validate_axis(2, df)
+
+        df2 = df[df[0] < 0.5]  # create unknown shape
+        self.assertEqual(validate_axis(0, df2), 0)

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -608,7 +608,7 @@ def wrap_notimplemented_exception(func):
     return wrapper
 
 
-def validate_axis(axis, tileable):
+def validate_axis(axis, tileable=None):
     if axis == 'index':
         axis = 0
     elif axis == 'columns':
@@ -617,7 +617,7 @@ def validate_axis(axis, tileable):
     illegal = False
     try:
         axis = operator.index(axis)
-        if axis < 0 or axis >= tileable.ndim:
+        if axis < 0 or (tileable is not None and axis >= tileable.ndim):
             illegal = True
     except TypeError:
         illegal = True

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -458,9 +458,10 @@ class PSRSConcatPivot(TensorOperand, TensorOperandMixin):
                 kth = xp.arange(p - 1, (p - 1) ** 2 + 1, p - 1)
                 a.partition(kth, axis=op.axis)
 
-            select = slice(p - 1, (p - 1) ** 2 + 1, p - 1)
+            select = slice(p, p ** 2 + 1, p)
             slc = (slice(None),) * op.axis + (select,)
-            ctx[op.outputs[0].key] = a[slc]
+            ctx[op.outputs[0].key] = result = a[slc]
+            assert result.shape[op.axis] == p - 1
 
 
 class PSRSShuffle(TensorMapReduceOperand, TensorOperandMixin):


### PR DESCRIPTION
Backport of #1091 .