### PR TITLE
Check if tileable.nsplits and chunk.shape is consistent

### DIFF
--- a/mars/context.py
+++ b/mars/context.py
@@ -292,7 +292,7 @@ class DistributedContext(ContextBase):
         return results
 
     # Meta API
-    def get_tileable_metas(self, tileable_keys, filter_fields: List[str]=None) -> List:
+    def get_tileable_metas(self, tileable_keys, filter_fields: List[str] = None) -> List:
         return self._meta_api.get_tileable_metas(self._session_id, tileable_keys, filter_fields)
 
     def get_chunk_metas(self, chunk_keys, filter_fields: List[str] = None) -> List:
@@ -302,8 +302,8 @@ class DistributedContext(ContextBase):
         return self._meta_api.get_tileable_key_by_name(self._session_id, name)
 
     # Worker API
-    def get_chunks_data(self, worker: str, chunk_keys: List[str], indexes: List=None,
-                        compression_types: List[str]=None):
+    def get_chunks_data(self, worker: str, chunk_keys: List[str], indexes: List = None,
+                        compression_types: List[str] = None):
         return self._worker_api.get_chunks_data(self._session_id, worker, chunk_keys, indexes=indexes,
                                                 compression_types=compression_types)
 

--- a/mars/core.py
+++ b/mars/core.py
@@ -579,7 +579,7 @@ class ChunksIndexer(object):
             if len(item) == 0 and self._tileable.is_scalar():
                 return self._tileable.chunks[0]
             if len(item) != self._tileable.ndim:
-                raise ValueError('Cannot get tensor chunk by %s, expect length %d' % (
+                raise ValueError('Cannot get chunk by %s, expect length %d' % (
                     item, self._tileable.ndim))
             slices, singleton = [], True
             for it, dim in zip(item, self._tileable.chunk_shape):
@@ -589,7 +589,7 @@ class ChunksIndexer(object):
                 elif np.issubdtype(type(it), np.integer):
                     slices.append([it if it >= 0 else dim + it])
                 else:
-                    raise TypeError('Cannot get tensor chunk by %s, invalid value has type %s' % (
+                    raise TypeError('Cannot get chunk by %s, invalid value has type %s' % (
                         it, type(it)))
 
             indexes = tuple(zip(*itertools.product(*slices)))

--- a/mars/dataframe/align.py
+++ b/mars/dataframe/align.py
@@ -675,8 +675,13 @@ def align_dataframe_dataframe(left, right):
 
     index_splits, index_nsplits = _calc_axis_splits(left.index_value, right.index_value,
                                                     left_index_chunks, right_index_chunks)
+    if _is_index_identical(left_index_chunks, right_index_chunks):
+        index_nsplits = left.nsplits[0]
+
     columns_splits, columns_nsplits = _calc_axis_splits(left.columns_value, right.columns_value,
                                                         left_columns_chunks, right_columns_chunks)
+    if _is_index_identical(left_columns_chunks, right_columns_chunks):
+        columns_nsplits = left.nsplits[1]
 
     nsplits = [index_nsplits, columns_nsplits]
     out_chunk_shape = tuple(len(ns) for ns in nsplits)
@@ -694,6 +699,8 @@ def align_dataframe_series(left, right, axis='columns'):
         right_index_chunks = [c.index_value for c in right.chunks]
         index_splits, index_nsplits = _calc_axis_splits(left.columns_value, right.index_value,
                                                         left_columns_chunks, right_index_chunks)
+        if _is_index_identical(left_columns_chunks, right_index_chunks):
+            index_nsplits = left.nsplits[1]
         dummy_splits, dummy_nsplits = _build_dummy_axis_split(left.chunk_shape[0]), left.nsplits[0]
         nsplits = [dummy_nsplits, index_nsplits]
         out_chunk_shape = tuple(len(ns) for ns in nsplits)
@@ -705,6 +712,8 @@ def align_dataframe_series(left, right, axis='columns'):
         right_index_chunks = [c.index_value for c in right.chunks]
         index_splits, index_nsplits = _calc_axis_splits(left.index_value, right.index_value,
                                                         left_index_chunks, right_index_chunks)
+        if _is_index_identical(left_index_chunks, right_index_chunks):
+            index_nsplits = left.nsplits[0]
         dummy_splits, dummy_nsplits = _build_dummy_axis_split(left.chunk_shape[1]), left.nsplits[1]
         nsplits = [index_nsplits, dummy_nsplits]
         out_chunk_shape = tuple(len(ns) for ns in nsplits)
@@ -720,7 +729,8 @@ def align_series_series(left, right):
 
     index_splits, index_nsplits = _calc_axis_splits(left.index_value, right.index_value,
                                                     left_index_chunks, right_index_chunks)
-
+    if _is_index_identical(left_index_chunks, right_index_chunks):
+        index_nsplits = left.nsplits[0]
     nsplits = [index_nsplits]
     out_chunk_shape = (len(index_nsplits),)
     splits = _MinMaxSplitInfo(index_splits, None)

--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -535,7 +535,7 @@ class DataFrameUnaryOpMixin(DataFrameOperandMixin):
         new_op = op.copy()
         kw = out_df.params
         kw['nsplits'] = in_df.nsplits
-        kw['chunks'] =  out_chunks
+        kw['chunks'] = out_chunks
         return new_op.new_tileables(op.inputs, kws=[kw])
 
     @classmethod

--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -88,7 +88,8 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
         out_chunks = []
         for idx, left_chunk, right_chunk in zip(out_chunk_indexes, left_chunks, right_chunks):
             out_chunk = op.copy().reset_key().new_chunk([left_chunk, right_chunk],
-                                                        shape=(np.nan, np.nan), index=idx)
+                                                        shape=(nsplits[0][idx[0]], nsplits[1][idx[1]]),
+                                                        index=idx)
             out_chunks.append(out_chunk)
 
         new_op = op.copy()
@@ -107,7 +108,7 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
         out_chunks = []
         for idx, left_chunk, right_chunk in zip(range(out_shape[0]), left_chunks, right_chunks):
             out_chunk = op.copy().reset_key().new_chunk([left_chunk, right_chunk],
-                                                        shape=(np.nan,), index=(idx,))
+                                                        shape=(nsplits[0][idx],), index=(idx,))
             out_chunks.append(out_chunk)
 
         new_op = op.copy()

--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -129,13 +129,13 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
             if op.axis == 'columns' or op.axis == 1:
                 series_chunk = right_chunks[out_idx[1]]
                 kw = {
-                    'shape': (df_chunk.shape[0], np.nan),
+                    'shape': (nsplits[0][out_idx[0]], nsplits[1][out_idx[1]]),
                     'index_value': df_chunk.index_value,
                 }
             else:
                 series_chunk = right_chunks[out_idx[0]]
                 kw = {
-                    'shape': (np.nan, df_chunk.shape[1]),
+                    'shape': (nsplits[0][out_idx[0]], nsplits[1][out_idx[1]]),
                     'columns_value': df_chunk.columns_value,
                 }
             out_chunk = op.copy().reset_key().new_chunk([df_chunk, series_chunk], index=out_idx, **kw)
@@ -420,11 +420,10 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
             properties = self._calc_properties(df1, df2, axis=self.axis)
 
         inputs = [inp for inp in inputs if isinstance(inp, (Chunk, ChunkData))]
-        shapes = [properties.pop('shape')]
-        shapes.extend(kw_item.pop('shape') for kw_item in kws or ())
+
+        shape = properties.pop('shape')
         if 'shape' in kw:
-            shapes.append(kw.pop('shape'))
-        shape = self._merge_shape(*shapes)
+            shape = kw.pop('shape')
 
         for prop, value in properties.items():
             if kw.get(prop, None) is None:

--- a/mars/dataframe/base/dropna.py
+++ b/mars/dataframe/base/dropna.py
@@ -128,7 +128,7 @@ class DataFrameDropNA(DataFrameOperand, DataFrameOperandMixin):
         out_chunks = []
         for out_idx, df_chunk in zip(out_chunk_indexes, left_chunks):
             series_chunk = right_chunks[out_idx[0]]
-            kw = dict(shape=(nsplits[0][out_idx[0]], nsplits[1][out_idx[1]]),
+            kw = dict(shape=(np.nan, nsplits[1][out_idx[1]]),
                       index_value=df_chunk.index_value, columns_value=df_chunk.columns_value)
 
             new_op = op.copy().reset_key()
@@ -138,7 +138,9 @@ class DataFrameDropNA(DataFrameOperand, DataFrameOperandMixin):
 
         new_op = op.copy().reset_key()
         params = out_df.params.copy()
-        params.update(dict(nsplits=tuple(tuple(ns) for ns in nsplits), chunks=out_chunks))
+        new_nsplits = list(tuple(ns) for ns in nsplits)
+        new_nsplits[0] = (np.nan,) * len(new_nsplits[0])
+        params.update(dict(nsplits=tuple(new_nsplits), chunks=out_chunks))
         return new_op.new_tileables(op.inputs, **params)
 
     @classmethod

--- a/mars/dataframe/base/fillna.py
+++ b/mars/dataframe/base/fillna.py
@@ -172,7 +172,7 @@ class FillNA(DataFrameOperand, DataFrameOperandMixin):
             new_chunks.append(new_op.new_chunk(inputs, **kw))
 
         kw = df.params.copy()
-        kw.update(dict(chunks=new_chunks))
+        kw.update(dict(chunks=new_chunks, nsplits=in_df.nsplits))
         new_op = op.copy().reset_key()
         return new_op.new_tileables(op.inputs, **kw)
 

--- a/mars/dataframe/base/fillna.py
+++ b/mars/dataframe/base/fillna.py
@@ -292,7 +292,8 @@ class FillNA(DataFrameOperand, DataFrameOperandMixin):
         out_chunks = []
         for out_idx, df_chunk in zip(out_chunk_indexes, left_chunks):
             series_chunk = right_chunks[out_idx[1]]
-            kw = dict(shape=(np.nan, df_chunk.shape[1]), columns_value=df_chunk.columns_value)
+            kw = dict(shape=(nsplits[0][out_idx[0]], nsplits[1][out_idx[1]]),
+                      columns_value=df_chunk.columns_value)
             out_chunk = op.copy().reset_key().new_chunk([df_chunk, series_chunk], index=out_idx, **kw)
             out_chunks.append(out_chunk)
 

--- a/mars/dataframe/base/reset_index.py
+++ b/mars/dataframe/base/reset_index.py
@@ -74,7 +74,7 @@ class DataFrameResetIndex(DataFrameOperand, DataFrameOperandMixin):
                                                name=c.name, index_value=index_value)
             else:
                 shape = (c.shape[0], out.shape[1])
-                out_chunk = chunk_op.new_chunk([c], shape=shape, index=c.index, dtypes=out.dtypes,
+                out_chunk = chunk_op.new_chunk([c], shape=shape, index=c.index + (0,), dtypes=out.dtypes,
                                                index_value=index_value, columns_value=out.columns_value)
             out_chunks.append(out_chunk)
         if not is_range_index and isinstance(out.index_value._index_value, IndexValue.RangeIndex):

--- a/mars/dataframe/datasource/dataframe.py
+++ b/mars/dataframe/datasource/dataframe.py
@@ -80,7 +80,7 @@ class DataFrameDataSource(DataFrameOperand, DataFrameOperandMixin):
             if i in index_values:
                 index_value = index_values[i]
             else:
-                index_value =index_values[i] = parse_index(chunk_op.data.index)
+                index_value = index_values[i] = parse_index(chunk_op.data.index)
             if j in column_values:
                 column_value = column_values[j]
             else:

--- a/mars/dataframe/datasource/date_range.py
+++ b/mars/dataframe/datasource/date_range.py
@@ -168,7 +168,7 @@ class DataFrameDateRange(DataFrameOperand, DataFrameOperandMixin):
         new_op = op.copy()
         params = out.params
         params['chunks'] = out_chunks
-        params['nsplits'] = (chunk_length,)
+        params['nsplits'] = (tuple(c.shape[0] for c in out_chunks),)
         return new_op.new_indexes(None, kws=[params])
 
     @classmethod

--- a/mars/dataframe/datasource/index.py
+++ b/mars/dataframe/datasource/index.py
@@ -208,6 +208,6 @@ def from_pandas(data, chunk_size=None, gpu=False, sparse=False):
 
 
 def from_tileable(tileable, dtype=None, name=None):
-    op =IndexDataSource(gpu=tileable.op.gpu, sparse=tileable.issparse(),
-                        dtype=dtype)
+    op = IndexDataSource(gpu=tileable.op.gpu, sparse=tileable.issparse(),
+                         dtype=dtype)
     return op(inp=tileable, name=name)

--- a/mars/dataframe/datastore/to_csv.py
+++ b/mars/dataframe/datastore/to_csv.py
@@ -202,8 +202,7 @@ class DataFrameToCSV(DataFrameOperand, DataFrameOperandMixin):
                     'order': TensorOrder.C_ORDER,
                     'object_type': ObjectType.scalar,
                     'type': 'csv',
-                },
-                {
+                }, {
                     'shape': (),
                     'dtype': np.dtype(np.intp),
                     'index': chunk.index,

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -353,8 +353,9 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
                                              index_value=out_df.index_value, dtypes=out_df.dtypes,
                                              columns_value=out_df.columns_value)
             else:
-                agg_chunk = agg_op.new_chunk([chunk], shape=out_df.shape, index=chunk.index, dtype=out_df.dtype,
-                                             index_value=out_df.index_value, name=out_df.name)
+                agg_chunk = agg_op.new_chunk([chunk], shape=out_df.shape, index=(chunk.index[0],),
+                                             dtype=out_df.dtype, index_value=out_df.index_value,
+                                             name=out_df.name)
             agg_chunks.append(agg_chunk)
 
         new_op = op.copy()

--- a/mars/dataframe/groupby/apply.py
+++ b/mars/dataframe/groupby/apply.py
@@ -100,7 +100,7 @@ class GroupByApply(DataFrameOperand, DataFrameOperandMixin):
                     columns_value=out_df.columns_value, index_value=out_df.index_value))
             else:
                 chunks.append(new_op.new_chunk(
-                    inp_chunks, name=out_df.name, index=c.index, shape=(np.nan,), dtype=out_df.dtype,
+                    inp_chunks, name=out_df.name, index=(c.index[0],), shape=(np.nan,), dtype=out_df.dtype,
                     index_value=out_df.index_value))
 
         new_op = op.copy().reset_key()

--- a/mars/dataframe/groupby/cum.py
+++ b/mars/dataframe/groupby/cum.py
@@ -104,12 +104,16 @@ class GroupByCumReductionOperand(DataFrameOperandMixin, DataFrameOperand):
                     columns_value=out_df.columns_value, index_value=new_index))
             else:
                 chunks.append(new_op.new_chunk(
-                    [c], index=c.index, shape=(np.nan,), dtype=out_df.dtype,
+                    [c], index=(c.index[0],), shape=(np.nan,), dtype=out_df.dtype,
                     index_value=new_index))
 
         new_op = op.copy().reset_key()
         kw = out_df.params.copy()
         kw['chunks'] = chunks
+        if op.object_type == ObjectType.dataframe:
+            kw['nsplits'] = ((np.nan,) * len(chunks), (len(out_df.dtypes),))
+        else:
+            kw['nsplits'] = ((np.nan,) * len(chunks),)
         return new_op.new_tileables([in_groupby], **kw)
 
     @classmethod

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -166,13 +166,9 @@ class Test(TestBase):
                                       df2.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count']))
         self.assertTrue(r13.op.as_index)
 
-        try:
-            r14 = mdf2.groupby('c2').agg(['cumsum', 'cumcount'])
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r14, concat=True)[0].sort_index(),
-                                          df2.groupby('c2').agg(['cumsum', 'cumcount']).sort_index())
-        except:
-            print(df2)
-            raise
+        r14 = mdf2.groupby('c2').agg(['cumsum', 'cumcount'])
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r14, concat=True)[0].sort_index(),
+                                      df2.groupby('c2').agg(['cumsum', 'cumcount']).sort_index())
 
     def testSeriesGroupByAgg(self):
         rs = np.random.RandomState(0)

--- a/mars/dataframe/groupby/transform.py
+++ b/mars/dataframe/groupby/transform.py
@@ -165,8 +165,6 @@ class GroupByTransform(DataFrameOperand, DataFrameOperandMixin):
 
         if op.call_agg:
             result = grouped.agg(op.func, *op.args, **op.kwds)
-            if isinstance(result, pd.DataFrame):
-                result = result.reindex(out_chunk.columns_value.to_pandas(), axis=1)
         else:
             result = grouped.transform(op.func, *op.args, **op.kwds)
         ctx[op.outputs[0].key] = result

--- a/mars/dataframe/groupby/transform.py
+++ b/mars/dataframe/groupby/transform.py
@@ -72,8 +72,13 @@ class GroupByTransform(DataFrameOperand, DataFrameOperandMixin):
         try:
             if in_df.op.object_type == ObjectType.dataframe:
                 empty_df = build_empty_df(in_df.dtypes, index=pd.RangeIndex(2))
+                obj_dtypes = in_df.dtypes[in_df.dtypes == np.dtype('O')]
+                empty_df[obj_dtypes.index] = 'O'
             else:
-                empty_df = build_empty_series(in_df.dtype, index=pd.RangeIndex(2), name=in_df.name)
+                if in_df.dtype == np.dtype('O'):
+                    empty_df = pd.Series('O', index=pd.RangeIndex(2), name=in_df.name, dtype=np.dtype('O'))
+                else:
+                    empty_df = build_empty_series(in_df.dtype, index=pd.RangeIndex(2), name=in_df.name)
 
             with np.errstate(all='ignore'):
                 if self.call_agg:
@@ -167,6 +172,11 @@ class GroupByTransform(DataFrameOperand, DataFrameOperandMixin):
             result = grouped.agg(op.func, *op.args, **op.kwds)
         else:
             result = grouped.transform(op.func, *op.args, **op.kwds)
+
+        if result.ndim == 2:
+            result = result.astype(op.outputs[0].dtypes, copy=False)
+        else:
+            result = result.astype(op.outputs[0].dtype, copy=False)
         ctx[op.outputs[0].key] = result
 
 

--- a/mars/dataframe/groupby/transform.py
+++ b/mars/dataframe/groupby/transform.py
@@ -136,12 +136,16 @@ class GroupByTransform(DataFrameOperand, DataFrameOperandMixin):
                     columns_value=out_df.columns_value, index_value=out_df.index_value))
             else:
                 chunks.append(new_op.new_chunk(
-                    inp_chunks, name=out_df.name, index=c.index, shape=(np.nan,), dtype=out_df.dtype,
+                    inp_chunks, name=out_df.name, index=(c.index[0],), shape=(np.nan,), dtype=out_df.dtype,
                     index_value=out_df.index_value))
 
         new_op = op.copy().reset_key()
         kw = out_df.params.copy()
         kw['chunks'] = chunks
+        if op.object_type == ObjectType.dataframe:
+            kw['nsplits'] = ((np.nan,) * len(chunks), (len(out_df.dtypes),))
+        else:
+            kw['nsplits'] = ((np.nan,) * len(chunks),)
         return new_op.new_tileables([in_groupby], **kw)
 
     @classmethod

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -315,7 +315,9 @@ class DataFrameIndex(DataFrameOperand, DataFrameOperandMixin):
                                                    columns_value=in_chunk.columns_value)
                     out_chunks.append(out_chunk)
 
-            nsplits = ((np.nan,) * in_df.chunk_shape[0], in_df.nsplits[1])
+        nsplits_on_columns = tuple(c.shape[1] for c in out_chunks if c.index[0] == 0)
+        row_chunk_num = len([c.shape[0] for c in out_chunks if c.index[1] == 0])
+        nsplits = ((np.nan,) * row_chunk_num, nsplits_on_columns)
 
         new_op = op.copy()
         return new_op.new_dataframes(op.inputs, shape=out_df.shape, dtypes=out_df.dtypes,

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -300,6 +300,7 @@ class DataFrameIndex(DataFrameOperand, DataFrameOperandMixin):
                                                             columns_value=df_chunk.columns_value)
                 out_chunks.append(out_chunk)
 
+            nsplits = ((np.nan,) * len(nsplits[0]), nsplits[1])
         else:
             check_chunks_unknown_shape([in_df], TilesError)
             nsplits_acc = np.cumsum((0,) + in_df.nsplits[0])

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -149,6 +149,7 @@ class SeriesIndex(DataFrameOperand, DataFrameOperandMixin):
 
         concat_op = DataFrameConcat(object_type=ObjectType.series)
         kw = {'name': out_series.name} if hasattr(out_series, 'name') else {}
+        kw['index'] = (0,)
         chk = concat_op.new_chunk(chunks, dtype=chunks[0].dtype, **kw)
         index_op = SeriesIndex(labels=op.labels)
         chunk = index_op.new_chunk([chk], dtype=chk.dtype, **kw)

--- a/mars/dataframe/indexing/index_lib.py
+++ b/mars/dataframe/indexing/index_lib.py
@@ -389,7 +389,11 @@ class LabelIndexHandler(IndexHandler):
         # thus chunks cannot have unknown shape on this axis
         tileable = context.tileable
         input_axis = index_info.input_axis
-        index_value = [tileable.index_value, tileable.columns_value][input_axis]
+        if tileable.ndim == 1:
+            index_value = tileable.index_value
+        else:
+            index_value = [tileable.index_value, tileable.columns_value][input_axis]
+
         if index_value.has_value():
             if any(np.isnan(ns) for ns in tileable.nsplits[input_axis]):
                 raise TilesError('Input tileable {} has chunks with unknown shape '
@@ -400,7 +404,10 @@ class LabelIndexHandler(IndexHandler):
                 context: IndexHandlerContext) -> None:
         tileable = context.tileable
         input_axis = index_info.input_axis
-        index_value = [tileable.index_value, tileable.columns_value][input_axis]
+        if tileable.ndim == 1:
+            index_value = tileable.index_value
+        else:
+            index_value = [tileable.index_value, tileable.columns_value][input_axis]
 
         if index_value.has_value():
             pd_index = index_value.to_pandas()
@@ -637,8 +644,8 @@ class NDArrayFancyIndexHandler(_FancyIndexHandler):
             new_out_chunks.append(reorder_chunk)
 
         new_nsplits = list(nsplits)
-        for ax, fancy_index in zip(to_concat_axes, fancy_indexes):
-            new_nsplits[ax] = (fancy_index.raw_index.shape[0],)
+        for fancy_index in fancy_indexes:
+            new_nsplits[fancy_index.output_axis] = (fancy_index.raw_index.shape[0],)
         context.out_chunks = new_out_chunks
         context.out_nsplits = new_nsplits
 
@@ -803,6 +810,7 @@ class LabelNDArrayFancyIndexHandler(_LabelFancyIndexHandler):
 
         axis = index_info.output_axis
         new_out_chunks = []
+        chunk_axis_shapes = dict()
         for chunk_index in itertools.product(*(range(len(ns)) for ax, ns in enumerate(nsplits)
                                                if ax != axis)):
             to_concat_chunks = []
@@ -825,22 +833,33 @@ class LabelNDArrayFancyIndexHandler(_LabelFancyIndexHandler):
                     del params['dtypes']
                     if getattr(context.op.outputs[0], 'name', None) is not None:
                         params['name'] = context.op.outputs[0].name
-                if context.op.outputs[0].ndim == 0:
-                    del params['index_value']
+                if len(params['index']) == chunks[0].ndim:
+                    index = list(params['index'])
+                    index.pop(index_info.output_axis)
+                    params['index'] = tuple(index)
                     shape = list(params['shape'])
                     shape.pop(index_info.output_axis)
                     params['shape'] = tuple(shape)
+                if context.op.outputs[0].ndim == 0:
+                    del params['index_value']
             elif axis == 0:
                 params['index_value'] = parse_index(pd.Index(index_info.raw_index), store_data=False)
             else:
                 params['dtypes'] = dtypes = concat_chunk.dtypes.loc[index_info.raw_index]
                 params['columns_value'] = parse_index(dtypes.index, store_data=True)
+                shape = list(params['shape'])
+                shape[1] = len(dtypes)
             chunk_op._indexes = indexes
             out_chunk = chunk_op.new_chunk([concat_chunk], kws=[params])
+            if len(out_chunk.shape) != 0:
+                chunk_axis_shapes[out_chunk.index[axis]] = out_chunk.shape[axis]
             new_out_chunks.append(out_chunk)
 
         new_nsplits = list(nsplits)
-        new_nsplits[axis] = (len(index_info.raw_index),)
+        if np.isscalar(index_info.raw_index):
+            new_nsplits = new_nsplits[:axis] + new_nsplits[axis + 1:]
+        else:
+            new_nsplits[axis] = (sum(chunk_axis_shapes.values()),)
         context.out_chunks = new_out_chunks
         context.out_nsplits = new_nsplits
 

--- a/mars/dataframe/indexing/index_lib.py
+++ b/mars/dataframe/indexing/index_lib.py
@@ -568,7 +568,7 @@ class NDArrayFancyIndexHandler(_FancyIndexHandler):
         chunk_index_to_info = context.chunk_index_to_info.copy()
         for chunk_index, chunk_index_info in chunk_index_to_info.items():
             i = chunk_index[index_info.input_axis]
-            fancy_index_array = chunk_index_to_fancy_index_arrays[i,][0]
+            fancy_index_array = chunk_index_to_fancy_index_arrays[i, ][0]
 
             if fancy_index_array.size == 0:
                 # not effected

--- a/mars/dataframe/indexing/set_index.py
+++ b/mars/dataframe/indexing/set_index.py
@@ -94,10 +94,14 @@ class DataFrameSetIndex(DataFrameOperand, DataFrameOperandMixin):
                 out_chunks.append(out_chunk)
 
         new_op = op.copy()
+        columns_nsplits = list(in_df.nsplits[1])
+        if op.drop:
+            columns_nsplits = tuple(split - 1 if i == 0 else split for i, split in enumerate(columns_nsplits))
+        nsplits = (in_df.nsplits[0], columns_nsplits)
         return new_op.new_dataframes(op.inputs, out_df.shape, dtypes=out_df.dtypes,
                                      index_value=out_df.index_value,
                                      columns_value=out_df.columns_value,
-                                     chunks=out_chunks, nsplits=in_df.nsplits)
+                                     chunks=out_chunks, nsplits=nsplits)
 
     @classmethod
     def execute(cls, ctx, op):

--- a/mars/dataframe/indexing/tests/test_indexing.py
+++ b/mars/dataframe/indexing/tests/test_indexing.py
@@ -50,7 +50,7 @@ class Test(TestBase):
 
         # index cannot be tuple
         with self.assertRaises(IndexingError):
-            _ = df2.iloc[(1,),]
+            _ = df2.iloc[(1,), ]
 
         # index wrong type
         with self.assertRaises(TypeError):
@@ -327,9 +327,9 @@ class Test(TestBase):
         self.assertEqual(series.shape, (10,))
         self.assertEqual(len(series.chunks), 4)
 
-        self.assertEqual(series.chunks[0].op.indexes, [slice(None, None, None),])
+        self.assertEqual(series.chunks[0].op.indexes, [slice(None, None, None), ])
         self.assertEqual(series.chunks[0].op.value, 2)
-        self.assertEqual(series.chunks[1].op.indexes, [slice(0, 1, 1),])
+        self.assertEqual(series.chunks[1].op.indexes, [slice(0, 1, 1), ])
         self.assertEqual(series.chunks[1].op.value, 2)
 
         # fancy index

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -309,7 +309,7 @@ class Test(TestBase):
         # label-based fancy index on index
         # whose index_value does not have value
         df = df1.loc[['a3', 'a1'], ['b', 'a', 'd']]
-        result = self.executor.execute_dataframe(df, concat=True)[0]
+        result = self.executor.execute_dataframe(df, concat=True, check_nsplits=False)[0]
         expected = raw1.loc[['a3', 'a1'], ['b', 'a', 'd']]
         pd.testing.assert_frame_equal(result, expected)
 

--- a/mars/dataframe/merge/concat.py
+++ b/mars/dataframe/merge/concat.py
@@ -138,10 +138,12 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
             for c in series.chunks:
                 if op.axis == 0:
                     index = (c.index[0] + cum_index,)
+                    shape = c.shape
                 else:
                     index = (c.index[0], cum_index)
+                    shape = (c.shape[0], 1)
                 iloc_op = SeriesIlocGetItem(indexes=(slice(None),))
-                out_chunks.append(iloc_op.new_chunk([c], shape=c.shape, index=index,
+                out_chunks.append(iloc_op.new_chunk([c], shape=shape, index=index,
                                                     index_value=c.index_value,
                                                     dtype=c.dtype,
                                                     name=c.name))

--- a/mars/dataframe/operands.py
+++ b/mars/dataframe/operands.py
@@ -17,7 +17,6 @@ from collections import OrderedDict
 from enum import Enum
 from functools import reduce
 
-import numpy as np
 import pandas as pd
 
 from .core import DATAFRAME_CHUNK_TYPE, SERIES_CHUNK_TYPE, INDEX_CHUNK_TYPE, \
@@ -148,15 +147,6 @@ class DataFrameOperandMixin(TileableOperandMixin):
             raise TypeError('cannot new tensor with more than 1 outputs')
 
         return self.new_scalars(inputs, dtype=dtype, **kw)[0]
-
-    @staticmethod
-    def _merge_shape(*shapes):
-        ret = [np.nan] * len(shapes[0])
-        for shape in shapes:
-            for i, s in enumerate(shape):
-                if np.isnan(ret[i]) and not np.isnan(s):
-                    ret[i] = s
-        return tuple(ret)
 
     @classmethod
     def concat_tileable_chunks(cls, tileable):

--- a/mars/dataframe/operands.py
+++ b/mars/dataframe/operands.py
@@ -132,7 +132,7 @@ class DataFrameOperandMixin(TileableOperandMixin):
                                   output_limit=output_limit, kws=kws, **kw)
 
     def new_index(self, inputs, shape=None, dtype=None, index_value=None, name=None, **kw):
-        if getattr(self, 'output_limit') !=  1:
+        if getattr(self, 'output_limit') != 1:
             raise TypeError('cannot new Index with more than 1 outputs')
 
         return self.new_indexes(inputs, shape=shape, dtype=dtype,

--- a/mars/dataframe/reduction/core.py
+++ b/mars/dataframe/reduction/core.py
@@ -120,7 +120,7 @@ class DataFrameReductionMixin(DataFrameOperandMixin):
         chunk_params['shape'] = df.shape
         chunk_params['index'] = chk.index
         if op.object_type == ObjectType.series:
-            chunk_params.update(dict(dtype=df.dtype, index_value=df.index_value))
+            chunk_params.update(dict(dtype=df.dtype, index_value=df.index_value, index=(0,)))
         elif op.object_type == ObjectType.dataframe:
             chunk_params.update(dict(dtypes=df.dtypes, index_value=df.index_value,
                                      columns_value=df.columns_value))

--- a/mars/dataframe/statistics/tests/test_statistics_execute.py
+++ b/mars/dataframe/statistics/tests/test_statistics_execute.py
@@ -140,8 +140,7 @@ class Test(unittest.TestCase):
                              'b': np.random.randint(1000, size=10),
                              'c': np.random.rand(10),
                              'd': [pd.Timestamp('201{}'.format(i)) for i in range(10)],
-                            },
-                           index=pd.RangeIndex(1, 11))
+                             }, index=pd.RangeIndex(1, 11))
         df2 = DataFrame(raw2, chunk_size=3)
 
         r = df2.quantile([0.3, 0.7], numeric_only=False)

--- a/mars/dataframe/window/rolling/aggregation.py
+++ b/mars/dataframe/window/rolling/aggregation.py
@@ -379,7 +379,7 @@ class DataFrameRollingAgg(DataFrameOperand, DataFrameOperandMixin):
         if input_ndim == 1 and output_ndim == 2:
             nsplits.append((out.shape[1],))
         elif input_ndim == 2 and output_ndim == 2:
-            nsplits[1] = (out.shape[1],)
+            nsplits[1 - op.axis] = (out.shape[1 - op.axis],)
         params['nsplits'] = tuple(nsplits)
         new_op = op.copy()
         return new_op.new_tileables([inp], kws=[params])

--- a/mars/dataframe/window/rolling/tests/test_rolling_execute.py
+++ b/mars/dataframe/window/rolling/tests/test_rolling_execute.py
@@ -83,7 +83,7 @@ class Test(TestBase):
         # test axis=1
         df2 = dfs[1].rolling(3, axis=1).agg('sum')
 
-        result = self.executor.execute_dataframe(df2, concat=True)[0]
+        result = self.executor.execute_dataframe(df2, concat=True, check_nsplits=False)[0]
         expected = raw.rolling(3, axis=1).agg('sum')
         pd.testing.assert_frame_equal(result, expected)
 

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -26,15 +26,6 @@ from enum import Enum
 from numbers import Integral
 
 import numpy as np
-try:
-    from numpy.core._exceptions import UFuncTypeError
-except ImportError:  # pragma: no cover
-    UFuncTypeError = None
-
-try:
-    import gevent
-except ImportError:  # pragma: no cover
-    gevent = None
 
 from .operands import Fetch, ShuffleProxy
 from .graph import DirectedGraph
@@ -46,6 +37,16 @@ from .graph_builder import TileableGraphBuilder
 from .context import LocalContext
 from .utils import kernel_mode, enter_build_mode, build_fetch, calc_nsplits,\
     has_unknown_shape
+
+try:
+    from numpy.core._exceptions import UFuncTypeError
+except ImportError:  # pragma: no cover
+    UFuncTypeError = None
+
+try:
+    import gevent
+except ImportError:  # pragma: no cover
+    gevent = None
 
 if gevent:
     from .actors.pool.gevent_pool import GeventThreadPool

--- a/mars/learn/contrib/pytorch/dataset.py
+++ b/mars/learn/contrib/pytorch/dataset.py
@@ -71,5 +71,3 @@ def enter_mars_context():
     scheduler = os.environ['MARS_SCHEDULER']
     session_id = os.environ['MARS_SESSION']
     return DistributedContext(scheduler_address=scheduler, session_id=session_id)
-
-

--- a/mars/learn/metrics/pairwise/euclidean.py
+++ b/mars/learn/metrics/pairwise/euclidean.py
@@ -100,7 +100,7 @@ class EuclideanDistances(PairwiseDistances):
                 raise ValueError(
                     "Incompatible dimensions for Y and Y_norm_squared")
             if YY.dtype == np.float32:
-                YY =  self._y_norm_squared = None
+                YY = self._y_norm_squared = None
         else:
             YY = None
 

--- a/mars/learn/metrics/pairwise/tests/test_manhattan_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_manhattan_distances.py
@@ -45,7 +45,7 @@ class Test(unittest.TestCase):
 
         d = manhattan_distances(x, y, sum_over_features=True)
         self.assertEqual(d.shape, (10, 11))
-        d =manhattan_distances(x, y, sum_over_features=False)
+        d = manhattan_distances(x, y, sum_over_features=False)
         self.assertEqual(d.shape, (110, 3))
 
     def testManhattanDistancesExecution(self):

--- a/mars/learn/metrics/pairwise/tests/test_pariwise_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_pariwise_distances.py
@@ -48,7 +48,7 @@ class Test(unittest.TestCase):
 
         # test precomputed
         d2 = d.copy()
-        d2[0, 0 ] = -1
+        d2[0, 0] = -1
         d2 = pairwise_distances(d2, y, metric='precomputed')
         with self.assertRaises(ValueError):
             _ = self.executor.execute_tensor(d2, concat=True)[0]

--- a/mars/scheduler/api.py
+++ b/mars/scheduler/api.py
@@ -36,11 +36,11 @@ class MetaAPI:
         sess_ref = self._get_session_ref(session_id)
         return sess_ref.get_tileable_key(name)
 
-    def get_tileable_metas(self, session_id, tileable_keys, filter_fields: List[str]=None) -> List:
+    def get_tileable_metas(self, session_id, tileable_keys, filter_fields: List[str] = None) -> List:
         session_ref = self._get_session_ref(session_id)
         graph_ref = self._actor_ctx.actor_ref(session_ref.get_graph_ref_by_tileable_key(tileable_keys[0]))
         return graph_ref.get_tileable_metas(tileable_keys, filter_fields=filter_fields)
 
-    def get_chunk_metas(self, session_id, chunk_keys, filter_fields: List[str]=None) -> List:
+    def get_chunk_metas(self, session_id, chunk_keys, filter_fields: List[str] = None) -> List:
         return self._chunk_meta_client.batch_get_chunk_meta(
             session_id, chunk_keys, filter_fields=filter_fields)

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -413,4 +413,3 @@ class Test(SchedulerIntegratedTest):
 
         state = self.wait_for_termination(actor_client, session_ref, graph_key)
         self.assertEqual(state, GraphState.SUCCEEDED)
-

--- a/mars/tensor/base/copyto.py
+++ b/mars/tensor/base/copyto.py
@@ -96,7 +96,7 @@ class TensorCopyTo(TensorOperand, TensorOperandMixin):
         if not np.can_cast(src.dtype, dst.dtype, casting=self.casting):
             raise TypeError('Cannot cast array from {0!r} to {1!r} '
                             'according to the rule {2!s}'.format(
-                src.dtype, dst.dtype, self.casting))
+                                src.dtype, dst.dtype, self.casting))
 
         try:
             broadcast_to(src, dst.shape)

--- a/mars/tensor/base/repeat.py
+++ b/mars/tensor/base/repeat.py
@@ -132,7 +132,7 @@ class TensorRepeat(TensorHasInput, TensorOperandMixin):
                 rp = repeats[start: stop]
                 size = rp.sum()
             elif not isinstance(repeats, Integral):
-                rp = repeats.cix[ax_idx,]
+                rp = repeats.cix[ax_idx, ]
                 size = np.nan
             else:
                 rp = repeats

--- a/mars/tensor/base/topk.py
+++ b/mars/tensor/base/topk.py
@@ -296,7 +296,7 @@ class TensorTopk(TensorOperand, TensorOperandMixin):
 
         new_op = op.copy()
         nsplits = list(a.nsplits)
-        nsplits[axis] = (op.k,)
+        nsplits[axis] = (min(a.shape[axis], op.k),)
         kws = [out.params for out in op.outputs]
         if return_value:
             kws[0]['nsplits'] = nsplits

--- a/mars/tensor/base/topk.py
+++ b/mars/tensor/base/topk.py
@@ -134,7 +134,7 @@ class TensorTopk(TensorOperand, TensorOperandMixin):
 
     @classmethod
     def _tile_one_chunk(cls, op):
-        return_value, return_indices = op.return_value ,op.return_indices
+        return_value, return_indices = op.return_value, op.return_indices
         out = op.outputs[0]
         chunk_op = op.copy().reset_key()
         kws = []

--- a/mars/tensor/base/topk.py
+++ b/mars/tensor/base/topk.py
@@ -226,7 +226,7 @@ class TensorTopk(TensorOperand, TensorOperandMixin):
             kws = []
             if op.return_value:
                 kws.append({
-                    'shape': shape,
+                    'shape': tuple(shape),
                     'order': input_chunk.order,
                     'dtype': input_chunk.dtype,
                     'index': chunk_index,
@@ -234,7 +234,7 @@ class TensorTopk(TensorOperand, TensorOperandMixin):
                 })
             if op.return_indices:
                 kws.append({
-                    'shape': shape,
+                    'shape': tuple(shape),
                     'order': TensorOrder.C_ORDER,
                     'dtype': np.dtype(np.int64),
                     'index': chunk_index,

--- a/mars/tensor/datastore/core.py
+++ b/mars/tensor/datastore/core.py
@@ -49,4 +49,4 @@ class TensorDataStore(TensorHasInput, TensorOperandMixin):
         new_op = op.copy()
         return new_op.new_tensors(op.inputs, op.outputs[0].shape,
                                   chunks=out_chunks,
-                                  nsplits=((0,) * len(ns) for ns in in_tensor.nsplits))
+                                  nsplits=((0,) for _ in range(in_tensor.ndim)))

--- a/mars/tensor/einsum/einsumfunc.py
+++ b/mars/tensor/einsum/einsumfunc.py
@@ -64,6 +64,7 @@ def _flop_count(idx_contraction, inner, num_terms, size_dictionary):
 
     return overall_size * op_factor
 
+
 def _compute_size_by_dict(indices, idx_dict):
     """
     Computes the product of the elements in indices based on the dictionary
@@ -203,7 +204,7 @@ def _optimal_path(input_sets, output_set, idx_dict, memory_limit):
                     continue
 
                 # Build (total_cost, positions, indices_remaining)
-                total_cost =  cost + _flop_count(idx_contract, idx_removed, len(con), idx_dict)
+                total_cost = cost + _flop_count(idx_contract, idx_removed, len(con), idx_dict)
                 new_pos = positions + [con]
                 iter_results.append((total_cost, new_pos, new_input_sets))
 
@@ -222,6 +223,7 @@ def _optimal_path(input_sets, output_set, idx_dict, memory_limit):
 
     path = min(full_results, key=lambda x: x[0])[1]
     return path
+
 
 def _parse_possible_contraction(positions, input_sets, output_set, idx_dict, memory_limit, path_cost, naive_cost):
     """Compute the cost (removed size + flops) and resultant indices for
@@ -319,6 +321,7 @@ def _update_other_results(results, best):
         mod_results.append((cost, mod_con, con_sets))
 
     return mod_results
+
 
 def _greedy_path(input_sets, output_set, idx_dict, memory_limit):
     """
@@ -573,7 +576,7 @@ def parse_einsum_input(operands):
             if s not in einsum_symbols:
                 raise ValueError("Character %s is not a valid symbol." % s)
 
-    else: # pragma: no cover
+    else:  # pragma: no cover
         tmp_operands = list(operands)
         operand_list = []
         subscript_list = []
@@ -980,7 +983,7 @@ def einsum_path(*operands, **kwargs):
     speedup = naive_cost / opt_cost
     max_i = max(size_list)
 
-    path_print  = "  Complete contraction:  %s\n" % overall_contraction
+    path_print  = "  Complete contraction:  %s\n" % overall_contraction  # noqa: E221
     path_print += "         Naive scaling:  %d\n" % len(indices)
     path_print += "     Optimized scaling:  %d\n" % max(scale_list)
     path_print += "      Naive FLOP count:  %.3e\n" % naive_cost

--- a/mars/tensor/einsum/tests/test_einsum.py
+++ b/mars/tensor/einsum/tests/test_einsum.py
@@ -66,4 +66,3 @@ class Test(TestBase):
 
         t = t.tiles()
         self.assertEqual(len(t.chunks), 3)
-

--- a/mars/tensor/images/imread.py
+++ b/mars/tensor/images/imread.py
@@ -62,7 +62,7 @@ class TensorImread(TensorOperand, TensorOperandMixin):
             nsplits = (tuple(splits),) + tuple((s,) for s in out_shape[1:])
         else:
             chunk_op = op.copy().reset_key()
-            chunks = [chunk_op.new_chunk(None, shape=out_shape)]
+            chunks = [chunk_op.new_chunk(None, shape=out_shape, index=(0,) * len(out_shape))]
             nsplits = tuple((s,) for s in out_shape)
         new_op = op.copy()
         return new_op.new_tensors(None, shape=out_shape, chunks=chunks, nsplits=nsplits)

--- a/mars/tensor/indexing/index_lib.py
+++ b/mars/tensor/indexing/index_lib.py
@@ -574,7 +574,6 @@ class NDArrayFancyIndexHandler(_FancyIndexHandler):
                                                     processed_index=fancy_index_array,
                                                     output_shape=output_axis_shape))
 
-
     @classmethod
     def need_postprocess(cls, context: IndexHandlerContext) -> bool:
         fancy_indexes = context.get_indexes(IndexType.fancy_index)
@@ -632,8 +631,8 @@ class NDArrayFancyIndexHandler(_FancyIndexHandler):
                                                        order=TensorOrder.C_ORDER)
             new_out_chunks.append(reorder_chunk)
 
-        new_nsplits = nsplits[:to_concat_axis] + tuple((s,) for s in fancy_index_shape) + \
-                      nsplits[to_concat_axis + 1:]
+        new_nsplits = nsplits[:to_concat_axis] + tuple((s,) for s in fancy_index_shape) \
+            + nsplits[to_concat_axis + 1:]
         context.out_chunks = new_out_chunks
         context.out_nsplits = new_nsplits
 

--- a/mars/tensor/random/permutation.py
+++ b/mars/tensor/random/permutation.py
@@ -125,7 +125,7 @@ class TensorPermutation(TensorRandomMapReduceOperand, TensorOperandMixin):
 
         new_op = op.copy()
         nsplits = list(in_tensor.nsplits)
-        nsplits[op.axis] = [np.nan,] * len(nsplits[op.axis])
+        nsplits[op.axis] = [np.nan, ] * len(nsplits[op.axis])
         return new_op.new_tensors(op.inputs, out_tensor.shape, order=out_tensor.order,
                                   chunks=reduce_chunks, nsplits=nsplits)
 

--- a/mars/tensor/random/permutation.py
+++ b/mars/tensor/random/permutation.py
@@ -125,7 +125,7 @@ class TensorPermutation(TensorRandomMapReduceOperand, TensorOperandMixin):
 
         new_op = op.copy()
         nsplits = list(in_tensor.nsplits)
-        nsplits[0] = [np.nan, ] * len(nsplits[0])
+        nsplits[op.axis] = [np.nan,] * len(nsplits[op.axis])
         return new_op.new_tensors(op.inputs, out_tensor.shape, order=out_tensor.order,
                                   chunks=reduce_chunks, nsplits=nsplits)
 

--- a/mars/tensor/spatial/distance/cdist.py
+++ b/mars/tensor/spatial/distance/cdist.py
@@ -99,7 +99,7 @@ class TensorCdist(TensorOperand, TensorOperandMixin):
             if val is not None:
                 chunk_inputs.append(val.chunks[0])
         chunk = chunk_op.new_chunk(chunk_inputs, shape=out_tensor.shape,
-                                   order=out_tensor.order)
+                                   order=out_tensor.order, index=(0,) * out_tensor.ndim)
 
         new_op = op.copy()
         return new_op.new_tensors(op.inputs, shape=out_tensor.shape,

--- a/mars/tensor/spatial/distance/pdist.py
+++ b/mars/tensor/spatial/distance/pdist.py
@@ -141,7 +141,7 @@ class TensorPdist(TensorMapReduceOperand, TensorOperandMixin):
             if val is not None:
                 chunk_inputs.append(val.chunks[0])
         chunk = chunk_op.new_chunk(chunk_inputs, shape=out_tensor.shape,
-                                   order=out_tensor.order)
+                                   order=out_tensor.order, index=(0,) * out_tensor.ndim)
 
         new_op = op.copy()
         return new_op.new_tensors(op.inputs, shape=out_tensor.shape,

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -522,13 +522,14 @@ class ExecutorForTest(MarsObjectCheckMixin, Executor):
         return super().execute_graph(graph, keys, **kw)
 
     def execute_tileable(self, tileable, *args, **kwargs):
+        from mars.core import OBJECT_TYPE
         from mars.dataframe.core import GROUPBY_TYPE
         self._extract_check_options(kwargs)
 
         result = super().execute_tileable(tileable, *args, **kwargs)
 
         # fixme with ISSUE:1036
-        if not isinstance(tileable, GROUPBY_TYPE):
+        if not isinstance(tileable, (GROUPBY_TYPE, OBJECT_TYPE)):
             if _check_options['check_nsplits']:
                 self._check_nsplits(tileable)
 

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -493,8 +493,8 @@ class ExecutorForTest(MarsObjectCheckMixin, Executor):
         try:
             self.assert_shape_consistent(nsplit_shape, tiled.shape)
         except AssertionError:
-            raise AssertionError('Operand %r: shape computed from nsplits %r not consistent with real shape %r'
-                                 % (tiled.op, nsplit_shape, tiled.shape)) from None
+            raise AssertionError('Operand %r: shape computed from nsplits %r -> %r not consistent with real shape %r'
+                                 % (tiled.op, tiled.nsplits, nsplit_shape, tiled.shape)) from None
 
         for c in tiled.chunks:
             try:

--- a/mars/worker/api.py
+++ b/mars/worker/api.py
@@ -22,8 +22,8 @@ class WorkerAPI:
     def __init__(self, actor_ctx=None):
         self._actor_context = actor_ctx or new_client()
 
-    def get_chunks_data(self, session_id, worker: str, chunk_keys: List[str], indexes: List=None,
-                        compression_types: List[str]=None):
+    def get_chunks_data(self, session_id, worker: str, chunk_keys: List[str], indexes: List = None,
+                        compression_types: List[str] = None):
         """
         Fetch chunks data from a specified worker.
         :param session_id: session_id


### PR DESCRIPTION
## What do these changes do?

Check if tileable.nsplits and chunk.shape is consistent.

Known issues:

* [x] mars/tensor/base/tests/test_base_execute.py::Test::testTopkExecution
* [x] mars/tensor/datastore/tests/test_datastore_execute.py::Test::testStoreTileDBExecution
* [x] mars/tensor/random/tests/test_random_execute.py::Test::testPermutationExecute
* [x] mars/dataframe/arithmetic/tests/test_arithmetic.py::TestBinary::testDataFrameAndSeriesIdentical
* [x] mars/dataframe/arithmetic/tests/test_arithmetic.py::TestBinary::testIdenticalIndexAndColumns
* [x] mars/dataframe/arithmetic/tests/test_arithmetic.py::TestBinary::testSeriesAndSeriesIdentical
* [x] mars/dataframe/base/tests/test_base_execution.py::Test::testDataFrameFillNAExecution
* [x] mars/dataframe/base/tests/test_base_execution.py::Test::testResetIndexExecution
* [x] mars/dataframe/base/tests/test_base_execution.py::Test::testStringMethodExecution
* [x] mars/dataframe/datasource/tests/test_datasource_execution.py::Test::testDateRangeExecution
* [x] mars/dataframe/datasource/tests/test_datasource_execution.py::Test::testIndexExecution
* [x] mars/dataframe/indexing/tests/test_indexing_execution.py::Test::testAt
* [x] mars/dataframe/indexing/tests/test_indexing_execution.py::Test::testDataFrameGetitemBool
* [x] mars/dataframe/indexing/tests/test_indexing_execution.py::Test::testILocGetItem
* [x] mars/dataframe/indexing/tests/test_indexing_execution.py::Test::testLocGetItem
* [x] mars/dataframe/indexing/tests/test_indexing_execution.py::Test::testSetIndex
* [x] mars/dataframe/merge/tests/test_merge_execution.py::Test::testConcat
* [x] mars/dataframe/window/rolling/tests/test_rolling_execute.py::Test::testRollingAggExecution

## Related issue number

NA