### PR TITLE
Fix error in calc_data_size() for GroupByWrapper

### DIFF
--- a/mars/lib/groupby_wrapper.py
+++ b/mars/lib/groupby_wrapper.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from collections.abc import Iterable
 
 import cloudpickle
@@ -77,6 +78,10 @@ class GroupByWrapper:
 
     def __iter__(self):
         return self.groupby_obj.__iter__()
+
+    def __sizeof__(self):
+        return sys.getsizeof(self.obj) \
+            + sys.getsizeof(getattr(self.groupby_obj.grouper, '_cache', None))
 
     @property
     def empty(self):

--- a/mars/lib/tests/test_lib.py
+++ b/mars/lib/tests/test_lib.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import unittest
 
 import pandas as pd
@@ -19,6 +20,7 @@ import numpy as np
 
 from mars.lib.groupby_wrapper import GroupByWrapper, wrapped_groupby
 from mars.tests.core import assert_groupby_equal
+from mars.utils import calc_data_size
 
 
 class Test(unittest.TestCase):
@@ -35,6 +37,8 @@ class Test(unittest.TestCase):
         assert_groupby_equal(grouped, df.groupby(level=0))
         self.assertEqual(grouped.shape, (8, 4))
         self.assertTrue(grouped.is_frame)
+        self.assertGreater(sys.getsizeof(grouped), sys.getsizeof(grouped.groupby_obj))
+        self.assertGreater(calc_data_size(grouped), sys.getsizeof(grouped.groupby_obj))
 
         grouped = GroupByWrapper.from_tuple(wrapped_groupby(df, level=0).C.to_tuple())
         assert_groupby_equal(grouped, df.groupby(level=0).C)

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -296,7 +296,7 @@ def calc_data_size(dt):
         return max(sys.getsizeof(dt), dt.nbytes)
     if hasattr(dt, 'shape') and len(dt.shape) == 0:
         return 0
-    if hasattr(dt, 'memory_usage'):
+    if hasattr(dt, 'memory_usage') or hasattr(dt, 'groupby_obj'):
         return sys.getsizeof(dt)
     if hasattr(dt, 'dtypes') and hasattr(dt, 'shape'):
         return dt.shape[0] * sum(dtype.itemsize for dtype in dt.dtypes)

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -384,7 +384,10 @@ class ExecutionActor(WorkerActor):
             for c in graph:
                 if not isinstance(c.op, Fetch):
                     break
-                data_size = calc_data_size(c)
+                try:
+                    data_size = calc_data_size(c)
+                except (AttributeError, TypeError, ValueError):
+                    data_size = 0
                 input_size += data_size
                 data_locations = self.storage_client.get_data_locations(session_id, [c.key])[0]
                 if (0, DataStorageDevice.VINEYARD) in data_locations or \


### PR DESCRIPTION
## What do these changes do?

Fix error in calc_data_size() for GroupByWrapper and allow executing groupby() with distributed sessions.

## Related issue number

Fixes #1306 
