### PR TITLE
Allow some operands to fail fast

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,6 @@
 .vscode
 .pytest*
 .dist-coverage
-bin
 build
 dist
 docs
@@ -28,3 +27,13 @@ README.rst
 **/*.pyc
 **/*.so
 **/*.pyd
+**/*_pb2.py
+mars/*.c*
+mars/*.h*
+mars/lib/*.c*
+mars/actors/*.c*
+mars/actors/pool/*.c*
+mars/optimizes/**/*.c*
+mars/scheduler/*.c*
+mars/serialize/*.c*
+mars/worker/*.c*

--- a/mars/deploy/kubernetes/docker/Dockerfile.base
+++ b/mars/deploy/kubernetes/docker/Dockerfile.base
@@ -5,6 +5,7 @@ COPY retry.sh /srv/retry.sh
 
 RUN /srv/retry.sh 3 /opt/conda/bin/conda install \
     bokeh \
+    cloudpickle \
     cython \
     gevent \
     jinja2 \

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -136,6 +136,10 @@ class Operand(AttributeAsDictKey, metaclass=OperandMetaclass):
     def output_limit(self):
         return 1
 
+    @property
+    def retryable(self) -> bool:
+        return True
+
     def get_dependent_data_keys(self):
         return [dep.key for dep, has_dep
                 in zip(self.inputs or (), self.prepare_inputs) if has_dep]

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -18,6 +18,7 @@ import logging
 import operator
 import os
 import random
+import sys
 import time
 from collections import defaultdict, OrderedDict
 from functools import lru_cache, reduce
@@ -388,6 +389,7 @@ class GraphActor(SchedulerActor):
             pass
         except:  # noqa: E722
             logger.exception('Failed to start graph execution.')
+            self._graph_meta_ref.set_exc_info(sys.exc_info(), _tell=True, _wait=False)
             self.stop_graph()
             self.state = GraphState.FAILED
             self._graph_meta_ref.set_graph_end(_tell=True, _wait=False)
@@ -857,6 +859,7 @@ class GraphActor(SchedulerActor):
                 initial_keys.append(op_key)
                 state = OperandState.READY
                 op_info['is_initial'] = True
+            op_info['retryable'] = op.retryable
             op_info['retries'] = 0
             meta_op_info['state'] = op_info['state'] = state
             meta_op_info['worker'] = op_info.get('worker')

--- a/mars/scheduler/operands/common.py
+++ b/mars/scheduler/operands/common.py
@@ -431,7 +431,7 @@ class OperandActor(BaseOperandActor):
                                  self.retries + 1, exc_type.__name__, self._op_key, self.worker, exc_info=exc)
                 # increase retry times
                 self.retries += 1
-                if self.retries >= options.scheduler.retry_num:
+                if not self._info['retryable'] or self.retries >= options.scheduler.retry_num:
                     # no further trial
                     self.state = OperandState.FATAL
                     self._exc = exc

--- a/mars/web/apihandlers.py
+++ b/mars/web/apihandlers.py
@@ -70,15 +70,19 @@ class SessionsApiHandler(MarsApiRequestHandler):
         if python_version[0] != sys.version_info[0]:
             raise web.HTTPError(400, reason='Python version not consistent')
 
+        import pyarrow
         session_id = tokenize(str(uuid.uuid1()))
         self.web_api.create_session(session_id, **args)
-        self.write(json.dumps(dict(session_id=session_id)))
+        self.write(json.dumps(dict(session_id=session_id, arrow_version=pyarrow.__version__)))
 
 
 class SessionApiHandler(MarsApiRequestHandler):
-    def head(self, session_id):
+    def get(self, session_id):
         if not self.web_api.has_session(session_id):
             raise web.HTTPError(404, 'Session doesn\'t not exists')
+
+        import pyarrow
+        self.write(json.dumps(dict(session_id=session_id, arrow_version=pyarrow.__version__)))
 
     def delete(self, session_id):
         self.web_api.delete_session(session_id)

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -273,6 +273,17 @@ class Test(unittest.TestCase):
         res = requests.post('%s/api/session' % service_ep, dict(pyver=wrong_version))
         self.assertEqual(res.status_code, 400)
 
+        import pyarrow
+        old_arrow_version = pyarrow.__version__
+        try:
+            pyarrow.__version__ = '0.0.0'
+
+            with self.assertWarns(RuntimeWarning):
+                with new_session(service_ep):
+                    pass
+        finally:
+            pyarrow.__version__ = old_arrow_version
+
         with new_session(service_ep) as sess:
             # Stop non-existing graph should raise an exception
             graph_key = str(uuid.uuid4())


### PR DESCRIPTION
## What do these changes do?

This PR does the things below:

1. Allow some operands to fail fast by adding ``retryable`` property to operands
2. Warns when pyarrow version between host and service does not agree
3. Fixes ``.dockerignore`` which ignores building protobuf files
4. Return errors in graph preparation to the client

## Related issue number

Fixes #1221