### PR TITLE
Fix `NearestNeighbors` that run failed in cluster mode

### DIFF
--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -1126,7 +1126,7 @@ class GraphActor(SchedulerActor):
         tileable = self._get_tileable_by_key(tileable_key)
         graph = DAG()
 
-        new_tileable = build_fetch_tileable(tileable)
+        new_tileable = build_fetch_tileable(tileable).data
         graph.add_node(new_tileable)
         return serialize_graph(graph)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Resolve the issue that `Object` type can't be serialized correctly in cluster mode.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1260.