### PR TITLE
Implements `mars.learn.metrics.{roc_curve, auc}` 

### DIFF
--- a/docs/source/dataframe/reference/api/mars.dataframe.Series.rst
+++ b/docs/source/dataframe/reference/api/mars.dataframe.Series.rst
@@ -93,6 +93,7 @@ mars.dataframe.Series
       ~Series.transform
       ~Series.truediv
       ~Series.tshift
+      ~Series.unique
       ~Series.value_counts
       ~Series.var
    

--- a/docs/source/learn/generated/mars.learn.metrics.auc.rst
+++ b/docs/source/learn/generated/mars.learn.metrics.auc.rst
@@ -1,0 +1,6 @@
+mars.learn.metrics.auc
+======================
+
+.. currentmodule:: mars.learn.metrics
+
+.. autofunction:: auc

--- a/docs/source/learn/generated/mars.learn.metrics.roc_curve.rst
+++ b/docs/source/learn/generated/mars.learn.metrics.roc_curve.rst
@@ -1,0 +1,6 @@
+mars.learn.metrics.roc\_curve
+=============================
+
+.. currentmodule:: mars.learn.metrics
+
+.. autofunction:: roc_curve

--- a/docs/source/learn/reference.rst
+++ b/docs/source/learn/reference.rst
@@ -68,6 +68,8 @@ Classification metrics
    :toctree: generated/
 
    metrics.accuracy_score
+   metrics.auc
+   metrics.roc_curve
 
 Pairwise metrics
 ----------------

--- a/docs/source/tensor/generated/mars.tensor.c_.rst
+++ b/docs/source/tensor/generated/mars.tensor.c_.rst
@@ -1,0 +1,6 @@
+mars.tensor.c\_
+===============
+
+.. currentmodule:: mars.tensor
+
+.. autodata:: c_

--- a/docs/source/tensor/generated/mars.tensor.r_.rst
+++ b/docs/source/tensor/generated/mars.tensor.r_.rst
@@ -1,0 +1,6 @@
+mars.tensor.r\_
+===============
+
+.. currentmodule:: mars.tensor
+
+.. autodata:: r_

--- a/docs/source/tensor/indexing.rst
+++ b/docs/source/tensor/indexing.rst
@@ -8,6 +8,8 @@ Generating index arrays
    :toctree: generated/
    :nosignatures:
 
+   mars.tensor.c_
+   mars.tensor.r_
    mars.tensor.nonzero
    mars.tensor.where
    mars.tensor.indices

--- a/mars/core.py
+++ b/mars/core.py
@@ -642,6 +642,16 @@ class ExecutableTuple(tuple, _ExecutableMixin):
         super().__init__()
         self._executed_sessions = []
 
+    def execute(self, session=None, **kw):
+        if len(self) == 0:
+            return self
+        return super().execute(session=session, **kw)
+
+    def fetch(self, session=None, **kw):
+        if len(self) == 0:
+            return tuple()
+        return super().fetch(session=session, **kw)
+
     def _attach_session(self, session):
         super()._attach_session(session)
         for t in self:

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -920,7 +920,7 @@ class Executor(object):
             return self.execute_tileables(tileables, **kw)
         finally:
             for to_release_tileable in to_release_tileables:
-                for c in get_tiled(to_release_tileable).chunks:
+                for c in get_tiled(to_release_tileable, mapping=tileable_optimized).chunks:
                     del self._chunk_result[c.key]
 
     def get_tileable_nsplits(self, tileable, chunk_result=None):

--- a/mars/learn/base.py
+++ b/mars/learn/base.py
@@ -43,6 +43,6 @@ class ClassifierMixin:
             Mean accuracy of self.predict(X) wrt. y.
         """
         from .metrics import accuracy_score
-        result = accuracy_score(y, self.predict(X), sample_weight=sample_weight)
-        result.execute(session=session, fetch=False, **(run_kwargs or dict()))
+        result = accuracy_score(y, self.predict(X), sample_weight=sample_weight,
+                                session=session, run_kwargs=run_kwargs)
         return result

--- a/mars/learn/metrics/__init__.py
+++ b/mars/learn/metrics/__init__.py
@@ -14,3 +14,4 @@
 
 from .pairwise import euclidean_distances, pairwise_distances
 from ._classification import accuracy_score
+from ._ranking import roc_curve, auc

--- a/mars/learn/metrics/_classification.py
+++ b/mars/learn/metrics/_classification.py
@@ -113,7 +113,8 @@ def _weighted_sum(sample_score, sample_weight, normalize=False):
         return sample_score.sum()
 
 
-def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
+def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None,
+                   session=None, run_kwargs=None):
     """Accuracy classification score.
 
     In multilabel classification, this function computes subset accuracy:
@@ -176,4 +177,5 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     # Compute accuracy for each possible representation
     op = AccuracyScore(y_true=y_true, y_pred=y_pred, normalize=normalize,
                        sample_weight=sample_weight)
-    return op(y_true, y_pred)
+    score = op(y_true, y_pred)
+    return score.execute(session=session, **(run_kwargs or dict()))

--- a/mars/learn/metrics/_ranking.py
+++ b/mars/learn/metrics/_ranking.py
@@ -1,0 +1,322 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+
+import numpy as np
+from sklearn.exceptions import UndefinedMetricWarning
+
+from ... import tensor as mt
+from ..utils.checks import assert_all_finite
+from ..utils.multiclass import type_of_target
+from ..utils.validation import check_consistent_length, column_or_1d
+
+
+def auc(x, y, session=None, run_kwargs=None):
+    """Compute Area Under the Curve (AUC) using the trapezoidal rule
+
+    This is a general function, given points on a curve.  For computing the
+    area under the ROC-curve, see :func:`roc_auc_score`.  For an alternative
+    way to summarize a precision-recall curve, see
+    :func:`average_precision_score`.
+
+    Parameters
+    ----------
+    x : tensor, shape = [n]
+        x coordinates. These must be either monotonic increasing or monotonic
+        decreasing.
+    y : tensor, shape = [n]
+        y coordinates.
+
+    Returns
+    -------
+    auc : tensor, with float value
+
+    Examples
+    --------
+    >>> import mars.tensor as mt
+    >>> from mars.learn import metrics
+    >>> y = mt.array([1, 1, 2, 2])
+    >>> pred = mt.array([0.1, 0.4, 0.35, 0.8])
+    >>> fpr, tpr, thresholds = metrics.roc_curve(y, pred, pos_label=2)
+    >>> metrics.auc(fpr, tpr)
+    0.75
+
+    See also
+    --------
+    roc_auc_score : Compute the area under the ROC curve
+    average_precision_score : Compute average precision from prediction scores
+    precision_recall_curve :
+        Compute precision-recall pairs for different probability thresholds
+    """
+    check_consistent_length(x, y)
+    x = column_or_1d(x)
+    y = column_or_1d(y)
+
+    if x.shape[0] < 2:
+        raise ValueError('At least 2 points are needed to compute'
+                         ' area under curve, but x.shape = %s' % x.shape)
+
+    direction = 1
+    dx = mt.diff(x)
+    any_dx_lt_0 = mt.any(dx < 0)
+    all_dx_le_0 = mt.all(dx <= 0)
+    mt.ExecutableTuple([x, any_dx_lt_0, all_dx_le_0]).execute(
+        session=session, **(run_kwargs or dict()))
+    if any_dx_lt_0.fetch():
+        if all_dx_le_0.fetch():
+            direction = -1
+        else:
+            raise ValueError("x is neither increasing nor decreasing "
+                             ": {}.".format(x.fetch()))
+
+    area = direction * mt.trapz(y, x)
+    return area.execute(session=session, **(run_kwargs or dict()))
+
+
+def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None,
+                      session=None, run_kwargs=None):
+    """Calculate true and false positives per binary classification threshold.
+
+    Parameters
+    ----------
+    y_true : tensor, shape = [n_samples]
+        True targets of binary classification
+
+    y_score : tensor, shape = [n_samples]
+        Estimated probabilities or decision function
+
+    pos_label : int or str, default=None
+        The label of the positive class
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    Returns
+    -------
+    fps : tensor, shape = [n_thresholds]
+        A count of false positives, at index i being the number of negative
+        samples assigned a score >= thresholds[i]. The total number of
+        negative samples is equal to fps[-1] (thus true negatives are given by
+        fps[-1] - fps).
+
+    tps : tensor, shape = [n_thresholds <= len(mt.unique(y_score))]
+        An increasing count of true positives, at index i being the number
+        of positive samples assigned a score >= thresholds[i]. The total
+        number of positive samples is equal to tps[-1] (thus false negatives
+        are given by tps[-1] - tps).
+
+    thresholds : tensor, shape = [n_thresholds]
+        Decreasing score values.
+    """
+    y_type = type_of_target(y_true).to_numpy(
+        session=session, **(run_kwargs or dict()))
+    if not (y_type == "binary" or
+            (y_type == "multiclass" and pos_label is not None)):
+        raise ValueError("{0} format is not supported".format(y_type))
+
+    check_consistent_length(y_true, y_score, sample_weight)
+    y_true = column_or_1d(y_true)
+    y_score = column_or_1d(y_score)
+    y_true = assert_all_finite(y_true, check_only=False)
+    y_score = assert_all_finite(y_score, check_only=False)
+
+    if sample_weight is not None:
+        sample_weight = column_or_1d(sample_weight)
+
+    # ensure binary classification if pos_label is not specified
+    # classes.dtype.kind in ('O', 'U', 'S') is required to avoid
+    # triggering a FutureWarning by calling np.array_equal(a, b)
+    # when elements in the two arrays are not comparable.
+    classes = mt.unique(y_true, aggregate_size=1).to_numpy(
+        session=session, **(run_kwargs or dict()))
+    if (pos_label is None and (
+            classes.dtype.kind in ('O', 'U', 'S') or
+            not (np.array_equal(classes, [0, 1]) or
+                 np.array_equal(classes, [-1, 1]) or
+                 np.array_equal(classes, [0]) or
+                 np.array_equal(classes, [-1]) or
+                 np.array_equal(classes, [1])))):
+        classes_repr = ", ".join(repr(c) for c in classes)
+        raise ValueError("y_true takes value in {{{classes_repr}}} and "
+                         "pos_label is not specified: either make y_true "
+                         "take value in {{0, 1}} or {{-1, 1}} or "
+                         "pass pos_label explicitly.".format(
+            classes_repr=classes_repr))
+    elif pos_label is None:
+        pos_label = 1.
+
+    # make y_true a boolean vector
+    y_true = (y_true == pos_label)
+
+    # sort scores and corresponding truth values
+    desc_score_indices = mt.argsort(y_score, kind="mergesort")[::-1]
+    y_score = y_score[desc_score_indices]
+    y_true = y_true[desc_score_indices]
+    if sample_weight is not None:
+        weight = sample_weight[desc_score_indices]
+    else:
+        weight = 1.
+
+    # y_score typically has many tied values. Here we extract
+    # the indices associated with the distinct values. We also
+    # concatenate a value for the end of the curve.
+    distinct_value_indices = mt.where(mt.diff(y_score))[0]
+    threshold_idxs = mt.r_[distinct_value_indices, y_true.size - 1]
+
+    # accumulate the true positives with decreasing threshold
+    tps = (y_true * weight).cumsum()[threshold_idxs]
+    if sample_weight is not None:
+        # express fps as a cumsum to ensure fps is increasing even in
+        # the presence of floating point errors
+        fps = ((1 - y_true) * weight).cumsum()[threshold_idxs]
+    else:
+        fps = 1 + threshold_idxs - tps
+    ret = mt.ExecutableTuple([fps, tps, y_score[threshold_idxs]])
+    return ret.execute(session=session, **(run_kwargs or dict()))
+
+
+def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
+              drop_intermediate=True, session=None, run_kwargs=None):
+    """Compute Receiver operating characteristic (ROC)
+
+    Note: this implementation is restricted to the binary classification task.
+
+    Read more in the :ref:`User Guide <roc_metrics>`.
+
+    Parameters
+    ----------
+
+    y_true : tensor, shape = [n_samples]
+        True binary labels. If labels are not either {-1, 1} or {0, 1}, then
+        pos_label should be explicitly given.
+
+    y_score : tensor, shape = [n_samples]
+        Target scores, can either be probability estimates of the positive
+        class, confidence values, or non-thresholded measure of decisions
+        (as returned by "decision_function" on some classifiers).
+
+    pos_label : int or str, default=None
+        The label of the positive class.
+        When ``pos_label=None``, if y_true is in {-1, 1} or {0, 1},
+        ``pos_label`` is set to 1, otherwise an error will be raised.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    drop_intermediate : boolean, optional (default=True)
+        Whether to drop some suboptimal thresholds which would not appear
+        on a plotted ROC curve. This is useful in order to create lighter
+        ROC curves.
+
+        .. versionadded:: 0.17
+           parameter *drop_intermediate*.
+
+    Returns
+    -------
+    fpr : tensor, shape = [>2]
+        Increasing false positive rates such that element i is the false
+        positive rate of predictions with score >= thresholds[i].
+
+    tpr : tensor, shape = [>2]
+        Increasing true positive rates such that element i is the true
+        positive rate of predictions with score >= thresholds[i].
+
+    thresholds : tensor, shape = [n_thresholds]
+        Decreasing thresholds on the decision function used to compute
+        fpr and tpr. `thresholds[0]` represents no instances being predicted
+        and is arbitrarily set to `max(y_score) + 1`.
+
+    See also
+    --------
+    roc_auc_score : Compute the area under the ROC curve
+
+    Notes
+    -----
+    Since the thresholds are sorted from low to high values, they
+    are reversed upon returning them to ensure they correspond to both ``fpr``
+    and ``tpr``, which are sorted in reversed order during their calculation.
+
+    References
+    ----------
+    .. [1] `Wikipedia entry for the Receiver operating characteristic
+            <https://en.wikipedia.org/wiki/Receiver_operating_characteristic>`_
+
+    .. [2] Fawcett T. An introduction to ROC analysis[J]. Pattern Recognition
+           Letters, 2006, 27(8):861-874.
+
+    Examples
+    --------
+    >>> import mars.tensor as mt
+    >>> from mars.learn import metrics
+    >>> y = mt.array([1, 1, 2, 2])
+    >>> scores = mt.array([0.1, 0.4, 0.35, 0.8])
+    >>> fpr, tpr, thresholds = metrics.roc_curve(y, scores, pos_label=2)
+    >>> fpr
+    array([0. , 0. , 0.5, 0.5, 1. ])
+    >>> tpr
+    array([0. , 0.5, 0.5, 1. , 1. ])
+    >>> thresholds
+    array([1.8 , 0.8 , 0.4 , 0.35, 0.1 ])
+
+    """
+    fps, tps, thresholds = _binary_clf_curve(
+        y_true, y_score, pos_label=pos_label, sample_weight=sample_weight,
+        session=session, run_kwargs=run_kwargs)
+
+    # Attempt to drop thresholds corresponding to points in between and
+    # collinear with other points. These are always suboptimal and do not
+    # appear on a plotted ROC curve (and thus do not affect the AUC).
+    # Here mt.diff(_, 2) is used as a "second derivative" to tell if there
+    # is a corner at the point. Both fps and tps must be tested to handle
+    # thresholds with multiple data points (which are combined in
+    # _binary_clf_curve). This keeps all cases where the point should be kept,
+    # but does not drop more complicated cases like fps = [1, 3, 7],
+    # tps = [1, 2, 4]; there is no harm in keeping too many thresholds.
+    if drop_intermediate and len(fps) > 2:
+        optimal_idxs = mt.where(mt.r_[True,
+                                      mt.logical_or(mt.diff(fps, 2),
+                                                    mt.diff(tps, 2)),
+                                      True])[0]
+        fps = fps[optimal_idxs]
+        tps = tps[optimal_idxs]
+        thresholds = thresholds[optimal_idxs]
+
+    # Add an extra threshold position
+    # to make sure that the curve starts at (0, 0)
+    tps = mt.r_[0, tps]
+    fps = mt.r_[0, fps]
+    thresholds = mt.r_[thresholds[0] + 1, thresholds]
+
+    mt.ExecutableTuple([tps, fps]).execute(session=session,
+                                           **(run_kwargs or dict()))
+
+    if fps[-1].fetch() <= 0:
+        warnings.warn("No negative samples in y_true, "
+                      "false positive value should be meaningless",
+                      UndefinedMetricWarning)
+        fpr = mt.repeat(mt.nan, fps.shape)
+    else:
+        fpr = fps / fps[-1]
+
+    if tps[-1].fetch() <= 0:
+        warnings.warn("No positive samples in y_true, "
+                      "true positive value should be meaningless",
+                      UndefinedMetricWarning)
+        tpr = mt.repeat(mt.nan, tps.shape)
+    else:
+        tpr = tps / tps[-1]
+
+    ret = mt.ExecutableTuple([fpr, tpr, thresholds])
+    return ret.execute(session=session, **(run_kwargs or dict()))

--- a/mars/learn/metrics/_ranking.py
+++ b/mars/learn/metrics/_ranking.py
@@ -15,7 +15,6 @@
 import warnings
 
 import numpy as np
-from sklearn.exceptions import UndefinedMetricWarning
 
 from ... import tensor as mt
 from ..utils.checks import assert_all_finite
@@ -271,6 +270,8 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
     array([1.8 , 0.8 , 0.4 , 0.35, 0.1 ])
 
     """
+    from sklearn.exceptions import UndefinedMetricWarning
+
     fps, tps, thresholds = _binary_clf_curve(
         y_true, y_score, pos_label=pos_label, sample_weight=sample_weight,
         session=session, run_kwargs=run_kwargs)

--- a/mars/learn/metrics/tests/test_ranking.py
+++ b/mars/learn/metrics/tests/test_ranking.py
@@ -1,0 +1,214 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import unittest
+
+import numpy as np
+try:
+    import sklearn
+    from sklearn.metrics import roc_auc_score
+    from sklearn.metrics.tests.test_ranking import make_prediction, _auc
+    from sklearn.exceptions import UndefinedMetricWarning
+    from sklearn.utils import check_random_state
+    from sklearn.utils._testing import assert_warns
+except ImportError:  # pragma: no cover
+    sklearn = None
+import pytest
+
+from mars import tensor as mt
+from mars.learn.metrics import roc_curve, auc
+from mars.tests.core import TestBase
+
+
+@unittest.skipIf(sklearn is None, 'scikit-learn not installed')
+class Test(TestBase):
+    def testRocCurve(self):
+        for drop in [True, False]:
+            # Test Area under Receiver Operating Characteristic (ROC) curve
+            y_true, _, probas_pred = make_prediction(binary=True)
+            expected_auc = _auc(y_true, probas_pred)
+
+            fpr, tpr, thresholds = roc_curve(y_true, probas_pred,
+                                             drop_intermediate=drop).execute().fetch()
+            roc_auc = auc(fpr, tpr).to_numpy()
+            np.testing.assert_array_almost_equal(roc_auc, expected_auc, decimal=2)
+            np.testing.assert_almost_equal(roc_auc, roc_auc_score(y_true, probas_pred))
+            assert fpr.shape == tpr.shape
+            assert fpr.shape == thresholds.shape
+
+    def testRocCurveEndPoints(self):
+        # Make sure that roc_curve returns a curve start at 0 and ending and
+        # 1 even in corner cases
+        rng = np.random.RandomState(0)
+        y_true = np.array([0] * 50 + [1] * 50)
+        y_pred = rng.randint(3, size=100)
+        fpr, tpr, thr = roc_curve(y_true, y_pred, drop_intermediate=True).fetch()
+        assert fpr[0] == 0
+        assert fpr[-1] == 1
+        assert fpr.shape == tpr.shape
+        assert fpr.shape == thr.shape
+
+    def testRocReturnsConsistency(self):
+        # Test whether the returned threshold matches up with tpr
+        # make small toy dataset
+        y_true, _, probas_pred = make_prediction(binary=True)
+        fpr, tpr, thresholds = roc_curve(y_true, probas_pred).fetch()
+
+        # use the given thresholds to determine the tpr
+        tpr_correct = []
+        for t in thresholds:
+            tp = np.sum((probas_pred >= t) & y_true)
+            p = np.sum(y_true)
+            tpr_correct.append(1.0 * tp / p)
+
+        # compare tpr and tpr_correct to see if the thresholds' order was correct
+        np.testing.assert_array_almost_equal(tpr, tpr_correct, decimal=2)
+        assert fpr.shape == tpr.shape
+        assert fpr.shape == thresholds.shape
+
+    def testRocCurveMulti(self):
+        # roc_curve not applicable for multi-class problems
+        y_true, _, probas_pred = make_prediction(binary=False)
+
+        with self.assertRaises(ValueError):
+            roc_curve(y_true, probas_pred)
+
+    def testRocCurveConfidence(self):
+        # roc_curve for confidence scores
+        y_true, _, probas_pred = make_prediction(binary=True)
+
+        fpr, tpr, thresholds = roc_curve(y_true, probas_pred - 0.5)
+        roc_auc = auc(fpr, tpr).fetch()
+        np.testing.assert_array_almost_equal(roc_auc, 0.90, decimal=2)
+        assert fpr.shape == tpr.shape
+        assert fpr.shape == thresholds.shape
+
+    def testRocCurveHard(self):
+        # roc_curve for hard decisions
+        y_true, pred, probas_pred = make_prediction(binary=True)
+
+        # always predict one
+        trivial_pred = np.ones(y_true.shape)
+        fpr, tpr, thresholds = roc_curve(y_true, trivial_pred)
+        roc_auc = auc(fpr, tpr).fetch()
+        np.testing.assert_array_almost_equal(roc_auc, 0.50, decimal=2)
+        assert fpr.shape == tpr.shape
+        assert fpr.shape == thresholds.shape
+
+        # always predict zero
+        trivial_pred = np.zeros(y_true.shape)
+        fpr, tpr, thresholds = roc_curve(y_true, trivial_pred)
+        roc_auc = auc(fpr, tpr).fetch()
+        np.testing.assert_array_almost_equal(roc_auc, 0.50, decimal=2)
+        assert fpr.shape == tpr.shape
+        assert fpr.shape == thresholds.shape
+
+        # hard decisions
+        fpr, tpr, thresholds = roc_curve(y_true, pred)
+        roc_auc = auc(fpr, tpr).fetch()
+        np.testing.assert_array_almost_equal(roc_auc, 0.78, decimal=2)
+        assert fpr.shape == tpr.shape
+        assert fpr.shape == thresholds.shape
+
+    def testRocCurveOneLabel(self):
+        y_true = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        y_pred = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+        # assert there are warnings
+        w = UndefinedMetricWarning
+        fpr, tpr, thresholds = assert_warns(w, roc_curve, y_true, y_pred)
+        # all true labels, all fpr should be nan
+        np.testing.assert_array_equal(fpr.fetch(), np.full(len(thresholds), np.nan))
+        assert fpr.shape == tpr.shape
+        assert fpr.shape == thresholds.shape
+
+        # assert there are warnings
+        fpr, tpr, thresholds = assert_warns(w, roc_curve,
+                                            [1 - x for x in y_true],
+                                            y_pred)
+        # all negative labels, all tpr should be nan
+        np.testing.assert_array_equal(tpr.fetch(), np.full(len(thresholds), np.nan))
+        assert fpr.shape == tpr.shape
+        assert fpr.shape == thresholds.shape
+
+    def testRocCurveDropIntermediate(self):
+        # Test that drop_intermediate drops the correct thresholds
+        y_true = [0, 0, 0, 0, 1, 1]
+        y_score = [0., 0.2, 0.5, 0.6, 0.7, 1.0]
+        tpr, fpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
+        np.testing.assert_array_almost_equal(thresholds.fetch(), [2., 1., 0.7, 0.])
+
+        # Test dropping thresholds with repeating scores
+        y_true = [0, 0, 0, 0, 0, 0, 0,
+                  1, 1, 1, 1, 1, 1]
+        y_score = [0., 0.1, 0.6, 0.6, 0.7, 0.8, 0.9,
+                   0.6, 0.7, 0.8, 0.9, 0.9, 1.0]
+        tpr, fpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
+        np.testing.assert_array_almost_equal(thresholds.fetch(),
+                                             [2.0, 1.0, 0.9, 0.7, 0.6, 0.])
+
+    def testRocCurveFprTprIncreasing(self):
+        # Ensure that fpr and tpr returned by roc_curve are increasing.
+        # Construct an edge case with float y_score and sample_weight
+        # when some adjacent values of fpr and tpr are actually the same.
+        y_true = [0, 0, 1, 1, 1]
+        y_score = [0.1, 0.7, 0.3, 0.4, 0.5]
+        sample_weight = np.repeat(0.2, 5)
+        fpr, tpr, _ = roc_curve(y_true, y_score, sample_weight=sample_weight)
+        assert ((mt.diff(fpr) < 0).sum() == 0).to_numpy()
+        assert ((mt.diff(tpr) < 0).sum() == 0).to_numpy()
+
+    def testAuc(self):
+        # Test Area Under Curve (AUC) computation
+        x = [0, 1]
+        y = [0, 1]
+        np.testing.assert_array_almost_equal(auc(x, y).fetch(), 0.5)
+        x = [1, 0]
+        y = [0, 1]
+        np.testing.assert_array_almost_equal(auc(x, y).fetch(), 0.5)
+        x = [1, 0, 0]
+        y = [0, 1, 1]
+        np.testing.assert_array_almost_equal(auc(x, y).fetch(), 0.5)
+        x = [0, 1]
+        y = [1, 1]
+        np.testing.assert_array_almost_equal(auc(x, y).fetch(), 1)
+        x = [0, 0.5, 1]
+        y = [0, 0.5, 1]
+        np.testing.assert_array_almost_equal(auc(x, y).fetch(), 0.5)
+
+    def testAucErrors(self):
+        # Incompatible shapes
+        with self.assertRaises(ValueError):
+            auc([0.0, 0.5, 1.0], [0.1, 0.2])
+
+        # Too few x values
+        with self.assertRaises(ValueError):
+            auc([0.0], [0.1])
+
+        # x is not in order
+        x = [2, 1, 3, 4]
+        y = [5, 6, 7, 8]
+        error_message = ("x is neither increasing nor decreasing : "
+                         "{}".format(np.array(x)))
+        with pytest.raises(ValueError, match=re.escape(error_message)):
+            auc(x, y)
+
+    def testBinaryClfCurveMulticlassError(self):
+        rng = check_random_state(404)
+        y_true = rng.randint(0, 3, size=10)
+        y_pred = rng.rand(10)
+        msg = "multiclass format is not supported"
+
+        with pytest.raises(ValueError, match=msg):
+            roc_curve(y_true, y_pred)

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -286,6 +286,7 @@ message OperandDef {
         NORMALIZE = 442;
         TOPK = 443;
         TRAPZ = 444;
+        GET_SHAPE = 445;
         // fancy index, distributed phase is a shuffle operation that
         // the fancy indexes will be distributed to the left chunks
         // the concat phase will concat back the indexed left chunks and index

--- a/mars/session.py
+++ b/mars/session.py
@@ -189,7 +189,8 @@ class Session(object):
             t._attach_session(self)
 
         for t in tileables:
-            if getattr(t, 'shape', None) is not None and np.nan in t.shape:
+            if getattr(t, 'shape', None) is not None and \
+                    any(np.isnan(s) for s in t.shape):
                 self._sess._update_tileable_shape(t)
 
         if fetch:

--- a/mars/tensor/__init__.py
+++ b/mars/tensor/__init__.py
@@ -25,7 +25,7 @@ from .base import result_type, ndim, copyto, transpose, where, broadcast_to, bro
     expand_dims, rollaxis, swapaxes, moveaxis, ravel, atleast_1d, atleast_2d, atleast_3d, argwhere, \
     array_split, split, hsplit, vsplit, dsplit, roll, squeeze, diff, ediff1d, \
     flip, flipud, fliplr, repeat, tile, isin, searchsorted, unique, \
-    sort, argsort, partition, argpartition, topk, argtopk, copy, trapz
+    sort, argsort, partition, argpartition, topk, argtopk, copy, trapz, shape
 from .arithmetic import add, subtract, multiply, divide, truediv as true_divide, \
     floordiv as floor_divide, mod, power, float_power, fmod, sqrt, \
     around, round_, round_ as round, logaddexp, logaddexp2, negative, positive, \

--- a/mars/tensor/__init__.py
+++ b/mars/tensor/__init__.py
@@ -58,7 +58,7 @@ from .rechunk import rechunk
 from .einsum import einsum
 from .images import imread
 # noinspection PyUnresolvedReferences
-from .lib.index_tricks import mgrid, ogrid, ndindex
+from .lib.index_tricks import mgrid, ogrid, ndindex, r_, c_
 from .core import mutable_tensor
 
 from . import random

--- a/mars/tensor/base/__init__.py
+++ b/mars/tensor/base/__init__.py
@@ -55,6 +55,7 @@ from .topk import topk
 from .argtopk import argtopk
 from .copy import copy
 from .trapz import trapz
+from .shape import shape
 from .to_gpu import to_gpu
 from .to_cpu import to_cpu
 

--- a/mars/tensor/base/shape.py
+++ b/mars/tensor/base/shape.py
@@ -1,0 +1,137 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from ... import opcodes
+from ...core import ExecutableTuple
+from ...serialize import KeyField, Int32Field
+from ...utils import calc_nsplits
+from ..datasource import tensor as astensor
+from ..operands import TensorOperand, TensorOperandMixin, TensorOrder
+
+
+class TensorGetShape(TensorOperand, TensorOperandMixin):
+    _op_type_ = opcodes.GET_SHAPE
+
+    _a = KeyField('a')
+    _ndim = Int32Field('ndim')
+
+    def __init__(self, prepare_inputs=None, a=None, ndim=None, dtype=None, **kw):
+        super().__init__(_dtype=dtype, _a=a, _ndim=ndim,
+                         _prepare_inputs=prepare_inputs, **kw)
+
+    @property
+    def a(self):
+        return self._a
+
+    @property
+    def ndim(self):
+        return self._ndim
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        if self._a is not None:
+            self._a = self._inputs[0]
+
+    @property
+    def output_limit(self):
+        return self._ndim
+
+    def __call__(self, a):
+        if not np.isnan(a.size):
+            return ExecutableTuple([astensor(s) for s in a.shape])
+
+        self._a = a
+        kws = []
+        for i in range(self.output_limit):
+            kws.append({
+                'shape': (),
+                'dtype': np.dtype(np.int64),
+                'order': TensorOrder.C_ORDER,
+                'i': i
+            })
+        return ExecutableTuple(self.new_tensors([a], kws=kws))
+
+    @classmethod
+    def tile(cls, op):
+        a = op.a
+        outs = op.outputs
+
+        chunk_op = TensorGetShape(prepare_inputs=[False] * len(a.chunks),
+                                  ndim=op.ndim)
+        chunk_kws = []
+        for out in outs:
+            params = out.params
+            params['index'] = ()
+            chunk_kws.append(params)
+        chunks = chunk_op.new_chunks(a.chunks, kws=chunk_kws)
+
+        kws = []
+        for c, out in zip(chunks, outs):
+            params = out.params
+            params['chunks'] = [c]
+            params['nsplits'] = ()
+            kws.append(params)
+        new_op = op.copy()
+        return new_op.new_tensors(op.inputs, kws=kws,
+                                  output_limit=op.output_limit)
+
+    @classmethod
+    def execute(cls, ctx, op):
+        chunk_idx_tochunk_shapes = \
+            {c.index: cm.chunk_shape for c, cm
+             in zip(op.inputs, ctx.get_chunk_metas([c.key for c in op.inputs]))}
+        nsplits = calc_nsplits(chunk_idx_tochunk_shapes)
+        shape = tuple(sum(ns) for ns in nsplits)
+        for o, s in zip(op.outputs, shape):
+            ctx[o.key] = s
+
+
+def shape(a):
+    """
+    Return the shape of a tensor.
+
+    Parameters
+    ----------
+    a : array_like
+        Input tensor.
+
+    Returns
+    -------
+    shape : ExecutableTuple of tensors
+        The elements of the shape tuple give the lengths of the
+        corresponding array dimensions.
+
+    Examples
+    --------
+    >>> import mars.tensor as mt
+
+    >>> mt.shape(mt.eye(3)).execute()
+    (3, 3)
+    >>> mt.shape([[1, 2]]).execute()
+    (1, 2)
+    >>> mt.shape([0]).execute()
+    (1,)
+    >>> mt.shape(0).execute()
+    ()
+
+    >>> a = mt.array([(1, 2), (3, 4)], dtype=[('x', 'i4'), ('y', 'i4')])
+    >>> mt.shape(a).execute()
+    (2,)
+
+    """
+    a = astensor(a)
+    op = TensorGetShape(ndim=a.ndim)
+    return op(a)

--- a/mars/tensor/base/shape.py
+++ b/mars/tensor/base/shape.py
@@ -58,7 +58,7 @@ class TensorGetShape(TensorOperand, TensorOperandMixin):
         for i in range(self.output_limit):
             kws.append({
                 'shape': (),
-                'dtype': np.dtype(np.int64),
+                'dtype': np.dtype(np.intc),
                 'order': TensorOrder.C_ORDER,
                 'i': i
             })

--- a/mars/tensor/datasource/array.py
+++ b/mars/tensor/datasource/array.py
@@ -280,7 +280,7 @@ def array(x, dtype=None, copy=True, order='K', ndmin=None, chunk_size=None):
     order = order or 'K'
     x = tensor(x, dtype=dtype, order=order, chunk_size=chunk_size)
     while ndmin is not None and x.ndim < ndmin:
-        x = x[np.newaxis, :]
+        x = x[np.newaxis]
 
     if copy and x is raw_x:
         x = x.copy(order=order)

--- a/mars/tensor/lib/index_tricks.py
+++ b/mars/tensor/lib/index_tricks.py
@@ -17,9 +17,14 @@
 import math
 
 import numpy as np
+from numpy.core.numerictypes import find_common_type
+from numpy.core.numeric import ScalarType
 from numpy.lib.index_tricks import ndindex
 
 from .. import datasource as _nx
+from ..core import Tensor
+from ..base import ndim
+from ..merge import concatenate
 
 
 class nd_grid(object):
@@ -133,7 +138,7 @@ class nd_grid(object):
                     nn[k] = nn[k][slobj]
                     slobj[k] = np.newaxis
             return nn
-        except (IndexError, TypeError):
+        except (IndexError, TypeError):  # pragma: no cover
             step = key.step
             stop = key.stop
             start = key.start
@@ -156,4 +161,241 @@ class nd_grid(object):
 mgrid = nd_grid(sparse=False)
 ogrid = nd_grid(sparse=True)
 
-__all__ = ['ndindex', 'mgrid', 'ogrid']
+
+class AxisConcatenator:
+    def __init__(self, axis=0, matrix=False, ndmin=1, trans1d=-1):
+        self.axis = axis
+        self.matrix = matrix
+        self.trans1d = trans1d
+        self.ndmin = ndmin
+
+    def __getitem__(self, key):
+        # handle matrix builder syntax
+        if isinstance(key, str):  # pragma: no cover
+            raise NotImplementedError('Does not support operation on matrix')
+
+        if not isinstance(key, tuple):
+            key = (key,)
+
+        # copy attributes, since they can be overridden in the first argument
+        trans1d = self.trans1d
+        ndmin = self.ndmin
+        matrix = self.matrix
+        axis = self.axis
+
+        objs = []
+        scalars = []
+        arraytypes = []
+        scalartypes = []
+
+        for k, item in enumerate(key):
+            scalar = False
+            if isinstance(item, slice):
+                step = item.step
+                start = item.start
+                stop = item.stop
+                if start is None:
+                    start = 0
+                if step is None:
+                    step = 1
+                if isinstance(step, complex):
+                    size = int(abs(step))
+                    newobj = _nx.linspace(start, stop, num=size)
+                else:
+                    newobj = _nx.arange(start, stop, step)
+                if ndmin > 1:
+                    newobj = _nx.array(newobj, copy=False, ndmin=ndmin)
+                    if trans1d != -1:
+                        newobj = newobj.swapaxes(-1, trans1d)
+            elif isinstance(item, str):
+                if k != 0:
+                    raise ValueError("special directives must be the "
+                                     "first entry.")
+                if item in ('r', 'c'):  # pragma: no cover
+                    raise NotImplementedError('Does not support operation on matrix')
+                if ',' in item:
+                    vec = item.split(',')
+                    try:
+                        axis, ndmin = [int(x) for x in vec[:2]]
+                        if len(vec) == 3:
+                            trans1d = int(vec[2])
+                        continue
+                    except Exception:  # pragma: no cover
+                        raise ValueError("unknown special directive")
+                try:
+                    axis = int(item)
+                    continue
+                except (ValueError, TypeError):  # pragma: no cover# pragma: no cover
+                    raise ValueError("unknown special directive")
+            elif type(item) in ScalarType:
+                newobj = _nx.array(item, ndmin=ndmin)
+                scalars.append(len(objs))
+                scalar = True
+                scalartypes.append(newobj.dtype)
+            else:
+                item_ndim = ndim(item)
+                newobj = _nx.array(item, copy=False, ndmin=ndmin)
+                if trans1d != -1 and item_ndim < ndmin:
+                    k2 = ndmin - item_ndim
+                    k1 = trans1d
+                    if k1 < 0:
+                        k1 += k2 + 1
+                    defaxes = list(range(ndmin))
+                    axes = defaxes[:k1] + defaxes[k2:] + defaxes[k1:k2]
+                    newobj = newobj.transpose(axes)
+            objs.append(newobj)
+            if not scalar and isinstance(newobj, Tensor):
+                arraytypes.append(newobj.dtype)
+
+        # Ensure that scalars won't up-cast unless warranted
+        final_dtype = find_common_type(arraytypes, scalartypes)
+        if final_dtype is not None:
+            for k in scalars:
+                objs[k] = objs[k].astype(final_dtype)
+
+        res = concatenate(tuple(objs), axis=axis)
+
+        if matrix:  # pragma: no cover
+            raise NotImplementedError('Does not support operation on matrix')
+        return res
+
+    def __len__(self):
+        return 0
+
+
+# separate classes are used here instead of just making r_ = concatentor(0),
+# etc. because otherwise we couldn't get the doc string to come out right
+# in help(r_)
+
+class RClass(AxisConcatenator):
+    """
+    Translates slice objects to concatenation along the first axis.
+
+    This is a simple way to build up tensor quickly. There are two use cases.
+
+    1. If the index expression contains comma separated tensors, then stack
+       them along their first axis.
+    2. If the index expression contains slice notation or scalars then create
+       a 1-D tensor with a range indicated by the slice notation.
+
+    If slice notation is used, the syntax ``start:stop:step`` is equivalent
+    to ``mt.arange(start, stop, step)`` inside of the brackets. However, if
+    ``step`` is an imaginary number (i.e. 100j) then its integer portion is
+    interpreted as a number-of-points desired and the start and stop are
+    inclusive. In other words ``start:stop:stepj`` is interpreted as
+    ``mt.linspace(start, stop, step, endpoint=1)`` inside of the brackets.
+    After expansion of slice notation, all comma separated sequences are
+    concatenated together.
+
+    Optional character strings placed as the first element of the index
+    expression can be used to change the output. The strings 'r' or 'c' result
+    in matrix output. If the result is 1-D and 'r' is specified a 1 x N (row)
+    matrix is produced. If the result is 1-D and 'c' is specified, then a N x 1
+    (column) matrix is produced. If the result is 2-D then both provide the
+    same matrix result.
+
+    A string integer specifies which axis to stack multiple comma separated
+    tensors along. A string of two comma-separated integers allows indication
+    of the minimum number of dimensions to force each entry into as the
+    second integer (the axis to concatenate along is still the first integer).
+
+    A string with three comma-separated integers allows specification of the
+    axis to concatenate along, the minimum number of dimensions to force the
+    entries to, and which axis should contain the start of the tensors which
+    are less than the specified number of dimensions. In other words the third
+    integer allows you to specify where the 1's should be placed in the shape
+    of the tensors that have their shapes upgraded. By default, they are placed
+    in the front of the shape tuple. The third argument allows you to specify
+    where the start of the tensor should be instead. Thus, a third argument of
+    '0' would place the 1's at the end of the tensor shape. Negative integers
+    specify where in the new shape tuple the last dimension of upgraded tensors
+    should be placed, so the default is '-1'.
+
+    Parameters
+    ----------
+    Not a function, so takes no parameters
+
+
+    Returns
+    -------
+    A concatenated tensor or matrix.
+
+    See Also
+    --------
+    concatenate : Join a sequence of tensors along an existing axis.
+    c_ : Translates slice objects to concatenation along the second axis.
+
+    Examples
+    --------
+    >>> import mars.tensor as mt
+    >>> mt.r_[mt.array([1,2,3]), 0, 0, mt.array([4,5,6])].execute()
+    array([1, 2, 3, ..., 4, 5, 6])
+    >>> mt.r_[-1:1:6j, [0]*3, 5, 6].execute()
+    array([-1. , -0.6, -0.2,  0.2,  0.6,  1. ,  0. ,  0. ,  0. ,  5. ,  6. ])
+
+    String integers specify the axis to concatenate along or the minimum
+    number of dimensions to force entries into.
+
+    >>> a = mt.array([[0, 1, 2], [3, 4, 5]])
+    >>> mt.r_['-1', a, a].execute() # concatenate along last axis
+    array([[0, 1, 2, 0, 1, 2],
+           [3, 4, 5, 3, 4, 5]])
+    >>> mt.r_['0,2', [1,2,3], [4,5,6]].execute() # concatenate along first axis, dim>=2
+    array([[1, 2, 3],
+           [4, 5, 6]])
+
+    >>> mt.r_['0,2,0', [1,2,3], [4,5,6]].execute()
+    array([[1],
+           [2],
+           [3],
+           [4],
+           [5],
+           [6]])
+    >>> mt.r_['1,2,0', [1,2,3], [4,5,6]].execute()
+    array([[1, 4],
+           [2, 5],
+           [3, 6]])
+    """
+
+    def __init__(self):
+        AxisConcatenator.__init__(self, 0)
+
+
+r_ = RClass()
+
+
+class CClass(AxisConcatenator):
+    """
+    Translates slice objects to concatenation along the second axis.
+
+    This is short-hand for ``mt.r_['-1,2,0', index expression]``, which is
+    useful because of its common occurrence. In particular, tensors will be
+    stacked along their last axis after being upgraded to at least 2-D with
+    1's post-pended to the shape (column vectors made out of 1-D tensors).
+
+    See Also
+    --------
+    column_stack : Stack 1-D tensors as columns into a 2-D tensor.
+    r_ : For more detailed documentation.
+
+    Examples
+    --------
+    >>> import mars.tensor as mt
+
+    >>> mt.c_[mt.array([1,2,3]), mt.array([4,5,6])].execute()
+    array([[1, 4],
+           [2, 5],
+           [3, 6]])
+    >>> mt.c_[mt.array([[1,2,3]]), 0, 0, mt.array([[4,5,6]])].execute()
+    array([[1, 2, 3, ..., 4, 5, 6]])
+
+    """
+
+    def __init__(self):
+        AxisConcatenator.__init__(self, -1, ndmin=2, trans1d=0)
+
+
+c_ = CClass()
+
+
+__all__ = ['ndindex', 'mgrid', 'ogrid', 'r_', 'c_']

--- a/mars/tensor/lib/tests/test_index_tricks.py
+++ b/mars/tensor/lib/tests/test_index_tricks.py
@@ -14,12 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import numpy as np
 
+from mars import tensor as mt
 from mars.tensor.lib import nd_grid
+from mars.tests.core import TestBase, ExecutorForTest
 
 
-class Test(unittest.TestCase):
+class Test(TestBase):
+    def setUp(self):
+        self.executor = ExecutorForTest('numpy')
+
     def testIndexTricks(self):
         mgrid = nd_grid()
         g = mgrid[0:5, 0:5]
@@ -28,3 +33,76 @@ class Test(unittest.TestCase):
         ogrid = nd_grid(sparse=True)
         o = ogrid[0:5, 0:5]
         [ob.tiles() for ob in o]  # tilesable means no loop exists
+
+    def testR_(self):
+        r = mt.r_[mt.array([1, 2, 3]), 0, 0, mt.array([4, 5, 6])]
+
+        result = self.executor.execute_tensor(r, concat=True)[0]
+        expected = np.r_[np.array([1, 2, 3]), 0, 0, np.array([4, 5, 6])]
+
+        np.testing.assert_array_equal(result, expected)
+
+        r = mt.r_[-1:1:6j, [0]*3, 5, 6]
+
+        result = self.executor.execute_tensor(r, concat=True)[0]
+        expected = np.r_[-1:1:6j, [0]*3, 5, 6]
+
+        np.testing.assert_array_equal(result, expected)
+
+        r = mt.r_[-1:1:6j]
+
+        result = self.executor.execute_tensor(r, concat=True)[0]
+        expected = np.r_[-1:1:6j]
+
+        np.testing.assert_array_equal(result, expected)
+
+        raw = [[0, 1, 2], [3, 4, 5]]
+        a = mt.array(raw, chunk_size=2)
+        r = mt.r_['-1', a, a]
+
+        result = self.executor.execute_tensor(r, concat=True)[0]
+        expected = np.r_['-1', raw, raw]
+
+        np.testing.assert_array_equal(result, expected)
+
+        r = mt.r_['0,2', [1, 2, 3], [4, 5, 6]]
+
+        result = self.executor.execute_tensor(r, concat=True)[0]
+        expected = np.r_['0,2', [1, 2, 3], [4, 5, 6]]
+
+        np.testing.assert_array_equal(result, expected)
+
+        r = mt.r_['0,2,0', [1, 2, 3], [4, 5, 6]]
+
+        result = self.executor.execute_tensor(r, concat=True)[0]
+        expected = np.r_['0,2,0', [1, 2, 3], [4, 5, 6]]
+        np.testing.assert_array_equal(result, expected)
+
+        r = mt.r_['1,2,0', [1, 2, 3], [4, 5, 6]]
+
+        result = self.executor.execute_tensor(r, concat=True)[0]
+        expected = np.r_['1,2,0', [1, 2, 3], [4, 5, 6]]
+        np.testing.assert_array_equal(result, expected)
+
+        self.assertEqual(len(mt.r_), 0)
+
+        with self.assertRaises(ValueError):
+            _ = mt.r_[:3, 'wrong']
+
+    def testC_(self):
+        r = mt.c_[mt.array([1, 2, 3]), mt.array([4, 5, 6])]
+
+        result = self.executor.execute_tensor(r, concat=True)[0]
+        expected = np.c_[np.array([1, 2, 3]), np.array([4, 5, 6])]
+        np.testing.assert_array_equal(result, expected)
+
+        r = mt.c_[mt.array([[1, 2, 3]]), 0, 0, mt.array([[4, 5, 6]])]
+
+        result = self.executor.execute_tensor(r, concat=True)[0]
+        expected = np.c_[np.array([[1, 2, 3]]), 0, 0, np.array([[4, 5, 6]])]
+        np.testing.assert_array_equal(result, expected)
+
+        r = mt.c_[:3, 1:4]
+        result = self.executor.execute_tensor(r, concat=True)[0]
+        expected = np.c_[:3, 1:4]
+        np.testing.assert_array_equal(result, expected)

--- a/mars/tensor/operands.py
+++ b/mars/tensor/operands.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from ..serialize import DataTypeField
 from ..operands import Operand, TileableOperandMixin, HasInput, ShuffleProxy, MapReduceOperand, Fuse
 from ..utils import calc_nsplits
@@ -57,6 +59,10 @@ class TensorOperandMixin(TileableOperandMixin):
         chunks = kw.pop('chunks', None)
         if nsplits is not None:
             kw['nsplits'] = nsplits
+            if any(np.isnan(s) for s in shape):
+                # in the situation that `nan` in shape,
+                # but not in nsplits
+                shape = tuple(sum(ns) for ns in nsplits)
         data = TensorData(shape=shape, dtype=dt, order=order,
                           op=self, chunks=chunks, **kw)
         return tensor_cls(data)

--- a/mars/tensor/operands.py
+++ b/mars/tensor/operands.py
@@ -59,7 +59,7 @@ class TensorOperandMixin(TileableOperandMixin):
         chunks = kw.pop('chunks', None)
         if nsplits is not None:
             kw['nsplits'] = nsplits
-            if any(np.isnan(s) for s in shape):
+            if shape is not None and any(np.isnan(s) for s in shape):
                 # in the situation that `nan` in shape,
                 # but not in nsplits
                 shape = tuple(sum(ns) for ns in nsplits)

--- a/mars/tensor/utils.py
+++ b/mars/tensor/utils.py
@@ -81,7 +81,7 @@ def broadcast_shape(*shapes):
 
     out_shapes = []
     for ss in itertools.zip_longest(*[reversed(s) for s in shapes], fillvalue=-1):
-        shape = max(ss)
+        shape = max(s for s in ss if s != -1)
         if any(i != -1 and i != 1 and i != shape and not np.isnan(i) for i in ss):
             raise ValueError('Operands could not be broadcast together '
                              'with shape {0}'.format(' '.join(map(str, shapes))))

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -72,6 +72,12 @@ class Test(unittest.TestCase):
 
         np.testing.assert_array_almost_equal(result, expected)
 
+        s = mt.shape(0)
+
+        result = s.execute().fetch()
+        expected = np.shape(0)
+        self.assertEqual(result, expected)
+
     def testReExecuteSame(self):
         data = np.random.random((5, 9))
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR introduced:

1. `mars.learn.metrics.roc_curve` as well as `mars.learn.metrics.auc`.
2. `mars.tenosr.shape` which returns a `ExcutableTuple`, if the shape is unknown, `.execute()` will return the actual shape.
3. `mars.tensor.r_` and `mars.tensor.c_` shortcuts.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1196 .
