### PR TITLE
[BACKPORT] Support `md.merge` when `on` column is in df.index (#1132)

### DIFF
--- a/.github/workflows/install-conda.sh
+++ b/.github/workflows/install-conda.sh
@@ -45,7 +45,7 @@ fi
 TEST_PACKAGES="virtualenv gevent psutil pyyaml lz4 pip setuptools wheel"
 
 if [[ "$FILE_EXT" == "sh" ]]; then
-  curl -s -o "miniconda.${FILE_EXT}" https://repo.continuum.io/miniconda/$CONDA_FILE
+  curl -L -o "miniconda.${FILE_EXT}" https://repo.continuum.io/miniconda/$CONDA_FILE
   bash miniconda.sh -b -p $HOME/miniconda && rm -f miniconda.*
   CONDA_BIN_PATH=$HOME/miniconda/bin
   TEST_PACKAGES="$TEST_PACKAGES nomkl libopenblas"

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -396,7 +396,7 @@ def build_split_idx_to_origin_idx(splits, increase=True):
 
 def build_empty_df(dtypes, index=None):
     columns = dtypes.index
-    df = pd.DataFrame(columns=columns)
+    df = pd.DataFrame(columns=columns, index=index)
     for c, d in zip(columns, dtypes):
         df[c] = pd.Series(dtype=d, index=index)
     return df


### PR DESCRIPTION
Backport of #1132 .