### PR TITLE
Support `md.merge` when `on` column is in df.index

### DIFF
--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -187,17 +187,17 @@ class _DataFrameMergeBase(DataFrameOperand, DataFrameOperandMixin):
     @staticmethod
     def _make_data(obj):
         empty_df = build_empty_df(obj.dtypes, index=obj.index_value.to_pandas()[:0])
+        dtypes = empty_df.dtypes
         record = [_DataFrameMergeBase._make_value(dtype) for dtype in empty_df.dtypes]
         if isinstance(empty_df.index, pd.MultiIndex):
             index = tuple(_DataFrameMergeBase._make_value(level.dtype)
                           for level in empty_df.index.levels)
-            dtypes = empty_df.dtypes
             empty_df.loc[index,] = record
-            # make sure dtypes correct for MultiIndex
-            empty_df = empty_df.astype(dtypes, copy=False)
         else:
             index = _DataFrameMergeBase._make_value(empty_df.index.dtype)
             empty_df.loc[index] = record
+        # make sure dtypes correct for MultiIndex
+        empty_df = empty_df.astype(dtypes, copy=False)
         return empty_df
 
     def __call__(self, left, right):

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -60,8 +60,22 @@ class DataFrameMergeAlign(DataFrameMapReduceOperand, DataFrameOperandMixin):
     def execute_map(cls, ctx, op):
         chunk = op.outputs[0]
         df = ctx[op.inputs[0].key]
+        shuffle_on = op.shuffle_on
 
-        filters = hash_dataframe_on(df, op.shuffle_on, op.index_shuffle_size)
+        if shuffle_on is not None:
+            # shuffle on field may be resident in index
+            to_reset_index_names = []
+            if not isinstance(shuffle_on, (list, tuple)):
+                if shuffle_on not in df.dtypes:
+                    to_reset_index_names.append(shuffle_on)
+            else:
+                for son in shuffle_on:
+                    if son not in df.dtypes:
+                        to_reset_index_names.append(shuffle_on)
+            if len(to_reset_index_names) > 0:
+                df = df.reset_index(to_reset_index_names)
+
+        filters = hash_dataframe_on(df, shuffle_on, op.index_shuffle_size)
 
         # shuffle on index
         for index_idx, index_filter in enumerate(filters):
@@ -159,15 +173,35 @@ class _DataFrameMergeBase(DataFrameOperand, DataFrameOperandMixin):
     def validate(self):
         return self._validate
 
+    @staticmethod
+    def _make_value(dtype):
+        # special handle for datetime64 and timedelta64
+        dispatch = {
+            np.datetime64: pd.Timestamp,
+            np.timedelta64: pd.Timedelta,
+        }
+        # otherwise, just use dtype.type itself to convert
+        convert = dispatch.get(dtype.type, dtype.type)
+        return convert(1)
+
+    @staticmethod
+    def _make_data(obj):
+        empty_df = build_empty_df(obj.dtypes, index=obj.index_value.to_pandas()[:0])
+        record = [_DataFrameMergeBase._make_value(dtype) for dtype in empty_df.dtypes]
+        if isinstance(empty_df.index, pd.MultiIndex):
+            index = tuple(_DataFrameMergeBase._make_value(level.dtype)
+                          for level in empty_df.index.levels)
+            dtypes = empty_df.dtypes
+            empty_df.loc[index,] = record
+            # make sure dtypes correct for MultiIndex
+            empty_df = empty_df.astype(dtypes, copy=False)
+        else:
+            index = _DataFrameMergeBase._make_value(empty_df.index.dtype)
+            empty_df.loc[index] = record
+        return empty_df
+
     def __call__(self, left, right):
-        empty_left, empty_right = build_empty_df(left.dtypes), build_empty_df(right.dtypes)
-        # left should have values to keep columns order.
-        gen_left_data = [np.random.rand(1).astype(dt)[0] for dt in left.dtypes]
-        empty_left = empty_left.append(pd.DataFrame([gen_left_data], columns=list(empty_left.columns))
-                                       .astype(left.dtypes))
-        gen_right_data = [np.random.rand(1).astype(dt)[0] for dt in right.dtypes]
-        empty_right = empty_right.append(pd.DataFrame([gen_right_data], columns=list(empty_right.columns))
-                                         .astype(right.dtypes))
+        empty_left, empty_right = self._make_data(left), self._make_data(right)
         # this `merge` will check whether the combination of those arguments is valid
         merged = empty_left.merge(empty_right, how=self.how, on=self.on,
                                   left_on=self.left_on, right_on=self.right_on,

--- a/mars/dataframe/merge/tests/test_merge_execution.py
+++ b/mars/dataframe/merge/tests/test_merge_execution.py
@@ -31,9 +31,15 @@ class Test(TestBase):
     def testMerge(self):
         df1 = pd.DataFrame(np.arange(20).reshape((4, 5)) + 1, columns=['a', 'b', 'c', 'd', 'e'])
         df2 = pd.DataFrame(np.arange(20).reshape((5, 4)) + 1, columns=['a', 'b', 'x', 'y'])
+        df3 = df1.copy()
+        df3.index = pd.RangeIndex(2, 6, name='index')
+        df4 = df1.copy()
+        df4.index = pd.MultiIndex.from_tuples([(i, i + 1) for i in range(4)], names=['i1', 'i2'])
 
         mdf1 = from_pandas(df1, chunk_size=2)
         mdf2 = from_pandas(df2, chunk_size=2)
+        mdf3 = from_pandas(df3, chunk_size=3)
+        mdf4 = from_pandas(df4, chunk_size=2)
 
         # Note [Index of Merge]
         #
@@ -87,6 +93,24 @@ class Test(TestBase):
         jdf5 = mdf1.merge(mdf2, how='inner', on=['a', 'b'])
         result5 = self.executor.execute_dataframe(jdf5, concat=True)[0]
         pd.testing.assert_frame_equal(sort_dataframe_inplace(expected5, 0), sort_dataframe_inplace(result5, 0))
+
+        # merge when some on is index
+        expected6 = df3.merge(df2, how='inner', left_on='index', right_on='a')
+        jdf6 = mdf3.merge(mdf2, how='inner', left_on='index', right_on='a')
+        result6 = self.executor.execute_dataframe(jdf6, concat=True)[0]
+        pd.testing.assert_frame_equal(sort_dataframe_inplace(expected6, 0), sort_dataframe_inplace(result6, 0))
+
+        # merge when on is in MultiIndex
+        expected7 = df4.merge(df2, how='inner', left_on='i1', right_on='a')
+        jdf7 = mdf4.merge(mdf2, how='inner', left_on='i1', right_on='a')
+        result7 = self.executor.execute_dataframe(jdf7, concat=True)[0]
+        pd.testing.assert_frame_equal(sort_dataframe_inplace(expected7, 0), sort_dataframe_inplace(result7, 0))
+
+        # merge when on is in MultiIndex, and on not in index
+        expected8 = df4.merge(df2, how='inner', on=['a', 'b'])
+        jdf8 = mdf4.merge(mdf2, how='inner', on=['a', 'b'])
+        result8 = self.executor.execute_dataframe(jdf8, concat=True)[0]
+        pd.testing.assert_frame_equal(sort_dataframe_inplace(expected8, 0), sort_dataframe_inplace(result8, 0))
 
     def testJoin(self):
         df1 = pd.DataFrame([[1, 3, 3], [4, 2, 6], [7, 8, 9]], index=['a1', 'a2', 'a3'])

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -392,7 +392,7 @@ def build_split_idx_to_origin_idx(splits, increase=True):
 
 def build_empty_df(dtypes, index=None):
     columns = dtypes.index
-    df = pd.DataFrame(columns=columns)
+    df = pd.DataFrame(columns=columns, index=index)
     for c, d in zip(columns, dtypes):
         df[c] = pd.Series(dtype=d, index=index)
     return df


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Support situation that `on` column is in df.index for `md.merge`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1110 .
