### PR TITLE
[BACKPORT] Fix worker assign when no evaluation sets specified in LGBM training (#1405)

### DIFF
--- a/mars/learn/contrib/lightgbm/tests/integrated/test_distributed_lightgbm.py
+++ b/mars/learn/contrib/lightgbm/tests/integrated/test_distributed_lightgbm.py
@@ -49,6 +49,15 @@ class Test(LearnIntegrationTestBase):
             X, y = self.X, self.y
             y = (y * 10).astype(mt.int32)
             classifier = LGBMClassifier(n_estimators=2)
+            classifier.fit(X, y, session=sess, run_kwargs=run_kwargs)
+            prediction = classifier.predict(X, session=sess, run_kwargs=run_kwargs)
+
+            self.assertEqual(prediction.ndim, 1)
+            self.assertEqual(prediction.shape[0], len(self.X))
+
+            self.assertIsInstance(prediction, mt.Tensor)
+
+            classifier = LGBMClassifier(n_estimators=2)
             classifier.fit(X, y, eval_set=[(X, y)], session=sess, run_kwargs=run_kwargs)
             prediction = classifier.predict(X, session=sess, run_kwargs=run_kwargs)
 


### PR DESCRIPTION
Backport of #1405