### PR TITLE
Fix pickling arrow types & allow specifying parallel number in IO runners

### DIFF
--- a/mars/api.py
+++ b/mars/api.py
@@ -26,7 +26,7 @@ from .scheduler.utils import SchedulerClusterInfoActor
 from .worker.transfer import ResultSenderActor, ReceiverManagerActor
 from .tensor.utils import slice_split
 from .serialize import dataserializer
-from .utils import tokenize, merge_chunks
+from .utils import tokenize, merge_chunks, arrow_array_to_objects
 
 logger = logging.getLogger(__name__)
 
@@ -210,6 +210,8 @@ class MarsAPI(object):
         if not serial:
             return ret
         compressions = max(compressions) if compressions else dataserializer.CompressType.NONE
+        if serial_type == dataserializer.SerialType.PICKLE:
+            ret = arrow_array_to_objects(ret)
         return dataserializer.dumps(ret, serial_type=serial_type, compress=compressions,
                                     pickle_protocol=pickle_protocol)
 

--- a/mars/base_app.py
+++ b/mars/base_app.py
@@ -261,6 +261,9 @@ class BaseApplication(object):
         environ = environ or os.environ
         args = parser.parse_args(argv)
 
+        args.host = args.host or environ.get('MARS_BIND_HOST')
+        args.port = args.port or environ.get('MARS_BIND_PORT')
+        args.endpoint = args.endpoint or environ.get('MARS_BIND_ENDPOINT')
         args.advertise = args.advertise or environ.get('MARS_CONTAINER_IP')
         load_modules = []
         for mods in tuple(args.load_modules or ()) + (environ.get('MARS_LOAD_MODULES'),):

--- a/mars/config.py
+++ b/mars/config.py
@@ -355,7 +355,7 @@ default_options.register_option('worker.transfer_block_size', 1 * 1024 ** 2, val
 default_options.register_option('worker.transfer_compression', 'lz4', validator=is_string, serialize=True)
 default_options.register_option('worker.prepare_data_timeout', 600, validator=is_integer)
 default_options.register_option('worker.peer_blacklist_time', 3600, validator=is_numeric, serialize=True)
-default_options.register_option('worker.lock_free_fileio', False, validator=is_bool, serialize=True)
+default_options.register_option('worker.io_parallel_num', 1, validator=is_integer, serialize=True)
 default_options.register_option('worker.recover_dead_process', True, validator=is_bool, serialize=True)
 
 default_options.register_option('worker.plasma_socket', '/tmp/plasma', validator=is_string)

--- a/mars/deploy/kubernetes/client.py
+++ b/mars/deploy/kubernetes/client.py
@@ -180,11 +180,12 @@ class KubernetesCluster:
         cnt = 0
         for el in query['items']:
             if el['status']['phase'] in ('Error', 'Failed'):
-                raise SystemError(el['status']['message'])
+                logger.warning('Error in starting pod, message: %s', el['status']['message'])
+                continue
             if 'status' not in el or 'conditions' not in el['status']:
                 cnt += 1
-            if any(cond['type'] == 'Ready' and cond['status'] == 'True'
-                   for cond in el['status'].get('conditions') or ()):
+            elif any(cond['type'] == 'Ready' and cond['status'] == 'True'
+                     for cond in el['status'].get('conditions') or ()):
                 cnt += 1
         return cnt
 

--- a/mars/scheduler/service.py
+++ b/mars/scheduler/service.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 class SchedulerService(object):
-    def __init__(self):
+    def __init__(self, **kwargs):
         self._cluster_info_ref = None
         self._session_manager_ref = None
         self._assigner_ref = None
@@ -40,6 +40,11 @@ class SchedulerService(object):
         self._kv_store_ref = None
         self._node_info_ref = None
         self._result_receiver_ref = None
+
+        options.scheduler.enable_failover = not (kwargs.pop('disable_failover', None) or False)
+
+        if kwargs:  # pragma: no cover
+            raise TypeError('Keyword arguments %r cannot be recognized.' % ', '.join(kwargs))
 
     def start(self, endpoint, discoverer, pool, distributed=True):
         """

--- a/mars/scheduler/tests/integrated/base.py
+++ b/mars/scheduler/tests/integrated/base.py
@@ -196,7 +196,8 @@ class SchedulerIntegratedTest(unittest.TestCase):
                 actor_address = self.cluster_info.get_scheduler(ResourceActor.default_uid())
                 resource_ref = actor_client.actor_ref(ResourceActor.default_uid(), address=actor_address)
 
-                if resource_ref.get_worker_count() < n_workers:
+                if not actor_client.has_actor(self.session_manager_ref) \
+                        or resource_ref.get_worker_count() < n_workers:
                     raise ProcessRequirementUnmetError('Workers does not met requirement: %d < %d.' % (
                         resource_ref.get_worker_count(), n_workers
                     ))

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -313,8 +313,7 @@ class Test(SchedulerIntegratedTest):
         b = mt.ones((10, 10))
         c = (a + b)
 
-        endpoint = self.scheduler_endpoints[0]
-        sess = new_session(endpoint)
+        sess = new_session(self.session_manager_ref.address)
 
         try:
             c.execute(session=sess, timeout=self.timeout)

--- a/mars/scheduler/tests/integrated/test_worker_failover.py
+++ b/mars/scheduler/tests/integrated/test_worker_failover.py
@@ -47,7 +47,7 @@ class Test(SchedulerIntegratedTest):
         terminate_file = self.add_state_file('OP_TERMINATE_STATE_FILE')
 
         self.start_processes(modules=['mars.scheduler.tests.integrated.op_delayer'],
-                             scheduler_args=['-Dscheduler.enable_failover=false'], log_worker=True)
+                             scheduler_args=['--disable-failover'], log_worker=True)
 
         np_a = np.random.random((100, 100))
         np_b = np.random.random((100, 100))

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1088,3 +1088,16 @@ def calc_object_overhead(chunk, shape):
     else:
         n_strings = 0
     return n_strings * shape[0] * OBJECT_FIELD_OVERHEAD
+
+
+def arrow_array_to_objects(obj):
+    from .dataframe.arrays import ArrowStringDtype
+
+    if isinstance(obj, pd.DataFrame):
+        for col_name, dtype in obj.dtypes.items():
+            if isinstance(dtype, ArrowStringDtype):
+                obj[col_name] = pd.Series(obj[col_name].to_numpy())
+    elif isinstance(obj, pd.Series):
+        if isinstance(obj.dtype, ArrowStringDtype):
+            obj = pd.Series(obj.to_numpy())
+    return obj

--- a/mars/worker/__main__.py
+++ b/mars/worker/__main__.py
@@ -50,8 +50,7 @@ class WorkerApplication(BaseApplication):
         parser.add_argument('--cache-mem', help='cache memory size limit')
         parser.add_argument('--min-mem', help='minimal free memory required to start worker')
         parser.add_argument('--spill-dir', help='spill directory')
-        parser.add_argument('--lock-free-fileio', action='store_true',
-                            help='make file io lock free, add this when using a mounted dfs')
+        parser.add_argument('--io-parallel-num', help='make file io lock free, add this when using a mounted dfs')
         parser.add_argument('--plasma-dir', help='path of plasma directory. When specified, the size '
                                                  'of plasma store will not be taken into account when '
                                                  'managing host memory')
@@ -73,8 +72,10 @@ class WorkerApplication(BaseApplication):
         args.plasma_dir = args.plasma_dir or os.environ.get('MARS_PLASMA_DIRS')
         args.spill_dir = args.spill_dir or os.environ.get('MARS_SPILL_DIRS')
         args.cache_mem = args.cache_mem or os.environ.get('MARS_CACHE_MEM_SIZE')
-        args.lock_free_fileio = args.lock_free_fileio \
-            or bool(int(os.environ.get('MARS_LOCK_FREE_FILEIO', '0')))
+        args.io_parallel_num = args.io_parallel_num \
+            or int(os.environ.get('MARS_IO_PARALLEL_NUM', '1'))
+        if args.io_parallel_num == 1 and bool(int(os.environ.get('MARS_LOCK_FREE_FILEIO', '0'))):
+            args.io_parallel_num = 2 ** 16
         return args
 
     def validate_arguments(self):
@@ -98,7 +99,7 @@ class WorkerApplication(BaseApplication):
             n_net_process=self.args.net_procs or self.args.io_procs,
             cuda_devices=cuda_devices,
             spill_dirs=self.args.spill_dir,
-            lock_free_fileio=self.args.lock_free_fileio,
+            io_parallel_num=self.args.io_parallel_num,
             total_mem=self.args.phy_mem,
             cache_mem_limit=self.args.cache_mem,
             ignore_avail_mem=self.args.ignore_avail_mem,

--- a/mars/worker/__main__.py
+++ b/mars/worker/__main__.py
@@ -51,6 +51,8 @@ class WorkerApplication(BaseApplication):
         parser.add_argument('--min-mem', help='minimal free memory required to start worker')
         parser.add_argument('--spill-dir', help='spill directory')
         parser.add_argument('--io-parallel-num', help='make file io lock free, add this when using a mounted dfs')
+        parser.add_argument('--disable-proc-recover', action='store_true',
+                            help='disable recovering failed processes')
         parser.add_argument('--plasma-dir', help='path of plasma directory. When specified, the size '
                                                  'of plasma store will not be taken into account when '
                                                  'managing host memory')
@@ -69,12 +71,16 @@ class WorkerApplication(BaseApplication):
 
     def parse_args(self, parser, argv, environ=None):
         args = super().parse_args(parser, argv)
-        args.plasma_dir = args.plasma_dir or os.environ.get('MARS_PLASMA_DIRS')
-        args.spill_dir = args.spill_dir or os.environ.get('MARS_SPILL_DIRS')
-        args.cache_mem = args.cache_mem or os.environ.get('MARS_CACHE_MEM_SIZE')
+        environ = environ or os.environ
+
+        args.plasma_dir = args.plasma_dir or environ.get('MARS_PLASMA_DIRS')
+        args.spill_dir = args.spill_dir or environ.get('MARS_SPILL_DIRS')
+        args.cache_mem = args.cache_mem or environ.get('MARS_CACHE_MEM_SIZE')
+        args.disable_proc_recover = args.disable_proc_recover \
+            or bool(int(environ.get('MARS_DISABLE_PROC_RECOVER', '0')))
         args.io_parallel_num = args.io_parallel_num \
-            or int(os.environ.get('MARS_IO_PARALLEL_NUM', '1'))
-        if args.io_parallel_num == 1 and bool(int(os.environ.get('MARS_LOCK_FREE_FILEIO', '0'))):
+            or int(environ.get('MARS_IO_PARALLEL_NUM', '1'))
+        if args.io_parallel_num == 1 and bool(int(environ.get('MARS_LOCK_FREE_FILEIO', '0'))):
             args.io_parallel_num = 2 ** 16
         return args
 
@@ -108,6 +114,7 @@ class WorkerApplication(BaseApplication):
             transfer_compression=self.args.transfer_compression.lower(),
             plasma_dir=self.args.plasma_dir,
             use_ext_plasma_dir=bool(self.args.plasma_dir),
+            disable_proc_recover=self.args.disable_proc_recover,
         )
         # start plasma
         self._service.start_plasma()

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -97,6 +97,7 @@ class WorkerService(object):
         options.worker.transfer_compression = kwargs.pop('transfer_compression', None) or \
             options.worker.transfer_compression
         options.worker.io_parallel_num = kwargs.pop('io_parallel_num', None) or False
+        options.worker.recover_dead_process = not (kwargs.pop('disable_proc_recover', None) or False)
 
         self._total_mem = kwargs.pop('total_mem', None)
         self._cache_mem_limit = kwargs.pop('cache_mem_limit', None)
@@ -160,22 +161,24 @@ class WorkerService(object):
         self._cache_mem_limit = _calc_size_limit(self._cache_mem_limit, self._total_mem)
         if self._cache_mem_limit is None:
             self._cache_mem_limit = mem_stats.free // 2
+        max_cache_mem = self._cache_mem_limit
 
         plasma_limit = self._get_plasma_limit()
         if plasma_limit is not None:
             self._cache_mem_limit = min(plasma_limit, self._cache_mem_limit)
+        self._hard_mem_limit -= max_cache_mem - self._cache_mem_limit
 
         self._soft_mem_limit = _calc_size_limit(self._soft_mem_limit, self._total_mem)
         actual_used = self._total_mem - mem_stats.available
         if self._ignore_avail_mem:
             self._soft_quota_limit = self._soft_mem_limit
         else:
-            used_cache_size = 0 if self._use_ext_plasma_dir else self._cache_mem_limit
+            used_cache_size = 0 if self._use_ext_plasma_dir else max_cache_mem
             self._soft_quota_limit = self._soft_mem_limit - used_cache_size - actual_used
             if self._soft_quota_limit < self._min_mem_size:
                 raise MemoryError('Memory not enough. soft_limit=%s, cache_limit=%s, used=%s' %
                                   tuple(readable_size(k) for k in (
-                                      self._soft_mem_limit, self._cache_mem_limit, actual_used)))
+                                      self._soft_mem_limit, max_cache_mem, actual_used)))
 
         logger.info('Setting soft limit to %s.', readable_size(self._soft_quota_limit))
 

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -96,7 +96,7 @@ class WorkerService(object):
             options.worker.disk_compression
         options.worker.transfer_compression = kwargs.pop('transfer_compression', None) or \
             options.worker.transfer_compression
-        options.worker.lock_free_fileio = kwargs.pop('lock_free_fileio', None) or False
+        options.worker.io_parallel_num = kwargs.pop('io_parallel_num', None) or False
 
         self._total_mem = kwargs.pop('total_mem', None)
         self._cache_mem_limit = kwargs.pop('cache_mem_limit', None)
@@ -256,7 +256,7 @@ class WorkerService(object):
             self._inproc_holder_actors.append(actor)
 
             actor = actor_holder.create_actor(
-                IORunnerActor, lock_free=True, dispatched=False, uid=IORunnerActor.gen_uid(cpu_id + 1))
+                IORunnerActor, dispatched=False, uid=IORunnerActor.gen_uid(cpu_id + 1))
             self._inproc_io_runner_actors.append(actor)
 
         start_pid = 1 + self._n_cpu_process
@@ -274,7 +274,7 @@ class WorkerService(object):
             self._cuda_holder_actors.append(actor)
 
             actor = actor_holder.create_actor(
-                IORunnerActor, lock_free=True, dispatched=False, uid=IORunnerActor.gen_uid(start_pid + cuda_id))
+                IORunnerActor, dispatched=False, uid=IORunnerActor.gen_uid(start_pid + cuda_id))
             self._inproc_io_runner_actors.append(actor)
 
         start_pid += self._n_cuda_process

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -161,24 +161,22 @@ class WorkerService(object):
         self._cache_mem_limit = _calc_size_limit(self._cache_mem_limit, self._total_mem)
         if self._cache_mem_limit is None:
             self._cache_mem_limit = mem_stats.free // 2
-        max_cache_mem = self._cache_mem_limit
 
         plasma_limit = self._get_plasma_limit()
         if plasma_limit is not None:
             self._cache_mem_limit = min(plasma_limit, self._cache_mem_limit)
-        self._hard_mem_limit -= max_cache_mem - self._cache_mem_limit
 
         self._soft_mem_limit = _calc_size_limit(self._soft_mem_limit, self._total_mem)
         actual_used = self._total_mem - mem_stats.available
         if self._ignore_avail_mem:
             self._soft_quota_limit = self._soft_mem_limit
         else:
-            used_cache_size = 0 if self._use_ext_plasma_dir else max_cache_mem
+            used_cache_size = 0 if self._use_ext_plasma_dir else self._cache_mem_limit
             self._soft_quota_limit = self._soft_mem_limit - used_cache_size - actual_used
             if self._soft_quota_limit < self._min_mem_size:
                 raise MemoryError('Memory not enough. soft_limit=%s, cache_limit=%s, used=%s' %
                                   tuple(readable_size(k) for k in (
-                                      self._soft_mem_limit, max_cache_mem, actual_used)))
+                                      self._soft_mem_limit, self._cache_mem_limit, actual_used)))
 
         logger.info('Setting soft limit to %s.', readable_size(self._soft_quota_limit))
 

--- a/mars/worker/storage/tests/test_client.py
+++ b/mars/worker/storage/tests/test_client.py
@@ -88,13 +88,13 @@ class Test(WorkerCase):
     plasma_storage_size = 1024 * 1024 * 10
 
     def tearDown(self):
-        options.worker.lock_free_fileio = False
+        options.worker.io_parallel_num = 1
         super().tearDown()
 
     def testClientReadAndWrite(self):
         test_addr = '127.0.0.1:%d' % get_next_port()
         with self.create_pool(n_process=1, address=test_addr) as pool:
-            options.worker.lock_free_fileio = True
+            options.worker.io_parallel_num = 1024
             pool.create_actor(WorkerDaemonActor, uid=WorkerDaemonActor.default_uid())
             pool.create_actor(StorageManagerActor, uid=StorageManagerActor.default_uid())
 
@@ -249,7 +249,7 @@ class Test(WorkerCase):
 
             pool.create_actor(InProcHolderActor, uid='w:1:InProcHolderActor1')
             pool.create_actor(InProcHolderActor, uid='w:2:InProcHolderActor2')
-            pool.create_actor(IORunnerActor, lock_free=True, dispatched=False, uid=IORunnerActor.gen_uid(1))
+            pool.create_actor(IORunnerActor, io_parallel_num=1024, dispatched=False, uid=IORunnerActor.gen_uid(1))
 
             test_ref = pool.create_actor(OtherProcessTestActor, uid='w:0:OtherProcTest')
 


### PR DESCRIPTION
## What do these changes do?

This PR does the following changes:

1. Convert ``ArrowStringArray`` to numpy array when using pickle to fetch data to client;
2. Allow specifying parallel num in ``IORunnerActor``. This allows ``IORunnerActor`` to behave like a semaphore limiting total IO operations;
3. Warn when encountering failed PODs when starting Mars cluster.  

## Related issue number

Fixes #1479 
