### PR TITLE
Support tileables as arguments for spawned functions

### DIFF
--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -100,7 +100,7 @@ cdef class Tokenizer:
             handler = self._handlers[object_type]
             return handler(obj)
         except KeyError:
-            if hasattr(obj, '__mars_tokenize__'):
+            if hasattr(obj, '__mars_tokenize__') and not isinstance(obj, type):
                 return self.tokenize(obj.__mars_tokenize__())
             if callable(obj):
                 return tokenize_function(obj)

--- a/mars/context.py
+++ b/mars/context.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import sys
 import threading
 import random
@@ -197,7 +198,8 @@ class LocalContext(ContextBase, dict):
         from .session import new_session
 
         sess = new_session()
-        sess._sess = self._local_session
+        sess._sess = copy.copy(self._local_session)
+        sess._sess.context = self
         return sess
 
     def set_ncores(self, ncores):

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -1046,6 +1046,21 @@ class Test(unittest.TestCase):
             r = session2.run(d, timeout=_exec_timeout)
             self.assertEqual(r, 6)
 
+            # test input tileable
+            def f(t, x):
+                return (t * x).sum().to_numpy()
+
+            rs = np.random.RandomState(0)
+            raw = rs.rand(5, 4)
+
+            t1 = mt.tensor(raw, chunk_size=3)
+            t2 = t1.sum(axis=0)
+            s = mr.spawn(f, args=(t2, 3), retry_when_fail=False)
+
+            r = session.run(s, timeout=_exec_timeout)
+            expected = (raw.sum(axis=0) * 3).sum()
+            self.assertAlmostEqual(r, expected)
+
     def testKNNInLocalCluster(self, *_):
         from mars.learn.neighbors import NearestNeighbors
         from sklearn.neighbors import NearestNeighbors as SkNearestNeighbors

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -611,6 +611,14 @@ class Executor(object):
         return self._chunk_result
 
     @property
+    def storage(self):
+        return self._chunk_result
+
+    @storage.setter
+    def storage(self, new_storage):
+        self._chunk_result = new_storage
+
+    @property
     def mock_max_memory(self):
         return self._mock_max_memory
 

--- a/mars/remote/utils.py
+++ b/mars/remote/utils.py
@@ -12,17 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..core import Base, Entity
-
 
 def find_objects(nested, types):
-    inputs = []
+    found = []
     stack = [nested]
 
     while len(stack) > 0:
         it = stack.pop()
         if isinstance(it, types):
-            inputs.append(it)
+            found.append(it)
             continue
 
         if isinstance(it, (list, tuple, set)):
@@ -30,7 +28,7 @@ def find_objects(nested, types):
         elif isinstance(it, dict):
             stack.extend(list(it.values())[::-1])
 
-    return inputs
+    return found
 
 
 def replace_inputs(nested, mapping):
@@ -46,10 +44,11 @@ def replace_inputs(nested, mapping):
     for val in vals:
         if isinstance(val, (dict, list, tuple, set)):
             new_val = replace_inputs(val, mapping)
-        elif isinstance(val, (Entity, Base)):
-            new_val = mapping.get(val, val)
         else:
-            new_val = val
+            try:
+                new_val = mapping.get(val, val)
+            except TypeError:
+                new_val = val
         new_vals.append(new_val)
 
     if isinstance(nested, dict):

--- a/mars/session.py
+++ b/mars/session.py
@@ -53,6 +53,12 @@ class LocalSession(object):
     def endpoint(self):
         return self._endpoint
 
+    @endpoint.setter
+    def endpoint(self, endpoint):
+        if endpoint is not None:
+            raise ValueError('Local session cannot set endpoint')
+        self._endpoint = endpoint
+
     @property
     def session_id(self):
         return self._session_id
@@ -65,15 +71,14 @@ class LocalSession(object):
     def context(self):
         return self._context
 
+    @context.setter
+    def context(self, new_context):
+        self._context = new_context
+        self._executor.storage = new_context
+
     @property
     def executed_tileables(self):
         return self._executor.stored_tileables.keys()
-
-    @endpoint.setter
-    def endpoint(self, endpoint):
-        if endpoint is not None:
-            raise ValueError('Local session cannot set endpoint')
-        self._endpoint = endpoint
 
     def run(self, *tileables, **kw):
         with self.context:

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -396,6 +396,7 @@ def kernel_mode(func):
 
 
 def build_tileable_graph(tileables, executed_tileable_keys, graph=None):
+    from .operands import Fetch
     from .tiles import TileableGraphBuilder
 
     with build_mode():
@@ -419,6 +420,11 @@ def build_tileable_graph(tileables, executed_tileable_keys, graph=None):
                     p = o.params.copy()
                     p.update(o.extra_params)
                     p['_key'] = o.key
+                    if isinstance(o.op, Fetch):
+                        # chunks may be generated in the remote functions,
+                        # thus bring chunks and nsplits for serialization
+                        p['chunks'] = o.chunks
+                        p['nsplits'] = o.nsplits
                     params.append(p)
                 copies = copy_op.new_tileables([replace_with_fetch_or_copy(inp) for inp in n.inputs],
                                                kws=params, output_limit=len(params))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR added support for possibility that tileables now  can be arguments for spawned functions.

```
In [1]: import mars.dataframe as md                                             

In [2]: df = md.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})                                                                             

In [4]: import mars.remote as mr 

In [6]: def h(f): 
   ...:     return f[:2].to_pandas() 
   ...:                                                                         

In [7]: mr.spawn(h, args=(df,)).execute().fetch()                               
Out[7]: 
   a  b
0  1  4
1  2  5
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Support part of #1227 .
