### PR TITLE
Support serializing complex scalars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,13 @@ jobs:
                 libxgboost py-xgboost xgboost lightgbm
             fi
             if [[ $UNAME == "linux" ]] && [[ "$PYTHON" =~ "3.6" ]]; then
-              retry pip install torch==1.4.0 torchvision==0.5.0
+              pip install torch==1.4.0 torchvision==0.5.0
               conda install -n test --quiet --yes -c pytorch python=$PYTHON faiss-cpu
             fi
             if [[ $UNAME == "linux" ]] && [[ ! "$PYTHON" =~ "3.8" ]]; then
-              retry pip install tensorflow\<2.3.0
-              retry pip install torch torchvision
-              retry pip install tsfresh
+              pip install tensorflow\<2.3.0
+              pip install torch torchvision
+              pip install tsfresh
             fi
             virtualenv testenv && source testenv/bin/activate
             pip install -r requirements.txt && pip install pytest pytest-timeout

--- a/.github/workflows/reload-env.sh
+++ b/.github/workflows/reload-env.sh
@@ -34,8 +34,10 @@ export PYTHON=$(python -c "import sys; print('.'.join(str(v) for v in sys.versio
 function retry {
   r=0
   until [ "$r" -ge 5 ]; do
-    $@ && break
+    $@ && break || true
     r=$((r+1))
     sleep 1
   done
 }
+alias pip="retry pip"
+shopt -s expand_aliases

--- a/mars/errors.py
+++ b/mars/errors.py
@@ -107,7 +107,7 @@ class SpillSizeExceeded(MarsError):
 class SerializationFailed(MarsError):
     def __init__(self, msg=None, **kwargs):
         obj = kwargs.pop('obj', None)
-        if obj:
+        if obj is not None:
             msg = (msg or '') + ' type=%s repr=%s' % (type(obj), repr(obj))
         super().__init__(msg)
 

--- a/mars/lib/nvutils.py
+++ b/mars/lib/nvutils.py
@@ -15,6 +15,7 @@
 
 import logging
 import os
+import sys
 import uuid
 from collections import namedtuple
 from ctypes import c_char, c_char_p, c_int, c_uint, c_ulonglong, byref,\
@@ -172,7 +173,11 @@ def _init_nvml():
     if _init_pid == os.getpid():
         return
 
-    _nvml_lib = _load_nv_library('libnvidia-ml.so', 'libnvidia-ml.dylib', 'nvml.dll')
+    nvml_paths = ['libnvidia-ml.so', 'libnvidia-ml.so.1', 'libnvidia-ml.dylib', 'nvml.dll']
+    if sys.platform[:3] == "win":
+        nvml_paths.append(os.path.join(os.getenv("ProgramFiles", "C:/Program Files"),
+                                       "NVIDIA Corporation/NVSMI/nvml.dll"))
+    _nvml_lib = _load_nv_library(*nvml_paths)
 
     if _nvml_lib is None:
         return

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -731,6 +731,17 @@ class Test(unittest.TestCase):
         dest_s = dataserializer.loads((dataserializer.dumps(s)))
         pd.testing.assert_index_equal(s, dest_s)
 
+        # test complex
+        s = complex(10 + 5j)
+        dest_s = dataserializer.loads((dataserializer.dumps(s)))
+        self.assertIs(type(s), type(dest_s))
+        self.assertEqual(s, dest_s)
+
+        s = np.complex64(10 + 5j)
+        dest_s = dataserializer.loads((dataserializer.dumps(s)))
+        self.assertIs(type(s), type(dest_s))
+        self.assertEqual(s, dest_s)
+
     @unittest.skipIf(pyarrow is None, 'PyArrow is not installed.')
     def testArrowSerialize(self):
         array = np.random.rand(1000, 100)

--- a/mars/session.py
+++ b/mars/session.py
@@ -96,7 +96,8 @@ class LocalSession(object):
                     # GPU
                     cnt = cuda_count() if cuda_count is not None else 0
                     if cnt == 0:
-                        raise RuntimeError('No GPU found for execution')
+                        raise RuntimeError('No GPU found for execution. '
+                                           'Make sure NVML library is in your library path.')
                     kw['n_parallel'] = cnt
                 else:
                     # CPU

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -133,7 +133,7 @@ class WorkerService(object):
         os.close(fd)
         size = stats.f_bsize * stats.f_bavail
         # keep some safety margin for allocator fragmentation
-        return 9 * size // 10
+        return 8 * size // 10
 
     def _calc_memory_limits(self):
         def _calc_size_limit(limit_str, total_size):

--- a/mars/worker/storage/manager.py
+++ b/mars/worker/storage/manager.py
@@ -70,7 +70,7 @@ class StorageManagerActor(WorkerActor):
             location_set.add(location)
             try:
                 attrs = self._data_attrs[session_data_key]
-                attrs.size = max(size, attrs.size)
+                attrs.size = size
                 if shape:
                     attrs.shape = shape
             except KeyError:

--- a/mars/worker/storage/sharedstore.py
+++ b/mars/worker/storage/sharedstore.py
@@ -16,6 +16,7 @@ import logging
 
 from ...actors import FunctionActor
 from ...errors import StorageFull, StorageDataExists, SerializationFailed
+from ...serialize import dataserializer
 
 try:
     import pyarrow
@@ -221,7 +222,7 @@ class PlasmaSharedStore(object):
 
         try:
             try:
-                serialized = pyarrow.serialize(value, self._serialize_context)
+                serialized = dataserializer.serialize(value)
             except SerializationCallbackError:
                 self._mapper_ref.delete(session_id, data_key)
                 raise SerializationFailed(obj=value) from None


### PR DESCRIPTION
## What do these changes do?

Support returning complex scalars when pyarrow does not support. Now code like

```python
mt.zeros([2, 2], dtype=mt.complex128).sum().execute()
```

can work as expected.

## Related issue number

Fixes #552