### PR TITLE
Serialize results in worker before storing into shared storages

### DIFF
--- a/mars/base_app.py
+++ b/mars/base_app.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -56,54 +57,33 @@ class BaseApplication(object):
 
         self._running = False
 
-    def __call__(self, argv=None):
-        import json
-
-        if argv is None:
-            argv = sys.argv[1:]
+    @staticmethod
+    def _handle_options(argv=None, config=None):
+        argv = argv or sys.argv[1:]
         new_argv = []
+        config = config or options
         for a in argv:
             if not a.startswith('-D'):
                 new_argv.append(a)
                 continue
             conf, val = a[2:].split('=', 1)
             conf_parts = conf.split('.')
-            conf_obj = options
+            conf_obj = config
             for g in conf_parts[:-1]:
                 conf_obj = getattr(conf_obj, g)
             try:
                 setattr(conf_obj, conf_parts[-1], json.loads(val))
-            except:  # noqa: E722
+            except json.JSONDecodeError:
                 setattr(conf_obj, conf_parts[-1], val)
+        return new_argv
 
-        return self._main(new_argv)
+    def __call__(self, argv=None, config=None):
+        return self._main(self._handle_options(argv, config))
 
     def _main(self, argv=None):
         parser = argparse.ArgumentParser(description=self.service_description)
-        parser.add_argument('-a', '--advertise', help='advertise ip exposed to other services')
-        parser.add_argument('-e', '--endpoint', help='endpoint of the service')
-        parser.add_argument('-k', '--kv-store', help='address of kv store service, '
-                                                     'for instance, etcd://localhost:4001')
-        parser.add_argument('-s', '--schedulers', help='endpoint of schedulers, needed for workers '
-                                                       'and webs when kv-store argument is not available, '
-                                                       'or when you need to use multiple schedulers '
-                                                       'without kv-store')
-        parser.add_argument('-H', '--host', help='host of the service, needed when `endpoint` is absent')
-        parser.add_argument('-p', '--port', help='port of the service, needed when `endpoint` is absent')
-        parser.add_argument('--log-level', help='log level')
-        parser.add_argument('--level', help=argparse.SUPPRESS,
-                            action=arg_deprecated_action('--log-level'))
-        parser.add_argument('--log-format', help='log format')
-        parser.add_argument('--format', help=argparse.SUPPRESS,
-                            action=arg_deprecated_action('--log-format'))
-        parser.add_argument('--log-conf', help='log config file, logging.conf by default')
-        parser.add_argument('--log_conf', help=argparse.SUPPRESS,
-                            action=arg_deprecated_action('--log-conf'))
-        parser.add_argument('--load-modules', nargs='*', help='modules to import')
         self.config_args(parser)
-        args = parser.parse_args(argv)
-        args.advertise = args.advertise or os.environ.get('MARS_CONTAINER_IP')
-        self.args = args
+        args = self.args = self.parse_args(parser, argv)
 
         endpoint = args.endpoint
         if endpoint is not None:
@@ -116,14 +96,9 @@ class BaseApplication(object):
 
         options.kv_store = args.kv_store if args.kv_store else options.kv_store
 
-        load_modules = []
-        for mods in tuple(args.load_modules or ()) + (os.environ.get('MARS_LOAD_MODULES'),):
-            if mods:
-                load_modules.extend(mods.split(','))
-        load_modules.extend(['mars.executor', 'mars.serialize.protos'])
-        for m in load_modules:
+        for m in args.load_modules:
             __import__(m, globals(), locals(), [])
-        self.service_logger.info('Modules %s loaded', ','.join(load_modules))
+        self.service_logger.info('Modules %s loaded', ','.join(args.load_modules))
 
         self.n_process = 1
 
@@ -258,7 +233,45 @@ class BaseApplication(object):
         pass
 
     def config_args(self, parser):
-        raise NotImplementedError
+        parser.add_argument('-a', '--advertise', help='advertise ip exposed to other services')
+        parser.add_argument('-e', '--endpoint', help='endpoint of the service')
+        parser.add_argument('-k', '--kv-store', help='address of kv store service, '
+                                                     'for instance, etcd://localhost:4001')
+        parser.add_argument('-s', '--schedulers', help='endpoint of schedulers, needed for workers '
+                                                       'and webs when kv-store argument is not available, '
+                                                       'or when you need to use multiple schedulers '
+                                                       'without kv-store')
+        parser.add_argument('-H', '--host', help='host of the service, needed when `endpoint` is absent')
+        parser.add_argument('-p', '--port', help='port of the service, needed when `endpoint` is absent')
+        parser.add_argument('--log-level', help='log level')
+        parser.add_argument('--level', help=argparse.SUPPRESS,
+                            action=arg_deprecated_action('--log-level'))
+        parser.add_argument('--log-format', help='log format')
+        parser.add_argument('--format', help=argparse.SUPPRESS,
+                            action=arg_deprecated_action('--log-format'))
+        parser.add_argument('--log-conf', help='log config file, logging.conf by default')
+        parser.add_argument('--log_conf', help=argparse.SUPPRESS,
+                            action=arg_deprecated_action('--log-conf'))
+        parser.add_argument('--load-modules', nargs='*', help='modules to import')
+
+    def parse_args(self, parser, argv, environ=None):
+        environ = environ or os.environ
+        args = parser.parse_args(argv)
+
+        args.advertise = args.advertise or environ.get('MARS_CONTAINER_IP')
+        load_modules = []
+        for mods in tuple(args.load_modules or ()) + (environ.get('MARS_LOAD_MODULES'),):
+            load_modules.extend(mods.split(',') if mods else [])
+        load_modules.extend(['mars.executor', 'mars.serialize.protos'])
+        args.load_modules = tuple(load_modules)
+
+        if 'MARS_TASK_DETAIL' in environ:
+            task_detail = json.loads(environ['MARS_TASK_DETAIL'])
+            task_type, task_index = task_detail['task']['type'], task_detail['task']['index']
+
+            args.advertise = args.advertise or task_detail['cluster'][task_type][task_index]
+            args.schedulers = args.schedulers or ','.join(task_detail['cluster']['scheduler'])
+        return args
 
     def start(self):
         raise NotImplementedError

--- a/mars/dataframe/arrays.py
+++ b/mars/dataframe/arrays.py
@@ -298,7 +298,7 @@ class ArrowStringArray(StringArrayBase):
             return pd.isna(self._arrow_array.to_pandas()).to_numpy()
 
     def take(self, indices, allow_fill=False, fill_value=None):
-        if allow_fill is False:
+        if allow_fill is False or (allow_fill and fill_value == self.dtype.na_value):
             return ArrowStringArray(self[indices])
 
         string_array = self._arrow_array.to_pandas().to_numpy()
@@ -310,6 +310,7 @@ class ArrowStringArray(StringArrayBase):
 
         result = take(string_array, indices, fill_value=fill_value,
                       allow_fill=allow_fill)
+        del string_array
         if replace:
             # pyarrow cannot recognize pa.NULL
             result[result == self.dtype.na_value] = None

--- a/mars/dataframe/arrays.py
+++ b/mars/dataframe/arrays.py
@@ -298,7 +298,7 @@ class ArrowStringArray(StringArrayBase):
             return pd.isna(self._arrow_array.to_pandas()).to_numpy()
 
     def take(self, indices, allow_fill=False, fill_value=None):
-        if allow_fill is False or (allow_fill and fill_value == self.dtype.na_value):
+        if allow_fill is False:
             return ArrowStringArray(self[indices])
 
         string_array = self._arrow_array.to_pandas().to_numpy()

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -976,11 +976,13 @@ class Test(unittest.TestCase):
             pd.testing.assert_frame_equal(pdf, result)
 
     def testTileContextInLocalCluster(self):
+        from mars.serialize import dataserializer
         with new_cluster(scheduler_n_process=2, worker_n_process=2,
                          shared_memory='20M', modules=[__name__], web=True) as cluster:
             session = cluster.session
 
             raw = np.random.rand(10, 20)
+            data_bytes = dataserializer.serialize(raw).total_bytes
             data = mt.tensor(raw)
 
             session.run(data)
@@ -988,7 +990,7 @@ class Test(unittest.TestCase):
             data2 = TileWithContextOperand().new_tensor([data], shape=data.shape)
 
             result = session.run(data2)
-            np.testing.assert_array_equal(raw * raw.nbytes, result)
+            np.testing.assert_array_equal(raw * data_bytes, result)
 
     @unittest.skipIf(h5py is None, 'h5py not installed')
     def testStoreHDF5ForLocalCluster(self):

--- a/mars/lib/mkl_interface.py
+++ b/mars/lib/mkl_interface.py
@@ -48,6 +48,7 @@ class MKLVersion(ctypes.Structure):
 
 mkl_free_buffers = None
 mkl_get_version = None
+mkl_mem_stat = None
 
 mkl_rt = _load_mkl_rt('mkl_rt')
 if mkl_rt:
@@ -55,6 +56,18 @@ if mkl_rt:
         mkl_free_buffers = mkl_rt.mkl_free_buffers
         mkl_free_buffers.argtypes = []
         mkl_free_buffers.restype = None
+    except AttributeError:
+        pass
+
+    try:
+        _mkl_mem_stat = mkl_rt.mkl_mem_stat
+        _mkl_mem_stat.argtypes = [ctypes.POINTER(ctypes.c_int32)]
+        _mkl_mem_stat.restype = ctypes.c_int64
+
+        def mkl_mem_stat():
+            n_bufs = ctypes.c_int32(0)
+            size = _mkl_mem_stat(ctypes.pointer(n_bufs))
+            return size, n_bufs.value
     except AttributeError:
         pass
 

--- a/mars/lib/mkl_interface.py
+++ b/mars/lib/mkl_interface.py
@@ -56,7 +56,7 @@ if mkl_rt:
         mkl_free_buffers = mkl_rt.mkl_free_buffers
         mkl_free_buffers.argtypes = []
         mkl_free_buffers.restype = None
-    except AttributeError:
+    except AttributeError:  # pragma: no cover
         pass
 
     try:
@@ -68,7 +68,7 @@ if mkl_rt:
             n_bufs = ctypes.c_int32(0)
             size = _mkl_mem_stat(ctypes.pointer(n_bufs))
             return size, n_bufs.value
-    except AttributeError:
+    except AttributeError:  # pragma: no cover
         pass
 
     try:
@@ -80,5 +80,5 @@ if mkl_rt:
             version = MKLVersion()
             _mkl_get_version(version)
             return version
-    except AttributeError:
+    except AttributeError:  # pragma: no cover
         pass

--- a/mars/scheduler/__main__.py
+++ b/mars/scheduler/__main__.py
@@ -31,6 +31,7 @@ class SchedulerApplication(BaseApplication):
         self._service = None
 
     def config_args(self, parser):
+        super().config_args(parser)
         parser.add_argument('--nproc', help='number of processes')
 
     def create_pool(self, *args, **kwargs):

--- a/mars/serialize/dataserializer.py
+++ b/mars/serialize/dataserializer.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     SerializationCallbackError = Exception
 try:
     from pyarrow.lib import ArrowNotImplementedError
-except ImportError:
+except ImportError:  # pragma: no cover
     ArrowNotImplementedError = type('ArrowNotImplementedError', (Exception,), {})
 
 
@@ -291,6 +291,8 @@ def dumps(obj, *, serial_type=None, compress=None, pickle_protocol=None):
 
 
 def serialize(data):
+    if isinstance(data, pyarrow.SerializedPyObject):
+        return data
     try:
         return pyarrow.serialize(data, mars_serialize_context())
     except (ArrowNotImplementedError, SerializationCallbackError):

--- a/mars/tests/test_base_app.py
+++ b/mars/tests/test_base_app.py
@@ -1,0 +1,61 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import unittest
+
+from mars.base_app import BaseApplication
+from mars.config import Config
+
+
+class Test(unittest.TestCase):
+    def testOptions(self):
+        config = Config()
+        config.register_option('config.str', None)
+        config.register_option('config.int', 0)
+
+        app = BaseApplication()
+        handled_options = app._handle_options(
+            ['-Dconfig.int=1024', '-Dconfig.str=config_val', '-s', '1.2.3.4'], config)
+        self.assertListEqual(handled_options, ['-s', '1.2.3.4'])
+        self.assertEqual(config.config.str, 'config_val')
+        self.assertEqual(config.config.int, 1024)
+
+    def testParseArgs(self):
+        parser = argparse.ArgumentParser(description='TestService')
+        app = BaseApplication()
+        app.config_args(parser)
+
+        task_detail = """
+        {
+          "cluster": {
+            "scheduler": ["sch1", "sch2"],
+            "worker": ["worker1", "worker2"],
+            "web": ["web1"]
+          },
+          "task": {
+            "type": "worker",
+            "index": 0
+          }
+        }
+        """
+
+        env = {
+            'MARS_LOAD_MODULES': 'extra.module',
+            'MARS_TASK_DETAIL': task_detail,
+        }
+        args = app.parse_args(parser, [], env)
+        self.assertEqual(args.advertise, 'worker1')
+        self.assertEqual(args.schedulers, 'sch1,sch2')
+        self.assertIn('extra.module', args.load_modules)

--- a/mars/web/__main__.py
+++ b/mars/web/__main__.py
@@ -29,12 +29,15 @@ logger = logging.getLogger(__name__)
 
 
 class WebApplication(BaseApplication):
+    service_description = 'Mars Web'
+
     def __init__(self):
         super().__init__()
         self.mars_web = None
         self.require_pool = False
 
     def config_args(self, parser):
+        super().config_args(parser)
         parser.add_argument('--ui-port', help=argparse.SUPPRESS, action=arg_deprecated_action('-p'))
 
     def create_scheduler_discoverer(self):

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -121,9 +121,7 @@ class Session(object):
                 resp_txt = resp_txt or '{}'
             resp_json = json.loads(resp_txt)
         except json.JSONDecodeError:
-            text_part = resp.text
-            if len(text_part) > 200:
-                text_part = text_part[:200] + '...'
+            text_part = resp.text if len(resp.text) < 100 else resp.text[:100] + '...'
             raise ResponseMalformed('Failed to parse server response. Status=%s Response="%s"'
                                     % (resp.status_code, text_part))
 

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -70,6 +70,8 @@ class BaseCalcActor(WorkerActor):
         self._status_ref = status_ref if self.ctx.has_actor(status_ref) else None
 
         self._execution_ref = self.ctx.actor_ref(ExecutionActor.default_uid())
+        if not self.ctx.has_actor(self._execution_ref):
+            self._execution_ref = None
 
         self._events_ref = self.ctx.actor_ref(EventsActor.default_uid())
         if not self.ctx.has_actor(self._events_ref):
@@ -182,8 +184,9 @@ class BaseCalcActor(WorkerActor):
         local_context_dict.update(context_dict)
         context_dict.clear()
 
-        self._execution_ref.deallocate_scheduler_resource(
-            session_id, graph_key, delay=0.5, _tell=True, _wait=False)
+        if self._execution_ref:
+            self._execution_ref.deallocate_scheduler_resource(
+                session_id, graph_key, delay=0.5, _tell=True, _wait=False)
 
         # start actual execution
         executor = Executor(storage=local_context_dict)

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -752,10 +752,8 @@ class ExecutionActor(WorkerActor):
         if mem_request:
             logger.debug('Ensuring resource %r for graph %s', mem_request, graph_key)
             return self._mem_quota_ref.request_batch_quota(mem_request, process_quota=True, _promise=True) \
-                .then(lambda *_: self._deallocate_scheduler_resource(session_id, graph_key, delay=2)) \
                 .then(_start_calc)
         else:
-            self._deallocate_scheduler_resource(session_id, graph_key, delay=2)
             return _start_calc()
 
     @log_unhandled
@@ -813,7 +811,7 @@ class ExecutionActor(WorkerActor):
         """
         storage_client = self.storage_client
 
-        self._deallocate_scheduler_resource(session_id, graph_key)
+        self.deallocate_scheduler_resource(session_id, graph_key)
 
         graph_record = self._graph_records[session_id, graph_key]
         chunk_keys = graph_record.chunk_targets
@@ -871,7 +869,7 @@ class ExecutionActor(WorkerActor):
                 .then(lambda *_: functools.partial(self._do_active_transfer,
                                                    session_id, graph_key, data_to_addresses))
 
-    def _deallocate_scheduler_resource(self, session_id, graph_key, delay=0):
+    def deallocate_scheduler_resource(self, session_id, graph_key, delay=0):
         try:
             graph_record = self._graph_records[(session_id, graph_key)]
             if not graph_record.resource_released:

--- a/mars/worker/prochelper.py
+++ b/mars/worker/prochelper.py
@@ -48,7 +48,11 @@ class ProcessHelperActor(WorkerActor):
         """
         Free MKL buffer
         """
-        from ..lib.mkl_interface import mkl_free_buffers
+        from ..lib.mkl_interface import mkl_free_buffers, mkl_mem_stat
         if mkl_free_buffers is None:
             return
+
+        size_before = mkl_mem_stat()
         mkl_free_buffers()
+        size_after = mkl_mem_stat()
+        logger.debug('free_mkl_buffers() called, %r -> %r', size_before, size_after)

--- a/mars/worker/quota.py
+++ b/mars/worker/quota.py
@@ -343,7 +343,8 @@ class QuotaActor(WorkerActor):
                 self._hold_sizes[key] = quota_size
             except KeyError:
                 pass
-            self._log_allocate('Quota key %s applied on %s. Diff: %s,', key, self.uid, size_diff)
+            self._log_allocate('Quota key %s applied on %s. Old Size: %s, Diff: %s,',
+                               key, self.uid, old_size, size_diff)
 
         if process_quota:
             self.process_quotas([key])

--- a/mars/worker/storage/client.py
+++ b/mars/worker/storage/client.py
@@ -253,12 +253,17 @@ class StorageClient(object):
                 data_dict.clear()
                 raise
 
-    def put_objects(self, session_id, data_keys, objs, device_order, sizes=None, serialize=False):
+    def put_objects(self, session_id, data_keys, objs, device_order, sizes=None,
+                    shapes=None, serialize=False):
         device_order = self._normalize_devices(device_order)
         if sizes:
             sizes_dict = dict(zip(data_keys, sizes))
         else:
             sizes_dict = dict((k, calc_data_size(obj)) for k, obj in zip(data_keys, objs))
+        if shapes:
+            shapes_dict = dict(zip(data_keys, shapes))
+        else:
+            shapes_dict = dict((k, getattr(obj, 'shape', None)) for k, obj in zip(data_keys, objs))
 
         data_dict = dict(zip(data_keys, objs))
         del objs
@@ -266,9 +271,10 @@ class StorageClient(object):
         def _action(h, keys):
             objects = [data_dict[k] for k in keys]
             data_sizes = [sizes_dict[k] for k in keys]
+            data_shapes = [shapes_dict[k] for k in keys]
             try:
-                return h.put_objects(session_id, keys, objects, sizes=data_sizes, serialize=serialize,
-                                     _promise=True)
+                return h.put_objects(session_id, keys, objects, sizes=data_sizes, shapes=data_shapes,
+                                     serialize=serialize, _promise=True)
             finally:
                 del objects
 

--- a/mars/worker/storage/core.py
+++ b/mars/worker/storage/core.py
@@ -376,8 +376,8 @@ class ObjectStorageMixin(object):
     def get_objects(self, session_id, data_keys, serialize=False, _promise=False):
         raise NotImplementedError
 
-    def put_objects(self, session_id, data_keys, objs, sizes=None, serialize=False, pin_token=False,
-                    _promise=False):
+    def put_objects(self, session_id, data_keys, objs, sizes=None, shapes=None,
+                    serialize=False, pin_token=False, _promise=False):
         raise NotImplementedError
 
 

--- a/mars/worker/storage/procmemhandler.py
+++ b/mars/worker/storage/procmemhandler.py
@@ -41,13 +41,13 @@ class ProcMemHandler(StorageHandler, ObjectStorageMixin):
         return objs
 
     @wrap_promised
-    def put_objects(self, session_id, data_keys, objs, sizes=None, serialize=False,
-                    pin_token=None, _promise=False):
+    def put_objects(self, session_id, data_keys, objs, sizes=None, shapes=None,
+                    serialize=False, pin_token=None, _promise=False):
         objs = [self._deserial(obj) if serialize else obj for obj in objs]
         obj = None
         try:
             sizes = sizes or [calc_data_size(obj) for obj in objs]
-            shapes = [getattr(obj, 'shape', None) for obj in objs]
+            shapes = shapes or [getattr(obj, 'shape', None) for obj in objs]
             self._inproc_store_ref.put_objects(session_id, data_keys, objs, sizes, pin_token=pin_token)
             self.register_data(session_id, data_keys, sizes, shapes)
         finally:

--- a/mars/worker/storage/sharedhandler.py
+++ b/mars/worker/storage/sharedhandler.py
@@ -141,18 +141,18 @@ class SharedStorageHandler(StorageHandler, BytesStorageMixin, ObjectStorageMixin
             return [self._shared_store.get(session_id, k) for k in data_keys]
 
     @wrap_promised
-    def put_objects(self, session_id, data_keys, objs, sizes=None, serialize=False,
-                    pin_token=None, _promise=False):
+    def put_objects(self, session_id, data_keys, objs, sizes=None, shapes=None,
+                    serialize=False, pin_token=None, _promise=False):
         succ_keys, succ_shapes = [], []
         affected_keys = []
         request_size, capacity = 0, 0
 
         objs = [self._deserial(obj) if serialize else obj for obj in objs]
+        shapes = shapes or [getattr(obj, 'shape', None) for obj in objs]
         obj_refs = []
         obj = None
         try:
-            for key, obj in zip(data_keys, objs):
-                shape = getattr(obj, 'shape', None)
+            for key, obj, shape in zip(data_keys, objs, shapes):
                 try:
                     obj_refs.append(self._shared_store.put(session_id, key, obj))
                     succ_keys.append(key)

--- a/mars/worker/storage/vineyardhandler.py
+++ b/mars/worker/storage/vineyardhandler.py
@@ -163,10 +163,12 @@ class VineyardHandler(StorageHandler, ObjectStorageMixin):
         return self._client.get_object(data_ids)
 
     @wrap_promised
-    def put_objects(self, session_id, data_keys, objs, sizes=None, serialize=False,
-                    pin_token=None, _promise=False):
+    def put_objects(self, session_id, data_keys, objs, sizes=None, shapes=None,
+                    serialize=False, pin_token=None, _promise=False):
         sizes, shapes = [], []
         for data_key, obj in zip(data_keys, objs):
+            if isinstance(obj, pyarrow.SerializedPyObject):
+                obj = obj.deserialize(dataserializer.mars_serialize_context())
             data_id, size, shape = self._client.put_object(obj)
             sizes.append(size)
             shapes.append(shape)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
 numpy>=1.14.0
 pandas>=0.24.0,<1.1.0
 requests>=2.4.0
+cloudpickle>=1.0.0
 pyarrow>=0.11.0,!=0.16.*
 cython>=0.29
 pytest>=3.5.0
 pytest-cov>=2.5.0
 pytest-timeout>=1.2.0
 pytest-xdist>=1.15.0
-cloudpickle>=1.0.0
 sqlalchemy>=1.2.0


### PR DESCRIPTION
## What do these changes do?

Serialize results in worker before storing into shared storages. This will provide more accurate memory sizes as well as reducing memory usage. Support passing cluster info json data as an environment variable as well.

## Related issue number

Fixes #1458 
