### PR TITLE
Fix error in starting local cluster with IPython

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,6 @@ jobs:
         fi
         if [[ "$PYTHON" =~ "3.8" ]]; then
           conda install -n test --quiet --yes python=$PYTHON numpy
-          # remove three lines below once gevent 1.5 is released
-          # resolve compatibility issue in tblib inside gevent
-          GEVENT_TBLIB_FILE=$(python -c "from gevent import _tblib; print(_tblib.__file__)")
-          curl https://raw.githubusercontent.com/gevent/gevent/1.5a2/src/gevent/_tblib.py -o "$GEVENT_TBLIB_FILE"
         fi
         pip install -r requirements-dev.txt
         pip install -r requirements-extra.txt

--- a/.github/workflows/install-conda.sh
+++ b/.github/workflows/install-conda.sh
@@ -35,7 +35,7 @@ fi
 
 CONDA_FILE="Miniconda3-latest-${CONDA_OS}-x86_64.${FILE_EXT}"
 
-TEST_PACKAGES="virtualenv gevent psutil pyyaml lz4"
+TEST_PACKAGES="virtualenv psutil pyyaml lz4"
 
 if [[ "$FILE_EXT" == "sh" ]]; then
   curl -L -o "miniconda.${FILE_EXT}" https://repo.continuum.io/miniconda/$CONDA_FILE

--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -170,6 +170,10 @@ def gen_endpoint(address):
 
 
 def _start_cluster(endpoint, event, n_process=None, shared_memory=None, **kw):
+    modules = kw.pop('modules', None) or []
+    for m in modules:
+        __import__(m, globals(), locals(), [])
+
     cluster = LocalDistributedCluster(endpoint, n_process=n_process,
                                       shared_memory=shared_memory, **kw)
     cluster.start_service()

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -66,6 +66,34 @@ class SerializeMustFailOperand(TensorOperand, TensorElementWise):
         super().__init__(_f=f, **kw)
 
 
+class FakeOp(TensorAbs):
+    _op_type_ = 9870102948
+
+    _multiplier = Int64Field('multiplier')
+
+    @classmethod
+    def tile(cls, op):
+        context = get_context()
+
+        if context.running_mode != RunningMode.local_cluster:
+            raise AssertionError
+
+        inp_chunk = op.inputs[0].chunks[0]
+        inp_size = context.get_chunk_metas([inp_chunk.key])[0].chunk_size
+        chunk_op = op.copy().reset_key()
+        chunk_op._multiplier = inp_size
+        chunk = chunk_op.new_chunk([inp_chunk], shape=inp_chunk.shape)
+
+        new_op = op.copy()
+        return new_op.new_tensors(op.inputs, shape=op.outputs[0].shape,
+                                  order=op.outputs[0].order, nsplits=op.inputs[0].nsplits,
+                                  chunks=[chunk])
+
+    @classmethod
+    def execute(cls, ctx, op):
+        ctx[op.outputs[0].key] = ctx[op.inputs[0].key] * op._multiplier
+
+
 @unittest.skipIf(sys.platform == 'win32', 'does not run in windows')
 @mock.patch('webbrowser.open_new_tab', new=lambda *_, **__: True)
 class Test(unittest.TestCase):
@@ -879,34 +907,8 @@ class Test(unittest.TestCase):
             pd.testing.assert_frame_equal(pdf, result)
 
     def testTileContextInLocalCluster(self):
-        class FakeOp(TensorAbs):
-            _op_type_ = 9870102948
-
-            _multiplier = Int64Field('multiplier')
-
-            @classmethod
-            def tile(cls, op):
-                context = get_context()
-
-                self.assertEqual(context.running_mode, RunningMode.local_cluster)
-
-                inp_chunk = op.inputs[0].chunks[0]
-                inp_size = context.get_chunk_metas([inp_chunk.key])[0].chunk_size
-                chunk_op = op.copy().reset_key()
-                chunk_op._multiplier = inp_size
-                chunk = chunk_op.new_chunk([inp_chunk], shape=inp_chunk.shape)
-
-                new_op = op.copy()
-                return new_op.new_tensors(op.inputs, shape=op.outputs[0].shape,
-                                          order=op.outputs[0].order, nsplits=op.inputs[0].nsplits,
-                                          chunks=[chunk])
-
-            @classmethod
-            def execute(cls, ctx, op):
-                ctx[op.outputs[0].key] = ctx[op.inputs[0].key] * op._multiplier
-
         with new_cluster(scheduler_n_process=2, worker_n_process=2,
-                         shared_memory='20M', web=True) as cluster:
+                         shared_memory='20M', modules=[__name__], web=True) as cluster:
             session = cluster.session
 
             raw = np.random.rand(10, 20)

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -277,8 +277,10 @@ def deserialize_graph(ser_graph, graph_cls=None):
         g.ParseFromString(ser_graph_bin)
         return graph_cls.from_pb(g)
     except (zlib.error, DecodeError):
-        json_obj = json.loads(to_str(ser_graph))
-        return graph_cls.from_json(json_obj)
+        pass
+
+    json_obj = json.loads(to_str(ser_graph))
+    return graph_cls.from_json(json_obj)
 
 
 def calc_data_size(dt):

--- a/mars/web/__main__.py
+++ b/mars/web/__main__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import gevent.monkey
-gevent.monkey.patch_all(thread=False)
+gevent.monkey.patch_all(thread=False, select=False)
 
 import argparse  # noqa: E402
 import logging   # noqa: E402


### PR DESCRIPTION
## What do these changes do?

Use multiprocessing with spawn method instead of gipc to fix errors caused by monkey patching after fork in IPython.

This PR also deal with failures of Mars Web with recent gevent versions (>=1.5), which is described in #1228.

## Related issue number

Fixes #1231