### PR TITLE
Raise timeout when assigning failed for a long time

### DIFF
--- a/mars/actors/core.pxd
+++ b/mars/actors/core.pxd
@@ -42,5 +42,6 @@ cdef class _FunctionActor(Actor):
 
 
 cpdef object create_actor_pool(str address=*, int n_process=*, object distributor=*,
-                               object parallel=*, str backend=*, str advertise_address=*)
+                               object parallel=*, str backend=*, str advertise_address=*,
+                               object pool_cls=*)
 cpdef object new_client(object parallel=*, str backend=*)

--- a/mars/actors/core.pyx
+++ b/mars/actors/core.pyx
@@ -124,7 +124,8 @@ class FunctionActor(_FunctionActor):
 
 
 cpdef object create_actor_pool(str address=None, int n_process=0, object distributor=None,
-                               object parallel=None, str backend='gevent', str advertise_address=None):
+                               object parallel=None, str backend='gevent',
+                               str advertise_address=None, object pool_cls=None):
     cdef bint standalone
     cdef ClusterInfo cluster_info
 
@@ -132,6 +133,7 @@ cpdef object create_actor_pool(str address=None, int n_process=0, object distrib
         raise ValueError('Only gevent-based actor pool is supported for now')
 
     from .pool.gevent_pool import ActorPool
+    pool_cls = pool_cls or ActorPool
 
     standalone = address is None
     if n_process <= 0:
@@ -142,7 +144,7 @@ cpdef object create_actor_pool(str address=None, int n_process=0, object distrib
 
     cluster_info = ClusterInfo(standalone, n_process, address=address,
                                advertise_address=advertise_address)
-    pool = ActorPool(cluster_info, distributor=distributor, parallel=parallel)
+    pool = pool_cls(cluster_info, distributor=distributor, parallel=parallel)
     pool.run()
 
     return pool

--- a/mars/base_app.py
+++ b/mars/base_app.py
@@ -212,6 +212,9 @@ class BaseApplication(object):
                     pass
                 finally:
                     self.stop()
+        except:
+            logger.exception('Unexpected error occurred in loop')
+            raise
         finally:
             self._running = False
 

--- a/mars/config.py
+++ b/mars/config.py
@@ -325,6 +325,7 @@ default_options.register_option('scheduler.enable_chunk_relocation', False, vali
 default_options.register_option('scheduler.check_interval', 1, validator=is_integer, serialize=True)
 default_options.register_option('scheduler.default_cpu_usage', 1, validator=(is_integer, is_float), serialize=True)
 default_options.register_option('scheduler.default_cuda_usage', 0.5, validator=(is_integer, is_float), serialize=True)
+default_options.register_option('scheduler.assign_timeout', 600, validator=is_integer, serialize=True)
 default_options.register_option('scheduler.execution_timeout', 600, validator=is_integer, serialize=True)
 default_options.register_option('scheduler.retry_num', 4, validator=is_integer, serialize=True)
 default_options.register_option('scheduler.fetch_limit', 10 * 1024 ** 2, validator=is_integer, serialize=True)
@@ -355,6 +356,7 @@ default_options.register_option('worker.transfer_compression', 'lz4', validator=
 default_options.register_option('worker.prepare_data_timeout', 600, validator=is_integer)
 default_options.register_option('worker.peer_blacklist_time', 3600, validator=is_numeric, serialize=True)
 default_options.register_option('worker.lock_free_fileio', False, validator=is_bool, serialize=True)
+default_options.register_option('worker.recover_dead_process', True, validator=is_bool, serialize=True)
 
 default_options.register_option('worker.plasma_socket', '/tmp/plasma', validator=is_string)
 

--- a/mars/scheduler/assigner.py
+++ b/mars/scheduler/assigner.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 from .. import promise
 from ..config import options
 from ..errors import DependencyMissing
-from ..utils import log_unhandled, build_exc_info
+from ..utils import log_unhandled
 from .operands import BaseOperandActor
 from .resource import ResourceActor
 from .utils import SchedulerActor

--- a/mars/scheduler/assigner.py
+++ b/mars/scheduler/assigner.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 from .. import promise
 from ..config import options
 from ..errors import DependencyMissing
-from ..utils import log_unhandled
+from ..utils import log_unhandled, build_exc_info
 from .operands import BaseOperandActor
 from .resource import ResourceActor
 from .utils import SchedulerActor
@@ -254,8 +254,7 @@ class AssignEvaluationActor(SchedulerActor):
         self._assigner_ref = assigner_ref
         self._resource_ref = None
 
-        self._sufficient_operands = set()
-        self._operand_sufficient_time = dict()
+        self._session_last_assigns = dict()
 
     def post_create(self):
         logger.debug('Actor %s running in process %d', self.uid, os.getpid())
@@ -319,6 +318,7 @@ class AssignEvaluationActor(SchedulerActor):
             if alloc_ep:
                 # assign successfully, we remove the application
                 self._assigner_ref.remove_apply(item.op_key, _tell=True)
+                self._session_last_assigns[item.session_id] = time.time()
                 assigned += 1
             else:
                 # put the unassigned item into unassigned list to add back to the queue later
@@ -372,22 +372,30 @@ class AssignEvaluationActor(SchedulerActor):
 
         # todo make more detailed allocation plans
         calc_device = op_info.get('calc_device', 'cpu')
+        mem_usage = sum(input_sizes.values())
         if calc_device == 'cpu':
-            alloc_dict = dict(cpu=options.scheduler.default_cpu_usage, memory=sum(input_sizes.values()))
+            alloc_dict = dict(cpu=options.scheduler.default_cpu_usage, mem_quota=mem_usage)
         elif calc_device == 'cuda':
-            alloc_dict = dict(cuda=options.scheduler.default_cuda_usage, memory=sum(input_sizes.values()))
+            alloc_dict = dict(cuda=options.scheduler.default_cuda_usage, mem_quota=mem_usage)
         else:  # pragma: no cover
             raise NotImplementedError('Calc device %s not supported.' % calc_device)
 
+        last_assign = self._session_last_assigns.get(session_id, time.time())
+        timeout_on_fail = time.time() - last_assign > options.scheduler.assign_timeout
+
         rejects = []
         for worker_ep in candidate_workers:
-            if self._resource_ref.allocate_resource(session_id, op_key, worker_ep, alloc_dict):
+            if self._resource_ref.allocate_resource(
+                    session_id, op_key, worker_ep, alloc_dict, log_fail=timeout_on_fail):
                 logger.debug('Operand %s(%s) allocated to run in %s', op_key, op_info['op_name'], worker_ep)
 
                 self.get_actor_ref(BaseOperandActor.gen_uid(session_id, op_key)) \
                     .submit_to_worker(worker_ep, input_metas, _tell=True, _wait=False)
                 return worker_ep, rejects
             rejects.append(worker_ep)
+
+        if timeout_on_fail:
+            raise TimeoutError('Assign resources to operand %s timed out' % op_key)
         return None, rejects
 
     def _get_chunks_meta(self, session_id, keys):

--- a/mars/scheduler/resource.py
+++ b/mars/scheduler/resource.py
@@ -201,13 +201,14 @@ class ResourceActor(SchedulerActor):
             ref = self.ctx.actor_ref(ExecutionActor.default_uid(), address=w)
             getattr(ref, handler)(*args, **kwargs)
 
-    def allocate_resource(self, session_id, op_key, endpoint, alloc_dict):
+    def allocate_resource(self, session_id, op_key, endpoint, alloc_dict, log_fail=False):
         """
         Try allocate resource for operands
         :param session_id: session id
         :param op_key: operand key
         :param endpoint: worker endpoint
         :param alloc_dict: allocation dict, listing resources needed by the operand
+        :param log_fail: log assign failure
         :return: True if allocated successfully
         """
         worker_stats = self._meta_cache[endpoint]['hardware']
@@ -232,6 +233,9 @@ class ResourceActor(SchedulerActor):
         for k, v in res_used.items():
             if res_used[k] > worker_stats.get(k, 0):
                 sufficient = False
+                if log_fail:
+                    logger.warning('Failed to assign %s resource for %s, res_used: %s, worker stat: %s',
+                                   k, op_key, res_used[k], worker_stats.get(k, 0))
                 break
 
         if sufficient:

--- a/mars/scheduler/resource.py
+++ b/mars/scheduler/resource.py
@@ -174,9 +174,6 @@ class ResourceActor(SchedulerActor):
             self._broadcast_workers(ExecutionActor.handle_worker_change, [worker], [])
 
     def _broadcast_sessions(self, handler, *args, **kwargs):
-        if not options.scheduler.enable_failover:  # pragma: no cover
-            return
-
         if hasattr(handler, '__name__'):
             handler = handler.__name__
 
@@ -189,9 +186,6 @@ class ResourceActor(SchedulerActor):
 
     def _broadcast_workers(self, handler, *args, **kwargs):
         from ..worker.execution import ExecutionActor
-
-        if not options.scheduler.enable_failover:  # pragma: no cover
-            return
 
         if hasattr(handler, '__name__'):
             handler = handler.__name__

--- a/mars/scheduler/tests/test_assigner.py
+++ b/mars/scheduler/tests/test_assigner.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import uuid
 
 import gevent

--- a/mars/worker/__main__.py
+++ b/mars/worker/__main__.py
@@ -124,7 +124,10 @@ class WorkerApplication(BaseApplication):
         self._service.start(self.endpoint, self.pool, discoverer=self.scheduler_discoverer)
 
     def handle_process_down(self, proc_indices):
-        self._service.handle_process_down(self.pool, proc_indices)
+        if options.worker.recover_dead_process and 0 not in proc_indices:
+            self._service.handle_process_down(self.pool, proc_indices)
+        else:
+            super().handle_process_down(proc_indices)
 
     def stop(self):
         self._service.stop()

--- a/mars/worker/daemon.py
+++ b/mars/worker/daemon.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from collections import defaultdict
 
 import psutil
 
 from .utils import WorkerActor
 from ..utils import kill_process_tree
+
+logger = logging.getLogger(__name__)
 
 
 class WorkerDaemonActor(WorkerActor):

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -958,7 +958,8 @@ class ExecutionActor(WorkerActor):
                 self._mem_quota_ref.cancel_requests(
                     tuple(graph_record.mem_request.keys()), build_exc_info(ExecutionInterrupted), _tell=True)
         elif graph_record.state == ExecutionState.CALCULATING:
-            if self._daemon_ref is not None and graph_record.calc_actor_uid is not None:
+            if options.worker.recover_dead_process \
+                    and self._daemon_ref is not None and graph_record.calc_actor_uid is not None:
                 self._daemon_ref.kill_actor_process(self.ctx.actor_ref(graph_record.calc_actor_uid), _tell=True)
 
     @log_unhandled

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -318,7 +318,7 @@ class WorkerService(object):
         logger.warning('Process %r halt, exitcodes=%r. Trying to recover.', proc_id_to_pid, exit_codes)
         for proc_id in proc_indices:
             pool.restart_process(proc_id)
-        self._daemon_ref.handle_process_down(proc_indices, _tell=True)
+        self._daemon_ref.handle_process_down(proc_indices)
 
     def stop(self):
         try:

--- a/mars/worker/status.py
+++ b/mars/worker/status.py
@@ -95,10 +95,16 @@ class StatusReporterActor(WorkerActor):
             mem_quota_allocations = self._status_ref.get_mem_quota_allocations()
             mem_quota_total = mem_quota_allocations.get('total', 0)
             mem_quota_allocated = mem_quota_allocations.get('allocated', 0)
-            hw_metrics['mem_quota'] = int(mem_quota_total - mem_quota_allocated)
-            hw_metrics['mem_quota_used'] = int(mem_quota_allocated)
-            hw_metrics['mem_quota_total'] = int(mem_quota_total)
-            hw_metrics['mem_quota_hold'] = int(mem_quota_allocations.get('hold', 0))
+            if not mem_quota_allocations:
+                hw_metrics['mem_quota'] = hw_metrics['memory']
+                hw_metrics['mem_quota_used'] = hw_metrics['memory_used']
+                hw_metrics['mem_quota_total'] = hw_metrics['memory_total']
+                hw_metrics['mem_quota_hold'] = 0
+            else:
+                hw_metrics['mem_quota'] = int(mem_quota_total - mem_quota_allocated) or hw_metrics['memory']
+                hw_metrics['mem_quota_used'] = int(mem_quota_allocated)
+                hw_metrics['mem_quota_total'] = int(mem_quota_total)
+                hw_metrics['mem_quota_hold'] = int(mem_quota_allocations.get('hold', 0))
 
             if options.worker.spill_directory:
                 if isinstance(options.worker.spill_directory, str):


### PR DESCRIPTION
## What do these changes do?

This PR implements several things.

1. Raise timeout when assigning failed for a long time
2. Check error raises when fail-over is disabled
3. Allow plugin ActorPool
4. Use mem_quota instead of memory when allocating resources. This will help reusing memory not released by pymalloc.

## Related issue number

Fixes #1472
