### PR TITLE
Fix `mt.isclose` when some of the arguments is scalar

### DIFF
--- a/mars/tensor/arithmetic/isclose.py
+++ b/mars/tensor/arithmetic/isclose.py
@@ -59,10 +59,13 @@ class TensorIsclose(TensorBinOp):
 
     @classmethod
     def execute(cls, ctx, op):
-        (a, b), device_id, xp = as_same_device(
+        inputs, device_id, xp = as_same_device(
             [ctx[c.key] for c in op.inputs], device=op.device, ret_extra=True)
 
         with device(device_id):
+            a = op.lhs if np.isscalar(op.lhs) else inputs[0]
+            b = op.rhs if np.isscalar(op.rhs) else inputs[-1]
+
             ctx[op.outputs[0].key] = xp.isclose(a, b, atol=op.atol, rtol=op.rtol,
                                                 equal_nan=op.equal_nan)
 

--- a/mars/tensor/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/tensor/arithmetic/tests/test_arithmetic_execution.py
@@ -510,18 +510,29 @@ class Test(unittest.TestCase):
 
         res = self.executor.execute_tensor(z, concat=True)[0]
         expected = np.isclose(data, data2, atol=.01)
-
         np.testing.assert_equal(res, expected)
 
         z = isclose(x, y, atol=.01, equal_nan=True)
 
         res = self.executor.execute_tensor(z, concat=True)[0]
         expected = np.isclose(data, data2, atol=.01, equal_nan=True)
+        np.testing.assert_equal(res, expected)
 
+        # test tensor with scalar
+        z = isclose(x, 1.0, atol=.01)
+        res = self.executor.execute_tensor(z, concat=True)[0]
+        expected = np.isclose(data, 1.0, atol=.01)
+        np.testing.assert_equal(res, expected)
+        z = isclose(1.0, y, atol=.01)
+        res = self.executor.execute_tensor(z, concat=True)[0]
+        expected = np.isclose(1.0, data2, atol=.01)
+        np.testing.assert_equal(res, expected)
+        z = isclose(1.0, 2.0, atol=.01)
+        res = self.executor.execute_tensor(z, concat=True)[0]
+        expected = np.isclose(1.0, 2.0, atol=.01)
         np.testing.assert_equal(res, expected)
 
         # test sparse
-
         data = sps.csr_matrix(np.array([0, 1.0, 1.01, np.nan]))
         data2 = sps.csr_matrix(np.array([0, 1.0, 1.03, np.nan]))
 
@@ -532,14 +543,12 @@ class Test(unittest.TestCase):
 
         res = self.executor.execute_tensor(z, concat=True)[0]
         expected = np.isclose(data.toarray(), data2.toarray(), atol=.01)
-
         np.testing.assert_equal(res, expected)
 
         z = isclose(x, y, atol=.01, equal_nan=True)
 
         res = self.executor.execute_tensor(z, concat=True)[0]
         expected = np.isclose(data.toarray(), data2.toarray(), atol=.01, equal_nan=True)
-
         np.testing.assert_equal(res, expected)
 
     @ignore_warning

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1101,5 +1101,5 @@ def arrow_array_to_objects(obj):
         obj = pd.DataFrame(out_cols, columns=list(obj.dtypes.keys()))
     elif isinstance(obj, pd.Series):
         if isinstance(obj.dtype, ArrowDtype):
-            obj = pd.Series(obj.to_numpy())
+            obj = pd.Series(obj.to_numpy(), index=obj.index, name=obj.name)
     return obj

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -213,15 +213,17 @@ class Test(unittest.TestCase):
                 value = sess.run(c, timeout=timeout)
                 np.testing.assert_array_equal(value, np.ones((10, 10)) * 10)
 
-                raw = pd.DataFrame(np.random.rand(10, 5), columns=list('ABCDE'))
+                raw = pd.DataFrame(np.random.rand(10, 5), columns=list('ABCDE'),
+                                   index=pd.RangeIndex(10, 0, -1))
                 data = md.DataFrame(raw).astype({'E': 'arrow_string'})
                 ret_data = data.execute(session=sess).fetch(session=sess)
                 self.assertEqual(ret_data.dtypes['E'], np.dtype('O'))
                 pd.testing.assert_frame_equal(
                     ret_data.astype({'E': 'float'}), raw, check_less_precise=True)
 
-                raw = pd.Series(np.random.rand(10))
-                data = md.Series(raw).astype('arrow_string')
+                raw = pd.Series(np.random.rand(10), index=pd.RangeIndex(10, 0, -1),
+                                name='r')
+                data = md.Series(raw).astype('Arrow[string]')
                 ret_data = data.execute(session=sess).fetch(session=sess)
                 self.assertEqual(ret_data.dtype, np.dtype('O'))
                 pd.testing.assert_series_equal(ret_data.astype('float'), raw)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixed `mt.isclose` when some of the arguments is scalar.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1497 .
