### PR TITLE
Fix serialize failed when FetchDataFrame's object_type is a list

### DIFF
--- a/.github/workflows/install-minikube.sh
+++ b/.github/workflows/install-minikube.sh
@@ -2,11 +2,8 @@
 set -e
 export CHANGE_MINIKUBE_NONE_USER=true
 
-sudo apt-get remove -y docker.io || true
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 sudo apt-get -q update || true
-sudo apt-get install -yq conntrack docker-ce
+sudo apt-get install -yq conntrack
 
 K8S_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 

--- a/mars/dataframe/fetch/core.py
+++ b/mars/dataframe/fetch/core.py
@@ -14,10 +14,10 @@
 
 import operator
 
-from ...serialize.core import TupleField, ValueType, Int8Field
+from ...serialize.core import TupleField, ValueType, Int8Field, AnyField
 from ...operands import Fetch, FetchShuffle, FetchMixin
 from ...utils import on_serialize_shape, on_deserialize_shape
-from ..operands import DataFrameOperandMixin, ObjectType
+from ..operands import DataFrameOperandMixin, ObjectType, on_deserialize_object_type, on_serialize_object_type
 
 
 class DataFrameFetchMixin(DataFrameOperandMixin, FetchMixin):
@@ -28,8 +28,8 @@ class DataFrameFetch(Fetch, DataFrameFetchMixin):
     # required fields
     _shape = TupleField('shape', ValueType.int64,
                         on_serialize=on_serialize_shape, on_deserialize=on_deserialize_shape)
-    _object_type = Int8Field('object_type', on_serialize=operator.attrgetter('value'),
-                             on_deserialize=ObjectType)
+    _object_type = AnyField('object_type', on_serialize=on_serialize_object_type,
+                            on_deserialize=on_deserialize_object_type)
 
     def __init__(self, to_fetch_key=None, sparse=False, object_type=None, **kw):
         super().__init__(

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -544,6 +544,16 @@ class Test(unittest.TestCase):
             r2 = session.fetch(df6)
             pd.testing.assert_series_equal(r1, r2)
 
+            raw = pd.DataFrame(np.random.rand(100, 3), columns=list('abc'))
+            df = md.DataFrame(raw)
+            bins = [0.006 * i for i in range(0, 101)]
+            cut = md.cut(df['a'], bins)
+            cut.execute()
+            # test fetch replacement
+            r = cut.iloc[:3].execute()
+            expected = pd.cut(raw['a'], bins).iloc[:3]
+            pd.testing.assert_series_equal(r.fetch(), expected)
+
     def testMultiSessionDecref(self, *_):
         with new_cluster(scheduler_n_process=2, worker_n_process=2,
                          shared_memory='20M', web=True) as cluster:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Set object_type as a `AnyField` in  `DataFrameFetchMixin`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1385 