### PR TITLE
Optimize `read_csv` if followed by `DataFrame.getitem`

### DIFF
--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -259,7 +259,7 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
         return df
 
     @classmethod
-    def _cudf_read_csv(cls, op):
+    def _cudf_read_csv(cls, op):  # pragma: no cover
         if op.usecols:
             usecols = op.usecols if isinstance(op.usecols, list) else [op.usecols]
         else:

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -429,5 +429,11 @@ def series_getitem(series, labels, combine_size=None):
         return op(series, name=series.name)
     elif isinstance(labels, _list_like_types) and astensor(labels).dtype == np.bool:
         return series.loc[labels]
+    elif isinstance(labels, slice):
+        edge = labels.start if labels.start is not None else labels.stop
+        if isinstance(edge, Integral):
+            return series.iloc[labels]
+        else:
+            return series.loc[labels]
     else:
         raise NotImplementedError('type %s is not support for getitem' % type(labels))

--- a/mars/dataframe/indexing/iloc.py
+++ b/mars/dataframe/indexing/iloc.py
@@ -214,6 +214,10 @@ class HeadTailOptimizedOperandMixin(DataFrameOperandMixin):
         params['chunks'] = chunks
         return new_op.new_tileables(op.inputs, kws=[params])
 
+    def is_head(self):
+        return self._is_indexes_head_or_tail(self._indexes) and \
+               self._is_head(self._indexes[0])
+
     @classmethod
     def tile(cls, op):
         if cls._need_tile_head_tail(op):
@@ -238,10 +242,6 @@ class DataFrameIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
     @property
     def indexes(self):
         return self._indexes
-
-    def is_head(self):
-        return self._is_indexes_head_or_tail(self._indexes) and \
-               self._is_head(self._indexes[0])
 
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
@@ -454,10 +454,6 @@ class SeriesIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
             else:
                 indexes.append(index)
         self._indexes = tuple(indexes)
-
-    def is_head(self):
-        return self._is_indexes_head_or_tail(self._indexes) and \
-               self._is_head(self._indexes[0])
 
     @classmethod
     def tile(cls, op):

--- a/mars/dataframe/indexing/index_lib.py
+++ b/mars/dataframe/indexing/index_lib.py
@@ -33,7 +33,7 @@ from ...tensor.indexing.index_lib import IndexHandlerContext, IndexHandler, \
 from ...tensor.utils import split_indexes_into_chunks, calc_pos, \
     filter_inputs, slice_split, calc_sliced_size, to_numpy
 from ...utils import check_chunks_unknown_shape, classproperty
-from ..core import SERIES_CHUNK_TYPE, IndexValue
+from ..core import SERIES_CHUNK_TYPE, SERIES_TYPE, IndexValue
 from ..utils import parse_index
 from .utils import convert_labels_into_positions
 
@@ -210,7 +210,10 @@ class LabelSliceIndexHandler(IndexHandler):
                    context: IndexHandlerContext) -> None:
         tileable = context.tileable
         input_axis = index_info.input_axis
-        index_value = [tileable.index_value, tileable.columns_value][input_axis]
+        if isinstance(tileable, SERIES_TYPE):
+            index_value = tileable.index_value
+        else:
+            index_value = [tileable.index_value, tileable.columns_value][input_axis]
 
         # check if chunks have unknown shape
         check = False
@@ -324,7 +327,10 @@ class LabelSliceIndexHandler(IndexHandler):
                 context: IndexHandlerContext) -> None:
         tileable = context.tileable
         input_axis = index_info.input_axis
-        index_value = [tileable.index_value, tileable.columns_value][input_axis]
+        if isinstance(tileable, SERIES_TYPE):
+            index_value = tileable.index_value
+        else:
+            index_value = [tileable.index_value, tileable.columns_value][input_axis]
 
         if index_value.has_value() or self._slice_all(index_info.raw_index):
             self._process_has_value_index(tileable, index_info,

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -907,19 +907,19 @@ class Test(unittest.TestCase):
             with tempfile.TemporaryDirectory() as d:
                 file_path = os.path.join(d, 'test.csv')
                 df = pd.DataFrame(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), columns=['a', 'b', 'c'])
-                df.to_csv(file_path)
+                df.to_csv(file_path, index=False)
 
-                mdf1 = md.read_csv(file_path, index_col=0, chunk_bytes=10)
+                mdf1 = md.read_csv(file_path, chunk_bytes=10)
                 r1 = mdf1.iloc[:3].to_pandas()
-                pd.testing.assert_frame_equal(df[:3], r1)
+                pd.testing.assert_frame_equal(df[:3], r1.reset_index(drop=True))
 
-                mdf2 = md.read_csv(file_path, index_col=0, chunk_bytes=10)
+                mdf2 = md.read_csv(file_path, chunk_bytes=10)
                 r2 = mdf2.iloc[:3].to_pandas()
-                pd.testing.assert_frame_equal(df[:3], r2)
+                pd.testing.assert_frame_equal(df[:3], r2.reset_index(drop=True))
 
                 f = mdf1[mdf1.a > mdf2.a]
                 r3 = f.iloc[:3].to_pandas()
-                pd.testing.assert_frame_equal(r3, df[df.a > df.a])
+                pd.testing.assert_frame_equal(r3, df[df.a > df.a].reset_index(drop=True))
 
     def testDataFrameShuffle(self, *_):
         from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df

--- a/mars/optimizes/runtime/dataframe.py
+++ b/mars/optimizes/runtime/dataframe.py
@@ -102,8 +102,7 @@ class DataSourceGetitemRule(DataFrameRuntimeOptimizeRule):
         getitem_data_source_chunk_params = data_source_chunk.params
         dtypes = getitem_data_source_chunk_params.pop('dtypes')
         getitem_data_source_chunk_params['_key'] = chunk.key
-        if len(usecols) == 1:
-            # if the number of usecols is 1, output type should be Series
+        if chunk.ndim == 1:
             getitem_data_source_chunk_op._usecols = usecols[0]
             name = usecols[0]
             getitem_data_source_chunk_params['shape'] = (data_source_chunk.shape[0],)

--- a/mars/optimizes/runtime/dataframe.py
+++ b/mars/optimizes/runtime/dataframe.py
@@ -14,6 +14,7 @@
 
 from ...dataframe.utils import parse_index
 from ...operands import OutputType
+from ...utils import replace_inputs
 
 
 class DataFrameRuntimeOptimizeRule:
@@ -30,14 +31,7 @@ class DataFrameRuntimeOptimizeRule:
         graph.add_node(new_chunk)
 
         for succ in list(graph.iter_successors(chunk)):
-            succ_inputs = succ.inputs
-            new_succ_inputs = []
-            for succ_input in succ_inputs:
-                if succ_input is chunk:
-                    new_succ_inputs.append(new_chunk)
-                else:
-                    new_succ_inputs.append(succ_input)
-            succ.inputs = new_succ_inputs
+            replace_inputs(succ, chunk, new_chunk)
             graph.add_edge(new_chunk, succ)
 
         graph.remove_node(chunk)

--- a/mars/optimizes/runtime/dataframe.py
+++ b/mars/optimizes/runtime/dataframe.py
@@ -12,15 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ...dataframe.utils import parse_index
+from ...operands import OutputType
+
 
 class DataFrameRuntimeOptimizeRule:
     @staticmethod
     def match(chunk, graph, keys):
         return False
 
-    @staticmethod
-    def apply(chunk, graph, keys):
+    @classmethod
+    def apply(cls, chunk, graph, keys):
         pass
+
+    @staticmethod
+    def _replace_successor_inputs(chunk, new_chunk, graph):
+        graph.add_node(new_chunk)
+
+        for succ in list(graph.iter_successors(chunk)):
+            succ_inputs = succ.inputs
+            new_succ_inputs = []
+            for succ_input in succ_inputs:
+                if succ_input is chunk:
+                    new_succ_inputs.append(new_chunk)
+                else:
+                    new_succ_inputs.append(succ_input)
+            succ.inputs = new_succ_inputs
+            graph.add_edge(new_chunk, succ)
+
+        graph.remove_node(chunk)
 
 
 class DataFrameRuntimeOptimizer:
@@ -44,8 +64,71 @@ class DataFrameRuntimeOptimizer:
                 continue
             visited.add(c)
             for rule in self._rules:
+                if c not in self._graph:
+                    continue
                 if rule.match(c, self._graph, keys):
                     rule.apply(c, self._graph, keys)
+
+
+class DataSourceGetitemRule(DataFrameRuntimeOptimizeRule):
+    @staticmethod
+    def match(chunk, graph, keys):
+        from ...dataframe.datasource.read_csv import DataFrameReadCSV
+        from ...dataframe.datasource.read_sql import DataFrameReadSQL
+        from ...dataframe.indexing.getitem import DataFrameIndex
+
+        op = chunk.op
+        inputs = graph.predecessors(chunk)
+        if len(inputs) != 1:
+            return False
+        else:
+            input_successors = graph.successors(inputs[0])
+            if len(input_successors) == 1 and isinstance(op, DataFrameIndex) and \
+                op.col_names is not None and isinstance(inputs[0].op, (DataFrameReadCSV, DataFrameReadSQL)) and \
+                    inputs[0].key not in keys:
+                return True
+            return False
+
+    @classmethod
+    def apply(cls, chunk, graph, keys):
+        data_source_chunk = graph.predecessors(chunk)[0]
+        data_source_usecols = data_source_chunk.op.usecols or []
+        if isinstance(chunk.op.col_names, list):
+            usecols = chunk.op.col_names
+        else:
+            usecols = [chunk.op.col_names]
+        extra_cols = [col for col in data_source_usecols if col not in usecols]
+        usecols += extra_cols
+
+        # delete datasource chunk from graph
+        graph.remove_node(data_source_chunk)
+
+        getitem_data_source_chunk_op = data_source_chunk.op.copy().reset_key()
+        getitem_data_source_chunk_op._keep_usecols_order = True
+        getitem_data_source_chunk_params = data_source_chunk.params
+        dtypes = getitem_data_source_chunk_params.pop('dtypes')
+        getitem_data_source_chunk_params['_key'] = chunk.key
+        if len(usecols) == 1:
+            # if the number of usecols is 1, output type should be Series
+            getitem_data_source_chunk_op._usecols = usecols[0]
+            name = usecols[0]
+            getitem_data_source_chunk_params['shape'] = (data_source_chunk.shape[0],)
+            getitem_data_source_chunk_params['name'] = name
+            getitem_data_source_chunk_params['dtype'] = dtypes[name]
+            source_chunk = getitem_data_source_chunk_op.new_chunk(
+                data_source_chunk.inputs, kws=[getitem_data_source_chunk_params],
+                output_type=OutputType.series).data
+        else:
+            getitem_data_source_chunk_op._usecols = usecols
+            dtypes = dtypes[usecols]
+            getitem_data_source_chunk_params['shape'] = (data_source_chunk.shape[0], len(usecols))
+            getitem_data_source_chunk_params['dtypes'] = dtypes
+            getitem_data_source_chunk_params['columns_value'] = parse_index(dtypes.index, store_data=True)
+            source_chunk = getitem_data_source_chunk_op.new_chunk(
+                data_source_chunk.inputs, kws=[getitem_data_source_chunk_params],
+                output_type=OutputType.dataframe).data
+
+        cls._replace_successor_inputs(chunk, source_chunk, graph)
 
 
 class DataSourceHeadRule(DataFrameRuntimeOptimizeRule):
@@ -53,24 +136,24 @@ class DataSourceHeadRule(DataFrameRuntimeOptimizeRule):
     def match(chunk, graph, keys):
         from ...dataframe.datasource.read_csv import DataFrameReadCSV
         from ...dataframe.datasource.read_sql import DataFrameReadSQL
-        from ...dataframe.indexing.iloc import DataFrameIlocGetItem
+        from ...dataframe.indexing.iloc import DataFrameIlocGetItem, SeriesIlocGetItem
 
         op = chunk.op
         inputs = graph.predecessors(chunk)
-        if len(inputs) == 1 and isinstance(op, DataFrameIlocGetItem) and \
+        if len(inputs) == 1 and isinstance(op, (DataFrameIlocGetItem, SeriesIlocGetItem)) and \
                 op.is_head() and isinstance(inputs[0].op, (DataFrameReadCSV, DataFrameReadSQL)) and \
                 inputs[0].key not in keys:
             return True
         return False
 
-    @staticmethod
-    def apply(chunk, graph, keys):
+    @classmethod
+    def apply(cls, chunk, graph, keys):
         from ...dataframe.utils import parse_index
 
         data_source_chunk = graph.predecessors(chunk)[0]
         nrows = data_source_chunk.op.nrows or 0
         head = chunk.op.indexes[0].stop
-        # delete read_csv from graph
+        # delete datasource chunk from graph
         graph.remove_node(data_source_chunk)
 
         head_data_source_chunk_op = data_source_chunk.op.copy().reset_key()
@@ -82,21 +165,11 @@ class DataSourceHeadRule(DataFrameRuntimeOptimizeRule):
             pd_index = chunk.index_value.to_pandas()[:head]
             head_data_source_chunk_params['index_value'] = parse_index(pd_index)
         head_data_source_chunk = head_data_source_chunk_op.new_chunk(
-            data_source_chunk.inputs, kws=[head_data_source_chunk_params]).data
-        graph.add_node(head_data_source_chunk)
+            data_source_chunk.inputs, kws=[head_data_source_chunk_params],
+            output_type=chunk.op.output_types[0]).data
 
-        for succ in list(graph.iter_successors(chunk)):
-            succ_inputs = succ.inputs
-            new_succ_inputs = []
-            for succ_input in succ_inputs:
-                if succ_input is chunk:
-                    new_succ_inputs.append(head_data_source_chunk)
-                else:
-                    new_succ_inputs.append(succ_input)
-            succ.inputs = new_succ_inputs
-            graph.add_edge(head_data_source_chunk, succ)
-
-        graph.remove_node(chunk)
+        cls._replace_successor_inputs(chunk, head_data_source_chunk, graph)
 
 
 DataFrameRuntimeOptimizer.register_rule(DataSourceHeadRule)
+DataFrameRuntimeOptimizer.register_rule(DataSourceGetitemRule)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

`md.read_csv('xx.csv')[['col1', 'col2']]` will read the entire data and select columns then, in this PR, `usecols` will be set if `read_csv` is followed by `getitem`, the expression will be like `md.read_csv('xx.csv', usecols=['col1', 'col2'])`, the optimization will reduce the memory usage greatly if the the number of DataFrame columns is large.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1384 