### PR TITLE
Add support for `ArrowListDtype` as well as `ArrowListArray`

### DIFF
--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 5, 0, 'b3')
+version_info = (0, 5, 0, 'rc1')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/config.py
+++ b/mars/config.py
@@ -297,6 +297,7 @@ default_options.register_option('check_interval', 20, validator=is_integer)
 
 # dataframe-related options
 default_options.register_option('dataframe.mode.use_inf_as_na', False, validator=is_bool)
+default_options.register_option('dataframe.use_arrow_dtype', None, validator=any_validator(is_null, is_bool))
 
 # learn options
 assume_finite = os.environ.get('SKLEARN_ASSUME_FINITE')

--- a/mars/dataframe/__init__.py
+++ b/mars/dataframe/__init__.py
@@ -50,7 +50,7 @@ del DataFrameFetch, DataFrameFetchShuffle
 
 # noinspection PyUnresolvedReferences
 from ..core import ExecutableTuple
-from .arrays import ArrowStringDtype, ArrowStringArray
+from .arrays import ArrowStringDtype, ArrowStringArray, ArrowListDtype, ArrowListArray
 
 # noinspection PyUnresolvedReferences
 from pandas import Timedelta, Timestamp, offsets, NaT, Interval

--- a/mars/dataframe/arrays.py
+++ b/mars/dataframe/arrays.py
@@ -14,6 +14,7 @@
 
 import itertools
 import operator
+import re
 from copy import copy as copy_obj
 from numbers import Integral
 from typing import Type, Sequence
@@ -22,14 +23,17 @@ import numpy as np
 import pandas as pd
 from pandas._libs import lib
 from pandas.api.indexers import check_array_indexer
-from pandas.api.types import pandas_dtype, is_scalar, is_array_like
-from pandas.api.extensions import ExtensionArray, ExtensionDtype, register_extension_dtype
+from pandas.api.types import pandas_dtype, is_scalar, \
+    is_array_like, is_string_dtype, is_list_like
+from pandas.api.extensions import ExtensionArray, \
+    ExtensionDtype, register_extension_dtype
 from pandas.core import ops
 from pandas.core.algorithms import take
 from pandas.compat import set_function_name
 try:
     from pandas.arrays import StringArray as StringArrayBase
-except ImportError:  # for pandas < 1.0
+except ImportError:  # pragma: no cover
+    # for pandas < 1.0
     StringArrayBase = ExtensionArray
 
 try:
@@ -40,8 +44,17 @@ except ImportError:  # pragma: no cover
     pa_null = None
 
 
+class ArrowDtype(ExtensionDtype):
+    @property
+    def arrow_type(self):  # pragma: no cover
+        raise NotImplementedError
+
+    def __from_arrow__(self, array):
+        return self.construct_array_type()(array)
+
+
 @register_extension_dtype
-class ArrowStringDtype(ExtensionDtype):
+class ArrowStringDtype(ArrowDtype):
     """
     Extension dtype for arrow string data.
 
@@ -70,7 +83,7 @@ class ArrowStringDtype(ExtensionDtype):
 
     type = str
     kind = "U"
-    name = "arrow_string"
+    name = "Arrow[string]"
     na_value = pa_null
 
     @classmethod
@@ -84,12 +97,109 @@ class ArrowStringDtype(ExtensionDtype):
     def construct_array_type(cls) -> "Type[ArrowStringArray]":
         return ArrowStringArray
 
-    def __from_arrow__(self, array):
-        return ArrowStringArray(array)
+    @property
+    def arrow_type(self):
+        return pa.string()
 
 
-class ArrowStringArray(StringArrayBase):
-    def __init__(self, values, copy=False):
+@register_extension_dtype
+class ArrowStringDtypeAlias(ArrowStringDtype):
+    name = 'arrow_string'  # register an alias name for compatibility
+
+
+class ArrowListDtype(ArrowDtype):
+    _metadata = ("_value_type",)
+
+    def __init__(self, dtype):
+        if isinstance(dtype, type(self)):
+            dtype = dtype.value_type
+        if pa and isinstance(dtype, pa.DataType):
+            dtype = dtype.to_pandas_dtype()
+
+        dtype = pandas_dtype(dtype)
+        if is_string_dtype(dtype) and \
+                not isinstance(dtype, ArrowStringDtype):
+            # convert string dtype to arrow string dtype
+            dtype = ArrowStringDtype()
+
+        self._value_type = dtype
+
+    @property
+    def value_type(self):
+        return self._value_type
+
+    @property
+    def kind(self):
+        return self._value_type.kind
+
+    @property
+    def type(self):
+        return self._value_type.type
+
+    @property
+    def name(self):
+        return f"Arrow[List[{self.value_type.name}]]"
+
+    @property
+    def arrow_type(self):
+        if isinstance(self._value_type, ArrowDtype):
+            arrow_subdtype = self._value_type.arrow_type
+        else:
+            arrow_subdtype = pa.from_numpy_dtype(self._value_type)
+        return pa.list_(arrow_subdtype)
+
+    def __repr__(self) -> str:
+        return self.name
+
+    @classmethod
+    def construct_array_type(cls) -> "Type[ArrowListArray]":
+        return ArrowListArray
+
+    @classmethod
+    def construct_from_string(cls, string):
+        msg = f"Cannot construct a 'ArrowListDtype' from '{string}'"
+        xpr = re.compile(r"Arrow\[List\[(?P<value_type>[^,]*)\]\]$")
+        m = xpr.match(string)
+        if m:
+            value_type = m.groupdict()["value_type"]
+            return ArrowListDtype(value_type)
+        else:
+            raise TypeError(msg)
+
+    @classmethod
+    def is_dtype(cls, dtype) -> bool:
+        dtype = getattr(dtype, "dtype", dtype)
+        if isinstance(dtype, str):
+            try:
+                cls.construct_from_string(dtype)
+            except TypeError:
+                return False
+            else:
+                return True
+        else:
+            return isinstance(dtype, cls)
+
+    def __hash__(self):
+        return super().__hash__()
+
+    def __eq__(self, other):
+        if not isinstance(other, ArrowListDtype):
+            return False
+
+        value_type = self._value_type
+        other_value_type = other._value_type
+
+        try:
+            return value_type == other_value_type
+        except TypeError:
+            # cannot compare numpy dtype and extension dtype
+            return other_value_type == value_type
+
+
+class ArrowArray(ExtensionArray):
+    _arrow_type = None
+
+    def __init__(self, values, dtype: ArrowDtype = None, copy=False):
         if isinstance(values, (pd.Index, pd.Series)):
             # for pandas Index and Series,
             # convert to PandasArray
@@ -104,50 +214,25 @@ class ArrowStringArray(StringArrayBase):
             arrow_array = pa.chunked_array([pa.array(values, from_pandas=True)])
         elif isinstance(values, pa.ChunkedArray):
             arrow_array = values
-        elif isinstance(values, pa.StringArray):
+        elif isinstance(values, pa.Array):
             arrow_array = pa.chunked_array([values])
         else:
-            arrow_array = pa.chunked_array([pa.array(values, type=pa.string())])
+            arrow_array = pa.chunked_array([pa.array(values, type=dtype.arrow_type)])
 
         if copy:
             arrow_array = copy_obj(arrow_array)
 
         self._arrow_array = arrow_array
-        self._dtype = ArrowStringDtype()
+        self._dtype = dtype
 
         # for test purpose
         self._force_use_pandas = False
-
-    @classmethod
-    def from_scalars(cls, values):
-        arrow_array = pa.chunked_array(
-            [pa.array(np.asarray(values)).cast(pa.string())])
-        return cls(arrow_array)
-
-    @classmethod
-    def _from_sequence(cls, scalars, dtype=None, copy=False):
-        if not hasattr(scalars, 'dtype'):
-            scalars = np.asarray(scalars)
-        if isinstance(scalars, cls):
-            if copy:
-                scalars = scalars.copy()
-            return scalars
-        arrow_array = pa.chunked_array([pa.array(scalars).cast(pa.string())])
-        return cls(arrow_array, copy=copy)
-
-    @classmethod
-    def _from_sequence_of_strings(cls, strings, dtype=None, copy=False):
-        return cls._from_sequence(strings, dtype=dtype, copy=copy)
-
-    @classmethod
-    def _from_factorized(cls, values, original):
-        return cls(values)
 
     def __repr__(self):
         return f"{type(self).__name__}({repr(self._arrow_array)})"
 
     @property
-    def dtype(self):
+    def dtype(self) -> "Type[ArrowDtype]":
         return self._dtype
 
     @property
@@ -159,6 +244,28 @@ class ArrowStringArray(StringArrayBase):
 
     def memory_usage(self, deep=True) -> int:
         return self.nbytes
+
+    @classmethod
+    def _to_arrow_array(cls, scalars):
+        return pa.array(scalars)
+
+    @classmethod
+    def _from_sequence(cls, scalars, dtype=None, copy=False):
+        if not hasattr(scalars, 'dtype'):
+            ret = np.empty(len(scalars), dtype=object)
+            for i, s in enumerate(scalars):
+                ret[i] = s
+            scalars = ret
+        if isinstance(scalars, cls):
+            if copy:
+                scalars = scalars.copy()
+            return scalars
+        arrow_array = pa.chunked_array([cls._to_arrow_array(scalars)])
+        return cls(arrow_array, dtype=dtype, copy=copy)
+
+    @classmethod
+    def _from_sequence_of_strings(cls, strings, dtype=None, copy=False):
+        return cls._from_sequence(strings, dtype=dtype, copy=copy)
 
     @staticmethod
     def _can_process_slice_via_arrow(slc):
@@ -183,66 +290,54 @@ class ArrowStringArray(StringArrayBase):
     def _values_for_argsort(self):
         return self.to_numpy()
 
+    @classmethod
+    def _from_factorized(cls, values, original):
+        return cls(values)
+
     @staticmethod
     def _process_pos(pos, length, is_start):
         if pos is None:
             return 0 if is_start else length
         return pos + length if pos < 0 else pos
 
+    @classmethod
+    def _post_scalar_getitem(cls, lst):
+        return lst.to_pandas()[0]
+
     def __getitem__(self, item):
+        cls = type(self)
         has_take = hasattr(self._arrow_array, 'take')
         if not self._force_use_pandas and has_take:
             if pd.api.types.is_scalar(item):
                 item = item + len(self) if item < 0 else item
-                return self._arrow_array.take([item]).to_pandas()[0]
+                return self._post_scalar_getitem(
+                    self._arrow_array.take([item]))
             elif self._can_process_slice_via_arrow(item):
                 length = len(self)
                 start, stop = item.start, item.stop
                 start = self._process_pos(start, length, True)
                 stop = self._process_pos(stop, length, False)
-                return ArrowStringArray(
-                    self._arrow_array.slice(offset=start,
-                                            length=stop - start))
+                return cls(self._arrow_array.slice(offset=start, length=stop - start),
+                           dtype=self._dtype)
             elif hasattr(item, 'dtype') and np.issubdtype(item.dtype, np.bool_):
-                return ArrowStringArray(self._arrow_array.filter(
-                    pa.array(item, from_pandas=True)))
+                return cls(self._arrow_array.filter(pa.array(item, from_pandas=True)),
+                           dtype=self._dtype)
             elif hasattr(item, 'dtype'):
                 length = len(self)
                 item = np.where(item < 0, item + length, item)
-                return ArrowStringArray(self._arrow_array.take(item))
+                return cls(self._arrow_array.take(item), dtype=self._dtype)
 
         array = np.asarray(self._arrow_array.to_pandas())
-        return ArrowStringArray(array[item])
+        return cls(array[item], dtype=self._dtype)
 
-    def __setitem__(self, key, value):
-        if isinstance(value, (pd.Index, pd.Series)):
-            value = value.to_numpy()
-        if isinstance(value, type(self)):
-            value = value.to_numpy()
-
-        key = check_array_indexer(self, key)
-        scalar_key = is_scalar(key)
-        scalar_value = is_scalar(value)
-        if scalar_key and not scalar_value:
-            raise ValueError("setting an array element with a sequence.")
-
-        # validate new items
-        if scalar_value:
-            if pd.isna(value):
-                value = None
-            elif not isinstance(value, str):
-                raise ValueError(
-                    f"Cannot set non-string value '{value}' into a StringArray."
-                )
-        else:
-            if not is_array_like(value):
-                value = np.asarray(value, dtype=object)
-            if len(value) and not lib.is_string_array(value, skipna=True):
-                raise ValueError("Must provide strings.")
-
-        string_array = np.asarray(self._arrow_array.to_pandas())
-        string_array[key] = value
-        self._arrow_array = pa.chunked_array([pa.array(string_array)])
+    @classmethod
+    def _concat_same_type(
+            cls, to_concat: Sequence["ArrowArray"]) -> "ArrowArray":
+        chunks = list(itertools.chain.from_iterable(
+            x._arrow_array.chunks for x in to_concat))
+        if len(chunks) == 0:
+            chunks = [pa.array([], type=to_concat[0].dtype.arrow_type)]
+        return cls(pa.chunked_array(chunks))
 
     def __len__(self):
         return len(self._arrow_array)
@@ -258,14 +353,21 @@ class ArrowStringArray(StringArrayBase):
             array[self.isna()] = na_value
         return array
 
+    @classmethod
+    def _array_fillna(cls, array, value):
+        return array.fillna(value)
+
     def fillna(self, value=None, method=None, limit=None):
         chunks = []
         for chunk_array in self._arrow_array.chunks:
             array = chunk_array.to_pandas()
-            result_array = array.fillna(value=value, method=method,
-                                        limit=limit)
+            if method is None:
+                result_array = self._array_fillna(array, value)
+            else:
+                result_array = array.fillna(value=value, method=method,
+                                            limit=limit)
             chunks.append(pa.array(result_array, from_pandas=True))
-        return ArrowStringArray(pa.chunked_array(chunks))
+        return type(self)(pa.chunked_array(chunks), dtype=self._dtype)
 
     def astype(self, dtype, copy=True):
         dtype = pandas_dtype(dtype)
@@ -299,44 +401,88 @@ class ArrowStringArray(StringArrayBase):
 
     def take(self, indices, allow_fill=False, fill_value=None):
         if allow_fill is False:
-            return ArrowStringArray(self[indices])
+            return type(self)(self[indices], dtype=self._dtype)
 
-        string_array = self._arrow_array.to_pandas().to_numpy()
+        array = self._arrow_array.to_pandas().to_numpy()
 
         replace = False
         if allow_fill and fill_value is None:
             fill_value = self.dtype.na_value
             replace = True
 
-        result = take(string_array, indices, fill_value=fill_value,
+        result = take(array, indices, fill_value=fill_value,
                       allow_fill=allow_fill)
-        del string_array
+        del array
         if replace:
             # pyarrow cannot recognize pa.NULL
             result[result == self.dtype.na_value] = None
-        return ArrowStringArray(result)
+        return type(self)(result, dtype=self._dtype)
 
     def copy(self):
         return type(self)(copy_obj(self._arrow_array))
 
-    @classmethod
-    def _concat_same_type(
-            cls, to_concat: Sequence["ArrowStringArray"]) -> "ArrowStringArray":
-        chunks = list(itertools.chain.from_iterable(
-            x._arrow_array.chunks for x in to_concat))
-        if len(chunks) == 0:
-            chunks = [pa.array([], type=pa.string())]
-        return cls(pa.chunked_array(chunks))
-
     def value_counts(self, dropna=False):
-        string_array = self._arrow_array.to_pandas()
-        return ArrowStringArray(string_array.value_counts(dropna=dropna))
+        series = self._arrow_array.to_pandas()
+        return type(self)(series.value_counts(dropna=dropna),
+                          dtype=self._dtype)
 
     def any(self, axis=0, out=None):
-        return self._arrow_array.to_pandas().any(axis=axis, out=out)
+        return self.to_numpy().any(axis=axis, out=out)
 
     def all(self, axis=0, out=None):
-        return self._arrow_array.to_pandas().all(axis=axis, out=out)
+        return self.to_numpy().all(axis=axis, out=out)
+
+    def __mars_tokenize__(self):
+        return [memoryview(x) for chunk in self._arrow_array.chunks
+                for x in chunk.buffers()
+                if x is not None]
+
+
+class ArrowStringArray(ArrowArray, StringArrayBase):
+
+    def __init__(self, values, dtype=None, copy=False):
+        if dtype is not None:
+            assert isinstance(dtype, ArrowStringDtype)
+        ArrowArray.__init__(self, values, ArrowStringDtype(), copy=copy)
+
+    @classmethod
+    def from_scalars(cls, values):
+        arrow_array = pa.chunked_array([cls._to_arrow_array(values)])
+        return cls(arrow_array)
+
+    @classmethod
+    def _to_arrow_array(cls, scalars):
+        return pa.array(scalars).cast(pa.string())
+
+    def __setitem__(self, key, value):
+        if isinstance(value, (pd.Index, pd.Series)):
+            value = value.to_numpy()
+        if isinstance(value, type(self)):
+            value = value.to_numpy()
+
+        key = check_array_indexer(self, key)
+        scalar_key = is_scalar(key)
+        scalar_value = is_scalar(value)
+        if scalar_key and not scalar_value:
+            raise ValueError("setting an array element with a sequence.")
+
+        # validate new items
+        if scalar_value:
+            if pd.isna(value):
+                value = None
+            elif not isinstance(value, str):
+                raise ValueError(
+                    f"Cannot set non-string value '{value}' into a ArrowStringArray."
+                )
+        else:
+            if not is_array_like(value):
+                value = np.asarray(value, dtype=object)
+            if len(value) and not lib.is_string_array(value, skipna=True):
+                raise ValueError("Must provide strings.")
+
+        string_array = np.asarray(self._arrow_array.to_pandas())
+        string_array[key] = value
+        self._arrow_array = pa.chunked_array([pa.array(string_array)])
 
     # Overrride parent because we have different return types.
     @classmethod
@@ -412,11 +558,79 @@ class ArrowStringArray(StringArrayBase):
 
     _create_comparison_method = _create_arithmetic_method
 
-    def __mars_tokenize__(self):
-        return [memoryview(x) for chunk in self._arrow_array.chunks
-                for x in chunk.buffers()
-                if x is not None]
-
 
 ArrowStringArray._add_arithmetic_ops()
 ArrowStringArray._add_comparison_ops()
+
+
+class ArrowListArray(ArrowArray):
+    def __init__(self, values, dtype: ArrowListDtype=None, copy=False):
+        if dtype is None:
+            if isinstance(values, type(self)):
+                dtype = values.dtype
+            elif isinstance(values, pa.Array):
+                dtype = ArrowListDtype(values.type.value_type)
+            elif isinstance(values, pa.ChunkedArray):
+                dtype = ArrowListDtype(values.type.value_type)
+            else:
+                values = pa.array(values)
+                dtype = ArrowListDtype(values.type.value_type)
+
+        super().__init__(values, dtype=dtype, copy=copy)
+
+    def to_numpy(self, dtype=None, copy=False, na_value=lib.no_default):
+        s = self._arrow_array.to_pandas().map(
+            lambda x: x.tolist() if x is not None else x)
+        if copy or na_value is not lib.no_default:
+            s = s.copy()
+        if na_value is not lib.no_default:
+            s[self.isna()] = na_value
+        return np.asarray(s)
+
+    @classmethod
+    def _post_scalar_getitem(cls, lst):
+        return lst[0].as_py()
+
+    def __setitem__(self, key, value):
+        if isinstance(value, (pd.Index, pd.Series)):
+            value = value.to_numpy()
+
+        key = check_array_indexer(self, key)
+        scalar_key = is_scalar(key)
+
+        # validate new items
+        if scalar_key:
+            if pd.isna(value):
+                value = None
+            elif not is_list_like(value):
+                raise ValueError('Must provide list.')
+
+        array = np.asarray(self._arrow_array.to_pandas())
+        array[key] = value
+        self._arrow_array = pa.chunked_array([
+            pa.array(array, type=self.dtype.arrow_type)])
+
+    @classmethod
+    def _array_fillna(cls, series, value):
+        # cannot fillna directly, because value is a list-like object
+        return series.apply(lambda x: x if is_list_like(x) or not pd.isna(x) else value)
+
+    def astype(self, dtype, copy=True):
+        msg = f'cannot astype from {self.dtype} to {dtype}'
+        dtype = pandas_dtype(dtype)
+        if isinstance(dtype, ArrowListDtype):
+            if self.dtype == dtype:
+                if copy:
+                    return self.copy()
+                return self
+            else:
+                try:
+                    arrow_array = self._arrow_array.cast(dtype.arrow_type)
+                    return ArrowListArray(arrow_array)
+                except (NotImplementedError, pa.ArrowInvalid):
+                    raise TypeError(msg)
+
+        try:
+            return super().astype(dtype, copy=copy)
+        except ValueError:
+            raise TypeError(msg)

--- a/mars/dataframe/reduction/nunique.py
+++ b/mars/dataframe/reduction/nunique.py
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import OrderedDict
-
 import pandas as pd
+try:
+    import pyarrow as pa
+except ImportError:  # pragma: no cover
+    pa = None
 
 from ... import opcodes as OperandDef
 from ...core import OutputType
+from ...config import options
 from ...serialize import BoolField
 from ...utils import lazy_import
+from ..arrays import ArrowListArray, ArrowListDtype
 from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 
@@ -31,16 +35,43 @@ class DataFrameNunique(DataFrameReductionOperand, DataFrameReductionMixin):
     _func_name = 'nunique'
 
     _dropna = BoolField('dropna')
+    _use_arrow_dtype = BoolField('use_arrow_dtype')
 
-    def __init__(self, dropna=None, **kw):
-        super(DataFrameNunique, self).__init__(_dropna=dropna, **kw)
+    def __init__(self, dropna=None, use_arrow_dtype=None, **kw):
+        super(DataFrameNunique, self).__init__(
+            _dropna=dropna, _use_arrow_dtype=use_arrow_dtype, **kw)
 
     @property
     def dropna(self):
         return self._dropna
 
+    @property
+    def use_arrow_dtype(self):
+        return self._use_arrow_dtype
+
     @classmethod
-    def _execute_map(cls, ctx, op):
+    def _if_use_arrow_dtype(cls, op):
+        use_arrow_dtype = op.use_arrow_dtype
+        if use_arrow_dtype is None:
+            # get options again,
+            # options may different when running
+            use_arrow_dtype = options.dataframe.use_arrow_dtype
+        return use_arrow_dtype
+
+    @classmethod
+    def _drop_duplicates_to_arrow(cls, v, explode=False):
+        if explode:
+            v = v.explode()
+        try:
+            return ArrowListArray([v.drop_duplicates().to_numpy()])
+        except pa.ArrowInvalid:
+            # fallback due to diverse dtypes
+            return [v.drop_duplicates().to_list()]
+
+    @classmethod
+    def _execute_map(cls, ctx, op: "DataFrameNunique"):
+        use_arrow_dtype = cls._if_use_arrow_dtype(op)
+
         xdf = cudf if op.gpu else pd
         in_data = ctx[op.inputs[0].key]
         if isinstance(in_data, xdf.Series) or op.output_types[0] == OutputType.series:
@@ -48,16 +79,26 @@ class DataFrameNunique(DataFrameReductionOperand, DataFrameReductionMixin):
             ctx[op.outputs[0].key] = xdf.Series(unique_values, name=in_data.name)
         else:
             if op.axis == 0:
-                df = xdf.DataFrame(OrderedDict((d, [v.drop_duplicates().to_list()])
-                                               for d, v in in_data.iteritems()))
+                data = dict()
+                for d, v in in_data.iteritems():
+                    if not use_arrow_dtype or xdf is cudf:
+                        data[d] = [v.drop_duplicates().to_list()]
+                    else:
+                        data[d] = cls._drop_duplicates_to_arrow(v)
+                df = xdf.DataFrame(data)
             else:
                 df = xdf.DataFrame(columns=[0])
                 for d, v in in_data.iterrows():
-                    df.loc[d] = [v.drop_duplicates().to_list()]
+                    if not use_arrow_dtype or xdf is cudf:
+                        df.loc[d] = [v.drop_duplicates().to_list()]
+                    else:
+                        df.loc[d] = cls._drop_duplicates_to_arrow(v)
             ctx[op.outputs[0].key] = df
 
     @classmethod
     def _execute_combine(cls, ctx, op):
+        use_arrow_dtype = cls._if_use_arrow_dtype(op)
+
         xdf = cudf if op.gpu else pd
         in_data = ctx[op.inputs[0].key]
         if isinstance(in_data, xdf.Series):
@@ -65,27 +106,38 @@ class DataFrameNunique(DataFrameReductionOperand, DataFrameReductionMixin):
             ctx[op.outputs[0].key] = xdf.Series(unique_values, name=in_data.name)
         else:
             if op.axis == 0:
-                df = xdf.DataFrame(OrderedDict((d, [v.explode().drop_duplicates().to_list()])
-                                               for d, v in in_data.iteritems()))
+                data = dict()
+                for d, v in in_data.iteritems():
+                    if not use_arrow_dtype or xdf is cudf:
+                        data[d] = [v.explode().drop_duplicates().to_list()]
+                    else:
+                        v = pd.Series(v.to_numpy())
+                        data[d] = cls._drop_duplicates_to_arrow(v, explode=True)
+                df = xdf.DataFrame(data)
             else:
                 df = xdf.DataFrame(columns=[0])
                 for d, v in in_data.iterrows():
-                    df.loc[d] = [v.explode().drop_duplicates().to_list()]
+                    if not use_arrow_dtype or xdf is cudf:
+                        df.loc[d] = [v.explode().drop_duplicates().to_list()]
+                    else:
+                        df.loc[d] = cls._drop_duplicates_to_arrow(v, explode=True)
             ctx[op.outputs[0].key] = df
 
     @classmethod
     def _execute_agg(cls, ctx, op):
         xdf = cudf if op.gpu else pd
         in_data = ctx[op.inputs[0].key]
+        dropna = op.dropna
         if isinstance(in_data, xdf.Series):
-            ctx[op.outputs[0].key] = in_data.explode().nunique(dropna=op.dropna)
+            ctx[op.outputs[0].key] = in_data.explode().nunique(dropna=dropna)
         else:
-            if op.axis == 0:
-                ctx[op.outputs[0].key] = xdf.Series(OrderedDict((d, v.explode().nunique(dropna=op.dropna))
-                                                    for d, v in in_data.iteritems()))
-            else:
-                ctx[op.outputs[0].key] = xdf.Series(OrderedDict((d, v.explode().nunique(dropna=op.dropna))
-                                                    for d, v in in_data.iterrows()))
+            in_data_iter = in_data.iteritems() if op.axis == 0 else in_data.iterrows()
+            data = dict()
+            for d, v in in_data_iter:
+                if isinstance(v.dtype, ArrowListDtype):
+                    v = xdf.Series(v.to_numpy())
+                data[d] = v.explode().nunique(dropna=dropna)
+            ctx[op.outputs[0].key] = xdf.Series(data)
 
     @classmethod
     def _execute_reduction(cls, in_data, op, min_count=None, reduction_func=None):
@@ -137,7 +189,8 @@ def nunique_dataframe(df, axis=0, dropna=True, combine_size=None):
     dtype: int64
     """
     op = DataFrameNunique(axis=axis, dropna=dropna, combine_size=combine_size,
-                          output_types=[OutputType.series])
+                          output_types=[OutputType.series],
+                          use_arrow_dtype=options.dataframe.use_arrow_dtype)
     return op(df)
 
 
@@ -179,5 +232,6 @@ def nunique_series(df, dropna=True, combine_size=None):
     4
     """
     op = DataFrameNunique(dropna=dropna, combine_size=combine_size,
-                          output_types=[OutputType.scalar])
+                          output_types=[OutputType.scalar],
+                          use_arrow_dtype=options.dataframe.use_arrow_dtype)
     return op(df)

--- a/mars/dataframe/reduction/tests/test_reduction_execute.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execute.py
@@ -17,9 +17,10 @@ import unittest
 import pandas as pd
 import numpy as np
 
-from mars.tests.core import TestBase, parameterized, ExecutorForTest
+from mars.config import option_context
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
 from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df
+from mars.tests.core import TestBase, parameterized, ExecutorForTest
 
 
 reduction_functions = dict(
@@ -298,6 +299,26 @@ class TestCount(TestBase):
         result = self.executor.execute_dataframe(df.nunique(axis=1), concat=True)[0]
         expected = data1.nunique(axis=1)
         pd.testing.assert_series_equal(result, expected)
+
+    def testUseArrowDtypeNUnique(self):
+        with option_context({'dataframe.use_arrow_dtype': True, 'combine_size': 2}):
+            rs = np.random.RandomState(0)
+            data1 = pd.DataFrame({'a': rs.random(10),
+                                  'b': [f's{i}' for i in rs.randint(100, size=10)]})
+            data1['c'] = data1['b'].copy()
+            data1['d'] = data1['b'].copy()
+            data1['e'] = data1['b'].copy()
+
+            df = from_pandas_df(data1, chunk_size=(3, 2))
+            r = df.nunique(axis=0)
+            result = self.executor.execute_dataframe(r, concat=True)[0]
+            expected = data1.nunique(axis=0)
+            pd.testing.assert_series_equal(result, expected)
+
+            r = df.nunique(axis=1)
+            result = self.executor.execute_dataframe(r, concat=True)[0]
+            expected = data1.nunique(axis=1)
+            pd.testing.assert_series_equal(result, expected)
 
     def testUnique(self):
         data1 = pd.Series(np.random.randint(0, 5, size=(20,)))

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -903,30 +903,34 @@ def arrow_table_to_pandas_dataframe(arrow_table, use_arrow_dtype=True, **kw):
         # if not use arrow string, just return
         return arrow_table.to_pandas(**kw)
 
-    from .arrays import ArrowStringArray
+    from .arrays import ArrowStringArray, ArrowListArray
 
     table: pa.Table = arrow_table
     schema: pa.Schema = arrow_table.schema
 
-    string_field_names = list()
-    string_arrays = list()
-    string_indexes = list()
+    arrow_field_names = list()
+    arrow_arrays = list()
+    arrow_indexes = list()
     other_field_names = list()
     other_arrays = list()
     for i, arrow_type in enumerate(schema.types):
-        if arrow_type == pa.string():
-            string_field_names.append(schema.names[i])
-            string_indexes.append(i)
-            string_arrays.append(table.columns[i])
+        if arrow_type == pa.string() or isinstance(arrow_type, pa.ListType):
+            arrow_field_names.append(schema.names[i])
+            arrow_indexes.append(i)
+            arrow_arrays.append(table.columns[i])
         else:
             other_field_names.append(schema.names[i])
             other_arrays.append(table.columns[i])
 
     df: pd.DataFrame = pa.Table.from_arrays(
         other_arrays, names=other_field_names).to_pandas(**kw)
-    for string_index, string_name, string_array in \
-            zip(string_indexes, string_field_names, string_arrays):
-        df.insert(string_index, string_name,
-                  pd.Series(ArrowStringArray(string_array)))
+    for arrow_index, arrow_name, arrow_array in \
+            zip(arrow_indexes, arrow_field_names, arrow_arrays):
+        if arrow_array.type == pa.string():
+            series = pd.Series(ArrowStringArray(arrow_array))
+        else:
+            assert isinstance(arrow_array.type, pa.ListType)
+            series = pd.Series(ArrowListArray(arrow_array))
+        df.insert(arrow_index, arrow_name, series)
 
     return df

--- a/mars/serialize/dataserializer.py
+++ b/mars/serialize/dataserializer.py
@@ -380,13 +380,18 @@ def _deserialize_pandas_categorical_dtype(data):
     return pd.CategoricalDtype(data[0], data[1])
 
 
-def _serialize_arrow_string_array(obj):
+def _serialize_arrow_array(obj):
     return obj._arrow_array.chunks
 
 
 def _deserialize_arrow_string_array(obj):
     from ..dataframe.arrays import ArrowStringArray
     return ArrowStringArray(pyarrow.chunked_array(obj))
+
+
+def _deserialize_arrow_list_array(obj):
+    from ..dataframe.arrays import ArrowListArray
+    return ArrowListArray(pyarrow.chunked_array(obj))
 
 
 def _serialize_sparse_array(obj):
@@ -491,7 +496,7 @@ def _apply_pyarrow_serialization_patch(serialization_context):  # pragma: no cov
 
 
 def mars_serialize_context():
-    from ..dataframe.arrays import ArrowStringArray
+    from ..dataframe.arrays import ArrowStringArray, ArrowListArray
 
     global _serialize_context
     if _serialize_context is None:
@@ -515,8 +520,11 @@ def mars_serialize_context():
                           custom_serializer=_serialize_pandas_categorical_dtype,
                           custom_deserializer=_deserialize_pandas_categorical_dtype)
         ctx.register_type(ArrowStringArray, 'mars.dataframe.ArrowStringArray',
-                          custom_serializer=_serialize_arrow_string_array,
+                          custom_serializer=_serialize_arrow_array,
                           custom_deserializer=_deserialize_arrow_string_array)
+        ctx.register_type(ArrowListArray, 'mars.dataframe.ArrowListArray',
+                          custom_serializer=_serialize_arrow_array,
+                          custom_deserializer=_deserialize_arrow_list_array)
         ctx.register_type(pd.arrays.SparseArray, 'pandas.arrays.SparseArray',
                           custom_serializer=_serialize_sparse_array,
                           custom_deserializer=_deserialzie_sparse_array)

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1089,13 +1089,13 @@ def calc_object_overhead(chunk, shape):
 
 
 def arrow_array_to_objects(obj):
-    from .dataframe.arrays import ArrowStringDtype
+    from .dataframe.arrays import ArrowDtype
 
     if isinstance(obj, pd.DataFrame):
         for col_name, dtype in obj.dtypes.items():
-            if isinstance(dtype, ArrowStringDtype):
+            if isinstance(dtype, ArrowDtype):
                 obj[col_name] = pd.Series(obj[col_name].to_numpy())
     elif isinstance(obj, pd.Series):
-        if isinstance(obj.dtype, ArrowStringDtype):
+        if isinstance(obj.dtype, ArrowDtype):
             obj = pd.Series(obj.to_numpy())
     return obj


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR added support for `ArrowListDtype` as well as `ArrowListArray`.

I did some experiments.

```python
In[9]: import pandas as pd

In[10]: s = pd.Series(lst)

In [11]: s
Out[11]: 
0                            [Kurt Olsen, Carlos Monroe]
1                          [Scott Weeks, Ashley Swanson]
2      [Anna Campbell, Tony Scott, Lawrence Clark, Mi...
3                          [Sandra Meyers, Kevin Arnold]
4      [Vanessa Garcia, Jonathan Carlson, John Nichol...
                             ...                        
995     [Dawn Salazar, Joel Garcia Jr., Rodney Anderson]
996                    [David Sanchez, James Richardson]
997    [Amanda Spears, Stephanie Mccormick, Deborah G...
998    [Katie Myers, Corey Williamson, Jonathan Pittman]
999                     [Jean Schneider, Caleb Stafford]
Length: 1000, dtype: object

In [12]: s.memory_usage(deep=True, index=False)
Out[12]: 80000

In [15]: s2 = s.astype(md.ArrowListDtype(str))

In [16]: s2.memory_usage(deep=True, index=False)
Out[16]: 56021
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1485 .
