### PR TITLE
Store and query graph information in batch

### DIFF
--- a/mars/scheduler/session.py
+++ b/mars/scheduler/session.py
@@ -29,6 +29,7 @@ class SessionActor(SchedulerActor):
         self._args = kwargs
 
         self._tileable_names = dict()
+        self._graph_infos = dict()
 
         self._cluster_info_ref = None
         self._assigner_ref = None
@@ -76,6 +77,16 @@ class SessionActor(SchedulerActor):
             self.ctx.destroy_actor(graph_ref)
         for mut_tensor_ref in self._mut_tensor_refs.values():
             self.ctx.destroy_actor(mut_tensor_ref)
+
+    def set_graph_info(self, graph_key, **kwargs):
+        try:
+            info_dict = self._graph_infos[graph_key]
+        except KeyError:
+            info_dict = self._graph_infos[graph_key] = dict()
+        info_dict.update(kwargs)
+
+    def get_graph_infos(self):
+        return self._graph_infos
 
     @log_unhandled
     def submit_tileable_graph(self, serialized_graph, graph_key, target_tileables=None, names=None, compose=True):
@@ -225,6 +236,9 @@ class SessionManagerActor(SchedulerActor):
         self.set_cluster_info_ref()
 
     def get_sessions(self):
+        return list(self._session_refs.keys())
+
+    def get_session_refs(self):
         return self._session_refs
 
     @log_unhandled

--- a/mars/web/apihandlers.py
+++ b/mars/web/apihandlers.py
@@ -87,6 +87,9 @@ class ApiEntryHandler(MarsApiRequestHandler):
 
 
 class SessionsApiHandler(MarsApiRequestHandler):
+    def get(self):
+        self.write(json.dumps(self.web_api.get_sessions()))
+
     def post(self):
         versions, args = self._handle_versions()
 

--- a/mars/web/tests/test_api.py
+++ b/mars/web/tests/test_api.py
@@ -300,6 +300,11 @@ class Test(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(int(res.text), 1)
 
+        # query sessions (should be empty)
+        res = requests.get(f'{service_ep}/api/session')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(json.loads(res.text)), 0)
+
         # raise on malicious python version
         res = requests.post(f'{service_ep}/api/session', dict(pyver='mal.version'))
         self.assertEqual(res.status_code, 400)


### PR DESCRIPTION
## What do these changes do?

Graph information (size, start time, end time and status) are now sent into SessionActor for batch retrieval.

## Related issue number

Fixes #1478