### PR TITLE
Fix compatibility for gevent>=20.5.1

### DIFF
--- a/mars/serialize/core.pyx
+++ b/mars/serialize/core.pyx
@@ -672,7 +672,8 @@ class Serializable(metaclass=SerializableMetaclass):
     def to_pb(self, obj=None, data_serial_type=None, pickle_protocol=None):
         from .pbserializer import ProtobufSerializeProvider
 
-        provider = ProtobufSerializeProvider(data_serial_type=data_serial_type)
+        provider = ProtobufSerializeProvider(data_serial_type=data_serial_type,
+                                             pickle_protocol=pickle_protocol)
         return self.serialize(provider, obj=obj)
 
     @classmethod
@@ -685,7 +686,8 @@ class Serializable(metaclass=SerializableMetaclass):
     def to_json(self, obj=None, data_serial_type=None, pickle_protocol=None):
         from .jsonserializer import JsonSerializeProvider
 
-        provider = JsonSerializeProvider(data_serial_type=data_serial_type)
+        provider = JsonSerializeProvider(data_serial_type=data_serial_type,
+                                         pickle_protocol=pickle_protocol)
         return self.serialize(provider, obj=obj)
 
     @classmethod

--- a/mars/serialize/jsonserializer.pyx
+++ b/mars/serialize/jsonserializer.pyx
@@ -108,7 +108,8 @@ cdef class JsonSerializeProvider(Provider):
                     'value': pos}
         else:
             return {'type': 'object',
-                    'value': self._to_str(base64.b64encode(pickle.dumps(pos)))}
+                    'value': self._to_str(base64.b64encode(
+                        pickle.dumps(pos, protocol=self.pickle_protocol)))}
 
     cdef inline dict _serialize_slice(self, slice value):
         return {
@@ -161,7 +162,7 @@ cdef class JsonSerializeProvider(Provider):
         if not isinstance(value, ExtensionDtype) and 'V' not in value.str:
             v = value.str
         else:
-            v = self._to_str(base64.b64encode(pickle.dumps(value)))
+            v = self._to_str(base64.b64encode(pickle.dumps(value, protocol=self.pickle_protocol)))
         return {
             'type': _get_name(ValueType.dtype),
             'value': v
@@ -347,7 +348,8 @@ cdef class JsonSerializeProvider(Provider):
     cdef inline dict _serialize_function(self, value):
         return {
             'type': 'function',
-            'value': self._to_str(base64.b64encode(serialize_function(value)))
+            'value': self._to_str(base64.b64encode(
+                serialize_function(value, pickle_protocol=self.pickle_protocol)))
         }
 
     cdef inline _deserialize_function(self, obj, list callbacks):
@@ -363,7 +365,7 @@ cdef class JsonSerializeProvider(Provider):
     cdef inline dict _serialize_tzinfo(self, value):
         return {
             'type': 'tzinfo',
-            'value': self._to_str(base64.b64encode(pickle.dumps(value)))
+            'value': self._to_str(base64.b64encode(pickle.dumps(value, protocol=self.pickle_protocol)))
         }
 
     cdef inline _deserialize_tzinfo(self, obj, list callbacks):

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -997,8 +997,8 @@ def prune_chunk_graph(chunk_graph, result_chunk_keys):
 
 
 @functools.lru_cache(500)
-def serialize_function(function):
-    return cloudpickle.dumps(function)
+def serialize_function(function, pickle_protocol=None):
+    return cloudpickle.dumps(function, protocol=pickle_protocol)
 
 
 class FixedSizeFileObject:
@@ -1092,9 +1092,13 @@ def arrow_array_to_objects(obj):
     from .dataframe.arrays import ArrowDtype
 
     if isinstance(obj, pd.DataFrame):
+        out_cols = dict()
         for col_name, dtype in obj.dtypes.items():
             if isinstance(dtype, ArrowDtype):
-                obj[col_name] = pd.Series(obj[col_name].to_numpy())
+                out_cols[col_name] = pd.Series(obj[col_name].to_numpy(), index=obj.index)
+            else:
+                out_cols[col_name] = obj[col_name]
+        obj = pd.DataFrame(out_cols, columns=list(obj.dtypes.keys()))
     elif isinstance(obj, pd.Series):
         if isinstance(obj.dtype, ArrowDtype):
             obj = pd.Series(obj.to_numpy())

--- a/mars/web/session.py
+++ b/mars/web/session.py
@@ -99,7 +99,11 @@ class Session(object):
         content = json.loads(resp.text)
         self._session_id = content['session_id']
         self._pickle_protocol = content.get('pickle_protocol', pickle.HIGHEST_PROTOCOL)
-        if not content.get('arrow_compatible'):
+
+        # as pyarrow will use pickle.HIGHEST_PROTOCOL to pickle, we need to use
+        # SerialType.PICKLE when pickle protocol between client and server
+        # does not agree with each other
+        if not content.get('arrow_compatible') or self._pickle_protocol != pickle.HIGHEST_PROTOCOL:
             self._serial_type = dataserializer.SerialType.PICKLE
 
     def _get_tileable_graph_key(self, tileable_key):

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -5,6 +5,6 @@ pyarrow>=0.11.0,!=0.16.*
 psutil>=4.0.0
 lz4>=1.0.0
 protobuf>=3.6
-gevent>=1.2.0,<20.5.0
+gevent>=1.2.0
 bokeh>=1.0.0
 jinja2>=2.0


### PR DESCRIPTION
## What do these changes do?

Fix incompatibility for gevent>=20.5.1. The compatibility break was caused by gevent/gevent#1632 which raises an GreenletExit on forked processes when calling ``Hub.destroy()`` and makes subprocesses failed to start after gevent hub creation on the main process.

## Related issue number

Fixes #1489 