### PR TITLE
Skip rechunk when DataFrame has unknown shape in `sort_values`.

### DIFF
--- a/mars/context.py
+++ b/mars/context.py
@@ -281,19 +281,6 @@ class LocalContext(ContextBase, dict):
             selected_metas.append(chunk_meta)
         return selected_metas
 
-    def get_tileable_metas(self, tileable_keys, filter_fields: List[str] = None) -> List:
-        metas = []
-        for key in tileable_keys:
-            tileable = self._local_session.executor.stored_tileables[key]
-            nsplits = tileable.nsplits
-            chunk_keys = [c.key for c in tileable]
-            chunk_indexes = [c.index for c in tileable]
-            metas.append(dict(nsplits=nsplits, chunk_keys=chunk_keys, chunk_indexes=chunk_indexes))
-
-        if filter_fields is not None:
-            metas = [[meta[name] for name in filter_fields] for meta in metas]
-        return metas
-
     def get_chunk_results(self, chunk_keys: List[str]) -> List:
         # As the context is actually holding the data,
         # so for the local context, we just fetch data from itself

--- a/mars/dataframe/base/__init__.py
+++ b/mars/dataframe/base/__init__.py
@@ -36,6 +36,7 @@ from .melt import melt
 
 def _install():
     from ..core import DATAFRAME_TYPE, SERIES_TYPE, INDEX_TYPE
+    from .standardize_range_index import ChunkStandardizeRangeIndex
     from .string_ import _string_method_to_handlers
     from .datetimes import _datetime_method_to_handlers
     from .accessor import StringAccessor, DatetimeAccessor, CachedAccessor

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -977,6 +977,61 @@ class BaseDataFrameData(HasShapeTileableData, _ToPandasMixin):
                          _chunks=chunks, **kw)
         self._accessors = dict()
 
+    @property
+    def params(self):
+        # params return the properties which useful to rebuild a new tileable object
+        return {
+            'shape': self.shape,
+            'dtypes': self.dtypes,
+            'index_value': self.index_value,
+            'columns_value': self.columns_value
+        }
+
+    @property
+    def dtypes(self):
+        dt = getattr(self, '_dtypes', None)
+        if dt is not None:
+            return dt
+        return getattr(self.op, 'dtypes', None)
+
+    @property
+    def index_value(self):
+        return self._index_value
+
+    @property
+    def columns_value(self):
+        return self._columns_value
+
+    def to_tensor(self, dtype=None):
+        from ..tensor.datasource.from_dataframe import from_dataframe
+        return from_dataframe(self, dtype=dtype)
+
+    @staticmethod
+    def from_tensor(in_tensor, index=None, columns=None):
+        from .datasource.from_tensor import dataframe_from_tensor
+        return dataframe_from_tensor(in_tensor, index=index, columns=columns)
+
+    @staticmethod
+    def from_records(records, **kw):
+        from .datasource.from_records import from_records
+        return from_records(records, **kw)
+
+    @property
+    def index(self):
+        from .datasource.index import from_tileable
+
+        return from_tileable(self)
+
+    @property
+    def columns(self):
+        from .datasource.index import from_pandas as from_pandas_index
+
+        return from_pandas_index(self.dtypes.index)
+
+
+class DataFrameData(BaseDataFrameData):
+    _type_name = 'DataFrame'
+
     def _to_str(self, representation=False):
         if build_mode().is_build_mode or len(self._executed_sessions) == 0:
             # in build mode, or not executed, just return representation
@@ -1046,61 +1101,6 @@ class BaseDataFrameData(HasShapeTileableData, _ToPandasMixin):
             buf.write('</div>')
 
         return buf.getvalue()
-
-    @property
-    def params(self):
-        # params return the properties which useful to rebuild a new tileable object
-        return {
-            'shape': self.shape,
-            'dtypes': self.dtypes,
-            'index_value': self.index_value,
-            'columns_value': self.columns_value
-        }
-
-    @property
-    def dtypes(self):
-        dt = getattr(self, '_dtypes', None)
-        if dt is not None:
-            return dt
-        return getattr(self.op, 'dtypes', None)
-
-    @property
-    def index_value(self):
-        return self._index_value
-
-    @property
-    def columns_value(self):
-        return self._columns_value
-
-    def to_tensor(self, dtype=None):
-        from ..tensor.datasource.from_dataframe import from_dataframe
-        return from_dataframe(self, dtype=dtype)
-
-    @staticmethod
-    def from_tensor(in_tensor, index=None, columns=None):
-        from .datasource.from_tensor import dataframe_from_tensor
-        return dataframe_from_tensor(in_tensor, index=index, columns=columns)
-
-    @staticmethod
-    def from_records(records, **kw):
-        from .datasource.from_records import from_records
-        return from_records(records, **kw)
-
-    @property
-    def index(self):
-        from .datasource.index import from_tileable
-
-        return from_tileable(self)
-
-    @property
-    def columns(self):
-        from .datasource.index import from_pandas as from_pandas_index
-
-        return from_pandas_index(self.dtypes.index)
-
-
-class DataFrameData(BaseDataFrameData):
-    _type_name = 'DataFrame'
 
     @classmethod
     def cls(cls, provider):

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -454,7 +454,6 @@ class Test(TestBase):
 
             mdf2 = sess.run(md.read_csv(file_path, incremental_index=True, chunk_bytes=10))
             pd.testing.assert_frame_equal(pdf, mdf2)
-
         finally:
             shutil.rmtree(tempdir)
 

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -454,6 +454,10 @@ class Test(TestBase):
 
             mdf2 = sess.run(md.read_csv(file_path, incremental_index=True, chunk_bytes=10))
             pd.testing.assert_frame_equal(pdf, mdf2)
+
+            mdf3 = md.read_csv(file_path, incremental_index=True, chunk_bytes=15)
+            r = sess.run(mdf3.sort_values(by='a'))
+            pd.testing.assert_frame_equal(pdf.sort_values(by='a'), r)
         finally:
             shutil.rmtree(tempdir)
 

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -455,9 +455,6 @@ class Test(TestBase):
             mdf2 = sess.run(md.read_csv(file_path, incremental_index=True, chunk_bytes=10))
             pd.testing.assert_frame_equal(pdf, mdf2)
 
-            mdf3 = md.read_csv(file_path, incremental_index=True, chunk_bytes=15)
-            r = sess.run(mdf3.sort_values(by='a'))
-            pd.testing.assert_frame_equal(pdf.sort_values(by='a'), r)
         finally:
             shutil.rmtree(tempdir)
 

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -473,9 +473,8 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def tile(cls, op: "DataFrameGroupByAgg"):
-        ctx = get_context()
-
         if op.method == 'auto':
+            ctx = get_context()
             if ctx.running_mode == RunningMode.distributed:
                 return cls._tile_with_shuffle(op)
             else:

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -475,7 +475,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
     def tile(cls, op: "DataFrameGroupByAgg"):
         if op.method == 'auto':
             ctx = get_context()
-            if ctx is not None and ctx.running_mode == RunningMode.distributed:
+            if ctx is not None and ctx.running_mode == RunningMode.distributed:  # pragma: no cover
                 return cls._tile_with_shuffle(op)
             else:
                 return cls._tile_with_tree(op)

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -23,6 +23,7 @@ from pandas.core.groupby import SeriesGroupBy
 
 from ... import opcodes as OperandDef
 from ...config import options
+from ...context import get_context, RunningMode
 from ...core import Base, Entity, OutputType
 from ...operands import OperandStage
 from ...serialize import ValueType, AnyField, StringField, ListField, DictField
@@ -472,6 +473,13 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def tile(cls, op: "DataFrameGroupByAgg"):
+        ctx = get_context()
+
+        if op.method == 'auto':
+            if ctx.running_mode == RunningMode.distributed:
+                return cls._tile_with_shuffle(op)
+            else:
+                return cls._tile_with_tree(op)
         if op.method == 'shuffle':
             return cls._tile_with_shuffle(op)
         elif op.method == 'tree':
@@ -617,13 +625,14 @@ def _check_if_func_available(func):
     return True
 
 
-def agg(groupby, func, method='tree', *args, **kwargs):
+def agg(groupby, func, method='auto', *args, **kwargs):
     """
     Aggregate using one or more operations on grouped data.
     :param groupby: Groupby data.
     :param func: Aggregation functions.
     :param method: 'shuffle' or 'tree', 'tree' method provide a better performance, 'shuffle' is recommended
-    if aggregated result is very large.
+    if aggregated result is very large, 'auto' will use 'shuffle' method in distributed mode and use 'tree'
+    in local mode.
     :return: Aggregated result.
     """
 
@@ -632,7 +641,7 @@ def agg(groupby, func, method='tree', *args, **kwargs):
     if not isinstance(groupby, GROUPBY_TYPE):
         raise TypeError('Input should be type of groupby, not %s' % type(groupby))
 
-    if method not in ['shuffle', 'tree']:
+    if method not in ['shuffle', 'tree', 'auto']:
         raise ValueError("Method %s is not available, "
                          "please specify 'tree' or 'shuffle" % method)
 

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -475,7 +475,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
     def tile(cls, op: "DataFrameGroupByAgg"):
         if op.method == 'auto':
             ctx = get_context()
-            if ctx.running_mode == RunningMode.distributed:
+            if ctx is not None and ctx.running_mode == RunningMode.distributed:
                 return cls._tile_with_shuffle(op)
             else:
                 return cls._tile_with_tree(op)

--- a/mars/dataframe/groupby/tests/test_groupby.py
+++ b/mars/dataframe/groupby/tests/test_groupby.py
@@ -62,6 +62,10 @@ class Test(TestBase):
         with self.assertRaises(TypeError):
             ms.groupby(lambda x: x + 1, as_index=False)
 
+        df = md.DataFrame(pd.DataFrame(np.random.rand(100, 3), columns=list('abc')))
+        grouped = df.groupby(['a', 'b'])
+        self.assertIn('DataFrameGroupBy', repr(grouped))
+
     def testGroupByGetItem(self):
         df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],
                             'b': [1, 3, 4, 5, 6, 5, 4, 4, 4],

--- a/mars/dataframe/groupby/tests/test_groupby.py
+++ b/mars/dataframe/groupby/tests/test_groupby.py
@@ -62,10 +62,6 @@ class Test(TestBase):
         with self.assertRaises(TypeError):
             ms.groupby(lambda x: x + 1, as_index=False)
 
-        df = md.DataFrame(pd.DataFrame(np.random.rand(100, 3), columns=list('abc')))
-        grouped = df.groupby(['a', 'b'])
-        self.assertIn('DataFrameGroupBy', repr(grouped))
-
     def testGroupByGetItem(self):
         df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],
                             'b': [1, 3, 4, 5, 6, 5, 4, 4, 4],

--- a/mars/dataframe/groupby/tests/test_groupby.py
+++ b/mars/dataframe/groupby/tests/test_groupby.py
@@ -89,7 +89,7 @@ class Test(TestBase):
         df = pd.DataFrame({'a': np.random.choice([2, 3, 4], size=(20,)),
                            'b': np.random.choice([2, 3, 4], size=(20,))})
         mdf = md.DataFrame(df, chunk_size=3)
-        r = mdf.groupby('a').agg('sum')
+        r = mdf.groupby('a').agg('sum', method='tree')
         self.assertIsInstance(r.op, DataFrameGroupByAgg)
         self.assertIsInstance(r, DataFrame)
         self.assertEqual(r.op.method, 'tree')

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -19,12 +19,20 @@ import pandas as pd
 
 import mars.dataframe as md
 from mars.tests.core import TestBase, ExecutorForTest, assert_groupby_equal
+from mars.session import new_session
+from mars.context import LocalContext
 
 
 class Test(TestBase):
     def setUp(self):
         super().setUp()
-        self.executor = ExecutorForTest()
+        self.session = new_session().as_default()
+        self._old_executor = self.session._sess._executor
+        self.executor = self.session._sess._executor = \
+            ExecutorForTest('numpy', storage=self.session._sess._context)
+
+    def tearDown(self) -> None:
+        self.session._sess._executor = self._old_executor
 
     def testGroupBy(self):
         df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],
@@ -82,283 +90,287 @@ class Test(TestBase):
                              series2.groupby(lambda x: int(x[1:]) % 3))
 
     def testGroupByGetItem(self):
-        df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],
-                            'b': [1, 3, 4, 5, 6, 5, 4, 4, 4],
-                            'c': list('aabaaddce')},
-                           index=pd.MultiIndex.from_tuples([(i % 3, 'i' + str(i)) for i in range(9)]))
-        mdf = md.DataFrame(df1, chunk_size=3)
+        with LocalContext(self.session._sess):
 
-        r = mdf.groupby(level=0)[['a', 'b']]
-        assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                             df1.groupby(level=0)[['a', 'b']], with_selection=True)
+            df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],
+                                'b': [1, 3, 4, 5, 6, 5, 4, 4, 4],
+                                'c': list('aabaaddce')},
+                               index=pd.MultiIndex.from_tuples([(i % 3, 'i' + str(i)) for i in range(9)]))
+            mdf = md.DataFrame(df1, chunk_size=3)
 
-        r = mdf.groupby(level=0)[['a', 'b']].sum()
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                      df1.groupby(level=0)[['a', 'b']].sum())
+            r = mdf.groupby(level=0)[['a', 'b']]
+            assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                 df1.groupby(level=0)[['a', 'b']], with_selection=True)
 
-        r = mdf.groupby(level=0)[['a', 'b']].apply(lambda x: x + 1)
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                      df1.groupby(level=0)[['a', 'b']].apply(lambda x: x + 1).sort_index())
+            r = mdf.groupby(level=0)[['a', 'b']].sum()
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                          df1.groupby(level=0)[['a', 'b']].sum())
 
-        r = mdf.groupby('b')[['a', 'b']]
-        assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                             df1.groupby('b')[['a', 'b']], with_selection=True)
+            r = mdf.groupby(level=0)[['a', 'b']].apply(lambda x: x + 1)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                          df1.groupby(level=0)[['a', 'b']].apply(lambda x: x + 1).sort_index())
 
-        r = mdf.groupby('b')[['a', 'c']]
-        assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                             df1.groupby('b')[['a', 'c']], with_selection=True)
+            r = mdf.groupby('b')[['a', 'b']]
+            assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                 df1.groupby('b')[['a', 'b']], with_selection=True)
 
-        r = mdf.groupby('b')[['a', 'b']].sum()
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                      df1.groupby('b')[['a', 'b']].sum())
+            r = mdf.groupby('b')[['a', 'c']]
+            assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                 df1.groupby('b')[['a', 'c']], with_selection=True)
 
-        r = mdf.groupby('b')[['a', 'b']].agg(['sum', 'count'])
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                      df1.groupby('b')[['a', 'b']].agg(['sum', 'count']))
+            r = mdf.groupby('b')[['a', 'b']].sum()
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                          df1.groupby('b')[['a', 'b']].sum())
 
-        r = mdf.groupby('b')[['a', 'c']].agg(['sum', 'count'])
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                      df1.groupby('b')[['a', 'c']].agg(['sum', 'count']))
+            r = mdf.groupby('b')[['a', 'b']].agg(['sum', 'count'])
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                          df1.groupby('b')[['a', 'b']].agg(['sum', 'count']))
 
-        r = mdf.groupby('b')[['a', 'b']].apply(lambda x: x + 1)
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                      df1.groupby('b')[['a', 'b']].apply(lambda x: x + 1).sort_index())
+            r = mdf.groupby('b')[['a', 'c']].agg(['sum', 'count'])
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                          df1.groupby('b')[['a', 'c']].agg(['sum', 'count']))
 
-        r = mdf.groupby('b')[['a', 'b']].transform(lambda x: x + 1)
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                      df1.groupby('b')[['a', 'b']].transform(lambda x: x + 1).sort_index())
+            r = mdf.groupby('b')[['a', 'b']].apply(lambda x: x + 1)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                          df1.groupby('b')[['a', 'b']].apply(lambda x: x + 1).sort_index())
 
-        r = mdf.groupby('b')[['a', 'b']].cumsum()
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                      df1.groupby('b')[['a', 'b']].cumsum().sort_index())
+            r = mdf.groupby('b')[['a', 'b']].transform(lambda x: x + 1)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                          df1.groupby('b')[['a', 'b']].transform(lambda x: x + 1).sort_index())
 
-        r = mdf.groupby('b').a
-        assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                             df1.groupby('b').a, with_selection=True)
+            r = mdf.groupby('b')[['a', 'b']].cumsum()
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                          df1.groupby('b')[['a', 'b']].cumsum().sort_index())
 
-        r = mdf.groupby('b').a.sum()
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                       df1.groupby('b').a.sum())
+            r = mdf.groupby('b').a
+            assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                 df1.groupby('b').a, with_selection=True)
 
-        r = mdf.groupby('b').a.agg(['sum', 'mean', 'var'])
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                      df1.groupby('b').a.agg(['sum', 'mean', 'var']))
+            r = mdf.groupby('b').a.sum()
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                           df1.groupby('b').a.sum())
 
-        r = mdf.groupby('b').a.apply(lambda x: x + 1)
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                       df1.groupby('b').a.apply(lambda x: x + 1).sort_index())
+            r = mdf.groupby('b').a.agg(['sum', 'mean', 'var'])
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                          df1.groupby('b').a.agg(['sum', 'mean', 'var']))
 
-        r = mdf.groupby('b').a.transform(lambda x: x + 1)
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                       df1.groupby('b').a.transform(lambda x: x + 1).sort_index())
+            r = mdf.groupby('b').a.apply(lambda x: x + 1)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                           df1.groupby('b').a.apply(lambda x: x + 1).sort_index())
 
-        r = mdf.groupby('b').a.cumsum()
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                       df1.groupby('b').a.cumsum().sort_index())
+            r = mdf.groupby('b').a.transform(lambda x: x + 1)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                           df1.groupby('b').a.transform(lambda x: x + 1).sort_index())
+
+            r = mdf.groupby('b').a.cumsum()
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                           df1.groupby('b').a.cumsum().sort_index())
 
     def testDataFrameGroupByAgg(self):
-        rs = np.random.RandomState(0)
-        df1 = pd.DataFrame({'a': rs.choice([2, 3, 4], size=(100,)),
-                            'b': rs.choice([2, 3, 4], size=(100,))})
-        mdf = md.DataFrame(df1, chunk_size=3)
+        with LocalContext(self.session._sess):
+            rs = np.random.RandomState(0)
+            df1 = pd.DataFrame({'a': rs.choice([2, 3, 4], size=(100,)),
+                                'b': rs.choice([2, 3, 4], size=(100,))})
+            mdf = md.DataFrame(df1, chunk_size=3)
 
-        df2 = pd.DataFrame({'c1': np.arange(10).astype(np.int64),
-                            'c2': rs.choice(['a', 'b', 'c'], (10,)),
-                            'c3': rs.rand(10)})
-        mdf2 = md.DataFrame(df2, chunk_size=2)
+            df2 = pd.DataFrame({'c1': np.arange(10).astype(np.int64),
+                                'c2': rs.choice(['a', 'b', 'c'], (10,)),
+                                'c3': rs.rand(10)})
+            mdf2 = md.DataFrame(df2, chunk_size=2)
 
-        for method in ['tree', 'shuffle']:
-            r0 = mdf2.groupby('c2').agg('size', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r0, concat=True)[0],
-                                           df2.groupby('c2').agg('size'))
+            for method in ['tree', 'shuffle']:
+                r0 = mdf2.groupby('c2').agg('size', method=method)
+                pd.testing.assert_series_equal(self.executor.execute_dataframe(r0, concat=True)[0],
+                                               df2.groupby('c2').agg('size'))
 
-            r1 = mdf.groupby('a').agg('sum', method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r1, concat=True)[0],
-                                          df1.groupby('a').agg('sum'))
-            r2 = mdf.groupby('b').agg('min', method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r2, concat=True)[0],
-                                          df1.groupby('b').agg('min'))
+                r1 = mdf.groupby('a').agg('sum', method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r1, concat=True)[0],
+                                              df1.groupby('a').agg('sum'))
+                r2 = mdf.groupby('b').agg('min', method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r2, concat=True)[0],
+                                              df1.groupby('b').agg('min'))
 
-            r1 = mdf2.groupby('c2').agg('prod', method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r1, concat=True)[0],
-                                          df2.groupby('c2').agg('prod'))
-            r2 = mdf2.groupby('c2').agg('max', method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r2, concat=True)[0],
-                                          df2.groupby('c2').agg('max'))
-            r3 = mdf2.groupby('c2').agg('count', method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                          df2.groupby('c2').agg('count'))
-            r4 = mdf2.groupby('c2').agg('mean', method=method)
+                r1 = mdf2.groupby('c2').agg('prod', method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r1, concat=True)[0],
+                                              df2.groupby('c2').agg('prod'))
+                r2 = mdf2.groupby('c2').agg('max', method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r2, concat=True)[0],
+                                              df2.groupby('c2').agg('max'))
+                r3 = mdf2.groupby('c2').agg('count', method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                              df2.groupby('c2').agg('count'))
+                r4 = mdf2.groupby('c2').agg('mean', method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r4, concat=True)[0],
+                                              df2.groupby('c2').agg('mean'))
+                r5 = mdf2.groupby('c2').agg('var', method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r5, concat=True)[0],
+                                              df2.groupby('c2').agg('var'))
+                r6 = mdf2.groupby('c2').agg('std', method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r6, concat=True)[0],
+                                              df2.groupby('c2').agg('std'))
+
+                agg = ['std', 'mean', 'var', 'max', 'count', 'size']
+                r3 = mdf2.groupby('c2').agg(agg, method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                              df2.groupby('c2').agg(agg))
+
+                agg = OrderedDict([('c1', ['min', 'mean']), ('c3', 'std')])
+                r3 = mdf2.groupby('c2').agg(agg, method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                              df2.groupby('c2').agg(agg))
+
+                agg = OrderedDict([('c1', 'min'), ('c3', 'sum')])
+                r3 = mdf2.groupby('c2').agg(agg, method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                              df2.groupby('c2').agg(agg))
+
+                r3 = mdf2.groupby('c2').agg({'c1': 'min'}, method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                              df2.groupby('c2').agg({'c1': 'min'}))
+
+                # test groupby series
+                r3 = mdf2.groupby(mdf2['c2']).sum(method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                              df2.groupby(df2['c2']).sum())
+
+            r8 = mdf2.groupby('c2').size()
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r8, concat=True)[0],
+                                           df2.groupby('c2').size())
+
+            r4 = mdf2.groupby('c2').sum()
             pd.testing.assert_frame_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                          df2.groupby('c2').agg('mean'))
-            r5 = mdf2.groupby('c2').agg('var', method=method)
+                                          df2.groupby('c2').sum())
+
+            r5 = mdf2.groupby('c2').prod()
             pd.testing.assert_frame_equal(self.executor.execute_dataframe(r5, concat=True)[0],
-                                          df2.groupby('c2').agg('var'))
-            r6 = mdf2.groupby('c2').agg('std', method=method)
+                                          df2.groupby('c2').prod())
+
+            r6 = mdf2.groupby('c2').min()
             pd.testing.assert_frame_equal(self.executor.execute_dataframe(r6, concat=True)[0],
-                                          df2.groupby('c2').agg('std'))
+                                          df2.groupby('c2').min())
 
-            agg = ['std', 'mean', 'var', 'max', 'count', 'size']
-            r3 = mdf2.groupby('c2').agg(agg, method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                          df2.groupby('c2').agg(agg))
+            r7 = mdf2.groupby('c2').max()
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r7, concat=True)[0],
+                                          df2.groupby('c2').max())
 
-            agg = OrderedDict([('c1', ['min', 'mean']), ('c3', 'std')])
-            r3 = mdf2.groupby('c2').agg(agg, method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                          df2.groupby('c2').agg(agg))
+            r8 = mdf2.groupby('c2').count()
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r8, concat=True)[0],
+                                          df2.groupby('c2').count())
 
-            agg = OrderedDict([('c1', 'min'), ('c3', 'sum')])
-            r3 = mdf2.groupby('c2').agg(agg, method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                          df2.groupby('c2').agg(agg))
+            r9 = mdf2.groupby('c2').mean()
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r9, concat=True)[0],
+                                          df2.groupby('c2').mean())
 
-            r3 = mdf2.groupby('c2').agg({'c1': 'min'}, method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                          df2.groupby('c2').agg({'c1': 'min'}))
+            r10 = mdf2.groupby('c2').var()
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r10, concat=True)[0],
+                                          df2.groupby('c2').var())
 
-            # test groupby series
-            r3 = mdf2.groupby(mdf2['c2']).sum(method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                          df2.groupby(df2['c2']).sum())
+            r11 = mdf2.groupby('c2').std()
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r11, concat=True)[0],
+                                          df2.groupby('c2').std())
 
-        r8 = mdf2.groupby('c2').size()
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r8, concat=True)[0],
-                                       df2.groupby('c2').size())
+            # test as_index=False
+            r12 = mdf2.groupby('c2', as_index=False).agg('mean')
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r12, concat=True)[0],
+                                          df2.groupby('c2', as_index=False).agg('mean'))
+            self.assertFalse(r12.op.groupby_params['as_index'])
 
-        r4 = mdf2.groupby('c2').sum()
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                      df2.groupby('c2').sum())
+            # test as_index=False takes no effect
+            r13 = mdf2.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count'])
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r13, concat=True)[0],
+                                          df2.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count']))
+            self.assertTrue(r13.op.groupby_params['as_index'])
 
-        r5 = mdf2.groupby('c2').prod()
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r5, concat=True)[0],
-                                      df2.groupby('c2').prod())
-
-        r6 = mdf2.groupby('c2').min()
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r6, concat=True)[0],
-                                      df2.groupby('c2').min())
-
-        r7 = mdf2.groupby('c2').max()
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r7, concat=True)[0],
-                                      df2.groupby('c2').max())
-
-        r8 = mdf2.groupby('c2').count()
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r8, concat=True)[0],
-                                      df2.groupby('c2').count())
-
-        r9 = mdf2.groupby('c2').mean()
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r9, concat=True)[0],
-                                      df2.groupby('c2').mean())
-
-        r10 = mdf2.groupby('c2').var()
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r10, concat=True)[0],
-                                      df2.groupby('c2').var())
-
-        r11 = mdf2.groupby('c2').std()
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r11, concat=True)[0],
-                                      df2.groupby('c2').std())
-
-        # test as_index=False
-        r12 = mdf2.groupby('c2', as_index=False).agg('mean')
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r12, concat=True)[0],
-                                      df2.groupby('c2', as_index=False).agg('mean'))
-        self.assertFalse(r12.op.groupby_params['as_index'])
-
-        # test as_index=False takes no effect
-        r13 = mdf2.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count'])
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r13, concat=True)[0],
-                                      df2.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count']))
-        self.assertTrue(r13.op.groupby_params['as_index'])
-
-        r14 = mdf2.groupby('c2').agg(['cumsum', 'cumcount'])
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r14, concat=True)[0].sort_index(),
-                                      df2.groupby('c2').agg(['cumsum', 'cumcount']).sort_index())
+            r14 = mdf2.groupby('c2').agg(['cumsum', 'cumcount'])
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r14, concat=True)[0].sort_index(),
+                                          df2.groupby('c2').agg(['cumsum', 'cumcount']).sort_index())
 
     def testSeriesGroupByAgg(self):
-        rs = np.random.RandomState(0)
-        series1 = pd.Series(rs.rand(10))
-        ms1 = md.Series(series1, chunk_size=3)
+        with LocalContext(self.session._sess):
+            rs = np.random.RandomState(0)
+            series1 = pd.Series(rs.rand(10))
+            ms1 = md.Series(series1, chunk_size=3)
 
-        for method in ['tree', 'shuffle']:
-            r0 = ms1.groupby(lambda x: x % 2).agg('size', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r0, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('size'))
+            for method in ['tree', 'shuffle']:
+                r0 = ms1.groupby(lambda x: x % 2).agg('size', method=method)
+                pd.testing.assert_series_equal(self.executor.execute_dataframe(r0, concat=True)[0],
+                                               series1.groupby(lambda x: x % 2).agg('size'))
 
-            r1 = ms1.groupby(lambda x: x % 2).agg('sum', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r1, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('sum'))
-            r2 = ms1.groupby(lambda x: x % 2).agg('min', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r2, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('min'))
+                r1 = ms1.groupby(lambda x: x % 2).agg('sum', method=method)
+                pd.testing.assert_series_equal(self.executor.execute_dataframe(r1, concat=True)[0],
+                                               series1.groupby(lambda x: x % 2).agg('sum'))
+                r2 = ms1.groupby(lambda x: x % 2).agg('min', method=method)
+                pd.testing.assert_series_equal(self.executor.execute_dataframe(r2, concat=True)[0],
+                                               series1.groupby(lambda x: x % 2).agg('min'))
 
-            r1 = ms1.groupby(lambda x: x % 2).agg('prod', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r1, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('prod'))
-            r2 = ms1.groupby(lambda x: x % 2).agg('max', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r2, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('max'))
-            r3 = ms1.groupby(lambda x: x % 2).agg('count', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('count'))
-            r4 = ms1.groupby(lambda x: x % 2).agg('mean', method=method)
+                r1 = ms1.groupby(lambda x: x % 2).agg('prod', method=method)
+                pd.testing.assert_series_equal(self.executor.execute_dataframe(r1, concat=True)[0],
+                                               series1.groupby(lambda x: x % 2).agg('prod'))
+                r2 = ms1.groupby(lambda x: x % 2).agg('max', method=method)
+                pd.testing.assert_series_equal(self.executor.execute_dataframe(r2, concat=True)[0],
+                                               series1.groupby(lambda x: x % 2).agg('max'))
+                r3 = ms1.groupby(lambda x: x % 2).agg('count', method=method)
+                pd.testing.assert_series_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                               series1.groupby(lambda x: x % 2).agg('count'))
+                r4 = ms1.groupby(lambda x: x % 2).agg('mean', method=method)
+                pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
+                                               series1.groupby(lambda x: x % 2).agg('mean'))
+                r5 = ms1.groupby(lambda x: x % 2).agg('var', method=method)
+                pd.testing.assert_series_equal(self.executor.execute_dataframe(r5, concat=True)[0],
+                                               series1.groupby(lambda x: x % 2).agg('var'))
+                r6 = ms1.groupby(lambda x: x % 2).agg('std', method=method)
+                pd.testing.assert_series_equal(self.executor.execute_dataframe(r6, concat=True)[0],
+                                               series1.groupby(lambda x: x % 2).agg('std'))
+
+                agg = ['std', 'mean', 'var', 'max', 'count', 'size']
+                r3 = ms1.groupby(lambda x: x % 2).agg(agg, method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                              series1.groupby(lambda x: x % 2).agg(agg))
+
+                # test groupby series
+                r3 = ms1.groupby(ms1).sum(method=method)
+                pd.testing.assert_series_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                               series1.groupby(series1).sum())
+
+            r4 = ms1.groupby(lambda x: x % 2).size()
             pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('mean'))
-            r5 = ms1.groupby(lambda x: x % 2).agg('var', method=method)
+                                           series1.groupby(lambda x: x % 2).size())
+
+            r4 = ms1.groupby(lambda x: x % 2).sum()
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).sum())
+
+            r5 = ms1.groupby(lambda x: x % 2).prod()
             pd.testing.assert_series_equal(self.executor.execute_dataframe(r5, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('var'))
-            r6 = ms1.groupby(lambda x: x % 2).agg('std', method=method)
+                                           series1.groupby(lambda x: x % 2).prod())
+
+            r6 = ms1.groupby(lambda x: x % 2).min()
             pd.testing.assert_series_equal(self.executor.execute_dataframe(r6, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('std'))
+                                           series1.groupby(lambda x: x % 2).min())
 
-            agg = ['std', 'mean', 'var', 'max', 'count', 'size']
-            r3 = ms1.groupby(lambda x: x % 2).agg(agg, method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                          series1.groupby(lambda x: x % 2).agg(agg))
+            r7 = ms1.groupby(lambda x: x % 2).max()
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r7, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).max())
 
-            # test groupby series
-            r3 = ms1.groupby(ms1).sum(method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                           series1.groupby(series1).sum())
+            r8 = ms1.groupby(lambda x: x % 2).count()
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r8, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).count())
 
-        r4 = ms1.groupby(lambda x: x % 2).size()
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).size())
+            r9 = ms1.groupby(lambda x: x % 2).mean()
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r9, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).mean())
 
-        r4 = ms1.groupby(lambda x: x % 2).sum()
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).sum())
+            r10 = ms1.groupby(lambda x: x % 2).var()
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r10, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).var())
 
-        r5 = ms1.groupby(lambda x: x % 2).prod()
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r5, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).prod())
+            r11 = ms1.groupby(lambda x: x % 2).std()
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r11, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).std())
 
-        r6 = ms1.groupby(lambda x: x % 2).min()
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r6, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).min())
-
-        r7 = ms1.groupby(lambda x: x % 2).max()
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r7, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).max())
-
-        r8 = ms1.groupby(lambda x: x % 2).count()
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r8, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).count())
-
-        r9 = ms1.groupby(lambda x: x % 2).mean()
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r9, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).mean())
-
-        r10 = ms1.groupby(lambda x: x % 2).var()
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r10, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).var())
-
-        r11 = ms1.groupby(lambda x: x % 2).std()
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r11, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).std())
-
-        r11 = ms1.groupby(lambda x: x % 2).agg(['cumsum', 'cumcount'])
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r11, concat=True)[0].sort_index(),
-                                      series1.groupby(lambda x: x % 2).agg(['cumsum', 'cumcount']).sort_index())
+            r11 = ms1.groupby(lambda x: x % 2).agg(['cumsum', 'cumcount'])
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r11, concat=True)[0].sort_index(),
+                                          series1.groupby(lambda x: x % 2).agg(['cumsum', 'cumcount']).sort_index())
 
     def testGroupByApply(self):
         df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -87,6 +87,11 @@ class Test(TestBase):
         assert_groupby_equal(self.executor.execute_dataframe(grouped, concat=True)[0],
                              series2.groupby(lambda x: int(x[1:]) % 3))
 
+        # test groupby repr
+        df = md.DataFrame(pd.DataFrame(np.random.rand(100, 3), columns=list('abc')))
+        grouped = df.groupby(['a', 'b']).execute
+        self.assertIn('DataFrameGroupBy', repr(grouped))
+
     def testGroupByGetItem(self):
         df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],
                             'b': [1, 3, 4, 5, 6, 5, 4, 4, 4],

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -87,11 +87,6 @@ class Test(TestBase):
         assert_groupby_equal(self.executor.execute_dataframe(grouped, concat=True)[0],
                              series2.groupby(lambda x: int(x[1:]) % 3))
 
-        # test groupby repr
-        df = md.DataFrame(pd.DataFrame(np.random.rand(100, 3), columns=list('abc')))
-        grouped = df.groupby(['a', 'b']).execute
-        self.assertIn('DataFrameGroupBy', repr(grouped))
-
     def testGroupByGetItem(self):
         df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],
                             'b': [1, 3, 4, 5, 6, 5, 4, 4, 4],

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -19,20 +19,17 @@ import pandas as pd
 
 import mars.dataframe as md
 from mars.tests.core import TestBase, ExecutorForTest, assert_groupby_equal
-from mars.session import new_session
-from mars.context import LocalContext
 
 
 class Test(TestBase):
     def setUp(self):
         super().setUp()
-        self.session = new_session().as_default()
-        self._old_executor = self.session._sess._executor
-        self.executor = self.session._sess._executor = \
-            ExecutorForTest('numpy', storage=self.session._sess._context)
+        self.executor = ExecutorForTest('numpy')
+        self.ctx, self.executor = self._create_test_context(self.executor)
+        self.ctx.__enter__()
 
     def tearDown(self) -> None:
-        self.session._sess._executor = self._old_executor
+        self.ctx.__exit__(None, None, None)
 
     def testGroupBy(self):
         df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],
@@ -90,287 +87,309 @@ class Test(TestBase):
                              series2.groupby(lambda x: int(x[1:]) % 3))
 
     def testGroupByGetItem(self):
-        with LocalContext(self.session._sess):
+        df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],
+                            'b': [1, 3, 4, 5, 6, 5, 4, 4, 4],
+                            'c': list('aabaaddce')},
+                           index=pd.MultiIndex.from_tuples([(i % 3, 'i' + str(i)) for i in range(9)]))
+        mdf = md.DataFrame(df1, chunk_size=3)
 
-            df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],
-                                'b': [1, 3, 4, 5, 6, 5, 4, 4, 4],
-                                'c': list('aabaaddce')},
-                               index=pd.MultiIndex.from_tuples([(i % 3, 'i' + str(i)) for i in range(9)]))
-            mdf = md.DataFrame(df1, chunk_size=3)
+        r = mdf.groupby(level=0)[['a', 'b']]
+        assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                             df1.groupby(level=0)[['a', 'b']], with_selection=True)
 
-            r = mdf.groupby(level=0)[['a', 'b']]
-            assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                 df1.groupby(level=0)[['a', 'b']], with_selection=True)
+        r = mdf.groupby(level=0)[['a', 'b']].sum(method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                      df1.groupby(level=0)[['a', 'b']].sum())
 
-            r = mdf.groupby(level=0)[['a', 'b']].sum()
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                          df1.groupby(level=0)[['a', 'b']].sum())
+        r = mdf.groupby(level=0)[['a', 'b']].apply(lambda x: x + 1)
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                      df1.groupby(level=0)[['a', 'b']].apply(lambda x: x + 1).sort_index())
 
-            r = mdf.groupby(level=0)[['a', 'b']].apply(lambda x: x + 1)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                          df1.groupby(level=0)[['a', 'b']].apply(lambda x: x + 1).sort_index())
+        r = mdf.groupby('b')[['a', 'b']]
+        assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                             df1.groupby('b')[['a', 'b']], with_selection=True)
 
-            r = mdf.groupby('b')[['a', 'b']]
-            assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                 df1.groupby('b')[['a', 'b']], with_selection=True)
+        r = mdf.groupby('b')[['a', 'c']]
+        assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                             df1.groupby('b')[['a', 'c']], with_selection=True)
 
-            r = mdf.groupby('b')[['a', 'c']]
-            assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                 df1.groupby('b')[['a', 'c']], with_selection=True)
+        r = mdf.groupby('b')[['a', 'b']].sum(method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                      df1.groupby('b')[['a', 'b']].sum())
 
-            r = mdf.groupby('b')[['a', 'b']].sum()
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                          df1.groupby('b')[['a', 'b']].sum())
+        r = mdf.groupby('b')[['a', 'b']].agg(['sum', 'count'], method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                      df1.groupby('b')[['a', 'b']].agg(['sum', 'count']))
 
-            r = mdf.groupby('b')[['a', 'b']].agg(['sum', 'count'])
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                          df1.groupby('b')[['a', 'b']].agg(['sum', 'count']))
+        r = mdf.groupby('b')[['a', 'c']].agg(['sum', 'count'], method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                      df1.groupby('b')[['a', 'c']].agg(['sum', 'count']))
 
-            r = mdf.groupby('b')[['a', 'c']].agg(['sum', 'count'])
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                          df1.groupby('b')[['a', 'c']].agg(['sum', 'count']))
+        r = mdf.groupby('b')[['a', 'b']].apply(lambda x: x + 1)
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                      df1.groupby('b')[['a', 'b']].apply(lambda x: x + 1).sort_index())
 
-            r = mdf.groupby('b')[['a', 'b']].apply(lambda x: x + 1)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                          df1.groupby('b')[['a', 'b']].apply(lambda x: x + 1).sort_index())
+        r = mdf.groupby('b')[['a', 'b']].transform(lambda x: x + 1)
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                      df1.groupby('b')[['a', 'b']].transform(lambda x: x + 1).sort_index())
 
-            r = mdf.groupby('b')[['a', 'b']].transform(lambda x: x + 1)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                          df1.groupby('b')[['a', 'b']].transform(lambda x: x + 1).sort_index())
+        r = mdf.groupby('b')[['a', 'b']].cumsum()
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                      df1.groupby('b')[['a', 'b']].cumsum().sort_index())
 
-            r = mdf.groupby('b')[['a', 'b']].cumsum()
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                          df1.groupby('b')[['a', 'b']].cumsum().sort_index())
+        r = mdf.groupby('b').a
+        assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                             df1.groupby('b').a, with_selection=True)
 
-            r = mdf.groupby('b').a
-            assert_groupby_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                 df1.groupby('b').a, with_selection=True)
+        r = mdf.groupby('b').a.sum(method='tree')
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                       df1.groupby('b').a.sum())
 
-            r = mdf.groupby('b').a.sum()
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                           df1.groupby('b').a.sum())
+        r = mdf.groupby('b').a.agg(['sum', 'mean', 'var'], method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                      df1.groupby('b').a.agg(['sum', 'mean', 'var']))
 
-            r = mdf.groupby('b').a.agg(['sum', 'mean', 'var'])
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
-                                          df1.groupby('b').a.agg(['sum', 'mean', 'var']))
+        r = mdf.groupby('b').a.apply(lambda x: x + 1)
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                       df1.groupby('b').a.apply(lambda x: x + 1).sort_index())
 
-            r = mdf.groupby('b').a.apply(lambda x: x + 1)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                           df1.groupby('b').a.apply(lambda x: x + 1).sort_index())
+        r = mdf.groupby('b').a.transform(lambda x: x + 1)
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                       df1.groupby('b').a.transform(lambda x: x + 1).sort_index())
 
-            r = mdf.groupby('b').a.transform(lambda x: x + 1)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                           df1.groupby('b').a.transform(lambda x: x + 1).sort_index())
-
-            r = mdf.groupby('b').a.cumsum()
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
-                                           df1.groupby('b').a.cumsum().sort_index())
+        r = mdf.groupby('b').a.cumsum()
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].sort_index(),
+                                       df1.groupby('b').a.cumsum().sort_index())
 
     def testDataFrameGroupByAgg(self):
-        with LocalContext(self.session._sess):
-            rs = np.random.RandomState(0)
-            df1 = pd.DataFrame({'a': rs.choice([2, 3, 4], size=(100,)),
-                                'b': rs.choice([2, 3, 4], size=(100,))})
-            mdf = md.DataFrame(df1, chunk_size=3)
+        rs = np.random.RandomState(0)
+        df1 = pd.DataFrame({'a': rs.choice([2, 3, 4], size=(100,)),
+                            'b': rs.choice([2, 3, 4], size=(100,))})
+        mdf = md.DataFrame(df1, chunk_size=3)
 
-            df2 = pd.DataFrame({'c1': np.arange(10).astype(np.int64),
-                                'c2': rs.choice(['a', 'b', 'c'], (10,)),
-                                'c3': rs.rand(10)})
-            mdf2 = md.DataFrame(df2, chunk_size=2)
+        df2 = pd.DataFrame({'c1': np.arange(10).astype(np.int64),
+                            'c2': rs.choice(['a', 'b', 'c'], (10,)),
+                            'c3': rs.rand(10)})
+        mdf2 = md.DataFrame(df2, chunk_size=2)
 
-            for method in ['tree', 'shuffle']:
-                r0 = mdf2.groupby('c2').agg('size', method=method)
-                pd.testing.assert_series_equal(self.executor.execute_dataframe(r0, concat=True)[0],
-                                               df2.groupby('c2').agg('size'))
+        for method in ['tree', 'shuffle']:
+            r0 = mdf2.groupby('c2').agg('size', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r0, concat=True)[0],
+                                           df2.groupby('c2').agg('size'))
 
-                r1 = mdf.groupby('a').agg('sum', method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r1, concat=True)[0],
-                                              df1.groupby('a').agg('sum'))
-                r2 = mdf.groupby('b').agg('min', method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r2, concat=True)[0],
-                                              df1.groupby('b').agg('min'))
+            r1 = mdf.groupby('a').agg('sum', method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r1, concat=True)[0],
+                                          df1.groupby('a').agg('sum'))
+            r2 = mdf.groupby('b').agg('min', method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r2, concat=True)[0],
+                                          df1.groupby('b').agg('min'))
 
-                r1 = mdf2.groupby('c2').agg('prod', method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r1, concat=True)[0],
-                                              df2.groupby('c2').agg('prod'))
-                r2 = mdf2.groupby('c2').agg('max', method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r2, concat=True)[0],
-                                              df2.groupby('c2').agg('max'))
-                r3 = mdf2.groupby('c2').agg('count', method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                              df2.groupby('c2').agg('count'))
-                r4 = mdf2.groupby('c2').agg('mean', method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                              df2.groupby('c2').agg('mean'))
-                r5 = mdf2.groupby('c2').agg('var', method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r5, concat=True)[0],
-                                              df2.groupby('c2').agg('var'))
-                r6 = mdf2.groupby('c2').agg('std', method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r6, concat=True)[0],
-                                              df2.groupby('c2').agg('std'))
-
-                agg = ['std', 'mean', 'var', 'max', 'count', 'size']
-                r3 = mdf2.groupby('c2').agg(agg, method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                              df2.groupby('c2').agg(agg))
-
-                agg = OrderedDict([('c1', ['min', 'mean']), ('c3', 'std')])
-                r3 = mdf2.groupby('c2').agg(agg, method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                              df2.groupby('c2').agg(agg))
-
-                agg = OrderedDict([('c1', 'min'), ('c3', 'sum')])
-                r3 = mdf2.groupby('c2').agg(agg, method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                              df2.groupby('c2').agg(agg))
-
-                r3 = mdf2.groupby('c2').agg({'c1': 'min'}, method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                              df2.groupby('c2').agg({'c1': 'min'}))
-
-                # test groupby series
-                r3 = mdf2.groupby(mdf2['c2']).sum(method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                              df2.groupby(df2['c2']).sum())
-
-            r8 = mdf2.groupby('c2').size()
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r8, concat=True)[0],
-                                           df2.groupby('c2').size())
-
-            r4 = mdf2.groupby('c2').sum()
+            r1 = mdf2.groupby('c2').agg('prod', method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r1, concat=True)[0],
+                                          df2.groupby('c2').agg('prod'))
+            r2 = mdf2.groupby('c2').agg('max', method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r2, concat=True)[0],
+                                          df2.groupby('c2').agg('max'))
+            r3 = mdf2.groupby('c2').agg('count', method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                          df2.groupby('c2').agg('count'))
+            r4 = mdf2.groupby('c2').agg('mean', method=method)
             pd.testing.assert_frame_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                          df2.groupby('c2').sum())
-
-            r5 = mdf2.groupby('c2').prod()
+                                          df2.groupby('c2').agg('mean'))
+            r5 = mdf2.groupby('c2').agg('var', method=method)
             pd.testing.assert_frame_equal(self.executor.execute_dataframe(r5, concat=True)[0],
-                                          df2.groupby('c2').prod())
-
-            r6 = mdf2.groupby('c2').min()
+                                          df2.groupby('c2').agg('var'))
+            r6 = mdf2.groupby('c2').agg('std', method=method)
             pd.testing.assert_frame_equal(self.executor.execute_dataframe(r6, concat=True)[0],
-                                          df2.groupby('c2').min())
+                                          df2.groupby('c2').agg('std'))
 
-            r7 = mdf2.groupby('c2').max()
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r7, concat=True)[0],
-                                          df2.groupby('c2').max())
+            agg = ['std', 'mean', 'var', 'max', 'count', 'size']
+            r3 = mdf2.groupby('c2').agg(agg, method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                          df2.groupby('c2').agg(agg))
 
-            r8 = mdf2.groupby('c2').count()
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r8, concat=True)[0],
-                                          df2.groupby('c2').count())
+            agg = OrderedDict([('c1', ['min', 'mean']), ('c3', 'std')])
+            r3 = mdf2.groupby('c2').agg(agg, method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                          df2.groupby('c2').agg(agg))
 
-            r9 = mdf2.groupby('c2').mean()
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r9, concat=True)[0],
-                                          df2.groupby('c2').mean())
+            agg = OrderedDict([('c1', 'min'), ('c3', 'sum')])
+            r3 = mdf2.groupby('c2').agg(agg, method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                          df2.groupby('c2').agg(agg))
 
-            r10 = mdf2.groupby('c2').var()
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r10, concat=True)[0],
-                                          df2.groupby('c2').var())
+            r3 = mdf2.groupby('c2').agg({'c1': 'min'}, method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                          df2.groupby('c2').agg({'c1': 'min'}))
 
-            r11 = mdf2.groupby('c2').std()
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r11, concat=True)[0],
-                                          df2.groupby('c2').std())
+            # test groupby series
+            r3 = mdf2.groupby(mdf2['c2']).sum(method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                          df2.groupby(df2['c2']).sum())
 
-            # test as_index=False
-            r12 = mdf2.groupby('c2', as_index=False).agg('mean')
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r12, concat=True)[0],
-                                          df2.groupby('c2', as_index=False).agg('mean'))
-            self.assertFalse(r12.op.groupby_params['as_index'])
+        r8 = mdf2.groupby('c2').size(method='tree')
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r8, concat=True)[0],
+                                       df2.groupby('c2').size())
 
-            # test as_index=False takes no effect
-            r13 = mdf2.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count'])
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r13, concat=True)[0],
-                                          df2.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count']))
-            self.assertTrue(r13.op.groupby_params['as_index'])
+        r4 = mdf2.groupby('c2').sum(method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r4, concat=True)[0],
+                                      df2.groupby('c2').sum())
 
-            r14 = mdf2.groupby('c2').agg(['cumsum', 'cumcount'])
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r14, concat=True)[0].sort_index(),
-                                          df2.groupby('c2').agg(['cumsum', 'cumcount']).sort_index())
+        r5 = mdf2.groupby('c2').prod(method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r5, concat=True)[0],
+                                      df2.groupby('c2').prod())
+
+        r6 = mdf2.groupby('c2').min(method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r6, concat=True)[0],
+                                      df2.groupby('c2').min())
+
+        r7 = mdf2.groupby('c2').max(method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r7, concat=True)[0],
+                                      df2.groupby('c2').max())
+
+        r8 = mdf2.groupby('c2').count(method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r8, concat=True)[0],
+                                      df2.groupby('c2').count())
+
+        r9 = mdf2.groupby('c2').mean(method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r9, concat=True)[0],
+                                      df2.groupby('c2').mean())
+
+        r10 = mdf2.groupby('c2').var(method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r10, concat=True)[0],
+                                      df2.groupby('c2').var())
+
+        r11 = mdf2.groupby('c2').std(method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r11, concat=True)[0],
+                                      df2.groupby('c2').std())
+
+        # test as_index=False
+        r12 = mdf2.groupby('c2', as_index=False).agg('mean', method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r12, concat=True)[0],
+                                      df2.groupby('c2', as_index=False).agg('mean'))
+        self.assertFalse(r12.op.groupby_params['as_index'])
+
+        # test as_index=False takes no effect
+        r13 = mdf2.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count'], method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r13, concat=True)[0],
+                                      df2.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count']))
+        self.assertTrue(r13.op.groupby_params['as_index'])
+
+        r14 = mdf2.groupby('c2').agg(['cumsum', 'cumcount'], method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r14, concat=True)[0].sort_index(),
+                                      df2.groupby('c2').agg(['cumsum', 'cumcount']).sort_index())
 
     def testSeriesGroupByAgg(self):
-        with LocalContext(self.session._sess):
-            rs = np.random.RandomState(0)
-            series1 = pd.Series(rs.rand(10))
-            ms1 = md.Series(series1, chunk_size=3)
+        rs = np.random.RandomState(0)
+        series1 = pd.Series(rs.rand(10))
+        ms1 = md.Series(series1, chunk_size=3)
 
-            for method in ['tree', 'shuffle']:
-                r0 = ms1.groupby(lambda x: x % 2).agg('size', method=method)
-                pd.testing.assert_series_equal(self.executor.execute_dataframe(r0, concat=True)[0],
-                                               series1.groupby(lambda x: x % 2).agg('size'))
+        for method in ['tree', 'shuffle']:
+            r0 = ms1.groupby(lambda x: x % 2).agg('size', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r0, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('size'))
 
-                r1 = ms1.groupby(lambda x: x % 2).agg('sum', method=method)
-                pd.testing.assert_series_equal(self.executor.execute_dataframe(r1, concat=True)[0],
-                                               series1.groupby(lambda x: x % 2).agg('sum'))
-                r2 = ms1.groupby(lambda x: x % 2).agg('min', method=method)
-                pd.testing.assert_series_equal(self.executor.execute_dataframe(r2, concat=True)[0],
-                                               series1.groupby(lambda x: x % 2).agg('min'))
+            r1 = ms1.groupby(lambda x: x % 2).agg('sum', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r1, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('sum'))
+            r2 = ms1.groupby(lambda x: x % 2).agg('min', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r2, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('min'))
 
-                r1 = ms1.groupby(lambda x: x % 2).agg('prod', method=method)
-                pd.testing.assert_series_equal(self.executor.execute_dataframe(r1, concat=True)[0],
-                                               series1.groupby(lambda x: x % 2).agg('prod'))
-                r2 = ms1.groupby(lambda x: x % 2).agg('max', method=method)
-                pd.testing.assert_series_equal(self.executor.execute_dataframe(r2, concat=True)[0],
-                                               series1.groupby(lambda x: x % 2).agg('max'))
-                r3 = ms1.groupby(lambda x: x % 2).agg('count', method=method)
-                pd.testing.assert_series_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                               series1.groupby(lambda x: x % 2).agg('count'))
-                r4 = ms1.groupby(lambda x: x % 2).agg('mean', method=method)
-                pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                               series1.groupby(lambda x: x % 2).agg('mean'))
-                r5 = ms1.groupby(lambda x: x % 2).agg('var', method=method)
-                pd.testing.assert_series_equal(self.executor.execute_dataframe(r5, concat=True)[0],
-                                               series1.groupby(lambda x: x % 2).agg('var'))
-                r6 = ms1.groupby(lambda x: x % 2).agg('std', method=method)
-                pd.testing.assert_series_equal(self.executor.execute_dataframe(r6, concat=True)[0],
-                                               series1.groupby(lambda x: x % 2).agg('std'))
-
-                agg = ['std', 'mean', 'var', 'max', 'count', 'size']
-                r3 = ms1.groupby(lambda x: x % 2).agg(agg, method=method)
-                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                              series1.groupby(lambda x: x % 2).agg(agg))
-
-                # test groupby series
-                r3 = ms1.groupby(ms1).sum(method=method)
-                pd.testing.assert_series_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                               series1.groupby(series1).sum())
-
-            r4 = ms1.groupby(lambda x: x % 2).size()
+            r1 = ms1.groupby(lambda x: x % 2).agg('prod', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r1, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('prod'))
+            r2 = ms1.groupby(lambda x: x % 2).agg('max', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r2, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('max'))
+            r3 = ms1.groupby(lambda x: x % 2).agg('count', method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                           series1.groupby(lambda x: x % 2).agg('count'))
+            r4 = ms1.groupby(lambda x: x % 2).agg('mean', method=method)
             pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).size())
-
-            r4 = ms1.groupby(lambda x: x % 2).sum()
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).sum())
-
-            r5 = ms1.groupby(lambda x: x % 2).prod()
+                                           series1.groupby(lambda x: x % 2).agg('mean'))
+            r5 = ms1.groupby(lambda x: x % 2).agg('var', method=method)
             pd.testing.assert_series_equal(self.executor.execute_dataframe(r5, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).prod())
-
-            r6 = ms1.groupby(lambda x: x % 2).min()
+                                           series1.groupby(lambda x: x % 2).agg('var'))
+            r6 = ms1.groupby(lambda x: x % 2).agg('std', method=method)
             pd.testing.assert_series_equal(self.executor.execute_dataframe(r6, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).min())
+                                           series1.groupby(lambda x: x % 2).agg('std'))
 
-            r7 = ms1.groupby(lambda x: x % 2).max()
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r7, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).max())
+            agg = ['std', 'mean', 'var', 'max', 'count', 'size']
+            r3 = ms1.groupby(lambda x: x % 2).agg(agg, method=method)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                          series1.groupby(lambda x: x % 2).agg(agg))
 
-            r8 = ms1.groupby(lambda x: x % 2).count()
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r8, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).count())
+            # test groupby series
+            r3 = ms1.groupby(ms1).sum(method=method)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                           series1.groupby(series1).sum())
 
-            r9 = ms1.groupby(lambda x: x % 2).mean()
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r9, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).mean())
+        r4 = ms1.groupby(lambda x: x % 2).size(method='tree')
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).size())
 
-            r10 = ms1.groupby(lambda x: x % 2).var()
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r10, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).var())
+        r4 = ms1.groupby(lambda x: x % 2).sum(method='tree')
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).sum())
 
-            r11 = ms1.groupby(lambda x: x % 2).std()
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r11, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).std())
+        r5 = ms1.groupby(lambda x: x % 2).prod(method='tree')
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r5, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).prod())
 
-            r11 = ms1.groupby(lambda x: x % 2).agg(['cumsum', 'cumcount'])
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r11, concat=True)[0].sort_index(),
-                                          series1.groupby(lambda x: x % 2).agg(['cumsum', 'cumcount']).sort_index())
+        r6 = ms1.groupby(lambda x: x % 2).min(method='tree')
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r6, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).min())
+
+        r7 = ms1.groupby(lambda x: x % 2).max(method='tree')
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r7, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).max())
+
+        r8 = ms1.groupby(lambda x: x % 2).count(method='tree')
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r8, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).count())
+
+        r9 = ms1.groupby(lambda x: x % 2).mean(method='tree')
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r9, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).mean())
+
+        r10 = ms1.groupby(lambda x: x % 2).var(method='tree')
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r10, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).var())
+
+        r11 = ms1.groupby(lambda x: x % 2).std(method='tree')
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r11, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).std())
+
+        r11 = ms1.groupby(lambda x: x % 2).agg(['cumsum', 'cumcount'], method='tree')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r11, concat=True)[0].sort_index(),
+                                      series1.groupby(lambda x: x % 2).agg(['cumsum', 'cumcount']).sort_index())
+
+    def testGroupByAuto(self):
+        rs = np.random.RandomState(0)
+        df2 = pd.DataFrame({'c1': np.arange(10).astype(np.int64),
+                            'c2': rs.choice(['a', 'b', 'c'], (10,)),
+                            'c3': rs.rand(10)})
+        mdf2 = md.DataFrame(df2, chunk_size=2)
+
+        r1 = mdf2.groupby('c2').agg('prod')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r1, concat=True)[0],
+                                      df2.groupby('c2').agg('prod'))
+        r2 = mdf2.groupby('c2').agg('max')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r2, concat=True)[0],
+                                      df2.groupby('c2').agg('max'))
+        r3 = mdf2.groupby('c2').agg('count')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
+                                      df2.groupby('c2').agg('count'))
+        r4 = mdf2.groupby('c2').agg('mean')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r4, concat=True)[0],
+                                      df2.groupby('c2').agg('mean'))
+        r5 = mdf2.groupby('c2').agg('var')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r5, concat=True)[0],
+                                      df2.groupby('c2').agg('var'))
+        r6 = mdf2.groupby('c2').agg('std')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r6, concat=True)[0],
+                                      df2.groupby('c2').agg('std'))
 
     def testGroupByApply(self):
         df1 = pd.DataFrame({'a': [3, 4, 5, 3, 5, 4, 1, 2, 3],

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -325,7 +325,10 @@ class DataFramePSRSSortRegularSample(DataFramePSRSChunkOperand, DataFrameOperand
     def execute(cls, ctx, op):
         a = ctx[op.inputs[0].key]
 
-        ctx[op.outputs[0].key] = res = execute_sort_values(a, op)
+        if op.sort_type == 'sort_values':
+            ctx[op.outputs[0].key] = res = execute_sort_values(a, op)
+        else:
+            ctx[op.outputs[0].key] = res = execute_sort_index(a, op)
 
         n = op.n_partition
         if a.shape[op.axis] < n:

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -325,19 +325,22 @@ class DataFramePSRSSortRegularSample(DataFramePSRSChunkOperand, DataFrameOperand
     def execute(cls, ctx, op):
         a = ctx[op.inputs[0].key]
 
+        ctx[op.outputs[0].key] = res = execute_sort_values(a, op)
+
         n = op.n_partition
-        w = int(a.shape[op.axis] // n)
+        if a.shape[op.axis] < n:
+            num = n // a.shape[op.axis] + 1
+            res = execute_sort_values(pd.concat([a] * num), op)
+        w = int(res.shape[op.axis] // n)
 
         slc = (slice(None),) * op.axis + (slice(0, n * w, w),)
         if op.sort_type == 'sort_values':
-            ctx[op.outputs[0].key] = res = execute_sort_values(a, op)
             # do regular sample
             if op.by is not None:
                 ctx[op.outputs[-1].key] = res[op.by].iloc[slc]
             else:
                 ctx[op.outputs[-1].key] = res.iloc[slc]
         else:
-            ctx[op.outputs[0].key] = res = execute_sort_index(a, op)
             # do regular sample
             ctx[op.outputs[-1].key] = res.iloc[slc]
 

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -140,6 +140,15 @@ class Test(unittest.TestCase):
 
         pd.testing.assert_frame_equal(result, df)
 
+        # test unknown shape
+        df = pd.DataFrame({'a': list(range(10)),
+                           'b': np.random.random(10)})
+        mdf = DataFrame(df, chunk_size=4)
+        filtered = mdf[mdf['a'] > 2]
+        result = self.executor.execute_dataframe(filtered.sort_values(by='b'), concat=True)[0]
+
+        pd.testing.assert_frame_equal(result, df[df['a'] > 2].sort_values(by='b'))
+
         # test Sereis.sort_values
         raw = pd.Series(np.random.rand(10))
         series = Series(raw)

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -733,7 +733,7 @@ def standardize_range_index(chunks, axis=0):
     for c in chunks:
         inputs = row_chunks[:c.index[axis]] + [c]
         op = ChunkStandardizeRangeIndex(
-            prepare_inputs=[False] * len(inputs), axis=axis, output_types=c.op.output_types)
+            prepare_inputs=[False] * (len(inputs) - 1) + [True], axis=axis, output_types=c.op.output_types)
         out_chunks.append(op.new_chunk(inputs, **c.params.copy()))
 
     return out_chunks

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -921,6 +921,10 @@ class Test(unittest.TestCase):
                 r3 = f.iloc[:3].to_pandas()
                 pd.testing.assert_frame_equal(r3, df[df.a > df.a].reset_index(drop=True))
 
+                mdf3 = md.read_csv(file_path, chunk_bytes=15, incremental_index=True)
+                r4 = mdf3.to_pandas()
+                pd.testing.assert_frame_equal(df, r4.reset_index(drop=True))
+
     def testDataFrameShuffle(self, *_):
         from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df
         from mars.dataframe.merge.merge import merge
@@ -1008,94 +1012,94 @@ class Test(unittest.TestCase):
                          shared_memory='20M', modules=[__name__], web=True) as cluster:
             session = cluster.session
 
-            # def f(x):
-            #     return x + 1
-            #
-            # def g(x, y):
-            #     return x * y
-            #
-            # a = mr.spawn(f, 3)
-            # b = mr.spawn(f, 4)
-            # c = mr.spawn(g, (a, b))
-            #
-            # r = session.run(c, timeout=_exec_timeout)
-            # self.assertEqual(r, 20)
-            #
-            # e = mr.spawn(f, mr.spawn(f, 2))
-            #
-            # r = session.run(e, timeout=_exec_timeout)
-            # self.assertEqual(r, 4)
-            #
-            # session2 = new_session(cluster.endpoint)
-            # expect_session_id = session2.session_id
-            #
-            # def f2():
-            #     session = Session.default
-            #     assert isinstance(session._sess, ClusterSession)
-            #     assert session._sess.session_id == expect_session_id
-            #
-            #     t = mt.ones((3, 2))
-            #     return t.sum().to_numpy()
-            #
-            # self.assertEqual(cloudpickle.loads(cloudpickle.dumps(Session.default)).session_id,
-            #                  session.session_id)
-            # self.assertIsInstance(serialize_function(f2), bytes)
-            #
-            # d = mr.spawn(f2, retry_when_fail=False)
-            #
-            # r = session2.run(d, timeout=_exec_timeout)
-            # self.assertEqual(r, 6)
-            #
-            # # test input tileable
-            # def f(t, x):
-            #     return (t * x).sum().to_numpy()
-            #
-            # rs = np.random.RandomState(0)
-            # raw = rs.rand(5, 4)
-            #
-            # t1 = mt.tensor(raw, chunk_size=3)
-            # t2 = t1.sum(axis=0)
-            # s = mr.spawn(f, args=(t2, 3), retry_when_fail=False)
-            #
-            # r = session.run(s, timeout=_exec_timeout)
-            # expected = (raw.sum(axis=0) * 3).sum()
-            # self.assertAlmostEqual(r, expected)
-            #
-            # # test named tileable
-            # session3 = new_session(cluster.endpoint)
-            # t = mt.ones((10, 10), chunk_size=3)
-            # session3.run(t, name='t_name')
-            #
-            # def f3():
-            #     import mars.tensor as mt
-            #
-            #     s = mt.named_tensor(name='t_name')
-            #     return (s + 1).to_numpy()
-            #
-            # d = mr.spawn(f3, retry_when_fail=False)
-            # r = session3.run(d, timeout=_exec_timeout)
-            # np.testing.assert_array_equal(r, np.ones((10, 10)) + 1)
-            #
-            # # test tileable that executed
-            # session4 = new_session(cluster.endpoint)
-            # df1 = md.DataFrame(raw, chunk_size=3)
-            # df1 = df1[df1.iloc[:, 0] < 1.5]
-            #
-            # def f4(input_df):
-            #     bonus = input_df.iloc[:, 0].fetch().sum()
-            #     return input_df.sum().to_pandas() + bonus
-            #
-            # d = mr.spawn(f4, args=(df1,), retry_when_fail=False)
-            # r = session4.run(d, timeout=_exec_timeout)
-            # expected = pd.DataFrame(raw).sum() + raw[:, 0].sum()
-            # pd.testing.assert_series_equal(r, expected)
-            #
+            def f(x):
+                return x + 1
+
+            def g(x, y):
+                return x * y
+
+            a = mr.spawn(f, 3)
+            b = mr.spawn(f, 4)
+            c = mr.spawn(g, (a, b))
+
+            r = session.run(c, timeout=_exec_timeout)
+            self.assertEqual(r, 20)
+
+            e = mr.spawn(f, mr.spawn(f, 2))
+
+            r = session.run(e, timeout=_exec_timeout)
+            self.assertEqual(r, 4)
+
+            session2 = new_session(cluster.endpoint)
+            expect_session_id = session2.session_id
+
+            def f2():
+                session = Session.default
+                assert isinstance(session._sess, ClusterSession)
+                assert session._sess.session_id == expect_session_id
+
+                t = mt.ones((3, 2))
+                return t.sum().to_numpy()
+
+            self.assertEqual(cloudpickle.loads(cloudpickle.dumps(Session.default)).session_id,
+                             session.session_id)
+            self.assertIsInstance(serialize_function(f2), bytes)
+
+            d = mr.spawn(f2, retry_when_fail=False)
+
+            r = session2.run(d, timeout=_exec_timeout)
+            self.assertEqual(r, 6)
+
+            # test input tileable
+            def f(t, x):
+                return (t * x).sum().to_numpy()
+
+            rs = np.random.RandomState(0)
+            raw = rs.rand(5, 4)
+
+            t1 = mt.tensor(raw, chunk_size=3)
+            t2 = t1.sum(axis=0)
+            s = mr.spawn(f, args=(t2, 3), retry_when_fail=False)
+
+            r = session.run(s, timeout=_exec_timeout)
+            expected = (raw.sum(axis=0) * 3).sum()
+            self.assertAlmostEqual(r, expected)
+
+            # test named tileable
+            session3 = new_session(cluster.endpoint)
+            t = mt.ones((10, 10), chunk_size=3)
+            session3.run(t, name='t_name')
+
+            def f3():
+                import mars.tensor as mt
+
+                s = mt.named_tensor(name='t_name')
+                return (s + 1).to_numpy()
+
+            d = mr.spawn(f3, retry_when_fail=False)
+            r = session3.run(d, timeout=_exec_timeout)
+            np.testing.assert_array_equal(r, np.ones((10, 10)) + 1)
+
+            # test tileable that executed
+            session4 = new_session(cluster.endpoint)
+            df1 = md.DataFrame(raw, chunk_size=3)
+            df1 = df1[df1.iloc[:, 0] < 1.5]
+
+            def f4(input_df):
+                bonus = input_df.iloc[:, 0].fetch().sum()
+                return input_df.sum().to_pandas() + bonus
+
+            d = mr.spawn(f4, args=(df1,), retry_when_fail=False)
+            r = session4.run(d, timeout=_exec_timeout)
+            expected = pd.DataFrame(raw).sum() + raw[:, 0].sum()
+            pd.testing.assert_series_equal(r, expected)
+
             # test tileable has unknown shape
             session5 = new_session(cluster.endpoint)
 
             def f5(t, x):
                 assert all(not np.isnan(s) for s in t.shape)
-                return (t * x).sum().to_numpy(check_nsplits=False)
+                return (t * x).sum().to_numpy()
 
             rs = np.random.RandomState(0)
             raw = rs.rand(5, 4)

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -549,7 +549,7 @@ class MapReduceOperand(Operand):
             inputs = self.inputs or ()
             deps = []
             for inp in inputs:
-                if isinstance(inp.op, ShuffleProxy):
+                if isinstance(inp.op, (ShuffleProxy, FetchShuffle)):
                     deps.extend([(chunk.key, self._shuffle_key) for chunk in inp.inputs or ()])
                 else:
                     deps.append(inp.key)

--- a/mars/remote/core.py
+++ b/mars/remote/core.py
@@ -15,7 +15,10 @@
 from collections.abc import Iterable
 from functools import partial
 
+import numpy as np
+
 from .. import opcodes
+from ..utils import calc_nsplits
 from ..context import ContextBase
 from ..core import Entity, Base, ChunkData
 from ..serialize import FunctionField, ListField, DictField, BoolField, Int32Field
@@ -190,7 +193,17 @@ class RemoteFunction(RemoteOperandMixin, ObjectOperand):
         for to_search in [op.function_args, op.function_kwargs]:
             tileable_placeholders = find_objects(to_search, _TileablePlaceholder)
             for ph in tileable_placeholders:
-                mapping[ph] = ph.tileable
+                tileable = ph.tileable
+                chunk_index_to_shape = dict()
+                for chunk in tileable.chunks:
+                    if any(np.isnan(s) for s in chunk.shape):
+                        shape = ctx.get_chunk_metas([chunk.key], filter_fields=['chunk_shape'])[0][0]
+                        chunk._shape = shape
+                    chunk_index_to_shape[chunk.index] = chunk.shape
+                nsplits = calc_nsplits(chunk_index_to_shape)
+                tileable._nsplits = nsplits
+                tileable._shape = tuple(sum(ns) for ns in nsplits)
+                mapping[ph] = tileable
 
         function = op.function
         function_args = replace_inputs(op.function_args, mapping)

--- a/mars/remote/core.py
+++ b/mars/remote/core.py
@@ -200,9 +200,10 @@ class RemoteFunction(RemoteOperandMixin, ObjectOperand):
                         shape = ctx.get_chunk_metas([chunk.key], filter_fields=['chunk_shape'])[0][0]
                         chunk._shape = shape
                     chunk_index_to_shape[chunk.index] = chunk.shape
-                nsplits = calc_nsplits(chunk_index_to_shape)
-                tileable._nsplits = nsplits
-                tileable._shape = tuple(sum(ns) for ns in nsplits)
+                if any(any(np.isnan(s) for s in ns) for ns in tileable._nsplits):
+                    nsplits = calc_nsplits(chunk_index_to_shape)
+                    tileable._nsplits = nsplits
+                    tileable._shape = tuple(sum(ns) for ns in nsplits)
                 mapping[ph] = tileable
 
         function = op.function

--- a/mars/remote/tests/test_remote_function.py
+++ b/mars/remote/tests/test_remote_function.py
@@ -161,12 +161,12 @@ class Test(TestBase):
         raw = rs.rand(5, 4)
 
         t1 = mt.tensor(raw, chunk_size=3)
-        t2 = t1[t1 < 0.5]
+        t2 = t1[t1 > 0]
         s = spawn(f, args=(t2, 3))
 
         sess = new_session()
         sess._sess._executor = ExecutorForTest('numpy', storage=sess._context)
 
         result = s.execute(session=sess).fetch(session=sess)
-        expected = (raw[raw < 0.5] * 3).sum()
+        expected = (raw[raw > 0] * 3).sum()
         self.assertAlmostEqual(result, expected)

--- a/mars/scheduler/tests/integrated/no_prepare_op.py
+++ b/mars/scheduler/tests/integrated/no_prepare_op.py
@@ -23,7 +23,7 @@ class NoPrepareOperand(TensorAdd):
     @classmethod
     def execute(cls, ctx, op):
         input_keys = [c.key for c in op.inputs]
-        has_all_data = all(k in ctx for k in input_keys)
+        has_all_data = all(((k in ctx) and (ctx[k] is not None)) for k in input_keys)
         if has_all_data:
             raise ValueError('Unexpected behavior')
         ctx[op.outputs[0].key] = np.array((len(op.inputs), 1))

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -32,21 +32,29 @@ from ..array_utils import as_same_device, device, cp
 class PSRSOperandMixin:
     @classmethod
     def preprocess(cls, op, in_data=None):
-        in_data = in_data or op.inputs[0]
+        if in_data is None:
+            in_data = op.inputs[0]
         axis_shape = in_data.shape[op.axis]
         axis_chunk_shape = in_data.chunk_shape[op.axis]
 
         # rechunk to ensure all chunks on axis have rough same size
-        axis_chunk_shape = min(axis_chunk_shape, int(np.sqrt(axis_shape)))
-        if np.isnan(axis_shape) or any(np.isnan(s) for s in in_data.nsplits[op.axis]):
-            raise TilesError('fail to tile because either the shape of '
-                             'input data on axis {} has unknown shape or chunk shape'.format(op.axis))
-        chunk_size = int(axis_shape / axis_chunk_shape)
-        chunk_sizes = [chunk_size for _ in range(int(axis_shape // chunk_size))]
-        if axis_shape % chunk_size > 0:
-            chunk_sizes[-1] += axis_shape % chunk_size
-        in_data = in_data.rechunk({op.axis: tuple(chunk_sizes)})._inplace_tile()
-        axis_chunk_shape = in_data.chunk_shape[op.axis]
+        has_unknown_shape = False
+        for ns in in_data.nsplits:
+            if any(np.isnan(s) for s in ns):
+                has_unknown_shape = True
+                break
+
+        if not has_unknown_shape:
+            axis_chunk_shape = min(axis_chunk_shape, int(np.sqrt(axis_shape)))
+            if np.isnan(axis_shape) or any(np.isnan(s) for s in in_data.nsplits[op.axis]):
+                raise TilesError('fail to tile because either the shape of '
+                                 'input data on axis {} has unknown shape or chunk shape'.format(op.axis))
+            chunk_size = int(axis_shape / axis_chunk_shape)
+            chunk_sizes = [chunk_size for _ in range(int(axis_shape // chunk_size))]
+            if axis_shape % chunk_size > 0:
+                chunk_sizes[-1] += axis_shape % chunk_size
+            in_data = in_data.rechunk({op.axis: tuple(chunk_sizes)})._inplace_tile()
+            axis_chunk_shape = in_data.chunk_shape[op.axis]
 
         left_chunk_shape = in_data.chunk_shape[:op.axis] + in_data.chunk_shape[op.axis + 1:]
         if len(left_chunk_shape) > 0:

--- a/mars/tensor/rechunk/core.py
+++ b/mars/tensor/rechunk/core.py
@@ -61,7 +61,8 @@ def plan_rechunks(tileable, new_chunk_size, itemsize, threshold=None, chunk_size
 
     steps = []
 
-    chunk_size_limit /= itemsize
+    if itemsize > 0:
+        chunk_size_limit /= itemsize
     chunk_size_limit = max([int(chunk_size_limit),
                             _largest_chunk_size(tileable.nsplits),
                             _largest_chunk_size(new_chunk_size)])

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -518,6 +518,12 @@ class Test(unittest.TestCase):
 
         self.assertIn('DatetimeIndex', repr(ind.execute()))
 
+        # test groupby repr
+        df = md.DataFrame(pd.DataFrame(np.random.rand(100, 3), columns=list('abc')))
+        grouped = df.groupby(['a', 'b']).execute()
+
+        self.assertIn('DataFrameGroupBy', repr(grouped))
+
     def testDataFrameIter(self):
         raw_data = pd.DataFrame(np.random.randint(1000, size=(20, 10)))
         df = md.DataFrame(raw_data, chunk_size=5)

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1050,6 +1050,9 @@ class FixedSizeFileObject:
 
 
 def is_object_dtype(dtype):
-    return np.issubdtype(dtype, np.object_) \
-        or np.issubdtype(dtype, np.unicode_) \
-        or np.issubdtype(dtype, np.bytes_)
+    try:
+        return np.issubdtype(dtype, np.object_) \
+            or np.issubdtype(dtype, np.unicode_) \
+            or np.issubdtype(dtype, np.bytes_)
+    except TypeError:
+        return False

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1054,5 +1054,5 @@ def is_object_dtype(dtype):
         return np.issubdtype(dtype, np.object_) \
             or np.issubdtype(dtype, np.unicode_) \
             or np.issubdtype(dtype, np.bytes_)
-    except TypeError:
+    except TypeError:  # pragma: no cover
         return False

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -167,6 +167,11 @@ class BaseCalcActor(WorkerActor):
         logger.debug('Start calculating operand %s in %s.', graph_key, self.uid)
         start_time = time.time()
 
+        for chunk in graph:
+            for inp, prepare_inp in zip(chunk.inputs, chunk.op.prepare_inputs):
+                if not prepare_inp:
+                    context_dict[inp.key] = None
+
         local_context_dict = DistributedDictContext(
             self.get_scheduler(self.default_uid()), session_id, actor_ctx=self.ctx,
             address=self.address, n_cpu=self._get_n_cpu())

--- a/mars/worker/tests/test_dispatcher.py
+++ b/mars/worker/tests/test_dispatcher.py
@@ -71,7 +71,7 @@ class Test(WorkerCase):
             # tasks within [0, group_size - 1] will run almost simultaneously,
             # while the last one will be delayed due to lack of slots
 
-            delay = 0.5
+            delay = 1
 
             with self.run_actor_test(pool) as test_actor:
                 p = promise.finished()
@@ -81,7 +81,7 @@ class Test(WorkerCase):
                     if uid is None:
                         call_records[key] = 'NoneUID'
                     else:
-                        test_actor.promise_ref(uid).queued_call(key, delay, _tell=True)
+                        test_actor.promise_ref(uid).queued_call(key, delay, _tell=True, _wait=False)
 
                 for idx in range(group_size + 1):
                     p = p.then(lambda *_: _dispatch_ref.acquire_free_slot('g1', _promise=True)) \


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

`sort_values` will rechunk tileable in tiles, which will trigger iterative tiling when tileable has unknown shape, in this PR, we skip rechunk to avoid iterative tiling.

## Related issue number
Fixes #1413.
<!-- Are there any issues opened that will be resolved by merging this change? -->
