### PR TITLE
Fix query alias & add estimation for object types

### DIFF
--- a/mars/dataframe/datasource/read_sql.py
+++ b/mars/dataframe/datasource/read_sql.py
@@ -174,12 +174,15 @@ class DataFrameReadSQL(DataFrameOperand, DataFrameOperandMixin):
                     selectable = sa.Table(self._table_or_sql, m, autoload=True,
                                           autoload_with=engine_or_conn, schema=self._schema)
                 except NoSuchTableError:
-                    temp_table_name = 'temp_' + binascii.b2a_hex(uuid.uuid4().bytes).decode()
+                    temp_name_1 = 't1_' + binascii.b2a_hex(uuid.uuid4().bytes).decode()
+                    temp_name_2 = 't2_' + binascii.b2a_hex(uuid.uuid4().bytes).decode()
                     if columns:
-                        selectable = sql.text(self._table_or_sql).columns(*[sql.column(c) for c in columns])
+                        selectable = sql.text(self._table_or_sql).columns(*[sql.column(c) for c in columns]) \
+                            .alias(temp_name_2)
                     else:
                         selectable = sql.select(
-                            '*', from_obj=sql.text('(%s) AS %s' % (self._table_or_sql, temp_table_name)))
+                            '*', from_obj=sql.text('(%s) AS %s' % (self._table_or_sql, temp_name_1))) \
+                            .alias(temp_name_2)
                     self._selectable = selectable
         return selectable
 

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -21,18 +21,19 @@ from typing import TypeVar, Union, List
 import numpy as np
 
 from . import opcodes as OperandDef
-from .serialize import SerializableMetaclass, ValueType, ProviderType, IdentityField, \
-    ListField, DictField, Int32Field, BoolField, StringField, ReferenceField
+from .context import RunningMode, get_context
 from .core import Entity, Chunk, Tileable, AttributeAsDictKey, ExecutableTuple, \
     FuseChunkData, FuseChunk, OutputType, get_chunk_types, get_tileable_types
-from .utils import AttributeDict, to_str, calc_data_size, is_eager_mode
+from .serialize import SerializableMetaclass, ValueType, ProviderType, IdentityField, \
+    ListField, DictField, Int32Field, BoolField, StringField, ReferenceField
 from .tiles import NotSupportTile
-from .context import RunningMode, get_context
+from .utils import AttributeDict, to_str, calc_data_size, is_eager_mode, is_object_dtype
 
 
 operand_type_to_oprand_cls = {}
 OP_TYPE_KEY = '_op_type_'
 OP_MODULE_KEY = '_op_module_'
+OBJECT_FIELD_OVERHEAD = 50
 T = TypeVar('T')
 
 
@@ -445,6 +446,8 @@ class TileableOperandMixin(object):
 
     @classmethod
     def estimate_size(cls, ctx, op):
+        from .dataframe.core import DATAFRAME_CHUNK_TYPE, SERIES_CHUNK_TYPE, INDEX_CHUNK_TYPE
+
         exec_size = 0
         outputs = op.outputs
         if all(not c.is_sparse() and hasattr(c, 'nbytes') and not np.isnan(c.nbytes) for c in outputs):
@@ -453,7 +456,17 @@ class TileableOperandMixin(object):
 
         for inp in op.inputs or ():
             try:
-                exec_size += ctx[inp.key][0]
+                # execution size of a specific data chunk may be
+                # larger than stored type due to objects
+                obj_overhead = n_strings = 0
+                if getattr(inp, 'shape', None) and not np.isnan(inp.shape[0]):
+                    if isinstance(inp, DATAFRAME_CHUNK_TYPE) and inp.dtypes is not None:
+                        n_strings = len([dt for dt in inp.dtypes if is_object_dtype(dt)])
+                    elif isinstance(inp, (INDEX_CHUNK_TYPE, SERIES_CHUNK_TYPE)) and inp.dtype is not None:
+                        n_strings = 1 if is_object_dtype(inp.dtype) else 0
+                    obj_overhead += n_strings * inp.shape[0] * OBJECT_FIELD_OVERHEAD
+
+                exec_size += ctx[inp.key][0] + obj_overhead
             except KeyError:
                 if not op.sparse:
                     inp_size = calc_data_size(inp)
@@ -472,6 +485,7 @@ class TileableOperandMixin(object):
                 total_out_size += chunk_size
             except (AttributeError, TypeError, ValueError):
                 pass
+
         exec_size = max(exec_size, total_out_size)
         for out in outputs:
             if out.key in ctx:

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1047,3 +1047,9 @@ class FixedSizeFileObject:
 
     def __getattr__(self, item):  # pragma: no cover
         return getattr(self._file_obj, item)
+
+
+def is_object_dtype(dtype):
+    return np.issubdtype(dtype, np.object_) \
+        or np.issubdtype(dtype, np.unicode_) \
+        or np.issubdtype(dtype, np.bytes_)


### PR DESCRIPTION
## What do these changes do?

Fix aliases for ``read_sql_query`` and add estimation for object sizes to reduce possibility of OOM.

## Related issue number

Fixes #1415 