### PR TITLE
Fix the dtype of LightGBM model's predicted results.

### DIFF
--- a/mars/learn/contrib/lightgbm/tests/test_ranker.py
+++ b/mars/learn/contrib/lightgbm/tests/test_ranker.py
@@ -54,6 +54,8 @@ class Test(unittest.TestCase):
         self.assertEqual(prediction.shape[0], len(self.X))
 
         self.assertIsInstance(prediction, mt.Tensor)
+        result = prediction.fetch()
+        self.assertEqual(prediction.dtype, result.dtype)
 
         # test weight
         weight = mt.random.rand(X.shape[0])
@@ -63,3 +65,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(prediction.ndim, 1)
         self.assertEqual(prediction.shape[0], len(self.X))
+
+        result = prediction.fetch()
+        self.assertEqual(prediction.dtype, result.dtype)

--- a/mars/learn/contrib/lightgbm/tests/test_regressor.py
+++ b/mars/learn/contrib/lightgbm/tests/test_regressor.py
@@ -33,7 +33,7 @@ class Test(unittest.TestCase):
         chunk_size = 20
         rs = mt.random.RandomState(0)
         self.X = rs.rand(n_rows, n_columns, chunk_size=chunk_size)
-        self.y = rs.rand(n_rows, chunk_size=chunk_size)
+        self.y = rs.randint(0, 10, n_rows, chunk_size=chunk_size)
 
         self.session = new_session().as_default()
         self._old_executor = self.session._sess._executor
@@ -53,6 +53,8 @@ class Test(unittest.TestCase):
         self.assertEqual(prediction.shape[0], len(self.X))
 
         self.assertIsInstance(prediction, mt.Tensor)
+        result = prediction.fetch()
+        self.assertEqual(prediction.dtype, result.dtype)
 
         # test weight
         weight = mt.random.rand(X.shape[0])
@@ -62,3 +64,5 @@ class Test(unittest.TestCase):
 
         self.assertEqual(prediction.ndim, 1)
         self.assertEqual(prediction.shape[0], len(self.X))
+        result = prediction.fetch()
+        self.assertEqual(prediction.dtype, result.dtype)

--- a/mars/learn/contrib/lightgbm/train.py
+++ b/mars/learn/contrib/lightgbm/train.py
@@ -296,7 +296,10 @@ class LGBMTrain(MergeDictOperand):
                       eval_set=eval_set, eval_sample_weight=eval_sample_weight,
                       eval_init_score=eval_init_score, **op.kwds)
 
-            if hasattr(label_val, 'dtype'):
+            if op.model_type == LGBMModelType.RANKER or \
+                    op.model_type == LGBMModelType.REGRESSOR:
+                model.set_params(out_dtype_=np.dtype('float'))
+            elif hasattr(label_val, 'dtype'):
                 model.set_params(out_dtype_=label_val.dtype)
             else:
                 model.set_params(out_dtype_=label_val.dtypes[0])


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
If the model is type of regressor or ranker, we specify the dtype to float.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1418.