### PR TITLE
Support `ExtensionDtype ` in `df.astype`

### DIFF
--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -199,6 +199,10 @@ cdef list tokenize_pandas_categorical(ob):
     return iterative_tokenize(l)
 
 
+cdef list tokenize_pd_extension_dtype(ob):
+    return iterative_tokenize([ob.name])
+
+
 cdef list tokenize_categories_dtype(ob):
     return iterative_tokenize([ob.categories, ob.ordered])
 
@@ -275,6 +279,8 @@ tokenize_handler.register(pd.arrays.DatetimeArray, tokenize_pandas_time_arrays)
 tokenize_handler.register(pd.arrays.TimedeltaArray, tokenize_pandas_time_arrays)
 tokenize_handler.register(pd.arrays.PeriodArray, tokenize_pandas_time_arrays)
 tokenize_handler.register(pd.arrays.IntervalArray, tokenize_pandas_interval_arrays)
+tokenize_handler.register(pd.api.extensions.ExtensionDtype, tokenize_pd_extension_dtype)
+
 if SATypeEngine is not None:
     tokenize_handler.register(SATypeEngine, tokenize_sqlalchemy_data_type)
 if SASelectable is not None:

--- a/mars/dataframe/arrays.py
+++ b/mars/dataframe/arrays.py
@@ -157,6 +157,9 @@ class ArrowStringArray(StringArrayBase):
                    for x in chunk.buffers()
                    if x is not None)
 
+    def memory_usage(self, deep=True) -> int:
+        return self.nbytes
+
     @staticmethod
     def _can_process_slice_via_arrow(slc):
         if not isinstance(slc, slice):

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -1144,6 +1144,14 @@ class Test(TestBase):
         expected = raw.astype({'c1': 'int32', 'c2': 'float', 'c8': 'str'})
         pd.testing.assert_frame_equal(expected, result)
 
+        # test arrow_string dtype
+        df = from_pandas_df(raw, chunk_size=8)
+        r = df.astype({'c1': 'arrow_string'})
+
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = raw.astype({'c1': 'arrow_string'})
+        pd.testing.assert_frame_equal(expected, result)
+
         # test series
         s = pd.Series(rs.randint(5, size=20))
         series = from_pandas_series(s)
@@ -1151,6 +1159,13 @@ class Test(TestBase):
 
         result = self.executor.execute_dataframe(r, concat=True)[0]
         expected = s.astype('int32')
+        pd.testing.assert_series_equal(result, expected)
+
+        series = from_pandas_series(s, chunk_size=6)
+        r = series.astype('arrow_string')
+
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s.astype('arrow_string')
         pd.testing.assert_series_equal(result, expected)
 
         # multiply chunks

--- a/mars/dataframe/tests/test_arrays.py
+++ b/mars/dataframe/tests/test_arrays.py
@@ -164,6 +164,10 @@ class Test(unittest.TestCase):
         self.assertLess(arrow_array.nbytes,
                         pd.Series(string_array).memory_usage(deep=True))
 
+        # test memory_usage
+        self.assertEqual(arrow_array.memory_usage(deep=True),
+                         arrow_array.nbytes)
+
         # test isna
         np.testing.assert_array_equal(has_na_arrow_array.isna(),
                                       has_na_string_array.isna())


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Support tokenize `ExtensionDtype` to support `ExtensionDtype ` in `df.astype`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1460.