### PR TITLE
Optimize performance of executor when running ops less than number of parallelism

### DIFF
--- a/.github/workflows/install-minikube.sh
+++ b/.github/workflows/install-minikube.sh
@@ -6,14 +6,14 @@ sudo apt-get remove -y docker.io || true
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 sudo apt-get -q update || true
-sudo apt-get install -yq docker-ce
+sudo apt-get install -yq conntrack docker-ce
 
 K8S_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$K8S_VERSION/bin/linux/amd64/kubectl && \
   chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.3.1/minikube-linux-amd64 && \
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && \
   chmod +x minikube && sudo mv minikube /usr/local/bin/
 
 sudo minikube start --vm-driver=none --kubernetes-version=$K8S_VERSION

--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 4, 0, 'b1')
+version_info = (0, 4, 0, 'b2')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -262,7 +262,7 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
 
 
 def read_csv(path, names=None, sep=',', index_col=None, compression=None, header='infer',
-             dtype=None, usecols=None, chunk_bytes=None, gpu=None, head_bytes='100k',
+             dtype=None, usecols=None, chunk_bytes='64M', gpu=None, head_bytes='100k',
              head_lines=None, sort_range_index=False, storage_options=None, **kwargs):
     """
     Read comma-separated values (csv) file(s) into DataFrame.

--- a/mars/dataframe/merge/concat.py
+++ b/mars/dataframe/merge/concat.py
@@ -195,31 +195,37 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
         def _auto_concat_dataframe_chunks(chunk, inputs):
             if chunk.op.axis is not None:
                 return pd.concat(inputs, axis=op.axis)
+
             # auto generated concat when executing a DataFrame
-            n_rows = max(inp.index[0] for inp in chunk.inputs) + 1
-            n_cols = int(len(inputs) // n_rows)
-            assert n_rows * n_cols == len(inputs)
-
-            xdf = pd if isinstance(inputs[0], (pd.DataFrame, pd.Series)) else cudf
-
-            concats = []
-            for i in range(n_rows):
-                if n_cols == 1:
-                    concats.append(inputs[i])
-                else:
-                    concat = xdf.concat([inputs[i * n_cols + j] for j in range(n_cols)], axis=1)
-                    concats.append(concat)
-
-            if xdf is pd:
-                # The `sort=False` is to suppress a `FutureWarning` of pandas, when the index or column of chunks to
-                # concatenate is not aligned, which may happens for certain ops.
-                #
-                # See also Note [Columns of Left Join] in test_merge_execution.py.
-                ret = xdf.concat(concats, sort=False)
+            if len(inputs) == 1:
+                ret = inputs[0]
             else:
-                ret = xdf.concat(concats)
-                # cuDF will lost index name when concat two seriess.
-                ret.index.name = concats[0].index.name
+                n_rows = max(inp.index[0] for inp in chunk.inputs) + 1
+                n_cols = int(len(inputs) // n_rows)
+                assert n_rows * n_cols == len(inputs)
+
+                xdf = pd if isinstance(inputs[0], (pd.DataFrame, pd.Series)) else cudf
+
+                concats = []
+                for i in range(n_rows):
+                    if n_cols == 1:
+                        concats.append(inputs[i])
+                    else:
+                        concat = xdf.concat([inputs[i * n_cols + j] for j in range(n_cols)], axis=1)
+                        concats.append(concat)
+
+                if xdf is pd:
+                    # The `sort=False` is to suppress a `FutureWarning` of pandas,
+                    # when the index or column of chunks to concatenate is not aligned,
+                    # which may happens for certain ops.
+                    #
+                    # See also Note [Columns of Left Join] in test_merge_execution.py.
+                    ret = xdf.concat(concats, sort=False)
+                else:
+                    ret = xdf.concat(concats)
+                    # cuDF will lost index name when concat two seriess.
+                    ret.index.name = concats[0].index.name
+
             if getattr(chunk.index_value, 'should_be_monotonic', False):
                 ret.sort_index(inplace=True)
             if getattr(chunk.columns_value, 'should_be_monotonic', False):
@@ -231,19 +237,25 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
             if all(np.isscalar(inp) for inp in inputs):
                 return pd.Series(inputs)
             else:
-                xdf = pd if isinstance(inputs[0], pd.Series) else cudf
-                if chunk.op.axis is not None:
-                    concat = xdf.concat(inputs, axis=chunk.op.axis)
+                if len(inputs) == 1:
+                    concat = inputs[0]
                 else:
-                    concat = xdf.concat(inputs)
+                    xdf = pd if isinstance(inputs[0], pd.Series) else cudf
+                    if chunk.op.axis is not None:
+                        concat = xdf.concat(inputs, axis=chunk.op.axis)
+                    else:
+                        concat = xdf.concat(inputs)
                 if getattr(chunk.index_value, 'should_be_monotonic', False):
                     concat.sort_index(inplace=True)
                 return concat
 
         def _auto_concat_index_chunks(chunk, inputs):
-            xdf = pd if isinstance(inputs[0], pd.Index) else cudf
-            empty_dfs = [xdf.DataFrame(index=inp) for inp in inputs]
-            concat_df = xdf.concat(empty_dfs, axis=0)
+            if len(inputs) == 1:
+                concat_df = inputs[0]
+            else:
+                xdf = pd if isinstance(inputs[0], pd.Index) else cudf
+                empty_dfs = [xdf.DataFrame(index=inp) for inp in inputs]
+                concat_df = xdf.concat(empty_dfs, axis=0)
             if getattr(chunk.index_value, 'should_be_monotonic', False):
                 concat_df.sort_index(inplace=True)
             return concat_df.index
@@ -251,10 +263,7 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
         chunk = op.outputs[0]
         inputs = [ctx[input.key] for input in op.inputs]
 
-        if len(inputs) == 1:
-            # no need to concat
-            ctx[chunk.key] = inputs[0]
-        elif isinstance(inputs[0], tuple):
+        if isinstance(inputs[0], tuple):
             ctx[chunk.key] = tuple(_base_concat(chunk, [input[i] for input in inputs])
                                    for i in range(len(inputs[0])))
         else:

--- a/mars/dataframe/merge/concat.py
+++ b/mars/dataframe/merge/concat.py
@@ -204,8 +204,11 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
 
             concats = []
             for i in range(n_rows):
-                concat = xdf.concat([inputs[i * n_cols + j] for j in range(n_cols)], axis=1)
-                concats.append(concat)
+                if n_cols == 1:
+                    concats.append(inputs[i])
+                else:
+                    concat = xdf.concat([inputs[i * n_cols + j] for j in range(n_cols)], axis=1)
+                    concats.append(concat)
 
             if xdf is pd:
                 # The `sort=False` is to suppress a `FutureWarning` of pandas, when the index or column of chunks to
@@ -248,7 +251,10 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
         chunk = op.outputs[0]
         inputs = [ctx[input.key] for input in op.inputs]
 
-        if isinstance(inputs[0], tuple):
+        if len(inputs) == 1:
+            # no need to concat
+            ctx[chunk.key] = inputs[0]
+        elif isinstance(inputs[0], tuple):
             ctx[chunk.key] = tuple(_base_concat(chunk, [input[i] for input in inputs])
                                    for i in range(len(inputs[0])))
         else:

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -74,6 +74,50 @@ class ExecutorSyncProvider(object):
     def event(cls):
         raise NotImplementedError
 
+    @classmethod
+    def queue(cls, *args, **kwargs):
+        raise NotImplementedError
+
+
+class EventQueue(list):
+    def __init__(self, event_cls, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if event_cls is not None:
+            self._has_value = event_cls()
+            if len(self) > 0:
+                self._has_value.set()
+        else:
+            self._has_value = None
+
+    def append(self, item):
+        super().append(item)
+        if self._has_value is not None:
+            self._has_value.set()
+
+    def insert(self, index: int, item) -> None:
+        super().insert(index, item)
+        if self._has_value is not None:
+            self._has_value.set()
+
+    def pop(self, index):
+        item = super().pop(index)
+        if self._has_value is not None and len(self) == 0:
+            self._has_value.clear()
+        return item
+
+    def clear(self) -> None:
+        super().clear()
+        if self._has_value is not None:
+            self._has_value.clear()
+
+    def wait(self, timeout=None):
+        if self._has_value is not None:
+            self._has_value.wait(timeout)
+
+    def errored(self):
+        if self._has_value is not None:
+            self._has_value.set()
+
 
 class ThreadExecutorSyncProvider(ExecutorSyncProvider):
     @classmethod
@@ -95,6 +139,10 @@ class ThreadExecutorSyncProvider(ExecutorSyncProvider):
     @classmethod
     def event(cls):
         return threading.Event()
+
+    @classmethod
+    def queue(cls, *args, **kwargs):
+        return EventQueue(threading.Event, *args, **kwargs)
 
 
 class GeventExecutorSyncProvider(ExecutorSyncProvider):
@@ -122,6 +170,10 @@ class GeventExecutorSyncProvider(ExecutorSyncProvider):
         # as gevent threadpool is the **real** thread, so use threading.Event
         return threading.Event()
 
+    @classmethod
+    def queue(cls, *args, **kwargs):
+        return EventQueue(threading.Event, *args, **kwargs)
+
 
 class MockThreadPoolExecutor(object):
     class _MockResult(object):
@@ -146,6 +198,10 @@ class MockThreadPoolExecutor(object):
             return self._MockResult(fn(*args, **kwargs))
         except:  # noqa: E722
             return self._MockResult(None, sys.exc_info())
+
+    @classmethod
+    def queue(cls, *args, **kwargs):
+        return EventQueue(None, *args, **kwargs)
 
 
 class MockExecutorSyncProvider(ThreadExecutorSyncProvider):
@@ -308,17 +364,19 @@ class GraphExecution(object):
         self._semaphore = sync_provider.semaphore(self._n_parallel)
         # event for setting error happened
         self._has_error = sync_provider.event()
-        self._queue = list(self._order_starts()) if len(graph) > 0 else []
-        assert len(self._queue) == graph.count_indep()
+        self._queue = sync_provider.queue(self._order_starts()) \
+            if len(graph) > 0 else sync_provider.queue()
         self._chunk_key_ref_counts = self._calc_ref_counts()
         self._op_key_to_ops = self._calc_op_key_to_ops()
         self._submitted_op_keys = set()
+        self._add_queue_op_keys = {op.key for op in self._queue}
         self._executed_op_keys = set()
         # initial assignment for GPU
         self._assign_devices()
 
     def _order_starts(self):
         visited = set()
+        op_keys = set()
         starts = deque(self._graph.iter_indep())
         stack = deque([starts.popleft()])
 
@@ -328,7 +386,10 @@ class GraphExecution(object):
                 preds = self._graph.predecessors(node)
                 if not preds or all(pred in visited for pred in preds):
                     if len(preds) == 0:
-                        yield node.op
+                        op_key = node.op.key
+                        if op_key not in op_keys:
+                            op_keys.add(op_key)
+                            yield node.op
                     visited.add(node)
                     stack.extend(n for n in self._graph[node] if n not in visited)
                 else:
@@ -402,11 +463,11 @@ class GraphExecution(object):
                     if rest_op_output.key not in executed_chunk_keys:
                         results[rest_op_output.key] = results[op_output.key]
 
-            with self._lock:
-                for output in itertools.chain(*[op.outputs for op in ops]):
-                    # the output not in the graph will be skipped
-                    if output not in self._graph:
-                        continue
+            for output in itertools.chain(*[op.outputs for op in ops]):
+                # the output not in the graph will be skipped
+                if output not in self._graph:
+                    continue
+                with self._lock:
                     # in case that operand has multiple outputs
                     # and some of the output not in result keys, delete them
                     if ref_counts.get(output.key) == 0:
@@ -415,22 +476,27 @@ class GraphExecution(object):
                             deleted_chunk_keys.add(output.key)
                             del results[output.key]
 
-                    # clean the predecessors' results if ref counts equals 0
-                    for dep_key in output.op.get_dependent_data_keys():
+                # clean the predecessors' results if ref counts equals 0
+                for dep_key in output.op.get_dependent_data_keys():
+                    with self._lock:
                         if dep_key in ref_counts:
                             ref_counts[dep_key] -= 1
                             if ref_counts[dep_key] == 0:
                                 del results[dep_key]
                                 del ref_counts[dep_key]
 
-                    # add successors' operands to queue
-                    for succ_chunk in self._graph.iter_successors(output):
-                        preds = self._graph.predecessors(succ_chunk)
-                        if succ_chunk.op.key not in self._submitted_op_keys and \
+                # add successors' operands to queue
+                for succ_chunk in self._graph.iter_successors(output):
+                    preds = self._graph.predecessors(succ_chunk)
+                    with self._lock:
+                        succ_op_key = succ_chunk.op.key
+                        if succ_op_key not in self._add_queue_op_keys and \
                                 (len(preds) == 0 or all(pred.op.key in op_keys for pred in preds)):
                             self._queue.insert(0, succ_chunk.op)
+                            self._add_queue_op_keys.add(succ_op_key)
         except Exception:
             self._has_error.set()
+            self._queue.errored()
             raise
         finally:
             self._semaphore.release()
@@ -465,16 +531,15 @@ class GraphExecution(object):
 
     def _submit_operand_to_execute(self):
         self._semaphore.acquire()
+        self._queue.wait()
 
-        with self._lock:
-            try:
-                to_submit_op = self._queue.pop(0)
-                if to_submit_op.key in self._submitted_op_keys:
-                    raise ValueError('Get submitted operand')
-                self._submitted_op_keys.add(to_submit_op.key)
-            except (IndexError, ValueError):
-                self._semaphore.release()
-                return
+        if self._has_error.is_set():
+            # error happens, ignore
+            return
+
+        to_submit_op = self._queue.pop(0)
+        assert to_submit_op.key not in self._submitted_op_keys
+        self._submitted_op_keys.add(to_submit_op.key)
 
         if self._print_progress:
             i, n = len(self._submitted_op_keys), len(self._op_key_to_ops)
@@ -490,7 +555,7 @@ class GraphExecution(object):
 
     def execute(self, retval=True):
         executed_futures = []
-        while len(self._submitted_op_keys) < len(self._op_key_to_ops):
+        for _ in range(len(self._op_key_to_ops)):
             if self._has_error.is_set():
                 # something wrong happened
                 break

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -99,7 +99,7 @@ class EventQueue(list):
         if self._has_value is not None:
             self._has_value.set()
 
-    def pop(self, index):
+    def pop(self, index=-1):
         item = super().pop(index)
         if self._has_value is not None and len(self) == 0:
             self._has_value.clear()

--- a/mars/tests/test_executor.py
+++ b/mars/tests/test_executor.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import sys
+import threading
 import unittest
 
 import numpy as np
 
 import mars.tensor as mt
-from mars.executor import Executor, register, GraphDeviceAssigner
+from mars.executor import Executor, register, GraphDeviceAssigner, EventQueue
 from mars.serialize import Int64Field
 from mars.tensor.operands import TensorOperand, TensorOperandMixin
 from mars.graph import DirectedGraph
@@ -181,3 +182,19 @@ class Test(unittest.TestCase):
         self.assertEqual(a.cix[0, 0].device, a.cix[0, 1].device)
         self.assertEqual(a.cix[1, 0].device, a.cix[1, 1].device)
         self.assertNotEqual(a.cix[0, 0].device, a.cix[1, 0].device)
+
+    def testEventQueue(self):
+        q = EventQueue(threading.Event)
+
+        self.assertFalse(q._has_value.is_set())
+        q.append(1)
+        self.assertTrue(q._has_value.is_set())
+        q.pop()
+        self.assertFalse(q._has_value.is_set())
+        q.insert(0, 2)
+        self.assertTrue(q._has_value.is_set())
+        q.wait()
+        q.clear()
+        self.assertFalse(q._has_value.is_set())
+        q.errored()
+        self.assertTrue(q._has_value.is_set())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 numpy>=1.14.0
-pandas>=0.24.0
+pandas>=0.24.0; python_version >= '3.6'
+pandas>=0.24.0,<1.0.0; python_version < '3.6'
 requests>=2.4.0
 pyarrow>=0.11.0,<0.16.0
 cython>=0.29

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -5,5 +5,6 @@ psutil>=4.0.0
 lz4>=1.0.0
 protobuf>=3.6
 gevent>=1.2.0
-bokeh>=1.0.0
+bokeh>=1.0.0; python_version >= '3.6'
+bokeh>=1.0.0,<2.0.0; python_version < '3.6'
 jinja2>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy>=1.14.0
-pandas>=0.24.0
+pandas>=0.24.0; python_version >= '3.6'
+pandas>=0.24.0,<1.0.0; python_version < '3.6'
 requests>=2.4.0
 pyarrow>=0.11.0,<0.16.0
 cloudpickle>=1.0.0


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

When running ops less than the number of parallelism a.k.a `n_parallel`, the performance of executor will become terrible.

Master branch, the file is around 500M, default `chunk_bytes` is 128M, and automatic `n_parallel` is 8.

```
In [1]: %%time 
   ...: import mars.dataframe as md 
   ...: df = md.read_csv('Downloads/ratings.csv') 
   ...: df.groupby('movieId').agg({'rating': ['max', 'min']}).execute() 
   ...:  
   ...:                                                                         
CPU times: user 14.4 s, sys: 2.49 s, total: 16.9 s
Wall time: 8.9 s
Out[1]: 
        rating     
           max  min
movieId            
1          5.0  0.5
2          5.0  0.5
3          5.0  0.5
4          5.0  0.5
5          5.0  0.5
...        ...  ...
131254     4.0  4.0
131256     4.0  4.0
131258     2.5  2.5
131260     3.0  3.0
131262     4.0  4.0

[26744 rows x 2 columns]
```

This PR:

```
In [2]: %%time 
   ...: import mars.dataframe as md 
   ...: df = md.read_csv('Downloads/ratings.csv') 
   ...: df.groupby('movieId').agg({'rating': ['max', 'min']}).execute() 
   ...:  
   ...:                                                                         
CPU times: user 5.53 s, sys: 1.97 s, total: 7.5 s
Wall time: 1.81 s
Out[2]: 
        rating     
           max  min
movieId            
1          5.0  0.5
2          5.0  0.5
3          5.0  0.5
4          5.0  0.5
5          5.0  0.5
...        ...  ...
131254     4.0  4.0
131256     4.0  4.0
131258     2.5  2.5
131260     3.0  3.0
131262     4.0  4.0

[26744 rows x 2 columns]
```

Performance of `groupby.agg` including `mean`, `var` and `std` has been improved quite a lot.

Master:

```
In [2]: %%time 
   ...: df = md.read_csv('Downloads/ratings.csv', chunk_bytes='64M') 
   ...: df.groupby('movieId').agg({'rating': ['mean', 'max', 'min', 'var']}).exe
   ...: cute() 
   ...:  
   ...:                                                                         
/Users/qinxuye/Workspace/mars/mars/dataframe/groupby/aggregation.py:256: RuntimeWarning: invalid value encountered in double_scalars
  return var_square / (reduced_cnt - 1)
CPU times: user 2min 4s, sys: 7.67 s, total: 2min 12s
Wall time: 1min 57s
Out[2]: 
           rating                    
             mean  max  min       var
movieId                              
1        3.921240  5.0  0.5  0.790342
2        3.211977  5.0  0.5  0.904686
3        3.151040  5.0  0.5  1.013328
4        2.861393  5.0  0.5  1.200563
5        3.064592  5.0  0.5  0.964598
...           ...  ...  ...       ...
131254   4.000000  4.0  4.0       NaN
131256   4.000000  4.0  4.0       NaN
131258   2.500000  2.5  2.5       NaN
131260   3.000000  3.0  3.0       NaN
131262   4.000000  4.0  4.0       NaN

[26744 rows x 4 columns]
```

This PR:

```
In [3]: %%time 
   ...: df = md.read_csv('Downloads/ratings.csv', chunk_bytes='64M') 
   ...: df.groupby('movieId').agg({'rating': ['mean', 'max', 'min', 'var']}).exe
   ...: cute() 
   ...:  
   ...:                                                                         
CPU times: user 9.62 s, sys: 3.46 s, total: 13.1 s
Wall time: 1.86 s
Out[3]: 
           rating                    
             mean  max  min       var
movieId                              
1        3.921240  5.0  0.5  0.790342
2        3.211977  5.0  0.5  0.904686
3        3.151040  5.0  0.5  1.013328
4        2.861393  5.0  0.5  1.200563
5        3.064592  5.0  0.5  0.964598
...           ...  ...  ...       ...
131254   4.000000  4.0  4.0       NaN
131256   4.000000  4.0  4.0       NaN
131258   2.500000  2.5  2.5       NaN
131260   3.000000  3.0  3.0       NaN
131262   4.000000  4.0  4.0       NaN

[26744 rows x 4 columns]
```

Tasks include:

- [x] Optimize executor.
- [x] Optimize `mean`, `var` and `std` for `groupby.agg`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA
