### PR TITLE
[BACKPORT] Support `use_arrow_dtype` for `md.read_csv` and `md.read_sql` (#1491)

### DIFF
--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 5, 0, 'rc1')
+version_info = (0, 5, 0)
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -25,8 +25,9 @@ from ...core import OutputType
 from ...utils import parse_readable_size, lazy_import, FixedSizeFileObject
 from ...serialize import StringField, DictField, ListField, Int32Field, Int64Field, BoolField, AnyField
 from ...filesystem import open_file, file_size, glob
+from ..arrays import ArrowStringDtype
 from ..core import IndexValue
-from ..utils import parse_index, build_empty_df, standardize_range_index
+from ..utils import parse_index, build_empty_df, standardize_range_index, to_arrow_dtypes
 from ..operands import DataFrameOperand, DataFrameOperandMixin
 
 try:
@@ -93,19 +94,20 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
     _size = Int64Field('size')
     _nrows = Int64Field('nrows')
     _incremental_index = BoolField('incremental_index')
+    _use_arrow_dtype = BoolField('use_arrow_dtype')
     _keep_usecols_order = BoolField('keep_usecols_order')
-
     _storage_options = DictField('storage_options')
 
     def __init__(self, path=None, names=None, sep=None, header=None, index_col=None,
                  compression=None, usecols=None, offset=None, size=None, nrows=None,
                  gpu=None, keep_usecols_order=None, incremental_index=None,
-                 storage_options=None, **kw):
+                 use_arrow_dtype=None, storage_options=None, **kw):
         super().__init__(_path=path, _names=names, _sep=sep, _header=header,
                          _index_col=index_col, _compression=compression,
                          _usecols=usecols, _offset=offset, _size=size, _nrows=nrows,
                          _gpu=gpu, _incremental_index=incremental_index,
                          _keep_usecols_order=keep_usecols_order,
+                         _use_arrow_dtype=use_arrow_dtype,
                          _storage_options=storage_options,
                          _output_types=[OutputType.dataframe], **kw)
 
@@ -154,6 +156,10 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
         return self._incremental_index
 
     @property
+    def use_arrow_dtype(self):
+        return self._use_arrow_dtype
+
+    @property
     def keep_usecols_order(self):
         return self._keep_usecols_order
 
@@ -195,6 +201,12 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
         chunk_bytes = df.extra_params.chunk_bytes
         chunk_bytes = int(parse_readable_size(chunk_bytes)[0])
 
+        dtypes = df.dtypes
+        if op.use_arrow_dtype is None and not op.gpu and \
+                options.dataframe.use_arrow_dtype:  # pragma: no cover
+            # check if use_arrow_dtype set on the server side
+            dtypes = to_arrow_dtypes(df.dtypes)
+
         paths = op.path if isinstance(op.path, (tuple, list)) else glob(op.path, storage_options=op.storage_options)
 
         out_chunks = []
@@ -207,10 +219,10 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                 chunk_op._path = path
                 chunk_op._offset = offset
                 chunk_op._size = min(chunk_bytes, total_bytes - offset)
-                shape = (np.nan, len(df.dtypes))
+                shape = (np.nan, len(dtypes))
                 index_value = parse_index(df.index_value.to_pandas(), path, index_num)
                 new_chunk = chunk_op.new_chunk(None, shape=shape, index=(index_num, 0), index_value=index_value,
-                                               columns_value=df.columns_value, dtypes=df.dtypes)
+                                               columns_value=df.columns_value, dtypes=dtypes)
                 out_chunks.append(new_chunk)
                 index_num += 1
                 offset += chunk_bytes
@@ -220,7 +232,7 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
             out_chunks = standardize_range_index(out_chunks)
         new_op = op.copy()
         nsplits = ((np.nan,) * len(out_chunks), (df.shape[1],))
-        return new_op.new_dataframes(None, df.shape, dtypes=df.dtypes,
+        return new_op.new_dataframes(None, df.shape, dtypes=dtypes,
                                      index_value=df.index_value,
                                      columns_value=df.columns_value,
                                      chunks=out_chunks, nsplits=nsplits)
@@ -252,6 +264,11 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                 usecols = op.usecols if isinstance(op.usecols, list) else [op.usecols]
             else:
                 usecols = op.usecols
+            if cls._contains_arrow_dtype(dtypes):
+                # when keep_default_na is True which is default,
+                # will replace null value with np.nan,
+                # which will cause failure when converting to arrow string array
+                csv_kwargs['keep_default_na'] = False
             df = pd.read_csv(b, sep=op.sep, names=op.names, index_col=op.index_col, usecols=usecols,
                              dtype=dtypes.to_dict(), nrows=op.nrows, **csv_kwargs)
             if op.keep_usecols_order:
@@ -277,6 +294,10 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
         return df
 
     @classmethod
+    def _contains_arrow_dtype(cls, dtypes):
+        return any(isinstance(dtype, ArrowStringDtype) for dtype in dtypes)
+
+    @classmethod
     def execute(cls, ctx, op):
         xdf = cudf if op.gpu else pd
         out_df = op.outputs[0]
@@ -286,8 +307,14 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
             if op.compression is not None:
                 # As we specify names and dtype, we need to skip header rows
                 csv_kwargs['skiprows'] = 1 if op.header == 'infer' else op.header
+                dtypes = cls._validate_dtypes(op.outputs[0].dtypes, op.gpu)
+                if cls._contains_arrow_dtype(dtypes.values()):
+                    # when keep_default_na is True which is default,
+                    # will replace null value with np.nan,
+                    # which will cause failure when converting to arrow string array
+                    csv_kwargs['keep_default_na'] = False
                 df = xdf.read_csv(f, sep=op.sep, names=op.names, index_col=op.index_col,
-                                  usecols=op.usecols, dtype=cls._validate_dtypes(op.outputs[0].dtypes, op.gpu),
+                                  usecols=op.usecols, dtype=dtypes,
                                   nrows=op.nrows, **csv_kwargs)
                 if op.keep_usecols_order:
                     df = df[op.usecols]
@@ -304,7 +331,8 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
 
 def read_csv(path, names=None, sep=',', index_col=None, compression=None, header='infer',
              dtype=None, usecols=None, nrows=None, chunk_bytes='64M', gpu=None, head_bytes='100k',
-             head_lines=None, incremental_index=False, storage_options=None, **kwargs):
+             head_lines=None, incremental_index=False, use_arrow_dtype=None,
+             storage_options=None, **kwargs):
     r"""
     Read a comma-separated values (csv) file into DataFrame.
     Also supports optionally iterating or breaking of the file
@@ -563,6 +591,8 @@ def read_csv(path, names=None, sep=',', index_col=None, compression=None, header
         Number of lines to use in the head of file, mainly for data inference.
     incremental_index: bool, default False
         Create a new RangeIndex if csv doesn't contain index columns.
+    use_arrow_dtype: bool, default None
+        If True, use arrow dtype to store columns.
     storage_options: dict, optional
         Options for storage connection.
 
@@ -594,7 +624,8 @@ def read_csv(path, names=None, sep=',', index_col=None, compression=None, header
             head_start, head_end = _find_chunk_start_end(f, 0, head_bytes)
             f.seek(head_start)
             b = f.read(head_end - head_start)
-        mini_df = pd.read_csv(BytesIO(b), sep=sep, index_col=index_col, dtype=dtype, names=names, header=header)
+        mini_df = pd.read_csv(BytesIO(b), sep=sep, index_col=index_col, dtype=dtype,
+                              names=names, header=header)
 
     if isinstance(mini_df.index, pd.RangeIndex):
         index_value = parse_index(pd.RangeIndex(-1))
@@ -606,11 +637,17 @@ def read_csv(path, names=None, sep=',', index_col=None, compression=None, header
     names = list(mini_df.columns)
     op = DataFrameReadCSV(path=path, names=names, sep=sep, header=header, index_col=index_col,
                           usecols=usecols, compression=compression, gpu=gpu,
-                          incremental_index=incremental_index, storage_options=storage_options,
+                          incremental_index=incremental_index, use_arrow_dtype=use_arrow_dtype,
+                          storage_options=storage_options,
                           **kwargs)
     chunk_bytes = chunk_bytes or options.chunk_store_limit
+    dtypes = mini_df.dtypes
+    if use_arrow_dtype is None:
+        use_arrow_dtype = options.dataframe.use_arrow_dtype
+    if not gpu and use_arrow_dtype:
+        dtypes = to_arrow_dtypes(dtypes, test_df=mini_df)
     ret = op(index_value=index_value, columns_value=columns_value,
-             dtypes=mini_df.dtypes, chunk_bytes=chunk_bytes)
+             dtypes=dtypes, chunk_bytes=chunk_bytes)
     if nrows is not None:
         return ret.head(nrows)
     return ret

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -14,7 +14,6 @@
 
 import os
 import tempfile
-import shutil
 import time
 from collections import OrderedDict
 from datetime import datetime
@@ -25,13 +24,15 @@ import pandas as pd
 
 import mars.tensor as mt
 import mars.dataframe as md
-from mars.session import new_session
-from mars.tests.core import TestBase, require_cudf
+from mars.config import option_context
 from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
 from mars.dataframe.datasource.index import from_pandas as from_pandas_index, from_tileable
 from mars.dataframe.datasource.from_tensor import dataframe_from_tensor, dataframe_from_1d_tileables
 from mars.dataframe.datasource.from_records import from_records
+from mars.session import new_session
+from mars.tests.core import TestBase, require_cudf
+from mars.utils import arrow_array_to_objects
 
 
 class Test(TestBase):
@@ -277,9 +278,9 @@ class Test(TestBase):
         pd.testing.assert_frame_equal(df2_result, pdf_expected)
 
     def testReadCSVExecution(self):
-        tempdir = tempfile.mkdtemp()
-        file_path = os.path.join(tempdir, 'test.csv')
-        try:
+        with tempfile.TemporaryDirectory() as tempdir:
+            file_path = os.path.join(tempdir, 'test.csv')
+
             df = pd.DataFrame(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.int64), columns=['a', 'b', 'c'])
             df.to_csv(file_path)
 
@@ -293,13 +294,11 @@ class Test(TestBase):
 
             mdf = self.executor.execute_dataframe(md.read_csv(file_path, index_col=0, nrows=1), concat=True)[0]
             pd.testing.assert_frame_equal(df[:1], mdf)
-        finally:
-            shutil.rmtree(tempdir)
 
         # test sep
-        tempdir = tempfile.mkdtemp()
-        file_path = os.path.join(tempdir, 'test.csv')
-        try:
+        with tempfile.TemporaryDirectory() as tempdir:
+            file_path = os.path.join(tempdir, 'test.csv')
+
             df = pd.DataFrame(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), columns=['a', 'b', 'c'])
             df.to_csv(file_path, sep=';')
 
@@ -311,13 +310,10 @@ class Test(TestBase):
                                                    concat=True)[0]
             pd.testing.assert_frame_equal(pdf, mdf2)
 
-        finally:
-            shutil.rmtree(tempdir)
-
         # test missing value
-        tempdir = tempfile.mkdtemp()
-        file_path = os.path.join(tempdir, 'test.csv')
-        try:
+        with tempfile.TemporaryDirectory() as tempdir:
+            file_path = os.path.join(tempdir, 'test.csv')
+
             df = pd.DataFrame({'c1': [np.nan, 'a', 'b', 'c'], 'c2': [1, 2, 3, np.nan],
                                'c3': [np.nan, np.nan, 3.4, 2.2]})
             df.to_csv(file_path)
@@ -330,12 +326,9 @@ class Test(TestBase):
                                                    concat=True)[0]
             pd.testing.assert_frame_equal(pdf, mdf2)
 
-        finally:
-            shutil.rmtree(tempdir)
+        with tempfile.TemporaryDirectory() as tempdir:
+            file_path = os.path.join(tempdir, 'test.csv')
 
-        tempdir = tempfile.mkdtemp()
-        file_path = os.path.join(tempdir, 'test.csv')
-        try:
             index = pd.date_range(start='1/1/2018', periods=100)
             df = pd.DataFrame({
                 'col1': np.random.rand(100),
@@ -352,13 +345,10 @@ class Test(TestBase):
                                                    concat=True)[0]
             pd.testing.assert_frame_equal(pdf, mdf2)
 
-        finally:
-            shutil.rmtree(tempdir)
-
         # test compression
-        tempdir = tempfile.mkdtemp()
-        file_path = os.path.join(tempdir, 'test.gzip')
-        try:
+        with tempfile.TemporaryDirectory() as tempdir:
+            file_path = os.path.join(tempdir, 'test.gzip')
+
             index = pd.date_range(start='1/1/2018', periods=100)
             df = pd.DataFrame({
                 'col1': np.random.rand(100),
@@ -376,12 +366,8 @@ class Test(TestBase):
                                                                chunk_bytes='1k'), concat=True)[0]
             pd.testing.assert_frame_equal(pdf, mdf2)
 
-        finally:
-            shutil.rmtree(tempdir)
-
         # test multiply files
-        tempdir = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as tempdir:
             df = pd.DataFrame(np.random.rand(300, 3), columns=['a', 'b', 'c'])
 
             file_paths = [os.path.join(tempdir, f'test{i}.csv') for i in range(3)]
@@ -396,12 +382,8 @@ class Test(TestBase):
                                                    concat=True)[0]
             pd.testing.assert_frame_equal(df, mdf2)
 
-        finally:
-            shutil.rmtree(tempdir)
-
         # test wildcards in path
-        tempdir = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as tempdir:
             df = pd.DataFrame(np.random.rand(300, 3), columns=['a', 'b', 'c'])
 
             file_paths = [os.path.join(tempdir, f'test{i}.csv') for i in range(3)]
@@ -419,14 +401,52 @@ class Test(TestBase):
                 md.read_csv(f'{tempdir}/*.csv', index_col=0, chunk_bytes=50), concat=True)[0]
             pd.testing.assert_frame_equal(df, mdf2.sort_index())
 
-        finally:
-            shutil.rmtree(tempdir)
+    def testReadCSVUseArrowDtype(self):
+        df = pd.DataFrame({
+            'col1': np.random.rand(100),
+            'col2': np.random.choice(['a' * 2, 'b' * 3, 'c' * 4], (100,)),
+            'col3': np.arange(100)
+        })
+        with tempfile.TemporaryDirectory() as tempdir:
+            file_path = os.path.join(tempdir, 'test.csv')
+            df.to_csv(file_path, index=False)
+
+            pdf = pd.read_csv(file_path)
+            mdf = md.read_csv(file_path, use_arrow_dtype=True)
+            result = self.executor.execute_dataframe(mdf, concat=True)[0]
+            self.assertIsInstance(mdf.dtypes.iloc[1], md.ArrowStringDtype)
+            self.assertIsInstance(result.dtypes.iloc[1], md.ArrowStringDtype)
+            pd.testing.assert_frame_equal(arrow_array_to_objects(result), pdf)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            with option_context({'dataframe.use_arrow_dtype': True}):
+                file_path = os.path.join(tempdir, 'test.csv')
+                df.to_csv(file_path, index=False)
+
+                pdf = pd.read_csv(file_path)
+                mdf = md.read_csv(file_path)
+                result = self.executor.execute_dataframe(mdf, concat=True)[0]
+                self.assertIsInstance(mdf.dtypes.iloc[1], md.ArrowStringDtype)
+                self.assertIsInstance(result.dtypes.iloc[1], md.ArrowStringDtype)
+                pd.testing.assert_frame_equal(arrow_array_to_objects(result), pdf)
+
+        # test compression
+        with tempfile.TemporaryDirectory() as tempdir:
+            file_path = os.path.join(tempdir, 'test.gzip')
+            df.to_csv(file_path, compression='gzip', index=False)
+
+            pdf = pd.read_csv(file_path, compression='gzip')
+            mdf = md.read_csv(file_path, compression='gzip', use_arrow_dtype=True)
+            result = self.executor.execute_dataframe(mdf, concat=True)[0]
+            self.assertIsInstance(mdf.dtypes.iloc[1], md.ArrowStringDtype)
+            self.assertIsInstance(result.dtypes.iloc[1], md.ArrowStringDtype)
+            pd.testing.assert_frame_equal(arrow_array_to_objects(result), pdf)
 
     @require_cudf
     def testReadCSVGPUExecution(self):
-        tempdir = tempfile.mkdtemp()
-        file_path = os.path.join(tempdir, 'test.csv')
-        try:
+        with tempfile.TemporaryDirectory() as tempdir:
+            file_path = os.path.join(tempdir, 'test.csv')
+
             df = pd.DataFrame({
                 'col1': np.random.rand(100),
                 'col2': np.random.choice(['a', 'b', 'c'], (100,)),
@@ -442,16 +462,13 @@ class Test(TestBase):
                                                    concat=True)[0]
             pd.testing.assert_frame_equal(pdf.reset_index(drop=True), mdf2.to_pandas().reset_index(drop=True))
 
-        finally:
-            shutil.rmtree(tempdir)
-
     def testReadCSVWithoutIndex(self):
         sess = new_session()
 
         # test csv file without storing index
-        tempdir = tempfile.mkdtemp()
-        file_path = os.path.join(tempdir, 'test.csv')
-        try:
+        with tempfile.TemporaryDirectory() as tempdir:
+            file_path = os.path.join(tempdir, 'test.csv')
+
             df = pd.DataFrame(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), columns=['a', 'b', 'c'])
             df.to_csv(file_path, index=False)
 
@@ -461,8 +478,6 @@ class Test(TestBase):
 
             mdf2 = sess.run(md.read_csv(file_path, incremental_index=True, chunk_bytes=10))
             pd.testing.assert_frame_equal(pdf, mdf2)
-        finally:
-            shutil.rmtree(tempdir)
 
     def testReadSQLExecution(self):
         import sqlalchemy as sa
@@ -564,6 +579,36 @@ class Test(TestBase):
                 pd.testing.assert_frame_equal(result, test_df)
             finally:
                 engine.dispose()
+
+    def testReadSQLUseArrowDtype(self):
+        test_df = pd.DataFrame({'a': np.arange(10).astype(np.int64, copy=False),
+                                'b': [f's{i}' for i in range(10)],
+                                'c': np.random.rand(10),
+                                'd': [datetime.fromtimestamp(time.time() + 3600 * (i - 5))
+                                      for i in range(10)]})
+
+        with tempfile.TemporaryDirectory() as d:
+            table_name = 'test'
+            uri = 'sqlite:///' + os.path.join(d, 'test.db')
+
+            test_df.to_sql(table_name, uri, index=False)
+
+            r = md.read_sql_table('test', uri, chunk_size=4, use_arrow_dtype=True)
+            result = self.executor.execute_dataframe(r, concat=True)[0]
+            self.assertIsInstance(r.dtypes.iloc[1], md.ArrowStringDtype)
+            self.assertIsInstance(result.dtypes.iloc[1], md.ArrowStringDtype)
+            pd.testing.assert_frame_equal(arrow_array_to_objects(result), test_df)
+
+            # test read with sql string and offset method
+            r = md.read_sql_query('select * from test where c > 0.5', uri,
+                                  parse_dates=['d'], chunk_size=4,
+                                  incremental_index=True,
+                                  use_arrow_dtype=True)
+            result = self.executor.execute_dataframe(r, concat=True)[0]
+            self.assertIsInstance(r.dtypes.iloc[1], md.ArrowStringDtype)
+            self.assertIsInstance(result.dtypes.iloc[1], md.ArrowStringDtype)
+            pd.testing.assert_frame_equal(arrow_array_to_objects(result),
+                                          test_df[test_df.c > 0.5].reset_index(drop=True))
 
     def testDateRangeExecution(self):
         for closed in [None, 'left', 'right']:


### PR DESCRIPTION
Backport of #1491 .