### PR TITLE
Implements DataFrame.{iterrows, itertuples}

### DIFF
--- a/docs/source/dataframe/reference/api/mars.dataframe.DataFrame.astype.rst
+++ b/docs/source/dataframe/reference/api/mars.dataframe.DataFrame.astype.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.astype
+===============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.astype

--- a/docs/source/dataframe/reference/api/mars.dataframe.DataFrame.iterrows.rst
+++ b/docs/source/dataframe/reference/api/mars.dataframe.DataFrame.iterrows.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.iterrows
+=================================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.iterrows

--- a/docs/source/dataframe/reference/api/mars.dataframe.DataFrame.itertuples.rst
+++ b/docs/source/dataframe/reference/api/mars.dataframe.DataFrame.itertuples.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.itertuples
+===================================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.itertuples

--- a/docs/source/dataframe/reference/api/mars.dataframe.Series.astype.rst
+++ b/docs/source/dataframe/reference/api/mars.dataframe.Series.astype.rst
@@ -1,0 +1,6 @@
+mars.dataframe.Series.astype
+============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: Series.astype

--- a/docs/source/dataframe/reference/frame.rst
+++ b/docs/source/dataframe/reference/frame.rst
@@ -34,6 +34,7 @@ Conversion
 .. autosummary::
    :toctree: api/
 
+   DataFrame.astype
    DataFrame.copy
    DataFrame.isna
    DataFrame.notna
@@ -48,6 +49,8 @@ Indexing, iteration
    DataFrame.iat
    DataFrame.loc
    DataFrame.iloc
+   DataFrame.iterrows
+   DataFrame.itertuples
    DataFrame.tail
 
 Binary operator functions

--- a/docs/source/dataframe/reference/series.rst
+++ b/docs/source/dataframe/reference/series.rst
@@ -32,6 +32,7 @@ Conversion
 .. autosummary::
    :toctree: api/
 
+   Series.astype
    Series.copy
    Series.to_tensor
 

--- a/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.DataFrame.astype.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.DataFrame.astype.po
@@ -1,0 +1,142 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 1999-2020, The Alibaba Group Holding Ltd.
+# This file is distributed under the same license as the mars package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: mars 0.5.0a1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-28 23:29+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: ../../source/dataframe/reference/api/mars.dataframe.DataFrame.astype.rst:2
+msgid "mars.dataframe.DataFrame.astype"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:1 of
+msgid "Cast a pandas object to a specified dtype ``dtype``."
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype of
+msgid "Parameters"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:3 of
+msgid ""
+"Use a numpy.dtype or Python type to cast entire pandas object to the same"
+" type. Alternatively, use {col: dtype, ...}, where col is a column label "
+"and dtype is a numpy.dtype or Python type to cast one or more of the "
+"DataFrame's columns to column-specific types."
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:8 of
+msgid ""
+"Return a copy when ``copy=True`` (be very careful setting ``copy=False`` "
+"as changes to values then may propagate to other pandas objects)."
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:12 of
+msgid ""
+"Control raising of exceptions on invalid data for provided dtype.  - "
+"``raise`` : allow exceptions to be raised - ``ignore`` : suppress "
+"exceptions. On error return original object."
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:12 of
+msgid "Control raising of exceptions on invalid data for provided dtype."
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:14 of
+msgid "``raise`` : allow exceptions to be raised"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:15 of
+msgid "``ignore`` : suppress exceptions. On error return original object."
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype of
+msgid "Returns"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:18 of
+msgid "**casted**"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype of
+msgid "Return type"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:24 of
+msgid ":meth:`to_datetime`"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:24 of
+msgid "Convert argument to datetime."
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:27 of
+msgid ":meth:`to_timedelta`"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:27 of
+msgid "Convert argument to timedelta."
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:30 of
+msgid ":meth:`to_numeric`"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:30 of
+msgid "Convert argument to a numeric type."
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:32 of
+msgid ":meth:`numpy.ndarray.astype`"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:33 of
+msgid "Cast a numpy array to a specified type."
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:36 of
+msgid "Examples"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:37 of
+msgid "Create a DataFrame:"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:46 of
+msgid "Cast all columns to int32:"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:53 of
+msgid "Cast col1 to int32 using a dictionary:"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:60 of
+msgid "Create a series:"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:72 of
+msgid "Convert to categorical type:"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:80 of
+msgid "Convert to ordered categorical type with custom ordering:"
+msgstr ""
+
+#: mars.dataframe.DataFrame.astype:90 of
+msgid ""
+"Note that using ``copy=False`` and changing data on a new pandas object "
+"may propagate changes:"
+msgstr ""
+

--- a/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.DataFrame.iterrows.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.DataFrame.iterrows.po
@@ -1,0 +1,89 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 1999-2020, The Alibaba Group Holding Ltd.
+# This file is distributed under the same license as the mars package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: mars 0.5.0a1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-28 23:29+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: ../../source/dataframe/reference/api/mars.dataframe.DataFrame.iterrows.rst:2
+msgid "mars.dataframe.DataFrame.iterrows"
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows:1 of
+msgid "Iterate over DataFrame rows as (index, Series) pairs."
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows of
+msgid "Yields"
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows:3 of
+msgid ""
+"**index** (*label or tuple of label*) -- The index of the row. A tuple "
+"for a `MultiIndex`."
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows:4 of
+msgid "**data** (*Series*) -- The data of the row as a Series."
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows:5 of
+msgid ""
+"**it** (*generator*) -- A generator that iterates over the rows of the "
+"frame."
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows:10 of
+msgid ":meth:`DataFrame.itertuples`"
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows:10 of
+msgid "Iterate over DataFrame rows as namedtuples of the values."
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows:12 of
+msgid ":meth:`DataFrame.items`"
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows:13 of
+msgid "Iterate over (column name, Series) pairs."
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows:16 of
+msgid "Notes"
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows:17 of
+msgid ""
+"Because ``iterrows`` returns a Series for each row, it does **not** "
+"preserve dtypes across the rows (dtypes are preserved across columns for "
+"DataFrames). For example,"
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows:33 of
+msgid ""
+"To preserve dtypes while iterating over the rows, it is better to use "
+":meth:`itertuples` which returns namedtuples of the values and which is "
+"generally faster than ``iterrows``."
+msgstr ""
+
+#: mars.dataframe.DataFrame.iterrows:37 of
+msgid ""
+"You should **never modify** something you are iterating over. This is not"
+" guaranteed to work in all cases. Depending on the data types, the "
+"iterator returns a copy and not a view, and writing to it will have no "
+"effect."
+msgstr ""
+

--- a/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.DataFrame.itertuples.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.DataFrame.itertuples.po
@@ -1,0 +1,98 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 1999-2020, The Alibaba Group Holding Ltd.
+# This file is distributed under the same license as the mars package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: mars 0.5.0a1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-28 23:29+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: ../../source/dataframe/reference/api/mars.dataframe.DataFrame.itertuples.rst:2
+msgid "mars.dataframe.DataFrame.itertuples"
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:1 of
+msgid "Iterate over DataFrame rows as namedtuples."
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples of
+msgid "Parameters"
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:3 of
+msgid "If True, return the index as the first element of the tuple."
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:5 of
+msgid "The name of the returned namedtuples or None to return regular tuples."
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples of
+msgid "Returns"
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:9 of
+msgid ""
+"An object to iterate over namedtuples for each row in the DataFrame with "
+"the first field possibly being the index and following fields being the "
+"column values."
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples of
+msgid "Return type"
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:17 of
+msgid ":meth:`DataFrame.iterrows`"
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:17 of
+msgid "Iterate over DataFrame rows as (index, Series) pairs."
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:19 of
+msgid ":meth:`DataFrame.items`"
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:20 of
+msgid "Iterate over (column name, Series) pairs."
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:23 of
+msgid "Notes"
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:24 of
+msgid ""
+"The column names will be renamed to positional names if they are invalid "
+"Python identifiers, repeated, or start with an underscore. On python "
+"versions < 3.7 regular tuples are returned for DataFrames with a large "
+"number of columns (>254)."
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:30 of
+msgid "Examples"
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:44 of
+msgid ""
+"By setting the `index` parameter to False we can remove the index as the "
+"first element of the tuple:"
+msgstr ""
+
+#: mars.dataframe.DataFrame.itertuples:53 of
+msgid ""
+"With the `name` parameter set we set a custom name for the yielded "
+"namedtuples:"
+msgstr ""
+

--- a/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.Series.astype.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.Series.astype.po
@@ -1,0 +1,142 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 1999-2020, The Alibaba Group Holding Ltd.
+# This file is distributed under the same license as the mars package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: mars 0.5.0a1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-28 23:29+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: ../../source/dataframe/reference/api/mars.dataframe.Series.astype.rst:2
+msgid "mars.dataframe.Series.astype"
+msgstr ""
+
+#: mars.dataframe.Series.astype:1 of
+msgid "Cast a pandas object to a specified dtype ``dtype``."
+msgstr ""
+
+#: mars.dataframe.Series.astype of
+msgid "Parameters"
+msgstr ""
+
+#: mars.dataframe.Series.astype:3 of
+msgid ""
+"Use a numpy.dtype or Python type to cast entire pandas object to the same"
+" type. Alternatively, use {col: dtype, ...}, where col is a column label "
+"and dtype is a numpy.dtype or Python type to cast one or more of the "
+"DataFrame's columns to column-specific types."
+msgstr ""
+
+#: mars.dataframe.Series.astype:8 of
+msgid ""
+"Return a copy when ``copy=True`` (be very careful setting ``copy=False`` "
+"as changes to values then may propagate to other pandas objects)."
+msgstr ""
+
+#: mars.dataframe.Series.astype:12 of
+msgid ""
+"Control raising of exceptions on invalid data for provided dtype.  - "
+"``raise`` : allow exceptions to be raised - ``ignore`` : suppress "
+"exceptions. On error return original object."
+msgstr ""
+
+#: mars.dataframe.Series.astype:12 of
+msgid "Control raising of exceptions on invalid data for provided dtype."
+msgstr ""
+
+#: mars.dataframe.Series.astype:14 of
+msgid "``raise`` : allow exceptions to be raised"
+msgstr ""
+
+#: mars.dataframe.Series.astype:15 of
+msgid "``ignore`` : suppress exceptions. On error return original object."
+msgstr ""
+
+#: mars.dataframe.Series.astype of
+msgid "Returns"
+msgstr ""
+
+#: mars.dataframe.Series.astype:18 of
+msgid "**casted**"
+msgstr ""
+
+#: mars.dataframe.Series.astype of
+msgid "Return type"
+msgstr ""
+
+#: mars.dataframe.Series.astype:24 of
+msgid ":meth:`to_datetime`"
+msgstr ""
+
+#: mars.dataframe.Series.astype:24 of
+msgid "Convert argument to datetime."
+msgstr ""
+
+#: mars.dataframe.Series.astype:27 of
+msgid ":meth:`to_timedelta`"
+msgstr ""
+
+#: mars.dataframe.Series.astype:27 of
+msgid "Convert argument to timedelta."
+msgstr ""
+
+#: mars.dataframe.Series.astype:30 of
+msgid ":meth:`to_numeric`"
+msgstr ""
+
+#: mars.dataframe.Series.astype:30 of
+msgid "Convert argument to a numeric type."
+msgstr ""
+
+#: mars.dataframe.Series.astype:32 of
+msgid ":meth:`numpy.ndarray.astype`"
+msgstr ""
+
+#: mars.dataframe.Series.astype:33 of
+msgid "Cast a numpy array to a specified type."
+msgstr ""
+
+#: mars.dataframe.Series.astype:36 of
+msgid "Examples"
+msgstr ""
+
+#: mars.dataframe.Series.astype:37 of
+msgid "Create a DataFrame:"
+msgstr ""
+
+#: mars.dataframe.Series.astype:46 of
+msgid "Cast all columns to int32:"
+msgstr ""
+
+#: mars.dataframe.Series.astype:53 of
+msgid "Cast col1 to int32 using a dictionary:"
+msgstr ""
+
+#: mars.dataframe.Series.astype:60 of
+msgid "Create a series:"
+msgstr ""
+
+#: mars.dataframe.Series.astype:72 of
+msgid "Convert to categorical type:"
+msgstr ""
+
+#: mars.dataframe.Series.astype:80 of
+msgid "Convert to ordered categorical type with custom ordering:"
+msgstr ""
+
+#: mars.dataframe.Series.astype:90 of
+msgid ""
+"Note that using ``copy=False`` and changing data on a new pandas object "
+"may propagate changes:"
+msgstr ""
+

--- a/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/frame.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/frame.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mars 0.4.0rc1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-29 18:27+0800\n"
+"POT-Creation-Date: 2020-05-28 23:29+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -71,635 +71,665 @@ msgstr ""
 msgid "Conversion"
 msgstr "转换"
 
-#: ../../source/dataframe/reference/frame.rst:40:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:41:<autosummary>:1
+msgid ""
+":obj:`DataFrame.astype <mars.dataframe.DataFrame.astype>`\\ "
+"\\(dtype\\[\\, copy\\, errors\\]\\)"
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:41:<autosummary>:1
+msgid "Cast a pandas object to a specified dtype ``dtype``."
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:41:<autosummary>:1
 msgid ":obj:`DataFrame.copy <mars.dataframe.DataFrame.copy>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:40:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:41:<autosummary>:1
 msgid ":obj:`DataFrame.isna <mars.dataframe.DataFrame.isna>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:40:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:41:<autosummary>:1
 msgid "Detect missing values."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:40:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:41:<autosummary>:1
 msgid ":obj:`DataFrame.notna <mars.dataframe.DataFrame.notna>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:40:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:41:<autosummary>:1
 msgid "Detect existing (non-missing) values."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:42
+#: ../../source/dataframe/reference/frame.rst:43
 msgid "Indexing, iteration"
 msgstr "索引和迭代"
 
-#: ../../source/dataframe/reference/frame.rst:131:<autosummary>:1
-#: ../../source/dataframe/reference/frame.rst:52:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:134:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
 msgid ":obj:`DataFrame.head <mars.dataframe.DataFrame.head>`\\ \\(\\[n\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:131:<autosummary>:1
-#: ../../source/dataframe/reference/frame.rst:52:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:134:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
 msgid "Return the first `n` rows."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:52:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
 msgid ":obj:`DataFrame.at <mars.dataframe.DataFrame.at>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:52:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
 msgid "Access a single value for a row/column label pair."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:52:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
 msgid ":obj:`DataFrame.iat <mars.dataframe.DataFrame.iat>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:52:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
 msgid ":obj:`DataFrame.loc <mars.dataframe.DataFrame.loc>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:52:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
 msgid ":obj:`DataFrame.iloc <mars.dataframe.DataFrame.iloc>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:131:<autosummary>:1
-#: ../../source/dataframe/reference/frame.rst:52:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
+msgid ""
+":obj:`DataFrame.iterrows <mars.dataframe.DataFrame.iterrows>`\\ "
+"\\(\\[batch\\_size\\, session\\]\\)"
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
+msgid "Iterate over DataFrame rows as (index, Series) pairs."
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
+msgid ""
+":obj:`DataFrame.itertuples <mars.dataframe.DataFrame.itertuples>`\\ "
+"\\(\\[index\\, name\\, ...\\]\\)"
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
+msgid "Iterate over DataFrame rows as namedtuples."
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:134:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
 msgid ":obj:`DataFrame.tail <mars.dataframe.DataFrame.tail>`\\ \\(\\[n\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:131:<autosummary>:1
-#: ../../source/dataframe/reference/frame.rst:52:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:134:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:55:<autosummary>:1
 msgid "Return the last `n` rows."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:54
+#: ../../source/dataframe/reference/frame.rst:57
 msgid "Binary operator functions"
 msgstr "二元运算函数"
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.add <mars.dataframe.DataFrame.add>`\\ \\(other\\[\\, "
 "axis\\, level\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid "Get Addition of dataframe and other, element-wise (binary operator `add`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.sub <mars.dataframe.DataFrame.sub>`\\ \\(other\\[\\, "
 "axis\\, level\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Subtraction of dataframe and other, element-wise (binary operator "
 "`subtract`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.mul <mars.dataframe.DataFrame.mul>`\\ \\(other\\[\\, "
 "axis\\, level\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Multiplication of dataframe and other, element-wise (binary operator "
 "`mul`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.div <mars.dataframe.DataFrame.div>`\\ \\(other\\[\\, "
 "axis\\, level\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Floating division of dataframe and other, element-wise (binary "
 "operator `truediv`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.truediv <mars.dataframe.DataFrame.truediv>`\\ "
 "\\(other\\[\\, axis\\, level\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.floordiv <mars.dataframe.DataFrame.floordiv>`\\ "
 "\\(other\\[\\, axis\\, level\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Integer division of dataframe and other, element-wise (binary "
 "operator `floordiv`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.mod <mars.dataframe.DataFrame.mod>`\\ \\(other\\[\\, "
 "axis\\, level\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid "Get Modulo of dataframe and other, element-wise (binary operator `mod`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.pow <mars.dataframe.DataFrame.pow>`\\ \\(other\\[\\, "
 "axis\\, level\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Exponential power of dataframe and other, element-wise (binary "
 "operator `pow`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ":obj:`DataFrame.dot <mars.dataframe.DataFrame.dot>`\\ \\(other\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid "Compute the matrix multiplication between the DataFrame and other."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.radd <mars.dataframe.DataFrame.radd>`\\ \\(other\\[\\, "
 "axis\\, level\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Addition of dataframe and other, element-wise (binary operator "
 "`radd`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.rsub <mars.dataframe.DataFrame.rsub>`\\ \\(other\\[\\, "
 "axis\\, level\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Subtraction of dataframe and other, element-wise (binary operator "
 "`rsubtract`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.rmul <mars.dataframe.DataFrame.rmul>`\\ \\(other\\[\\, "
 "axis\\, level\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Multiplication of dataframe and other, element-wise (binary operator "
 "`rmul`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.rdiv <mars.dataframe.DataFrame.rdiv>`\\ \\(other\\[\\, "
 "axis\\, level\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Floating division of dataframe and other, element-wise (binary "
 "operator `rtruediv`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.rtruediv <mars.dataframe.DataFrame.rtruediv>`\\ "
 "\\(other\\[\\, axis\\, level\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.rfloordiv <mars.dataframe.DataFrame.rfloordiv>`\\ "
 "\\(other\\[\\, axis\\, level\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Integer division of dataframe and other, element-wise (binary "
 "operator `rfloordiv`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.rmod <mars.dataframe.DataFrame.rmod>`\\ \\(other\\[\\, "
 "axis\\, level\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid "Get Modulo of dataframe and other, element-wise (binary operator `rmod`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.rpow <mars.dataframe.DataFrame.rpow>`\\ \\(other\\[\\, "
 "axis\\, level\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Exponential power of dataframe and other, element-wise (binary "
 "operator `rpow`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.lt <mars.dataframe.DataFrame.lt>`\\ \\(other\\[\\, "
 "axis\\, level\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid "Get Less than of dataframe and other, element-wise (binary operator `lt`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.gt <mars.dataframe.DataFrame.gt>`\\ \\(other\\[\\, "
 "axis\\, level\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Greater than of dataframe and other, element-wise (binary operator "
 "`gt`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.le <mars.dataframe.DataFrame.le>`\\ \\(other\\[\\, "
 "axis\\, level\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Less than or equal to of dataframe and other, element-wise (binary "
 "operator `le`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.ge <mars.dataframe.DataFrame.ge>`\\ \\(other\\[\\, "
 "axis\\, level\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Greater than or equal to of dataframe and other, element-wise (binary"
 " operator `ge`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.ne <mars.dataframe.DataFrame.ne>`\\ \\(other\\[\\, "
 "axis\\, level\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 "Get Not equal to of dataframe and other, element-wise (binary operator "
 "`ne`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.eq <mars.dataframe.DataFrame.eq>`\\ \\(other\\[\\, "
 "axis\\, level\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:81:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:84:<autosummary>:1
 msgid "Get Equal to of dataframe and other, element-wise (binary operator `eq`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:83
+#: ../../source/dataframe/reference/frame.rst:86
 msgid "Function application, GroupBy & window"
 msgstr "应用函数、分组和窗口"
 
-#: ../../source/dataframe/reference/frame.rst:95:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:98:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.apply <mars.dataframe.DataFrame.apply>`\\ \\(func\\[\\, "
 "axis\\, raw\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:95:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:98:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.agg <mars.dataframe.DataFrame.agg>`\\ \\(func\\[\\, "
 "axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:95:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:98:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.aggregate <mars.dataframe.DataFrame.aggregate>`\\ "
 "\\(func\\[\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:95:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:98:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.transform <mars.dataframe.DataFrame.transform>`\\ "
 "\\(func\\[\\, axis\\, dtypes\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:95:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:98:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.groupby <mars.dataframe.DataFrame.groupby>`\\ \\(\\[by\\,"
 " level\\, as\\_index\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:95:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:98:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.rolling <mars.dataframe.DataFrame.rolling>`\\ "
 "\\(window\\[\\, min\\_periods\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:95:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:98:<autosummary>:1
 msgid "Provide rolling window calculations."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:95:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:98:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.expanding <mars.dataframe.DataFrame.expanding>`\\ "
 "\\(\\[min\\_periods\\, center\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:95:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:98:<autosummary>:1
 msgid "Provide expanding transformations."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:95:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:98:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.ewm <mars.dataframe.DataFrame.ewm>`\\ \\(\\[com\\, "
 "span\\, halflife\\, alpha\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:95:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:98:<autosummary>:1
 msgid "Provide exponential weighted functions."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:99
+#: ../../source/dataframe/reference/frame.rst:102
 msgid "Computations / descriptive stats"
 msgstr "计算和描述统计"
 
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
 msgid ":obj:`DataFrame.abs <mars.dataframe.DataFrame.abs>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.count <mars.dataframe.DataFrame.count>`\\ \\(\\[axis\\, "
 "level\\, numeric\\_only\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.cummax <mars.dataframe.DataFrame.cummax>`\\ \\(\\[axis\\,"
 " skipna\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.cummin <mars.dataframe.DataFrame.cummin>`\\ \\(\\[axis\\,"
 " skipna\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.cumprod <mars.dataframe.DataFrame.cumprod>`\\ "
 "\\(\\[axis\\, skipna\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.cumsum <mars.dataframe.DataFrame.cumsum>`\\ \\(\\[axis\\,"
 " skipna\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.describe <mars.dataframe.DataFrame.describe>`\\ "
 "\\(\\[percentiles\\, include\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.max <mars.dataframe.DataFrame.max>`\\ \\(\\[axis\\, "
 "skipna\\, level\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.mean <mars.dataframe.DataFrame.mean>`\\ \\(\\[axis\\, "
 "skipna\\, level\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.min <mars.dataframe.DataFrame.min>`\\ \\(\\[axis\\, "
 "skipna\\, level\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
-msgid ""
-":obj:`DataFrame.prod <mars.dataframe.DataFrame.prod>`\\ \\(\\[axis\\, "
-"skipna\\, level\\, ...\\]\\)"
-msgstr ""
-
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
-msgid ""
-":obj:`DataFrame.product <mars.dataframe.DataFrame.product>`\\ "
-"\\(\\[axis\\, skipna\\, level\\, ...\\]\\)"
-msgstr ""
-
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
-msgid ""
-":obj:`DataFrame.quantile <mars.dataframe.DataFrame.quantile>`\\ "
-"\\(\\[q\\, axis\\, numeric\\_only\\, ...\\]\\)"
-msgstr ""
-
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
-msgid "Return values at the given quantile over requested axis."
-msgstr ""
-
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
-msgid ""
-":obj:`DataFrame.round <mars.dataframe.DataFrame.round>`\\ "
-"\\(\\[decimals\\]\\)"
-msgstr ""
-
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
-msgid "Round a DataFrame to a variable number of decimal places."
-msgstr ""
-
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
-msgid ""
-":obj:`DataFrame.sum <mars.dataframe.DataFrame.sum>`\\ \\(\\[axis\\, "
-"skipna\\, level\\, ...\\]\\)"
-msgstr ""
-
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
-msgid ""
-":obj:`DataFrame.std <mars.dataframe.DataFrame.std>`\\ \\(\\[axis\\, "
-"skipna\\, level\\, ddof\\, ...\\]\\)"
-msgstr ""
-
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
-msgid ""
-":obj:`DataFrame.var <mars.dataframe.DataFrame.var>`\\ \\(\\[axis\\, "
-"skipna\\, level\\, ddof\\, ...\\]\\)"
-msgstr ""
-
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.nunique <mars.dataframe.DataFrame.nunique>`\\ "
 "\\(\\[axis\\, dropna\\, combine\\_size\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:121:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
 msgid "Count distinct observations over requested axis."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:123
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
+msgid ""
+":obj:`DataFrame.prod <mars.dataframe.DataFrame.prod>`\\ \\(\\[axis\\, "
+"skipna\\, level\\, ...\\]\\)"
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
+msgid ""
+":obj:`DataFrame.product <mars.dataframe.DataFrame.product>`\\ "
+"\\(\\[axis\\, skipna\\, level\\, ...\\]\\)"
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
+msgid ""
+":obj:`DataFrame.quantile <mars.dataframe.DataFrame.quantile>`\\ "
+"\\(\\[q\\, axis\\, numeric\\_only\\, ...\\]\\)"
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
+msgid "Return values at the given quantile over requested axis."
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
+msgid ""
+":obj:`DataFrame.round <mars.dataframe.DataFrame.round>`\\ "
+"\\(\\[decimals\\]\\)"
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
+msgid "Round a DataFrame to a variable number of decimal places."
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
+msgid ""
+":obj:`DataFrame.std <mars.dataframe.DataFrame.std>`\\ \\(\\[axis\\, "
+"skipna\\, level\\, ddof\\, ...\\]\\)"
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
+msgid ""
+":obj:`DataFrame.sum <mars.dataframe.DataFrame.sum>`\\ \\(\\[axis\\, "
+"skipna\\, level\\, ...\\]\\)"
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:124:<autosummary>:1
+msgid ""
+":obj:`DataFrame.var <mars.dataframe.DataFrame.var>`\\ \\(\\[axis\\, "
+"skipna\\, level\\, ddof\\, ...\\]\\)"
+msgstr ""
+
+#: ../../source/dataframe/reference/frame.rst:126
 msgid "Reindexing / selection / label manipulation"
 msgstr "重设索引、选择和标签操作"
 
-#: ../../source/dataframe/reference/frame.rst:131:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:134:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.reset_index <mars.dataframe.DataFrame.reset_index>`\\ "
 "\\(\\[level\\, drop\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:131:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:134:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.set_index <mars.dataframe.DataFrame.set_index>`\\ "
 "\\(keys\\[\\, drop\\, append\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:135
+#: ../../source/dataframe/reference/frame.rst:138
 msgid "Missing data handling"
 msgstr "缺失值处理"
 
-#: ../../source/dataframe/reference/frame.rst:141:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:144:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.dropna <mars.dataframe.DataFrame.dropna>`\\ \\(\\[axis\\,"
 " how\\, thresh\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:141:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:144:<autosummary>:1
 msgid "Remove missing values."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:141:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:144:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.fillna <mars.dataframe.DataFrame.fillna>`\\ "
 "\\(\\[value\\, method\\, axis\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:141:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:144:<autosummary>:1
 msgid "Fill NA/NaN values using the specified method."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:143
+#: ../../source/dataframe/reference/frame.rst:146
 msgid "Reshaping, sorting, transposing"
 msgstr "形状变换、排序和转置"
 
-#: ../../source/dataframe/reference/frame.rst:149:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:152:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.sort_values <mars.dataframe.DataFrame.sort_values>`\\ "
 "\\(by\\[\\, axis\\, ascending\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:149:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:152:<autosummary>:1
 msgid "Sort by the values along either axis."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:149:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:152:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.sort_index <mars.dataframe.DataFrame.sort_index>`\\ "
 "\\(\\[axis\\, level\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:149:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:152:<autosummary>:1
 msgid "Sort object by labels (along an axis)."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:151
+#: ../../source/dataframe/reference/frame.rst:154
 msgid "Combining / joining / merging"
 msgstr "数据合并"
 
-#: ../../source/dataframe/reference/frame.rst:158:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:161:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.append <mars.dataframe.DataFrame.append>`\\ "
 "\\(other\\[\\, ignore\\_index\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:158:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:161:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.join <mars.dataframe.DataFrame.join>`\\ \\(other\\[\\, "
 "on\\, how\\, lsuffix\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:158:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:161:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.merge <mars.dataframe.DataFrame.merge>`\\ \\(right\\[\\, "
 "how\\, on\\, left\\_on\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:160
+#: ../../source/dataframe/reference/frame.rst:163
 msgid "Time series-related"
 msgstr "时间序列相关"
 
-#: ../../source/dataframe/reference/frame.rst:167:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:170:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.diff <mars.dataframe.DataFrame.diff>`\\ \\(\\[periods\\, "
 "axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:167:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:170:<autosummary>:1
 msgid "First discrete difference of element."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:167:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:170:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.shift <mars.dataframe.DataFrame.shift>`\\ "
 "\\(\\[periods\\, freq\\, axis\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:167:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:170:<autosummary>:1
 msgid "Shift index by desired number of periods with an optional time `freq`."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:167:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:170:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.tshift <mars.dataframe.DataFrame.tshift>`\\ "
 "\\(\\[periods\\, freq\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:167:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:170:<autosummary>:1
 msgid "Shift the time index, using the index's frequency if available."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:171
+#: ../../source/dataframe/reference/frame.rst:174
 msgid "Plotting"
 msgstr "绘图"
 
-#: ../../source/dataframe/reference/frame.rst:172
+#: ../../source/dataframe/reference/frame.rst:175
 msgid ""
 "``DataFrame.plot`` is both a callable method and a namespace attribute "
 "for specific plotting methods of the form ``DataFrame.plot.<kind>``."
@@ -707,139 +737,139 @@ msgstr ""
 "``DataFrame.plot`` 既是一个可被调用的方法，也是一个通过 ``DataFrame.plot."
 "<kind>`` 提供特定画图方法的属性。"
 
-#: ../../source/dataframe/reference/frame.rst:179:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:182:<autosummary>:1
 msgid ":obj:`DataFrame.plot <mars.dataframe.DataFrame.plot>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:179:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:182:<autosummary>:1
 msgid "alias of :class:`mars.dataframe.plotting.core.PlotAccessor`"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.plot.area <mars.dataframe.DataFrame.plot.area>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid "Draw a stacked area plot."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.plot.bar <mars.dataframe.DataFrame.plot.bar>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid "Vertical bar plot."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.plot.barh <mars.dataframe.DataFrame.plot.barh>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid "Make a horizontal bar plot."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.plot.box <mars.dataframe.DataFrame.plot.box>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid "Make a box plot of the DataFrame columns."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.plot.density <mars.dataframe.DataFrame.plot.density>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid "Generate Kernel Density Estimate plot using Gaussian kernels."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.plot.hexbin <mars.dataframe.DataFrame.plot.hexbin>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid "Generate a hexagonal binning plot."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.plot.hist <mars.dataframe.DataFrame.plot.hist>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid "Draw one histogram of the DataFrame's columns."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.plot.kde <mars.dataframe.DataFrame.plot.kde>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.plot.line <mars.dataframe.DataFrame.plot.line>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid "Plot Series or DataFrame as lines."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.plot.pie <mars.dataframe.DataFrame.plot.pie>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid "Generate a pie plot."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.plot.scatter <mars.dataframe.DataFrame.plot.scatter>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:194:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:197:<autosummary>:1
 msgid "Create a scatter plot with varying marker point size and color."
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:200:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:203:<autosummary>:1
 msgid ":obj:`DataFrame.boxplot <DataFrame.boxplot>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:200:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:203:<autosummary>:1
 msgid ":obj:`DataFrame.hist <DataFrame.hist>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:202
+#: ../../source/dataframe/reference/frame.rst:205
 msgid "Serialization / IO / conversion"
 msgstr "序列化、IO 和转换"
 
-#: ../../source/dataframe/reference/frame.rst:206:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:209:<autosummary>:1
 msgid ""
 ":obj:`DataFrame.to_csv <mars.dataframe.DataFrame.to_csv>`\\ \\(path\\[\\,"
 " sep\\, na\\_rep\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/frame.rst:206:<autosummary>:1
+#: ../../source/dataframe/reference/frame.rst:209:<autosummary>:1
 msgid "Write object to a comma-separated values (csv) file."
 msgstr ""
 

--- a/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/series.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/series.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mars 0.4.0rc1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-29 18:27+0800\n"
+"POT-Creation-Date: 2020-05-28 23:29+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -75,637 +75,647 @@ msgstr ""
 msgid "Conversion"
 msgstr "转换"
 
-#: ../../source/dataframe/reference/series.rst:37:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:38:<autosummary>:1
+msgid ""
+":obj:`Series.astype <mars.dataframe.Series.astype>`\\ \\(dtype\\[\\, "
+"copy\\, errors\\]\\)"
+msgstr ""
+
+#: ../../source/dataframe/reference/series.rst:38:<autosummary>:1
+msgid "Cast a pandas object to a specified dtype ``dtype``."
+msgstr ""
+
+#: ../../source/dataframe/reference/series.rst:38:<autosummary>:1
 msgid ":obj:`Series.copy <mars.dataframe.Series.copy>`\\ \\(\\[deep\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:37:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:38:<autosummary>:1
 msgid "Make a copy of this object's indices and data."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:37:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:38:<autosummary>:1
 msgid ""
 ":obj:`Series.to_tensor <mars.dataframe.Series.to_tensor>`\\ "
 "\\(\\[dtype\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:39
+#: ../../source/dataframe/reference/series.rst:40
 msgid "Indexing, iteration"
 msgstr "索引和迭代"
 
-#: ../../source/dataframe/reference/series.rst:47:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:48:<autosummary>:1
 msgid ":obj:`Series.at <mars.dataframe.Series.at>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:47:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:48:<autosummary>:1
 msgid "Access a single value for a row/column label pair."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:47:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:48:<autosummary>:1
 msgid ":obj:`Series.iat <mars.dataframe.Series.iat>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:47:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:48:<autosummary>:1
 msgid ":obj:`Series.loc <mars.dataframe.Series.loc>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:47:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:48:<autosummary>:1
 msgid ":obj:`Series.iloc <mars.dataframe.Series.iloc>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:49
+#: ../../source/dataframe/reference/series.rst:50
 msgid "Binary operator functions"
 msgstr "二元运算函数"
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.add <mars.dataframe.Series.add>`\\ \\(other\\[\\, level\\, "
 "fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid "Return Addition of series and other, element-wise (binary operator `add`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.sub <mars.dataframe.Series.sub>`\\ \\(other\\[\\, level\\, "
 "fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Subtraction of series and other, element-wise (binary operator "
 "`subtract`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.mul <mars.dataframe.Series.mul>`\\ \\(other\\[\\, level\\, "
 "fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Multiplication of series and other, element-wise (binary operator "
 "`mul`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.div <mars.dataframe.Series.div>`\\ \\(other\\[\\, level\\, "
 "fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Floating division of series and other, element-wise (binary "
 "operator `truediv`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.truediv <mars.dataframe.Series.truediv>`\\ \\(other\\[\\, "
 "level\\, fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.floordiv <mars.dataframe.Series.floordiv>`\\ \\(other\\[\\, "
 "level\\, fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Integer division of series and other, element-wise (binary "
 "operator `floordiv`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.mod <mars.dataframe.Series.mod>`\\ \\(other\\[\\, level\\, "
 "fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid "Return Modulo of series and other, element-wise (binary operator `mod`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.pow <mars.dataframe.Series.pow>`\\ \\(other\\[\\, level\\, "
 "fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Exponential power of series and other, element-wise (binary "
 "operator `pow`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.radd <mars.dataframe.Series.radd>`\\ \\(other\\[\\, level\\,"
 " fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Addition of series and other, element-wise (binary operator "
 "`radd`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.rsub <mars.dataframe.Series.rsub>`\\ \\(other\\[\\, level\\,"
 " fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Subtraction of series and other, element-wise (binary operator "
 "`rsubtract`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.rmul <mars.dataframe.Series.rmul>`\\ \\(other\\[\\, level\\,"
 " fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Multiplication of series and other, element-wise (binary operator "
 "`rmul`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.rdiv <mars.dataframe.Series.rdiv>`\\ \\(other\\[\\, level\\,"
 " fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Floating division of series and other, element-wise (binary "
 "operator `rtruediv`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.rtruediv <mars.dataframe.Series.rtruediv>`\\ \\(other\\[\\, "
 "level\\, fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.rfloordiv <mars.dataframe.Series.rfloordiv>`\\ "
 "\\(other\\[\\, level\\, fill\\_value\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Integer division of series and other, element-wise (binary "
 "operator `rfloordiv`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.rmod <mars.dataframe.Series.rmod>`\\ \\(other\\[\\, level\\,"
 " fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid "Return Modulo of series and other, element-wise (binary operator `rmod`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.rpow <mars.dataframe.Series.rpow>`\\ \\(other\\[\\, level\\,"
 " fill\\_value\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Exponential power of series and other, element-wise (binary "
 "operator `rpow`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.lt <mars.dataframe.Series.lt>`\\ \\(other\\[\\, level\\, "
 "axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid "Return Less than of series and other, element-wise (binary operator `lt`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.gt <mars.dataframe.Series.gt>`\\ \\(other\\[\\, level\\, "
 "axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Greater than of series and other, element-wise (binary operator "
 "`gt`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.le <mars.dataframe.Series.le>`\\ \\(other\\[\\, level\\, "
 "axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Less than or equal to of series and other, element-wise (binary "
 "operator `le`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.ge <mars.dataframe.Series.ge>`\\ \\(other\\[\\, level\\, "
 "axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Greater than or equal to of series and other, element-wise (binary"
 " operator `ge`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.ne <mars.dataframe.Series.ne>`\\ \\(other\\[\\, level\\, "
 "axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 "Return Not equal to of series and other, element-wise (binary operator "
 "`ne`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ""
 ":obj:`Series.eq <mars.dataframe.Series.eq>`\\ \\(other\\[\\, level\\, "
 "axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid "Return Equal to of series and other, element-wise (binary operator `eq`)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid ":obj:`Series.dot <mars.dataframe.Series.dot>`\\ \\(other\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:76:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:77:<autosummary>:1
 msgid "Compute the dot product between the Series and the columns of other."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:78
+#: ../../source/dataframe/reference/series.rst:79
 msgid "Function application, groupby & window"
 msgstr "应用函数、分组和窗口"
 
-#: ../../source/dataframe/reference/series.rst:91:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:92:<autosummary>:1
 msgid ""
 ":obj:`Series.apply <mars.dataframe.Series.apply>`\\ \\(func\\[\\, "
 "convert\\_dtype\\, args\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:91:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:92:<autosummary>:1
 msgid ":obj:`Series.agg <mars.dataframe.Series.agg>`\\ \\(func\\[\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:91:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:92:<autosummary>:1
 msgid ""
 ":obj:`Series.aggregate <mars.dataframe.Series.aggregate>`\\ \\(func\\[\\,"
 " axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:91:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:92:<autosummary>:1
 msgid ""
 ":obj:`Series.transform <mars.dataframe.Series.transform>`\\ \\(func\\[\\,"
 " convert\\_dtype\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:91:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:92:<autosummary>:1
 msgid ""
 ":obj:`Series.map <mars.dataframe.Series.map>`\\ \\(arg\\[\\, "
 "na\\_action\\, dtype\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:91:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:92:<autosummary>:1
 msgid ""
 ":obj:`Series.groupby <mars.dataframe.Series.groupby>`\\ \\(\\[by\\, "
 "level\\, as\\_index\\, sort\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:91:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:92:<autosummary>:1
 msgid ""
 ":obj:`Series.rolling <mars.dataframe.Series.rolling>`\\ \\(window\\[\\, "
 "min\\_periods\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:91:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:92:<autosummary>:1
 msgid "Provide rolling window calculations."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:91:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:92:<autosummary>:1
 msgid ""
 ":obj:`Series.expanding <mars.dataframe.Series.expanding>`\\ "
 "\\(\\[min\\_periods\\, center\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:91:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:92:<autosummary>:1
 msgid "Provide expanding transformations."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:91:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:92:<autosummary>:1
 msgid ""
 ":obj:`Series.ewm <mars.dataframe.Series.ewm>`\\ \\(\\[com\\, span\\, "
 "halflife\\, alpha\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:91:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:92:<autosummary>:1
 msgid "Provide exponential weighted functions."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:95
+#: ../../source/dataframe/reference/series.rst:96
 msgid "Computations / descriptive stats"
 msgstr "计算和描述统计"
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ":obj:`Series.abs <mars.dataframe.Series.abs>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.count <mars.dataframe.Series.count>`\\ \\(\\[level\\, "
 "combine\\_size\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.cummax <mars.dataframe.Series.cummax>`\\ \\(\\[axis\\, "
 "skipna\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.cummin <mars.dataframe.Series.cummin>`\\ \\(\\[axis\\, "
 "skipna\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.cumprod <mars.dataframe.Series.cumprod>`\\ \\(\\[axis\\, "
 "skipna\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.cumsum <mars.dataframe.Series.cumsum>`\\ \\(\\[axis\\, "
 "skipna\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.describe <mars.dataframe.Series.describe>`\\ "
 "\\(\\[percentiles\\, include\\, exclude\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.max <mars.dataframe.Series.max>`\\ \\(\\[axis\\, skipna\\, "
 "level\\, combine\\_size\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.mean <mars.dataframe.Series.mean>`\\ \\(\\[axis\\, skipna\\,"
 " level\\, combine\\_size\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.min <mars.dataframe.Series.min>`\\ \\(\\[axis\\, skipna\\, "
 "level\\, combine\\_size\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.prod <mars.dataframe.Series.prod>`\\ \\(\\[axis\\, skipna\\,"
 " level\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.product <mars.dataframe.Series.product>`\\ \\(\\[axis\\, "
 "skipna\\, level\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.quantile <mars.dataframe.Series.quantile>`\\ \\(\\[q\\, "
 "interpolation\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid "Return value at the given quantile."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ":obj:`Series.round <mars.dataframe.Series.round>`\\ \\(\\[decimals\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid "Round each value in a Series to the given number of decimals."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.std <mars.dataframe.Series.std>`\\ \\(\\[axis\\, skipna\\, "
 "level\\, ddof\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.sum <mars.dataframe.Series.sum>`\\ \\(\\[axis\\, skipna\\, "
 "level\\, min\\_count\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.var <mars.dataframe.Series.var>`\\ \\(\\[axis\\, skipna\\, "
 "level\\, ddof\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.nunique <mars.dataframe.Series.nunique>`\\ \\(\\[dropna\\, "
 "combine\\_size\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid "Return number of unique elements in the object."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid ""
 ":obj:`Series.value_counts <mars.dataframe.Series.value_counts>`\\ "
 "\\(\\[normalize\\, sort\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:118:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:119:<autosummary>:1
 msgid "Return a Series containing counts of unique values."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:120
+#: ../../source/dataframe/reference/series.rst:121
 msgid "Reindexing / selection / label manipulation"
 msgstr "重设索引、选择和标签操作"
 
-#: ../../source/dataframe/reference/series.rst:128:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:129:<autosummary>:1
 msgid ":obj:`Series.head <mars.dataframe.Series.head>`\\ \\(\\[n\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:128:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:129:<autosummary>:1
 msgid "Return the first `n` rows."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:128:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:129:<autosummary>:1
 msgid ":obj:`Series.isin <mars.dataframe.Series.isin>`\\ \\(values\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:128:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:129:<autosummary>:1
 msgid ""
 ":obj:`Series.reset_index <mars.dataframe.Series.reset_index>`\\ "
 "\\(\\[level\\, drop\\, name\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:128:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:129:<autosummary>:1
 msgid ":obj:`Series.tail <mars.dataframe.Series.tail>`\\ \\(\\[n\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:128:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:129:<autosummary>:1
 msgid "Return the last `n` rows."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:130
+#: ../../source/dataframe/reference/series.rst:131
 msgid "Missing data handling"
 msgstr "缺失值处理"
 
-#: ../../source/dataframe/reference/series.rst:138:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:139:<autosummary>:1
 msgid ":obj:`Series.isna <mars.dataframe.Series.isna>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:138:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:139:<autosummary>:1
 msgid "Detect missing values."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:138:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:139:<autosummary>:1
 msgid ":obj:`Series.notna <mars.dataframe.Series.notna>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:138:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:139:<autosummary>:1
 msgid "Detect existing (non-missing) values."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:138:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:139:<autosummary>:1
 msgid ""
 ":obj:`Series.dropna <mars.dataframe.Series.dropna>`\\ \\(\\[axis\\, "
 "inplace\\, how\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:138:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:139:<autosummary>:1
 msgid "Return a new Series with missing values removed."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:138:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:139:<autosummary>:1
 msgid ""
 ":obj:`Series.fillna <mars.dataframe.Series.fillna>`\\ \\(\\[value\\, "
 "method\\, axis\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:138:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:139:<autosummary>:1
 msgid "Fill NA/NaN values using the specified method."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:140
+#: ../../source/dataframe/reference/series.rst:141
 msgid "Reshaping, sorting"
 msgstr "形状变换和排序"
 
-#: ../../source/dataframe/reference/series.rst:146:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:147:<autosummary>:1
 msgid ""
 ":obj:`Series.sort_values <mars.dataframe.Series.sort_values>`\\ "
 "\\(\\[axis\\, ascending\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:146:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:147:<autosummary>:1
 msgid "Sort by the values."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:146:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:147:<autosummary>:1
 msgid ""
 ":obj:`Series.sort_index <mars.dataframe.Series.sort_index>`\\ "
 "\\(\\[axis\\, level\\, ascending\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:146:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:147:<autosummary>:1
 msgid "Sort object by labels (along an axis)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:148
+#: ../../source/dataframe/reference/series.rst:149
 msgid "Combining / joining / merging"
 msgstr "数据合并"
 
-#: ../../source/dataframe/reference/series.rst:153:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:154:<autosummary>:1
 msgid ""
 ":obj:`Series.append <mars.dataframe.Series.append>`\\ \\(other\\[\\, "
 "ignore\\_index\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:155
+#: ../../source/dataframe/reference/series.rst:156
 msgid "Time Series-related"
 msgstr "时间序列相关"
 
-#: ../../source/dataframe/reference/series.rst:162:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:163:<autosummary>:1
 msgid ":obj:`Series.diff <mars.dataframe.Series.diff>`\\ \\(\\[periods\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:162:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:163:<autosummary>:1
 msgid "First discrete difference of element."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:162:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:163:<autosummary>:1
 msgid ""
 ":obj:`Series.shift <mars.dataframe.Series.shift>`\\ \\(\\[periods\\, "
 "freq\\, axis\\, fill\\_value\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:162:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:163:<autosummary>:1
 msgid "Shift index by desired number of periods with an optional time `freq`."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:162:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:163:<autosummary>:1
 msgid ""
 ":obj:`Series.tshift <mars.dataframe.Series.tshift>`\\ \\(\\[periods\\, "
 "freq\\, axis\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:162:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:163:<autosummary>:1
 msgid "Shift the time index, using the index's frequency if available."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:164
+#: ../../source/dataframe/reference/series.rst:165
 msgid "Accessors"
 msgstr "类型访问器"
 
-#: ../../source/dataframe/reference/series.rst:166
+#: ../../source/dataframe/reference/series.rst:167
 msgid ""
 "Pandas provides dtype-specific methods under various accessors. These are"
 " separate namespaces within :class:`Series` that only apply to specific "
@@ -714,35 +724,35 @@ msgstr ""
 "Pandas 提供了针对不同数据类型的访问器。下面列出了 :class:`Series` 下只"
 "针对特定类型的独立名称空间。"
 
-#: ../../source/dataframe/reference/series.rst:171
+#: ../../source/dataframe/reference/series.rst:172
 msgid "Data Type"
 msgstr "数据类型"
 
-#: ../../source/dataframe/reference/series.rst:171
+#: ../../source/dataframe/reference/series.rst:172
 msgid "Accessor"
 msgstr "访问器"
 
-#: ../../source/dataframe/reference/series.rst:173
+#: ../../source/dataframe/reference/series.rst:174
 msgid "Datetime, Timedelta, Period"
 msgstr "日期时间、时间差和时间段"
 
-#: ../../source/dataframe/reference/series.rst:173
+#: ../../source/dataframe/reference/series.rst:174
 msgid ":ref:`dt <api.series.dt>`"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:174
+#: ../../source/dataframe/reference/series.rst:175
 msgid "String"
 msgstr "字符串"
 
-#: ../../source/dataframe/reference/series.rst:174
+#: ../../source/dataframe/reference/series.rst:175
 msgid ":ref:`str <api.series.str>`"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:180
+#: ../../source/dataframe/reference/series.rst:181
 msgid "Datetimelike properties"
 msgstr "日期时间类属性"
 
-#: ../../source/dataframe/reference/series.rst:182
+#: ../../source/dataframe/reference/series.rst:183
 msgid ""
 "``Series.dt`` can be used to access the values of the series as "
 "datetimelike and return several properties. These can be accessed like "
@@ -751,425 +761,425 @@ msgstr ""
 "``Series.dt`` 可被用于访问日期时间类型的 Series，返回若干个属性值。这些"
 "属性值可通过 ``Series.dt.<property>`` 来调用。"
 
-#: ../../source/dataframe/reference/series.rst:187
+#: ../../source/dataframe/reference/series.rst:188
 msgid "Datetime properties"
 msgstr "日期时间属性"
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.date <mars.dataframe.Series.dt.date>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ""
 "Returns numpy array of python datetime.date objects (namely, the date "
 "part of Timestamps without timezone information)."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.time <mars.dataframe.Series.dt.time>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "Returns numpy array of datetime.time."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.timetz <mars.dataframe.Series.dt.timetz>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "Returns numpy array of datetime.time also containing timezone information."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.year <mars.dataframe.Series.dt.year>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "The year of the datetime."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.month <mars.dataframe.Series.dt.month>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "The month as January=1, December=12."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.day <mars.dataframe.Series.dt.day>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.hour <mars.dataframe.Series.dt.hour>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "The hours of the datetime."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.minute <mars.dataframe.Series.dt.minute>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "The minutes of the datetime."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.second <mars.dataframe.Series.dt.second>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "The seconds of the datetime."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.microsecond <mars.dataframe.Series.dt.microsecond>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "The microseconds of the datetime."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.nanosecond <mars.dataframe.Series.dt.nanosecond>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "The nanoseconds of the datetime."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.week <mars.dataframe.Series.dt.week>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "The week ordinal of the year."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.weekofyear <mars.dataframe.Series.dt.weekofyear>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.dayofweek <mars.dataframe.Series.dt.dayofweek>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "The day of the week with Monday=0, Sunday=6."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.weekday <mars.dataframe.Series.dt.weekday>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.dayofyear <mars.dataframe.Series.dt.dayofyear>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "The ordinal day of the year."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.quarter <mars.dataframe.Series.dt.quarter>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "The quarter of the date."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.is_month_start "
 "<mars.dataframe.Series.dt.is_month_start>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "Indicates whether the date is the first day of the month."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.is_month_end <mars.dataframe.Series.dt.is_month_end>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "Indicates whether the date is the last day of the month."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.is_quarter_start "
 "<mars.dataframe.Series.dt.is_quarter_start>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "Indicator for whether the date is the first day of a quarter."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.is_quarter_end "
 "<mars.dataframe.Series.dt.is_quarter_end>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "Indicator for whether the date is the last day of a quarter."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.is_year_start <mars.dataframe.Series.dt.is_year_start>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "Indicate whether the date is the first day of a year."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.is_year_end <mars.dataframe.Series.dt.is_year_end>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "Indicate whether the date is the last day of the year."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.is_leap_year <mars.dataframe.Series.dt.is_leap_year>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "Boolean indicator if the date belongs to a leap year."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.daysinmonth <mars.dataframe.Series.dt.daysinmonth>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "The number of days in the month."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.days_in_month <mars.dataframe.Series.dt.days_in_month>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.tz <mars.dataframe.Series.dt.tz>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid "Return timezone, if any."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:220:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:221:<autosummary>:1
 msgid ":obj:`Series.dt.freq <mars.dataframe.Series.dt.freq>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:222
+#: ../../source/dataframe/reference/series.rst:223
 msgid "Datetime methods"
 msgstr "日期时间方法"
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.to_period <mars.dataframe.Series.dt.to_period>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid "Cast to PeriodArray/Index at a particular frequency."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.to_pydatetime <mars.dataframe.Series.dt.to_pydatetime>`\\"
 " \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid "Return the data as an array of native Python datetime objects."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.tz_localize <mars.dataframe.Series.dt.tz_localize>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid "Localize tz-naive Datetime Array/Index to tz-aware Datetime Array/Index."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.tz_convert <mars.dataframe.Series.dt.tz_convert>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid "Convert tz-aware Datetime Array/Index from one time zone to another."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.normalize <mars.dataframe.Series.dt.normalize>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid "Convert times to midnight."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.strftime <mars.dataframe.Series.dt.strftime>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid "Convert to Index using specified date_format."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.round <mars.dataframe.Series.dt.round>`\\ \\(\\*args\\, "
 "\\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid "Perform round operation on the data to the specified `freq`."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.floor <mars.dataframe.Series.dt.floor>`\\ \\(\\*args\\, "
 "\\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid "Perform floor operation on the data to the specified `freq`."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.ceil <mars.dataframe.Series.dt.ceil>`\\ \\(\\*args\\, "
 "\\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid "Perform ceil operation on the data to the specified `freq`."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.month_name <mars.dataframe.Series.dt.month_name>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid "Return the month names of the DateTimeIndex with specified locale."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.day_name <mars.dataframe.Series.dt.day_name>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:238:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:239:<autosummary>:1
 msgid "Return the day names of the DateTimeIndex with specified locale."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:240
+#: ../../source/dataframe/reference/series.rst:241
 msgid "Period properties"
 msgstr "时间段属性"
 
-#: ../../source/dataframe/reference/series.rst:248:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:249:<autosummary>:1
 msgid ":obj:`Series.dt.qyear <mars.dataframe.Series.dt.qyear>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:248:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:249:<autosummary>:1
 msgid ":obj:`Series.dt.start_time <mars.dataframe.Series.dt.start_time>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:248:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:249:<autosummary>:1
 msgid ":obj:`Series.dt.end_time <mars.dataframe.Series.dt.end_time>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:250
+#: ../../source/dataframe/reference/series.rst:251
 msgid "Timedelta properties"
 msgstr "时间差属性"
 
-#: ../../source/dataframe/reference/series.rst:260:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:261:<autosummary>:1
 msgid ":obj:`Series.dt.days <mars.dataframe.Series.dt.days>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:260:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:261:<autosummary>:1
 msgid "Number of days for each element."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:260:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:261:<autosummary>:1
 msgid ":obj:`Series.dt.seconds <mars.dataframe.Series.dt.seconds>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:260:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:261:<autosummary>:1
 msgid "Number of seconds (>= 0 and less than 1 day) for each element."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:260:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:261:<autosummary>:1
 msgid ":obj:`Series.dt.microseconds <mars.dataframe.Series.dt.microseconds>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:260:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:261:<autosummary>:1
 msgid "Number of microseconds (>= 0 and less than 1 second) for each element."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:260:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:261:<autosummary>:1
 msgid ":obj:`Series.dt.nanoseconds <mars.dataframe.Series.dt.nanoseconds>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:260:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:261:<autosummary>:1
 msgid "Number of nanoseconds (>= 0 and less than 1 microsecond) for each element."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:260:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:261:<autosummary>:1
 msgid ":obj:`Series.dt.components <mars.dataframe.Series.dt.components>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:260:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:261:<autosummary>:1
 msgid "Return a Dataframe of the components of the Timedeltas."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:262
+#: ../../source/dataframe/reference/series.rst:263
 msgid "Timedelta methods"
 msgstr "时间差方法"
 
-#: ../../source/dataframe/reference/series.rst:270:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:271:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.to_pytimedelta "
 "<mars.dataframe.Series.dt.to_pytimedelta>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:270:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:271:<autosummary>:1
 msgid "Return an array of native `datetime.timedelta` objects."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:270:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:271:<autosummary>:1
 msgid ""
 ":obj:`Series.dt.total_seconds <mars.dataframe.Series.dt.total_seconds>`\\"
 " \\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:270:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:271:<autosummary>:1
 msgid "Return total duration of each element expressed in seconds."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:274
+#: ../../source/dataframe/reference/series.rst:275
 msgid "String handling"
 msgstr "处理字符串"
 
-#: ../../source/dataframe/reference/series.rst:276
+#: ../../source/dataframe/reference/series.rst:277
 msgid ""
 "``Series.str`` can be used to access the values of the series as strings "
 "and apply several methods to it. These can be accessed like "
@@ -1178,508 +1188,508 @@ msgstr ""
 "``Series.str`` 可被用于以字符串方式访问 Series，并应用若干方法。这些功能"
 "可通过 ``Series.str.<function/property>`` 来调用。"
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.capitalize <mars.dataframe.Series.str.capitalize>`\\ "
 "\\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Convert strings in the Series/Index to be capitalized."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.casefold <mars.dataframe.Series.str.casefold>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Convert strings in the Series/Index to be casefolded."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.cat <mars.dataframe.Series.str.cat>`\\ \\(\\[others\\, "
 "sep\\, na\\_rep\\, join\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Concatenate strings in the Series/Index with given separator."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.center <mars.dataframe.Series.str.center>`\\ "
 "\\(width\\[\\, fillchar\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 "Filling left and right side of strings in the Series/Index with an "
 "additional character."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.contains <mars.dataframe.Series.str.contains>`\\ "
 "\\(pat\\[\\, case\\, flags\\, na\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 "Test if pattern or regex is contained within a string of a Series or "
 "Index."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.count <mars.dataframe.Series.str.count>`\\ \\(pat\\[\\, "
 "flags\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Count occurrences of pattern in each string of the Series/Index."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.decode <mars.dataframe.Series.str.decode>`\\ "
 "\\(encoding\\[\\, errors\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Decode character string in the Series/Index using indicated encoding."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.encode <mars.dataframe.Series.str.encode>`\\ "
 "\\(encoding\\[\\, errors\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Encode character string in the Series/Index using indicated encoding."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.endswith <mars.dataframe.Series.str.endswith>`\\ "
 "\\(pat\\[\\, na\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Test if the end of each string element matches a pattern."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.extract <mars.dataframe.Series.str.extract>`\\ "
 "\\(pat\\[\\, flags\\, expand\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Extract capture groups in the regex `pat` as columns in a DataFrame."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.extractall <mars.dataframe.Series.str.extractall>`\\ "
 "\\(pat\\[\\, flags\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 "For each subject string in the Series, extract groups from all matches of"
 " regular expression pat."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.find <mars.dataframe.Series.str.find>`\\ \\(sub\\[\\, "
 "start\\, end\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 "Return lowest indexes in each strings in the Series/Index where the "
 "substring is fully contained between [start:end]."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.findall <mars.dataframe.Series.str.findall>`\\ "
 "\\(pat\\[\\, flags\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Find all occurrences of pattern or regular expression in the Series/Index."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.get <mars.dataframe.Series.str.get>`\\ \\(i\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Extract element from each component at specified position."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.index <mars.dataframe.Series.str.index>`\\ \\(sub\\[\\, "
 "start\\, end\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 "Return lowest indexes in each strings where the substring is fully "
 "contained between [start:end]."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.join <mars.dataframe.Series.str.join>`\\ \\(sep\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 "Join lists contained as elements in the Series/Index with passed "
 "delimiter."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.len <mars.dataframe.Series.str.len>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Compute the length of each element in the Series/Index."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.ljust <mars.dataframe.Series.str.ljust>`\\ "
 "\\(width\\[\\, fillchar\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 "Filling right side of strings in the Series/Index with an additional "
 "character."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.lower <mars.dataframe.Series.str.lower>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Convert strings in the Series/Index to lowercase."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.lstrip <mars.dataframe.Series.str.lstrip>`\\ "
 "\\(\\[to\\_strip\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Remove leading and trailing characters."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.match <mars.dataframe.Series.str.match>`\\ \\(pat\\[\\, "
 "case\\, flags\\, na\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Determine if each string matches a regular expression."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.normalize <mars.dataframe.Series.str.normalize>`\\ "
 "\\(form\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Return the Unicode normal form for the strings in the Series/Index."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.pad <mars.dataframe.Series.str.pad>`\\ \\(width\\[\\, "
 "side\\, fillchar\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Pad strings in the Series/Index up to width."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.partition <mars.dataframe.Series.str.partition>`\\ "
 "\\(\\[sep\\, expand\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Split the string at the first occurrence of `sep`."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.repeat <mars.dataframe.Series.str.repeat>`\\ "
 "\\(repeats\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Duplicate each string in the Series or Index."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.replace <mars.dataframe.Series.str.replace>`\\ \\(pat\\,"
 " repl\\[\\, n\\, case\\, ...\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 "Replace occurrences of pattern/regex in the Series/Index with some other "
 "string."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.rfind <mars.dataframe.Series.str.rfind>`\\ \\(sub\\[\\, "
 "start\\, end\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 "Return highest indexes in each strings in the Series/Index where the "
 "substring is fully contained between [start:end]."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.rindex <mars.dataframe.Series.str.rindex>`\\ "
 "\\(sub\\[\\, start\\, end\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 "Return highest indexes in each strings where the substring is fully "
 "contained between [start:end]."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.rjust <mars.dataframe.Series.str.rjust>`\\ "
 "\\(width\\[\\, fillchar\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 "Filling left side of strings in the Series/Index with an additional "
 "character."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.rpartition <mars.dataframe.Series.str.rpartition>`\\ "
 "\\(\\[sep\\, expand\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Split the string at the last occurrence of `sep`."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.rstrip <mars.dataframe.Series.str.rstrip>`\\ "
 "\\(\\[to\\_strip\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.slice <mars.dataframe.Series.str.slice>`\\ "
 "\\(\\[start\\, stop\\, step\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Slice substrings from each element in the Series or Index."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.slice_replace "
 "<mars.dataframe.Series.str.slice_replace>`\\ \\(\\[start\\, stop\\, "
 "repl\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Replace a positional slice of a string with another value."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.split <mars.dataframe.Series.str.split>`\\ \\(\\[pat\\, "
 "n\\, expand\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Split strings around given separator/delimiter."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.rsplit <mars.dataframe.Series.str.rsplit>`\\ "
 "\\(\\[pat\\, n\\, expand\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.startswith <mars.dataframe.Series.str.startswith>`\\ "
 "\\(pat\\[\\, na\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Test if the start of each string element matches a pattern."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.strip <mars.dataframe.Series.str.strip>`\\ "
 "\\(\\[to\\_strip\\]\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.swapcase <mars.dataframe.Series.str.swapcase>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Convert strings in the Series/Index to be swapcased."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.title <mars.dataframe.Series.str.title>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Convert strings in the Series/Index to titlecase."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.translate <mars.dataframe.Series.str.translate>`\\ "
 "\\(table\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Map all characters in the string through the given mapping table."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.upper <mars.dataframe.Series.str.upper>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Convert strings in the Series/Index to uppercase."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 ":obj:`Series.str.wrap <mars.dataframe.Series.str.wrap>`\\ \\(width\\, "
 "\\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ""
 "Wrap long strings in the Series/Index to be formatted in paragraphs with "
 "length less than a given width."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.zfill <mars.dataframe.Series.str.zfill>`\\ \\(width\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Pad strings in the Series/Index by prepending '0' characters."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.isalnum <mars.dataframe.Series.str.isalnum>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Check whether all characters in each string are alphanumeric."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.isalpha <mars.dataframe.Series.str.isalpha>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Check whether all characters in each string are alphabetic."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.isdigit <mars.dataframe.Series.str.isdigit>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Check whether all characters in each string are digits."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.isspace <mars.dataframe.Series.str.isspace>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Check whether all characters in each string are whitespace."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.islower <mars.dataframe.Series.str.islower>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Check whether all characters in each string are lowercase."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.isupper <mars.dataframe.Series.str.isupper>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Check whether all characters in each string are uppercase."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.istitle <mars.dataframe.Series.str.istitle>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Check whether all characters in each string are titlecase."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.isnumeric <mars.dataframe.Series.str.isnumeric>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Check whether all characters in each string are numeric."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid ":obj:`Series.str.isdecimal <mars.dataframe.Series.str.isdecimal>`\\ \\(\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:335:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:336:<autosummary>:1
 msgid "Check whether all characters in each string are decimal."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:348
+#: ../../source/dataframe/reference/series.rst:349
 msgid "Plotting"
 msgstr "绘图"
 
-#: ../../source/dataframe/reference/series.rst:349
+#: ../../source/dataframe/reference/series.rst:350
 msgid ""
 "``Series.plot`` is both a callable method and a namespace attribute for "
 "specific plotting methods of the form ``Series.plot.<kind>``."
@@ -1687,101 +1697,101 @@ msgstr ""
 "``Series.plot`` 既是一个可被调用的方法，也是一个通过 ``Series.plot.<kind>"
 "`` 提供特定画图方法的属性。"
 
-#: ../../source/dataframe/reference/series.rst:356:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:357:<autosummary>:1
 msgid ":obj:`Series.plot <mars.dataframe.Series.plot>`\\"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:356:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:357:<autosummary>:1
 msgid "alias of :class:`mars.dataframe.plotting.core.PlotAccessor`"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid ""
 ":obj:`Series.plot.area <mars.dataframe.Series.plot.area>`\\ \\(\\*args\\,"
 " \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid "Draw a stacked area plot."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid ""
 ":obj:`Series.plot.bar <mars.dataframe.Series.plot.bar>`\\ \\(\\*args\\, "
 "\\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid "Vertical bar plot."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid ""
 ":obj:`Series.plot.barh <mars.dataframe.Series.plot.barh>`\\ \\(\\*args\\,"
 " \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid "Make a horizontal bar plot."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid ""
 ":obj:`Series.plot.box <mars.dataframe.Series.plot.box>`\\ \\(\\*args\\, "
 "\\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid "Make a box plot of the DataFrame columns."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid ""
 ":obj:`Series.plot.density <mars.dataframe.Series.plot.density>`\\ "
 "\\(\\*args\\, \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid "Generate Kernel Density Estimate plot using Gaussian kernels."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid ""
 ":obj:`Series.plot.hist <mars.dataframe.Series.plot.hist>`\\ \\(\\*args\\,"
 " \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid "Draw one histogram of the DataFrame's columns."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid ""
 ":obj:`Series.plot.kde <mars.dataframe.Series.plot.kde>`\\ \\(\\*args\\, "
 "\\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid ""
 ":obj:`Series.plot.line <mars.dataframe.Series.plot.line>`\\ \\(\\*args\\,"
 " \\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid "Plot Series or DataFrame as lines."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid ""
 ":obj:`Series.plot.pie <mars.dataframe.Series.plot.pie>`\\ \\(\\*args\\, "
 "\\*\\*kwargs\\)"
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:369:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:370:<autosummary>:1
 msgid "Generate a pie plot."
 msgstr ""
 
-#: ../../source/dataframe/reference/series.rst:373:<autosummary>:1
+#: ../../source/dataframe/reference/series.rst:374:<autosummary>:1
 msgid ":obj:`Series.hist <Series.hist>`\\"
 msgstr ""
 

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -517,3 +517,24 @@ class Test(unittest.TestCase):
         ind = md.Index(pind, chunk_size=5)
 
         self.assertIn('DatetimeIndex', repr(ind.execute()))
+
+    def testDataFrameIter(self):
+        raw_data = pd.DataFrame(np.random.randint(1000, size=(20, 10)))
+        df = md.DataFrame(raw_data, chunk_size=5)
+
+        i = 0
+        for result_row, expect_row in zip(df.iterrows(batch_size=15),
+                                          raw_data.iterrows()):
+            self.assertEqual(result_row[0], expect_row[0])
+            pd.testing.assert_series_equal(result_row[1], expect_row[1])
+            i += 1
+
+        self.assertEqual(i, len(raw_data))
+
+        i = 0
+        for result_tup, expect_tup in zip(df.itertuples(batch_size=10),
+                                          raw_data.itertuples()):
+            self.assertEqual(result_tup, expect_tup)
+            i += 1
+
+        self.assertEqual(i, len(raw_data))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This PR implements `DataFrame.iterrows` as well as `DataFrame.itertuples`.

`df.execute()` will be triggered first internally.

<!-- Please give a short brief about these changes. -->

## Related issue number

Resolves #1251 .

<!-- Are there any issues opened that will be resolved by merging this change? -->
