### PR TITLE
Fix `.fetch()` that may cause some op executed again

### DIFF
--- a/mars/optimizes/tileable_graph/core.py
+++ b/mars/optimizes/tileable_graph/core.py
@@ -60,7 +60,9 @@ class OptimizeIntegratedTileableGraphBuilder(TileableGraphBuilder):
     def _apply_rules(node_processor, optimizer_context):
         def inner(node):
             node = node_processor(node) if node_processor is not None else node
-            if type(node.op) in _rules:
+            if node in tileable_optimized:
+                node = tileable_optimized[node]
+            elif type(node.op) in _rules:
                 for rule in _rules[type(node.op)]:
                     ruler = rule(optimizer_context)
                     if ruler.match(node):

--- a/mars/optimizes/tileable_graph/core.py
+++ b/mars/optimizes/tileable_graph/core.py
@@ -62,6 +62,15 @@ class OptimizeIntegratedTileableGraphBuilder(TileableGraphBuilder):
             node = node_processor(node) if node_processor is not None else node
             if node in tileable_optimized:
                 node = tileable_optimized[node]
+            elif len(node.inputs or []) > 0 and \
+                    any(inp in tileable_optimized for inp in node.inputs):
+                new_inputs = []
+                for inp in node.inputs:
+                    if inp in tileable_optimized:
+                        new_inputs.append(tileable_optimized[inp])
+                    else:
+                        new_inputs.append(inp)
+                node.inputs = new_inputs
             elif type(node.op) in _rules:
                 for rule in _rules[type(node.op)]:
                     ruler = rule(optimizer_context)

--- a/mars/optimizes/tileable_graph/tests/test_column_pruning.py
+++ b/mars/optimizes/tileable_graph/tests/test_column_pruning.py
@@ -164,6 +164,6 @@ class Test(TestBase):
                 register(DataFrameReadCSV, _execute_read_csv)
 
                 pd.testing.assert_frame_equal(df2.fetch(), expected)
-                pd.testing.assert_frame_equal(df2.fetch().iloc[:3], expected.iloc[:3])
+                pd.testing.assert_frame_equal(df2.iloc[:3].fetch(), expected.iloc[:3])
             finally:
                 del Executor._op_runners[DataFrameReadCSV]

--- a/mars/optimizes/tileable_graph/tests/test_column_pruning.py
+++ b/mars/optimizes/tileable_graph/tests/test_column_pruning.py
@@ -23,6 +23,8 @@ import pandas as pd
 import mars.dataframe as md
 from mars.core import ExecutableTuple
 from mars.config import option_context
+from mars.dataframe.datasource.read_csv import DataFrameReadCSV
+from mars.executor import register, Executor
 from mars.tests.core import TestBase, ExecutorForTest
 from mars.optimizes.tileable_graph.core import tileable_optimized
 
@@ -140,3 +142,28 @@ class Test(TestBase):
 
         finally:
             shutil.rmtree(tempdir)
+
+    def testFetch(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            filename = os.path.join(tempdir, 'test_fetch.csv')
+            pd_df = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],
+                                  'b': [1, 3, 4, 5, 6, 5, 4, 4, 4],
+                                  'c': list('aabaaddce'),
+                                  'd': list('abaaaddce')})
+            pd_df.to_csv(filename, index=False)
+
+            df = md.read_csv(filename)
+            df2 = df.groupby('d').agg({'b': 'min'})
+            expected = pd_df.groupby('d').agg({'b': 'min'})
+            _ = df2.execute()
+
+            def _execute_read_csv(*_):  # pragma: no cover
+                raise ValueError('cannot run read_csv again')
+
+            try:
+                register(DataFrameReadCSV, _execute_read_csv)
+
+                pd.testing.assert_frame_equal(df2.fetch(), expected)
+                pd.testing.assert_frame_equal(df2.fetch().iloc[:3], expected.iloc[:3])
+            finally:
+                del Executor._op_runners[DataFrameReadCSV]

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -929,6 +929,19 @@ def adapt_mars_docstring(doc):
     return '\n'.join(lines)
 
 
+def prune_chunk_graph(chunk_graph, result_chunk_keys):
+    reverse_chunk_graph = chunk_graph.build_reversed()
+    marked = set()
+    for c in reverse_chunk_graph.topological_iter():
+        if c.key in result_chunk_keys:
+            marked.update(o for o in c.op.outputs)
+        elif any(inp in marked for inp in reverse_chunk_graph.iter_predecessors(c)):
+            marked.update(o for o in c.op.outputs)
+    for n in list(chunk_graph):
+        if n not in marked:
+            chunk_graph.remove_node(n)
+
+
 @functools.lru_cache(500)
 def serialize_function(function):
     return cloudpickle.dumps(function)

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -4,7 +4,7 @@ numexpr>=2.6.4
 psutil>=4.0.0
 lz4>=1.0.0
 protobuf>=3.6
-gevent>=1.2.0
+gevent>=1.2.0,<20.5.0
 bokeh>=1.0.0; python_version >= '3.6'
 bokeh>=1.0.0,<2.0.0; python_version < '3.6'
 jinja2>=2.0


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

As reported in #1242 , performance declined since #1201 merged.

After investigation, I found that the reason is that `.fetch()` may cause some op executed again.

Now, for local execution, `.fetch()` will just submit the tilables to executor for running, in the executor, after tiling, the executed op will be replaced with fetch op. 

Consider the situation below:

```
chunk_a -> chunk_b
```

Since `chunk_b` has been executed, it will be replace by fetch_chunk_b, but chunk_a exists still, this graph will be

```
chunk_a
fetch_chunk_b
```

Thus we need to remove all the predecessors of the tileables that has been executed before execution.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1242 .