### PR TITLE
Fix tokenizing partial function

### DIFF
--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -116,7 +116,7 @@ cdef inline list iterative_tokenize(object ob):
         elif isinstance(x, set):
             dq.extend(sorted(x))
         elif isinstance(x, dict):
-            dq.extend(sorted(list(x.items())))
+            dq.extend(sorted(x.items()))
         else:
             h_list.append(tokenize_handler.tokenize(x))
     return h_list
@@ -212,7 +212,7 @@ cdef list tokenize_pandas_interval_arrays(ob):
 def tokenize_function(ob):
     if isinstance(ob, partial):
         args = iterative_tokenize(ob.args)
-        keywords = iterative_tokenize(ob.keywords) if ob.keywords else None
+        keywords = iterative_tokenize(ob.keywords.items()) if ob.keywords else None
         return tokenize_function(ob.func), args, keywords
     else:
         try:
@@ -244,7 +244,7 @@ for t in (list, tuple, dict, set):
     tokenize_handler.register(t, iterative_tokenize)
 
 tokenize_handler.register(np.ndarray, tokenize_numpy)
-tokenize_handler.register(dict, lambda ob: iterative_tokenize(sorted(list(ob.items()))))
+tokenize_handler.register(dict, lambda ob: iterative_tokenize(sorted(ob.items())))
 tokenize_handler.register(set, lambda ob: iterative_tokenize(sorted(ob)))
 tokenize_handler.register(np.random.RandomState, lambda ob: iterative_tokenize(ob.get_state()))
 tokenize_handler.register(Enum, lambda ob: iterative_tokenize((type(ob), ob.name)))

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -149,8 +149,10 @@ class Test(unittest.TestCase):
             return np.add(a, b)
         self.assertEqual(utils.tokenize(f), utils.tokenize(copy.deepcopy(f)))
 
-        partial_f = partial(f, 1)
+        partial_f = partial(f, 1, k=0)
+        partial_f2 = partial(f, 1, k=1)
         self.assertEqual(utils.tokenize(partial_f), utils.tokenize(copy.deepcopy(partial_f)))
+        self.assertNotEqual(utils.tokenize(partial_f), utils.tokenize(partial_f2))
 
     def testBuildTileableGraph(self):
         a = mt.ones((10, 10), chunk_size=8)


### PR DESCRIPTION
## What do these changes do?

Fix tokenizing partial function by extracting dict items directly.

## Related issue number

Fixes #1148 