### PR TITLE
Optimize DataFrame.{head, tail} when DataFrame has unknown chunk shape

### DIFF
--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -22,7 +22,7 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...config import options
 from ...core import OutputType
-from ...utils import parse_readable_size, lazy_import
+from ...utils import parse_readable_size, lazy_import, FixedSizeFileObject
 from ...serialize import StringField, DictField, ListField, Int32Field, Int64Field, BoolField, AnyField
 from ...filesystem import open_file, file_size, glob
 from ..core import IndexValue
@@ -91,16 +91,17 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
     _usecols = ListField('usecols')
     _offset = Int64Field('offset')
     _size = Int64Field('size')
+    _nrows = Int64Field('nrows')
     _incremental_index = BoolField('incremental_index')
 
     _storage_options = DictField('storage_options')
 
     def __init__(self, path=None, names=None, sep=None, header=None, index_col=None,
-                 compression=None, usecols=None, offset=None, size=None, gpu=None,
-                 incremental_index=None, storage_options=None, **kw):
+                 compression=None, usecols=None, offset=None, size=None, nrows=None,
+                 gpu=None, incremental_index=None, storage_options=None, **kw):
         super().__init__(_path=path, _names=names, _sep=sep, _header=header,
                          _index_col=index_col, _compression=compression,
-                         _usecols=usecols, _offset=offset, _size=size,
+                         _usecols=usecols, _offset=offset, _size=size, _nrows=nrows,
                          _gpu=gpu, _incremental_index=incremental_index,
                          _storage_options=storage_options,
                          _output_types=[OutputType.dataframe], **kw)
@@ -132,6 +133,10 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
     @property
     def usecols(self):
         return self._usecols
+
+    @property
+    def nrows(self):
+        return self._nrows
 
     @property
     def offset(self):
@@ -219,7 +224,7 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
         out_df = op.outputs[0]
         start, end = _find_chunk_start_end(f, op.offset, op.size)
         f.seek(start)
-        b = BytesIO(f.read(end - start))
+        b = FixedSizeFileObject(f, end - start)
         if end == start:
             # the last chunk may be empty
             df = build_empty_df(out_df.dtypes)
@@ -229,7 +234,7 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                 # As we specify names and dtype, we need to skip header rows
                 csv_kwargs['skiprows'] = 1 if op.header == 'infer' else op.header
             df = pd.read_csv(b, sep=op.sep, names=op.names, index_col=op.index_col, usecols=op.usecols,
-                             dtype=out_df.dtypes.to_dict(), **csv_kwargs)
+                             dtype=out_df.dtypes.to_dict(), nrows=op.nrows, **csv_kwargs)
         return df
 
     @classmethod
@@ -240,7 +245,7 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
         else:
             df = cudf.read_csv(op.path, byte_range=(op.offset, op.size), sep=op.sep, names=op.names,
                                usecols=op.usecols, dtype=cls._validate_dtypes(op.outputs[0].dtypes, op.gpu),
-                               **csv_kwargs)
+                               nrows=op.nrows, **csv_kwargs)
         return df
 
     @classmethod
@@ -253,9 +258,9 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
             if op.compression is not None:
                 # As we specify names and dtype, we need to skip header rows
                 csv_kwargs['skiprows'] = 1 if op.header == 'infer' else op.header
-                df = xdf.read_csv(BytesIO(f.read()), sep=op.sep, names=op.names, index_col=op.index_col,
+                df = xdf.read_csv(f, sep=op.sep, names=op.names, index_col=op.index_col,
                                   usecols=op.usecols, dtype=cls._validate_dtypes(op.outputs[0].dtypes, op.gpu),
-                                  **csv_kwargs)
+                                  nrows=op.nrows, **csv_kwargs)
             else:
                 df = cls._cudf_read_csv(op) if op.gpu else cls._pandas_read_csv(f, op)
 

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -20,15 +20,14 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...config import options
-from ...core import OutputType
+from ...core import Base, Entity, OutputType
 from ...serialize import AnyField, Int32Field, BoolField
 from ...tensor.core import TENSOR_TYPE
 from ...tensor.datasource import tensor as astensor
 from ...utils import check_chunks_unknown_shape
 from ...tiles import TilesError
 from ..align import align_dataframe_series, align_dataframe_dataframe
-from ..core import SERIES_TYPE, SERIES_CHUNK_TYPE, DATAFRAME_TYPE, \
-    DATAFRAME_CHUNK_TYPE, TILEABLE_TYPE, CHUNK_TYPE
+from ..core import SERIES_TYPE, SERIES_CHUNK_TYPE, DATAFRAME_TYPE, DATAFRAME_CHUNK_TYPE
 from ..merge import DataFrameConcat
 from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index, in_range_index
@@ -235,9 +234,9 @@ class DataFrameIndex(DataFrameOperand, DataFrameOperandMixin):
 
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
-        if isinstance(self._col_names, (TILEABLE_TYPE, CHUNK_TYPE)):
+        if isinstance(self._col_names, (Base, Entity)):
             self._col_names = self._inputs[0]
-        if isinstance(self._mask, (TILEABLE_TYPE, CHUNK_TYPE)):
+        if isinstance(self._mask, (Base, Entity)):
             self._mask = self._inputs[-1]
 
     def __call__(self, df):

--- a/mars/dataframe/indexing/iloc.py
+++ b/mars/dataframe/indexing/iloc.py
@@ -20,12 +20,14 @@ import pandas as pd
 from pandas.core.dtypes.cast import find_common_type
 from pandas.core.indexing import IndexingError
 
+from ... import opcodes as OperandDef
 from ...core import Entity, Base, OutputType
+from ...config import options
 from ...serialize import AnyField, KeyField, ListField
 from ...tensor import asarray
 from ...tensor.datasource.empty import empty
 from ...tensor.indexing.core import calc_shape
-from ... import opcodes as OperandDef
+from ...utils import ceildiv
 from ..operands import DataFrameOperand, DataFrameOperandMixin, DATAFRAME_TYPE
 from ..utils import indexing_index_value
 from .index_lib import DataFrameIlocIndexesHandler
@@ -99,7 +101,7 @@ def process_iloc_indexes(inp, indexes):
     return new_indexes
 
 
-class DataFrameIloc(object):
+class DataFrameIloc:
     def __init__(self, obj):
         self._obj = obj
 
@@ -123,7 +125,99 @@ class DataFrameIloc(object):
         self._obj.data = ret.data
 
 
-class DataFrameIlocGetItem(DataFrameOperand, DataFrameOperandMixin):
+class HeadTailOptimizedOperandMixin(DataFrameOperandMixin):
+    __slots__ = ()
+
+    @classmethod
+    def _is_head(cls, index0):
+        return (index0.start is None or index0.start == 0) and \
+               index0.stop is not None and index0.stop > 0
+
+    @classmethod
+    def _is_tail(cls, index0):
+        return index0.start is not None and index0.start < 0 and \
+               index0.stop is None
+
+    @classmethod
+    def _is_indexes_head_or_tail(cls, indexes):
+        index0 = indexes[0]
+        if not isinstance(index0, slice):
+            # have to be slice
+            return False
+        if index0.step is not None:
+            return False
+        if len(indexes) == 2 and indexes[1] != slice(None):
+            return False
+        if cls._is_tail(index0):
+            # tail
+            return True
+        if cls._is_head(index0):
+            # head
+            return True
+        return False
+
+    @classmethod
+    def _need_tile_head_tail(cls, op):
+        # first, the input DataFrame should
+        # have unknown chunk shapes on the index axis,
+        inp = op.input
+        if not any(np.isnan(s) for s in inp.nsplits[0]):
+            return False
+
+        # if input is a DataFrame,
+        # should have 1 chunk on columns axis
+        if inp.ndim > 1 and inp.chunk_shape[1] > 1:
+            return False
+
+        return cls._is_indexes_head_or_tail(op.indexes)
+
+    @classmethod
+    def _tile_head_tail(cls, op):
+        from ..merge import DataFrameConcat
+
+        inp = op.input
+        out = op.outputs[0]
+        combine_size = options.combine_size
+
+        chunks = inp.chunks
+
+        new_chunks = []
+        for c in chunks:
+            chunk_op = op.copy().reset_key()
+            params = out.params
+            params['index'] = c.index
+            new_chunks.append(chunk_op.new_chunk([c], kws=[params]))
+        chunks = new_chunks
+
+        while len(chunks) > 1:
+            new_size = ceildiv(len(chunks), combine_size)
+            new_chunks = []
+            for i in range(new_size):
+                in_chunks = chunks[combine_size * i: combine_size * (i + 1)]
+                chunk_index = (i, 0) if in_chunks[0].ndim == 2 else (i,)
+                concat_chunk = DataFrameConcat(
+                    axis=0, output_types=in_chunks[0].op.output_types).new_chunk(
+                    in_chunks, index=chunk_index,
+                    shape=(sum(c.shape[0] for c in in_chunks), in_chunks[0].shape[1]))
+                chunk_op = op.copy().reset_key()
+                params = out.params
+                params['index'] = chunk_index
+                new_chunks.append(chunk_op.new_chunk([concat_chunk], kws=[params]))
+            chunks = new_chunks
+
+        new_op = op.copy()
+        params = out.params
+        params['nsplits'] = tuple((s,) for s in out.shape)
+        params['chunks'] = chunks
+        return new_op.new_tileables(op.inputs, kws=[params])
+
+    @classmethod
+    def tile(cls, op):
+        if cls._need_tile_head_tail(op):
+            return cls._tile_head_tail(op)
+
+
+class DataFrameIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
     _op_type_ = OperandDef.DATAFRAME_ILOC_GETITEM
 
     _input = KeyField('input')
@@ -141,6 +235,10 @@ class DataFrameIlocGetItem(DataFrameOperand, DataFrameOperandMixin):
     @property
     def indexes(self):
         return self._indexes
+
+    def is_head(self):
+        return self._is_indexes_head_or_tail(self._indexes) and \
+               self._is_head(self._indexes[0])
 
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
@@ -234,6 +332,10 @@ class DataFrameIlocGetItem(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def tile(cls, op):
+        tileds = super().tile(op)
+        if tileds is not None:
+            return tileds
+
         handler = DataFrameIlocIndexesHandler()
         return [handler.handle(op)]
 

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -31,7 +31,7 @@ from .operands import Fetch, ShuffleProxy
 from .graph import DAG, DirectedGraph
 from .config import options
 from .tiles import IterativeChunkGraphBuilder, ChunkGraphBuilder, get_tiled
-from .optimizes.runtime.optimizers.core import Optimizer
+from .optimizes.runtime.optimizers.core import RuntimeOptimizer
 from .optimizes.tileable_graph import tileable_optimized, OptimizeIntegratedTileableGraphBuilder
 from .graph_builder import TileableGraphBuilder
 from .context import LocalContext
@@ -665,7 +665,7 @@ class Executor(object):
         :return: execution result
         """
         if compose:
-            Optimizer(graph, self._engine).optimize(keys=keys)
+            RuntimeOptimizer(graph, self._engine).optimize(keys=keys)
         optimized_graph = graph
 
         if not mock:

--- a/mars/graph.pyx
+++ b/mars/graph.pyx
@@ -289,6 +289,14 @@ cdef class DirectedGraph:
                 graph._add_edge(n, succ)
         return graph
 
+    def copyto(self, DirectedGraph other_graph):
+        if other_graph is self:
+            return
+
+        other_graph._nodes = self._nodes.copy()
+        other_graph._predecessors = self._predecessors.copy()
+        other_graph._successors = self._successors.copy()
+
     def build_undirected(self):
         cdef DirectedGraph graph = DirectedGraph()
         for n in self:
@@ -464,12 +472,22 @@ cdef class DirectedGraph:
         g = Source(self.to_dot(graph_attrs, node_attrs, result_chunk_keys=result_chunk_keys))
         g.view(filename=filename, cleanup=True)
 
+    def to_dag(self):
+        dag = DAG()
+        dag._nodes = self._nodes.copy()
+        dag._predecessors = self._predecessors.copy()
+        dag._successors = self._successors.copy()
+        return dag
+
 
 class GraphContainsCycleError(Exception):
     pass
 
 
 cdef class DAG(DirectedGraph):
+    def to_dag(self):
+        return self
+
     def topological_iter(self, succ_checker=None, reverse=False):
         cdef:
             dict preds, succs

--- a/mars/optimizes/runtime/optimizers/cp.py
+++ b/mars/optimizes/runtime/optimizers/cp.py
@@ -30,9 +30,13 @@ CP_ELEMENTWISE_OP = {
 CP_OP = CP_ELEMENTWISE_OP
 
 
-class CpOptimizer(object):
+class CpRuntimeOptimizer:
     def __init__(self, graph):
         self._graph = graph
+
+    @classmethod
+    def is_available(cls):
+        return CP_INSTALLED
 
     def optimize(self, keys=None):
         self.compose(keys=keys)

--- a/mars/optimizes/runtime/optimizers/dataframe.py
+++ b/mars/optimizes/runtime/optimizers/dataframe.py
@@ -1,0 +1,95 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class DataFrameRuntimeOptimizeRule:
+    @staticmethod
+    def match(chunk, graph, keys):
+        return False
+
+    @staticmethod
+    def apply(chunk, graph, keys):
+        pass
+
+
+class DataFrameRuntimeOptimizer:
+    _rules = []
+
+    def __init__(self, graph):
+        self._graph = graph
+
+    @staticmethod
+    def register_rule(rule):
+        DataFrameRuntimeOptimizer._rules.append(rule)
+
+    @classmethod
+    def is_available(cls):
+        return True
+
+    def optimize(self, keys=None):
+        visited = set()
+        for c in list(self._graph.topological_iter()):
+            if c in visited:
+                continue
+            visited.add(c)
+            for rule in self._rules:
+                if rule.match(c, self._graph, keys):
+                    rule.apply(c, self._graph, keys)
+
+
+class ReadCSVHeadRule(DataFrameRuntimeOptimizeRule):
+    @staticmethod
+    def match(chunk, graph, keys):
+        from ....dataframe.indexing.iloc import DataFrameIlocGetItem
+        from ....dataframe.datasource.read_csv import DataFrameReadCSV
+
+        op = chunk.op
+        inputs = graph.predecessors(chunk)
+        if len(inputs) == 1 and isinstance(op, DataFrameIlocGetItem) and \
+                op.is_head() and isinstance(inputs[0].op, DataFrameReadCSV) and \
+                inputs[0].key not in keys:
+            return True
+        return False
+
+    @staticmethod
+    def apply(chunk, graph, keys):
+        read_csv_chunk = graph.predecessors(chunk)[0]
+        nrows = read_csv_chunk.op.nrows or 0
+        head = chunk.op.indexes[0].stop
+        # delete read_csv from graph
+        graph.remove_node(read_csv_chunk)
+
+        head_read_csv_chunk_op = read_csv_chunk.op.copy().reset_key()
+        head_read_csv_chunk_op._nrows = max(nrows, head)
+        head_read_csv_chunk_params = read_csv_chunk.params
+        head_read_csv_chunk_params['_key'] = chunk.key
+        head_read_csv_chunk = head_read_csv_chunk_op.new_chunk(
+            read_csv_chunk.inputs, kws=[head_read_csv_chunk_params]).data
+        graph.add_node(head_read_csv_chunk)
+
+        for succ in list(graph.iter_successors(chunk)):
+            succ_inputs = succ.inputs
+            new_succ_inputs = []
+            for succ_input in succ_inputs:
+                if succ_input is chunk:
+                    new_succ_inputs.append(head_read_csv_chunk)
+                else:
+                    new_succ_inputs.append(succ_input)
+            succ.inputs = new_succ_inputs
+            graph.add_edge(head_read_csv_chunk, succ)
+
+        graph.remove_node(chunk)
+
+
+DataFrameRuntimeOptimizer.register_rule(ReadCSVHeadRule)

--- a/mars/optimizes/runtime/optimizers/ne.py
+++ b/mars/optimizes/runtime/optimizers/ne.py
@@ -17,6 +17,7 @@
 from ....tensor import arithmetic
 from ....tensor import reduction
 from ....tensor.fuse import TensorNeFuseChunk
+from ....tensor.fuse.ne import NUMEXPR_INSTALLED
 
 REDUCTION_OP = {reduction.TensorSum, reduction.TensorProd,
                 reduction.TensorMax, reduction.TensorMin}
@@ -88,9 +89,13 @@ def _transfer_op(node):
     return op
 
 
-class NeOptimizer(object):
+class NeRuntimeOptimizer:
     def __init__(self, graph):
         self._graph = graph
+
+    @classmethod
+    def is_available(cls):
+        return NUMEXPR_INSTALLED
 
     def optimize(self, keys=None):
         self.compose(keys=keys)

--- a/mars/optimizes/runtime/optimizers/tests/test_compose.py
+++ b/mars/optimizes/runtime/optimizers/tests/test_compose.py
@@ -20,7 +20,7 @@ from mars.executor import Executor
 from mars.tensor.arithmetic import TensorTreeAdd
 from mars.tensor.indexing import TensorSlice
 from mars.graph import DirectedGraph
-from mars.optimizes.runtime.optimizers.ne import NeOptimizer
+from mars.optimizes.runtime.optimizers.ne import NeRuntimeOptimizer
 
 
 class Test(unittest.TestCase):
@@ -82,14 +82,14 @@ class Test(unittest.TestCase):
         self.assertIn(composed_nodes[0], graph.successors(chunks[0]))
         self.assertIn(composed_nodes[0], graph.successors(chunks[1]))
         # check composed's inputs
-        self.assertIn(chunks[0].key, [n.key for n in composed_nodes[0].inputs])
-        self.assertIn(chunks[1].key, [n.key for n in composed_nodes[0].inputs])
+        self.assertIn(chunks[0].data, composed_nodes[0].inputs)
+        self.assertIn(chunks[1].data, composed_nodes[0].inputs)
         # check composed's predecessors
         self.assertIn(chunks[0], graph.predecessors(composed_nodes[0]))
         self.assertIn(chunks[1], graph.predecessors(composed_nodes[0]))
         # check 4 and 5's inputs
-        self.assertIn(composed_nodes[0].key, [n.key for n in graph.successors(composed_nodes[0])[0].inputs])
-        self.assertIn(composed_nodes[0].key, [n.key for n in graph.successors(composed_nodes[0])[0].inputs])
+        self.assertIn(composed_nodes[0].data, graph.successors(composed_nodes[0])[0].inputs)
+        self.assertIn(composed_nodes[0].data, graph.successors(composed_nodes[0])[0].inputs)
         # check 4 and 5's predecessors
         self.assertIn(composed_nodes[0], graph.predecessors(chunks[4]))
         self.assertIn(composed_nodes[0], graph.predecessors(chunks[5]))
@@ -118,7 +118,7 @@ class Test(unittest.TestCase):
         graph.add_edge(chunks[3], chunk_slice)
         graph.add_edge(chunk_slice, chunks[4])
         graph.add_edge(chunk_slice, chunks[5])
-        optimizer = NeOptimizer(graph)
+        optimizer = NeRuntimeOptimizer(graph)
         composed_nodes = optimizer.compose()
         self.assertTrue(composed_nodes[0].composed == chunks[2:4])
 
@@ -136,7 +136,7 @@ class Test(unittest.TestCase):
         graph.add_edge(chunks[0], chunks[1])
         graph.add_edge(chunks[1], chunk_slice)
         graph.add_edge(chunk_slice, chunks[2])
-        optimizer = NeOptimizer(graph)
+        optimizer = NeRuntimeOptimizer(graph)
         composed_nodes = optimizer.compose()
         self.assertTrue(composed_nodes[0].composed == chunks[:2])
         self.assertTrue(len(composed_nodes) == 1)
@@ -156,7 +156,7 @@ class Test(unittest.TestCase):
         graph.add_edge(chunks[1], chunk_slice)
         graph.add_edge(chunk_slice, chunks[2])
         graph.add_edge(chunks[2], chunks[3])
-        optimizer = NeOptimizer(graph)
+        optimizer = NeRuntimeOptimizer(graph)
         composed_nodes = optimizer.compose()
         self.assertTrue(composed_nodes[0].composed == chunks[:2])
         self.assertTrue(composed_nodes[1].composed == chunks[2:4])

--- a/mars/tensor/base/partition.py
+++ b/mars/tensor/base/partition.py
@@ -387,7 +387,7 @@ class CalcPartitionsInfo(TensorOperand, TensorPSRSOperandMixin):
 
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
-        if isinstance(self._kth, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
+        if isinstance(self._kth, (Base, Entity)):
             self._kth = self._inputs[0]
 
     @classmethod

--- a/mars/tensor/fuse/tests/test_cupy_execute.py
+++ b/mars/tensor/fuse/tests/test_cupy_execute.py
@@ -20,7 +20,7 @@ from mars.executor import Executor
 from mars.tensor.fuse.cp import _evaluate
 from mars.tensor.datasource import ones
 from mars.tensor import sqrt
-from mars.optimizes.runtime.optimizers.core import Optimizer
+from mars.optimizes.runtime.optimizers.core import RuntimeOptimizer
 
 
 class Test(unittest.TestCase):
@@ -33,7 +33,7 @@ class Test(unittest.TestCase):
         t = (t1 - t2) / sqrt(t2 * (1 - t2) * len(t2))
 
         g = t.build_graph(tiled=True)
-        Optimizer(g, self.executor._engine).optimize([])
+        RuntimeOptimizer(g, self.executor._engine).optimize([], False)
         self.assertTrue(any(n.op.__class__.__name__ == 'TensorCpFuseChunk' for n in g))
 
         c = next(n for n in g if n.op.__class__.__name__ == 'TensorCpFuseChunk')

--- a/mars/tensor/indexing/index_lib.py
+++ b/mars/tensor/indexing/index_lib.py
@@ -158,6 +158,8 @@ class IndexHandlerContext(ABC):
         params = out.params
         params['chunks'] = self.out_chunks
         params['nsplits'] = self.out_nsplits
+        if 'shape' in params and any(np.isnan(s) for s in params['shape']):
+            params['shape'] = tuple(sum(ns) for ns in self.out_nsplits)
         new_op = out.op.copy()
         return new_op.new_tileable(out.inputs, kws=[params])
 

--- a/mars/tensor/statistics/histogram.py
+++ b/mars/tensor/statistics/histogram.py
@@ -43,7 +43,7 @@ def _ptp(range_):
     return _unsigned_subtract(*range_[::-1])
 
 
-class HistBinSelector(object):
+class HistBinSelector:
     def __init__(self, histogram_bin_edges_op, x, range, raw_range):
         self._op = histogram_bin_edges_op
         self._x = x

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -22,6 +22,7 @@ import textwrap
 import time
 import unittest
 from functools import partial
+from io import BytesIO
 from enum import Enum
 
 import numpy as np
@@ -357,3 +358,21 @@ class Test(unittest.TestCase):
             pass
 
         self.assertIsNone(should_not_exist_np)
+
+    def testFixedSizeFileObject(self):
+        arr = [str(i).encode() * 20 for i in range(10)]
+        bts = os.linesep.encode().join(arr)
+        bio = BytesIO(bts)
+
+        ref_bio = BytesIO(bio.read(100))
+        bio.seek(0)
+        ref_bio.seek(0)
+        fix_bio = utils.FixedSizeFileObject(bio, 100)
+
+        self.assertEqual(ref_bio.readline(), fix_bio.readline())
+        self.assertEqual(ref_bio.tell(), fix_bio.tell())
+        pos = ref_bio.tell() + 10
+        self.assertEqual(ref_bio.seek(pos), fix_bio.seek(pos))
+        self.assertEqual(ref_bio.read(5), fix_bio.read(5))
+        self.assertEqual(ref_bio.readlines(25), fix_bio.readlines(25))
+        self.assertEqual(list(ref_bio), list(fix_bio))

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,6 @@ else:
 cy_extension_kw['include_dirs'] = [np.get_include()]
 cy_extensions = [
     Extension('mars.graph', ['mars/graph.pyx'], **cy_extension_kw),
-    Extension('mars.optimizes.chunk_graph.fuse', ['mars/optimizes/chunk_graph/fuse.pyx'], **cy_extension_kw),
     Extension('mars._utils', ['mars/_utils.pyx'], **cy_extension_kw),
     Extension('mars.lib.gipc', ['mars/lib/gipc.pyx'], **cy_extension_kw),
     Extension('mars.actors.core', ['mars/actors/core.pyx'], **cy_extension_kw),


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

### Motivation

Before this PR, if DataFrame has unknown chunk shape, for instance, DataFrame created from `md.read_csv()`, `df.head()` will trigger iterative tiling, thus the entire data will be read, then get the head data, it's a huge waste, and may cause bad experience.

This PR tries to address the problem. The main point is that for this sort of `head`, try to fetch head data of each chunk, and do tree reduction to get the final head. The runtime optimization is used as well, the iloc[:n] will be `nrows`  for `read_csv`.

I did some tests on my laptop, the input csv file is around 700M.

### Result

#### Threaded

|   | Master | This PR |
| ------------- | ------------- | ------------- |
| Memory Usage | 2548.06M  | 67.62M |
| Time  | 1.71s | 0.51s |

Detail code:

This PR:

```
In [1]: import mars.dataframe as md                                             

In [2]: df = md.read_csv('ratings.csv')                                         

In [3]: import ipython_memory_usage                                             

In [4]: %ipython_memory_usage_start                                             
Out[4]: 'memory profile enabled'
In [4] used 0.2461 MiB RAM in 3.41s, peaked 0.00 MiB above current, total RAM usage 118.12 MiB

In [5]: %time df.head(5).execute()                                              
CPU times: user 405 ms, sys: 95 ms, total: 500 ms
Wall time: 508 ms
Out[5]: 
   userId  movieId  rating   timestamp
0       1      110     1.0  1425941529
1       1      147     4.5  1425942435
2       1      858     5.0  1425941523
3       1     1221     5.0  1425941546
4       1     1246     5.0  1425941556
In [5] used 67.6172 MiB RAM in 0.62s, peaked 0.00 MiB above current, total RAM usage 185.99 MiB
```

Master:

```
In [1]: import mars.dataframe as md                                             

In [2]: df = md.read_csv('ratings.csv')                                         

In [3]: import ipython_memory_usage                                             

In [4]: %ipython_memory_usage_start                                             
Out[4]: 'memory profile enabled'
In [4] used 0.3516 MiB RAM in 9.11s, peaked 0.00 MiB above current, total RAM usage 132.46 MiB

In [5]: %time df.head(5).execute()                                              
CPU times: user 9.28 s, sys: 5.5 s, total: 14.8 s
Wall time: 1.71 s
Out[5]: 
   userId  movieId  rating   timestamp
0       1      110     1.0  1425941529
1       1      147     4.5  1425942435
2       1      858     5.0  1425941523
3       1     1221     5.0  1425941546
4       1     1246     5.0  1425941556
In [5] used 2548.0586 MiB RAM in 1.82s, peaked 0.01 MiB above current, total RAM usage 2664.92 MiB
```

#### Local Cluster

|   | Master | This PR |
| ------------- | ------------- | ------------- |
| Memory Usage | not test  | not test |
| Time  | 1.56 s | 0.34s |

### Limitation

For now, the optimization will only work for `head` or `tail` on data source, the optimization will fail for like `md.read_csv()['a', 'b'].head()`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1261 .
