### PR TITLE
Fix `mt.arctan2` when arguments contain scalar

### DIFF
--- a/mars/tensor/arithmetic/arctan2.py
+++ b/mars/tensor/arithmetic/arctan2.py
@@ -29,11 +29,12 @@ class TensorArctan2(TensorBinOp):
 
     @classmethod
     def _is_sparse(cls, x1, x2):
-        # x2 is sparse or not does not matter
-        if hasattr(x1, 'issparse') and x1.issparse() and np.isscalar(x2):
+        if hasattr(x1, 'issparse') and x1.issparse():
+            # if x1 is sparse, will be sparse always
             return True
-        elif x1 == 0:
-            return True
+        elif np.isscalar(x1) and x1 == 0:
+            # x1 == 0, return sparse if x2 is
+            return x2.issparse() if hasattr(x2, 'issparse') else False
         return False
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes `mt.arctan2` when arguments contains scalar.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1500 .
