### PR TITLE
Implements `md.to_datetime`, support `__setitem__` for DataFrame as well

### DIFF
--- a/docs/source/dataframe/reference/api/mars.dataframe.to_datetime.rst
+++ b/docs/source/dataframe/reference/api/mars.dataframe.to_datetime.rst
@@ -1,0 +1,6 @@
+mars.dataframe.to\_datetime
+===========================
+
+.. currentmodule:: mars.dataframe
+
+.. autofunction:: to_datetime

--- a/docs/source/dataframe/reference/general_functions.rst
+++ b/docs/source/dataframe/reference/general_functions.rst
@@ -29,4 +29,5 @@ Top-level dealing with datetimelike
 .. autosummary::
    :toctree: api/
 
+   to_datetime
    date_range

--- a/mars/dataframe/__init__.py
+++ b/mars/dataframe/__init__.py
@@ -24,6 +24,7 @@ from .datasource.from_vineyard import from_vineyard
 from .datasource.read_csv import read_csv
 from .datasource.read_sql_table import read_sql_table
 from .datasource.date_range import date_range
+from .tseries.to_datetime import to_datetime
 from .merge import concat, merge
 from .fetch import DataFrameFetch, DataFrameFetchShuffle
 

--- a/mars/dataframe/indexing/__init__.py
+++ b/mars/dataframe/indexing/__init__.py
@@ -21,6 +21,7 @@ def _install():
     from .at import at
     from .set_index import set_index
     from .getitem import dataframe_getitem, series_getitem
+    from .setitem import dataframe_setitem
     from ..operands import DATAFRAME_TYPE, SERIES_TYPE
 
     for cls in DATAFRAME_TYPE + SERIES_TYPE:
@@ -34,6 +35,7 @@ def _install():
     for cls in DATAFRAME_TYPE:
         setattr(cls, 'set_index', set_index)
         setattr(cls, '__getitem__', dataframe_getitem)
+        setattr(cls, '__setitem__', dataframe_setitem)
     for cls in SERIES_TYPE:
         setattr(cls, '__getitem__', series_getitem)
 

--- a/mars/dataframe/indexing/setitem.py
+++ b/mars/dataframe/indexing/setitem.py
@@ -1,0 +1,175 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_list_like
+
+from ... import opcodes
+from ...serialize import KeyField, AnyField
+from ...tensor.core import TENSOR_TYPE
+from ...tiles import TilesError
+from ..core import SERIES_TYPE, DataFrame
+from ..initializer import Series as asseries
+from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..utils import parse_index
+
+
+class DataFrameSetitem(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = opcodes.INDEXSETVALUE
+
+    _target = KeyField('target')
+    _indexes = AnyField('indexes')
+    _value = AnyField('value')
+
+    def __init__(self, target=None, indexes=None, value=None, object_type=None, **kw):
+        super().__init__(_target=target, _indexes=indexes,
+                         _value=value, _object_type=object_type, **kw)
+        if self._object_type is None:
+            self._object_type = ObjectType.dataframe
+
+    @property
+    def target(self):
+        return self._target
+
+    @property
+    def indexes(self):
+        return self._indexes
+
+    @property
+    def value(self):
+        return self._value
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        self._target = self._inputs[0]
+        if len(inputs) > 1:
+            self._value = self._inputs[-1]
+
+    def __call__(self, target: DataFrame, value):
+        inputs = [target]
+        if np.isscalar(value):
+            value_dtype = np.array(value).dtype
+        else:
+            if isinstance(value, (pd.Series, SERIES_TYPE)):
+                value = asseries(value)
+                inputs.append(value)
+                value_dtype = value.dtype
+            elif is_list_like(value) or isinstance(value, TENSOR_TYPE):
+                value = asseries(value, index=target.index)
+                inputs.append(value)
+                value_dtype = value.dtype
+            else:  # pragma: no cover
+                raise TypeError('Wrong value type, could be one of scalar, Series or tensor')
+
+            if value.index_value.key != target.index_value.key:  # pragma: no cover
+                raise NotImplementedError('Does not support setting value '
+                                          'with different index for now')
+
+        index_value = target.index_value
+        dtypes = target.dtypes
+        dtypes.loc[self._indexes] = value_dtype
+        columns_value = parse_index(dtypes.index, store_data=True)
+        ret = self.new_dataframe(inputs, shape=(target.shape[0], len(dtypes)),
+                                 dtypes=dtypes, index_value=index_value,
+                                 columns_value=columns_value)
+        target.data = ret.data
+
+    @classmethod
+    def tile(cls, op):
+        out = op.outputs[0]
+        target = op.target
+        value = op.value
+        col = op.indexes
+        columns = target.columns_value.to_pandas()
+
+        if not np.isscalar(value):
+            # check if all chunk's index_value are identical
+            target_chunk_index_values = [c.index_value for c in target.chunks
+                                         if c.index[1] == 0]
+            value_chunk_index_values = [v.index_value for v in value.chunks]
+            is_identical = len(target_chunk_index_values) == len(target_chunk_index_values) and \
+                           all(c.key == v.key for c, v
+                               in zip(target_chunk_index_values, value_chunk_index_values))
+            if not is_identical:
+                # do rechunk
+                if any(np.isnan(s) for s in target.nsplits[0]) or \
+                        any(np.isnan(s) for s in value.nsplits[0]):  # pragma: no cover
+                    raise TilesError('target or value has unknown chunk shape')
+
+                value = value.rechunk({0: target.nsplits[0]})._inplace_tile()
+
+        out_chunks = []
+        nsplits = [list(ns) for ns in target.nsplits]
+        if col not in columns:
+            nsplits[1][-1] += 1
+            column_chunk_shape = target.chunk_shape[1]
+            # append to the last chunk on columns axis direction
+            for c in target.chunks:
+                if c.index[-1] != column_chunk_shape - 1:
+                    # not effected, just output
+                    out_chunks.append(c)
+                else:
+                    chunk_op = op.copy().reset_key()
+                    if np.isscalar(value):
+                        chunk_inputs = [c]
+                    else:
+                        value_chunk = value.cix[c.index[0], ]
+                        chunk_inputs = [c, value_chunk]
+
+                    dtypes = c.dtypes
+                    dtypes.loc[out.dtypes.index[-1]] = out.dtypes.iloc[-1]
+                    chunk = chunk_op.new_chunk(chunk_inputs,
+                                               shape=(c.shape[0], c.shape[1] + 1),
+                                               dtypes=dtypes,
+                                               index_value=c.index_value,
+                                               columns_value=parse_index(dtypes.index,
+                                                                         store_data=True),
+                                               index=c.index)
+                    out_chunks.append(chunk)
+        else:
+            # replace exist column
+            for c in target.chunks:
+                if col in c.dtypes:
+                    chunk_inputs = [c]
+                    if not np.isscalar(value):
+                        chunk_inputs.append(value.cix[c.index[0], ])
+                    chunk_op = op.copy().reset_key()
+                    chunk = chunk_op.new_chunk(chunk_inputs,
+                                               shape=c.shape,
+                                               dtypes=c.dtypes,
+                                               index_value=c.index_value,
+                                               columns_value=c.columns_value,
+                                               index=c.index)
+                    out_chunks.append(chunk)
+                else:
+                    out_chunks.append(c)
+
+        params = out.params
+        params['nsplits'] = tuple(tuple(ns) for ns in nsplits)
+        params['chunks'] = out_chunks
+        new_op = op.copy()
+        return new_op.new_tileables(op.inputs, kws=[params])
+
+    @classmethod
+    def execute(cls, ctx, op):
+        target = ctx[op.target.key].copy()
+        value = ctx[op.value.key] if not np.isscalar(op.value) else op.value
+        target[op.indexes] = value
+        ctx[op.outputs[0].key] = target
+
+
+def dataframe_setitem(df, col, value):
+    op = DataFrameSetitem(target=df, indexes=col, value=value)
+    return op(df, value)

--- a/mars/dataframe/tseries/__init__.py
+++ b/mars/dataframe/tseries/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mars/dataframe/tseries/tests/__init__.py
+++ b/mars/dataframe/tseries/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mars/dataframe/tseries/tests/test_tseries.py
+++ b/mars/dataframe/tseries/tests/test_tseries.py
@@ -1,0 +1,34 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+
+import unittest
+import mars.dataframe as md
+
+
+class Test(unittest.TestCase):
+    def testToDatetime(self):
+        wrong_args = [
+            pd.DataFrame({'a': [1, 2]}),
+            {'a': [1, 2]}
+        ]
+
+        for arg in wrong_args:
+            with self.assertRaises(ValueError) as cm:
+                md.to_datetime(arg)
+            self.assertIn('[year, month, day]', str(cm.exception))
+
+        with self.assertRaises(TypeError):
+            md.to_datetime([[1, 2], [3, 4]])

--- a/mars/dataframe/tseries/tests/test_tseries_execution.py
+++ b/mars/dataframe/tseries/tests/test_tseries_execution.py
@@ -1,0 +1,90 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+
+from mars.dataframe import to_datetime, Series, DataFrame, Index
+from mars.tensor import tensor
+from mars.tests.core import TestBase, ExecutorForTest
+
+
+class Test(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.executor = ExecutorForTest()
+
+    def testToDatetimeExecution(self):
+        # scalar
+        r = to_datetime(1490195805, unit='s')
+
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = pd.to_datetime(1490195805, unit='s')
+        self.assertEqual(result, expected)
+
+        # test list like
+        raw = ['3/11/2000', '3/12/2000', '3/13/2000']
+        t = tensor(raw, chunk_size=2)
+        r = to_datetime(t, infer_datetime_format=True)
+
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = pd.to_datetime(raw, infer_datetime_format=True)
+        pd.testing.assert_index_equal(result, expected)
+
+        # test series
+        raw_series = pd.Series(raw)
+        s = Series(raw_series, chunk_size=2)
+        r = to_datetime(s)
+
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = pd.to_datetime(raw_series)
+        pd.testing.assert_series_equal(result, expected)
+
+        # test DataFrame
+        raw_df = pd.DataFrame({'year': [2015, 2016],
+                               'month': [2, 3],
+                               'day': [4, 5]})
+        df = DataFrame(raw_df, chunk_size=(1, 2))
+        r = to_datetime(df)
+
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = pd.to_datetime(raw_df)
+        pd.testing.assert_series_equal(result, expected)
+
+        # test Index
+        raw_index = pd.Index([1, 2, 3])
+        s = Index(raw_index, chunk_size=2)
+        r = to_datetime(s)
+
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = pd.to_datetime(raw_index)
+        pd.testing.assert_index_equal(result, expected)
+
+        # test raises == 'ignore'
+        raw = ['13000101']
+        r = to_datetime(raw, format='%Y%m%d', errors='ignore')
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = pd.to_datetime(raw, format='%Y%m%d', errors='ignore')
+        pd.testing.assert_index_equal(result, expected)
+
+        # test unit
+        r = to_datetime([1490195805], unit='s')
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = pd.to_datetime([1490195805], unit='s')
+        pd.testing.assert_index_equal(result, expected)
+
+        # test origin
+        r = to_datetime([1, 2, 3], unit='D', origin=pd.Timestamp('1960-01-01'))
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = pd.to_datetime([1, 2, 3], unit='D', origin=pd.Timestamp('1960-01-01'))
+        pd.testing.assert_index_equal(result, expected)

--- a/mars/dataframe/tseries/to_datetime.py
+++ b/mars/dataframe/tseries/to_datetime.py
@@ -1,0 +1,368 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_scalar, is_dict_like
+
+from ... import opcodes
+from ...serialize import KeyField, StringField, BoolField, AnyField
+from ...tensor import tensor as astensor
+from ...tensor.core import CHUNK_TYPE as TENSOR_CHUNK_TYPE
+from ...tiles import TilesError
+from ..core import DATAFRAME_TYPE, SERIES_TYPE, INDEX_TYPE, INDEX_CHUNK_TYPE
+from ..initializer import DataFrame as asdataframe, Series as asseries, Index as asindex
+from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..utils import parse_index
+
+
+class DataFrameToDatetime(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = opcodes.TO_DATETIME
+
+    _arg = KeyField('arg')
+    _errors = StringField('errors')
+    _dayfirst = BoolField('dayfirst')
+    _yearfirst = BoolField('yearfirst')
+    _utc = BoolField('utc')
+    _format = StringField('format')
+    _exact = BoolField('exact')
+    _unit = StringField('unit')
+    _infer_datetime_format = BoolField('infer_datetime_format')
+    _origin = AnyField('origin')
+    _cache = BoolField('cache')
+
+    def __init__(self, errors=None, dayfirst=None, yearfirst=None, utc=None,
+                 format=None, exact=None, unit=None, infer_datetime_format=None,
+                 origin=None, cache=None, **kw):
+        super().__init__(_errors=errors, _dayfirst=dayfirst, _yearfirst=yearfirst,
+                         _utc=utc, _format=format, _exact=exact, _unit=unit,
+                         _infer_datetime_format=infer_datetime_format, _origin=origin,
+                         _cache=cache, **kw)
+
+    @property
+    def arg(self):
+        return self._arg
+
+    @property
+    def errors(self):
+        return self._errors
+
+    @property
+    def dayfirst(self):
+        return self._dayfirst
+
+    @property
+    def yearfirst(self):
+        return self._yearfirst
+
+    @property
+    def utc(self):
+        return self._utc
+
+    @property
+    def format(self):
+        return self._format
+
+    @property
+    def exact(self):
+        return self._exact
+
+    @property
+    def unit(self):
+        return self._unit
+
+    @property
+    def infer_datetime_format(self):
+        return self._infer_datetime_format
+
+    @property
+    def origin(self):
+        return self._origin
+
+    @property
+    def cache(self):
+        return self._cache
+
+    @property
+    def _params(self):
+        return tuple(getattr(self, k) for k in self._keys_
+                     if k not in self._no_copy_attrs_ and
+                     k != '_arg' and hasattr(self, k))
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        self._arg = self._inputs[0]
+
+    def __call__(self, arg):
+        if is_scalar(arg):
+            ret = pd.to_datetime(arg, errors=self._errors, dayfirst=self._dayfirst,
+                                 yearfirst=self._yearfirst, utc=self._utc,
+                                 format=self._format, exact=self._exact,
+                                 unit=self._unit, infer_datetime_format=self._infer_datetime_format,
+                                 origin=self._origin, cache=self._cache)
+            return astensor(ret)
+
+        dtype = np.datetime64(1, 'ns').dtype
+        if isinstance(arg, (pd.Series, SERIES_TYPE)):
+            arg = asseries(arg)
+            self._object_type = ObjectType.series
+            return self.new_series([arg], shape=arg.shape,
+                                   dtype=dtype, index_value=arg.index_value,
+                                   name=arg.name)
+        if is_dict_like(arg) or isinstance(arg, DATAFRAME_TYPE):
+            arg = asdataframe(arg)
+            columns = arg.columns_value.to_pandas().tolist()
+            if sorted(columns) != sorted(['year', 'month', 'day']):
+                missing = ','.join(c for c in ['day', 'month', 'year'] if c not in columns)
+                raise ValueError('to assemble mappings requires at least '
+                                 'that [year, month, day] be specified: [{}] is missing'.format(missing))
+            self._object_type = ObjectType.series
+            return self.new_series([arg], shape=(arg.shape[0],),
+                                   dtype=dtype, index_value=arg.index_value)
+        elif isinstance(arg, (pd.Index, INDEX_TYPE)):
+            arg = asindex(arg)
+            self._object_type = ObjectType.index
+            return self.new_series([arg], shape=arg.shape,
+                                   dtype=dtype,
+                                   index_value=parse_index(pd.Index([], dtype=dtype),
+                                                           self._params, arg),
+                                   name=arg.name)
+        else:
+            arg = astensor(arg)
+            if arg.ndim != 1:
+                raise TypeError('arg must be a string, datetime, '
+                                'list, tuple, 1-d tensor, or Series')
+            self._object_type = ObjectType.index
+            return self.new_index([arg], shape=arg.shape,
+                                  dtype=dtype,
+                                  index_value=parse_index(pd.Index([], dtype=dtype),
+                                                          self._params, arg))
+
+    @classmethod
+    def tile(cls, op: "DataFrameToDatetime"):
+        out = op.outputs[0]
+        arg = op.arg
+
+        if isinstance(arg, DATAFRAME_TYPE):
+            if np.isnan(arg.shape[0]) or \
+                    any(np.isnan(s) for s in arg.nsplits[1]):  # pragma: no cover
+                raise TilesError('unknown chunk shape on columns axis')
+
+            arg = arg.rechunk({1: arg.shape[1]})._inplace_tile()
+
+        out_chunks = []
+        for chunk in arg.chunks:
+            chunk_op = op.copy().reset_key()
+            if isinstance(chunk, (TENSOR_CHUNK_TYPE, INDEX_CHUNK_TYPE)):
+                chunk_index_value = parse_index(
+                    pd.Index([], dtype=out.dtype), op._params, chunk)
+            else:
+                chunk_index_value = chunk.index_value
+
+            out_chunk = chunk_op.new_chunk([chunk], shape=(chunk.shape[0],),
+                                           dtype=out.dtype,
+                                           index_value=chunk_index_value,
+                                           name=out.name,
+                                           index=(chunk.index[0],))
+            out_chunks.append(out_chunk)
+
+        params = out.params
+        params['nsplits'] = (arg.nsplits[0],)
+        params['chunks'] = out_chunks
+        new_op = op.copy()
+        return new_op.new_tileables(op.inputs, kws=[params])
+
+    @classmethod
+    def execute(cls, ctx, op: "DataFrameToDatetime"):
+        arg = ctx[op.arg.key]
+
+        call = partial(pd.to_datetime,
+                       errors=op.errors, dayfirst=op.dayfirst,
+                       yearfirst=op.yearfirst, utc=op.utc,
+                       format=op.format, exact=op.exact, unit=op.unit,
+                       infer_datetime_format=op.infer_datetime_format,
+                       origin=op.origin, cache=op.cache)
+
+        try:
+            ctx[op.outputs[0].key] = call(arg)
+        except ValueError:  # pragma: no cover
+            ctx[op.outputs[0].key] = call(arg.copy())
+
+
+def to_datetime(arg,
+                errors: str = 'raise',
+                dayfirst: bool = False,
+                yearfirst: bool = False,
+                utc: bool = None,
+                format: str = None,
+                exact: bool = True,
+                unit: str = None,
+                infer_datetime_format: bool = False,
+                origin: Any = 'unix',
+                cache: bool = True):
+    """
+    Convert argument to datetime.
+
+    Parameters
+    ----------
+    arg : int, float, str, datetime, list, tuple, 1-d array, Series DataFrame/dict-like
+        The object to convert to a datetime.
+    errors : {'ignore', 'raise', 'coerce'}, default 'raise'
+        - If 'raise', then invalid parsing will raise an exception.
+        - If 'coerce', then invalid parsing will be set as NaT.
+        - If 'ignore', then invalid parsing will return the input.
+    dayfirst : bool, default False
+        Specify a date parse order if `arg` is str or its list-likes.
+        If True, parses dates with the day first, eg 10/11/12 is parsed as
+        2012-11-10.
+        Warning: dayfirst=True is not strict, but will prefer to parse
+        with day first (this is a known bug, based on dateutil behavior).
+    yearfirst : bool, default False
+        Specify a date parse order if `arg` is str or its list-likes.
+
+        - If True parses dates with the year first, eg 10/11/12 is parsed as
+          2010-11-12.
+        - If both dayfirst and yearfirst are True, yearfirst is preceded (same
+          as dateutil).
+
+        Warning: yearfirst=True is not strict, but will prefer to parse
+        with year first (this is a known bug, based on dateutil behavior).
+    utc : bool, default None
+        Return UTC DatetimeIndex if True (converting any tz-aware
+        datetime.datetime objects as well).
+    format : str, default None
+        The strftime to parse time, eg "%d/%m/%Y", note that "%f" will parse
+        all the way up to nanoseconds.
+        See strftime documentation for more information on choices:
+        https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior.
+    exact : bool, True by default
+        Behaves as:
+        - If True, require an exact format match.
+        - If False, allow the format to match anywhere in the target string.
+
+    unit : str, default 'ns'
+        The unit of the arg (D,s,ms,us,ns) denote the unit, which is an
+        integer or float number. This will be based off the origin.
+        Example, with unit='ms' and origin='unix' (the default), this
+        would calculate the number of milliseconds to the unix epoch start.
+    infer_datetime_format : bool, default False
+        If True and no `format` is given, attempt to infer the format of the
+        datetime strings, and if it can be inferred, switch to a faster
+        method of parsing them. In some cases this can increase the parsing
+        speed by ~5-10x.
+    origin : scalar, default 'unix'
+        Define the reference date. The numeric values would be parsed as number
+        of units (defined by `unit`) since this reference date.
+
+        - If 'unix' (or POSIX) time; origin is set to 1970-01-01.
+        - If 'julian', unit must be 'D', and origin is set to beginning of
+          Julian Calendar. Julian day number 0 is assigned to the day starting
+          at noon on January 1, 4713 BC.
+        - If Timestamp convertible, origin is set to Timestamp identified by
+          origin.
+    cache : bool, default True
+        If True, use a cache of unique, converted dates to apply the datetime
+        conversion. May produce significant speed-up when parsing duplicate
+        date strings, especially ones with timezone offsets. The cache is only
+        used when there are at least 50 values. The presence of out-of-bounds
+        values will render the cache unusable and may slow down parsing.
+
+    Returns
+    -------
+    datetime
+        If parsing succeeded.
+        Return type depends on input:
+
+        - list-like: DatetimeIndex
+        - Series: Series of datetime64 dtype
+        - scalar: Timestamp
+
+        In case when it is not possible to return designated types (e.g. when
+        any element of input is before Timestamp.min or after Timestamp.max)
+        return will have datetime.datetime type (or corresponding
+        array/Series).
+
+    See Also
+    --------
+    DataFrame.astype : Cast argument to a specified dtype.
+    to_timedelta : Convert argument to timedelta.
+    convert_dtypes : Convert dtypes.
+
+    Examples
+    --------
+    Assembling a datetime from multiple columns of a DataFrame. The keys can be
+    common abbreviations like ['year', 'month', 'day', 'minute', 'second',
+    'ms', 'us', 'ns']) or plurals of the same
+
+    >>> import mars.dataframe as md
+
+    >>> df = md.DataFrame({'year': [2015, 2016],
+    ...                    'month': [2, 3],
+    ...                    'day': [4, 5]})
+    >>> md.to_datetime(df).execute()
+    0   2015-02-04
+    1   2016-03-05
+    dtype: datetime64[ns]
+
+    If a date does not meet the `timestamp limitations
+    <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html
+    #timeseries-timestamp-limits>`_, passing errors='ignore'
+    will return the original input instead of raising any exception.
+
+    Passing errors='coerce' will force an out-of-bounds date to NaT,
+    in addition to forcing non-dates (or non-parseable dates) to NaT.
+
+    >>> md.to_datetime('13000101', format='%Y%m%d', errors='ignore').execute()
+    datetime.datetime(1300, 1, 1, 0, 0)
+    >>> md.to_datetime('13000101', format='%Y%m%d', errors='coerce').execute()
+    NaT
+
+    Passing infer_datetime_format=True can often-times speedup a parsing
+    if its not an ISO8601 format exactly, but in a regular format.
+
+    >>> s = md.Series(['3/11/2000', '3/12/2000', '3/13/2000'] * 1000)
+    >>> s.head().execute()
+    0    3/11/2000
+    1    3/12/2000
+    2    3/13/2000
+    3    3/11/2000
+    4    3/12/2000
+    dtype: object
+
+    Using a unix epoch time
+
+    >>> md.to_datetime(1490195805, unit='s').execute()
+    Timestamp('2017-03-22 15:16:45')
+    >>> md.to_datetime(1490195805433502912, unit='ns').execute()
+    Timestamp('2017-03-22 15:16:45.433502912')
+
+    .. warning:: For float arg, precision rounding might happen. To prevent
+        unexpected behavior use a fixed-width exact type.
+
+    Using a non-unix epoch origin
+
+    >>> md.to_datetime([1, 2, 3], unit='D',
+    ...                origin=md.Timestamp('1960-01-01')).execute()
+    DatetimeIndex(['1960-01-02', '1960-01-03', '1960-01-04'], \
+dtype='datetime64[ns]', freq=None)
+    """
+    op = DataFrameToDatetime(errors=errors, dayfirst=dayfirst,
+                             yearfirst=yearfirst, utc=utc, format=format,
+                             exact=exact, unit=unit,
+                             infer_datetime_format=infer_datetime_format,
+                             origin=origin, cache=cache)
+    return op(arg)

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -205,7 +205,6 @@ message OperandDef {
         ANGLE = 195;
         SET_REAL = 196;
         SET_IMAG = 197;
-        TRAPZ = 198;
 
         // special
         GAMMALN = 200;
@@ -286,6 +285,7 @@ message OperandDef {
         FILL_DIAGONAL = 441;
         NORMALIZE = 442;
         TOPK = 443;
+        TRAPZ = 444;
         // fancy index, distributed phase is a shuffle operation that
         // the fancy indexes will be distributed to the left chunks
         // the concat phase will concat back the indexed left chunks and index
@@ -350,6 +350,7 @@ message OperandDef {
         SHIFT = 723;
         DATAFRAME_DIFF = 724;
         VALUE_COUNTS = 725;
+        TO_DATETIME = 726;
 
         FUSE = 801;
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR contributed two changes:

1. Implementation of `md.to_datetime`.
2. Support `__setitem__` for DataFrame.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Support part of #1121 .
