### PR TITLE
Fix failure when executing None-result spawn functions

### DIFF
--- a/mars/web/server.py
+++ b/mars/web/server.py
@@ -244,7 +244,10 @@ class MarsWeb(object):
             if event:
                 event.set()
 
-            self._server.io_loop.start()
+            try:
+                self._server.io_loop.start()
+            except KeyboardInterrupt:
+                pass
 
     def stop(self):
         if self._server is not None:

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -300,26 +300,28 @@ class WorkerService(object):
 
     def stop(self):
         try:
+            destroy_futures = []
             for actor in (self._cpu_calc_actors + self._sender_actors + self._inproc_holder_actors
                           + self._inproc_io_runner_actors + self._cuda_calc_actors
                           + self._cuda_holder_actors + self._receiver_actors + self._spill_actors
                           + self._process_helper_actors):
                 if actor and actor.ctx:
-                    actor.destroy(wait=False)
+                    destroy_futures.append(actor.destroy(wait=False))
 
             if self._result_sender_ref:
-                self._result_sender_ref.destroy(wait=False)
+                destroy_futures.append(self._result_sender_ref.destroy(wait=False))
             if self._status_ref:
-                self._status_ref.destroy(wait=False)
+                destroy_futures.append(self._status_ref.destroy(wait=False))
             if self._shared_holder_ref:
-                self._shared_holder_ref.destroy(wait=False)
+                destroy_futures.append(self._shared_holder_ref.destroy(wait=False))
             if self._storage_manager_ref:
-                self._storage_manager_ref.destroy(wait=False)
+                destroy_futures.append(self._storage_manager_ref.destroy(wait=False))
             if self._events_ref:
-                self._events_ref.destroy(wait=False)
+                destroy_futures.append(self._events_ref.destroy(wait=False))
             if self._dispatch_ref:
-                self._dispatch_ref.destroy(wait=False)
+                destroy_futures.append(self._dispatch_ref.destroy(wait=False))
             if self._execution_ref:
-                self._execution_ref.destroy(wait=False)
+                destroy_futures.append(self._execution_ref.destroy(wait=False))
+            [f.result(5) for f in destroy_futures]
         finally:
             self._plasma_store.__exit__(None, None, None)

--- a/mars/worker/storage/client.py
+++ b/mars/worker/storage/client.py
@@ -294,7 +294,7 @@ class StorageClient(object):
         device_total_size = defaultdict(lambda: 0)
         lift_reqs = defaultdict(list)
         for k, devices, size in zip(data_keys, existing_devs, data_sizes):
-            if not devices or not size:
+            if not devices or size is None:
                 err_msg = 'Data key (%s, %s) not exist, proc_id=%s' % (session_id, k, self.proc_id)
                 return promise.finished(*build_exc_info(KeyError, err_msg), _accept=False)
 


### PR DESCRIPTION
## What do these changes do?

Fix failure when executing None-result functions in distributed environment. Add tests as well.

## Related issue number

Fixes #1270 