### PR TITLE
Fix shape calculation in TensorIndex for tensor.__setitem__

### DIFF
--- a/mars/tensor/indexing/getitem.py
+++ b/mars/tensor/indexing/getitem.py
@@ -333,7 +333,15 @@ def _calc_order(a, index):
 def _getitem_nocheck(a, item, convert_bool_to_fancy=None):
     index = process_index(a.ndim, item,
                           convert_bool_to_fancy=convert_bool_to_fancy)
-    shape = calc_shape(a.shape, index)
+    if convert_bool_to_fancy is False:
+        # come from __setitem__, the bool index is not converted to fancy index
+        # if multiple bool indexes or bool + fancy indexes exist,
+        # thus the shape will be wrong,
+        # here we just convert when calculating shape,
+        # refer to issue #1282.
+        shape = calc_shape(a.shape, process_index(a.ndim, index))
+    else:
+        shape = calc_shape(a.shape, index)
     tensor_order = _calc_order(a, index)
     op = TensorIndex(dtype=a.dtype, sparse=a.issparse(), indexes=index,
                      create_view=_is_create_view(index))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

In `tensor.__setitem__`, it will just leverage `TensorIndex` for index preprocess, but for `setitem`, if multiple bool indexes or bool + fancy indexes exist, the bool index will not be converted to fancy index for the convenience of calculating setitem, thus the shape will be wrong for `TensorIndex`.

Thus in this case, we will convert to fancy index only for shape calculation.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1282 .
