### PR TITLE
Fix incorrect `index_value` in `df.drop()`

### DIFF
--- a/mars/dataframe/base/drop.py
+++ b/mars/dataframe/base/drop.py
@@ -117,7 +117,7 @@ class DataFrameDrop(DataFrameOperandMixin, DataFrameOperand):
                     col_to_args[c.index[1]] = (new_dtypes, new_col_id)
 
                 params.update(dict(dtypes=new_dtypes, index=(c.index[0], new_col_id),
-                                   index_value=parse_index(None, (c.key, c.index_value.key))))
+                                   index_value=c.index_value))
                 if op.index is not None:
                     params.update(dict(shape=(np.nan, len(new_dtypes)),
                                        index_value=parse_index(None, (c.key, c.index_value.key))))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Fix incorrect `index_value` in `df.drop()`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1463.