### PR TITLE
Add `Series.value_counts()` support

### DIFF
--- a/docs/source/dataframe/reference/api/mars.dataframe.Series.append.rst
+++ b/docs/source/dataframe/reference/api/mars.dataframe.Series.append.rst
@@ -1,0 +1,6 @@
+mars.dataframe.Series.append
+============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: Series.append

--- a/docs/source/dataframe/reference/api/mars.dataframe.Series.value_counts.rst
+++ b/docs/source/dataframe/reference/api/mars.dataframe.Series.value_counts.rst
@@ -1,0 +1,6 @@
+mars.dataframe.Series.value\_counts
+===================================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: Series.value_counts

--- a/docs/source/dataframe/reference/series.rst
+++ b/docs/source/dataframe/reference/series.rst
@@ -113,6 +113,7 @@ Computations / descriptive stats
    Series.sum
    Series.var
    Series.nunique
+   Series.value_counts
 
 Reindexing / selection / label manipulation
 -------------------------------------------
@@ -146,6 +147,17 @@ Combining / joining / merging
 -----------------------------
 .. autosummary::
    :toctree: api/
+
+   Series.append
+
+Time Series-related
+-------------------
+.. autosummary::
+   :toctree: api/
+
+   Series.diff
+   Series.shift
+   Series.tshift
 
 Accessors
 ---------
@@ -330,15 +342,6 @@ strings and apply several methods to it. These can be accessed like
 
        Series.str
        Series.dt
-
-Time Series-related
--------------------
-.. autosummary::
-   :toctree: api/
-
-   Series.diff
-   Series.shift
-   Series.tshift
 
 Plotting
 --------

--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -214,7 +214,8 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
         else:
             # shape differs only when dataframe add 1-d tensor, we need rechunk on columns axis.
             rechunk_size = other.nsplits[1] if op.axis == 'columns' or op.axis == 1 else other.nsplits[0]
-            tensor = tensor.rechunk((rechunk_size,))._inplace_tile()
+            if tensor.ndim > 0:
+                tensor = tensor.rechunk((rechunk_size,))._inplace_tile()
 
         out_chunks = []
         for out_index in itertools.product(*(map(range, other.chunk_shape))):

--- a/mars/dataframe/base/__init__.py
+++ b/mars/dataframe/base/__init__.py
@@ -27,6 +27,7 @@ from .dropna import df_dropna, series_dropna
 from .cut import cut
 from .shift import shift, tshift
 from .diff import df_diff, series_diff
+from .value_counts import value_counts
 
 
 def _install():
@@ -76,6 +77,7 @@ def _install():
         setattr(t, 'shift', shift)
         setattr(t, 'tshift', tshift)
         setattr(t, 'diff', series_diff)
+        setattr(t, 'value_counts', value_counts)
 
     for t in INDEX_TYPE:
         setattr(t, 'rechunk', rechunk)

--- a/mars/dataframe/base/value_counts.py
+++ b/mars/dataframe/base/value_counts.py
@@ -1,0 +1,169 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+
+from ... import opcodes
+from ...operands import OperandStage
+from ...serialize import KeyField, BoolField, Int64Field, StringField
+from ...utils import recursive_tile
+from ..core import Series
+from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..utils import build_series, parse_index
+
+
+class DataFrameValueCounts(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = opcodes.VALUE_COUNTS
+
+    _input = KeyField('input')
+    _normalize = BoolField('normalize')
+    _sort = BoolField('sort')
+    _ascending = BoolField('ascending')
+    _bins = Int64Field('bins')
+    _dropna = BoolField('dropna')
+    _method = StringField('method')
+
+    def __init__(self, normalize=None, sort=None, ascending=None,
+                 bins=None, dropna=None, method=None, stage=None, **kw):
+        super().__init__(_normalize=normalize, _sort=sort, _ascending=ascending,
+                         _bins=bins, _dropna=dropna, _method=method,
+                         _stage=stage, **kw)
+        self._object_type = ObjectType.series
+
+    @property
+    def input(self):
+        return self._input
+
+    @property
+    def normalize(self):
+        return self._normalize
+
+    @property
+    def sort(self):
+        return self._sort
+
+    @property
+    def ascending(self):
+        return self._ascending
+
+    @property
+    def bins(self):
+        return self._bins
+
+    @property
+    def dropna(self):
+        return self._dropna
+
+    @property
+    def method(self):
+        return self._method
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        self._input = self._inputs[0]
+
+    def __call__(self, inp):
+        test_series = build_series(inp).value_counts(normalize=self.normalize)
+        if self._bins is not None:
+            from .cut import cut
+
+            # cut
+            try:
+                inp = cut(inp, self._bins, include_lowest=True)
+            except TypeError:  # pragma: no cover
+                raise TypeError("bins argument only works with numeric data.")
+
+            self._bins = None
+            return self.new_series([inp], shape=(np.nan,),
+                                   index_value=parse_index(pd.CategoricalIndex([]),
+                                                           inp, store_data=False),
+                                   name=inp.name, dtype=test_series.dtype)
+        else:
+            return self.new_series([inp], shape=(np.nan,),
+                                   index_value=parse_index(test_series.index, store_data=False),
+                                   name=inp.name, dtype=test_series.dtype)
+
+    @classmethod
+    def tile(cls, op):
+        from .cut import DataFrameCut
+
+        out = op.outputs[0]
+
+        if np.prod(op.input.chunk_shape) == 1:
+            inp = op.input
+            chunk_op = op.copy().reset_key()
+            chunk_param = out.params
+            chunk_param['index'] = (0,)
+            chunk = chunk_op.new_chunk(inp.chunks, kws=[chunk_param])
+
+            new_op = op.copy()
+            param = out.params
+            param['chunks'] = [chunk]
+            param['nsplits'] = ((np.nan,),)
+            return new_op.new_seriess(op.inputs, kws=[param])
+
+        inp = Series(op.input)
+
+        if op.dropna:
+            inp = inp.dropna()
+
+        inp = inp.groupby(inp).count(method=op.method)
+
+        if op.normalize:
+            inp = inp.truediv(inp.sum(), axis=0)
+
+        if op.sort:
+            inp = inp.sort_values(ascending=op.ascending)
+
+        ret = recursive_tile(inp)
+
+        if isinstance(op.input.op, DataFrameCut):
+            # convert index to IntervalDtype
+            chunks = []
+            for c in ret.chunks:
+                chunk_op = DataFrameValueCounts(stage=OperandStage.map)
+                chunk_params = c.params
+                chunk_params['index_value'] = parse_index(pd.IntervalIndex([]),
+                                                          c, store_data=False)
+                chunks.append(chunk_op.new_chunk([c], kws=[chunk_params]))
+
+            new_op = op.copy()
+            params = out.params
+            params['chunks'] = chunks
+            params['nsplits'] = ret.nsplits
+            return new_op.new_seriess(out.inputs, kws=[params])
+
+        return [ret]
+
+    @classmethod
+    def execute(cls, ctx, op: "DataFrameValueCounts"):
+        if op.stage != OperandStage.map:
+            result = ctx[op.input.key].value_counts(
+                normalize=op.normalize, sort=op.sort, ascending=op.ascending,
+                bins=op.bins, dropna=op.dropna)
+        else:
+            result = ctx[op.input.key]
+        # convert CategoricalDtype which generated in `cut`
+        # to IntervalDtype
+        result.index = result.index.astype('interval')
+        ctx[op.outputs[0].key] = result
+
+
+def value_counts(series, normalize=False, sort=True, ascending=False,
+                 bins=None, dropna=True, method='tree'):
+    op = DataFrameValueCounts(normalize=normalize, sort=sort,
+                              ascending=ascending, bins=bins,
+                              dropna=dropna, method=method)
+    return op(series)

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -13,16 +13,20 @@
 # limitations under the License.
 
 import itertools
+from functools import partial
 
 import numpy as np
 import pandas as pd
 
 from ... import opcodes as OperandDef
-from ...core import Entity
+from ...core import Entity, Base
 from ...lib.groupby_wrapper import wrapped_groupby
 from ...operands import OperandStage
 from ...serialize import BoolField, Int32Field, AnyField
 from ...utils import get_shuffle_input_keys_idxes
+from ..align import align_dataframe_series, align_series_series
+from ..initializer import Series as asseries
+from ..core import SERIES_TYPE, SERIES_CHUNK_TYPE
 from ..utils import build_concatenated_rows_frame, hash_dataframe_on, \
     build_empty_df, build_empty_series, parse_index
 from ..operands import DataFrameOperandMixin, \
@@ -106,32 +110,105 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
         new_kw.update(kwargs)
         if new_kw.get('level'):
             new_kw['level'] = 0
+        if isinstance(new_kw['by'], list):
+            new_by = []
+            for v in new_kw['by']:
+                if isinstance(v, (Base, Entity)):
+                    new_by.append(build_empty_series(v.dtype, index=pd.RangeIndex(2), name=v.name))
+                else:
+                    new_by.append(v)
+            new_kw['by'] = new_by
         return empty_df.groupby(**new_kw)
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        inputs_iter = iter(self._inputs[1:])
+        if len(inputs) > 1:
+            by = []
+            for k in self._by:
+                if isinstance(k, (SERIES_TYPE, SERIES_CHUNK_TYPE)):
+                    by.append(next(inputs_iter))
+                else:
+                    by.append(k)
+            self._by = by
 
     def __call__(self, df):
         params = df.params.copy()
         params['index_value'] = parse_index(None, df.key, df.index_value.key)
         if df.ndim == 2:
-            if isinstance(self.by, str):
-                if self.by not in df.dtypes:
-                    raise KeyError(self.by)
-                params['key_dtypes'] = df.dtypes[[self.by]]
-            elif isinstance(self.by, list):
+            if isinstance(self.by, list):
+                index, types = [], []
                 for k in self.by:
-                    if k not in df.dtypes:
-                        raise KeyError(k)
-                params['key_dtypes'] = df.dtypes[self.by]
-        return self.new_tileable([df], **params)
+                    if isinstance(k, str):
+                        if k not in df.dtypes:
+                            raise KeyError(k)
+                        else:
+                            index.append(k)
+                            types.append(df.dtypes[k])
+                    else:
+                        assert isinstance(k, SERIES_TYPE)
+                        index.append(k.name)
+                        types.append(k.dtype)
+                params['key_dtypes'] = pd.Series(types, index=index)
+
+        inputs = [df]
+        if isinstance(self.by, list):
+            for k in self.by:
+                if isinstance(k, SERIES_TYPE):
+                    inputs.append(k)
+
+        return self.new_tileable(inputs, **params)
+
+    @classmethod
+    def _align_input_and_by(cls, op, inp, by):
+        align_method = partial(align_dataframe_series, axis='index') \
+            if op.is_dataframe_obj else align_series_series
+        nsplits, _, inp_chunks, by_chunks =  align_method(inp, by)
+
+        inp_params = inp.params
+        inp_params['chunks'] = inp_chunks
+        inp_params['nsplits'] = nsplits
+        inp = op.copy().new_tileable(op.inputs, kws=[inp_params])
+
+        by_params = by.params
+        by_params['chunks'] = by_chunks
+        if len(nsplits) == 2:
+            by_nsplits = nsplits[:1]
+        else:
+            by_nsplits = nsplits
+        by_params['nsplits'] = by_nsplits
+        by = by.op.copy().new_tileable(by.op.inputs, kws=[by_params])
+
+        return inp, by
 
     @classmethod
     def tile(cls, op):
+        in_df = op.inputs[0]
+        by = op.by
+
+        series_in_by = False
+        new_inputs = []
+        if len(op.inputs) > 1:
+            # by series
+            new_by = []
+            for k in by:
+                if isinstance(k, SERIES_TYPE):
+                    in_df, k = cls._align_input_and_by(op, in_df, k)
+                    if len(new_inputs) == 0:
+                        new_inputs.append(in_df)
+                    new_inputs.append(k)
+                    series_in_by = True
+                new_by.append(k)
+            by = new_by
+        else:
+            new_inputs = op.inputs
+
         is_dataframe_obj = op.is_dataframe_obj
         if is_dataframe_obj:
-            in_df = build_concatenated_rows_frame(op.inputs[0])
+            in_df = build_concatenated_rows_frame(in_df)
             out_object_type = ObjectType.dataframe
             chunk_shape = (in_df.chunk_shape[0], 1)
         else:
-            in_df = op.inputs[0]
             out_object_type = ObjectType.series
             chunk_shape = (in_df.chunk_shape[0],)
 
@@ -141,7 +218,18 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
             map_op = op.copy().reset_key()
             map_op._stage = OperandStage.map
             map_op._shuffle_size = chunk_shape[0]
-            map_chunks.append(map_op.new_chunk([chunk], shape=(np.nan, np.nan), index=chunk.index))
+            chunk_inputs = [chunk]
+            if len(op.inputs) > 1:
+                chunk_by = []
+                for k in by:
+                    if isinstance(k, SERIES_TYPE):
+                        by_chunk = k.cix[chunk.index[0],]
+                        chunk_by.append(by_chunk)
+                        chunk_inputs.append(by_chunk)
+                    else:
+                        chunk_by.append(k)
+                map_op._by = chunk_by
+            map_chunks.append(map_op.new_chunk(chunk_inputs, shape=(np.nan, np.nan), index=chunk.index))
 
         proxy_chunk = DataFrameShuffleProxy(object_type=out_object_type).new_chunk(map_chunks, shape=())
 
@@ -150,6 +238,7 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
         for out_idx in itertools.product(*(range(s) for s in chunk_shape)):
             shuffle_key = ','.join(str(idx) for idx in out_idx)
             reduce_op = op.copy().reset_key()
+            reduce_op._by = None
             reduce_op._stage = OperandStage.reduce
             reduce_op._shuffle_key = shuffle_key
             reduce_chunks.append(
@@ -159,6 +248,9 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
         out_chunks = []
         for chunk in reduce_chunks:
             groupby_op = op.copy().reset_key()
+            if series_in_by:
+                # set by to None, cuz data of by will be passed from map to reduce to groupby
+                groupby_op._by = None
             if is_dataframe_obj:
                 new_shape = (np.nan, in_df.shape[1])
             else:
@@ -179,7 +271,7 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
         else:
             params['nsplits'] = ((np.nan,) * len(out_chunks),)
         params['chunks'] = out_chunks
-        return new_op.new_tileables(op.inputs, **params)
+        return new_op.new_tileables(new_inputs, **params)
 
     @classmethod
     def execute_map(cls, ctx, op):
@@ -187,6 +279,17 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
         by = op.by
         chunk = op.outputs[0]
         df = ctx[op.inputs[0].key]
+
+        deliver_by = False  # output by for the upcoming process
+        if isinstance(by, list):
+            new_by = []
+            for v in by:
+                if isinstance(v, Base):
+                    deliver_by = True
+                    new_by.append(ctx[v.key])
+                else:
+                    new_by.append(v)
+            by = new_by
 
         if isinstance(by, list) or callable(by):
             on = by
@@ -199,10 +302,17 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
                 group_key = ','.join([str(index_idx), str(chunk.index[1])])
             else:
                 group_key = str(index_idx)
-            if index_filter is not None and index_filter is not list():
-                ctx[(chunk.key, group_key)] = df.loc[index_filter]
+
+            if deliver_by:
+                filtered_by = []
+                for v in by:
+                    if isinstance(v, pd.Series):
+                        filtered_by.append(v.loc[index_filter])
+                    else:
+                        filtered_by.append(v)
+                ctx[(chunk.key, group_key)] = (df.loc[index_filter], filtered_by)
             else:
-                ctx[(chunk.key, group_key)] = None
+                ctx[(chunk.key, group_key)] = df.loc[index_filter]
 
     @classmethod
     def execute_reduce(cls, ctx, op):
@@ -221,10 +331,28 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
                 row_df = input_idx_to_df.get((row_idx,), None)
             if row_df is not None:
                 res.append(row_df)
-        r = pd.concat(res, axis=0)
+        by = None
+        if isinstance(res[0], tuple):
+            # By is series
+            r = pd.concat([it[0] for it in res], axis=0)
+            by = [None] * len(res[0][1])
+            for it in res:
+                for i, v in enumerate(it[1]):
+                    if isinstance(v, pd.Series):
+                        if by[i] is None:
+                            by[i] = v
+                        else:
+                            by[i] = pd.concat([by[i], v], axis=0)
+                    else:
+                        by[i] = v
+        else:
+            r = pd.concat(res, axis=0)
         if chunk.index_value is not None:
             r.index.name = chunk.index_value.name
-        ctx[chunk.key] = r
+        if by is None:
+            ctx[chunk.key] = r
+        else:
+            ctx[chunk.key] = (r, by)
 
     @classmethod
     def execute(cls, ctx, op: "DataFrameGroupByOperand"):
@@ -233,9 +361,15 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
         elif op.stage == OperandStage.reduce:
             cls.execute_reduce(ctx, op)
         else:
-            df = ctx[op.inputs[0].key]
+            inp = ctx[op.inputs[0].key]
+            if isinstance(inp, tuple):
+                # df, by
+                df, by = inp
+            else:
+                df = inp
+                by = op.by
             ctx[op.outputs[0].key] = wrapped_groupby(
-                df, by=op.by, level=op.level, as_index=op.as_index, sort=op.sort,
+                df, by=by, level=op.level, as_index=op.as_index, sort=op.sort,
                 group_keys=op.group_keys)
 
 
@@ -244,7 +378,9 @@ def groupby(df, by=None, level=None, as_index=True, sort=True, group_keys=True):
         raise TypeError('as_index=False only valid with DataFrame')
 
     object_type = ObjectType.dataframe_groupby if df.ndim == 2 else ObjectType.series_groupby
-    if isinstance(by, str):
+    if isinstance(by, (str, SERIES_TYPE, pd.Series)):
+        if isinstance(by, pd.Series):
+            by = asseries(by)
         by = [by]
     op = DataFrameGroupByOperand(by=by, level=level, as_index=as_index, sort=sort,
                                  group_keys=group_keys, object_type=object_type)

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -44,6 +44,16 @@ class Test(TestBase):
         assert_groupby_equal(self.executor.execute_dataframe(grouped, concat=True)[0],
                              df2.groupby('b'))
 
+        # test groupby series
+        grouped = mdf.groupby(mdf['b'])
+        assert_groupby_equal(self.executor.execute_dataframe(grouped, concat=True)[0],
+                             df2.groupby(df2['b']))
+
+        # test groupby multiple series
+        grouped = mdf.groupby(by=[mdf['b'], mdf['c']])
+        assert_groupby_equal(self.executor.execute_dataframe(grouped, concat=True)[0],
+                             df2.groupby(by=[df2['b'], df2['c']]))
+
         df3 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],
                             'b': [1, 3, 4, 5, 6, 5, 4, 4, 4],
                             'c': list('aabaaddce')},
@@ -58,6 +68,11 @@ class Test(TestBase):
         grouped = ms1.groupby(lambda x: x % 3)
         assert_groupby_equal(self.executor.execute_dataframe(grouped, concat=True)[0],
                              series1.groupby(lambda x: x % 3))
+
+        # test groupby series
+        grouped = ms1.groupby(ms1)
+        assert_groupby_equal(self.executor.execute_dataframe(grouped, concat=True)[0],
+                             series1.groupby(series1))
 
         series2 = pd.Series([3, 4, 5, 3, 5, 4, 1, 2, 3],
                             index=['i' + str(i) for i in range(9)])
@@ -198,6 +213,11 @@ class Test(TestBase):
             pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
                                           df2.groupby('c2').agg({'c1': 'min'}))
 
+            # test groupby series
+            r3 = mdf2.groupby(mdf2['c2']).sum(method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                          df2.groupby(df2['c2']).sum())
+
         r4 = mdf2.groupby('c2').sum()
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(r4, concat=True)[0],
                                       df2.groupby('c2').sum())
@@ -282,6 +302,11 @@ class Test(TestBase):
             r3 = ms1.groupby(lambda x: x % 2).agg(agg, method=method)
             pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
                                           series1.groupby(lambda x: x % 2).agg(agg))
+
+            # test groupby series
+            r3 = ms1.groupby(ms1).sum(method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                           series1.groupby(series1).sum())
 
         r4 = ms1.groupby(lambda x: x % 2).sum()
         pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -724,7 +724,7 @@ class Executor(object):
                     c._shape = chunk_result[c.key].shape
                 except AttributeError:
                     # Fuse chunk
-                    pass
+                    c._composed[-1]._shape = chunk_result[c.key].shape
 
     def _update_tileable_and_chunk_shape(self, tileable_graph, chunk_result, failed_ops):
         for n in tileable_graph:

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -348,6 +348,7 @@ message OperandDef {
         CUT = 722;
         SHIFT = 723;
         DATAFRAME_DIFF = 724;
+        VALUE_COUNTS = 725;
 
         FUSE = 801;
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR introduced:

1. Support `Series.value_counts()`.
2. Support `{DataFrame, Series}.groupby(by=series)`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1119 .
Partially implement #1036 .