### PR TITLE
Fix `mt.linalg.norm` when chunk shape on axis > 1

### DIFF
--- a/mars/tensor/linalg/norm.py
+++ b/mars/tensor/linalg/norm.py
@@ -64,7 +64,7 @@ class TensorNorm(TensorHasInput, TensorOperandMixin):
 
     @classmethod
     def tile(cls, op):
-        x = op.input
+        x = astensor(op.input)
         axis = op.axis
         ord = op.ord
         keepdims = op.keepdims

--- a/mars/tensor/linalg/tests/test_linalg_execute.py
+++ b/mars/tensor/linalg/tests/test_linalg_execute.py
@@ -811,6 +811,12 @@ class Test(unittest.TestCase):
         res = self.executor.execute_tensor(t)[0]
         self.assertAlmostEqual(res, 3.14, delta=1)
 
+        raw = np.random.RandomState(0).rand(10, 10)
+        d = norm(tensor(raw, chunk_size=5))
+        expected = self.executor.execute_tensor(d, concat=True)[0]
+        result = np.linalg.norm(raw)
+        np.testing.assert_allclose(expected, result)
+
     def testTensordotExecution(self):
         size_executor = ExecutorForTest(sync_provider_type=ExecutorForTest.SyncProviderType.MOCK)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes `mt.linalg.norm` when chunk shape on axis > 1.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1301 .