### PR TITLE
Support slice that can be integer or other types on non-int64 index

### DIFF
--- a/mars/dataframe/__init__.py
+++ b/mars/dataframe/__init__.py
@@ -21,13 +21,13 @@ from .datasource.from_records import from_records
 from .datasource.read_csv import read_csv
 from .datasource.read_sql_table import read_sql_table
 from .datasource.date_range import date_range
-from .merge import concat
+from .merge import concat, merge
 from .fetch import DataFrameFetch, DataFrameFetchShuffle
 
 from . import arithmetic
 from . import base
 from . import indexing
-from . import merge
+from . import merge as merge_
 from . import reduction
 from . import statistics
 from . import sort
@@ -36,8 +36,8 @@ from . import ufunc
 from . import datastore
 from . import window
 
-del reduction, statistics, arithmetic, indexing, merge, base, \
-    groupby, ufunc, datastore, sort, window
+del reduction, statistics, arithmetic, indexing, merge_, \
+    base, groupby, ufunc, datastore, sort, window
 del DataFrameFetch, DataFrameFetchShuffle
 
 # noinspection PyUnresolvedReferences

--- a/mars/dataframe/indexing/index_lib.py
+++ b/mars/dataframe/indexing/index_lib.py
@@ -33,7 +33,7 @@ from ...tensor.indexing.index_lib import IndexHandlerContext, IndexHandler, \
 from ...tensor.utils import split_indexes_into_chunks, calc_pos, \
     filter_inputs, slice_split, calc_sliced_size, to_numpy
 from ...utils import check_chunks_unknown_shape, classproperty
-from ..core import SERIES_CHUNK_TYPE
+from ..core import SERIES_CHUNK_TYPE, IndexValue
 from ..operands import ObjectType
 from ..utils import parse_index
 from .utils import convert_labels_into_positions
@@ -751,6 +751,7 @@ class LabelNDArrayFancyIndexHandler(_LabelFancyIndexHandler):
     def process(self,
                 index_info: IndexInfo,
                 context: IndexHandlerContext) -> None:
+        tileable = context.tileable
         input_axis = index_info.input_axis
         chunk_index_to_labels = index_info.chunk_index_to_labels
 
@@ -759,17 +760,26 @@ class LabelNDArrayFancyIndexHandler(_LabelFancyIndexHandler):
         for chunk_index, chunk_index_info in chunk_index_to_info.items():
             i = chunk_index[input_axis]
             chunk_labels = chunk_index_to_labels[i]
+            size = chunk_labels.size
 
-            if chunk_labels.size == 0:
+            if size == 0:
                 # not effected
                 del context.chunk_index_to_info[chunk_index]
                 continue
+
+            if np.isscalar(index_info.raw_index) and \
+                    isinstance(tileable.index_value.value, IndexValue.DatetimeIndex) and \
+                    isinstance(chunk_labels[0], str):
+                # special case when index is DatetimeIndex and loc by string
+                # convert back list to scalar because if keep list,
+                # KeyError will always happen
+                chunk_labels = chunk_labels[0].item()
 
             other_index = chunk_index[:1] if input_axis == 1 else chunk_index[1:]
             if other_index not in other_index_to_iter:
                 other_index_to_iter[other_index] = itertools.count()
             output_axis_index = next(other_index_to_iter[other_index])
-            output_axis_shape = chunk_labels.size
+            output_axis_shape = size
             self.set_chunk_index_info(context, index_info, chunk_index,
                                       chunk_index_info, output_axis_index,
                                       chunk_labels, output_axis_shape)
@@ -778,12 +788,6 @@ class LabelNDArrayFancyIndexHandler(_LabelFancyIndexHandler):
     def need_postprocess(cls,
                          index_info: IndexInfo,
                          context: IndexHandlerContext):
-        tileable = context.tileable
-
-        if tileable.chunk_shape[index_info.input_axis] == 1:
-            # if tileable only has 1 chunk on this axis
-            # do not need postprocess
-            return False
         # if ascending sorted, no need to postprocess
         return not index_info.is_label_asc_sorted
 

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -223,11 +223,15 @@ class Test(TestBase):
         # columns are non unique and non monotonic
         raw4 = raw1.copy()
         raw4.columns = ['b', 'a', 'b', 'd']
+        # index that is timestamp
+        raw5 = raw1.copy()
+        raw5.index = pd.date_range('2020-1-1', periods=5)
 
         df1 = md.DataFrame(raw1, chunk_size=2)
         df2 = md.DataFrame(raw2, chunk_size=2)
         df3 = md.DataFrame(raw3, chunk_size=2)
         df4 = md.DataFrame(raw4, chunk_size=2)
+        df5 = md.DataFrame(raw5, chunk_size=2)
 
         df = df2.loc[3, 'b']
         result = self.executor.execute_tensor(df, concat=True)[0]
@@ -308,6 +312,18 @@ class Test(TestBase):
         result = self.executor.execute_dataframe(df, concat=True)[0]
         expected = raw1.loc[['a3', 'a1'], ['b', 'a', 'd']]
         pd.testing.assert_frame_equal(result, expected)
+
+        # get timestamp by str
+        df = df5.loc['20200101']
+        result = self.executor.execute_dataframe(df, concat=True, check_series_name=False)[0]
+        expected = raw5.loc['20200101']
+        pd.testing.assert_series_equal(result, expected)
+
+        # get timestamp by str, return scalar
+        df = df5.loc['2020-1-1', 'c']
+        result = self.executor.execute_dataframe(df, concat=True)[0]
+        expected = raw5.loc['2020-1-1', 'c']
+        self.assertEqual(result, expected)
 
     def testDataFrameGetitem(self):
         data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'c3', 'c4', 'c5'])

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -418,6 +418,11 @@ class Test(TestBase):
         pd.testing.assert_frame_equal(
             self.executor.execute_dataframe(df[mask], concat=True)[0].sort_index(), data[mask_data])
 
+        # getitem by DataFrame with all bool columns
+        r = df[df > 0.5]
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        pd.testing.assert_frame_equal(result, data[data > 0.5])
+
     def testDataFrameGetitemUsingAttr(self):
         data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'key', 'dtypes', 'size'])
         df = md.DataFrame(data, chunk_size=2)

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -312,6 +312,9 @@ class Test(TestBase):
     def testDataFrameGetitem(self):
         data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'c3', 'c4', 'c5'])
         df = md.DataFrame(data, chunk_size=2)
+        data2 = data.copy()
+        data2.index = pd.date_range('2020-1-1', periods=10)
+        mdf = md.DataFrame(data2, chunk_size=3)
 
         series1 = df['c2']
         pd.testing.assert_series_equal(
@@ -352,6 +355,14 @@ class Test(TestBase):
         series3 = df['c1'][0]
         self.assertEqual(
             self.executor.execute_dataframe(series3, concat=True)[0], data['c1'][0])
+
+        df8 = mdf[3:7]
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df8, concat=True)[0], data2[3:7])
+
+        df9 = mdf['2020-1-2': '2020-1-5']
+        pd.testing.assert_frame_equal(
+            self.executor.execute_dataframe(df9, concat=True)[0], data2['2020-1-2': '2020-1-5'])
 
     def testDataFrameGetitemBool(self):
         data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'c3', 'c4', 'c5'])

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -347,6 +347,19 @@ class Test(unittest.TestCase):
         tensor = md.dataframe_from_tensor(mt.array([1, 2, 3]))
         np.testing.assert_equal(sess.run(tensor), np.array([1, 2, 3]).reshape(3, 1))
 
+    def testDataFrameExecution(self):
+        sess = new_session()
+
+        raw = pd.DataFrame(np.random.rand(5, 3),
+                           index=pd.date_range('2020-1-1', periods=5))
+
+        for chunk_size in (3, 5):
+            df = md.DataFrame(raw, chunk_size=chunk_size)
+
+            r = df.loc['2020-1-2']
+            result = sess.run(r)
+            pd.testing.assert_series_equal(result, raw.loc['2020-1-2'])
+
     def testFetchSlices(self):
         sess = new_session()
 

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -92,6 +92,8 @@ def on_deserialize_shape(shape):
 
 
 def on_serialize_numpy_type(value):
+    if value is pd.NaT:
+        value = None
     return value.item() if isinstance(value, np.generic) else value
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

As mentioned in #1102 , when input DataFrame's index is not int64 index e.g. RangeIndex, the slice is very flexible that it can be integer which could act same as `iloc`, or can be other types which act same as `loc`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1102 .
