### PR TITLE
Create backup CalcActor when spawning a new graph in mars.remote

### DIFF
--- a/mars/api.py
+++ b/mars/api.py
@@ -224,6 +224,8 @@ class MarsAPI(object):
 
     def fetch_chunk_data(self, session_id, chunk_key, index_obj=None):
         endpoints = self.chunk_meta_client.get_workers(session_id, chunk_key)
+        if endpoints is None:
+            raise KeyError('Chunk key %s not exist in cluster' % chunk_key)
         sender_ref = self.actor_client.actor_ref(ResultSenderActor.default_uid(),
                                                  address=random.choice(endpoints))
         return sender_ref.fetch_data(session_id, chunk_key, index_obj, _wait=False)

--- a/mars/context.py
+++ b/mars/context.py
@@ -452,9 +452,9 @@ class DistributedDictContext(DistributedContext, dict):
         dict.__init__(self)
 
     def yield_execution_pool(self):
-        actor_cls = self.pop('_actor_cls', None)
-        actor_uid = self.pop('_actor_uid', None)
-        op_key = self.pop('_op_key', None)
+        actor_cls = self.get('_actor_cls')
+        actor_uid = self.get('_actor_uid')
+        op_key = self.get('_op_key')
         if not actor_cls or not actor_uid:  # pragma: no cover
             return
 

--- a/mars/context.py
+++ b/mars/context.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import copy
+import os
+import random
 import sys
 import threading
-import random
 from collections import namedtuple, defaultdict
 from enum import Enum
 from typing import List
@@ -76,9 +77,9 @@ class ContextBase(object):
         """
         raise NotImplementedError
 
-    # ---------------
-    # Meta relative
-    # ---------------
+    # ------------
+    # Meta related
+    # ------------
 
     def get_chunk_metas(self, chunk_keys, filter_fields=None):
         """
@@ -90,9 +91,9 @@ class ContextBase(object):
         """
         raise NotImplementedError
 
-    # -----------------
-    # Cluster relative
-    # -----------------
+    # ---------------
+    # Cluster related
+    # ---------------
 
     def get_scheduler_addresses(self):
         """
@@ -132,9 +133,9 @@ class ContextBase(object):
         """
         raise NotImplementedError
 
-    # ---------------
-    # Graph relative
-    # ---------------
+    # -------------
+    # Graph related
+    # -------------
 
     def submit_chunk_graph(self, graph, result_keys):
         """
@@ -156,9 +157,22 @@ class ContextBase(object):
         """
         raise NotImplementedError
 
-    # ----------------
-    # Result relative
-    # ----------------
+    # -----------------------
+    # Pool occupation related
+    # -----------------------
+
+    def yield_execution_pool(self):
+        """
+        Yields current execution pool to allow running other tasks
+        """
+        pass
+
+    def acquire_execution_pool(self, yield_info):
+        pass
+
+    # --------------
+    # Result related
+    # --------------
 
     def get_chunk_results(self, chunk_keys: List[str]) -> List:
         """
@@ -290,10 +304,10 @@ class DistributedContext(ContextBase):
         is_distributed = self._cluster_info.is_distributed()
         self._running_mode = RunningMode.local_cluster \
             if not is_distributed else RunningMode.distributed
-        self._address = kw.pop('address', None)
         self._resource_actor_ref = self._actor_ctx.actor_ref(
             ResourceActor.default_uid(), address=scheduler_address)
 
+        self._address = kw.pop('address', None)
         self._extra_info = kw
 
     @property
@@ -436,3 +450,28 @@ class DistributedDictContext(DistributedContext, dict):
     def __init__(self, *args, **kwargs):
         DistributedContext.__init__(self, *args, **kwargs)
         dict.__init__(self)
+
+    def yield_execution_pool(self):
+        actor_cls = self.pop('_actor_cls', None)
+        op_key = self.pop('_op_key', None)
+        proc_id = self._extra_info.get('proc_id')
+        if not actor_cls or not proc_id:  # pragma: no cover
+            return
+
+        from .actors import new_client
+        from .worker.daemon import WorkerDaemonActor
+        client = new_client()
+
+        daemon_ref = client.actor_ref(WorkerDaemonActor.default_uid(), address=self.get_local_address())
+        uid = 'w:%d:mars-cpu-calc-backup-%d-%s-%d' % (proc_id, os.getpid(), op_key, random.randint(-1, 9999))
+        ref = daemon_ref.create_actor(actor_cls, uid=uid)
+        return ref
+
+    def acquire_execution_pool(self, yield_info):
+        if yield_info is None:
+            return
+
+        from .actors import new_client
+        client = new_client()
+        calc_ref = client.actor_ref(yield_info, address=self.get_local_address())
+        calc_ref.mark_destroy()

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -281,7 +281,7 @@ class GraphActor(SchedulerActor):
         self.set_cluster_info_ref()
         self._assigner_actor_ref = self.get_actor_ref(AssignerActor.gen_uid(self._session_id))
         self._resource_actor_ref = self.get_actor_ref(ResourceActor.default_uid())
-        self._session_ref = self.ctx.actor_ref(SessionActor.gen_uid(self._session_id))
+        self._session_ref = self.get_actor_ref(SessionActor.gen_uid(self._session_id))
 
         uid = GraphMetaActor.gen_uid(self._session_id, self._graph_key)
         self._graph_meta_ref = self.ctx.create_actor(

--- a/mars/scheduler/tests/integrated/base.py
+++ b/mars/scheduler/tests/integrated/base.py
@@ -47,6 +47,7 @@ class SchedulerIntegratedTest(unittest.TestCase):
 
         options.worker.spill_directory = os.path.join(tempfile.gettempdir(), 'mars_test_spill')
         cls._kv_store = kvstore.get(options.kv_store)
+        cls.timeout = int(os.environ.get('CHECK_TIMEOUT', 120))
 
     @classmethod
     def tearDownClass(cls):
@@ -115,7 +116,7 @@ class SchedulerIntegratedTest(unittest.TestCase):
 
     def _start_processes(self, n_schedulers=2, n_workers=2, etcd=False, cuda=False, modules=None,
                          log_scheduler=True, log_worker=True, env=None, scheduler_args=None,
-                         worker_args=None):
+                         worker_args=None, worker_cpu=1):
         old_not_errors = gevent.hub.Hub.NOT_ERROR
         gevent.hub.Hub.NOT_ERROR = (Exception,)
 
@@ -161,7 +162,7 @@ class SchedulerIntegratedTest(unittest.TestCase):
         self.proc_workers = [
             subprocess.Popen([sys.executable, '-m', 'mars.worker',
                               '-a', '127.0.0.1',
-                              '--cpu-procs', '1',
+                              '--cpu-procs', str(worker_cpu),
                               '--log-level', 'debug' if log_worker else 'warning',
                               '--log-format', 'WOR%d %%(asctime)-15s %%(message)s' % idx,
                               '--cache-mem', '16m',

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -12,29 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import logging
 import operator
 import os
 import sys
 import unittest
-import uuid
 from functools import reduce
 
 import numpy as np
-from numpy.testing import assert_allclose
+import pandas as pd
 
-from mars import tensor as mt
-from mars.actors.core import new_client
+import mars.dataframe as md
+import mars.tensor as mt
 from mars.errors import ExecutionFailed
-from mars.session import new_session
-from mars.scheduler.graph import GraphState
 from mars.scheduler.resource import ResourceActor
 from mars.scheduler.tests.integrated.base import SchedulerIntegratedTest
 from mars.scheduler.tests.integrated.no_prepare_op import NoPrepareOperand
+from mars.session import new_session
 from mars.remote import spawn
-from mars.utils import build_tileable_graph
-from mars.serialize.dataserializer import loads
 from mars.tests.core import EtcdProcessHelper, require_cupy, require_cudf
 from mars.context import DistributedContext
 
@@ -45,263 +40,125 @@ logger = logging.getLogger(__name__)
 class Test(SchedulerIntegratedTest):
     def testMainTensorWithoutEtcd(self):
         self.start_processes()
-
-        session_id = uuid.uuid1()
-        actor_client = new_client()
-
-        session_ref = actor_client.actor_ref(self.session_manager_ref.create_session(session_id))
+        sess = new_session(self.session_manager_ref.address)
 
         a = mt.ones((100, 100), chunk_size=30) * 2 * 1 + 1
         b = mt.ones((100, 100), chunk_size=30) * 2 * 1 + 1
         c = (a * b * 2 + 1).sum()
-        graph = c.build_graph()
-        targets = [c.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
 
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        result = session_ref.fetch_result(graph_key, c.key)
+        result = c.execute(session=sess, timeout=self.timeout).fetch(session=sess)
         expected = (np.ones(a.shape) * 2 * 1 + 1) ** 2 * 2 + 1
-        assert_allclose(loads(result), expected.sum())
+        np.testing.assert_allclose(result, expected.sum())
 
         a = mt.ones((100, 50), chunk_size=35) * 2 + 1
         b = mt.ones((50, 200), chunk_size=35) * 2 + 1
         c = a.dot(b)
-        graph = c.build_graph()
-        targets = [c.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-        result = session_ref.fetch_result(graph_key, c.key)
-        assert_allclose(loads(result), np.ones((100, 200)) * 450)
+        result = c.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        np.testing.assert_allclose(result, np.ones((100, 200)) * 450)
 
         base_arr = np.random.random((100, 100))
         a = mt.array(base_arr)
-        sumv = reduce(operator.add, [a[:10, :10] for _ in range(10)])
-        graph = sumv.build_graph()
-        targets = [sumv.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
+        r = reduce(operator.add, [a[:10, :10] for _ in range(10)])
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
         expected = reduce(operator.add, [base_arr[:10, :10] for _ in range(10)])
-        result = session_ref.fetch_result(graph_key, sumv.key)
-        assert_allclose(loads(result), expected)
+        np.testing.assert_allclose(result, expected)
 
         a = mt.ones((31, 27), chunk_size=10)
         b = a.reshape(27, 31)
         b.op.extra_params['_reshape_with_shuffle'] = True
         r = b.sum(axis=1)
-        graph = r.build_graph()
-        targets = [r.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        result = session_ref.fetch_result(graph_key, r.key)
-        assert_allclose(loads(result), np.ones((27, 31)).sum(axis=1))
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        np.testing.assert_allclose(result, np.ones((27, 31)).sum(axis=1))
 
         raw = np.random.RandomState(0).rand(10, 10)
         a = mt.tensor(raw, chunk_size=(5, 4))
-        b = a[a.argmin(axis=1), mt.tensor(np.arange(10))]
-        graph = b.build_graph()
-        targets = [b.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        result = session_ref.fetch_result(graph_key, b.key)
-
-        np.testing.assert_array_equal(loads(result), raw[raw.argmin(axis=1), np.arange(10)])
+        r = a[a.argmin(axis=1), mt.tensor(np.arange(10))]
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        np.testing.assert_array_equal(result, raw[raw.argmin(axis=1), np.arange(10)])
 
     @unittest.skipIf('CI' not in os.environ and not EtcdProcessHelper().is_installed(),
                      'does not run without etcd')
     def testMainTensorWithEtcd(self):
         self.start_processes(etcd=True)
-
-        session_id = uuid.uuid1()
-        actor_client = new_client()
-
-        session_ref = actor_client.actor_ref(self.session_manager_ref.create_session(session_id))
+        sess = new_session(self.session_manager_ref.address)
 
         a = mt.ones((100, 100), chunk_size=30) * 2 * 1 + 1
         b = mt.ones((100, 100), chunk_size=30) * 2 * 1 + 1
-        c = (a * b * 2 + 1).sum()
-        graph = c.build_graph()
-        targets = [c.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        result = session_ref.fetch_result(graph_key, c.key)
+        r = (a * b * 2 + 1).sum()
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
         expected = (np.ones(a.shape) * 2 * 1 + 1) ** 2 * 2 + 1
-        assert_allclose(loads(result), expected.sum())
+        np.testing.assert_allclose(result, expected.sum())
 
     @require_cupy
     @require_cudf
     def testMainTensorWithCuda(self):
         self.start_processes(cuda=True)
-
-        session_id = uuid.uuid1()
-        actor_client = new_client()
-
-        session_ref = actor_client.actor_ref(self.session_manager_ref.create_session(session_id))
+        sess = new_session(self.session_manager_ref.address)
 
         a = mt.ones((100, 100), chunk_size=30, gpu=True) * 2 * 1 + 1
         b = mt.ones((100, 100), chunk_size=30, gpu=True) * 2 * 1 + 1
-        c = (a * b * 2 + 1).sum()
-        graph = c.build_graph()
-        targets = [c.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        result = session_ref.fetch_result(graph_key, c.key)
-        expected = (np.ones(a.shape) * 2 * 1 + 1) ** 2 * 2 + 1
-        assert_allclose(loads(result), expected.sum())
+        r = (a * b * 2 + 1).sum()
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        expected = ((np.ones(a.shape) * 2 * 1 + 1) ** 2 * 2 + 1).sum()
+        np.testing.assert_allclose(result, expected)
 
     def testMainDataFrameWithoutEtcd(self):
-        import pandas as pd
-        from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df
-        from mars.dataframe.datasource.series import from_pandas as from_pandas_series
-        from mars.dataframe.arithmetic import add
-
         self.start_processes(etcd=False, scheduler_args=['-Dscheduler.aggressive_assign=true'])
+        sess = new_session(self.session_manager_ref.address)
 
-        session_id = uuid.uuid1()
-        actor_client = new_client()
+        raw1 = pd.DataFrame(np.random.rand(10, 10))
+        df1 = md.DataFrame(raw1, chunk_size=5)
+        raw2 = pd.DataFrame(np.random.rand(10, 10))
+        df2 = md.DataFrame(raw2, chunk_size=6)
+        r = df1 + df2
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        pd.testing.assert_frame_equal(result, raw1 + raw2)
 
-        session_ref = actor_client.actor_ref(self.session_manager_ref.create_session(session_id))
+        raw1 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(10),
+                            columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
+        df1 = md.DataFrame(raw1, chunk_size=(10, 5))
+        raw2 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(11, 1, -1),
+                            columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
+        df2 = md.DataFrame(raw2, chunk_size=(10, 6))
+        r = df1 + df2
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        pd.testing.assert_frame_equal(result, raw1 + raw2)
 
-        data1 = pd.DataFrame(np.random.rand(10, 10))
-        df1 = from_pandas_df(data1, chunk_size=5)
-        data2 = pd.DataFrame(np.random.rand(10, 10))
-        df2 = from_pandas_df(data2, chunk_size=6)
-
-        df3 = add(df1, df2)
-
-        graph = df3.build_graph()
-        targets = [df3.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        expected = data1 + data2
-        result = session_ref.fetch_result(graph_key, df3.key)
-        pd.testing.assert_frame_equal(expected, loads(result))
-
-        data1 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(10),
-                             columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
-        df1 = from_pandas_df(data1, chunk_size=(10, 5))
-        data2 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(11, 1, -1),
-                             columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
-        df2 = from_pandas_df(data2, chunk_size=(10, 6))
-
-        df3 = add(df1, df2)
-
-        graph = df3.build_graph()
-        targets = [df3.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        expected = data1 + data2
-        result = session_ref.fetch_result(graph_key, df3.key)
-        pd.testing.assert_frame_equal(expected, loads(result))
-
-        data1 = pd.DataFrame(np.random.rand(10, 10), index=[0, 10, 2, 3, 4, 5, 6, 7, 8, 9],
-                             columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
-        df1 = from_pandas_df(data1, chunk_size=5)
-        data2 = pd.DataFrame(np.random.rand(10, 10), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3],
-                             columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
-        df2 = from_pandas_df(data2, chunk_size=6)
-
-        df3 = add(df1, df2)
-
-        graph = df3.build_graph()
-        targets = [df3.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        expected = data1 + data2
-        result = session_ref.fetch_result(graph_key, df3.key)
-        pd.testing.assert_frame_equal(expected, loads(result))
+        raw1 = pd.DataFrame(np.random.rand(10, 10), index=[0, 10, 2, 3, 4, 5, 6, 7, 8, 9],
+                            columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
+        df1 = md.DataFrame(raw1, chunk_size=5)
+        raw2 = pd.DataFrame(np.random.rand(10, 10), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3],
+                            columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
+        df2 = md.DataFrame(raw2, chunk_size=6)
+        r = df1 + df2
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        pd.testing.assert_frame_equal(result, raw1 + raw2)
 
         s1 = pd.Series(np.random.rand(10), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3])
-        series1 = from_pandas_series(s1)
-
-        graph = series1.build_graph()
-        targets = [series1.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        result = session_ref.fetch_result(graph_key, series1.key)
-        pd.testing.assert_series_equal(s1, loads(result))
+        series1 = md.Series(s1, chunk_size=6)
+        result = series1.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        pd.testing.assert_series_equal(result, s1)
 
     def testIterativeTilingWithoutEtcd(self):
         self.start_processes(etcd=False)
-
-        session_id = uuid.uuid1()
-        actor_client = new_client()
+        sess = new_session(self.session_manager_ref.address)
+        actor_client = sess._api.actor_client
+        session_ref = actor_client.actor_ref(self.session_manager_ref.create_session(sess.session_id))
         rs = np.random.RandomState(0)
-
-        session_ref = actor_client.actor_ref(self.session_manager_ref.create_session(session_id))
 
         raw = rs.rand(100)
         a = mt.tensor(raw, chunk_size=10)
         a.sort()
-        c = a[:5]
-
-        graph = c.build_graph()
-        targets = [c.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        result = session_ref.fetch_result(graph_key, c.key)
+        r = a[:5]
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
         expected = np.sort(raw)[:5]
-        assert_allclose(loads(result), expected)
+        np.testing.assert_allclose(result, expected)
 
+        graph_key = sess._get_tileable_graph_key(r.key)
+        graph_ref = actor_client.actor_ref(session_ref.get_graph_refs()[graph_key])
         with self.assertRaises(KeyError):
-            session_ref.fetch_result(graph_key, a.key, check=False)
+            _, keys, _ = graph_ref.get_tileable_metas([a.key])[0]
+            sess._api.fetch_chunk_data(sess.session_id, keys[0])
 
         raw1 = rs.rand(20)
         raw2 = rs.rand(20)
@@ -310,62 +167,30 @@ class Test(SchedulerIntegratedTest):
         b = mt.tensor(raw2, chunk_size=15) + 1
         c = mt.concatenate([a[:10], b])
         c.sort()
-        d = c[:5]
-
-        graph = d.build_graph()
-        targets = [d.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        result = session_ref.fetch_result(graph_key, d.key)
+        r = c[:5]
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
         expected = np.sort(np.concatenate([np.sort(raw1)[:10], raw2 + 1]))[:5]
-        assert_allclose(loads(result), expected)
+        np.testing.assert_allclose(result, expected)
 
         raw = rs.randint(100, size=(100,))
         a = mt.tensor(raw, chunk_size=53)
         a.sort()
-        b = mt.histogram(a, bins='scott')
-
-        graph = build_tileable_graph(b, set())
-        targets = [b[0].key, b[1].key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        res = session_ref.fetch_result(graph_key, b[0].key), \
-              session_ref.fetch_result(graph_key, b[1].key)
+        r = mt.histogram(a, bins='scott')
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
         expected = np.histogram(np.sort(raw), bins='scott')
-        assert_allclose(loads(res[0]), expected[0])
-        assert_allclose(loads(res[1]), expected[1])
+        np.testing.assert_allclose(result[0], expected[0])
+        np.testing.assert_allclose(result[1], expected[1])
 
     def testDistributedContext(self):
         self.start_processes(etcd=False)
-
-        session_id = uuid.uuid1()
-        actor_client = new_client()
+        sess = new_session(self.session_manager_ref.address)
         rs = np.random.RandomState(0)
+        context = DistributedContext(scheduler_address=self.session_manager_ref.address,
+                                     session_id=sess.session_id)
 
-        context = DistributedContext(scheduler_address=self.scheduler_endpoints[0], session_id=session_id)
-
-        session_ref = actor_client.actor_ref(self.session_manager_ref.create_session(session_id))
         raw1 = rs.rand(10, 10)
         a = mt.tensor(raw1, chunk_size=4)
-
-        graph = a.build_graph()
-        targets = [a.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()), graph_key,
-                                          target_tileables=targets, names=['test'])
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
+        a.execute(session=sess, timeout=self.timeout, name='test')
 
         tileable_infos = context.get_named_tileable_infos('test')
         self.assertEqual(a.key, tileable_infos.tileable_key)
@@ -391,14 +216,10 @@ class Test(SchedulerIntegratedTest):
 
     def testOperandsWithoutPrepareInputs(self):
         self.start_processes(etcd=False, modules=['mars.scheduler.tests.integrated.no_prepare_op'])
-
-        session_id = uuid.uuid1()
-        actor_client = new_client()
-
-        session_ref = actor_client.actor_ref(self.session_manager_ref.create_session(session_id))
+        sess = new_session(self.session_manager_ref.address)
 
         actor_address = self.cluster_info.get_scheduler(ResourceActor.default_uid())
-        resource_ref = actor_client.actor_ref(ResourceActor.default_uid(), address=actor_address)
+        resource_ref = sess._api.actor_client.actor_ref(ResourceActor.default_uid(), address=actor_address)
         worker_endpoints = resource_ref.get_worker_endpoints()
 
         t1 = mt.random.rand(10)
@@ -408,23 +229,19 @@ class Test(SchedulerIntegratedTest):
 
         t = NoPrepareOperand().new_tileable([t1, t2])
         t.op._prepare_inputs = [False, False]
-
-        graph = t.build_graph()
-        targets = [t.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
+        t.execute(session=sess, timeout=self.timeout)
 
     def testRemoteWithoutEtcd(self):
+        from mars.scheduler.resource import ResourceActor
+        from mars.worker.dispatcher import DispatchActor
+
         self.start_processes(etcd=False, modules=['mars.scheduler.tests.integrated.no_prepare_op'])
-
-        session_id = uuid.uuid1()
-        actor_client = new_client()
-
-        session_ref = actor_client.actor_ref(self.session_manager_ref.create_session(session_id))
+        sess = new_session(self.session_manager_ref.address)
+        resource_ref = sess._api.actor_client.actor_ref(
+            ResourceActor.default_uid(),
+            address=self.cluster_info.get_scheduler(ResourceActor.default_uid())
+        )
+        worker_ips = resource_ref.get_worker_endpoints()
 
         rs = np.random.RandomState(0)
         raw1 = rs.rand(10, 10)
@@ -434,18 +251,8 @@ class Test(SchedulerIntegratedTest):
             return None
 
         r_none = spawn(f_none, raw1)
-
-        graph = r_none.build_graph()
-        targets = [r_none.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        result = session_ref.fetch_result(graph_key, r_none.key)
-        self.assertIsNone(loads(result))
+        result = r_none.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        self.assertIsNone(result)
 
         def f1(x):
             return x + 1
@@ -456,19 +263,27 @@ class Test(SchedulerIntegratedTest):
         r1 = spawn(f1, raw1)
         r2 = spawn(f1, raw2)
         r3 = spawn(f2, (r1, r2), {'z': [r1, r2]})
-
-        graph = r3.build_graph()
-        targets = [r3.key]
-        graph_key = uuid.uuid1()
-        session_ref.submit_tileable_graph(json.dumps(graph.to_json()),
-                                          graph_key, target_tileables=targets)
-
-        state = self.wait_for_termination(actor_client, session_ref, graph_key)
-        self.assertEqual(state, GraphState.SUCCEEDED)
-
-        result = session_ref.fetch_result(graph_key, r3.key)
+        result = r3.execute(session=sess, timeout=self.timeout).fetch(session=sess)
         expected = (raw1 + 1) * (raw2 + 1) * (raw1 + 1 + raw2 + 1)
-        assert_allclose(loads(result), expected)
+        np.testing.assert_allclose(result, expected)
+
+        def f(t, x):
+            return (t * x).sum().to_numpy()
+
+        rs = np.random.RandomState(0)
+        raw = rs.rand(5, 4)
+
+        t1 = mt.tensor(raw, chunk_size=3)
+        t2 = t1.sum(axis=0)
+        s = spawn(f, args=(t2, 3))
+
+        result = s.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        expected = (raw.sum(axis=0) * 3).sum()
+        self.assertAlmostEqual(result, expected)
+
+        for worker_ip in worker_ips:
+            ref = sess._api.actor_client.actor_ref(DispatchActor.default_uid(), address=worker_ip)
+            self.assertEqual(len(ref.get_slots('cpu')), 1)
 
     def testNoWorkerException(self):
         self.start_processes(etcd=False, n_workers=0)
@@ -481,6 +296,6 @@ class Test(SchedulerIntegratedTest):
         sess = new_session(endpoint)
 
         try:
-            c.execute(session=sess)
+            c.execute(session=sess, timeout=self.timeout)
         except ExecutionFailed as e:
             self.assertIsInstance(e.__cause__, RuntimeError)

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -16,6 +16,7 @@ import logging
 import operator
 import os
 import sys
+import time
 import unittest
 from functools import reduce
 
@@ -282,6 +283,7 @@ class Test(SchedulerIntegratedTest):
         expected = (raw.sum(axis=0) * 3).sum()
         self.assertAlmostEqual(result, expected)
 
+        time.sleep(1)
         for worker_ip in worker_ips:
             ref = sess._api.actor_client.actor_ref(DispatchActor.default_uid(), address=worker_ip)
             self.assertEqual(len(ref.get_slots('cpu')), 1)

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -268,7 +268,8 @@ class Test(SchedulerIntegratedTest):
         np.testing.assert_allclose(result, expected)
 
         def f(t, x):
-            return (t * x).sum().to_numpy()
+            mul = (t * x).execute()
+            return mul.sum().to_numpy()
 
         rs = np.random.RandomState(0)
         raw = rs.rand(5, 4)

--- a/mars/worker/daemon.py
+++ b/mars/worker/daemon.py
@@ -44,6 +44,12 @@ class WorkerDaemonActor(WorkerActor):
         self._proc_actors[proc_idx][ref_key] = (ref_key, args, kwargs, False)
         return ref
 
+    def destroy_actor(self, ref):
+        proc_idx = self.ctx.distributor.distribute(ref.uid)
+        ref_key = (ref.uid, ref.address)
+        self._proc_actors[proc_idx].pop(ref_key, None)
+        self.ctx.destroy_actor(ref)
+
     def register_child_actor(self, actor_ref):
         proc_idx = self.ctx.distributor.distribute(actor_ref.uid)
         ref_key = (actor_ref.uid, actor_ref.address)

--- a/mars/worker/dispatcher.py
+++ b/mars/worker/dispatcher.py
@@ -150,5 +150,5 @@ class DispatchActor(WorkerActor):
 
     @log_unhandled
     def remove_slot(self, uid, queue_name):
-        self._free_slots[queue_name].pop(uid)
-        self._all_slots[queue_name].pop(uid)
+        self._free_slots[queue_name].pop(uid, None)
+        self._all_slots[queue_name].pop(uid, None)

--- a/mars/worker/dispatcher.py
+++ b/mars/worker/dispatcher.py
@@ -64,9 +64,9 @@ class DispatchActor(WorkerActor):
                 self.ref().register_free_slot(slot, queue_name, _tell=True)
 
     @log_unhandled
-    def get_free_slot(self, queue_name, callback=None):
+    def acquire_free_slot(self, queue_name, callback=None):
         """
-        Get uid of a free actor when available
+        Acquire uid of a free actor when available
         :param queue_name: queue name
         :param callback: promise callback
         """
@@ -147,3 +147,8 @@ class DispatchActor(WorkerActor):
         if self._status_ref is not None:
             self._status_ref.update_slots({queue_name: len(self._free_slots[queue_name])},
                                           _tell=True, _wait=False)
+
+    @log_unhandled
+    def remove_slot(self, uid, queue_name):
+        self._free_slots[queue_name].pop(uid)
+        self._all_slots[queue_name].pop(uid)

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -346,7 +346,7 @@ class ExecutionActor(WorkerActor):
             ).then(_finish_fetch)
 
         return promise.finished() \
-            .then(lambda *_: remote_disp_ref.get_free_slot('sender', _promise=True, _timeout=timeout)) \
+            .then(lambda *_: remote_disp_ref.acquire_free_slot('sender', _promise=True, _timeout=timeout)) \
             .then(_fetch_step) \
             .catch(_handle_network_error)
 
@@ -543,7 +543,7 @@ class ExecutionActor(WorkerActor):
                 .then(lambda *_: self._mem_quota_ref.request_batch_quota(
                     quota_request, _promise=True) if quota_request else None) \
                 .then(lambda *_: self._prepare_graph_inputs(session_id, graph_key)) \
-                .then(lambda *_: self._dispatch_ref.get_free_slot(calc_device, _promise=True)) \
+                .then(lambda *_: self._dispatch_ref.acquire_free_slot(calc_device, _promise=True)) \
                 .then(lambda uid: self._send_calc_request(session_id, graph_key, uid)) \
                 .then(lambda saved_keys: self._store_results(session_id, graph_key, saved_keys)) \
                 .then(_handle_success, _handle_rejection)
@@ -766,7 +766,7 @@ class ExecutionActor(WorkerActor):
             if target == self.address:
                 continue
             promises.append(promise.finished()
-                            .then(lambda: self._dispatch_ref.get_free_slot('sender', _promise=True))
+                            .then(lambda: self._dispatch_ref.acquire_free_slot('sender', _promise=True))
                             .then(functools.partial(_send_chunk, data_keys=keys, target_addr=target))
                             .catch(lambda *_: None))
 

--- a/mars/worker/tests/base.py
+++ b/mars/worker/tests/base.py
@@ -148,7 +148,7 @@ class WorkerCase(unittest.TestCase):
         if accept:
             return r
         else:
-            raise r[1].with_traceback(r[2]) from None
+            raise r[1].with_traceback(r[2])
 
     @staticmethod
     def rm_spill_dirs(spill_dirs=None):

--- a/mars/worker/tests/test_calc.py
+++ b/mars/worker/tests/test_calc.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import contextlib
+import random
 import uuid
 import weakref
 
@@ -70,7 +71,7 @@ class Test(WorkerCase):
 
         inputs = []
         for idx, d in enumerate(data_list):
-            chunk_key = 'chunk-%d' % idx
+            chunk_key = 'chunk-%d-%d' % (random.randint(0, 999), idx)
             fetch_chunk = TensorFetch(to_fetch_key=chunk_key, dtype=d.dtype) \
                 .new_chunk([], shape=d.shape, _key=chunk_key)
             inputs.append(fetch_chunk)
@@ -198,6 +199,7 @@ class Test(WorkerCase):
         with self._start_calc_pool() as (_pool, test_actor):
             calc_ref = _pool.actor_ref(CpuCalcActor.default_uid())
             calc_ref.mark_destroy()
+            gevent.sleep(0.8)
             self.assertFalse(_pool.has_actor(calc_ref))
 
         with self._start_calc_pool() as (_pool, test_actor):
@@ -206,6 +208,7 @@ class Test(WorkerCase):
             session_id = str(uuid.uuid4())
             data_list = [np.random.random((10, 10)) for _ in range(2)]
             exec_graph, fetch_chunks, add_chunk = self._build_test_graph(data_list)
+            exec_graph2, fetch_chunks2, add_chunk2 = self._build_test_graph(data_list[::-1])
 
             storage_client = test_actor.storage_client
 
@@ -214,13 +217,17 @@ class Test(WorkerCase):
                     storage_client.put_objects(
                         session_id, [fetch_chunk.key], [d], [DataStorageDevice.SHARED_MEMORY]),
                 )
+            for fetch_chunk2, d in zip(fetch_chunks2, data_list[::-1]):
+                self.waitp(
+                    storage_client.put_objects(
+                        session_id, [fetch_chunk2.key], [d], [DataStorageDevice.SHARED_MEMORY]),
+                )
 
             orig_calc_results = CpuCalcActor._calc_results
 
             start_event = gevent.event.Event()
 
             def _mock_calc_delayed(actor_obj, *args, **kwargs):
-                actor_obj._executing = True
                 start_event.set()
                 gevent.sleep(1)
                 return orig_calc_results(actor_obj, *args, **kwargs)
@@ -228,11 +235,19 @@ class Test(WorkerCase):
             with patch_method(CpuCalcActor._calc_results, _mock_calc_delayed):
                 p = calc_ref.calc(session_id, add_chunk.op.key, serialize_graph(exec_graph),
                                   [add_chunk.key], _promise=True) \
-                        .then(lambda *_: calc_ref.store_results(
-                            session_id, add_chunk.op.key, [add_chunk.key], None, _promise=True))
+                    .then(lambda *_: calc_ref.store_results(
+                        session_id, add_chunk.op.key, [add_chunk.key], None, _promise=True))
                 start_event.wait()
                 calc_ref.mark_destroy()
+
+                p2 = calc_ref.calc(session_id, add_chunk2.op.key, serialize_graph(exec_graph2),
+                                   [add_chunk2.key], _promise=True) \
+                    .then(lambda *_: calc_ref.store_results(
+                        session_id, add_chunk2.op.key, [add_chunk2.key], None, _promise=True))
+
                 self.assertTrue(_pool.has_actor(calc_ref._ref))
                 self.waitp(p)
+                self.waitp(p2)
 
+            gevent.sleep(0.8)
             self.assertFalse(_pool.has_actor(calc_ref._ref))

--- a/mars/worker/tests/test_calc.py
+++ b/mars/worker/tests/test_calc.py
@@ -191,3 +191,48 @@ class Test(WorkerCase):
                         .then(lambda *_: calc_ref.store_results(
                             session_id, add_chunk.op.key, [add_chunk.key], None, _promise=True))
                 )
+
+    def testDestroyCalcActor(self):
+        import gevent.event
+
+        with self._start_calc_pool() as (_pool, test_actor):
+            calc_ref = _pool.actor_ref(CpuCalcActor.default_uid())
+            calc_ref.mark_destroy()
+            self.assertFalse(_pool.has_actor(calc_ref))
+
+        with self._start_calc_pool() as (_pool, test_actor):
+            calc_ref = test_actor.promise_ref(CpuCalcActor.default_uid())
+
+            session_id = str(uuid.uuid4())
+            data_list = [np.random.random((10, 10)) for _ in range(2)]
+            exec_graph, fetch_chunks, add_chunk = self._build_test_graph(data_list)
+
+            storage_client = test_actor.storage_client
+
+            for fetch_chunk, d in zip(fetch_chunks, data_list):
+                self.waitp(
+                    storage_client.put_objects(
+                        session_id, [fetch_chunk.key], [d], [DataStorageDevice.SHARED_MEMORY]),
+                )
+
+            orig_calc_results = CpuCalcActor._calc_results
+
+            start_event = gevent.event.Event()
+
+            def _mock_calc_delayed(actor_obj, *args, **kwargs):
+                actor_obj._executing = True
+                start_event.set()
+                gevent.sleep(1)
+                return orig_calc_results(actor_obj, *args, **kwargs)
+
+            with patch_method(CpuCalcActor._calc_results, _mock_calc_delayed):
+                p = calc_ref.calc(session_id, add_chunk.op.key, serialize_graph(exec_graph),
+                                  [add_chunk.key], _promise=True) \
+                        .then(lambda *_: calc_ref.store_results(
+                            session_id, add_chunk.op.key, [add_chunk.key], None, _promise=True))
+                start_event.wait()
+                calc_ref.mark_destroy()
+                self.assertTrue(_pool.has_actor(calc_ref._ref))
+                self.waitp(p)
+
+            self.assertFalse(_pool.has_actor(calc_ref._ref))

--- a/mars/worker/tests/test_transfer.py
+++ b/mars/worker/tests/test_transfer.py
@@ -580,7 +580,7 @@ class Test(WorkerCase):
                                     session_id, chunk_key, targets, _promise=True)
                                       .then(lambda remote_data: assert_array_equal(local_data, remote_data))) \
 
-                        remote_dispatch_ref.get_free_slot('sender', _promise=True) \
+                        remote_dispatch_ref.acquire_free_slot('sender', _promise=True) \
                             .then(_call_send_data) \
                             .then(_test_data_exist) \
                             .then(


### PR DESCRIPTION
## What do these changes do?

We create backup CalcActor when spawning a new graph in mars.remote. This will make the worker process blocked by waiting calls continues running.

## Related issue number

Fixes #1407