### PR TITLE
Optimize `read_sql` + `head`

### DIFF
--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -273,7 +273,7 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
 
 
 def read_csv(path, names=None, sep=',', index_col=None, compression=None, header='infer',
-             dtype=None, usecols=None, chunk_bytes='64M', gpu=None, head_bytes='100k',
+             dtype=None, usecols=None, nrows=None, chunk_bytes='64M', gpu=None, head_bytes='100k',
              head_lines=None, incremental_index=False, storage_options=None, **kwargs):
     r"""
     Read a comma-separated values (csv) file into DataFrame.
@@ -579,5 +579,8 @@ def read_csv(path, names=None, sep=',', index_col=None, compression=None, header
                           incremental_index=incremental_index, storage_options=storage_options,
                           **kwargs)
     chunk_bytes = chunk_bytes or options.chunk_store_limit
-    return op(index_value=index_value, columns_value=columns_value,
-              dtypes=mini_df.dtypes, chunk_bytes=chunk_bytes)
+    ret = op(index_value=index_value, columns_value=columns_value,
+             dtypes=mini_df.dtypes, chunk_bytes=chunk_bytes)
+    if nrows is not None:
+        return ret.head(nrows)
+    return ret

--- a/mars/dataframe/datasource/read_sql.py
+++ b/mars/dataframe/datasource/read_sql.py
@@ -56,13 +56,14 @@ class DataFrameReadSQL(DataFrameOperand, DataFrameOperandMixin):
     _high_limit = AnyField('high_limit')
     _left_end = BoolField('left_end')
     _right_end = BoolField('right_end')
+    _nrows = Int64Field('nrows')
 
     def __init__(self, table_or_sql=None, selectable=None, con=None, schema=None,
                  index_col=None, coerce_float=None, parse_dates=None, columns=None,
                  engine_kwargs=None, row_memory_usage=None, method=None,
                  incremental_index=None, offset=None, partition_col=None,
                  num_partitions=None, low_limit=None, high_limit=None, left_end=None,
-                 right_end=None, output_types=None, gpu=None, **kw):
+                 right_end=None, nrows=None, output_types=None, gpu=None, **kw):
         super().__init__(_table_or_sql=table_or_sql, _selectable=selectable, _con=con,
                          _schema=schema, _index_col=index_col, _coerce_float=coerce_float,
                          _parse_dates=parse_dates, _columns=columns,
@@ -70,7 +71,8 @@ class DataFrameReadSQL(DataFrameOperand, DataFrameOperandMixin):
                          _method=method, _incremental_index=incremental_index, _offset=offset,
                          _partition_col=partition_col, _num_partitions=num_partitions,
                          _low_limit=low_limit, _left_end=left_end, _right_end=right_end,
-                         _high_limit=high_limit, _output_types=output_types, _gpu=gpu, **kw)
+                         _high_limit=high_limit, _nrows=nrows, _output_types=output_types,
+                         _gpu=gpu, **kw)
         if not self.output_types:
             self._output_types = [OutputType.dataframe]
 
@@ -149,6 +151,10 @@ class DataFrameReadSQL(DataFrameOperand, DataFrameOperandMixin):
     @property
     def right_end(self):
         return self._right_end
+
+    @property
+    def nrows(self):
+        return self._nrows
 
     def _get_selectable(self, engine_or_conn, columns=None):
         import sqlalchemy as sa
@@ -435,11 +441,17 @@ class DataFrameReadSQL(DataFrameOperand, DataFrameOperandMixin):
                 if op.offset > 0:
                     query = query.offset(op.offset)
 
+            if op.nrows is not None:
+                query = query.limit(op.nrows)
+
             df = pd.read_sql(query, engine, index_col=op.index_col,
                              coerce_float=op.coerce_float,
                              parse_dates=op.parse_dates)
             if op.method == 'offset' and op.index_col is None and op.offset > 0:
-                df.index = pd.RangeIndex(op.offset, op.offset + out.shape[0])
+                index = pd.RangeIndex(op.offset, op.offset + out.shape[0])
+                if op.nrows is not None:
+                    index = index[:op.nrows]
+                df.index = index
             ctx[out.key] = df
         finally:
             engine.dispose()

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -273,7 +273,7 @@ class Test(TestBase):
         tempdir = tempfile.mkdtemp()
         file_path = os.path.join(tempdir, 'test.csv')
         try:
-            df = pd.DataFrame(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), columns=['a', 'b', 'c'])
+            df = pd.DataFrame(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.int64), columns=['a', 'b', 'c'])
             df.to_csv(file_path)
 
             pdf = pd.read_csv(file_path, index_col=0)
@@ -284,6 +284,8 @@ class Test(TestBase):
                                                    concat=True)[0]
             pd.testing.assert_frame_equal(pdf, mdf2)
 
+            mdf = self.executor.execute_dataframe(md.read_csv(file_path, index_col=0, nrows=1), concat=True)[0]
+            pd.testing.assert_frame_equal(df[:1], mdf)
         finally:
             shutil.rmtree(tempdir)
 

--- a/mars/dataframe/indexing/iloc.py
+++ b/mars/dataframe/indexing/iloc.py
@@ -144,7 +144,7 @@ class HeadTailOptimizedOperandMixin(DataFrameOperandMixin):
         if not isinstance(index0, slice):
             # have to be slice
             return False
-        if index0.step is not None:
+        if index0.step is not None and index0.step != 1:
             return False
         if len(indexes) == 2 and indexes[1] != slice(None):
             return False

--- a/mars/tensor/stats/entropy.py
+++ b/mars/tensor/stats/entropy.py
@@ -49,7 +49,7 @@ def entropy(pk, qk=None, base=None):
 
     """
     pk = astensor(pk)
-    pk = 1.0*pk / mt.sum(pk, axis=0)
+    pk = 1.0 * pk / mt.sum(pk, axis=0)
     if qk is None:
         vec = entr(pk)
     else:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR optimized `read_sql` and `head`. 

What's more, if input DataFrame's index is RangeIndex started with 0, `df.loc[:n]` will be rewritten with `df.iloc[:n]`, so that it can leverage the universal optimization about head, and ensure correctness when input DataFrame does not ensure index incremental.

|   | Master | This PR |
| ------------- | ------------- | ------------- |
| Memory Usage | 191.38M  | 61.73M |
| Time  | 12.2s | 9.5s |

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA
