### PR TITLE
[BACKPORT] Skip rechunk when DataFrame has unknown shape in `sort_values` (#1414)

### DIFF
--- a/mars/dataframe/base/__init__.py
+++ b/mars/dataframe/base/__init__.py
@@ -36,6 +36,7 @@ from .melt import melt
 
 def _install():
     from ..core import DATAFRAME_TYPE, SERIES_TYPE, INDEX_TYPE
+    from .standardize_range_index import ChunkStandardizeRangeIndex
     from .string_ import _string_method_to_handlers
     from .datetimes import _datetime_method_to_handlers
     from .accessor import StringAccessor, DatetimeAccessor, CachedAccessor

--- a/mars/dataframe/groupby/tests/test_groupby.py
+++ b/mars/dataframe/groupby/tests/test_groupby.py
@@ -89,7 +89,7 @@ class Test(TestBase):
         df = pd.DataFrame({'a': np.random.choice([2, 3, 4], size=(20,)),
                            'b': np.random.choice([2, 3, 4], size=(20,))})
         mdf = md.DataFrame(df, chunk_size=3)
-        r = mdf.groupby('a').agg('sum')
+        r = mdf.groupby('a').agg('sum', method='tree')
         self.assertIsInstance(r.op, DataFrameGroupByAgg)
         self.assertIsInstance(r, DataFrame)
         self.assertEqual(r.op.method, 'tree')

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -325,19 +325,25 @@ class DataFramePSRSSortRegularSample(DataFramePSRSChunkOperand, DataFrameOperand
     def execute(cls, ctx, op):
         a = ctx[op.inputs[0].key]
 
+        if op.sort_type == 'sort_values':
+            ctx[op.outputs[0].key] = res = execute_sort_values(a, op)
+        else:
+            ctx[op.outputs[0].key] = res = execute_sort_index(a, op)
+
         n = op.n_partition
-        w = int(a.shape[op.axis] // n)
+        if a.shape[op.axis] < n:
+            num = n // a.shape[op.axis] + 1
+            res = execute_sort_values(pd.concat([a] * num), op)
+        w = int(res.shape[op.axis] // n)
 
         slc = (slice(None),) * op.axis + (slice(0, n * w, w),)
         if op.sort_type == 'sort_values':
-            ctx[op.outputs[0].key] = res = execute_sort_values(a, op)
             # do regular sample
             if op.by is not None:
                 ctx[op.outputs[-1].key] = res[op.by].iloc[slc]
             else:
                 ctx[op.outputs[-1].key] = res.iloc[slc]
         else:
-            ctx[op.outputs[0].key] = res = execute_sort_index(a, op)
             # do regular sample
             ctx[op.outputs[-1].key] = res.iloc[slc]
 

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -140,6 +140,15 @@ class Test(unittest.TestCase):
 
         pd.testing.assert_frame_equal(result, df)
 
+        # test unknown shape
+        df = pd.DataFrame({'a': list(range(10)),
+                           'b': np.random.random(10)})
+        mdf = DataFrame(df, chunk_size=4)
+        filtered = mdf[mdf['a'] > 2]
+        result = self.executor.execute_dataframe(filtered.sort_values(by='b'), concat=True)[0]
+
+        pd.testing.assert_frame_equal(result, df[df['a'] > 2].sort_values(by='b'))
+
         # test Sereis.sort_values
         raw = pd.Series(np.random.rand(10))
         series = Series(raw)

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -733,7 +733,7 @@ def standardize_range_index(chunks, axis=0):
     for c in chunks:
         inputs = row_chunks[:c.index[axis]] + [c]
         op = ChunkStandardizeRangeIndex(
-            prepare_inputs=[False] * len(inputs), axis=axis, object_type=c.op.object_type)
+            prepare_inputs=[False] * (len(inputs) - 1) + [True], axis=axis, object_type=c.op.object_type)
         out_chunks.append(op.new_chunk(inputs, **c.params.copy()))
 
     return out_chunks

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -142,8 +142,7 @@ class Operand(AttributeAsDictKey, metaclass=OperandMetaclass):
         return True
 
     def get_dependent_data_keys(self):
-        return [dep.key for dep, has_dep
-                in zip(self.inputs or (), self.prepare_inputs) if has_dep]
+        return [dep.key for dep in self.inputs or ()]
 
     @property
     def gpu(self):
@@ -476,8 +475,13 @@ class MapReduceOperand(Operand):
     def get_dependent_data_keys(self):
         if self.stage == OperandStage.reduce:
             inputs = self.inputs or ()
-            return [(chunk.key, self._shuffle_key)
-                    for proxy in inputs for chunk in proxy.inputs or ()]
+            deps = []
+            for inp in inputs:
+                if isinstance(inp.op, (ShuffleProxy, FetchShuffle)):
+                    deps.extend([(chunk.key, self._shuffle_key) for chunk in inp.inputs or ()])
+                else:
+                    deps.append(inp.key)
+            return deps
         return super().get_dependent_data_keys()
 
 

--- a/mars/remote/core.py
+++ b/mars/remote/core.py
@@ -15,7 +15,10 @@
 from collections.abc import Iterable
 from functools import partial
 
+import numpy as np
+
 from .. import opcodes
+from ..utils import calc_nsplits
 from ..context import ContextBase
 from ..core import Entity, Base, ChunkData
 from ..serialize import FunctionField, ListField, DictField, BoolField, Int32Field
@@ -199,7 +202,18 @@ class RemoteFunction(ObjectOperand, RemoteOperandMixin):
         for to_search in [op.function_args, op.function_kwargs]:
             tileable_placeholders = find_objects(to_search, _TileablePlaceholder)
             for ph in tileable_placeholders:
-                mapping[ph] = ph.tileable
+                tileable = ph.tileable
+                chunk_index_to_shape = dict()
+                for chunk in tileable.chunks:
+                    if any(np.isnan(s) for s in chunk.shape):
+                        shape = ctx.get_chunk_metas([chunk.key], filter_fields=['chunk_shape'])[0][0]
+                        chunk._shape = shape
+                    chunk_index_to_shape[chunk.index] = chunk.shape
+                if any(any(np.isnan(s) for s in ns) for ns in tileable._nsplits):
+                    nsplits = calc_nsplits(chunk_index_to_shape)
+                    tileable._nsplits = nsplits
+                    tileable._shape = tuple(sum(ns) for ns in nsplits)
+                mapping[ph] = tileable
 
         function = op.function
         function_args = replace_inputs(op.function_args, mapping)

--- a/mars/remote/tests/test_remote_function.py
+++ b/mars/remote/tests/test_remote_function.py
@@ -151,3 +151,22 @@ class Test(TestBase):
             result = s.execute(session=sess).fetch(session=sess)
             expected = pd.DataFrame(raw).sum() + raw[:, 0].sum()
             pd.testing.assert_series_equal(result, expected)
+
+    def testUnknownShapeInputs(self):
+        def f(t, x):
+            assert all(not np.isnan(s) for s in t.shape)
+            return (t * x).sum().to_numpy(check_nsplits=False)
+
+        rs = np.random.RandomState(0)
+        raw = rs.rand(5, 4)
+
+        t1 = mt.tensor(raw, chunk_size=3)
+        t2 = t1[t1 > 0]
+        s = spawn(f, args=(t2, 3))
+
+        sess = new_session()
+        sess._sess._executor = ExecutorForTest('numpy', storage=sess._context)
+
+        result = s.execute(session=sess).fetch(session=sess)
+        expected = (raw[raw > 0] * 3).sum()
+        self.assertAlmostEqual(result, expected)

--- a/mars/scheduler/tests/integrated/no_prepare_op.py
+++ b/mars/scheduler/tests/integrated/no_prepare_op.py
@@ -23,7 +23,7 @@ class NoPrepareOperand(TensorAdd):
     @classmethod
     def execute(cls, ctx, op):
         input_keys = [c.key for c in op.inputs]
-        has_all_data = all(k in ctx for k in input_keys)
+        has_all_data = all(((k in ctx) and (ctx[k] is not None)) for k in input_keys)
         if has_all_data:
             raise ValueError('Unexpected behavior')
         ctx[op.outputs[0].key] = np.array((len(op.inputs), 1))

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -32,21 +32,29 @@ from ..array_utils import as_same_device, device, cp
 class PSRSOperandMixin:
     @classmethod
     def preprocess(cls, op, in_data=None):
-        in_data = in_data or op.inputs[0]
+        if in_data is None:
+            in_data = op.inputs[0]
         axis_shape = in_data.shape[op.axis]
         axis_chunk_shape = in_data.chunk_shape[op.axis]
 
         # rechunk to ensure all chunks on axis have rough same size
-        axis_chunk_shape = min(axis_chunk_shape, int(np.sqrt(axis_shape)))
-        if np.isnan(axis_shape) or any(np.isnan(s) for s in in_data.nsplits[op.axis]):
-            raise TilesError('fail to tile because either the shape of '
-                             'input data on axis {} has unknown shape or chunk shape'.format(op.axis))
-        chunk_size = int(axis_shape / axis_chunk_shape)
-        chunk_sizes = [chunk_size for _ in range(int(axis_shape // chunk_size))]
-        if axis_shape % chunk_size > 0:
-            chunk_sizes[-1] += axis_shape % chunk_size
-        in_data = in_data.rechunk({op.axis: tuple(chunk_sizes)})._inplace_tile()
-        axis_chunk_shape = in_data.chunk_shape[op.axis]
+        has_unknown_shape = False
+        for ns in in_data.nsplits:
+            if any(np.isnan(s) for s in ns):
+                has_unknown_shape = True
+                break
+
+        if not has_unknown_shape:
+            axis_chunk_shape = min(axis_chunk_shape, int(np.sqrt(axis_shape)))
+            if np.isnan(axis_shape) or any(np.isnan(s) for s in in_data.nsplits[op.axis]):
+                raise TilesError('fail to tile because either the shape of '
+                                 'input data on axis {} has unknown shape or chunk shape'.format(op.axis))
+            chunk_size = int(axis_shape / axis_chunk_shape)
+            chunk_sizes = [chunk_size for _ in range(int(axis_shape // chunk_size))]
+            if axis_shape % chunk_size > 0:
+                chunk_sizes[-1] += axis_shape % chunk_size
+            in_data = in_data.rechunk({op.axis: tuple(chunk_sizes)})._inplace_tile()
+            axis_chunk_shape = in_data.chunk_shape[op.axis]
 
         left_chunk_shape = in_data.chunk_shape[:op.axis] + in_data.chunk_shape[op.axis + 1:]
         if len(left_chunk_shape) > 0:

--- a/mars/tensor/rechunk/core.py
+++ b/mars/tensor/rechunk/core.py
@@ -61,7 +61,8 @@ def plan_rechunks(tileable, new_chunk_size, itemsize, threshold=None, chunk_size
 
     steps = []
 
-    chunk_size_limit /= itemsize
+    if itemsize > 0:
+        chunk_size_limit /= itemsize
     chunk_size_limit = max([int(chunk_size_limit),
                             _largest_chunk_size(tileable.nsplits),
                             _largest_chunk_size(new_chunk_size)])

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -518,6 +518,12 @@ class Test(unittest.TestCase):
 
         self.assertIn('DatetimeIndex', repr(ind.execute()))
 
+        # test groupby repr
+        df = md.DataFrame(pd.DataFrame(np.random.rand(100, 3), columns=list('abc')))
+        grouped = df.groupby(['a', 'b']).execute()
+
+        self.assertIn('DataFrameGroupBy', repr(grouped))
+
     def testDataFrameIter(self):
         raw_data = pd.DataFrame(np.random.randint(1000, size=(20, 10)))
         df = md.DataFrame(raw_data, chunk_size=5)

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1047,5 +1047,5 @@ def is_object_dtype(dtype):
         return np.issubdtype(dtype, np.object_) \
             or np.issubdtype(dtype, np.unicode_) \
             or np.issubdtype(dtype, np.bytes_)
-    except TypeError:
+    except TypeError:  # pragma: no cover
         return False

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -167,6 +167,11 @@ class BaseCalcActor(WorkerActor):
         logger.debug('Start calculating operand %s in %s.', graph_key, self.uid)
         start_time = time.time()
 
+        for chunk in graph:
+            for inp, prepare_inp in zip(chunk.inputs, chunk.op.prepare_inputs):
+                if not prepare_inp:
+                    context_dict[inp.key] = None
+
         local_context_dict = DistributedDictContext(
             self.get_scheduler(self.default_uid()), session_id, actor_ctx=self.ctx,
             address=self.address, n_cpu=self._get_n_cpu())

--- a/mars/worker/tests/test_dispatcher.py
+++ b/mars/worker/tests/test_dispatcher.py
@@ -71,7 +71,7 @@ class Test(WorkerCase):
             # tasks within [0, group_size - 1] will run almost simultaneously,
             # while the last one will be delayed due to lack of slots
 
-            delay = 0.5
+            delay = 1
 
             with self.run_actor_test(pool) as test_actor:
                 p = promise.finished()
@@ -81,7 +81,7 @@ class Test(WorkerCase):
                     if uid is None:
                         call_records[key] = 'NoneUID'
                     else:
-                        test_actor.promise_ref(uid).queued_call(key, delay, _tell=True)
+                        test_actor.promise_ref(uid).queued_call(key, delay, _tell=True, _wait=False)
 
                 for idx in range(group_size + 1):
                     p = p.then(lambda *_: _dispatch_ref.acquire_free_slot('g1', _promise=True)) \


### PR DESCRIPTION
Backport of #1414.