### PR TITLE
Support `use_arrow_dtype` for `md.read_csv` and `md.read_sql`

### DIFF
--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 5, 0, 'rc1')
+version_info = (0, 6, 0, 'a1')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -308,7 +308,7 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                 # As we specify names and dtype, we need to skip header rows
                 csv_kwargs['skiprows'] = 1 if op.header == 'infer' else op.header
                 dtypes = cls._validate_dtypes(op.outputs[0].dtypes, op.gpu)
-                if cls._contains_arrow_dtype(dtypes):
+                if cls._contains_arrow_dtype(dtypes.values()):
                     # when keep_default_na is True which is default,
                     # will replace null value with np.nan,
                     # which will cause failure when converting to arrow string array


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR added `use_arrow_dtype` argument for `md.read_csv` and `md.read_sql`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1465 .