### PR TITLE
Allow retrieving shape of a groupby object

### DIFF
--- a/mars/lib/groupby_wrapper.py
+++ b/mars/lib/groupby_wrapper.py
@@ -54,12 +54,12 @@ class GroupByWrapper:
         else:
             self.groupby_obj = groupby_obj
 
-        self.is_frame = isinstance(self.groupby_obj, DataFrameGroupBy)
-
         if grouper_cache:
             self.groupby_obj.grouper._cache = grouper_cache
         if selection:
             self.groupby_obj = self.groupby_obj[selection]
+
+        self.is_frame = isinstance(self.groupby_obj, DataFrameGroupBy)
 
     def __getitem__(self, item):
         return GroupByWrapper(
@@ -81,6 +81,13 @@ class GroupByWrapper:
     @property
     def empty(self):
         return self.obj.empty
+
+    @property
+    def shape(self):
+        shape = list(self.groupby_obj.obj.shape)
+        if self.is_frame and self.selection:
+            shape[1] = len(self.selection)
+        return tuple(shape)
 
     def to_tuple(self, truncate=False, pickle_function=False):
         if self.selection and truncate:

--- a/mars/lib/tests/test_lib.py
+++ b/mars/lib/tests/test_lib.py
@@ -33,45 +33,71 @@ class Test(unittest.TestCase):
 
         grouped = GroupByWrapper.from_tuple(wrapped_groupby(df, level=0).to_tuple())
         assert_groupby_equal(grouped, df.groupby(level=0))
+        self.assertEqual(grouped.shape, (8, 4))
+        self.assertTrue(grouped.is_frame)
 
         grouped = GroupByWrapper.from_tuple(wrapped_groupby(df, level=0).C.to_tuple())
         assert_groupby_equal(grouped, df.groupby(level=0).C)
+        self.assertEqual(grouped.shape, (8,))
+        self.assertFalse(grouped.is_frame)
 
         grouped = GroupByWrapper.from_tuple(wrapped_groupby(df, 'B').to_tuple())
         assert_groupby_equal(grouped, df.groupby('B'))
+        self.assertEqual(grouped.shape, (8, 4))
+        self.assertTrue(grouped.is_frame)
 
         grouped = GroupByWrapper.from_tuple(wrapped_groupby(df, 'B').C.to_tuple(truncate=True))
         assert_groupby_equal(grouped, df.groupby('B').C, with_selection=True)
+        self.assertEqual(grouped.shape, (8,))
+        self.assertFalse(grouped.is_frame)
 
         grouped = GroupByWrapper.from_tuple(wrapped_groupby(df, 'B')[['C', 'D']].to_tuple(truncate=True))
         assert_groupby_equal(grouped, df.groupby('B')[['C', 'D']], with_selection=True)
+        self.assertEqual(grouped.shape, (8, 2))
+        self.assertTrue(grouped.is_frame)
 
         grouped = GroupByWrapper.from_tuple(wrapped_groupby(df, ['B', 'C']).to_tuple(truncate=True))
         assert_groupby_equal(grouped, df.groupby(['B', 'C']))
+        self.assertEqual(grouped.shape, (8, 4))
+        self.assertTrue(grouped.is_frame)
 
         grouped = GroupByWrapper.from_tuple(
             wrapped_groupby(df, ['B', 'C']).C.to_tuple(truncate=True))
         assert_groupby_equal(grouped, df.groupby(['B', 'C']).C, with_selection=True)
+        self.assertEqual(grouped.shape, (8,))
+        self.assertFalse(grouped.is_frame)
 
         grouped = GroupByWrapper.from_tuple(
             wrapped_groupby(df, ['B', 'C'])[['A', 'D']].to_tuple(truncate=True))
         assert_groupby_equal(grouped, df.groupby(['B', 'C'])[['A', 'D']], with_selection=True)
+        self.assertEqual(grouped.shape, (8, 2))
+        self.assertTrue(grouped.is_frame)
 
         grouped = GroupByWrapper.from_tuple(
             wrapped_groupby(df, ['B', 'C'])[['C', 'D']].to_tuple(truncate=True))
         assert_groupby_equal(grouped, df.groupby(['B', 'C'])[['C', 'D']], with_selection=True)
+        self.assertEqual(grouped.shape, (8, 2))
+        self.assertTrue(grouped.is_frame)
 
         grouped = GroupByWrapper.from_tuple(
             wrapped_groupby(df, lambda x: x[-1] % 2).to_tuple(pickle_function=True))
         assert_groupby_equal(grouped, df.groupby(lambda x: x[-1] % 2), with_selection=True)
+        self.assertEqual(grouped.shape, (8, 4))
+        self.assertTrue(grouped.is_frame)
 
         grouped = GroupByWrapper.from_tuple(
             wrapped_groupby(df, lambda x: x[-1] % 2).C.to_tuple(pickle_function=True))
         assert_groupby_equal(grouped, df.groupby(lambda x: x[-1] % 2).C, with_selection=True)
+        self.assertEqual(grouped.shape, (8,))
+        self.assertFalse(grouped.is_frame)
 
         grouped = GroupByWrapper.from_tuple(
             wrapped_groupby(df, lambda x: x[-1] % 2)[['C', 'D']].to_tuple(pickle_function=True))
         assert_groupby_equal(grouped, df.groupby(lambda x: x[-1] % 2)[['C', 'D']], with_selection=True)
+        self.assertEqual(grouped.shape, (8, 2))
+        self.assertTrue(grouped.is_frame)
 
         grouped = GroupByWrapper.from_tuple(wrapped_groupby(df.B, lambda x: x[-1] % 2).to_tuple())
         assert_groupby_equal(grouped, df.B.groupby(lambda x: x[-1] % 2), with_selection=True)
+        self.assertEqual(grouped.shape, (8,))
+        self.assertFalse(grouped.is_frame)


### PR DESCRIPTION
## What do these changes do?

Add size property for GroupByWrapper to make sure ``_update_tileable_and_chunk_shape`` works.

## Related issue number

Fixes #1154 
