### PR TITLE
Fix `arrow_array_to_objects` when input is a Series whose index is not RangeIndex(n)

### DIFF
--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 4, 6)
+version_info = (0, 4, 7)
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1096,5 +1096,5 @@ def arrow_array_to_objects(obj):
         obj = pd.DataFrame(out_cols, columns=list(obj.dtypes.keys()))
     elif isinstance(obj, pd.Series):
         if isinstance(obj.dtype, ArrowDtype):
-            obj = pd.Series(obj.to_numpy())
+            obj = pd.Series(obj.to_numpy(), index=obj.index, name=obj.name)
     return obj

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -212,15 +212,17 @@ class Test(unittest.TestCase):
                 value = sess.run(c, timeout=timeout)
                 np.testing.assert_array_equal(value, np.ones((10, 10)) * 10)
 
-                raw = pd.DataFrame(np.random.rand(10, 5), columns=list('ABCDE'))
+                raw = pd.DataFrame(np.random.rand(10, 5), columns=list('ABCDE'),
+                                   index=pd.RangeIndex(10, 0, -1))
                 data = md.DataFrame(raw).astype({'E': 'arrow_string'})
                 ret_data = data.execute(session=sess).fetch(session=sess)
                 self.assertEqual(ret_data.dtypes['E'], np.dtype('O'))
                 pd.testing.assert_frame_equal(
                     ret_data.astype({'E': 'float'}), raw, check_less_precise=True)
 
-                raw = pd.Series(np.random.rand(10))
-                data = md.Series(raw).astype('arrow_string')
+                raw = pd.Series(np.random.rand(10), index=pd.RangeIndex(10, 0, -1),
+                                name='r')
+                data = md.Series(raw).astype('Arrow[string]')
                 ret_data = data.execute(session=sess).fetch(session=sess)
                 self.assertEqual(ret_data.dtype, np.dtype('O'))
                 pd.testing.assert_series_equal(ret_data.astype('float'), raw)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes `arrow_array_to_objects` when input is a Series whose index is not RangeIndex(n)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA
