### PR TITLE
Fix read_sql when no data selected & refine error when no worker attached

### DIFF
--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -505,6 +505,11 @@ class Test(TestBase):
             result = self.executor.execute_dataframe(r, concat=True)[0]
             pd.testing.assert_frame_equal(result, test_df[test_df.b > 's5'].set_index('d'))
 
+            # test SQL that return no result
+            r = md.read_sql_query('select * from test where a > 1000', uri)
+            result = self.executor.execute_dataframe(r, concat=True)[0]
+            pd.testing.assert_frame_equal(result, pd.DataFrame(columns=test_df.columns))
+
             engine = sa.create_engine(uri)
             m = sa.MetaData()
             try:

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -753,6 +753,9 @@ class GraphActor(SchedulerActor):
                 operand_infos[k]['optimize']['successor_size'] = succ_size
 
         worker_slots = self._get_worker_slots()
+        if not worker_slots:
+            raise RuntimeError('No worker attached for execution')
+
         self._assigned_workers = set(worker_slots)
         analyzer = GraphAnalyzer(chunk_graph, worker_slots)
 

--- a/mars/scheduler/tests/test_graph.py
+++ b/mars/scheduler/tests/test_graph.py
@@ -27,6 +27,8 @@ from mars.tests.core import patch_method, create_actor_pool
 
 
 @patch_method(ResourceActor._broadcast_sessions)
+@patch_method(GraphActor._get_worker_slots,
+              new=lambda *_: {'localhost:12345': 1, 'localhost:23456': 1})
 class Test(unittest.TestCase):
     @contextlib.contextmanager
     def prepare_graph_in_pool(self, expr, clean_io_meta=True, compose=False):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes `md.read_sql` when no data is selected, error is refined as well when no worker attached.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1368 .
