### PR TITLE
[ENH] Allow client-side to use pickle to serialize / deserialize tensor data

### DIFF
--- a/mars/api.py
+++ b/mars/api.py
@@ -178,7 +178,8 @@ class MarsAPI(object):
         graph_meta_ref = self.get_graph_meta_ref(session_id, graph_key)
         self.actor_client.actor_ref(graph_meta_ref.get_wait_ref()).wait(timeout)
 
-    def fetch_data(self, session_id, graph_key, tileable_key, index_obj=None, compressions=None):
+    def fetch_data(self, session_id, graph_key, tileable_key, index_obj=None,
+                   serial_type=None, compressions=None, pickle_protocol=None):
         graph_uid = GraphActor.gen_uid(session_id, graph_key)
         graph_ref = self.get_actor_ref(graph_uid)
         nsplits, chunk_keys, chunk_indexes = graph_ref.get_tileable_metas([tileable_key])[0]
@@ -209,7 +210,8 @@ class MarsAPI(object):
         else:
             ret = merge_chunks(chunk_results)
         compressions = max(compressions) if compressions else dataserializer.CompressType.NONE
-        return dataserializer.dumps(ret, compress=compressions)
+        return dataserializer.dumps(ret, serial_type=serial_type, compress=compressions,
+                                    pickle_protocol=pickle_protocol)
 
     def fetch_chunk_data(self, session_id, chunk_key, index_obj=None):
         endpoints = self.chunk_meta_client.get_workers(session_id, chunk_key)

--- a/mars/config.py
+++ b/mars/config.py
@@ -368,6 +368,9 @@ default_options.register_option('optimize_tileable_graph', True, validator=is_bo
 # eager mode
 default_options.register_option('eager_mode', False, validator=is_bool)
 
+# client serialize type
+default_options.register_option('client.serial_type', 'arrow', validator=is_string)
+
 # vineyard
 default_options.register_option('vineyard.socket', None)
 

--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -18,7 +18,6 @@ from io import BytesIO
 
 import pandas as pd
 import numpy as np
-from pyarrow import HdfsFile
 
 from ... import opcodes as OperandDef
 from ...config import options
@@ -28,6 +27,11 @@ from ...filesystem import open_file, file_size, glob
 from ..core import IndexValue
 from ..utils import parse_index, build_empty_df, standardize_range_index
 from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
+
+try:
+    from pyarrow import HdfsFile
+except ImportError:  # pragma: no cover
+    HdfsFile = None
 
 
 cudf = lazy_import('cudf', globals=globals())

--- a/mars/dataframe/datasource/tests/test_hdfs.py
+++ b/mars/dataframe/datasource/tests/test_hdfs.py
@@ -16,7 +16,6 @@ import unittest
 import os
 from io import BytesIO
 
-import pyarrow
 import pandas as pd
 
 import mars.dataframe as md
@@ -44,6 +43,8 @@ A,B,C,D,E
 class TestHDFS(TestBase):
     def setUp(self):
         super().setUp()
+
+        import pyarrow
         self.hdfs = pyarrow.hdfs.connect(host="localhost", port=8020)
         if self.hdfs.exists(TEST_DIR):
             self.hdfs.rm(TEST_DIR, recursive=True)

--- a/mars/graph.pyx
+++ b/mars/graph.pyx
@@ -428,8 +428,9 @@ cdef class DirectedGraph:
 
         return graph
 
-    def to_pb(self, pb_obj=None):
-        return self.serialize().to_pb(obj=pb_obj)
+    def to_pb(self, pb_obj=None, data_serial_type=None, pickle_protocol=None):
+        return self.serialize().to_pb(
+            obj=pb_obj, data_serial_type=data_serial_type, pickle_protocol=pickle_protocol)
 
     @classmethod
     def from_pb(cls, pb_obj):
@@ -439,8 +440,9 @@ cdef class DirectedGraph:
             logger.error('Failed to deserialize graph, graph_def: {0}'.format(pb_obj))
             raise
 
-    def to_json(self, json_obj=None):
-        return self.serialize().to_json(obj=json_obj)
+    def to_json(self, json_obj=None, data_serial_type=None, pickle_protocol=None):
+        return self.serialize().to_json(
+            obj=json_obj, data_serial_type=data_serial_type, pickle_protocol=pickle_protocol)
 
     @classmethod
     def from_json(cls, json_obj):

--- a/mars/serialize/core.pxd
+++ b/mars/serialize/core.pxd
@@ -265,6 +265,8 @@ cpdef object get_serializable_by_index(object index)
 
 cdef class Provider:
     cdef public object type
+    cdef public object data_serial_type
+    cdef public object pickle_protocol
 
     cpdef serialize_field(self, Field field, model_instance, obj)
     cpdef serialize_model(self, model_instance, obj=?)

--- a/mars/serialize/core.pyx
+++ b/mars/serialize/core.pyx
@@ -669,10 +669,10 @@ class Serializable(metaclass=SerializableMetaclass):
             [cb(key_to_instance) for cb in callbacks]
         return obj
 
-    def to_pb(self, obj=None):
+    def to_pb(self, obj=None, data_serial_type=None, pickle_protocol=None):
         from .pbserializer import ProtobufSerializeProvider
 
-        provider = ProtobufSerializeProvider()
+        provider = ProtobufSerializeProvider(data_serial_type=data_serial_type)
         return self.serialize(provider, obj=obj)
 
     @classmethod
@@ -682,10 +682,10 @@ class Serializable(metaclass=SerializableMetaclass):
         provider = ProtobufSerializeProvider()
         return cls.deserialize(provider, obj)
 
-    def to_json(self, obj=None):
+    def to_json(self, obj=None, data_serial_type=None, pickle_protocol=None):
         from .jsonserializer import JsonSerializeProvider
 
-        provider = JsonSerializeProvider()
+        provider = JsonSerializeProvider(data_serial_type=data_serial_type)
         return self.serialize(provider, obj=obj)
 
     @classmethod

--- a/mars/serialize/jsonserializer.pyx
+++ b/mars/serialize/jsonserializer.pyx
@@ -82,8 +82,10 @@ cdef inline object _get_type(str value_type_name):
 
 
 cdef class JsonSerializeProvider(Provider):
-    def __init__(self):
+    def __init__(self, data_serial_type=None, pickle_protocol=None):
         self.type = ProviderType.json
+        self.data_serial_type = data_serial_type
+        self.pickle_protocol = pickle_protocol
 
     cdef inline str _to_str(self, val):
         assert isinstance(val, (bytes, unicode))
@@ -137,7 +139,8 @@ cdef class JsonSerializeProvider(Provider):
             value = value.astype(object)
         return {
             'type': _get_name(ValueType.arr),
-            'value': self._to_str(base64.b64encode(datadumps(value)))
+            'value': self._to_str(base64.b64encode(datadumps(value, serial_type=self.data_serial_type,
+                                                             pickle_protocol=self.pickle_protocol)))
         }
 
     cdef inline np.ndarray _deserialize_arr(self, object obj, list callbacks):
@@ -175,7 +178,8 @@ cdef class JsonSerializeProvider(Provider):
     cdef inline dict _serialize_index(self, value):
         return {
             'type': _get_name(ValueType.index),
-            'value': self._to_str(base64.b64encode(datadumps(value)))
+            'value': self._to_str(base64.b64encode(datadumps(value, serial_type=self.data_serial_type,
+                                                             pickle_protocol=self.pickle_protocol)))
         }
 
     cdef inline object _deserialize_pd_entity(self, object obj, list callbacks):
@@ -193,13 +197,15 @@ cdef class JsonSerializeProvider(Provider):
     cdef inline dict _serialize_series(self, value):
         return {
             'type': _get_name(ValueType.series),
-            'value': self._to_str(base64.b64encode(datadumps(value)))
+            'value': self._to_str(base64.b64encode(datadumps(value, serial_type=self.data_serial_type,
+                                                             pickle_protocol=self.pickle_protocol)))
         }
 
     cdef inline dict _serialize_dataframe(self, value):
         return {
             'type': _get_name(ValueType.dataframe),
-            'value': self._to_str(base64.b64encode(datadumps(value)))
+            'value': self._to_str(base64.b64encode(datadumps(value, serial_type=self.data_serial_type,
+                                                             pickle_protocol=self.pickle_protocol)))
         }
 
     cdef inline dict _serialize_key(self, value):
@@ -374,8 +380,10 @@ cdef class JsonSerializeProvider(Provider):
         return {
             'type': 'interval_arr',
             'value': {
-                'left': self._to_str(base64.b64encode(datadumps(value.left))),
-                'right': self._to_str(base64.b64encode(datadumps(value.right))),
+                'left': self._to_str(base64.b64encode(datadumps(value.left, serial_type=self.data_serial_type,
+                                                                pickle_protocol=self.pickle_protocol))),
+                'right': self._to_str(base64.b64encode(datadumps(value.right, serial_type=self.data_serial_type,
+                                                                 pickle_protocol=self.pickle_protocol))),
                 'closed': value.closed,
                 'dtype': self._serialize_dtype(value.dtype)
             }

--- a/mars/session.py
+++ b/mars/session.py
@@ -280,10 +280,8 @@ class ClusterSession(object):
             if graph_state == GraphState.FAILED:
                 exc_info = self._api.get_graph_exc_info(self._session_id, graph_key)
                 if exc_info is not None:
-                    try:
-                        raise exc_info[1].with_traceback(exc_info[2]) from None
-                    except:  # noqa: E722
-                        raise ExecutionFailed('Graph execution failed.')
+                    exc = exc_info[1].with_traceback(exc_info[2])
+                    raise ExecutionFailed('Graph execution failed.') from exc
                 else:
                     raise ExecutionFailed('Graph execution failed with unknown reason')
             time_elapsed = time.time() - exec_start_time

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -252,8 +252,9 @@ def lazy_import(name, package=None, globals=None, locals=None, rename=None):
         return None
 
 
-def serialize_graph(graph, compress=False):
-    ser_graph = graph.to_pb().SerializeToString()
+def serialize_graph(graph, compress=False, data_serial_type=None, pickle_protocol=None):
+    ser_graph = graph.to_pb(data_serial_type=data_serial_type,
+                            pickle_protocol=pickle_protocol).SerializeToString()
     if compress:
         ser_graph = zlib.compress(ser_graph)
     return ser_graph

--- a/mars/web/server.py
+++ b/mars/web/server.py
@@ -20,7 +20,6 @@ import os
 from collections import defaultdict
 
 import numpy as np
-import pyarrow
 from bokeh.application import Application
 from bokeh.application.handlers import FunctionHandler
 from bokeh.server.server import Server
@@ -130,6 +129,8 @@ class MarsWebAPI(MarsAPI):
         return ref.query_by_time(category, time_start=time_start, time_end=time_end)
 
     def write_mutable_tensor(self, session_id, name, payload_type, body):
+        import pyarrow
+
         from ..serialize import dataserializer
         from ..tensor.core import Indexes
         session_uid = SessionActor.gen_uid(session_id)
@@ -139,7 +140,7 @@ class MarsWebAPI(MarsAPI):
         index_json = json.loads(body[8:8+index_json_size].decode('ascii'))
         index = Indexes.from_json(index_json).indexes
         if payload_type is None:
-            value = dataserializer.loads(body[8+index_json_size:], raw=False)
+            value = dataserializer.loads(body[8+index_json_size:])
         elif payload_type == 'tensor':
             tensor_chunk_offset = 8 + index_json_size
             with pyarrow.BufferReader(body[tensor_chunk_offset:]) as reader:

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -133,11 +133,9 @@ class Session(object):
             raise ExecutionInterrupted
         elif resp_json['state'] == 'failed':
             if 'exc_info' in resp_json:
-                try:
-                    exc_info = pickle.loads(base64.b64decode(resp_json['exc_info']))
-                    raise exc_info[1].with_traceback(exc_info[2])
-                except:  # noqa: E722
-                    raise ExecutionFailed('Graph execution failed.')
+                exc_info = pickle.loads(base64.b64decode(resp_json['exc_info']))
+                exc = exc_info[1].with_traceback(exc_info[2])
+                raise ExecutionFailed('Graph execution failed.') from exc
             else:
                 raise ExecutionFailed('Graph execution failed with unknown reason.')
         raise ExecutionStateUnknown(

--- a/mars/worker/storage/diskhandler.py
+++ b/mars/worker/storage/diskhandler.py
@@ -91,7 +91,7 @@ class DiskIO(BytesStorageIO):
                     buf, 'w', compress_in=compress, block_size=block_size)
             else:
                 dataserializer.write_file_header(buf, dataserializer.file_header(
-                    dataserializer.SERIAL_VERSION, nbytes, compress
+                    dataserializer.SerialType.ARROW, dataserializer.SERIAL_VERSION, nbytes, compress
                 ))
                 self._buf = dataserializer.open_compression_file(buf, compress)
         elif self.is_readable:

--- a/mars/worker/storage/sharedhandler.py
+++ b/mars/worker/storage/sharedhandler.py
@@ -14,8 +14,6 @@
 
 import functools
 
-import pyarrow
-
 from ... import promise
 from ...config import options
 from ...errors import StorageFull, StorageDataExists
@@ -53,6 +51,7 @@ class SharedStorageIO(BytesStorageIO):
             if packed:
                 self._buf = ArrowBufferIO(self._shared_buf, 'w', block_size=block_size)
             else:
+                import pyarrow
                 self._buf = pyarrow.FixedSizeBufferWriter(self._shared_buf)
                 self._buf.set_memcopy_threads(6)
         elif self.is_readable:

--- a/mars/worker/storage/tests/test_disk_io.py
+++ b/mars/worker/storage/tests/test_disk_io.py
@@ -162,7 +162,7 @@ class Test(WorkerCase):
                 storage_client.delete(session_id, [data_key1])
                 self.rm_spill_dirs()
 
-                block_data1 = dataserializer.dumps(data1, handler._compress)
+                block_data1 = dataserializer.dumps(data1, compress=handler._compress)
 
                 def _write_data(ser, writer):
                     with writer:

--- a/mars/worker/storage/tests/test_shared_io.py
+++ b/mars/worker/storage/tests/test_shared_io.py
@@ -129,7 +129,7 @@ class Test(WorkerCase):
 
             data1 = np.random.random((100, 100))
             ser_data1 = dataserializer.serialize(data1)
-            block_data1 = dataserializer.dumps(data1, dataserializer.CompressType.NONE)
+            block_data1 = dataserializer.dumps(data1, compress=dataserializer.CompressType.NONE)
 
             session_id = str(uuid.uuid4())
             data_key1 = str(uuid.uuid4())

--- a/mars/worker/tests/test_dataio.py
+++ b/mars/worker/tests/test_dataio.py
@@ -30,7 +30,6 @@ class Test(unittest.TestCase):
     def testArrowBufferIO(self):
         if not np:
             return
-        import pyarrow
         from numpy.testing import assert_array_equal
 
         for compress in [dataserializer.CompressType.LZ4, dataserializer.CompressType.GZIP]:

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -839,7 +839,7 @@ class ResultSenderActor(WorkerActor):
                 sliced_value = value[tuple(index_obj)]
 
             return self._serialize_pool.submit(
-                dataserializer.dumps, sliced_value, compression_type).result()
+                dataserializer.dumps, sliced_value, compress=compression_type).result()
 
 
 def put_remote_chunk(session_id, chunk_key, data, receiver_manager_ref):

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,6 +1,7 @@
 scipy>=1.0.0
 scikit-learn>=0.20
 numexpr>=2.6.4
+pyarrow>=0.11.0,!=0.16.*
 psutil>=4.0.0
 lz4>=1.0.0
 protobuf>=3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ numpy>=1.14.0
 pandas>=0.24.0; python_version >= '3.6'
 pandas>=0.24.0,<1.0.0; python_version < '3.6'
 requests>=2.4.0
-pyarrow>=0.11.0,!=0.16.*
 cloudpickle>=1.0.0


### PR DESCRIPTION
## What do these changes do?

This PR allows clients to use pickle to serialize / deserialize data and communicate with servers under two scenarios:

1. pyarrow is absent
2. the version of pyarrow is not consistent with the version at server side

## Related issue number

Fixes #1288 
