### PR TITLE
Fix wrong columns value in `reset_index`

### DIFF
--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -70,7 +70,7 @@ class DataFrameBinOp(DataFrameOperand):
         else:
             if isinstance(self._lhs, (DATAFRAME_TYPE, SERIES_TYPE)):
                 self._lhs = self._inputs[0]
-            elif np.isscalar(self._lhs):
+            elif pd.api.types.is_scalar(self._lhs):
                 self._rhs = self._inputs[0]
 
 
@@ -181,7 +181,7 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
 
     @classmethod
     def _tile_scalar(cls, op):
-        tileable = op.rhs if np.isscalar(op.lhs) else op.lhs
+        tileable = op.rhs if pd.api.types.is_scalar(op.lhs) else op.lhs
         df = op.outputs[0]
         out_chunks = []
         for chunk in tileable.chunks:
@@ -270,7 +270,7 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
                 func_name = getattr(cls, '_rfunc_name')
             else:
                 func_name = getattr(cls, '_func_name')
-        elif np.isscalar(op.lhs) or isinstance(op.lhs, np.ndarray):
+        elif pd.api.types.is_scalar(op.lhs) or isinstance(op.lhs, np.ndarray):
             df = ctx[op.rhs.key]
             other = op.lhs
             func_name = getattr(cls, '_rfunc_name')
@@ -297,10 +297,10 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
     @classmethod
     def _calc_properties(cls, x1, x2=None, axis='columns'):
         if isinstance(x1, (DATAFRAME_TYPE, DATAFRAME_CHUNK_TYPE)) \
-                and (x2 is None or np.isscalar(x2) or isinstance(x2, TENSOR_TYPE)):
+                and (x2 is None or pd.api.types.is_scalar(x2) or isinstance(x2, TENSOR_TYPE)):
             if x2 is None:
                 dtypes = x1.dtypes
-            elif np.isscalar(x2):
+            elif pd.api.types.is_scalar(x2):
                 dtypes = infer_dtypes(x1.dtypes, pd.Series(np.array(x2).dtype), cls._operator)
             elif x1.dtypes is not None and isinstance(x2, TENSOR_TYPE):
                 dtypes = pd.Series(
@@ -312,7 +312,7 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
                     'columns_value': x1.columns_value, 'index_value': x1.index_value}
 
         if isinstance(x1, (SERIES_TYPE, SERIES_CHUNK_TYPE)) \
-                and (x2 is None or np.isscalar(x2) or isinstance(x2, TENSOR_TYPE)):
+                and (x2 is None or pd.api.types.is_scalar(x2) or isinstance(x2, TENSOR_TYPE)):
             x2_dtype = x2.dtype if hasattr(x2, 'dtype') else type(x2)
             dtype = infer_dtype(x1.dtype, np.dtype(x2_dtype), cls._operator)
             return {'shape': x1.shape, 'dtype': dtype, 'index_value': x1.index_value}
@@ -436,7 +436,7 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
 
     @staticmethod
     def _process_input(x):
-        if isinstance(x, (DATAFRAME_TYPE, SERIES_TYPE)) or np.isscalar(x):
+        if isinstance(x, (DATAFRAME_TYPE, SERIES_TYPE)) or pd.api.types.is_scalar(x):
             return x
         elif isinstance(x, pd.Series):
             return Series(x)
@@ -478,7 +478,7 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
             df1, df2 = (x1, x2) if isinstance(x1, DATAFRAME_TYPE) else (x2, x1)
             setattr(self, '_object_type', ObjectType.dataframe)
             kw = self._calc_properties(df1, df2, axis=self.axis)
-            if not np.isscalar(df2):
+            if not pd.api.types.is_scalar(df2):
                 return self.new_dataframe([x1, x2], **kw)
             else:
                 return self.new_dataframe([df1], **kw)
@@ -486,7 +486,7 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
             s1, s2 = (x1, x2) if isinstance(x1, SERIES_TYPE) else (x2, x1)
             setattr(self, '_object_type', ObjectType.series)
             kw = self._calc_properties(s1, s2)
-            if not np.isscalar(s2):
+            if not pd.api.types.is_scalar(s2):
                 return self.new_series([x1, x2], **kw)
             else:
                 return self.new_series([s1], **kw)

--- a/mars/dataframe/arithmetic/tests/test_comparison.py
+++ b/mars/dataframe/arithmetic/tests/test_comparison.py
@@ -14,6 +14,7 @@
 
 import operator
 import unittest
+from datetime import datetime
 
 import numpy as np
 import pandas as pd
@@ -48,3 +49,11 @@ class Test(unittest.TestCase):
                                          columns=['a', 'b', 'c']))
             with self.assertRaises(ValueError):
                 op(df1, df4)
+
+        # test datetime
+        df = DataFrame(pd.DataFrame(pd.date_range('20130101', periods=6)))
+        for op in [operator.eq, operator.ne, operator.lt, operator.gt,
+                   operator.le, operator.ge]:
+            r_df = op(df, datetime(2013, 1, 2))
+            pd.testing.assert_index_equal(r_df.index_value.to_pandas(),
+                                          df.index_value.to_pandas())

--- a/mars/dataframe/base/reset_index.py
+++ b/mars/dataframe/base/reset_index.py
@@ -96,11 +96,15 @@ class DataFrameResetIndex(DataFrameOperand, DataFrameOperandMixin):
         out_df = op.outputs[0]
         added_columns_num = len(out_df.dtypes) - len(in_df.dtypes)
         out_chunks = []
-        is_range_index = out_df.index_value.has_value()
+        index_has_value = out_df.index_value.has_value()
+        chunk_has_nan = any(np.isnan(s) for s in in_df.nsplits[0])
         cum_range = np.cumsum((0, ) + in_df.nsplits[0])
         for c in in_df.chunks:
-            if is_range_index:
-                index_value = parse_index(pd.RangeIndex(cum_range[c.index[0]], cum_range[c.index[0] + 1]))
+            if index_has_value:
+                if chunk_has_nan:
+                    index_value = parse_index(pd.RangeIndex(-1))
+                else:
+                    index_value = parse_index(pd.RangeIndex(cum_range[c.index[0]], cum_range[c.index[0] + 1]))
             else:
                 index_value = out_df.index_value
             if c.index[1] == 0:
@@ -116,8 +120,9 @@ class DataFrameResetIndex(DataFrameOperand, DataFrameOperandMixin):
                 new_chunk = chunk_op.new_chunk([c], shape=c.shape, index_value=index_value,
                                                index=c.index, columns_value=c.columns_value, dtypes=c.dtypes)
             out_chunks.append(new_chunk)
-        if not is_range_index and isinstance(out_df.index_value._index_value, IndexValue.RangeIndex):
-            out_chunks = standardize_range_index(out_chunks)
+        if not index_has_value or chunk_has_nan:
+            if isinstance(out_df.index_value._index_value, IndexValue.RangeIndex):
+                out_chunks = standardize_range_index(out_chunks)
         new_op = op.copy()
         columns_splits = list(in_df.nsplits[1])
         columns_splits[0] += added_columns_num
@@ -187,7 +192,7 @@ class DataFrameResetIndex(DataFrameOperand, DataFrameOperandMixin):
             empty_df.index = a.index_value.to_pandas()[:0]
             empty_df = empty_df.reset_index(level=self.level, col_level=self.col_level, col_fill=self.col_fill)
             shape = (a.shape[0], len(empty_df.columns))
-            columns_value = parse_index(empty_df.columns)
+            columns_value = parse_index(empty_df.columns, store_data=True)
             dtypes = empty_df.dtypes
             index_value = self._get_out_index(empty_df, shape)
         return self.new_dataframe([a], shape=shape, columns_value=columns_value,

--- a/mars/dataframe/base/tests/test_base.py
+++ b/mars/dataframe/base/tests/test_base.py
@@ -192,6 +192,7 @@ class Test(TestBase):
 
         self.assertEqual(df.shape, (4, 3))
         pd.testing.assert_series_equal(df.dtypes, r.dtypes)
+        pd.testing.assert_index_equal(df.columns_value.to_pandas(), r.columns)
 
         df2 = df.tiles()
 

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -204,6 +204,15 @@ class Test(TestBase):
         expected = (data1 + data2).reset_index()
         np.testing.assert_array_equal(result.to_numpy(), expected.to_numpy())
 
+        # case from https://github.com/mars-project/mars/issues/1286
+        data = pd.DataFrame(np.random.rand(10, 3), columns=list('abc'))
+        df = from_pandas_df(data, chunk_size=3)
+
+        r = df.sort_values('a').reset_index(drop=True)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = data.sort_values('a').reset_index(drop=True)
+        pd.testing.assert_frame_equal(result, expected)
+
     def testSeriesMapExecution(self):
         raw = pd.Series(np.arange(10))
         s = from_pandas_series(raw, chunk_size=7)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
- Fix wrong columns value in `reset_index`.
- Use `pd.api.types.is_scalar` instead of `np.isscalar` in DataFrame.arithmetic.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1313.
Fixes #1286.