### PR TITLE
Set output type when calling new_xxx methods on DataFrames

### DIFF
--- a/mars/dataframe/arithmetic/around.py
+++ b/mars/dataframe/arithmetic/around.py
@@ -26,8 +26,8 @@ class DataFrameAround(DataFrameUnaryUfunc):
 
     _decimals = Int32Field('decimals')
 
-    def __init__(self, decimals=None, object_type=None, **kw):
-        super().__init__(_decimals=decimals, object_type=object_type, **kw)
+    def __init__(self, decimals=None, output_types=None, **kw):
+        super().__init__(_decimals=decimals, output_types=output_types, **kw)
 
     @classproperty
     def tensor_op_type(self):

--- a/mars/dataframe/arithmetic/dot.py
+++ b/mars/dataframe/arithmetic/dot.py
@@ -23,7 +23,7 @@ from ...tensor import tensor as astensor
 from ...tensor.core import TENSOR_TYPE
 from ...tensor.utils import decide_unify_split, validate_axis
 from ..core import DATAFRAME_TYPE, SERIES_TYPE, IndexValue
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index
 
 
@@ -33,8 +33,8 @@ class DataFrameDot(DataFrameOperand, DataFrameOperandMixin):
     _lhs = KeyField('lhs')
     _rhs = KeyField('rhs')
 
-    def __init__(self, object_type=None, lhs=None, rhs=None, **kw):
-        super().__init__(_object_type=object_type, _lhs=lhs, _rhs=rhs, **kw)
+    def __init__(self, output_types=None, lhs=None, rhs=None, **kw):
+        super().__init__(_output_types=output_types, _lhs=lhs, _rhs=rhs, **kw)
 
     @property
     def lhs(self):
@@ -61,10 +61,8 @@ class DataFrameDot(DataFrameOperand, DataFrameOperandMixin):
             if isinstance(lhs, SERIES_TYPE) and isinstance(rhs, TENSOR_TYPE):
                 # return tensor
                 return test_ret
-            self._object_type = ObjectType.scalar
             return self.new_scalar([lhs, rhs], dtype=test_ret.dtype)
         elif test_ret.ndim == 1:
-            self._object_type = ObjectType.series
             if lhs.ndim == 1:
                 if hasattr(rhs, 'columns_value'):
                     index_value = rhs.columns_value
@@ -79,7 +77,6 @@ class DataFrameDot(DataFrameOperand, DataFrameOperandMixin):
             return self.new_series([lhs, rhs], shape=test_ret.shape,
                                    dtype=test_ret.dtype, index_value=index_value)
         else:
-            self._object_type = ObjectType.dataframe
             if isinstance(rhs, TENSOR_TYPE):
                 dtypes = pd.Series(np.repeat(test_ret.dtype, test_ret.shape[1]),
                                    index=pd.RangeIndex(test_ret.shape[1]))

--- a/mars/dataframe/arithmetic/tests/test_arithmetic.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic.py
@@ -19,9 +19,9 @@ import unittest
 import numpy as np
 import pandas as pd
 
+from mars.core import OutputType
 from mars.operands import OperandStage
 from mars.dataframe.core import IndexValue
-from mars.dataframe.operands import ObjectType
 from mars.dataframe.utils import hash_dtypes
 from mars.dataframe.utils import split_monotonic_index_min_max, \
     build_split_idx_to_origin_idx, filter_index_value
@@ -336,7 +336,7 @@ class TestBinary(TestBase):
             # test the right side
             self.assertIsInstance(c.inputs[1].op, DataFrameIndexAlign)
             self.assertEqual(c.inputs[1].op.stage, OperandStage.reduce)
-            self.assertEqual(c.inputs[1].op.object_type, ObjectType.series)
+            self.assertEqual(c.inputs[1].op.output_types[0], OutputType.series)
             self.assertIsInstance(c.inputs[1].inputs[0].op, DataFrameShuffleProxy)
             for j, ci, ic in zip(itertools.count(0), c.inputs[1].inputs[0].inputs, s1.chunks):
                 self.assertIsInstance(ci.op, DataFrameIndexAlign)
@@ -437,7 +437,7 @@ class TestBinary(TestBase):
         self.assertEqual(s3.chunk_shape, (2,))
         for c in s3.chunks:
             self.assertIsInstance(c.op, self.op)
-            self.assertEqual(c.op.object_type, ObjectType.series)
+            self.assertEqual(c.op.output_types[0], OutputType.series)
             self.assertEqual(len(c.inputs), 2)
             self.assertEqual(c.shape, (5,))
             self.assertEqual(c.index_value.key, s1.cix[c.index].index_value.key)
@@ -477,7 +477,7 @@ class TestBinary(TestBase):
             # test the left side
             self.assertIsInstance(c.inputs[0].op, DataFrameIndexAlign)
             self.assertEqual(c.inputs[0].op.stage, OperandStage.reduce)
-            self.assertEqual(c.inputs[0].op.object_type, ObjectType.series)
+            self.assertEqual(c.inputs[0].op.output_types[0], OutputType.series)
             self.assertIsInstance(c.inputs[0].inputs[0].op, DataFrameShuffleProxy)
             for j, ci, ic in zip(itertools.count(0), c.inputs[0].inputs[0].inputs, s1.chunks):
                 self.assertIsInstance(ci.op, DataFrameIndexAlign)
@@ -489,7 +489,7 @@ class TestBinary(TestBase):
             # test the right side
             self.assertIsInstance(c.inputs[1].op, DataFrameIndexAlign)
             self.assertEqual(c.inputs[1].op.stage, OperandStage.reduce)
-            self.assertEqual(c.inputs[1].op.object_type, ObjectType.series)
+            self.assertEqual(c.inputs[1].op.output_types[0], OutputType.series)
             self.assertIsInstance(c.inputs[1].inputs[0].op, DataFrameShuffleProxy)
             for j, ci, ic in zip(itertools.count(0), c.inputs[1].inputs[0].inputs, s2.chunks):
                 self.assertIsInstance(ci.op, DataFrameIndexAlign)

--- a/mars/dataframe/base/astype.py
+++ b/mars/dataframe/base/astype.py
@@ -22,7 +22,7 @@ from ...utils import recursive_tile
 from ...tensor.base import sort
 from ..utils import build_empty_df, build_empty_series
 from ..core import SERIES_TYPE
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 
 
 class DataFrameAstype(DataFrameOperand, DataFrameOperandMixin):
@@ -32,11 +32,9 @@ class DataFrameAstype(DataFrameOperand, DataFrameOperandMixin):
     _errors = StringField('errors')
     _category_cols = ListField('category_cols')
 
-    def __init__(self, dtype_values=None, copy=None, errors=None,
-                 category_cols=None, object_type=None, **kw):
-        super().__init__(_dtype_values=dtype_values,
-                         _errors=errors, _category_cols=category_cols,
-                         _object_type=object_type, **kw)
+    def __init__(self, dtype_values=None, errors=None, category_cols=None, output_types=None, **kw):
+        super().__init__(_dtype_values=dtype_values, _errors=errors, _category_cols=category_cols,
+                         _output_types=output_types, **kw)
 
     @property
     def dtype_values(self):
@@ -172,7 +170,6 @@ class DataFrameAstype(DataFrameOperand, DataFrameOperandMixin):
 
     def __call__(self, df):
         if isinstance(df, SERIES_TYPE):
-            self._object_type = ObjectType.series
             empty_series = build_empty_series(df.dtype)
             new_series = empty_series.astype(self.dtype_values, errors=self.errors)
             if new_series.dtype != df.dtype:
@@ -183,7 +180,6 @@ class DataFrameAstype(DataFrameOperand, DataFrameOperandMixin):
             return self.new_series([df], shape=df.shape, dtype=dtype,
                                    name=df.name, index_value=df.index_value)
         else:
-            self._object_type = ObjectType.dataframe
             empty_df = build_empty_df(df.dtypes)
             new_df = empty_df.astype(self.dtype_values, errors=self.errors)
             dtypes = []

--- a/mars/dataframe/base/checkna.py
+++ b/mars/dataframe/base/checkna.py
@@ -17,9 +17,9 @@ import pandas as pd
 
 from ... import opcodes
 from ...config import options
+from ...core import OutputType
 from ...serialize import BoolField
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType, \
-    DATAFRAME_TYPE
+from ..operands import DataFrameOperand, DataFrameOperandMixin, DATAFRAME_TYPE
 
 
 class DataFrameCheckNA(DataFrameOperand, DataFrameOperandMixin):
@@ -28,9 +28,9 @@ class DataFrameCheckNA(DataFrameOperand, DataFrameOperandMixin):
     _positive = BoolField('positive')
     _use_inf_as_na = BoolField('use_inf_as_na')
 
-    def __init__(self, positive=None, use_inf_as_na=None, sparse=None, object_type=None, **kw):
+    def __init__(self, positive=None, use_inf_as_na=None, sparse=None, output_types=None, **kw):
         super().__init__(_positive=positive, _use_inf_as_na=use_inf_as_na, _sparse=sparse,
-                         _object_type=object_type, **kw)
+                         _output_types=output_types, **kw)
 
     @property
     def positive(self) -> bool:
@@ -42,12 +42,12 @@ class DataFrameCheckNA(DataFrameOperand, DataFrameOperandMixin):
 
     def __call__(self, df):
         if isinstance(df, DATAFRAME_TYPE):
-            self._object_type = ObjectType.dataframe
+            self.output_types = [OutputType.dataframe]
         else:
-            self._object_type = ObjectType.series
+            self.output_types = [OutputType.series]
 
         params = df.params.copy()
-        if self.object_type == ObjectType.dataframe:
+        if self.output_types[0] == OutputType.dataframe:
             params['dtypes'] = pd.Series([np.dtype('bool')] * len(df.dtypes),
                                          index=df.columns_value.to_pandas())
         else:
@@ -62,7 +62,7 @@ class DataFrameCheckNA(DataFrameOperand, DataFrameOperandMixin):
         chunks = []
         for c in in_df.chunks:
             params = c.params.copy()
-            if op.object_type == ObjectType.dataframe:
+            if op.output_types[0] == OutputType.dataframe:
                 params['dtypes'] = pd.Series([np.dtype('bool')] * len(c.dtypes),
                                              index=c.columns_value.to_pandas())
             else:

--- a/mars/dataframe/base/core.py
+++ b/mars/dataframe/base/core.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from ...serialize import KeyField
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..core import DATAFRAME_TYPE, SERIES_TYPE
 
 
@@ -30,13 +30,11 @@ class DataFrameDeviceConversionBase(DataFrameOperand, DataFrameOperandMixin):
 
     def __call__(self, obj):
         if isinstance(obj, DATAFRAME_TYPE):
-            self._object_type = ObjectType.dataframe
             return self.new_dataframe([obj], shape=obj.shape, dtypes=obj.dtypes,
                                       index_value=obj.index_value,
                                       columns_value=obj.columns_value)
         else:
             assert isinstance(obj, SERIES_TYPE)
-            self._object_type = ObjectType.series
             return self.new_series([obj], shape=obj.shape, dtype=obj.dtype,
                                    index_value=obj.index_value, name=obj.name)
 
@@ -50,6 +48,6 @@ class DataFrameDeviceConversionBase(DataFrameOperand, DataFrameOperandMixin):
 
         new_op = op.copy().reset_key()
         out = op.outputs[0]
-        return new_op.new_dataframes(op.inputs, chunks=out_chunks,
-                                     nsplits=op.inputs[0].nsplits,
-                                     **out.params)
+        return new_op.new_tileables(op.inputs, chunks=out_chunks,
+                                    nsplits=op.inputs[0].nsplits,
+                                    **out.params)

--- a/mars/dataframe/base/datetimes.py
+++ b/mars/dataframe/base/datetimes.py
@@ -15,8 +15,9 @@
 import pandas as pd
 
 from ... import opcodes as OperandDef
+from ...core import OutputType
 from ...serialize import KeyField, StringField, TupleField, DictField, BoolField
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import build_empty_series
 
 
@@ -30,12 +31,12 @@ class SeriesDatetimeMethod(DataFrameOperand, DataFrameOperandMixin):
     _is_property = BoolField('is_property')
 
     def __init__(self, method=None, method_args=None, method_kwargs=None,
-                 is_property=None, stage=None, object_type=None, **kw):
+                 is_property=None, stage=None, output_types=None, **kw):
         super().__init__(_method=method, _method_args=method_args,
                          _method_kwargs=method_kwargs, _is_property=is_property,
-                         _stage=stage, _object_type=object_type, **kw)
-        if self._object_type is None:
-            self._object_type = ObjectType.series
+                         _stage=stage, _output_types=output_types, **kw)
+        if not self.output_types:
+            self.output_types = [OutputType.series]
 
     @property
     def input(self):

--- a/mars/dataframe/base/describe.py
+++ b/mars/dataframe/base/describe.py
@@ -21,7 +21,7 @@ from ...serialize import ValueType, KeyField, ListField
 from ...utils import recursive_tile
 from ..core import SERIES_TYPE
 from ..initializer import DataFrame, Series
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index, build_empty_df
 
 
@@ -34,9 +34,9 @@ class DataFrameDescribe(DataFrameOperand, DataFrameOperandMixin):
     _exclude = ListField('exclude')
 
     def __init__(self, percentiles=None, include=None, exclude=None,
-                 object_type=None, **kw):
+                 output_types=None, **kw):
         super().__init__(_percentiles=percentiles, _include=include,
-                         _exclude=exclude, _object_type=object_type, **kw)
+                         _exclude=exclude, _output_types=output_types, **kw)
 
     @property
     def input(self):
@@ -60,7 +60,6 @@ class DataFrameDescribe(DataFrameOperand, DataFrameOperandMixin):
 
     def __call__(self, df_or_series):
         if isinstance(df_or_series, SERIES_TYPE):
-            self._object_type = ObjectType.series
             if not np.issubdtype(df_or_series.dtype, np.number):
                 raise NotImplementedError('non-numeric type is not supported for now')
             test_series = pd.Series([], dtype=df_or_series.dtype).describe(
@@ -69,7 +68,6 @@ class DataFrameDescribe(DataFrameOperand, DataFrameOperandMixin):
                                    dtype=test_series.dtype,
                                    index_value=parse_index(test_series.index, store_data=True))
         else:
-            self._object_type = ObjectType.dataframe
             test_inp_df = build_empty_df(df_or_series.dtypes)
             test_df = test_inp_df.describe(
                 percentiles=self._percentiles, include=self._include, exclude=self._exclude)

--- a/mars/dataframe/base/diff.py
+++ b/mars/dataframe/base/diff.py
@@ -18,8 +18,8 @@ import numpy as np
 
 from ... import opcodes
 from ...serialize import AnyField, Int8Field, Int64Field
-from ..core import DATAFRAME_TYPE
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..core import DATAFRAME_TYPE, OutputType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import build_empty_df, build_empty_series, validate_axis
 from .shift import DataFrameShift
 
@@ -51,11 +51,11 @@ class DataFrameDiff(DataFrameOperandMixin, DataFrameOperand):
         params = df_or_series.params.copy()
 
         if isinstance(df_or_series, DATAFRAME_TYPE):
-            self._object_type = ObjectType.dataframe
+            self.output_types = [OutputType.dataframe]
             mock_obj = build_empty_df(df_or_series.dtypes)
             params['dtypes'] = mock_obj.diff().dtypes
         else:
-            self._object_type = ObjectType.series
+            self.output_types = [OutputType.series]
             mock_obj = build_empty_series(df_or_series.dtype, name=df_or_series.name)
             params['dtype'] = mock_obj.diff().dtype
 

--- a/mars/dataframe/base/drop.py
+++ b/mars/dataframe/base/drop.py
@@ -18,10 +18,10 @@ from collections import OrderedDict
 import numpy as np
 
 from ... import opcodes
-from ...core import Entity, Chunk, CHUNK_TYPE
+from ...core import Entity, Chunk, CHUNK_TYPE, OutputType
 from ...serialize import AnyField, StringField
 from ..core import IndexValue, DATAFRAME_TYPE, SERIES_TYPE, INDEX_CHUNK_TYPE
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index, validate_axis
 
 
@@ -80,11 +80,11 @@ class DataFrameDrop(DataFrameOperandMixin, DataFrameOperand):
             params['columns_value'] = parse_index(new_dtypes.index, store_data=True)
             params['dtypes'] = new_dtypes
             shape_list[1] = len(new_dtypes)
-            self._object_type = ObjectType.dataframe
+            self.output_types = [OutputType.dataframe]
         elif isinstance(df_or_series, SERIES_TYPE):
-            self._object_type = ObjectType.series
+            self.output_types = [OutputType.series]
         else:
-            self._object_type = ObjectType.index
+            self.output_types = [OutputType.index]
 
         params['shape'] = tuple(shape_list)
 

--- a/mars/dataframe/base/dropna.py
+++ b/mars/dataframe/base/dropna.py
@@ -18,10 +18,11 @@ import numpy as np
 import pandas as pd
 
 from ... import opcodes
+from ...core import OutputType
 from ...config import options
 from ...serialize import AnyField, BoolField, StringField, Int32Field
 from ..align import align_dataframe_series
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index, validate_axis
 
 
@@ -41,10 +42,10 @@ class DataFrameDropNA(DataFrameOperand, DataFrameOperandMixin):
     _subset_size = Int32Field('subset_size')
 
     def __init__(self, axis=None, how=None, thresh=None, subset=None, use_inf_as_na=None,
-                 drop_directly=None, subset_size=None, sparse=None, object_type=None, **kw):
+                 drop_directly=None, subset_size=None, sparse=None, output_types=None, **kw):
         super().__init__(_axis=axis, _how=how, _thresh=thresh, _subset=subset,
                          _use_inf_as_na=use_inf_as_na, _drop_directly=drop_directly,
-                         _subset_size=subset_size, _sparse=sparse, _object_type=object_type, **kw)
+                         _subset_size=subset_size, _sparse=sparse, _output_types=output_types, **kw)
 
     @property
     def axis(self) -> int:
@@ -272,7 +273,7 @@ def df_dropna(df, axis=0, how='any', thresh=None, subset=None, inplace=False):
 
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameDropNA(axis=axis, how=how, thresh=thresh, subset=subset,
-                         object_type=ObjectType.dataframe, use_inf_as_na=use_inf_as_na)
+                         output_types=[OutputType.dataframe], use_inf_as_na=use_inf_as_na)
     out_df = op(df)
     if inplace:
         df.data = out_df.data
@@ -354,7 +355,7 @@ def series_dropna(series, axis=0, inplace=False, how=None):
     """
     axis = validate_axis(axis, series)
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
-    op = DataFrameDropNA(axis=axis, how=how, object_type=ObjectType.series,
+    op = DataFrameDropNA(axis=axis, how=how, output_types=[OutputType.series],
                          use_inf_as_na=use_inf_as_na)
     out_series = op(series)
     if inplace:

--- a/mars/dataframe/base/isin.py
+++ b/mars/dataframe/base/isin.py
@@ -16,12 +16,13 @@ import numpy as np
 from pandas.api.types import is_list_like
 
 from ... import opcodes as OperandDef
+from ...core import OutputType
 from ...serialize import KeyField, AnyField
 from ...tensor.core import TENSOR_TYPE
 from ...tiles import TilesError
 from ...utils import check_chunks_unknown_shape
 from ..core import SERIES_TYPE, INDEX_TYPE
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 
 
 class DataFrameIsin(DataFrameOperand, DataFrameOperandMixin):
@@ -30,10 +31,10 @@ class DataFrameIsin(DataFrameOperand, DataFrameOperandMixin):
     _input = KeyField('input')
     _values = AnyField('values')
 
-    def __init__(self, values=None, object_type=None, **kw):
-        if object_type is None:
-            object_type = ObjectType.series
-        super().__init__(_values=values, _object_type=object_type, **kw)
+    def __init__(self, values=None, output_types=None, **kw):
+        if output_types is None:
+            output_types = [OutputType.series]
+        super().__init__(_values=values, _output_types=output_types, **kw)
 
     @property
     def input(self):

--- a/mars/dataframe/base/map.py
+++ b/mars/dataframe/base/map.py
@@ -19,11 +19,12 @@ import numpy as np
 import pandas as pd
 
 from ... import opcodes as OperandDef
+from ...core import OutputType
 from ...serialize import KeyField, AnyField, StringField
 from ...tiles import TilesError
 from ...utils import check_chunks_unknown_shape
 from ..core import SERIES_TYPE
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 
 
 class DataFrameMap(DataFrameOperand, DataFrameOperandMixin):
@@ -33,11 +34,11 @@ class DataFrameMap(DataFrameOperand, DataFrameOperandMixin):
     _arg = AnyField('arg')
     _na_action = StringField('na_action')
 
-    def __init__(self, arg=None, na_action=None, object_type=None, **kw):
+    def __init__(self, arg=None, na_action=None, output_types=None, **kw):
         super().__init__(_arg=arg, _na_action=na_action,
-                         _object_type=object_type, **kw)
-        if self._object_type is None:
-            self._object_type = ObjectType.series
+                         _output_types=output_types, **kw)
+        if not self.output_types:
+            self.output_types = [OutputType.series]
 
     @property
     def input(self):

--- a/mars/dataframe/base/melt.py
+++ b/mars/dataframe/base/melt.py
@@ -17,7 +17,7 @@ import pandas as pd
 
 from ... import opcodes
 from ...serialize.core import AnyField, StringField
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin, OutputType
 from ..utils import build_empty_df, parse_index, standardize_range_index
 
 
@@ -59,7 +59,7 @@ class DataFrameMelt(DataFrameOperand, DataFrameOperandMixin):
         empty_result = build_empty_df(df.dtypes).melt(id_vars=self.id_vars, value_vars=self.value_vars,
                                                       var_name=self.var_name, value_name=self.value_name,
                                                       col_level=self.col_level)
-        self._object_type = ObjectType.dataframe
+        self._output_types = [OutputType.dataframe]
         return self.new_tileable([df], shape=(np.nan, len(empty_result.columns)), dtypes=empty_result.dtypes,
                                  index_value=parse_index(pd.RangeIndex(-1), df.key, df.index_value.key),
                                  columns_value=parse_index(empty_result.columns, store_data=True))

--- a/mars/dataframe/base/reset_index.py
+++ b/mars/dataframe/base/reset_index.py
@@ -18,8 +18,9 @@ import pandas as pd
 import numpy as np
 
 from ... import opcodes as OperandDef
+from ...core import OutputType
 from ...serialize import BoolField, AnyField, StringField
-from ..operands import DataFrameOperandMixin, DataFrameOperand, DATAFRAME_TYPE, ObjectType
+from ..operands import DataFrameOperandMixin, DataFrameOperand, DATAFRAME_TYPE
 from ..core import IndexValue
 from ..utils import parse_index, build_empty_df, build_empty_series, standardize_range_index
 
@@ -33,9 +34,9 @@ class DataFrameResetIndex(DataFrameOperand, DataFrameOperandMixin):
     _col_level = AnyField('col_level')
     _col_fill = AnyField('col_fill')
 
-    def __init__(self, level=None, drop=None, name=None, col_level=None, col_fill=None, object_type=None, **kwargs):
+    def __init__(self, level=None, drop=None, name=None, col_level=None, col_fill=None, output_types=None, **kwargs):
         super().__init__(_level=level, _drop=drop, _name=name, _col_level=col_level,
-                         _col_fill=col_fill, _object_type=object_type, **kwargs)
+                         _col_fill=col_fill, _output_types=output_types, **kwargs)
 
     @property
     def level(self):
@@ -171,7 +172,6 @@ class DataFrameResetIndex(DataFrameOperand, DataFrameOperandMixin):
             index_value = parse_index(pd.RangeIndex(range_value))
             return self.new_series([a], shape=a.shape, dtype=a.dtype, name=a.name, index_value=index_value)
         else:
-            self._object_type = ObjectType.dataframe
             empty_series = build_empty_series(dtype=a.dtype, index=a.index_value.to_pandas()[:0], name=a.name)
             empty_df = empty_series.reset_index(level=self.level, name=self.name)
             shape = (a.shape[0], len(empty_df.dtypes))
@@ -207,10 +207,10 @@ class DataFrameResetIndex(DataFrameOperand, DataFrameOperandMixin):
 
 def df_reset_index(df, level=None, drop=False, col_level=None, col_fill=None):
     op = DataFrameResetIndex(level=level, drop=drop, col_level=col_level,
-                             col_fill=col_fill, object_type=ObjectType.dataframe)
+                             col_fill=col_fill, output_types=[OutputType.dataframe])
     return op(df)
 
 
 def series_reset_index(series, level=None, drop=False, name=None):
-    op = DataFrameResetIndex(level=level, drop=drop, name=name, object_type=ObjectType.series)
+    op = DataFrameResetIndex(level=level, drop=drop, name=name, output_types=[OutputType.series])
     return op(series)

--- a/mars/dataframe/base/set_label.py
+++ b/mars/dataframe/base/set_label.py
@@ -50,7 +50,7 @@ class DataFrameSetLabel(DataFrameOperand, DataFrameOperandMixin):
         self._input = self._inputs[0]
 
     def __call__(self, inp):
-        self._object_type = inp.op.object_type
+        self._output_types = inp.op.output_types
         if not isinstance(inp, DATAFRAME_TYPE) or self._axis != 1:  # pragma: no cover
             raise NotImplementedError('Only support set DataFrame columns for now')
         if isinstance(self._value, (Base, Entity)):  # pragma: no cover

--- a/mars/dataframe/base/standardize_range_index.py
+++ b/mars/dataframe/base/standardize_range_index.py
@@ -30,8 +30,8 @@ class ChunkStandardizeRangeIndex(DataFrameOperand, DataFrameOperandMixin):
 
     _axis = Int32Field('axis')
 
-    def __init__(self, prepare_inputs=None, axis=None, object_type=None, **kwargs):
-        super().__init__(_prepare_inputs=prepare_inputs, _axis=axis, _object_type=object_type, **kwargs)
+    def __init__(self, prepare_inputs=None, axis=None, output_types=None, **kwargs):
+        super().__init__(_prepare_inputs=prepare_inputs, _axis=axis, _output_types=output_types, **kwargs)
 
     @property
     def axis(self):

--- a/mars/dataframe/base/to_cpu.py
+++ b/mars/dataframe/base/to_cpu.py
@@ -19,8 +19,8 @@ from .core import DataFrameDeviceConversionBase
 class DataFrameToCPU(DataFrameDeviceConversionBase):
     _op_type_ = OperandDef.TO_CPU
 
-    def __init__(self, dtypes=None, gpu=None, sparse=None, object_type=None, **kw):
-        super().__init__(_dtypes=dtypes, _gpu=gpu, _sparse=sparse, _object_type=object_type, **kw)
+    def __init__(self, dtypes=None, gpu=None, sparse=None, output_types=None, **kw):
+        super().__init__(_dtypes=dtypes, _gpu=gpu, _sparse=sparse, _output_types=output_types, **kw)
         if self._gpu or self._gpu is None:
             self._gpu = False
 

--- a/mars/dataframe/base/to_gpu.py
+++ b/mars/dataframe/base/to_gpu.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ..operands import ObjectType
 from .core import DataFrameDeviceConversionBase
 
 
 class DataFrameToGPU(DataFrameDeviceConversionBase):
     _op_type_ = OperandDef.TO_GPU
 
-    def __init__(self, dtypes=None, gpu=None, sparse=None, object_type=None, **kw):
-        super().__init__(_dtypes=dtypes, _gpu=gpu, _sparse=sparse, _object_type=object_type, **kw)
+    def __init__(self, dtypes=None, gpu=None, sparse=None, output_types=None, **kw):
+        super().__init__(_dtypes=dtypes, _gpu=gpu, _sparse=sparse, _output_types=output_types, **kw)
         if not self._gpu:
             self._gpu = True
 
@@ -29,10 +28,11 @@ class DataFrameToGPU(DataFrameDeviceConversionBase):
     def execute(cls, ctx, op):
         import cudf
 
-        if op.object_type == ObjectType.dataframe:
-            ctx[op.outputs[0].key] = cudf.DataFrame.from_pandas(ctx[op.inputs[0].key])
+        out_df = op.outputs[0]
+        if out_df.ndim == 2:
+            ctx[out_df.key] = cudf.DataFrame.from_pandas(ctx[op.inputs[0].key])
         else:
-            ctx[op.outputs[0].key] = cudf.Series.from_pandas(ctx[op.inputs[0].key])
+            ctx[out_df.key] = cudf.Series.from_pandas(ctx[op.inputs[0].key])
 
 
 def to_gpu(df_or_series):

--- a/mars/dataframe/base/value_counts.py
+++ b/mars/dataframe/base/value_counts.py
@@ -16,12 +16,13 @@ import numpy as np
 import pandas as pd
 
 from ... import opcodes
+from ...core import OutputType
 from ...operands import OperandStage
 from ...serialize import KeyField, BoolField, Int64Field, StringField
 from ...tiles import TilesError
 from ...utils import recursive_tile, check_chunks_unknown_shape
 from ..core import Series
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import build_series, parse_index
 
 
@@ -44,7 +45,7 @@ class DataFrameValueCounts(DataFrameOperand, DataFrameOperandMixin):
                          _bins=bins, _dropna=dropna, _method=method,
                          _convert_index_to_interval=convert_index_to_interval,
                          _stage=stage, **kw)
-        self._object_type = ObjectType.series
+        self.output_types = [OutputType.series]
 
     @property
     def input(self):

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -21,13 +21,13 @@ from typing import Union
 import numpy as np
 import pandas as pd
 
-from ..utils import on_serialize_shape, on_deserialize_shape, on_serialize_numpy_type, \
-    is_eager_mode, build_mode, ceildiv
-from ..core import ChunkData, Chunk, TileableEntity, \
-    HasShapeTileableData, HasShapeTileableEnity
+from ..core import ChunkData, Chunk, TileableEntity, HasShapeTileableData, \
+    HasShapeTileableEnity, OutputType, register_output_types
 from ..serialize import Serializable, ValueType, ProviderType, DataTypeField, AnyField, \
     SeriesField, BoolField, Int32Field, StringField, ListField, SliceField, \
     TupleField, OneOfField, ReferenceField, NDArrayField, IntervalArrayField
+from ..utils import on_serialize_shape, on_deserialize_shape, on_serialize_numpy_type, \
+    is_eager_mode, build_mode, ceildiv
 from .utils import fetch_corner_data, ReprSeries
 
 
@@ -1688,3 +1688,10 @@ CATEGORICAL_CHUNK_TYPE = (CategoricalChunk, CategoricalChunkData)
 TILEABLE_TYPE = INDEX_TYPE + SERIES_TYPE + DATAFRAME_TYPE + GROUPBY_TYPE + CATEGORICAL_TYPE
 CHUNK_TYPE = INDEX_CHUNK_TYPE + SERIES_CHUNK_TYPE + DATAFRAME_CHUNK_TYPE + \
              GROUPBY_CHUNK_TYPE + CATEGORICAL_CHUNK_TYPE
+
+register_output_types(OutputType.dataframe, DATAFRAME_TYPE, DATAFRAME_CHUNK_TYPE)
+register_output_types(OutputType.series, SERIES_TYPE, SERIES_CHUNK_TYPE)
+register_output_types(OutputType.index, INDEX_TYPE, INDEX_CHUNK_TYPE)
+register_output_types(OutputType.categorical, CATEGORICAL_TYPE, CATEGORICAL_CHUNK_TYPE)
+register_output_types(OutputType.dataframe_groupby, DATAFRAME_GROUPBY_TYPE, DATAFRAME_GROUPBY_CHUNK_TYPE)
+register_output_types(OutputType.series_groupby, SERIES_GROUPBY_TYPE, SERIES_GROUPBY_CHUNK_TYPE)

--- a/mars/dataframe/datasource/dataframe.py
+++ b/mars/dataframe/datasource/dataframe.py
@@ -15,11 +15,12 @@
 import itertools
 
 from ... import opcodes as OperandDef
-from ...serialize import DataFrameField, SeriesField
 from ...config import options
+from ...core import OutputType
+from ...serialize import DataFrameField, SeriesField
 from ...tensor.utils import get_chunk_slices
 from ..utils import decide_dataframe_chunk_sizes, parse_index
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 
 
 class DataFrameDataSource(DataFrameOperand, DataFrameOperandMixin):
@@ -36,7 +37,7 @@ class DataFrameDataSource(DataFrameOperand, DataFrameOperandMixin):
         if dtypes is None and data is not None:
             dtypes = data.dtypes
         super().__init__(_data=data, _dtypes=dtypes, _gpu=gpu, _sparse=sparse,
-                         _object_type=ObjectType.dataframe, **kw)
+                         _output_types=[OutputType.dataframe], **kw)
 
     @property
     def data(self):

--- a/mars/dataframe/datasource/date_range.py
+++ b/mars/dataframe/datasource/date_range.py
@@ -22,9 +22,10 @@ from pandas._libs.tslibs import timezones
 
 from ... import opcodes as OperandDef
 from ...config import options
+from ...core import OutputType
 from ...serialize import AnyField, Int64Field, BoolField, StringField
 from ...tensor.utils import decide_chunk_sizes
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index
 
 try:
@@ -57,13 +58,13 @@ class DataFrameDateRange(DataFrameOperand, DataFrameOperandMixin):
 
     def __init__(self, start=None, end=None, periods=None,
                  freq=None, tz=None, normalize=None, name=None,
-                 closed=None, object_type=None, **kw):
+                 closed=None, output_types=None, **kw):
         super().__init__(_start=start, _end=end, _periods=periods,
                          _freq=freq, _tz=tz, _normalize=normalize,
                          _name=name, _closed=closed,
-                         _object_type=object_type, **kw)
-        if self._object_type is None:
-            self._object_type = ObjectType.index
+                         _output_types=output_types, **kw)
+        if self.output_types is None:
+            self.output_types = [OutputType.index]
 
     @property
     def start(self):

--- a/mars/dataframe/datasource/from_records.py
+++ b/mars/dataframe/datasource/from_records.py
@@ -17,11 +17,12 @@
 import numpy as np
 import pandas as pd
 
-from ...serialize import BoolField, ListField, Int32Field
 from ... import opcodes as OperandDef
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
-from ..utils import parse_index
+from ...core import OutputType
+from ...serialize import BoolField, ListField, Int32Field
 from ...tensor.core import TENSOR_TYPE
+from ..operands import DataFrameOperand, DataFrameOperandMixin
+from ..utils import parse_index
 
 
 class DataFrameFromRecords(DataFrameOperand, DataFrameOperandMixin):
@@ -37,7 +38,7 @@ class DataFrameFromRecords(DataFrameOperand, DataFrameOperandMixin):
         if index is not None or columns is not None:
             raise NotImplementedError('Specifying index value is not supported for now')
         super().__init__(_exclude=exclude, _columns=columns, _coerce_float=coerce_float, _nrows=nrows,
-                         _gpu=gpu, _sparse=sparse, _object_type=ObjectType.dataframe, **kw)
+                         _gpu=gpu, _sparse=sparse, _output_types=[OutputType.dataframe], **kw)
 
     @property
     def columns(self):

--- a/mars/dataframe/datasource/from_tensor.py
+++ b/mars/dataframe/datasource/from_tensor.py
@@ -20,14 +20,14 @@ import numpy as np
 import pandas as pd
 
 from ... import opcodes as OperandDef
-from ...core import Base, Entity
+from ...core import Base, Entity, OutputType
 from ...serialize import KeyField, SeriesField, DataTypeField, AnyField
 from ...tensor.datasource import tensor as astensor
 from ...tensor.utils import unify_chunks
 from ...tiles import TilesError
 from ...utils import check_chunks_unknown_shape
 from ..core import INDEX_TYPE
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index
 
 
@@ -43,7 +43,7 @@ class DataFrameFromTensor(DataFrameOperand, DataFrameOperandMixin):
 
     def __init__(self, input_=None, index=None, dtypes=None, gpu=None, sparse=None, **kw):
         super().__init__(_input=input_, _index=index, _dtypes=dtypes, _gpu=gpu,
-                         _sparse=sparse, _object_type=ObjectType.dataframe, **kw)
+                         _sparse=sparse, _output_types=[OutputType.dataframe], **kw)
 
     @property
     def dtypes(self):
@@ -372,7 +372,7 @@ class SeriesFromTensor(DataFrameOperand, DataFrameOperandMixin):
 
     def __init__(self, index=None, dtype=None, gpu=None, sparse=None, **kw):
         super().__init__(_index=index, _dtype=dtype, _gpu=gpu,
-                         _sparse=sparse, _object_type=ObjectType.series, **kw)
+                         _sparse=sparse, _output_types=[OutputType.series], **kw)
 
     @property
     def index(self):
@@ -427,9 +427,9 @@ class SeriesFromTensor(DataFrameOperand, DataFrameOperandMixin):
             out_chunks.append(out_chunk)
 
         new_op = op.copy()
-        return new_op.new_dataframes(op.inputs, out_series.shape, dtype=out_series.dtype,
-                                     index_value=out_series.index_value, name=out_series.name,
-                                     chunks=out_chunks, nsplits=in_tensor.nsplits)
+        return new_op.new_tileables(op.inputs, shape=out_series.shape, dtype=out_series.dtype,
+                                    index_value=out_series.index_value, name=out_series.name,
+                                    chunks=out_chunks, nsplits=in_tensor.nsplits)
 
     @classmethod
     def execute(cls, ctx, op):

--- a/mars/dataframe/datasource/from_vineyard.py
+++ b/mars/dataframe/datasource/from_vineyard.py
@@ -18,12 +18,13 @@ from pandas.core.internals.blocks import Block
 from pandas.core.internals.managers import BlockManager
 
 from ... import opcodes as OperandDef
+from ...core import OutputType
 from ...config import options
 from ...serialize import StringField
 from ...context import get_context, RunningMode
 from ...tiles import TilesError
 from ...utils import calc_nsplits, check_chunks_unknown_shape
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 
 try:
     import vineyard
@@ -42,7 +43,7 @@ class DataFrameFromVineyard(DataFrameOperand, DataFrameOperandMixin):
 
     def __init__(self, vineyard_socket=None, object_id=None, **kw):
         super().__init__(_vineyard_socket=vineyard_socket, _object_id=object_id,
-                         _object_type=ObjectType.dataframe, **kw)
+                         _output_types=[OutputType.dataframe], **kw)
 
     @property
     def vineyard_socket(self):
@@ -69,7 +70,7 @@ class DataFrameFromVineyard(DataFrameOperand, DataFrameOperandMixin):
 
     def __call__(self, shape, chunk_size=None):
         return self.new_dataframe(None, shape, dtypes=[], raw_chunk_size=chunk_size,
-                                  object_type=ObjectType.dataframe)
+                                  output_types=[OutputType.dataframe])
 
     @classmethod
     def tile(cls, op):
@@ -125,7 +126,7 @@ class DataFrameFromVineyardChunk(DataFrameOperand, DataFrameOperandMixin):
 
     def __init__(self, vineyard_socket=None, **kw):
         super().__init__(_vineyard_socket=vineyard_socket, _object_id=None,
-                         _object_type=ObjectType.dataframe, **kw)
+                         _output_types=[OutputType.dataframe], **kw)
 
     @property
     def vineyard_socket(self):
@@ -139,7 +140,7 @@ class DataFrameFromVineyardChunk(DataFrameOperand, DataFrameOperandMixin):
         if not isinstance(a.op, DataFrameFromVineyard):
             raise ValueError('Not a vineyard dataframe')
         self._object_id = a.op.object_id
-        return self.new_dataframe([a], object_type=ObjectType.dataframe)
+        return self.new_dataframe([a], output_types=[OutputType.dataframe])
 
     @classmethod
     def tile(cls, op):

--- a/mars/dataframe/datasource/index.py
+++ b/mars/dataframe/datasource/index.py
@@ -19,9 +19,10 @@ import pandas as pd
 
 from ... import opcodes as OperandDef
 from ...config import options
+from ...core import OutputType
 from ...serialize import IndexField, DataTypeField, KeyField
 from ...tensor.utils import get_chunk_slices
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index, decide_series_chunk_size
 
 
@@ -39,7 +40,7 @@ class IndexDataSource(DataFrameOperand, DataFrameOperandMixin):
     def __init__(self, input=None, data=None, dtype=None, gpu=None,  # pylint: disable=redefined-builtin
                  sparse=None, **kw):
         super().__init__(_input=input, _data=data, _dtype=dtype, _gpu=gpu,
-                         _sparse=sparse, _object_type=ObjectType.index, **kw)
+                         _sparse=sparse, _output_types=[OutputType.index], **kw)
 
     @property
     def input(self):

--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -21,12 +21,13 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...config import options
+from ...core import OutputType
 from ...utils import parse_readable_size, lazy_import
 from ...serialize import StringField, DictField, ListField, Int32Field, Int64Field, BoolField, AnyField
 from ...filesystem import open_file, file_size, glob
 from ..core import IndexValue
 from ..utils import parse_index, build_empty_df, standardize_range_index
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 
 try:
     from pyarrow import HdfsFile
@@ -101,7 +102,8 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                          _index_col=index_col, _compression=compression,
                          _usecols=usecols, _offset=offset, _size=size,
                          _gpu=gpu, _incremental_index=incremental_index,
-                         _storage_options=storage_options, _object_type=ObjectType.dataframe, **kw)
+                         _storage_options=storage_options,
+                         _output_types=[OutputType.dataframe], **kw)
 
     @property
     def path(self):

--- a/mars/dataframe/datasource/read_sql.py
+++ b/mars/dataframe/datasource/read_sql.py
@@ -27,7 +27,7 @@ from ...serialize import StringField, AnyField, BoolField, ListField, \
     Int64Field, Float64Field, BytesField
 from ...tensor.utils import normalize_chunk_sizes
 from ..core import IndexValue
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin, OutputType
 from ..utils import parse_index, create_sa_connection, standardize_range_index
 
 
@@ -62,7 +62,7 @@ class DataFrameReadSQL(DataFrameOperand, DataFrameOperandMixin):
                  engine_kwargs=None, row_memory_usage=None, method=None,
                  incremental_index=None, offset=None, partition_col=None,
                  num_partitions=None, low_limit=None, high_limit=None, left_end=None,
-                 right_end=None, object_type=None, gpu=None, **kw):
+                 right_end=None, output_types=None, gpu=None, **kw):
         super().__init__(_table_or_sql=table_or_sql, _selectable=selectable, _con=con,
                          _schema=schema, _index_col=index_col, _coerce_float=coerce_float,
                          _parse_dates=parse_dates, _columns=columns,
@@ -70,9 +70,9 @@ class DataFrameReadSQL(DataFrameOperand, DataFrameOperandMixin):
                          _method=method, _incremental_index=incremental_index, _offset=offset,
                          _partition_col=partition_col, _num_partitions=num_partitions,
                          _low_limit=low_limit, _left_end=left_end, _right_end=right_end,
-                         _high_limit=high_limit, _object_type=object_type, _gpu=gpu, **kw)
-        if self._object_type is None:
-            self._object_type = ObjectType.dataframe
+                         _high_limit=high_limit, _output_types=output_types, _gpu=gpu, **kw)
+        if not self.output_types:
+            self._output_types = [OutputType.dataframe]
 
     @property
     def table_or_sql(self):

--- a/mars/dataframe/datasource/series.py
+++ b/mars/dataframe/datasource/series.py
@@ -17,8 +17,9 @@ import itertools
 from ... import opcodes as OperandDef
 from ...serialize import SeriesField, DataTypeField
 from ...config import options
+from ...core import OutputType
 from ...tensor.utils import get_chunk_slices
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index, decide_series_chunk_size
 
 
@@ -36,7 +37,7 @@ class SeriesDataSource(DataFrameOperand, DataFrameOperandMixin):
         if dtype is None and data is not None:
             dtype = data.dtype
         super().__init__(_data=data, _dtype=dtype, _gpu=gpu, _sparse=sparse,
-                         _object_type=ObjectType.series, **kw)
+                         _output_types=[OutputType.series], **kw)
 
     @property
     def data(self):

--- a/mars/dataframe/datastore/to_sql.py
+++ b/mars/dataframe/datastore/to_sql.py
@@ -19,7 +19,7 @@ from ... import opcodes
 from ...serialize import StringField, AnyField, BoolField, \
     Int64Field, BytesField
 from ..core import DATAFRAME_TYPE
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index, build_empty_df, build_empty_series, create_sa_connection
 
 
@@ -98,13 +98,11 @@ class DataFrameToSQLTable(DataFrameOperand, DataFrameOperandMixin):
 
             index_value = parse_index(df_or_series.index_value.to_pandas()[:0], df_or_series.key, 'index')
             if isinstance(df_or_series, DATAFRAME_TYPE):
-                self._object_type = ObjectType.dataframe
                 columns_value = parse_index(df_or_series.columns_value.to_pandas()[:0],
                                             df_or_series.key, 'columns', store_data=True)
                 return self.new_dataframe([df_or_series], shape=(0, 0), dtypes=df_or_series.dtypes[:0],
                                           index_value=index_value, columns_value=columns_value)
             else:
-                self._object_type = ObjectType.series
                 return self.new_series([df_or_series], shape=(0,), dtype=df_or_series.dtype,
                                        index_value=index_value)
 

--- a/mars/dataframe/datastore/to_vineyard.py
+++ b/mars/dataframe/datastore/to_vineyard.py
@@ -18,11 +18,12 @@ import pandas as pd
 
 from ... import opcodes as OperandDef
 from ...config import options
+from ...core import OutputType
 from ...context import get_context, RunningMode
 from ...serialize import TupleField, ListField, StringField
 from ...tiles import TilesError
 from ...utils import check_chunks_unknown_shape
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 
 try:
     import vineyard
@@ -37,7 +38,7 @@ class DataFrameToVineyardChunk(DataFrameOperand, DataFrameOperandMixin):
     _vineyard_socket = StringField('vineyard_socket')
 
     def __init__(self, vineyard_socket=None, dtypes=None, **kw):
-        super().__init__(_vineyard_socket=vineyard_socket, _dtypes=dtypes, _object_type=ObjectType.dataframe, **kw)
+        super().__init__(_vineyard_socket=vineyard_socket, _dtypes=dtypes, _output_types=[OutputType.dataframe], **kw)
 
     def __call__(self, df):
         return self.new_dataframe([df], shape=(0, 0), dtypes=df.dtypes,
@@ -106,7 +107,7 @@ class DataFrameToVineyardChunkMap(DataFrameOperand, DataFrameOperandMixin):
     _vineyard_socket = StringField('vineyard_socket')
 
     def __init__(self, vineyard_socket=None, **kw):
-        super().__init__(_vineyard_socket=vineyard_socket, _object_type=ObjectType.dataframe, **kw)
+        super().__init__(_vineyard_socket=vineyard_socket, _output_types=[OutputType.dataframe], **kw)
 
     @property
     def local_chunks(self):
@@ -188,7 +189,7 @@ class DataFrameToVinyardStoreGlobalMeta(DataFrameOperand, DataFrameOperandMixin)
     def __init__(self, vineyard_socket=None, chunk_shape=None, shape=None, **kw):
         super().__init__(_vineyard_socket=vineyard_socket,
                          _chunk_shape=chunk_shape, _shape=shape,
-                         _object_type=ObjectType.dataframe, **kw)
+                         _output_types=[OutputType.dataframe], **kw)
 
     @property
     def shape(self):

--- a/mars/dataframe/fetch/core.py
+++ b/mars/dataframe/fetch/core.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import operator
-
-from ...serialize.core import TupleField, ValueType, Int8Field
+from ...serialize.core import TupleField, ValueType
 from ...operands import Fetch, FetchShuffle, FetchMixin
 from ...utils import on_serialize_shape, on_deserialize_shape
-from ..operands import DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperandMixin
 
 
 class DataFrameFetchMixin(DataFrameOperandMixin, FetchMixin):
@@ -28,16 +26,10 @@ class DataFrameFetch(Fetch, DataFrameFetchMixin):
     # required fields
     _shape = TupleField('shape', ValueType.int64,
                         on_serialize=on_serialize_shape, on_deserialize=on_deserialize_shape)
-    _object_type = Int8Field('object_type', on_serialize=operator.attrgetter('value'),
-                             on_deserialize=ObjectType)
 
-    def __init__(self, to_fetch_key=None, sparse=False, object_type=None, **kw):
+    def __init__(self, to_fetch_key=None, sparse=False, output_types=None, **kw):
         super().__init__(
-            _to_fetch_key=to_fetch_key, _sparse=sparse, _object_type=object_type, **kw)
-
-    @property
-    def object_type(self):
-        return self._object_type
+            _to_fetch_key=to_fetch_key, _sparse=sparse, _output_types=output_types, **kw)
 
     def _new_chunks(self, inputs, kws=None, **kw):
         if '_key' in kw and self._to_fetch_key is None:
@@ -56,14 +48,8 @@ class DataFrameFetchShuffle(FetchShuffle, DataFrameFetchMixin):
     # required fields
     _shape = TupleField('shape', ValueType.int64,
                         on_serialize=on_serialize_shape, on_deserialize=on_deserialize_shape)
-    _object_type = Int8Field('object_type', on_serialize=operator.attrgetter('value'),
-                             on_deserialize=ObjectType)
 
-    def __init__(self, to_fetch_keys=None, to_fetch_idxes=None, object_type=None, **kw):
+    def __init__(self, to_fetch_keys=None, to_fetch_idxes=None, output_types=None, **kw):
         super().__init__(
             _to_fetch_keys=to_fetch_keys, _to_fetch_idxes=to_fetch_idxes,
-            _object_type=object_type, **kw)
-
-    @property
-    def object_type(self):
-        return self._object_type
+            _output_types=output_types, **kw)

--- a/mars/dataframe/groupby/tests/test_groupby.py
+++ b/mars/dataframe/groupby/tests/test_groupby.py
@@ -18,11 +18,11 @@ from collections import OrderedDict
 
 import mars.dataframe as md
 from mars import opcodes
+from mars.core import OutputType
 from mars.dataframe.core import DataFrameGroupBy, SeriesGroupBy, DataFrame
 from mars.dataframe.groupby.core import DataFrameGroupByOperand, DataFrameShuffleProxy
 from mars.dataframe.groupby.aggregation import DataFrameGroupByAgg
 from mars.dataframe.groupby.getitem import GroupByIndex
-from mars.dataframe.operands import ObjectType
 from mars.operands import OperandStage
 from mars.tests.core import TestBase
 
@@ -143,7 +143,7 @@ class Test(TestBase):
         pd.testing.assert_series_equal(applied.dtypes, df1.dtypes)
         self.assertEqual(applied.shape, (np.nan, 3))
         self.assertEqual(applied.op._op_type_, opcodes.APPLY)
-        self.assertEqual(applied.op.object_type, ObjectType.dataframe)
+        self.assertEqual(applied.op.output_types[0], OutputType.dataframe)
         self.assertEqual(len(applied.chunks), 3)
         self.assertEqual(applied.chunks[0].shape, (np.nan, 3))
         pd.testing.assert_series_equal(applied.chunks[0].dtypes, df1.dtypes)
@@ -152,7 +152,7 @@ class Test(TestBase):
         self.assertEqual(applied.dtype, df1.a.dtype)
         self.assertEqual(applied.shape, (np.nan,))
         self.assertEqual(applied.op._op_type_, opcodes.APPLY)
-        self.assertEqual(applied.op.object_type, ObjectType.series)
+        self.assertEqual(applied.op.output_types[0], OutputType.series)
         self.assertEqual(len(applied.chunks), 3)
         self.assertEqual(applied.chunks[0].shape, (np.nan,))
         self.assertEqual(applied.chunks[0].dtype, df1.a.dtype)
@@ -161,7 +161,7 @@ class Test(TestBase):
         self.assertEqual(applied.dtype, df1.a.dtype)
         self.assertEqual(applied.shape, (np.nan,))
         self.assertEqual(applied.op._op_type_, opcodes.APPLY)
-        self.assertEqual(applied.op.object_type, ObjectType.series)
+        self.assertEqual(applied.op.output_types[0], OutputType.series)
         self.assertEqual(len(applied.chunks), 3)
         self.assertEqual(applied.chunks[0].shape, (np.nan,))
         self.assertEqual(applied.chunks[0].dtype, df1.a.dtype)
@@ -173,7 +173,7 @@ class Test(TestBase):
         self.assertEqual(applied.dtype, series1.dtype)
         self.assertEqual(applied.shape, (np.nan,))
         self.assertEqual(applied.op._op_type_, opcodes.APPLY)
-        self.assertEqual(applied.op.object_type, ObjectType.series)
+        self.assertEqual(applied.op.output_types[0], OutputType.series)
         self.assertEqual(len(applied.chunks), 3)
         self.assertEqual(applied.chunks[0].shape, (np.nan,))
         self.assertEqual(applied.chunks[0].dtype, series1.dtype)
@@ -200,7 +200,7 @@ class Test(TestBase):
         self.assertListEqual(r.dtypes.index.tolist(), list('acdef'))
         self.assertEqual(r.shape, (9, 5))
         self.assertEqual(r.op._op_type_, opcodes.TRANSFORM)
-        self.assertEqual(r.op.object_type, ObjectType.dataframe)
+        self.assertEqual(r.op.output_types[0], OutputType.dataframe)
         self.assertEqual(len(r.chunks), 3)
         self.assertEqual(r.chunks[0].shape, (np.nan, 5))
         self.assertListEqual(r.chunks[0].dtypes.index.tolist(), list('acdef'))
@@ -208,7 +208,7 @@ class Test(TestBase):
         r = mdf.groupby('b').transform(['cummax', 'cumcount'], _call_agg=True).tiles()
         self.assertEqual(r.shape, (np.nan, 6))
         self.assertEqual(r.op._op_type_, opcodes.TRANSFORM)
-        self.assertEqual(r.op.object_type, ObjectType.dataframe)
+        self.assertEqual(r.op.output_types[0], OutputType.dataframe)
         self.assertEqual(len(r.chunks), 3)
         self.assertEqual(r.chunks[0].shape, (np.nan, 6))
 
@@ -216,7 +216,7 @@ class Test(TestBase):
         r = mdf.groupby('b').transform(agg_dict, _call_agg=True).tiles()
         self.assertEqual(r.shape, (np.nan, 2))
         self.assertEqual(r.op._op_type_, opcodes.TRANSFORM)
-        self.assertEqual(r.op.object_type, ObjectType.dataframe)
+        self.assertEqual(r.op.output_types[0], OutputType.dataframe)
         self.assertEqual(len(r.chunks), 3)
         self.assertEqual(r.chunks[0].shape, (np.nan, 2))
 
@@ -224,7 +224,7 @@ class Test(TestBase):
         r = mdf.groupby('b').transform(agg_list, _call_agg=True).tiles()
         self.assertEqual(r.shape, (np.nan, 10))
         self.assertEqual(r.op._op_type_, opcodes.TRANSFORM)
-        self.assertEqual(r.op.object_type, ObjectType.dataframe)
+        self.assertEqual(r.op.output_types[0], OutputType.dataframe)
         self.assertEqual(len(r.chunks), 3)
         self.assertEqual(r.chunks[0].shape, (np.nan, 10))
 
@@ -235,7 +235,7 @@ class Test(TestBase):
         self.assertEqual(r.dtype, series1.dtype)
         self.assertEqual(r.shape, series1.shape)
         self.assertEqual(r.op._op_type_, opcodes.TRANSFORM)
-        self.assertEqual(r.op.object_type, ObjectType.series)
+        self.assertEqual(r.op.output_types[0], OutputType.series)
         self.assertEqual(len(r.chunks), 3)
         self.assertEqual(r.chunks[0].shape, (np.nan,))
         self.assertEqual(r.chunks[0].dtype, series1.dtype)
@@ -243,7 +243,7 @@ class Test(TestBase):
         r = ms1.groupby(lambda x: x % 3).transform('cummax', _call_agg=True).tiles()
         self.assertEqual(r.shape, (np.nan,))
         self.assertEqual(r.op._op_type_, opcodes.TRANSFORM)
-        self.assertEqual(r.op.object_type, ObjectType.series)
+        self.assertEqual(r.op.output_types[0], OutputType.series)
         self.assertEqual(len(r.chunks), 3)
         self.assertEqual(r.chunks[0].shape, (np.nan,))
 
@@ -251,7 +251,7 @@ class Test(TestBase):
         r = ms1.groupby(lambda x: x % 3).transform(agg_list, _call_agg=True).tiles()
         self.assertEqual(r.shape, (np.nan, 2))
         self.assertEqual(r.op._op_type_, opcodes.TRANSFORM)
-        self.assertEqual(r.op.object_type, ObjectType.dataframe)
+        self.assertEqual(r.op.output_types[0], OutputType.dataframe)
         self.assertEqual(len(r.chunks), 3)
         self.assertEqual(r.chunks[0].shape, (np.nan, 2))
 
@@ -263,21 +263,21 @@ class Test(TestBase):
 
         for fun in ['cummin', 'cummax', 'cumprod', 'cumsum']:
             r = getattr(mdf.groupby('b'), fun)().tiles()
-            self.assertEqual(r.op.object_type, ObjectType.dataframe)
+            self.assertEqual(r.op.output_types[0], OutputType.dataframe)
             self.assertEqual(len(r.chunks), 4)
             self.assertEqual(r.shape, (len(df1), 2))
             self.assertEqual(r.chunks[0].shape, (np.nan, 2))
             pd.testing.assert_index_equal(r.chunks[0].columns_value.to_pandas(), pd.Index(['a', 'c']))
 
             r = getattr(mdf.groupby('b'), fun)(axis=1).tiles()
-            self.assertEqual(r.op.object_type, ObjectType.dataframe)
+            self.assertEqual(r.op.output_types[0], OutputType.dataframe)
             self.assertEqual(len(r.chunks), 4)
             self.assertEqual(r.shape, (len(df1), 3))
             self.assertEqual(r.chunks[0].shape, (np.nan, 3))
             pd.testing.assert_index_equal(r.chunks[0].columns_value.to_pandas(), df1.columns)
 
         r = mdf.groupby('b').cumcount().tiles()
-        self.assertEqual(r.op.object_type, ObjectType.series)
+        self.assertEqual(r.op.output_types[0], OutputType.series)
         self.assertEqual(len(r.chunks), 4)
         self.assertEqual(r.shape, (len(df1),))
         self.assertEqual(r.chunks[0].shape, (np.nan,))
@@ -287,7 +287,7 @@ class Test(TestBase):
 
         for fun in ['cummin', 'cummax', 'cumprod', 'cumsum', 'cumcount']:
             r = getattr(ms1.groupby(lambda x: x % 2), fun)().tiles()
-            self.assertEqual(r.op.object_type, ObjectType.series)
+            self.assertEqual(r.op.output_types[0], OutputType.series)
             self.assertEqual(len(r.chunks), 4)
             self.assertEqual(r.shape, (len(series1),))
             self.assertEqual(r.chunks[0].shape, (np.nan,))

--- a/mars/dataframe/indexing/index_lib.py
+++ b/mars/dataframe/indexing/index_lib.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 from pandas.core.dtypes.cast import find_common_type
 
-from ...core import TileableEntity, Chunk
+from ...core import TileableEntity, Chunk, OutputType
 from ...operands import OperandStage
 from ...tiles import TilesError
 from ...tensor.core import TENSOR_TYPE
@@ -34,7 +34,6 @@ from ...tensor.utils import split_indexes_into_chunks, calc_pos, \
     filter_inputs, slice_split, calc_sliced_size, to_numpy
 from ...utils import check_chunks_unknown_shape, classproperty
 from ..core import SERIES_CHUNK_TYPE, IndexValue
-from ..operands import ObjectType
 from ..utils import parse_index
 from .utils import convert_labels_into_positions
 
@@ -131,17 +130,17 @@ class DataFrameIndexHandlerContext(IndexHandlerContext):
         index_values = chunk_index_info.index_values
         if len(shape) == 0:
             # scalar
-            chunk_op._object_type = ObjectType.scalar
+            chunk_op.output_types = [OutputType.scalar]
             kw['dtype'] = self.op.outputs[0].dtype
         elif len(shape) == 1:
             # Series
-            chunk_op._object_type = ObjectType.series
+            chunk_op.output_types = [OutputType.series]
             kw['index_value'] = index_values[0]
             kw['dtype'] = self.op.outputs[0].dtype
             kw['name'] = getattr(self.op.outputs[0], 'name', None)
         else:
             # dataframe
-            chunk_op._object_type = ObjectType.dataframe
+            chunk_op.output_types = [OutputType.dataframe]
             kw['index_value'] = index_values[0]
             kw['columns_value'] = index_values[1]
             kw['dtypes'] = chunk_index_info.dtypes

--- a/mars/dataframe/indexing/loc.py
+++ b/mars/dataframe/indexing/loc.py
@@ -27,7 +27,7 @@ from ...tensor.datasource import asarray
 from ...tensor.utils import calc_sliced_size, filter_inputs
 from ...utils import lazy_import
 from ..core import IndexValue, DATAFRAME_TYPE
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index
 from .index_lib import DataFrameLocIndexesHandler
 
@@ -80,9 +80,9 @@ class DataFrameLocGetItem(DataFrameOperand, DataFrameOperandMixin):
     _input = KeyField('input')
     _indexes = ListField('indexes')
 
-    def __init__(self, indexes=None, gpu=False, sparse=False, object_type=None, **kw):
+    def __init__(self, indexes=None, gpu=False, sparse=False, output_types=None, **kw):
         super().__init__(_indexes=indexes, _gpu=gpu, _sparse=sparse,
-                         _object_type=object_type, **kw)
+                         _output_types=output_types, **kw)
 
     @property
     def input(self):
@@ -263,7 +263,6 @@ class DataFrameLocGetItem(DataFrameOperand, DataFrameOperandMixin):
         shape = tuple(shape)
         if len(shape) == 0:
             # scalar
-            self._object_type = ObjectType.scalar
             if isinstance(inp, DATAFRAME_TYPE):
                 dtype = inp.dtypes[self._indexes[1]]
             else:
@@ -271,7 +270,6 @@ class DataFrameLocGetItem(DataFrameOperand, DataFrameOperandMixin):
             return self.new_scalar(inputs, dtype=dtype)
         elif len(shape) == 1:
             # series
-            self._object_type = ObjectType.series
             if isinstance(inp, DATAFRAME_TYPE):
                 if sizes[0] is None:
                     # label on axis 0
@@ -288,7 +286,6 @@ class DataFrameLocGetItem(DataFrameOperand, DataFrameOperandMixin):
                                        index_value=index_value, name=inp.name)
         else:
             # dataframe
-            self._object_type = ObjectType.dataframe
             return self.new_dataframe(inputs, shape=shape, dtypes=dtypes,
                                       index_value=index_value, columns_value=columns_value)
 

--- a/mars/dataframe/indexing/set_index.py
+++ b/mars/dataframe/indexing/set_index.py
@@ -15,9 +15,10 @@
 import numpy as np
 import pandas as pd
 
-from ...serialize import AnyField, BoolField
 from ... import opcodes as OperandDef
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ...core import OutputType
+from ...serialize import AnyField, BoolField
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import build_empty_df, parse_index
 
 
@@ -30,9 +31,9 @@ class DataFrameSetIndex(DataFrameOperand, DataFrameOperandMixin):
     _verify_integrity = BoolField('verify_integrity')
 
     def __init__(self, keys=None, drop=True, append=False, verify_integrity=False,
-                 object_type=None, **kw):
+                 output_types=None, **kw):
         super().__init__(_keys=keys, _drop=drop, _append=append,
-                         _verify_integrity=verify_integrity, _object_type=object_type, **kw)
+                         _verify_integrity=verify_integrity, _output_types=output_types, **kw)
 
     @property
     def keys(self):
@@ -118,5 +119,5 @@ class DataFrameSetIndex(DataFrameOperand, DataFrameOperandMixin):
 
 def set_index(df, keys, drop=True, append=False, verify_integrity=False, **kw):
     op = DataFrameSetIndex(keys=keys, drop=drop, append=append,
-                           verify_integrity=verify_integrity, object_type=ObjectType.dataframe, **kw)
+                           verify_integrity=verify_integrity, output_types=[OutputType.dataframe], **kw)
     return op(df)

--- a/mars/dataframe/indexing/setitem.py
+++ b/mars/dataframe/indexing/setitem.py
@@ -17,12 +17,13 @@ import pandas as pd
 from pandas.api.types import is_list_like
 
 from ... import opcodes
+from ...core import OutputType
 from ...serialize import KeyField, AnyField
 from ...tensor.core import TENSOR_TYPE
 from ...tiles import TilesError
 from ..core import SERIES_TYPE, DataFrame
 from ..initializer import Series as asseries
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index
 
 
@@ -33,11 +34,11 @@ class DataFrameSetitem(DataFrameOperand, DataFrameOperandMixin):
     _indexes = AnyField('indexes')
     _value = AnyField('value')
 
-    def __init__(self, target=None, indexes=None, value=None, object_type=None, **kw):
+    def __init__(self, target=None, indexes=None, value=None, output_types=None, **kw):
         super().__init__(_target=target, _indexes=indexes,
-                         _value=value, _object_type=object_type, **kw)
-        if self._object_type is None:
-            self._object_type = ObjectType.dataframe
+                         _value=value, _output_types=output_types, **kw)
+        if self.output_types is None:
+            self.output_types = [OutputType.dataframe]
 
     @property
     def target(self):

--- a/mars/dataframe/indexing/tests/test_indexing.py
+++ b/mars/dataframe/indexing/tests/test_indexing.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 
 import mars.dataframe as md
-from mars.tensor.core import CHUNK_TYPE as TENSOR_CHUNK_TYPE, Tensor
+from mars.tensor.core import TENSOR_CHUNK_TYPE, Tensor
 from mars.tests.core import TestBase
 from mars.dataframe.core import SERIES_CHUNK_TYPE, Series, DataFrame, DATAFRAME_CHUNK_TYPE
 from mars.dataframe.indexing.iloc import DataFrameIlocGetItem, DataFrameIlocSetItem, IndexingError

--- a/mars/dataframe/initializer.py
+++ b/mars/dataframe/initializer.py
@@ -14,10 +14,9 @@
 
 import pandas as pd
 
-from ..core import Base, Entity
+from ..core import Base, Entity, OutputType
 from ..tensor import tensor as astensor
 from ..tensor.core import TENSOR_TYPE
-from .operands import ObjectType
 from .core import DATAFRAME_TYPE, SERIES_TYPE, INDEX_TYPE, DataFrame as _Frame, \
     Series as _Series, Index as _Index
 from .datasource.dataframe import from_pandas as from_pandas_df
@@ -105,7 +104,7 @@ def named_dataframe(name, session=None):
 
     sess = session or Session.default_or_local()
     tileable_infos = sess.get_named_tileable_infos(name=name)
-    fetch_op = DataFrameFetch(object_type=ObjectType.dataframe)
+    fetch_op = DataFrameFetch(output_types=[OutputType.dataframe])
     return fetch_op.new_dataframe([], shape=tileable_infos.tileable_shape,
                                   _key=tileable_infos.tileable_key)
 
@@ -115,6 +114,6 @@ def named_series(name, session=None):
 
     sess = session or Session.default_or_local()
     tileable_infos = sess.get_named_tileable_infos(name=name)
-    fetch_op = DataFrameFetch(object_type=ObjectType.series)
+    fetch_op = DataFrameFetch(output_types=[OutputType.series])
     return fetch_op.new_series([], shape=tileable_infos.tileable_shape,
                                _key=tileable_infos.tileable_key)

--- a/mars/dataframe/merge/append.py
+++ b/mars/dataframe/merge/append.py
@@ -14,13 +14,13 @@
 
 import pandas as pd
 
-from ...serialize import BoolField
 from ... import opcodes as OperandDef
+from ...core import OutputType
+from ...serialize import BoolField
 from ..datasource.dataframe import from_pandas
 from ..indexing.iloc import DataFrameIlocGetItem, SeriesIlocGetItem
 from ..utils import parse_index, standardize_range_index
-from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType, \
-    DATAFRAME_TYPE, SERIES_TYPE
+from ..operands import DataFrameOperand, DataFrameOperandMixin, DATAFRAME_TYPE, SERIES_TYPE
 
 
 class DataFrameAppend(DataFrameOperand, DataFrameOperandMixin):
@@ -30,11 +30,11 @@ class DataFrameAppend(DataFrameOperand, DataFrameOperandMixin):
     _verify_integrity = BoolField('verify_integrity')
     _sort = BoolField('sort')
 
-    def __init__(self, ignore_index=None, verify_integrity=None, sort=None, object_type=None, **kw):
+    def __init__(self, ignore_index=None, verify_integrity=None, sort=None, output_types=None, **kw):
         super(DataFrameAppend, self).__init__(_ignore_index=ignore_index,
                                               _verify_integrity=verify_integrity,
                                               _sort=sort,
-                                              _object_type=object_type, **kw)
+                                              _output_types=output_types, **kw)
 
     @property
     def ignore_index(self):
@@ -111,7 +111,7 @@ class DataFrameAppend(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def tile(cls, op):
-        if op.object_type == ObjectType.dataframe:
+        if op.output_types[0] == OutputType.dataframe:
             return cls._tile_dataframe(op)
         else:
             return cls._tile_series(op)
@@ -182,10 +182,10 @@ class DataFrameAppend(DataFrameOperand, DataFrameOperandMixin):
 
     def __call__(self, df, other):
         if isinstance(df, DATAFRAME_TYPE):
-            self._object_type = ObjectType.dataframe
+            self.output_types = [OutputType.dataframe]
             return self._call_dataframe(df, other)
         else:
-            self._object_type = ObjectType.series
+            self.output_types = [OutputType.series]
             return self._call_series(df, other)
 
 

--- a/mars/dataframe/reduction/count.py
+++ b/mars/dataframe/reduction/count.py
@@ -16,8 +16,9 @@ import pandas as pd
 
 from ... import opcodes as OperandDef
 from ...config import options
+from ...core import OutputType
 from ...utils import lazy_import
-from .core import DataFrameReductionOperand, DataFrameReductionMixin, ObjectType
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 cudf = lazy_import('cudf', globals=globals())
 
@@ -48,7 +49,7 @@ class DataFrameCount(DataFrameReductionOperand, DataFrameReductionMixin):
 
 def count_series(series, level=None, combine_size=None, **kw):
     use_inf_as_na = kw.pop('_use_inf_as_na', options.dataframe.mode.use_inf_as_na)
-    op = DataFrameCount(level=level, combine_size=combine_size, object_type=ObjectType.scalar,
+    op = DataFrameCount(level=level, combine_size=combine_size, output_types=[OutputType.scalar],
                         use_inf_as_na=use_inf_as_na)
     return op(series)
 
@@ -56,5 +57,5 @@ def count_series(series, level=None, combine_size=None, **kw):
 def count_dataframe(df, axis=0, level=None, numeric_only=False, combine_size=None, **kw):
     use_inf_as_na = kw.pop('_use_inf_as_na', options.dataframe.mode.use_inf_as_na)
     op = DataFrameCount(axis=axis, level=level, numeric_only=numeric_only, combine_size=combine_size,
-                        object_type=ObjectType.series, use_inf_as_na=use_inf_as_na)
+                        output_types=[OutputType.series], use_inf_as_na=use_inf_as_na)
     return op(df)

--- a/mars/dataframe/reduction/cummax.py
+++ b/mars/dataframe/reduction/cummax.py
@@ -24,6 +24,6 @@ class DataFrameCummax(DataFrameCumReductionOperand, DataFrameCumReductionMixin):
 
 def cummax(df, axis=None, skipna=True):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
-    op = DataFrameCummax(axis=axis, skipna=skipna, object_type=df.op.object_type,
+    op = DataFrameCummax(axis=axis, skipna=skipna, output_types=df.op.output_types,
                          use_inf_as_na=use_inf_as_na)
     return op(df)

--- a/mars/dataframe/reduction/cummin.py
+++ b/mars/dataframe/reduction/cummin.py
@@ -24,6 +24,6 @@ class DataFrameCummin(DataFrameCumReductionOperand, DataFrameCumReductionMixin):
 
 def cummin(df, axis=None, skipna=True):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
-    op = DataFrameCummin(axis=axis, skipna=skipna, object_type=df.op.object_type,
+    op = DataFrameCummin(axis=axis, skipna=skipna, output_types=df.op.output_types,
                          use_inf_as_na=use_inf_as_na)
     return op(df)

--- a/mars/dataframe/reduction/cumprod.py
+++ b/mars/dataframe/reduction/cumprod.py
@@ -24,6 +24,6 @@ class DataFrameCumprod(DataFrameCumReductionOperand, DataFrameCumReductionMixin)
 
 def cumprod(df, axis=None, skipna=True):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
-    op = DataFrameCumprod(axis=axis, skipna=skipna, object_type=df.op.object_type,
+    op = DataFrameCumprod(axis=axis, skipna=skipna, output_types=df.op.output_types,
                           use_inf_as_na=use_inf_as_na)
     return op(df)

--- a/mars/dataframe/reduction/cumsum.py
+++ b/mars/dataframe/reduction/cumsum.py
@@ -24,6 +24,6 @@ class DataFrameCumsum(DataFrameCumReductionOperand, DataFrameCumReductionMixin):
 
 def cumsum(df, axis=None, skipna=True):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
-    op = DataFrameCumsum(axis=axis, skipna=skipna, object_type=df.op.object_type,
+    op = DataFrameCumsum(axis=axis, skipna=skipna, output_types=df.op.output_types,
                          use_inf_as_na=use_inf_as_na)
     return op(df)

--- a/mars/dataframe/reduction/max.py
+++ b/mars/dataframe/reduction/max.py
@@ -14,7 +14,8 @@
 
 from ... import opcodes as OperandDef
 from ...config import options
-from .core import DataFrameReductionOperand, DataFrameReductionMixin, ObjectType
+from ...core import OutputType
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 
 class DataFrameMax(DataFrameReductionOperand, DataFrameReductionMixin):
@@ -25,13 +26,13 @@ class DataFrameMax(DataFrameReductionOperand, DataFrameReductionMixin):
 def max_series(df, axis=None, skipna=None, level=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMax(axis=axis, skipna=skipna, level=level, combine_size=combine_size,
-                      object_type=ObjectType.scalar, use_inf_as_na=use_inf_as_na)
+                      output_types=[OutputType.scalar], use_inf_as_na=use_inf_as_na)
     return op(df)
 
 
 def max_dataframe(df, axis=None, skipna=None, level=None, numeric_only=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMax(axis=axis, skipna=skipna, level=level, numeric_only=numeric_only,
-                      combine_size=combine_size, object_type=ObjectType.series,
+                      combine_size=combine_size, output_types=[OutputType.series],
                       use_inf_as_na=use_inf_as_na)
     return op(df)

--- a/mars/dataframe/reduction/mean.py
+++ b/mars/dataframe/reduction/mean.py
@@ -14,8 +14,9 @@
 
 from ... import opcodes as OperandDef
 from ...config import options
+from ...core import OutputType
 from ...utils import lazy_import
-from .core import DataFrameReductionOperand, DataFrameReductionMixin, ObjectType
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 cudf = lazy_import('cudf', globals=globals())
 
@@ -43,13 +44,13 @@ class DataFrameMean(DataFrameReductionOperand, DataFrameReductionMixin):
 def mean_series(df, axis=None, skipna=None, level=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMean(axis=axis, skipna=skipna, level=level, combine_size=combine_size,
-                       object_type=ObjectType.scalar, use_inf_as_na=use_inf_as_na)
+                       output_types=[OutputType.scalar], use_inf_as_na=use_inf_as_na)
     return op(df)
 
 
 def mean_dataframe(df, axis=None, skipna=None, level=None, numeric_only=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMean(axis=axis, skipna=skipna, level=level, numeric_only=numeric_only,
-                       combine_size=combine_size, object_type=ObjectType.series,
+                       combine_size=combine_size, output_types=[OutputType.series],
                        use_inf_as_na=use_inf_as_na)
     return op(df)

--- a/mars/dataframe/reduction/min.py
+++ b/mars/dataframe/reduction/min.py
@@ -14,7 +14,8 @@
 
 from ... import opcodes as OperandDef
 from ...config import options
-from .core import DataFrameReductionOperand, DataFrameReductionMixin, ObjectType
+from ...core import OutputType
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 
 class DataFrameMin(DataFrameReductionOperand, DataFrameReductionMixin):
@@ -25,13 +26,13 @@ class DataFrameMin(DataFrameReductionOperand, DataFrameReductionMixin):
 def min_series(df, axis=None, skipna=None, level=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMin(axis=axis, skipna=skipna, level=level, combine_size=combine_size,
-                      object_type=ObjectType.scalar, use_inf_as_na=use_inf_as_na)
+                      output_types=[OutputType.scalar], use_inf_as_na=use_inf_as_na)
     return op(df)
 
 
 def min_dataframe(df, axis=None, skipna=None, level=None, numeric_only=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMin(axis=axis, skipna=skipna, level=level, numeric_only=numeric_only,
-                      combine_size=combine_size, object_type=ObjectType.series,
+                      combine_size=combine_size, output_types=[OutputType.series],
                       use_inf_as_na=use_inf_as_na)
     return op(df)

--- a/mars/dataframe/reduction/prod.py
+++ b/mars/dataframe/reduction/prod.py
@@ -14,7 +14,8 @@
 
 from ... import opcodes as OperandDef
 from ...config import options
-from .core import DataFrameReductionOperand, DataFrameReductionMixin, ObjectType
+from ...core import OutputType
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 
 class DataFrameProd(DataFrameReductionOperand, DataFrameReductionMixin):
@@ -25,12 +26,12 @@ class DataFrameProd(DataFrameReductionOperand, DataFrameReductionMixin):
 def prod_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameProd(axis=axis, skipna=skipna, level=level, min_count=min_count, combine_size=combine_size,
-                       object_type=ObjectType.scalar, use_inf_as_na=use_inf_as_na)
+                       output_types=[OutputType.scalar], use_inf_as_na=use_inf_as_na)
     return op(df)
 
 
 def prod_dataframe(df, axis=None, skipna=None, level=None, min_count=0, numeric_only=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameProd(axis=axis, skipna=skipna, level=level, min_count=min_count, numeric_only=numeric_only,
-                       combine_size=combine_size, object_type=ObjectType.series, use_inf_as_na=use_inf_as_na)
+                       combine_size=combine_size, output_types=[OutputType.series], use_inf_as_na=use_inf_as_na)
     return op(df)

--- a/mars/dataframe/reduction/sum.py
+++ b/mars/dataframe/reduction/sum.py
@@ -14,7 +14,8 @@
 
 from ... import opcodes as OperandDef
 from ...config import options
-from .core import DataFrameReductionOperand, DataFrameReductionMixin, ObjectType
+from ...core import OutputType
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 
 class DataFrameSum(DataFrameReductionOperand, DataFrameReductionMixin):
@@ -25,7 +26,7 @@ class DataFrameSum(DataFrameReductionOperand, DataFrameReductionMixin):
 def sum_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameSum(axis=axis, skipna=skipna, level=level, min_count=min_count,
-                      combine_size=combine_size, object_type=ObjectType.scalar,
+                      combine_size=combine_size, output_types=[OutputType.scalar],
                       use_inf_as_na=use_inf_as_na)
     return op(df)
 
@@ -34,5 +35,5 @@ def sum_dataframe(df, axis=None, skipna=None, level=None, min_count=0, numeric_o
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameSum(axis=axis, skipna=skipna, level=level, min_count=min_count,
                       numeric_only=numeric_only, combine_size=combine_size,
-                      object_type=ObjectType.series, use_inf_as_na=use_inf_as_na)
+                      output_types=[OutputType.series], use_inf_as_na=use_inf_as_na)
     return op(df)

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -23,14 +23,13 @@ from mars import opcodes as OperandDef
 from mars.operands import OperandStage
 from mars.tests.core import TestBase, parameterized
 from mars.tensor import Tensor
-from mars.dataframe.core import DataFrame, IndexValue, Series
+from mars.dataframe.core import DataFrame, IndexValue, Series, OutputType
 from mars.dataframe.reduction import DataFrameSum, DataFrameProd, DataFrameMin, \
     DataFrameMax, DataFrameCount, DataFrameMean, DataFrameVar, DataFrameCummin, \
     DataFrameCummax, DataFrameCumprod, DataFrameCumsum, DataFrameNunique
 from mars.dataframe.merge import DataFrameConcat
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
 from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df
-from mars.dataframe.operands import ObjectType
 
 
 reduction_functions = dict(
@@ -376,7 +375,7 @@ class TestCumReduction(TestBase):
         result = df.nunique()
 
         self.assertEqual(result.shape, (10,))
-        self.assertEqual(result.op.object_type, ObjectType.series)
+        self.assertEqual(result.op.output_types[0], OutputType.series)
         self.assertIsInstance(result.op, DataFrameNunique)
 
         tiled = result.tiles()
@@ -391,7 +390,7 @@ class TestCumReduction(TestBase):
         result2 = df2.nunique(axis=1)
 
         self.assertEqual(result2.shape, (20,))
-        self.assertEqual(result2.op.object_type, ObjectType.series)
+        self.assertEqual(result2.op.output_types[0], OutputType.series)
         self.assertIsInstance(result2.op, DataFrameNunique)
 
         tiled = result2.tiles()
@@ -413,7 +412,7 @@ class TestAggregate(TestBase):
         self.assertEqual(result.shape, (6, data.shape[1]))
         self.assertListEqual(list(result.columns_value.to_pandas()), list(range(19)))
         self.assertListEqual(list(result.index_value.to_pandas()), agg_funcs)
-        self.assertEqual(result.op.object_type, ObjectType.dataframe)
+        self.assertEqual(result.op.output_types[0], OutputType.dataframe)
         self.assertListEqual(result.op.func, agg_funcs)
 
         df = from_pandas_df(data, chunk_size=(3, 4))
@@ -422,7 +421,7 @@ class TestAggregate(TestBase):
         self.assertEqual(len(result.chunks), 5)
         self.assertEqual(result.shape, (data.shape[1],))
         self.assertListEqual(list(result.index_value.to_pandas()), list(range(data.shape[1])))
-        self.assertEqual(result.op.object_type, ObjectType.series)
+        self.assertEqual(result.op.output_types[0], OutputType.series)
         self.assertListEqual(result.op.func, ['sum'])
         agg_chunk = result.chunks[0]
         self.assertEqual(agg_chunk.shape, (4,))
@@ -433,7 +432,7 @@ class TestAggregate(TestBase):
         self.assertEqual(len(result.chunks), 7)
         self.assertEqual(result.shape, (data.shape[0],))
         self.assertListEqual(list(result.index_value.to_pandas()), list(range(data.shape[0])))
-        self.assertEqual(result.op.object_type, ObjectType.series)
+        self.assertEqual(result.op.output_types[0], OutputType.series)
         agg_chunk = result.chunks[0]
         self.assertEqual(agg_chunk.shape, (3,))
         self.assertListEqual(list(agg_chunk.index_value.to_pandas()), list(range(3)))
@@ -443,7 +442,7 @@ class TestAggregate(TestBase):
         self.assertEqual(len(result.chunks), 7)
         self.assertEqual(result.shape, (data.shape[0],))
         self.assertListEqual(list(result.index_value.to_pandas()), list(range(data.shape[0])))
-        self.assertEqual(result.op.object_type, ObjectType.series)
+        self.assertEqual(result.op.output_types[0], OutputType.series)
         self.assertListEqual(result.op.func, ['var'])
         agg_chunk = result.chunks[0]
         self.assertEqual(agg_chunk.shape, (3,))
@@ -455,7 +454,7 @@ class TestAggregate(TestBase):
         self.assertEqual(result.shape, (len(agg_funcs), data.shape[1]))
         self.assertListEqual(list(result.columns_value.to_pandas()), list(range(data.shape[1])))
         self.assertListEqual(list(result.index_value.to_pandas()), agg_funcs)
-        self.assertEqual(result.op.object_type, ObjectType.dataframe)
+        self.assertEqual(result.op.output_types[0], OutputType.dataframe)
         self.assertListEqual(result.op.func, agg_funcs)
         agg_chunk = result.chunks[0]
         self.assertEqual(agg_chunk.shape, (len(agg_funcs), 4))
@@ -468,7 +467,7 @@ class TestAggregate(TestBase):
         self.assertEqual(result.shape, (data.shape[0], len(agg_funcs)))
         self.assertListEqual(list(result.columns_value.to_pandas()), agg_funcs)
         self.assertListEqual(list(result.index_value.to_pandas()), list(range(data.shape[0])))
-        self.assertEqual(result.op.object_type, ObjectType.dataframe)
+        self.assertEqual(result.op.output_types[0], OutputType.dataframe)
         self.assertListEqual(result.op.func, agg_funcs)
         agg_chunk = result.chunks[0]
         self.assertEqual(agg_chunk.shape, (3, len(agg_funcs)))
@@ -483,7 +482,7 @@ class TestAggregate(TestBase):
         self.assertEqual(result.shape, (len(all_cols), len(dict_fun)))
         self.assertSetEqual(set(result.columns_value.to_pandas()), set(dict_fun.keys()))
         self.assertSetEqual(set(result.index_value.to_pandas()), all_cols)
-        self.assertEqual(result.op.object_type, ObjectType.dataframe)
+        self.assertEqual(result.op.output_types[0], OutputType.dataframe)
         self.assertListEqual(result.op.func[0], [dict_fun[0]])
         self.assertListEqual(result.op.func[2], dict_fun[2])
         agg_chunk = result.chunks[0]
@@ -505,7 +504,7 @@ class TestAggregate(TestBase):
         self.assertEqual(len(result.chunks), 1)
         self.assertEqual(result.shape, (6,))
         self.assertListEqual(list(result.index_value.to_pandas()), agg_funcs)
-        self.assertEqual(result.op.object_type, ObjectType.series)
+        self.assertEqual(result.op.output_types[0], OutputType.series)
         self.assertListEqual(result.op.func, agg_funcs)
 
         series = from_pandas_series(data, chunk_size=3)
@@ -513,7 +512,7 @@ class TestAggregate(TestBase):
         result = series.agg('sum').tiles()
         self.assertEqual(len(result.chunks), 1)
         self.assertEqual(result.shape, ())
-        self.assertEqual(result.op.object_type, ObjectType.scalar)
+        self.assertEqual(result.op.output_types[0], OutputType.scalar)
         agg_chunk = result.chunks[0]
         self.assertEqual(agg_chunk.shape, ())
         self.assertEqual(agg_chunk.op.stage, OperandStage.agg)
@@ -522,7 +521,7 @@ class TestAggregate(TestBase):
         self.assertEqual(len(result.chunks), 1)
         self.assertEqual(result.shape, (len(agg_funcs),))
         self.assertListEqual(list(result.index_value.to_pandas()), agg_funcs)
-        self.assertEqual(result.op.object_type, ObjectType.series)
+        self.assertEqual(result.op.output_types[0], OutputType.series)
         self.assertListEqual(result.op.func, agg_funcs)
         agg_chunk = result.chunks[0]
         self.assertEqual(agg_chunk.shape, (len(agg_funcs),))

--- a/mars/dataframe/reduction/unique.py
+++ b/mars/dataframe/reduction/unique.py
@@ -16,11 +16,12 @@
 import pandas as pd
 import numpy as np
 
-from ...tensor.core import TensorOrder
 from ... import opcodes as OperandDef
+from ...core import OutputType
 from ...serialize import StringField
+from ...tensor.core import TensorOrder
 from ...utils import lazy_import
-from .core import DataFrameReductionOperand, DataFrameReductionMixin, ObjectType
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 
 cudf = lazy_import('cudf', globals=globals())
@@ -72,7 +73,7 @@ class DataFrameUnique(DataFrameReductionOperand, DataFrameReductionMixin):
         ctx[op.outputs[0].key] = in_data.unique()
 
     def __call__(self, a):
-        self._object_type = ObjectType.tensor
+        self.output_types = [OutputType.tensor]
         return self.new_tileables([a], shape=(np.nan,), dtype=a.dtype, order=TensorOrder.C_ORDER)[0]
 
 

--- a/mars/dataframe/reduction/var.py
+++ b/mars/dataframe/reduction/var.py
@@ -17,9 +17,10 @@ import pandas as pd
 
 from ... import opcodes as OperandDef
 from ...config import options
+from ...core import OutputType
 from ...serialize import Int32Field
 from ...utils import lazy_import
-from .core import DataFrameReductionOperand, DataFrameReductionMixin, ObjectType
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 cudf = lazy_import('cudf', globals=globals())
 
@@ -104,7 +105,7 @@ class DataFrameVar(DataFrameReductionOperand, DataFrameReductionMixin):
 def var_series(series, axis=None, skipna=None, level=None, ddof=1, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameVar(axis=axis, skipna=skipna, level=level, ddof=ddof,
-                      combine_size=combine_size, object_type=ObjectType.scalar,
+                      combine_size=combine_size, output_types=[OutputType.scalar],
                       use_inf_as_na=use_inf_as_na)
     return op(series)
 
@@ -113,5 +114,5 @@ def var_dataframe(df, axis=None, skipna=None, level=None, ddof=1, numeric_only=N
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameVar(axis=axis, skipna=skipna, level=level, ddof=ddof,
                       numeric_only=numeric_only, combine_size=combine_size,
-                      object_type=ObjectType.series, use_inf_as_na=use_inf_as_na)
+                      output_types=[OutputType.series], use_inf_as_na=use_inf_as_na)
     return op(df)

--- a/mars/dataframe/sort/sort_index.py
+++ b/mars/dataframe/sort/sort_index.py
@@ -14,11 +14,12 @@
 
 import pandas as pd
 
-from ...serialize import ListField, BoolField
 from ... import opcodes as OperandDef
+from ...core import OutputType
+from ...serialize import ListField, BoolField
 from ...tensor.base.sort import _validate_sort_psrs_kinds
 from ..utils import parse_index, validate_axis, build_concatenated_rows_frame, standardize_range_index
-from ..operands import DATAFRAME_TYPE, ObjectType
+from ..operands import DATAFRAME_TYPE
 from .core import DataFrameSortOperand
 from .psrs import DataFramePSRSOperandMixin, execute_sort_index
 
@@ -46,7 +47,7 @@ class DataFrameSortIndex(DataFrameSortOperand, DataFramePSRSOperandMixin):
 
         if op.axis == 0:
             if df.chunk_shape[op.axis] == 1:
-                if op.object_type == ObjectType.dataframe:
+                if op.output_types[0] == OutputType.dataframe:
                     df = build_concatenated_rows_frame(df)
                     out_chunks = []
                     for chunk in df.chunks:
@@ -72,7 +73,7 @@ class DataFrameSortIndex(DataFrameSortOperand, DataFramePSRSOperandMixin):
                     kws['chunks'] = out_chunks
                     return new_op.new_seriess(op.inputs, **kws)
             else:
-                if op.object_type == ObjectType.dataframe:
+                if op.output_types[0] == OutputType.dataframe:
                     df = build_concatenated_rows_frame(df)
                 if op.na_position != 'last':  # pragma: no cover
                     raise NotImplementedError('Only support puts NaNs at the end.')
@@ -126,10 +127,10 @@ class DataFrameSortIndex(DataFrameSortOperand, DataFramePSRSOperandMixin):
 
     def __call__(self, a):
         if isinstance(a, DATAFRAME_TYPE):
-            self._object_type = ObjectType.dataframe
+            self.output_types = [OutputType.dataframe]
             return self._call_dataframe(a)
         else:
-            self._object_type = ObjectType.series
+            self.output_types = [OutputType.series]
             return self._call_series(a)
 
 

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -500,7 +500,7 @@ def concat_index_value(index_values, store_data=False):
 
 
 def build_concatenated_rows_frame(df):
-    from .operands import ObjectType
+    from ..core import OutputType
     from .merge.concat import DataFrameConcat
 
     # When the df isn't splitted along the column axis, return the df directly.
@@ -513,13 +513,13 @@ def build_concatenated_rows_frame(df):
 
     out_chunks = []
     for idx in range(df.chunk_shape[0]):
-        out_chunk = DataFrameConcat(axis=1, object_type=ObjectType.dataframe).new_chunk(
+        out_chunk = DataFrameConcat(axis=1, output_types=[OutputType.dataframe]).new_chunk(
             [df.cix[idx, k] for k in range(df.chunk_shape[1])], index=(idx, 0),
             shape=(df.cix[idx, 0].shape[0], columns_size), dtypes=df.dtypes,
             index_value=df.cix[idx, 0].index_value, columns_value=columns)
         out_chunks.append(out_chunk)
 
-    return DataFrameConcat(axis=1, object_type=ObjectType.dataframe).new_dataframe(
+    return DataFrameConcat(axis=1, output_types=[OutputType.dataframe]).new_dataframe(
         [df], chunks=out_chunks, nsplits=((chunk.shape[0] for chunk in out_chunks), (df.shape[1],)),
         shape=df.shape, dtypes=df.dtypes,
         index_value=df.index_value, columns_value=df.columns_value)
@@ -734,7 +734,7 @@ def standardize_range_index(chunks, axis=0):
     for c in chunks:
         inputs = row_chunks[:c.index[axis]] + [c]
         op = ChunkStandardizeRangeIndex(
-            prepare_inputs=[False] * len(inputs), axis=axis, object_type=c.op.object_type)
+            prepare_inputs=[False] * len(inputs), axis=axis, output_types=c.op.output_types)
         out_chunks.append(op.new_chunk(inputs, **c.params.copy()))
 
     return out_chunks

--- a/mars/dataframe/window/rolling/aggregation.py
+++ b/mars/dataframe/window/rolling/aggregation.py
@@ -20,7 +20,7 @@ from ....serialize import ValueType, AnyField, Int64Field, BoolField, \
     StringField, Int32Field, KeyField, TupleField, DictField, ListField
 from ....tiles import TilesError
 from ....utils import lazy_import, check_chunks_unknown_shape
-from ...operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ...operands import DataFrameOperand, DataFrameOperandMixin
 from ...core import DATAFRAME_TYPE
 from ...utils import build_empty_df, build_empty_series, parse_index
 
@@ -47,13 +47,13 @@ class DataFrameRollingAgg(DataFrameOperand, DataFrameOperandMixin):
 
     def __init__(self, input=None, window=None, min_periods=None, center=None,  # pylint: disable=redefined-builtin
                  win_type=None, on=None, axis=None, closed=None, func=None,
-                 func_args=None, func_kwargs=None, object_type=None,
+                 func_args=None, func_kwargs=None, output_types=None,
                  preds=None, succs=None, **kw):
         super().__init__(_input=input, _window=window, _min_periods=min_periods,
                          _center=center, _win_type=win_type, _on=on,
                          _axis=axis, _closed=closed, _func=func,
                          _func_args=func_args, _func_kwargs=func_kwargs,
-                         _object_type=object_type,
+                         _output_types=output_types,
                          _preds=preds, _succs=succs, **kw)
 
     @property
@@ -135,7 +135,6 @@ class DataFrameRollingAgg(DataFrameOperand, DataFrameOperandMixin):
                 index_value = parse_index(test_df.index,
                                           rolling.params, inp,
                                           store_data=False)
-            self._object_type = ObjectType.dataframe
             return self.new_dataframe(
                 [inp], shape=(inp.shape[0], test_df.shape[1]),
                 dtypes=test_df.dtypes, index_value=index_value,
@@ -146,14 +145,12 @@ class DataFrameRollingAgg(DataFrameOperand, DataFrameOperandMixin):
                                               name=inp.name)
             test_obj = empty_series.rolling(**rolling.params).agg(self._func)
             if isinstance(test_obj, pd.DataFrame):
-                self._object_type = ObjectType.dataframe
                 return self.new_dataframe(
                     [inp], shape=(inp.shape[0], test_obj.shape[1]),
                     dtypes=test_obj.dtypes, index_value=inp.index_value,
                     columns_value=parse_index(test_obj.dtypes.index,
                                               store_data=True))
             else:
-                self._object_type = ObjectType.series
                 return self.new_series(
                     [inp], shape=inp.shape, dtype=test_obj.dtype,
                     index_value=inp.index_value, name=test_obj.name)
@@ -285,7 +282,7 @@ class DataFrameRollingAgg(DataFrameOperand, DataFrameOperandMixin):
                 slices = [slice(None)] * ndim
                 slices[axis] = slice(start, None)
                 prev_chunk_op = DataFrameLocGetItem(indexes=slices,
-                                                    object_type=prev_chunk.op.object_type)
+                                                    output_types=prev_chunk.op.output_types)
                 slice_prev_chunk = prev_chunk_op.new_chunk([prev_chunk])
                 prev_chunks.insert(0, slice_prev_chunk)
             else:

--- a/mars/learn/contrib/lightgbm/align.py
+++ b/mars/learn/contrib/lightgbm/align.py
@@ -14,10 +14,9 @@
 
 from .... import opcodes
 from ....context import get_context, RunningMode
-from ....core import ExecutableTuple
+from ....core import ExecutableTuple, get_output_types
 from ....serialize import AnyField
 from ...operands import LearnOperand, LearnOperandMixin
-from ...utils import get_output_types
 
 
 class LGBMAlign(LearnOperand, LearnOperandMixin):

--- a/mars/learn/contrib/lightgbm/predict.py
+++ b/mars/learn/contrib/lightgbm/predict.py
@@ -79,11 +79,11 @@ class LGBMPredict(LearnOperand, LearnOperandMixin):
         else:
             dtype = self.model.out_dtype_
 
-        if self._output_types[0] == OutputType.tensor:
+        if self.output_types[0] == OutputType.tensor:
             # tensor
             return self.new_tileable([self.data], shape=shape, dtype=dtype,
                                      order=TensorOrder.C_ORDER)
-        elif self._output_types[0] == OutputType.dataframe:
+        elif self.output_types[0] == OutputType.dataframe:
             # dataframe
             dtypes = pd.Series([dtype] * num_class)
             return self.new_tileable([self.data], shape=shape, dtypes=dtypes,

--- a/mars/learn/contrib/lightgbm/train.py
+++ b/mars/learn/contrib/lightgbm/train.py
@@ -66,8 +66,8 @@ class LGBMTrain(LearnMergeDictOperand):
                          _eval_init_scores=eval_init_scores, _kwds=kwds, _lgbm_endpoints=lgbm_endpoints,
                          _lgbm_port=lgbm_port, _tree_learner=tree_learner, _timeout=timeout, _merge=merge,
                          _output_types=output_types, **kw)
-        if self._output_types is None:
-            self._output_types = [OutputType.object]
+        if self.output_types is None:
+            self.output_types = [OutputType.object]
 
     @property
     def model_type(self) -> LGBMModelType:

--- a/mars/learn/contrib/pytorch/run_script.py
+++ b/mars/learn/contrib/pytorch/run_script.py
@@ -46,8 +46,8 @@ class RunPyTorch(LearnMergeDictOperand):
                          _master_port=master_port, _master_addr=master_addr, _rank=rank,
                          _init_method=init_method, _merge=merge, _output_types=output_types,
                          _gpu=gpu, **kw)
-        if self._output_types is None:
-            self._output_types = [OutputType.object]
+        if self.output_types is None:
+            self.output_types = [OutputType.object]
 
     @property
     def code(self):

--- a/mars/learn/contrib/tensorflow/run_script.py
+++ b/mars/learn/contrib/tensorflow/run_script.py
@@ -50,8 +50,8 @@ class RunTensorFlow(LearnMergeDictOperand):
                          _command_args=command_args, _port=port, _tf_task_type=tf_task_type,
                          _tf_task_index=tf_task_index, _merge=merge, _output_types=output_types,
                          _gpu=gpu, **kw)
-        if self._output_types is None:
-            self._output_types = [OutputType.object]
+        if self.output_types is None:
+            self.output_types = [OutputType.object]
 
     @property
     def code(self):

--- a/mars/learn/contrib/xgboost/dmatrix.py
+++ b/mars/learn/contrib/xgboost/dmatrix.py
@@ -14,14 +14,14 @@
 
 import itertools
 
-from ....core import ExecutableTuple
 from .... import opcodes as OperandDef
+from ....core import ExecutableTuple, get_output_types
 from ....serialize.core import KeyField, Float64Field, ListField, BoolField
-from ....tensor.core import TENSOR_TYPE, CHUNK_TYPE as TENSOR_CHUNK_TYPE
+from ....tensor.core import TENSOR_TYPE, TENSOR_CHUNK_TYPE
 from ....tensor import tensor as astensor
 from ....dataframe.core import DATAFRAME_TYPE
 from ...operands import LearnOperand, LearnOperandMixin
-from ...utils import convert_to_tensor_or_dataframe, get_output_types, concat_chunks
+from ...utils import convert_to_tensor_or_dataframe, concat_chunks
 
 
 class ToDMatrix(LearnOperand, LearnOperandMixin):
@@ -117,6 +117,8 @@ class ToDMatrix(LearnOperand, LearnOperandMixin):
                 kw = self._get_kw(self._weight)
                 kw['type'] = 'weight'
                 kws.append(kw)
+        if not self.output_types:
+            self.output_types = get_output_types(*inputs)
 
         tileables = self.new_tileables(inputs, kws=kws)
         if not self._multi_output:

--- a/mars/learn/contrib/xgboost/predict.py
+++ b/mars/learn/contrib/xgboost/predict.py
@@ -63,11 +63,11 @@ class XGBPredict(LearnOperand, LearnOperandMixin):
             shape = (len(self._data), num_class)
         else:
             shape = (len(self._data),)
-        if self._output_types[0] == OutputType.tensor:
+        if self.output_types[0] == OutputType.tensor:
             # tensor
             return self.new_tileable([self._data], shape=shape, dtype=np.dtype(np.float32),
                                      order=TensorOrder.C_ORDER)
-        elif self._output_types[0] == OutputType.dataframe:
+        elif self.output_types[0] == OutputType.dataframe:
             # dataframe
             dtypes = pd.DataFrame(np.random.rand(0, num_class), dtype=np.float32).dtypes
             return self.new_tileable([self._data], shape=shape, dtypes=dtypes,

--- a/mars/learn/contrib/xgboost/start_tracker.py
+++ b/mars/learn/contrib/xgboost/start_tracker.py
@@ -29,8 +29,8 @@ class StartTracker(LearnOperand, LearnOperandMixin):
 
     def __init__(self, n_workers=None, output_types=None, **kw):
         super().__init__(_n_workers=n_workers, _output_types=output_types, **kw)
-        if self._output_types is None:
-            self._output_types = [OutputType.object]
+        if self.output_types is None:
+            self.output_types = [OutputType.object]
 
     @property
     def n_workers(self):

--- a/mars/learn/contrib/xgboost/train.py
+++ b/mars/learn/contrib/xgboost/train.py
@@ -45,8 +45,8 @@ class XGBTrain(LearnMergeDictOperand):
         super().__init__(_params=params, _dtrain=dtrain, _evals=evals, _kwargs=kwargs,
                          _tracker=tracker, _merge=merge, _gpu=gpu,
                          _output_types=output_types, **kw)
-        if self._output_types is None:
-            self._output_types = [OutputType.object]
+        if self.output_types is None:
+            self.output_types = [OutputType.object]
 
     @property
     def params(self):

--- a/mars/learn/metrics/_check_targets.py
+++ b/mars/learn/metrics/_check_targets.py
@@ -16,16 +16,15 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ... import tensor as mt
-from ...core import Base, Entity, ExecutableTuple
+from ...core import Base, Entity, ExecutableTuple, get_output_types
 from ...context import get_context
 from ...serialize import AnyField, KeyField
 from ...tiles import TilesError
-from ...tensor.core import TENSOR_TYPE
-from ...tensor.operands import TensorOrder
+from ...tensor.core import TENSOR_TYPE, TensorOrder
 from ...utils import recursive_tile
 from ..operands import LearnOperand, LearnOperandMixin, OutputType
 from ..utils.multiclass import type_of_target
-from ..utils import get_output_types, check_consistent_length, column_or_1d
+from ..utils import check_consistent_length, column_or_1d
 
 
 class CheckTargets(LearnOperand, LearnOperandMixin):
@@ -40,7 +39,7 @@ class CheckTargets(LearnOperand, LearnOperandMixin):
         super().__init__(_y_true=y_true, _y_pred=y_pred,
                          _type_true=type_true, _type_pred=type_pred, **kw)
         # scalar(y_type), y_true, y_pred
-        self._output_types = \
+        self.output_types = \
             [OutputType.tensor] + get_output_types(*[y_true, y_pred],
                                                    unknown_as=OutputType.tensor)
 

--- a/mars/learn/metrics/_classification.py
+++ b/mars/learn/metrics/_classification.py
@@ -19,7 +19,7 @@ from ... import tensor as mt
 from ...core import Base, Entity
 from ...context import get_context
 from ...serialize import AnyField, BoolField, KeyField
-from ...tensor.operands import TensorOrder
+from ...tensor.core import TensorOrder
 from ...tiles import TilesError
 from ...utils import recursive_tile
 from ..operands import LearnOperand, LearnOperandMixin, OutputType
@@ -40,7 +40,7 @@ class AccuracyScore(LearnOperand, LearnOperandMixin):
         super().__init__(_y_true=y_true, _y_pred=y_pred,
                          _normalize=normalize, _sample_weight=sample_weight,
                          _type_true=type_true, **kw)
-        self._output_types = [OutputType.tensor]
+        self.output_types = [OutputType.tensor]
 
     @property
     def y_true(self):

--- a/mars/learn/neighbors/_faiss.py
+++ b/mars/learn/neighbors/_faiss.py
@@ -83,8 +83,8 @@ class FaissBuildIndex(LearnOperand, LearnOperandMixin):
                          _return_index_type=return_index_type,
                          _accuracy=accuracy, _memory_require=memory_require, _gpu=gpu,
                          _stage=stage, _output_types=output_types, **kw)
-        if self._output_types is None:
-            self._output_types = [OutputType.object]
+        if self.output_types is None:
+            self.output_types = [OutputType.object]
 
     @property
     def input(self):
@@ -441,8 +441,8 @@ class FaissTrainSampledIndex(LearnOperand, LearnOperandMixin):
         super().__init__(_faiss_index=faiss_index, _metric=metric,
                          _return_index_type=return_index_type,
                          _output_types=output_types, **kw)
-        if self._output_types is None:
-            self._output_types = [OutputType.object]
+        if self.output_types is None:
+            self.output_types = [OutputType.object]
 
     @property
     def input(self):
@@ -610,8 +610,8 @@ class FaissQuery(LearnOperand, LearnOperandMixin):
         super().__init__(_faiss_index=faiss_index, _n_neighbors=n_neighbors, _metric=metric,
                          _return_distance=return_distance, _output_types=output_types,
                          _nprobe=nprobe, _return_index_type=return_index_type, _gpu=gpu, **kw)
-        if self._output_types is None:
-            self._output_types = [OutputType.tensor] * self.output_limit
+        if self.output_types is None:
+            self.output_types = [OutputType.tensor] * self.output_limit
 
     @property
     def input(self):

--- a/mars/learn/neighbors/_kneighbors_graph.py
+++ b/mars/learn/neighbors/_kneighbors_graph.py
@@ -18,7 +18,7 @@ from ... import opcodes as OperandDef
 from ...lib.sparse.array import get_sparse_module, SparseNDArray
 from ...serialize import KeyField, Int64Field
 from ...tensor.array_utils import as_same_device, device
-from ...tensor.operands import TensorOrder
+from ...tensor.core import TensorOrder
 from ...tensor.utils import decide_unify_split
 from ...tiles import TilesError
 from ...utils import check_chunks_unknown_shape
@@ -36,7 +36,7 @@ class KNeighborsGraph(LearnOperand, LearnOperandMixin):
                  sparse=None, gpu=None, **kw):
         super().__init__(_a_data=a_data, _a_ind=a_ind, _n_neighbors=n_neighbors,
                          _sparse=sparse, _gpu=gpu, **kw)
-        self._output_types = [OutputType.tensor]
+        self.output_types = [OutputType.tensor]
 
     @property
     def a_data(self):

--- a/mars/learn/neighbors/tree.py
+++ b/mars/learn/neighbors/tree.py
@@ -43,8 +43,8 @@ class TreeBase(LearnOperand, LearnOperandMixin):
         super().__init__(_leaf_size=leaf_size, _metric=metric,
                          _metric_params=metric_params,
                          _output_types=output_types, **kw)
-        if self._output_types is None:
-            self._output_types = [OutputType.object]
+        if self.output_types is None:
+            self.output_types = [OutputType.object]
 
     @property
     def input(self):
@@ -128,8 +128,8 @@ class TreeQueryBase(LearnOperand, LearnOperandMixin):
         super().__init__(_tree=tree, _n_neighbors=n_neighbors,
                          _return_distance=return_distance,
                          _output_types=output_types, **kw)
-        if self._output_types is None:
-            self._output_types = [OutputType.tensor] * self.output_limit
+        if self.output_types is None:
+            self.output_types = [OutputType.tensor] * self.output_limit
 
     @property
     def input(self):

--- a/mars/learn/operands.py
+++ b/mars/learn/operands.py
@@ -12,92 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
-
 from ..operands import Operand, TileableOperandMixin, Fetch, FetchMixin, \
-    Fuse, FuseChunkMixin, MapReduceOperand, ShuffleProxy
-from ..serialize import ValueType, ListField, BoolField
-from ..tensor.core import TensorChunkData, TensorChunk, TensorData, Tensor, \
-    TENSOR_TYPE, CHUNK_TYPE as TENSOR_CHUNK_TYPE
+    Fuse, FuseChunkMixin, MapReduceOperand, ShuffleProxy, OutputType
+from ..serialize import BoolField
+from ..tensor.core import TENSOR_TYPE, TENSOR_CHUNK_TYPE
 from ..tensor.operands import TensorOperandMixin
 from ..tensor.fuse import TensorFuseChunk
 from ..tensor.fetch import TensorFetch
-from ..dataframe.core import DataFrameChunkData, DataFrameChunk, DataFrameData, DataFrame, \
-    SeriesChunkData, SeriesChunk, SeriesData, Series, SERIES_TYPE, SERIES_CHUNK_TYPE, \
-    TILEABLE_TYPE as DATAFRAME_TYPE, CHUNK_TYPE as DATAFRAME_CHUNK_TYPE
-from ..dataframe.operands import DataFrameOperandMixin, DataFrameFuseChunk, ObjectType
+from ..dataframe.core import SERIES_TYPE, SERIES_CHUNK_TYPE, TILEABLE_TYPE as DATAFRAME_TYPE, \
+    CHUNK_TYPE as DATAFRAME_CHUNK_TYPE
+from ..dataframe.operands import DataFrameOperandMixin, DataFrameFuseChunk
 from ..dataframe.fetch import DataFrameFetch
-from ..core import ObjectChunkData, ObjectChunk, ObjectData, Object
 
 
-class OutputType(Enum):
-    object = 1
-    tensor = 2
-    dataframe = 3
-    series = 4
-
-
-def _on_serialize_output_types(output_types):
-    if output_types is not None:
-        return [ot.value for ot in output_types]
-
-
-def _on_deserialize_output_types(output_types):
-    if output_types is not None:
-        return [OutputType(ot) for ot in output_types]
-
-
-class LearnOperand(Operand):
-    _output_types = ListField('output_type', tp=ValueType.int8,
-                              on_serialize=_on_serialize_output_types,
-                              on_deserialize=_on_deserialize_output_types)
-
-    @property
-    def output_types(self):
-        return self._output_types
+LearnOperand = Operand
 
 
 class LearnOperandMixin(TileableOperandMixin):
     __slots__ = ()
     _op_module_ = 'learn'
-
-    def _create_chunk(self, output_idx, index, **kw):
-        output_type = self.output_types[output_idx] \
-            if self.output_types is not None else OutputType.tensor
-        if output_type == OutputType.tensor:
-            chunk_data_type = TensorChunkData
-            chunk_type = TensorChunk
-        elif output_type == OutputType.dataframe:
-            chunk_data_type = DataFrameChunkData
-            chunk_type = DataFrameChunk
-        elif output_type == OutputType.series:
-            chunk_data_type = SeriesChunkData
-            chunk_type = SeriesChunk
-        else:
-            assert output_type == OutputType.object
-            chunk_data_type = ObjectChunkData
-            chunk_type = ObjectChunk
-        data = chunk_data_type(op=self, index=index, **kw)
-        return chunk_type(data)
-
-    def _create_tileable(self, output_idx, **kw):
-        output_type = self.output_types[output_idx] \
-            if self.output_types is not None else OutputType.tensor
-        if output_type == OutputType.tensor:
-            data_type = TensorData
-            entity_type = Tensor
-        elif output_type == OutputType.dataframe:
-            data_type = DataFrameData
-            entity_type = DataFrame
-        elif output_type == OutputType.series:
-            data_type = SeriesData
-            entity_type = Series
-        else:
-            assert output_type == OutputType.object
-            data_type = ObjectData
-            entity_type = Object
-        data = data_type(op=self, **kw)
-        return entity_type(data)
 
     @classmethod
     def concat_tileable_chunks(cls, tileable):
@@ -127,10 +60,10 @@ class LearnOperandMixin(TileableOperandMixin):
             return TensorFetch
         elif isinstance(obj, (DATAFRAME_TYPE, DATAFRAME_CHUNK_TYPE)):
             def _inner(**kw):
-                object_type = ObjectType.series \
+                output_types = [OutputType.series] \
                     if isinstance(obj, (SERIES_TYPE, SERIES_CHUNK_TYPE)) else \
-                    ObjectType.dataframe
-                return DataFrameFetch(object_type=object_type, **kw)
+                    [OutputType.dataframe]
+                return DataFrameFetch(output_types=output_types, **kw)
 
             return _inner
         else:
@@ -153,16 +86,8 @@ class LearnObjectFetchMixin(LearnOperandMixin, FetchMixin):
 
 
 class LearnObjectFetch(Fetch, LearnObjectFetchMixin):
-    _output_types = ListField('output_type', tp=ValueType.int8,
-                              on_serialize=_on_serialize_output_types,
-                              on_deserialize=_on_deserialize_output_types)
-
     def __init__(self, to_fetch_key=None, output_types=None, **kw):
         super().__init__(_to_fetch_key=to_fetch_key, _output_types=output_types, **kw)
-
-    @property
-    def output_types(self):
-        return self._output_types
 
     def _new_chunks(self, inputs, kws=None, **kw):
         if '_key' in kw and self._to_fetch_key is None:
@@ -178,36 +103,21 @@ class LearnObjectFetch(Fetch, LearnObjectFetchMixin):
 class LearnObjectFuseChunkMixin(FuseChunkMixin, LearnOperandMixin):
     __slots__ = ()
 
+    _output_type_ = OutputType.object
 
-class LearnObjectFuseChunk(Fuse, LearnObjectFuseChunkMixin):
-    @property
-    def output_types(self):
-        return [OutputType.object]
+
+class LearnObjectFuseChunk(LearnObjectFuseChunkMixin, Fuse):
+    pass
 
 
 class LearnShuffleProxy(ShuffleProxy, LearnOperandMixin):
-    _output_types = ListField('output_type', tp=ValueType.int8,
-                              on_serialize=_on_serialize_output_types,
-                              on_deserialize=_on_deserialize_output_types)
-
     def __init__(self, output_types=None, **kw):
         super().__init__(_output_types=output_types, **kw)
-        if self._output_types is None:
-            self._output_types = [OutputType.object]
-
-    @property
-    def output_types(self):
-        return self._output_types
+        if not self.output_types:
+            self.output_types = [OutputType.object]
 
 
-class LearnMapReduceOperand(MapReduceOperand):
-    _output_types = ListField('output_type', tp=ValueType.int8,
-                              on_serialize=_on_serialize_output_types,
-                              on_deserialize=_on_deserialize_output_types)
-
-    @property
-    def output_types(self):
-        return self._output_types
+LearnMapReduceOperand = MapReduceOperand
 
 
 class LearnMergeDictOperand(LearnOperand, LearnOperandMixin):

--- a/mars/learn/utils/__init__.py
+++ b/mars/learn/utils/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from .core import convert_to_tensor_or_dataframe, get_output_types, concat_chunks
+from .core import convert_to_tensor_or_dataframe, concat_chunks
 from .validation import check_array, assert_all_finite, \
     check_consistent_length, column_or_1d, check_X_y
 from .shuffle import shuffle

--- a/mars/learn/utils/checks.py
+++ b/mars/learn/utils/checks.py
@@ -20,15 +20,14 @@ except ImportError:  # pragma: no cover
 
 from ... import opcodes as OperandDef
 from ... import tensor as mt
-from ...core import Base, Entity
+from ...core import Base, Entity, get_output_types
 from ...config import options
 from ...serialize import KeyField, StringField, BoolField, DataTypeField
 from ...operands import OperandStage
-from ...tensor.core import TensorOrder, CHUNK_TYPE as TENSOR_CHUNK_TYPE
+from ...tensor.core import TensorOrder, TENSOR_CHUNK_TYPE
 from ...tensor.array_utils import as_same_device, device, issparse, get_array_module
 from ...utils import ceildiv, recursive_tile
 from ..operands import LearnOperand, LearnOperandMixin, OutputType
-from .core import get_output_types
 
 
 class CheckBase(LearnOperand, LearnOperandMixin):
@@ -64,7 +63,7 @@ class CheckBase(LearnOperand, LearnOperandMixin):
     def __call__(self, x, value=None):
         # output input if value not specified
         self._value = value = value if value is not None else x
-        self._output_types = get_output_types(value)
+        self.output_types = get_output_types(value)
         self._stage = OperandStage.agg
         return self.new_tileable([x, value],
                                  kws=[value.params])
@@ -313,7 +312,7 @@ class AssertAllFinite(LearnOperand, LearnOperandMixin):
             new_out_chunks = []
             for i in range(size):
                 chunk_op = AssertAllFinite(
-                    check_only=True,
+                    check_only=True, output_types=op.output_types,
                     stage=OperandStage.combine if size > 1 else OperandStage.agg)
                 chunk_index = (i,) if size > 1 else ()
                 out_chunk = chunk_op.new_chunk(

--- a/mars/learn/utils/core.py
+++ b/mars/learn/utils/core.py
@@ -15,11 +15,8 @@
 import pandas as pd
 
 from ...tensor import tensor as astensor
-from ...tensor.core import TENSOR_TYPE, CHUNK_TYPE as TENSOR_CHUNK_TYPE
 from ...dataframe import DataFrame, Series
-from ...dataframe.core import DATAFRAME_TYPE, SERIES_TYPE, \
-    DATAFRAME_CHUNK_TYPE, SERIES_CHUNK_TYPE
-from ..operands import OutputType
+from ...dataframe.core import DATAFRAME_TYPE, SERIES_TYPE
 
 
 def convert_to_tensor_or_dataframe(item):
@@ -30,24 +27,6 @@ def convert_to_tensor_or_dataframe(item):
     else:
         item = astensor(item)
     return item
-
-
-def get_output_types(*objs, unknown_as=None):
-    output_types = []
-    for obj in objs:
-        if obj is None:
-            continue
-        if isinstance(obj, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
-            output_types.append(OutputType.tensor)
-        elif isinstance(obj, (DATAFRAME_TYPE, DATAFRAME_CHUNK_TYPE)):
-            output_types.append(OutputType.dataframe)
-        elif isinstance(obj, (SERIES_TYPE, SERIES_CHUNK_TYPE)):
-            output_types.append(OutputType.series)
-        elif unknown_as is not None:
-            output_types.append(unknown_as)
-        else:  # pragma: no cover
-            raise TypeError('Output can only be tensor, dataframe or series')
-    return output_types
 
 
 def concat_chunks(chunks):

--- a/mars/learn/utils/multiclass.py
+++ b/mars/learn/utils/multiclass.py
@@ -24,7 +24,7 @@ from ... import opcodes as OperandDef
 from ... import tensor as mt
 from ...core import Base, Entity
 from ...serialize import KeyField, BoolField, TupleField, DataTypeField, AnyField, ListField
-from ...tensor.operands import TensorOrder
+from ...tensor.core import TensorOrder
 from ...tiles import TilesError
 from ...utils import recursive_tile
 from ..operands import LearnOperand, LearnOperandMixin, OutputType
@@ -42,7 +42,7 @@ class IsMultilabel(LearnOperand, LearnOperandMixin):
     def __init__(self, y=None, unique_y=None, is_y_sparse=None, **kw):
         super().__init__(_y=y, _unique_y=unique_y,
                          _is_y_sparse=is_y_sparse, **kw)
-        self._output_types = [OutputType.tensor]
+        self.output_types = [OutputType.tensor]
 
     @property
     def y(self):
@@ -186,7 +186,7 @@ class TypeOfTarget(LearnOperand, LearnOperandMixin):
                          _assert_all_finite=assert_all_finite,
                          _unique_y=unique_y, _y_shape=y_shape,
                          _y_dtype=y_dtype, _checked_targets=checked_targets, **kw)
-        self._output_types = [OutputType.tensor]
+        self.output_types = [OutputType.tensor]
 
     @property
     def y(self):

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -21,6 +21,7 @@ import numpy as np
 import pandas as pd
 
 from ... import opcodes as OperandDef
+from ...core import get_output_types
 from ...dataframe.utils import parse_index
 from ...lib import sparse
 from ...operands import OperandStage
@@ -31,7 +32,7 @@ from ...utils import tokenize, get_shuffle_input_keys_idxes, lazy_import, check_
 from ...tiles import TilesError
 from ...core import ExecutableTuple
 from ..operands import LearnOperandMixin, OutputType, LearnMapReduceOperand, LearnShuffleProxy
-from ..utils import convert_to_tensor_or_dataframe, get_output_types
+from ..utils import convert_to_tensor_or_dataframe
 
 
 cudf = lazy_import('cudf')
@@ -83,7 +84,7 @@ class LearnShuffle(LearnMapReduceOperand, LearnOperandMixin):
     @property
     def output_limit(self):
         if self.stage is None:
-            return len(self._output_types)
+            return len(self.output_types)
         return 1
 
     def _set_inputs(self, inputs):
@@ -105,7 +106,7 @@ class LearnShuffle(LearnMapReduceOperand, LearnOperandMixin):
 
     def _calc_params(self, params):
         axes = set(self.axes)
-        for i, output_type, param in zip(itertools.count(0), self._output_types, params):
+        for i, output_type, param in zip(itertools.count(0), self.output_types, params):
             if output_type == OutputType.dataframe:
                 if 0 in axes:
                     param['index_value'] = self._shuffle_index_value(param['index_value'])

--- a/mars/remote/core.py
+++ b/mars/remote/core.py
@@ -56,7 +56,7 @@ class _TileablePlaceholder:
         pass
 
 
-class RemoteFunction(ObjectOperand, RemoteOperandMixin):
+class RemoteFunction(RemoteOperandMixin, ObjectOperand):
     _op_type_ = opcodes.REMOTE_FUNCATION
     _op_module_ = 'remote'
 

--- a/mars/remote/operands.py
+++ b/mars/remote/operands.py
@@ -16,7 +16,7 @@ from ..core import FuseChunkData, FuseChunk
 from ..operands import Fuse, FuseChunkMixin, ObjectOperandMixin
 
 
-class RemoteFuseChunkMixin(FuseChunkMixin, ObjectOperandMixin):
+class RemoteFuseChunkMixin(ObjectOperandMixin, FuseChunkMixin):
     __slots__ = ()
 
     def _create_chunk(self, output_idx, index, **kw):
@@ -25,7 +25,7 @@ class RemoteFuseChunkMixin(FuseChunkMixin, ObjectOperandMixin):
         return FuseChunk(data)
 
 
-class RemoteFuseChunk(Fuse, RemoteFuseChunkMixin):
+class RemoteFuseChunk(RemoteFuseChunkMixin, Fuse):
     pass
 
 

--- a/mars/tensor/base/partition.py
+++ b/mars/tensor/base/partition.py
@@ -23,7 +23,7 @@ from ...utils import check_chunks_unknown_shape, flatten, stack_back
 from ...tiles import TilesError
 from ...core import Base, Entity, ExecutableTuple
 from ..operands import TensorOperand, TensorShuffleProxy
-from ..core import TENSOR_TYPE, CHUNK_TYPE, TensorOrder
+from ..core import TENSOR_TYPE, TENSOR_CHUNK_TYPE, TensorOrder
 from ..array_utils import as_same_device, device
 from ..datasource import tensor as astensor
 from ..utils import validate_axis, validate_order
@@ -387,7 +387,7 @@ class CalcPartitionsInfo(TensorOperand, TensorPSRSOperandMixin):
 
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
-        if isinstance(self._kth, (TENSOR_TYPE, CHUNK_TYPE)):
+        if isinstance(self._kth, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
             self._kth = self._inputs[0]
 
     @classmethod
@@ -396,7 +396,7 @@ class CalcPartitionsInfo(TensorOperand, TensorPSRSOperandMixin):
             [ctx[inp.key] for inp in op.inputs], device=op.device, ret_extra=True)
 
         with device(device_id):
-            if isinstance(op.kth, CHUNK_TYPE):
+            if isinstance(op.kth, TENSOR_CHUNK_TYPE):
                 kth = inputs[0]
                 sort_infos = inputs[1:]
                 # make kth all positive

--- a/mars/tensor/base/repeat.py
+++ b/mars/tensor/base/repeat.py
@@ -23,7 +23,7 @@ from ... import opcodes as OperandDef
 from ...serialize import KeyField, AnyField, Int32Field
 from ...utils import check_chunks_unknown_shape
 from ...tiles import TilesError
-from ..core import Tensor, TENSOR_TYPE, CHUNK_TYPE, TensorOrder
+from ..core import Tensor, TENSOR_TYPE, TENSOR_CHUNK_TYPE, TensorOrder
 from ..utils import broadcast_shape, unify_chunks
 from ..operands import TensorHasInput, TensorOperandMixin
 from ..datasource import tensor as astensor
@@ -139,7 +139,7 @@ class TensorRepeat(TensorHasInput, TensorOperandMixin):
                 size = in_chunk.shape[ax] * rp
 
             chunk_inputs = [in_chunk]
-            if isinstance(rp, CHUNK_TYPE):
+            if isinstance(rp, TENSOR_CHUNK_TYPE):
                 chunk_inputs.append(rp)
 
             chunk_shape = in_chunk.shape[:ax] + (size,) + in_chunk.shape[ax + 1:]

--- a/mars/tensor/base/searchsorted.py
+++ b/mars/tensor/base/searchsorted.py
@@ -69,10 +69,6 @@ class TensorSearchsorted(TensorOperand, TensorOperandMixin):
     def combine_size(self):
         return self._combine_size
 
-    @property
-    def stage(self):
-        return self._stage
-
     def __call__(self, a, v):
         inputs = [a]
         if isinstance(v, TENSOR_TYPE):

--- a/mars/tensor/base/shape.py
+++ b/mars/tensor/base/shape.py
@@ -18,8 +18,9 @@ from ... import opcodes
 from ...core import ExecutableTuple
 from ...serialize import KeyField, Int32Field
 from ...utils import calc_nsplits
+from ..core import TensorOrder
 from ..datasource import tensor as astensor
-from ..operands import TensorOperand, TensorOperandMixin, TensorOrder
+from ..operands import TensorOperand, TensorOperandMixin
 
 
 class TensorGetShape(TensorOperand, TensorOperandMixin):

--- a/mars/tensor/base/sort.py
+++ b/mars/tensor/base/sort.py
@@ -17,9 +17,10 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import ValueType, Int32Field, StringField, ListField, BoolField
 from ...core import ExecutableTuple
-from ..operands import TensorOperand, TensorShuffleProxy, TensorOrder
 from ..array_utils import as_same_device, device
+from ..core import TensorOrder
 from ..datasource import tensor as astensor
+from ..operands import TensorOperand, TensorShuffleProxy
 from ..utils import validate_axis, validate_order
 from .psrs import TensorPSRSOperandMixin
 

--- a/mars/tensor/base/topk.py
+++ b/mars/tensor/base/topk.py
@@ -23,9 +23,10 @@ from ...serialize import ValueType, KeyField, Int64Field, Int32Field, \
     BoolField, StringField, ListField
 from ...operands import OperandStage
 from ...utils import ceildiv, flatten, recursive_tile
-from ..operands import TensorOperand, TensorOperandMixin, TensorOrder
-from ..datasource import tensor as astensor
 from ..array_utils import as_same_device, device
+from ..core import TensorOrder
+from ..datasource import tensor as astensor
+from ..operands import TensorOperand, TensorOperandMixin
 from ..utils import validate_axis, validate_order
 from .sort import _validate_sort_psrs_kinds
 

--- a/mars/tensor/base/trapz.py
+++ b/mars/tensor/base/trapz.py
@@ -19,8 +19,9 @@ from ...serialize import KeyField, Float64Field, Int8Field
 from ...tiles import TilesError
 from ...utils import check_chunks_unknown_shape, recursive_tile
 from ..array_utils import as_same_device, device
+from ..core import TensorOrder
 from ..datasource import tensor as astensor
-from ..operands import TensorOperand, TensorOperandMixin, TensorOrder
+from ..operands import TensorOperand, TensorOperandMixin
 from ..utils import validate_axis
 
 

--- a/mars/tensor/datastore/to_tiledb.py
+++ b/mars/tensor/datastore/to_tiledb.py
@@ -149,7 +149,7 @@ class TensorTileDBDataStore(TensorDataStore):
                                            shape=chunk.shape)
 
 
-class TensorTileDBConsolidate(Operand, TensorOperandMixin):
+class TensorTileDBConsolidate(TensorOperandMixin, Operand):
     _op_type_ = OperandDef.TENSOR_STORE_TILEDB_CONSOLIDATE
 
     _tiledb_config = DictField('tiledb_config')

--- a/mars/tensor/fetch/core.py
+++ b/mars/tensor/fetch/core.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...operands import Fetch, FetchShuffle, FetchMixin
+from ...operands import Fetch, FetchShuffle, FetchMixin, OutputType
 from ...serialize import DataTypeField
 from ..operands import TensorOperandMixin
 
 
 class TensorFetchMixin(TensorOperandMixin, FetchMixin):
     __slots__ = ()
+    _output_type_ = OutputType.tensor
 
 
-class TensorFetch(Fetch, TensorFetchMixin):
+class TensorFetch(TensorFetchMixin, Fetch):
     _dtype = DataTypeField('dtype')
 
     def __init__(self, dtype=None, to_fetch_key=None, sparse=False, **kw):
@@ -43,7 +44,7 @@ class TensorFetch(Fetch, TensorFetchMixin):
         return super()._new_tileables(inputs, kws=kws, **kw)
 
 
-class TensorFetchShuffle(FetchShuffle, TensorFetchMixin):
+class TensorFetchShuffle(TensorFetchMixin, FetchShuffle):
     _dtype = DataTypeField('dtype')
 
     def __init__(self, dtype=None, to_fetch_keys=None, to_fetch_idxes=None, **kw):

--- a/mars/tensor/indexing/core.py
+++ b/mars/tensor/indexing/core.py
@@ -18,7 +18,7 @@ from numbers import Integral
 
 import numpy as np
 
-from ..core import TENSOR_TYPE, CHUNK_TYPE
+from ..core import TENSOR_TYPE, TENSOR_CHUNK_TYPE
 from ..utils import calc_sliced_size, broadcast_shape, replace_ellipsis, index_ndim
 from ..datasource import tensor as astensor
 
@@ -34,7 +34,7 @@ def calc_shape(tensor_shape, index):
     fancy_index = None
     fancy_index_shapes = []
     for ind in index:
-        if isinstance(ind, TENSOR_TYPE + CHUNK_TYPE + (np.ndarray,)) and ind.dtype == np.bool_:
+        if isinstance(ind, TENSOR_TYPE + TENSOR_CHUNK_TYPE + (np.ndarray,)) and ind.dtype == np.bool_:
             # bool
             shape.append(np.nan if not isinstance(ind, np.ndarray) else ind.sum())
             for i, t_size, size in zip(itertools.count(0), ind.shape, tensor_shape[in_axis:ind.ndim + in_axis]):
@@ -46,7 +46,7 @@ def calc_shape(tensor_shape, index):
                     )
             in_axis += ind.ndim
             out_axis += 1
-        elif isinstance(ind, TENSOR_TYPE + CHUNK_TYPE + (np.ndarray,)):
+        elif isinstance(ind, TENSOR_TYPE + TENSOR_CHUNK_TYPE + (np.ndarray,)):
             first_fancy_index = False
             if fancy_index is None:
                 first_fancy_index = True

--- a/mars/tensor/random/choice.py
+++ b/mars/tensor/random/choice.py
@@ -24,7 +24,7 @@ from ...serialize import ValueType, AnyField, KeyField, BoolField, TupleField
 from ...tiles import TilesError
 from ...utils import check_chunks_unknown_shape, ceildiv, recursive_tile
 from ..operands import TensorOperandMixin
-from ..core import TENSOR_TYPE, CHUNK_TYPE, TensorOrder
+from ..core import TENSOR_TYPE, TENSOR_CHUNK_TYPE, TensorOrder
 from ..datasource import arange, array
 from ..utils import decide_chunk_sizes, normalize_chunk_sizes, gen_random_seeds
 from ..array_utils import as_same_device, device
@@ -62,9 +62,9 @@ class TensorChoice(TensorRandomOperand, TensorOperandMixin):
 
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
-        if isinstance(self._a, (TENSOR_TYPE, CHUNK_TYPE)):
+        if isinstance(self._a, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
             self._a = self._inputs[0]
-        if isinstance(self._p, (TENSOR_TYPE, CHUNK_TYPE)):
+        if isinstance(self._p, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
             self._p = self._inputs[-1]
 
     def __call__(self, a, p, chunk_size=None):
@@ -240,11 +240,11 @@ class TensorChoice(TensorRandomOperand, TensorOperandMixin):
     def execute(cls, ctx, op):
         inputs, device_id, xp = as_same_device(
             [ctx[inp.key] for inp in op.inputs], device=op.device, ret_extra=True)
-        if isinstance(op.a, CHUNK_TYPE):
+        if isinstance(op.a, TENSOR_CHUNK_TYPE):
             a = inputs[0]
         else:
             a = op.a
-        if isinstance(op.p, CHUNK_TYPE):
+        if isinstance(op.p, TENSOR_CHUNK_TYPE):
             p = inputs[-1]
         else:
             p = op.p

--- a/mars/tensor/random/core.py
+++ b/mars/tensor/random/core.py
@@ -22,7 +22,7 @@ import numpy as np
 from ...config import options
 from ...serialize import ValueType, TupleField, Int32Field
 from ...utils import tokenize
-from ..core import TENSOR_TYPE, CHUNK_TYPE
+from ..core import TENSOR_TYPE, TENSOR_CHUNK_TYPE
 from ..utils import decide_chunk_sizes, gen_random_seeds, broadcast_shape
 from ..array_utils import array_module, device
 from ..operands import TensorOperand, TensorMapReduceOperand, TensorOperandMixin
@@ -161,7 +161,7 @@ class TensorRandomOperandMixin(TensorOperandMixin):
             device_id = -1
         else:
             device_id = op.device or 0
-        get_val = lambda x: ctx[x.key] if isinstance(x, CHUNK_TYPE) else x
+        get_val = lambda x: ctx[x.key] if isinstance(x, TENSOR_CHUNK_TYPE) else x
 
         with device(device_id):
             rs = xp.random.RandomState(op.seed)
@@ -234,7 +234,7 @@ class TensorRandomOperandMixin(TensorOperandMixin):
                             val = np.asarray(val)
                         if tensor:
                             val = self._handle_arg(val, raw_chunk_size)
-                    if isinstance(val, TENSOR_TYPE + CHUNK_TYPE):
+                    if isinstance(val, TENSOR_TYPE + TENSOR_CHUNK_TYPE):
                         field_to_obj[field] = val
                         if field not in to_one_chunk_fields:
                             to_broadcast_shapes.append(val.shape)
@@ -242,7 +242,7 @@ class TensorRandomOperandMixin(TensorOperandMixin):
             else:
                 inputs_iter = iter(inputs)
                 for field in fields:
-                    if isinstance(getattr(self, field), TENSOR_TYPE + CHUNK_TYPE):
+                    if isinstance(getattr(self, field), TENSOR_TYPE + TENSOR_CHUNK_TYPE):
                         field_to_obj[field] = next(inputs_iter)
 
         if tensor:
@@ -344,7 +344,7 @@ class TensorDistribution(TensorRandomOperand):
             args = []
             for k in op.args:
                 val = getattr(op, k, None)
-                if isinstance(val, CHUNK_TYPE):
+                if isinstance(val, TENSOR_CHUNK_TYPE):
                     args.append(ctx[val.key])
                 else:
                     args.append(val)

--- a/mars/tensor/random/multivariate_normal.py
+++ b/mars/tensor/random/multivariate_normal.py
@@ -23,7 +23,7 @@ from ...serialize import NDArrayField, StringField, Float64Field
 from ...config import options
 from ..utils import decide_chunk_sizes, gen_random_seeds
 from ..array_utils import array_module, device
-from .core import TensorRandomOperandMixin, TensorDistribution, CHUNK_TYPE
+from .core import TensorRandomOperandMixin, TensorDistribution, TENSOR_CHUNK_TYPE
 
 
 class TensorMultivariateNormal(TensorDistribution, TensorRandomOperandMixin):
@@ -109,7 +109,7 @@ class TensorMultivariateNormal(TensorDistribution, TensorRandomOperandMixin):
             args = []
             for k in op.args:
                 val = getattr(op, k, None)
-                if isinstance(val, CHUNK_TYPE):
+                if isinstance(val, TENSOR_CHUNK_TYPE):
                     args.append(ctx[val.key])
                 else:
                     args.append(val)

--- a/mars/tensor/statistics/digitize.py
+++ b/mars/tensor/statistics/digitize.py
@@ -21,10 +21,10 @@ from ...serialize import KeyField, AnyField, BoolField
 from ...lib.sparse.core import get_array_module
 from ...utils import check_chunks_unknown_shape
 from ...tiles import TilesError
-from ..operands import TensorHasInput, TensorOperandMixin, Tensor
-from ..datasource import tensor as astensor
 from ..array_utils import as_same_device, device
-from ..core import TensorOrder
+from ..core import Tensor, TensorOrder
+from ..datasource import tensor as astensor
+from ..operands import TensorHasInput, TensorOperandMixin
 
 
 class TensorDigitize(TensorHasInput, TensorOperandMixin):

--- a/mars/tensor/statistics/histogram.py
+++ b/mars/tensor/statistics/histogram.py
@@ -23,7 +23,7 @@ from ...serialize import AnyField, TupleField, KeyField, BoolField
 from ...tiles import TilesError
 from ...context import get_context
 from ...utils import check_chunks_unknown_shape, recursive_tile
-from ..core import TENSOR_TYPE, CHUNK_TYPE, TensorOrder
+from ..core import TENSOR_TYPE, TENSOR_CHUNK_TYPE, TensorOrder
 from ..operands import TensorOperand, TensorOperandMixin
 from ..datasource import tensor as astensor
 from ..arithmetic.utils import tree_add
@@ -871,7 +871,7 @@ class TensorHistogram(TensorOperand, TensorOperandMixin):
         inputs, device_id, xp = as_same_device(
             [ctx[inp.key] for inp in op.inputs], device=op.device, ret_extra=True)
         a = inputs[0]
-        bins = inputs[1] if isinstance(op.bins, CHUNK_TYPE) else op.bins
+        bins = inputs[1] if isinstance(op.bins, TENSOR_CHUNK_TYPE) else op.bins
         weights = None
         if op.weights is not None:
             weights = inputs[-1]

--- a/mars/tensor/statistics/quantile.py
+++ b/mars/tensor/statistics/quantile.py
@@ -28,7 +28,7 @@ from ..indexing import take
 from ..arithmetic import isnan, add
 from ..reduction import any as tensor_any
 from ..operands import TensorOperand, TensorOperandMixin
-from ..core import TENSOR_TYPE, CHUNK_TYPE, TensorOrder
+from ..core import TENSOR_TYPE, TENSOR_CHUNK_TYPE, TensorOrder
 from ..utils import check_out_param
 from ..array_utils import as_same_device, device
 from .core import _ureduce
@@ -203,9 +203,9 @@ class TensorQuantile(TensorOperand, TensorOperandMixin):
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
         self._a = self._inputs[0]
-        if isinstance(self._q, (TENSOR_TYPE, CHUNK_TYPE)):
+        if isinstance(self._q, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
             self._q = self._inputs[1]
-        if isinstance(self._out, (TENSOR_TYPE, CHUNK_TYPE)):
+        if isinstance(self._out, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
             self._out = self._inputs[-1]
 
     @property

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -535,7 +535,7 @@ class MarsObjectCheckMixin:
         from mars.dataframe.core import DATAFRAME_TYPE, SERIES_TYPE, GROUPBY_TYPE, \
             INDEX_TYPE, CATEGORICAL_TYPE
 
-        from mars.tensor.core import CHUNK_TYPE as TENSOR_CHUNK_TYPE
+        from mars.tensor.core import TENSOR_CHUNK_TYPE
         from mars.dataframe.core import DATAFRAME_CHUNK_TYPE, SERIES_CHUNK_TYPE, \
             GROUPBY_CHUNK_TYPE, INDEX_CHUNK_TYPE, CATEGORICAL_CHUNK_TYPE
 


### PR DESCRIPTION
## What do these changes do?

Set object type when {df,series,index,categorial}.new_xxx() is invoked.

## Related issue number

Fixes #1211
