### PR TITLE
Implements `mars.learn.model_selection.train_test_split`

### DIFF
--- a/docs/source/reference/dataframe/api/mars.dataframe.Series.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.Series.rst
@@ -91,6 +91,7 @@ mars.dataframe.Series
       ~Series.tiles
       ~Series.to_cpu
       ~Series.to_csv
+      ~Series.to_frame
       ~Series.to_gpu
       ~Series.to_pandas
       ~Series.to_sql

--- a/docs/source/reference/learn/generated/mars.learn.model_selection.train_test_split.rst
+++ b/docs/source/reference/learn/generated/mars.learn.model_selection.train_test_split.rst
@@ -1,0 +1,6 @@
+mars.learn.model\_selection.train\_test\_split
+==============================================
+
+.. currentmodule:: mars.learn.model_selection
+
+.. autofunction:: train_test_split

--- a/docs/source/reference/learn/reference.rst
+++ b/docs/source/reference/learn/reference.rst
@@ -91,6 +91,16 @@ Pairwise metrics
    metrics.pairwise.rbf_kernel
    metrics.pairwise_distances
 
+Splitter Functions
+------------------
+
+.. currentmodule:: mars.learn
+
+.. autosummary::
+   :toctree: generated/
+
+   model_selection.train_test_split
+
 .. _neighbors_ref:
 
 Nearest Neighbors

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -27,7 +27,7 @@ from ...utils import check_chunks_unknown_shape
 from ...tiles import TilesError
 from ..align import align_dataframe_series, align_dataframe_dataframe
 from ..core import SERIES_TYPE, SERIES_CHUNK_TYPE, DATAFRAME_TYPE, \
-    DATAFRAME_CHUNK_TYPE, TILEABLE_TYPE, CHUNK_TYPE, IndexValue
+    DATAFRAME_CHUNK_TYPE, TILEABLE_TYPE, CHUNK_TYPE
 from ..merge import DataFrameConcat
 from ..operands import DataFrameOperand, DataFrameOperandMixin, ObjectType
 from ..utils import parse_index, in_range_index
@@ -402,9 +402,7 @@ def dataframe_getitem(df, item):
 
     if isinstance(item, slice):
         edge = item.start if item.start is not None else item.stop
-        if isinstance(edge, Integral) and not \
-                isinstance(df.index_value, (IndexValue.RangeIndex, IndexValue.Int64Index,
-                                            IndexValue.UInt64Index)):
+        if isinstance(edge, Integral):
             return df.iloc[item]
         else:
             return df.loc[item]

--- a/mars/learn/model_selection/__init__.py
+++ b/mars/learn/model_selection/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._split import train_test_split

--- a/mars/learn/model_selection/_split.py
+++ b/mars/learn/model_selection/_split.py
@@ -1,0 +1,210 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from itertools import chain
+from math import ceil, floor
+
+import numpy as np
+
+from ...core import ExecutableTuple
+from ..utils import shuffle as shuffle_arrays
+from ..utils.validation import indexable, _num_samples
+
+
+def train_test_split(*arrays, **options):
+    """Split arrays or matrices into random train and test subsets
+
+    Parameters
+    ----------
+    *arrays : sequence of indexables with same length / shape[0]
+        Allowed inputs are lists, numpy arrays, scipy-sparse
+        matrices or pandas dataframes.
+
+    test_size : float, int or None, optional (default=None)
+        If float, should be between 0.0 and 1.0 and represent the proportion
+        of the dataset to include in the test split. If int, represents the
+        absolute number of test samples. If None, the value is set to the
+        complement of the train size. If ``train_size`` is also None, it will
+        be set to 0.25.
+
+    train_size : float, int, or None, (default=None)
+        If float, should be between 0.0 and 1.0 and represent the
+        proportion of the dataset to include in the train split. If
+        int, represents the absolute number of train samples. If None,
+        the value is automatically set to the complement of the test size.
+
+    random_state : int, RandomState instance or None, optional (default=None)
+        If int, random_state is the seed used by the random number generator;
+        If RandomState instance, random_state is the random number generator;
+        If None, the random number generator is the RandomState instance used
+        by `np.random`.
+
+    shuffle : boolean, optional (default=True)
+        Whether or not to shuffle the data before splitting. If shuffle=False
+        then stratify must be None.
+
+    stratify : array-like or None (default=None)
+        If not None, data is split in a stratified fashion, using this as
+        the class labels.
+
+    Returns
+    -------
+    splitting : list, length=2 * len(arrays)
+        List containing train-test split of inputs.
+
+    Examples
+    --------
+    >>> import mars.tensor as mt
+    >>> from mars.learn.model_selection import train_test_split
+    >>> X, y = mt.arange(10).reshape((5, 2)), range(5)
+    >>> X.execute()
+    array([[0, 1],
+           [2, 3],
+           [4, 5],
+           [6, 7],
+           [8, 9]])
+    >>> list(y)
+    [0, 1, 2, 3, 4]
+
+    >>> X_train, X_test, y_train, y_test = train_test_split(
+    ...     X, y, test_size=0.33, random_state=42)
+    ...
+    >>> X_train.execute()
+    array([[8, 9],
+           [0, 1],
+           [4, 5]])
+    >>> y_train.execute()
+    array([4, 0, 2])
+    >>> X_test.execute()
+    array([[2, 3],
+           [6, 7]])
+    >>> y_test.execute()
+    array([1, 3])
+
+    >>> train_test_split(y, shuffle=False)
+    [array([0, 1, 2]), array([3, 4])]
+
+    """
+
+    n_arrays = len(arrays)
+    if n_arrays == 0:
+        raise ValueError("At least one array required as input")
+    test_size = options.pop('test_size', None)
+    train_size = options.pop('train_size', None)
+    random_state = options.pop('random_state', None)
+    stratify = options.pop('stratify', None)
+    shuffle = options.pop('shuffle', True)
+    session = options.pop('session', None)
+    run_kwargs = options.pop('run_kwargs', None)
+
+    if options:
+        raise TypeError("Invalid parameters passed: %s" % str(options))
+
+    arrays = indexable(*arrays, session=session, run_kwargs=run_kwargs)
+
+    n_samples = _num_samples(arrays[0])
+    n_train, n_test = _validate_shuffle_split(n_samples, test_size, train_size,
+                                              default_test_size=0.25)
+
+    if shuffle is False:
+        if stratify is not None:  # pragma: no cover
+            raise ValueError(
+                "Stratified train/test split is not implemented for "
+                "shuffle=False")
+
+        iterables = ((a[:n_train], a[n_train: n_train + n_test])
+                     for a in arrays)
+    else:
+        if stratify is not None:  # pragma: no cover
+            raise NotImplementedError('stratify is not implemented yet')
+        else:
+            shuffled_arrays = shuffle_arrays(
+                *arrays, random_state=random_state)
+            if not isinstance(shuffled_arrays, tuple):
+                shuffled_arrays = (shuffled_arrays,)
+            iterables = ((a[:n_train], a[n_train: n_train + n_test])
+                         for a in shuffled_arrays)
+
+    return list(ExecutableTuple(chain.from_iterable(iterables)).execute(
+        session=session, **(run_kwargs or dict())))
+
+
+def _validate_shuffle_split(n_samples, test_size, train_size,
+                            default_test_size=None):
+    """
+    Validation helper to check if the test/test sizes are meaningful wrt to the
+    size of the data (n_samples)
+    """
+    if test_size is None and train_size is None:
+        test_size = default_test_size
+
+    test_size_type = np.asarray(test_size).dtype.kind
+    train_size_type = np.asarray(train_size).dtype.kind
+
+    if (test_size_type == 'i' and (test_size >= n_samples or test_size <= 0)
+            or test_size_type == 'f' and (test_size <= 0 or test_size >= 1)):
+        raise ValueError('test_size={0} should be either positive and smaller'
+                         ' than the number of samples {1} or a float in the '
+                         '(0, 1) range'.format(test_size, n_samples))
+
+    if (train_size_type == 'i' and (train_size >= n_samples or train_size <= 0)
+            or train_size_type == 'f' and (train_size <= 0 or train_size >= 1)):
+        raise ValueError('train_size={0} should be either positive and smaller'
+                         ' than the number of samples {1} or a float in the '
+                         '(0, 1) range'.format(train_size, n_samples))
+
+    if train_size is not None and train_size_type not in ('i', 'f'):  # pragma: no cover
+        raise ValueError("Invalid value for train_size: {}".format(train_size))
+    if test_size is not None and test_size_type not in ('i', 'f'):
+        raise ValueError("Invalid value for test_size: {}".format(test_size))
+
+    if (train_size_type == 'f' and test_size_type == 'f' and
+            train_size + test_size > 1):
+        raise ValueError(
+            'The sum of test_size and train_size = {}, should be in the (0, 1)'
+            ' range. Reduce test_size and/or train_size.'
+                .format(train_size + test_size))
+
+    if test_size_type == 'f':
+        n_test = ceil(test_size * n_samples)
+    elif test_size_type == 'i':
+        n_test = float(test_size)
+
+    if train_size_type == 'f':
+        n_train = floor(train_size * n_samples)
+    elif train_size_type == 'i':  # pragma: no cover
+        n_train = float(train_size)
+
+    if train_size is None:
+        n_train = n_samples - n_test
+    elif test_size is None:
+        n_test = n_samples - n_train
+
+    if n_train + n_test > n_samples:  # pragma: no cover
+        raise ValueError('The sum of train_size and test_size = %d, '
+                         'should be smaller than the number of '
+                         'samples %d. Reduce test_size and/or '
+                         'train_size.' % (n_train + n_test, n_samples))
+
+    n_train, n_test = int(n_train), int(n_test)
+
+    if n_train == 0:  # pragma: no cover
+        raise ValueError(
+            'With n_samples={}, test_size={} and train_size={}, the '
+            'resulting train set will be empty. Adjust any of the '
+            'aforementioned parameters.'.format(n_samples, test_size,
+                                                train_size)
+        )
+
+    return n_train, n_test

--- a/mars/learn/model_selection/tests/__init__.py
+++ b/mars/learn/model_selection/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mars/learn/model_selection/tests/test_split.py
+++ b/mars/learn/model_selection/tests/test_split.py
@@ -1,0 +1,161 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import pandas as pd
+import pytest
+try:
+    import scipy.sparse as sps
+except ImportError:  # pragma: no cover
+    sps = None
+
+from mars import dataframe as md
+from mars import tensor as mt
+from mars.dataframe.core import DATAFRAME_TYPE
+from mars.learn.model_selection import train_test_split
+from mars.lib.sparse import SparseNDArray
+from mars.tests.core import TestBase
+
+
+class Test(TestBase):
+    def setUp(self) -> None:
+        self.ctx, self.executor = self._create_test_context()
+        self.ctx.__enter__()
+
+    def tearDown(self) -> None:
+        self.ctx.__exit__(None, None, None)
+
+    def testTrainTestSplitErrors(self):
+        self.assertRaises(ValueError, train_test_split)
+
+        self.assertRaises(ValueError, train_test_split, range(3), train_size=1.1)
+
+        self.assertRaises(ValueError, train_test_split, range(3), test_size=0.6,
+                          train_size=0.6)
+        self.assertRaises(ValueError, train_test_split, range(3),
+                          test_size=np.float32(0.6), train_size=np.float32(0.6))
+        self.assertRaises(ValueError, train_test_split, range(3),
+                          test_size="wrong_type")
+        self.assertRaises(ValueError, train_test_split, range(3), test_size=2,
+                          train_size=4)
+        self.assertRaises(TypeError, train_test_split, range(3),
+                          some_argument=1.1)
+        self.assertRaises(ValueError, train_test_split, range(3), range(42))
+        self.assertRaises(ValueError, train_test_split, range(10),
+                          shuffle=False, stratify=True)
+
+        with pytest.raises(ValueError,
+                           match=r'train_size=11 should be either positive and '
+                                 r'smaller than the number of samples 10 or a '
+                                 r'float in the \(0, 1\) range'):
+            train_test_split(range(10), train_size=11, test_size=1)
+
+    def testTrainTestSplitInvalidSizes1(self):
+        for train_size, test_size in [
+                (1.2, 0.8),
+                (1., 0.8),
+                (0.0, 0.8),
+                (-.2, 0.8),
+                (0.8, 1.2),
+                (0.8, 1.),
+                (0.8, 0.),
+                (0.8, -.2)]:
+            with pytest.raises(ValueError,
+                               match=r'should be .* in the \(0, 1\) range'):
+                train_test_split(range(10), train_size=train_size, test_size=test_size)
+
+    def testTrainTestSplitInvalidSizes2(self):
+        for train_size, test_size in [
+                (-10, 0.8),
+                (0, 0.8),
+                (11, 0.8),
+                (0.8, -10),
+                (0.8, 0),
+                (0.8, 11)]:
+            with pytest.raises(ValueError,
+                               match=r'should be .* in the \(0, 1\) range'):
+                train_test_split(range(10), train_size=train_size, test_size=test_size)
+
+    def testTrainTestSplit(self):
+        X = np.arange(100).reshape((10, 10))
+        y = np.arange(10)
+
+        # simple test
+        split = train_test_split(X, y, test_size=None, train_size=.5)
+        X_train, X_test, y_train, y_test = split
+        assert len(y_test) == len(y_train)
+        # test correspondence of X and y
+        np.testing.assert_array_equal(X_train[:, 0], y_train * 10)
+        np.testing.assert_array_equal(X_test[:, 0], y_test * 10)
+
+        # allow nd-arrays
+        X_4d = np.arange(10 * 5 * 3 * 2).reshape(10, 5, 3, 2)
+        y_3d = np.arange(10 * 7 * 11).reshape(10, 7, 11)
+        split = train_test_split(X_4d, y_3d)
+        assert split[0].shape == (7, 5, 3, 2)
+        assert split[1].shape == (3, 5, 3, 2)
+        assert split[2].shape == (7, 7, 11)
+        assert split[3].shape == (3, 7, 11)
+
+        # test unshuffled split
+        y = np.arange(10)
+        for test_size in [2, 0.2]:
+            train, test = train_test_split(y, shuffle=False, test_size=test_size)
+            np.testing.assert_array_equal(test, [8, 9])
+            np.testing.assert_array_equal(train, [0, 1, 2, 3, 4, 5, 6, 7])
+
+    def testTrainTestSplitDataFrame(self):
+        X = np.ones(10)
+        types = [pd.DataFrame, md.DataFrame]
+        for InputFeatureType in types:
+            # X dataframe
+            X_df = InputFeatureType(X)
+            X_train, X_test = train_test_split(X_df)
+            assert isinstance(X_train, DATAFRAME_TYPE)
+            assert isinstance(X_test, DATAFRAME_TYPE)
+
+    @unittest.skipIf(sps is None, 'scipy not installed')
+    def testTrainTestSplitSparse(self):
+        # check that train_test_split converts scipy sparse matrices
+        # to csr, as stated in the documentation
+        X = np.arange(100).reshape((10, 10))
+        sparse_types = [sps.csr_matrix, sps.csc_matrix, sps.coo_matrix]
+        for InputFeatureType in sparse_types:
+            X_s = InputFeatureType(X)
+            for x in (X_s, mt.tensor(X_s, chunk_size=(2, 5))):
+                X_train, X_test = train_test_split(x)
+                assert isinstance(X_train.fetch(), SparseNDArray)
+                assert isinstance(X_test.fetch(), SparseNDArray)
+
+    def testTrainTestplitListInput(self):
+        # Check that when y is a list / list of string labels, it works.
+        X = np.ones(7)
+        y1 = ['1'] * 4 + ['0'] * 3
+        y2 = np.hstack((np.ones(4), np.zeros(3)))
+        y3 = y2.tolist()
+
+        for stratify in (False,):
+            X_train1, X_test1, y_train1, y_test1 = train_test_split(
+                X, y1, stratify=y1 if stratify else None, random_state=0)
+            X_train2, X_test2, y_train2, y_test2 = train_test_split(
+                X, y2, stratify=y2 if stratify else None, random_state=0)
+            X_train3, X_test3, y_train3, y_test3 = train_test_split(
+                X, y3, stratify=y3 if stratify else None, random_state=0)
+
+            np.testing.assert_equal(X_train1, X_train2)
+            np.testing.assert_equal(y_train2, y_train3)
+            np.testing.assert_equal(X_test1, X_test3)
+            np.testing.assert_equal(y_test3, y_test2)

--- a/mars/lib/sparse/array.py
+++ b/mars/lib/sparse/array.py
@@ -1084,9 +1084,6 @@ class SparseArray(SparseNDArray):
         if isinstance(item, list):
             item = tuple(item)
 
-        if not all(isinstance(i, slice) for i in item):
-            raise NotImplementedError('sparse matrix only support slice for indexing')
-
         x = self.spmatrix[item]
         if issparse(x):
             return SparseNDArray(x, shape=self.shape)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Thit PR implements `mars.learn.model_selection.train_test_split`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1188 .
