### PR TITLE
Fix `mt.linalg.norm` when axis is negative

### DIFF
--- a/mars/tensor/linalg/norm.py
+++ b/mars/tensor/linalg/norm.py
@@ -22,6 +22,7 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...serialize import ValueType, KeyField, AnyField, TupleField, BoolField
 from ...utils import recursive_tile
+from ..utils import validate_axis
 from ..array_utils import device, as_same_device
 from ..operands import TensorHasInput, TensorOperandMixin
 from ..arithmetic import sqrt
@@ -299,14 +300,15 @@ def norm(x, ord=None, axis=None, keepdims=False):
 
     """
     x = astensor(x)
+    ndim = x.ndim
 
     if ord == 'fro':
         ord = None
     if axis is not None:
         if isinstance(axis, Iterable):
-            axis = tuple(axis)
+            axis = tuple([validate_axis(ndim, a) for a in axis])
         else:
-            axis = (axis,)
+            axis = (validate_axis(ndim, axis),)
     else:
         axis = tuple(range(x.ndim))
 

--- a/mars/tensor/linalg/norm.py
+++ b/mars/tensor/linalg/norm.py
@@ -306,7 +306,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
         ord = None
     if axis is not None:
         if isinstance(axis, Iterable):
-            axis = tuple([validate_axis(ndim, a) for a in axis])
+            axis = tuple(validate_axis(ndim, a) for a in axis)
         else:
             axis = (validate_axis(ndim, axis),)
     else:

--- a/mars/tensor/linalg/tests/test_linalg_execute.py
+++ b/mars/tensor/linalg/tests/test_linalg_execute.py
@@ -797,13 +797,17 @@ class Test(unittest.TestCase):
         for i, a in enumerate(ma):
             data = d if i < 2 else d2
             for ord in (None, 'nuc', np.inf, -np.inf, 0, 1, -1, 2, -2):
-                for axis in (0, 1, (0, 1)):
+                for axis in (0, 1, (0, 1), -1):
                     for keepdims in (True, False):
                         try:
                             expected = np.linalg.norm(data, ord=ord, axis=axis, keepdims=keepdims)
                             t = norm(a, ord=ord, axis=axis, keepdims=keepdims)
                             concat = t.ndim > 0
                             res = self.executor.execute_tensor(t, concat=concat)[0]
+
+                            expected_shape = expected.shape
+                            t_shape = t.shape
+                            np.testing.assert_equal(expected_shape, t_shape)
 
                             np.testing.assert_allclose(res, expected, atol=.0001)
                         except ValueError:

--- a/mars/tensor/linalg/tests/test_linalg_execute.py
+++ b/mars/tensor/linalg/tests/test_linalg_execute.py
@@ -805,9 +805,9 @@ class Test(unittest.TestCase):
                             concat = t.ndim > 0
                             res = self.executor.execute_tensor(t, concat=concat)[0]
 
-                            expected_shape = expected.shape
+                            expected_shape = expected.shapes
                             t_shape = t.shape
-                            np.testing.assert_equal(expected_shape, t_shape)
+                            self.assertEqual(expected_shape, t_shape)
 
                             np.testing.assert_allclose(res, expected, atol=.0001)
                         except ValueError:

--- a/mars/tensor/linalg/tests/test_linalg_execute.py
+++ b/mars/tensor/linalg/tests/test_linalg_execute.py
@@ -805,7 +805,7 @@ class Test(unittest.TestCase):
                             concat = t.ndim > 0
                             res = self.executor.execute_tensor(t, concat=concat)[0]
 
-                            expected_shape = expected.shapes
+                            expected_shape = expected.shape
                             t_shape = t.shape
                             self.assertEqual(expected_shape, t_shape)
 


### PR DESCRIPTION

## What do these changes do?

fix a bug that derived shape is incorrect when negative axis is assign to `linalg.norm` function.
add some tests

## Related issue number

Fixes #1492 
<!-- Are there any issues opened that will be resolved by merging this change? -->
