### PR TITLE
Add support for {DataFrame,Series,Index}.drop

### DIFF
--- a/docs/source/dataframe/reference/api/mars.dataframe.DataFrame.drop.rst
+++ b/docs/source/dataframe/reference/api/mars.dataframe.DataFrame.drop.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.drop
+=============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.drop

--- a/docs/source/dataframe/reference/api/mars.dataframe.DataFrame.pop.rst
+++ b/docs/source/dataframe/reference/api/mars.dataframe.DataFrame.pop.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.pop
+============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.pop

--- a/docs/source/dataframe/reference/api/mars.dataframe.Series.drop.rst
+++ b/docs/source/dataframe/reference/api/mars.dataframe.Series.drop.rst
@@ -1,0 +1,6 @@
+mars.dataframe.Series.drop
+==========================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: Series.drop

--- a/docs/source/dataframe/reference/frame.rst
+++ b/docs/source/dataframe/reference/frame.rst
@@ -51,6 +51,7 @@ Indexing, iteration
    DataFrame.iloc
    DataFrame.iterrows
    DataFrame.itertuples
+   DataFrame.pop
    DataFrame.tail
 
 Binary operator functions
@@ -127,6 +128,7 @@ Reindexing / selection / label manipulation
 .. autosummary::
    :toctree: api/
 
+   DataFrame.drop
    DataFrame.head
    DataFrame.reset_index
    DataFrame.set_index

--- a/docs/source/dataframe/reference/series.rst
+++ b/docs/source/dataframe/reference/series.rst
@@ -122,6 +122,7 @@ Reindexing / selection / label manipulation
 .. autosummary::
    :toctree: api/
 
+   Series.drop
    Series.head
    Series.isin
    Series.reset_index

--- a/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.DataFrame.drop.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.DataFrame.drop.po
@@ -1,0 +1,146 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 1999-2020, The Alibaba Group Holding Ltd.
+# This file is distributed under the same license as the mars package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: mars 0.5.0a2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-02 15:10+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: ../../source/dataframe/reference/api/mars.dataframe.DataFrame.drop.rst:2
+msgid "mars.dataframe.DataFrame.drop"
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:1 of
+msgid "Drop specified labels from rows or columns."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:3 of
+msgid ""
+"Remove rows or columns by specifying label names and corresponding axis, "
+"or by specifying directly index or column names. When using a multi-"
+"index, labels on different levels can be removed by specifying the level."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop of
+msgid "Parameters"
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:8 of
+msgid "Index or column labels to drop."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:10 of
+msgid ""
+"Whether to drop labels from the index (0 or 'index') or columns (1 or "
+"'columns')."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:13 of
+msgid ""
+"Alternative to specifying axis (``labels, axis=0`` is equivalent to "
+"``index=labels``)."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:16 of
+msgid ""
+"Alternative to specifying axis (``labels, axis=1`` is equivalent to "
+"``columns=labels``)."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:19 of
+msgid "For MultiIndex, level from which the labels will be removed."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:21 of
+msgid "If True, do operation inplace and return None."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:23 of
+msgid ""
+"If 'ignore', suppress error and only existing labels are dropped. Note "
+"that errors for missing indices will not raise."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop of
+msgid "Returns"
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:27 of
+msgid "DataFrame without the removed index or column labels."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop of
+msgid "Return type"
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop of
+msgid "Raises"
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:30 of
+msgid "If any of the labels is not found in the selected axis."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:35 of
+msgid ":meth:`DataFrame.loc`"
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:35 of
+msgid "Label-location based indexer for selection by label."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:38 of
+msgid ":meth:`DataFrame.dropna`"
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:38 of
+msgid ""
+"Return DataFrame with labels on given axis omitted where (all or any) "
+"data are missing."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:41 of
+msgid ":meth:`DataFrame.drop_duplicates`"
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:41 of
+msgid ""
+"Return DataFrame with duplicate rows removed, optionally only considering"
+" certain columns."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:43 of
+msgid ":meth:`Series.drop`"
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:44 of
+msgid "Return Series with specified index labels removed."
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:47 of
+msgid "Examples"
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:59 of
+msgid "Drop columns"
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:73 of
+msgid "Drop a row by index"
+msgstr ""
+
+#: mars.dataframe.DataFrame.drop:79 of
+msgid "Drop columns and/or rows of MultiIndex DataFrame"
+msgstr ""
+

--- a/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.DataFrame.pop.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.DataFrame.pop.po
@@ -1,0 +1,47 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 1999-2020, The Alibaba Group Holding Ltd.
+# This file is distributed under the same license as the mars package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: mars 0.5.0a2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-02 15:10+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: ../../source/dataframe/reference/api/mars.dataframe.DataFrame.pop.rst:2
+msgid "mars.dataframe.DataFrame.pop"
+msgstr ""
+
+#: mars.dataframe.DataFrame.pop:1 of
+msgid "Return item and drop from frame. Raise KeyError if not found."
+msgstr ""
+
+#: mars.dataframe.DataFrame.pop of
+msgid "Parameters"
+msgstr ""
+
+#: mars.dataframe.DataFrame.pop:3 of
+msgid "Label of column to be popped."
+msgstr ""
+
+#: mars.dataframe.DataFrame.pop of
+msgid "Returns"
+msgstr ""
+
+#: mars.dataframe.DataFrame.pop of
+msgid "Return type"
+msgstr ""
+
+#: mars.dataframe.DataFrame.pop:10 of
+msgid "Examples"
+msgstr ""
+

--- a/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.Series.drop.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/dataframe/reference/api/mars.dataframe.Series.drop.po
@@ -1,0 +1,146 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 1999-2020, The Alibaba Group Holding Ltd.
+# This file is distributed under the same license as the mars package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: mars 0.5.0a2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-02 15:10+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: ../../source/dataframe/reference/api/mars.dataframe.Series.drop.rst:2
+msgid "mars.dataframe.Series.drop"
+msgstr ""
+
+#: mars.dataframe.Series.drop:1 of
+msgid "Return Series with specified index labels removed."
+msgstr ""
+
+#: mars.dataframe.Series.drop:3 of
+msgid ""
+"Remove elements of a Series based on specifying the index labels. When "
+"using a multi-index, labels on different levels can be removed by "
+"specifying the level."
+msgstr ""
+
+#: mars.dataframe.Series.drop of
+msgid "Parameters"
+msgstr ""
+
+#: mars.dataframe.Series.drop:7 of
+msgid "Index labels to drop."
+msgstr ""
+
+#: mars.dataframe.Series.drop:9 of
+msgid "Redundant for application on Series."
+msgstr ""
+
+#: mars.dataframe.Series.drop:11 of
+msgid ""
+"Redundant for application on Series, but 'index' can be used instead of "
+"'labels'.  .. versionadded:: 0.21.0"
+msgstr ""
+
+#: mars.dataframe.Series.drop:11 of
+msgid ""
+"Redundant for application on Series, but 'index' can be used instead of "
+"'labels'."
+msgstr ""
+
+#: mars.dataframe.Series.drop:16 of
+msgid ""
+"No change is made to the Series; use 'index' or 'labels' instead.  .. "
+"versionadded:: 0.21.0"
+msgstr ""
+
+#: mars.dataframe.Series.drop:16 of
+msgid "No change is made to the Series; use 'index' or 'labels' instead."
+msgstr ""
+
+#: mars.dataframe.Series.drop:20 of
+msgid "For MultiIndex, level for which the labels will be removed."
+msgstr ""
+
+#: mars.dataframe.Series.drop:22 of
+msgid "If True, do operation inplace and return None."
+msgstr ""
+
+#: mars.dataframe.Series.drop:24 of
+msgid ""
+"Note that this argument is kept only for compatibility, and errors will "
+"not raise even if ``errors=='raise'``."
+msgstr ""
+
+#: mars.dataframe.Series.drop of
+msgid "Returns"
+msgstr ""
+
+#: mars.dataframe.Series.drop:28 of
+msgid "Series with specified index labels removed."
+msgstr ""
+
+#: mars.dataframe.Series.drop of
+msgid "Return type"
+msgstr ""
+
+#: mars.dataframe.Series.drop of
+msgid "Raises"
+msgstr ""
+
+#: mars.dataframe.Series.drop:31 of
+msgid "If none of the labels are found in the index."
+msgstr ""
+
+#: mars.dataframe.Series.drop:36 of
+msgid ":meth:`Series.reindex`"
+msgstr ""
+
+#: mars.dataframe.Series.drop:36 of
+msgid "Return only specified index labels of Series."
+msgstr ""
+
+#: mars.dataframe.Series.drop:39 of
+msgid ":meth:`Series.dropna`"
+msgstr ""
+
+#: mars.dataframe.Series.drop:39 of
+msgid "Return series without null values."
+msgstr ""
+
+#: mars.dataframe.Series.drop:42 of
+msgid ":meth:`Series.drop_duplicates`"
+msgstr ""
+
+#: mars.dataframe.Series.drop:42 of
+msgid "Return Series with duplicate values removed."
+msgstr ""
+
+#: mars.dataframe.Series.drop:44 of
+msgid ":meth:`DataFrame.drop`"
+msgstr ""
+
+#: mars.dataframe.Series.drop:45 of
+msgid "Drop specified labels from rows or columns."
+msgstr ""
+
+#: mars.dataframe.Series.drop:48 of
+msgid "Examples"
+msgstr ""
+
+#: mars.dataframe.Series.drop:59 of
+msgid "Drop labels B en C"
+msgstr ""
+
+#: mars.dataframe.Series.drop:65 of
+msgid "Drop 2nd level label in MultiIndex Series"
+msgstr ""
+

--- a/mars/dataframe/base/__init__.py
+++ b/mars/dataframe/base/__init__.py
@@ -29,6 +29,7 @@ from .shift import shift, tshift
 from .diff import df_diff, series_diff
 from .value_counts import value_counts
 from .astype import astype
+from .drop import df_drop, df_pop, series_drop, index_drop
 
 
 def _install():
@@ -57,6 +58,9 @@ def _install():
         setattr(t, 'tshift', tshift)
         setattr(t, 'diff', df_diff)
         setattr(t, 'astype', astype)
+        setattr(t, 'drop', df_drop)
+        setattr(t, 'pop', df_pop)
+        setattr(t, '__delitem__', lambda df, items: df_drop(df, items, axis=1, inplace=True))
 
     for t in SERIES_TYPE:
         setattr(t, 'to_gpu', to_gpu)
@@ -81,9 +85,11 @@ def _install():
         setattr(t, 'diff', series_diff)
         setattr(t, 'value_counts', value_counts)
         setattr(t, 'astype', astype)
+        setattr(t, 'drop', series_drop)
 
     for t in INDEX_TYPE:
         setattr(t, 'rechunk', rechunk)
+        setattr(t, 'drop', index_drop)
 
     for method in _string_method_to_handlers:
         if not hasattr(StringAccessor, method):

--- a/mars/dataframe/base/drop.py
+++ b/mars/dataframe/base/drop.py
@@ -1,0 +1,480 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+from collections import OrderedDict
+
+import numpy as np
+
+from ... import opcodes
+from ...core import Entity, Chunk, CHUNK_TYPE
+from ...serialize import AnyField, StringField
+from ..core import IndexValue, DATAFRAME_TYPE, SERIES_TYPE, INDEX_CHUNK_TYPE
+from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+from ..utils import parse_index, validate_axis
+
+
+class DataFrameDrop(DataFrameOperandMixin, DataFrameOperand):
+    _op_type_ = opcodes.DATAFRAME_DROP
+
+    _index = AnyField('index')
+    _columns = AnyField('columns')
+    _level = AnyField('level')
+    _errors = StringField('errors')
+
+    def __init__(self, index=None, columns=None, level=None, errors=None, **kw):
+        super().__init__(_index=index, _columns=columns, _level=level, _errors=errors,
+                         **kw)
+
+    @property
+    def index(self):
+        return self._index
+
+    @property
+    def columns(self):
+        return self._columns
+
+    @property
+    def level(self):
+        return self._level
+
+    @property
+    def errors(self):
+        return self._errors
+
+    def _filter_dtypes(self, dtypes, ignore_errors=False):
+        if self._columns:
+            return dtypes.drop(index=self._columns, level=self._level,
+                               errors='ignore' if ignore_errors else self._errors)
+        else:
+            return dtypes
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        inputs_iter = iter(self._inputs[1:])
+        if len(self._inputs) > 1:
+            self._index = next(inputs_iter)
+
+    def __call__(self, df_or_series):
+        params = df_or_series.params.copy()
+        shape_list = list(df_or_series.shape)
+
+        if self._index is not None:
+            if isinstance(df_or_series.index_value.value, IndexValue.RangeIndex):
+                params['index_value'] = parse_index(None, (df_or_series.key, df_or_series.index_value.key))
+            shape_list[0] = np.nan
+
+        if isinstance(df_or_series, DATAFRAME_TYPE):
+            new_dtypes = self._filter_dtypes(df_or_series.dtypes)
+            params['columns_value'] = parse_index(new_dtypes.index, store_data=True)
+            params['dtypes'] = new_dtypes
+            shape_list[1] = len(new_dtypes)
+            self._object_type = ObjectType.dataframe
+        elif isinstance(df_or_series, SERIES_TYPE):
+            self._object_type = ObjectType.series
+        else:
+            self._object_type = ObjectType.index
+
+        params['shape'] = tuple(shape_list)
+
+        inputs = [df_or_series]
+        if isinstance(self._index, Entity):
+            inputs.append(self._index)
+        return self.new_tileable(inputs, **params)
+
+    @classmethod
+    def tile(cls, op: 'DataFrameDrop'):
+        inp = op.inputs[0]
+        out = op.outputs[0]
+        if len(op.inputs) > 1:
+            index_chunk = op.index.rechunk({0: (op.index.shape[0],)})._inplace_tile().chunks[0]
+        else:
+            index_chunk = op.index
+
+        col_to_args = OrderedDict()
+        chunks = []
+        for c in inp.chunks:
+            params = c.params.copy()
+            if isinstance(inp, DATAFRAME_TYPE):
+                new_dtypes, new_col_id = col_to_args.get(c.index[1], (None, None))
+
+                if new_dtypes is None:
+                    new_col_id = len(col_to_args)
+                    new_dtypes = op._filter_dtypes(c.dtypes, ignore_errors=True)
+                    if len(new_dtypes) == 0:
+                        continue
+                    col_to_args[c.index[1]] = (new_dtypes, new_col_id)
+
+                params.update(dict(dtypes=new_dtypes, index=(c.index[0], new_col_id),
+                                   index_value=parse_index(None, (c.key, c.index_value.key))))
+                if op.index is not None:
+                    params.update(dict(shape=(np.nan, len(new_dtypes)),
+                                       index_value=parse_index(None, (c.key, c.index_value.key))))
+                else:
+                    params['shape'] = (c.shape[0], len(new_dtypes))
+            elif op.index is not None:
+                params.update(dict(shape=(np.nan,), index_value=parse_index(None, (c.key, c.index_value.key))))
+
+            chunk_inputs = [c]
+            if isinstance(index_chunk, Chunk):
+                chunk_inputs.append(index_chunk)
+
+            new_op = op.copy().reset_key()
+            new_op._index = index_chunk
+            chunks.append(new_op.new_chunk(chunk_inputs, **params))
+
+        new_op = op.copy().reset_key()
+        params = out.params.copy()
+        if op.index is not None:
+            nsplits_list = [(np.nan,) * inp.chunk_shape[0]]
+        else:
+            nsplits_list = [inp.nsplits[0]]
+        if isinstance(inp, DATAFRAME_TYPE):
+            nsplits_list.append(tuple(len(dt) for dt, _ in col_to_args.values()))
+        params.update(dict(chunks=chunks, nsplits=tuple(nsplits_list)))
+        return new_op.new_tileables(op.inputs, **params)
+
+    @classmethod
+    def execute(cls, ctx, op: 'DataFrameDrop'):
+        inp = op.inputs[0]
+        if isinstance(op.index, CHUNK_TYPE):
+            index_val = ctx[op.index.key]
+        else:
+            index_val = op.index
+
+        if isinstance(inp, INDEX_CHUNK_TYPE):
+            ctx[op.outputs[0].key] = ctx[inp.key].drop(index_val, errors='ignore')
+        else:
+            ctx[op.outputs[0].key] = ctx[inp.key].drop(
+                index=index_val, columns=op.columns, level=op.level, errors='ignore')
+
+
+def _drop(df_or_series, labels=None, axis=0, index=None, columns=None, level=None,
+          inplace=False, errors='raise'):
+    axis = validate_axis(axis, df_or_series)
+    if labels is not None:
+        if axis == 0:
+            index = labels
+        else:
+            columns = labels
+
+    if index is not None and errors == 'raise':
+        warnings.warn('Errors will not raise for non-existing indices')
+    if isinstance(columns, Entity):
+        raise NotImplementedError('Columns cannot be Mars objects')
+
+    op = DataFrameDrop(index=index, columns=columns, level=level, errors=errors)
+    df = op(df_or_series)
+    if inplace:
+        df_or_series.data = df.data
+    else:
+        return df
+
+
+def df_drop(df, labels=None, axis=0, index=None, columns=None, level=None,
+            inplace=False, errors='raise'):
+    """
+    Drop specified labels from rows or columns.
+
+    Remove rows or columns by specifying label names and corresponding
+    axis, or by specifying directly index or column names. When using a
+    multi-index, labels on different levels can be removed by specifying
+    the level.
+
+    Parameters
+    ----------
+    labels : single label or list-like
+        Index or column labels to drop.
+    axis : {0 or 'index', 1 or 'columns'}, default 0
+        Whether to drop labels from the index (0 or 'index') or
+        columns (1 or 'columns').
+    index : single label or list-like
+        Alternative to specifying axis (``labels, axis=0``
+        is equivalent to ``index=labels``).
+    columns : single label or list-like
+        Alternative to specifying axis (``labels, axis=1``
+        is equivalent to ``columns=labels``).
+    level : int or level name, optional
+        For MultiIndex, level from which the labels will be removed.
+    inplace : bool, default False
+        If True, do operation inplace and return None.
+    errors : {'ignore', 'raise'}, default 'raise'
+        If 'ignore', suppress error and only existing labels are
+        dropped. Note that errors for missing indices will not raise.
+
+    Returns
+    -------
+    DataFrame
+        DataFrame without the removed index or column labels.
+
+    Raises
+    ------
+    KeyError
+        If any of the labels is not found in the selected axis.
+
+    See Also
+    --------
+    DataFrame.loc : Label-location based indexer for selection by label.
+    DataFrame.dropna : Return DataFrame with labels on given axis omitted
+        where (all or any) data are missing.
+    DataFrame.drop_duplicates : Return DataFrame with duplicate rows
+        removed, optionally only considering certain columns.
+    Series.drop : Return Series with specified index labels removed.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> import mars.dataframe as md
+    >>> df = md.DataFrame(np.arange(12).reshape(3, 4),
+    ...                   columns=['A', 'B', 'C', 'D'])
+    >>> df.execute()
+       A  B   C   D
+    0  0  1   2   3
+    1  4  5   6   7
+    2  8  9  10  11
+
+    Drop columns
+
+    >>> df.drop(['B', 'C'], axis=1).execute()
+       A   D
+    0  0   3
+    1  4   7
+    2  8  11
+
+    >>> df.drop(columns=['B', 'C']).execute()
+       A   D
+    0  0   3
+    1  4   7
+    2  8  11
+
+    Drop a row by index
+
+    >>> df.drop([0, 1]).execute()
+       A  B   C   D
+    2  8  9  10  11
+
+    Drop columns and/or rows of MultiIndex DataFrame
+
+    >>> midx = pd.MultiIndex(levels=[['lama', 'cow', 'falcon'],
+    ...                              ['speed', 'weight', 'length']],
+    ...                      codes=[[0, 0, 0, 1, 1, 1, 2, 2, 2],
+    ...                             [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+    >>> df = md.DataFrame(index=midx, columns=['big', 'small'],
+    ...                   data=[[45, 30], [200, 100], [1.5, 1], [30, 20],
+    ...                         [250, 150], [1.5, 0.8], [320, 250],
+    ...                         [1, 0.8], [0.3, 0.2]])
+    >>> df.execute()
+                    big     small
+    lama    speed   45.0    30.0
+            weight  200.0   100.0
+            length  1.5     1.0
+    cow     speed   30.0    20.0
+            weight  250.0   150.0
+            length  1.5     0.8
+    falcon  speed   320.0   250.0
+            weight  1.0     0.8
+            length  0.3     0.2
+
+    >>> df.drop(index='cow', columns='small').execute()
+                    big
+    lama    speed   45.0
+            weight  200.0
+            length  1.5
+    falcon  speed   320.0
+            weight  1.0
+            length  0.3
+
+    >>> df.drop(index='length', level=1).execute()
+                    big     small
+    lama    speed   45.0    30.0
+            weight  200.0   100.0
+    cow     speed   30.0    20.0
+            weight  250.0   150.0
+    falcon  speed   320.0   250.0
+            weight  1.0     0.8
+    """
+    return _drop(df, labels=labels, axis=axis, index=index, columns=columns,
+                 level=level, inplace=inplace, errors=errors)
+
+
+def df_pop(df, item):
+    """
+    Return item and drop from frame. Raise KeyError if not found.
+
+    Parameters
+    ----------
+    item : str
+        Label of column to be popped.
+
+    Returns
+    -------
+    Series
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import mars.dataframe as md
+    >>> df = md.DataFrame([('falcon', 'bird', 389.0),
+    ...                    ('parrot', 'bird', 24.0),
+    ...                    ('lion', 'mammal', 80.5),
+    ...                    ('monkey', 'mammal', np.nan)],
+    ...                   columns=('name', 'class', 'max_speed'))
+    >>> df.execute()
+         name   class  max_speed
+    0  falcon    bird      389.0
+    1  parrot    bird       24.0
+    2    lion  mammal       80.5
+    3  monkey  mammal        NaN
+
+    >>> df.pop('class').execute()
+    0      bird
+    1      bird
+    2    mammal
+    3    mammal
+    Name: class, dtype: object
+
+    >>> df.execute()
+         name  max_speed
+    0  falcon      389.0
+    1  parrot       24.0
+    2    lion       80.5
+    3  monkey        NaN
+    """
+    series = df.data[item]
+    df_drop(df, item, axis=1, inplace=True)
+    return series
+
+
+def series_drop(series, labels=None, axis=0, index=None, columns=None, level=None,
+                inplace=False, errors='raise'):
+    """
+    Return Series with specified index labels removed.
+
+    Remove elements of a Series based on specifying the index labels.
+    When using a multi-index, labels on different levels can be removed
+    by specifying the level.
+
+    Parameters
+    ----------
+    labels : single label or list-like
+        Index labels to drop.
+    axis : 0, default 0
+        Redundant for application on Series.
+    index : single label or list-like
+        Redundant for application on Series, but 'index' can be used instead
+        of 'labels'.
+
+        .. versionadded:: 0.21.0
+    columns : single label or list-like
+        No change is made to the Series; use 'index' or 'labels' instead.
+
+        .. versionadded:: 0.21.0
+    level : int or level name, optional
+        For MultiIndex, level for which the labels will be removed.
+    inplace : bool, default False
+        If True, do operation inplace and return None.
+    errors : {'ignore', 'raise'}, default 'raise'
+        Note that this argument is kept only for compatibility, and errors
+        will not raise even if ``errors=='raise'``.
+
+    Returns
+    -------
+    Series
+        Series with specified index labels removed.
+
+    Raises
+    ------
+    KeyError
+        If none of the labels are found in the index.
+
+    See Also
+    --------
+    Series.reindex : Return only specified index labels of Series.
+    Series.dropna : Return series without null values.
+    Series.drop_duplicates : Return Series with duplicate values removed.
+    DataFrame.drop : Drop specified labels from rows or columns.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> import mars.dataframe as md
+    >>> s = md.Series(data=np.arange(3), index=['A', 'B', 'C'])
+    >>> s.execute()
+    A  0
+    B  1
+    C  2
+    dtype: int64
+
+    Drop labels B en C
+
+    >>> s.drop(labels=['B', 'C']).execute()
+    A  0
+    dtype: int64
+
+    Drop 2nd level label in MultiIndex Series
+
+    >>> midx = pd.MultiIndex(levels=[['lama', 'cow', 'falcon'],
+    ...                              ['speed', 'weight', 'length']],
+    ...                      codes=[[0, 0, 0, 1, 1, 1, 2, 2, 2],
+    ...                             [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+    >>> s = md.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+    ...               index=midx)
+    >>> s.execute()
+    lama    speed      45.0
+            weight    200.0
+            length      1.2
+    cow     speed      30.0
+            weight    250.0
+            length      1.5
+    falcon  speed     320.0
+            weight      1.0
+            length      0.3
+    dtype: float64
+
+    >>> s.drop(labels='weight', level=1).execute()
+    lama    speed      45.0
+            length      1.2
+    cow     speed      30.0
+            length      1.5
+    falcon  speed     320.0
+            length      0.3
+    dtype: float64
+    """
+    return _drop(series, labels=labels, axis=axis, index=index, columns=columns,
+                 level=level, inplace=inplace, errors=errors)
+
+
+def index_drop(index, labels, errors='raise'):
+    """
+    Make new Index with passed list of labels deleted.
+
+    Parameters
+    ----------
+    labels : array-like
+    errors : {'ignore', 'raise'}, default 'raise'
+        Note that this argument is kept only for compatibility, and errors
+        will not raise even if ``errors=='raise'``.
+
+    Returns
+    -------
+    dropped : Index
+
+    Raises
+    ------
+    KeyError
+        If not all of the labels are found in the selected axis
+    """
+    return _drop(index, labels=labels, errors=errors)

--- a/mars/dataframe/datasource/index.py
+++ b/mars/dataframe/datasource/index.py
@@ -107,7 +107,7 @@ class IndexDataSource(DataFrameOperand, DataFrameOperandMixin):
             chunk_op = op.copy().reset_key()
             slc = get_chunk_slices(chunk_size, chunk_index)
             chunk_op._data = chunk_data = raw_index[slc]
-            out_chunk = chunk_op.new_chunk(None, shape=chunk_shape, dtype=op.dtype,
+            out_chunk = chunk_op.new_chunk(None, shape=chunk_shape, dtype=index.dtype,
                                            index=chunk_index, name=index.name,
                                            index_value=parse_index(chunk_data))
             out_chunks.append(out_chunk)

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -352,6 +352,7 @@ message OperandDef {
         DATAFRAME_DIFF = 724;
         VALUE_COUNTS = 725;
         TO_DATETIME = 726;
+        DATAFRAME_DROP = 727;
 
         FUSE = 801;
 

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -421,6 +421,8 @@ class MarsObjectCheckMixin:
 
     @staticmethod
     def assert_dtype_consistent(expected_dtype, real_dtype):
+        if isinstance(real_dtype, pd.DatetimeTZDtype):
+            real_dtype = real_dtype.base
         if expected_dtype != real_dtype:
             if expected_dtype == np.dtype('O') and real_dtype.type is np.str_:
                 # real dtype is string, this matches expectation


### PR DESCRIPTION
## What do these changes do?

Add support for {DataFrame,Series,Index}.drop().

## Related issue number

Fix drop() part of #1241.