### PR TITLE
Implements `mars.learn.metrics.pairwise.rbf_kernel`

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -14,3 +14,4 @@ sphinx>=1.7
 sphinx_rtd_theme>=0.2
 sphinx-intl>=0.9.9
 ipython>=4.0
+matplotlib>=3.0.0

--- a/mars/learn/metrics/pairwise/__init__.py
+++ b/mars/learn/metrics/pairwise/__init__.py
@@ -17,3 +17,4 @@ from .haversine import haversine_distances
 from .manhattan import manhattan_distances
 from .cosine import cosine_distances, cosine_similarity
 from .pairwise import pairwise_distances, PAIRWISE_DISTANCE_FUNCTIONS
+from .rbf_kernel import rbf_kernel

--- a/mars/learn/metrics/pairwise/rbf_kernel.py
+++ b/mars/learn/metrics/pairwise/rbf_kernel.py
@@ -1,0 +1,51 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .... import tensor as mt
+from .core import PairwiseDistances
+from .euclidean import euclidean_distances
+
+
+def rbf_kernel(X, Y=None, gamma=None):
+    """
+    Compute the rbf (gaussian) kernel between X and Y::
+
+        K(x, y) = exp(-gamma ||x-y||^2)
+
+    for each pair of rows x in X and y in Y.
+
+    Read more in the :ref:`User Guide <rbf_kernel>`.
+
+    Parameters
+    ----------
+    X : tensor of shape (n_samples_X, n_features)
+
+    Y : tensor of shape (n_samples_Y, n_features)
+
+    gamma : float, default None
+        If None, defaults to 1.0 / n_features
+
+    Returns
+    -------
+    kernel_matrix : tensor of shape (n_samples_X, n_samples_Y)
+    """
+
+    X, Y = PairwiseDistances.check_pairwise_arrays(X, Y)
+    if gamma is None:
+        gamma = 1.0 / X.shape[1]
+
+    K = euclidean_distances(X, Y, squared=True)
+    K *= -gamma
+    K = mt.exp(K)
+    return K

--- a/mars/learn/metrics/pairwise/tests/test_rbf_kernel.py
+++ b/mars/learn/metrics/pairwise/tests/test_rbf_kernel.py
@@ -1,0 +1,39 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+try:
+    import sklearn
+
+    from sklearn.metrics.pairwise import rbf_kernel as sklearn_rbf_kernel
+except ImportError:  # pragma: no cover
+    sklearn = None
+
+from mars.learn.metrics.pairwise import rbf_kernel
+
+
+@unittest.skipIf(sklearn is None, 'scikit-learn not installed')
+class Test(unittest.TestCase):
+    def testRbfKernel(self):
+        rs = np.random.RandomState(0)
+        raw_X = rs.rand(10, 4)
+        raw_Y = rs.rand(11, 4)
+
+        r = rbf_kernel(raw_X, raw_Y)
+        result = r.execute()
+        expected = sklearn_rbf_kernel(raw_X, raw_Y)
+
+        np.testing.assert_almost_equal(result, expected)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR added support for `mars.learn.metrics.pairwise.rbf_kernel`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA
