### PR TITLE
Update `mt.split` to support list and tuple

### DIFF
--- a/mars/tensor/base/split.py
+++ b/mars/tensor/base/split.py
@@ -20,8 +20,8 @@ from ... import opcodes as OperandDef
 from ...serialize import KeyField, AnyField, Int32Field
 from ...lib.sparse.core import get_array_module
 from ...core import ExecutableTuple
-from ..datasource import tensor as astensor
 from ..core import Tensor
+from ..datasource import tensor as astensor
 from ..utils import calc_sliced_size
 from ..operands import TensorHasInput, TensorOperandMixin
 

--- a/mars/tensor/base/split.py
+++ b/mars/tensor/base/split.py
@@ -20,6 +20,7 @@ from ... import opcodes as OperandDef
 from ...serialize import KeyField, AnyField, Int32Field
 from ...lib.sparse.core import get_array_module
 from ...core import ExecutableTuple
+from ..datasource import tensor as astensor
 from ..core import Tensor
 from ..utils import calc_sliced_size
 from ..operands import TensorHasInput, TensorOperandMixin
@@ -198,4 +199,4 @@ def split(ary, indices_or_sections, axis=0):
      array([], dtype=float64)]
 
     """
-    return _split(ary, indices_or_sections, axis=axis, is_split=True)
+    return _split(astensor(ary), indices_or_sections, axis=axis, is_split=True)

--- a/mars/tensor/base/tests/test_base.py
+++ b/mars/tensor/base/tests/test_base.py
@@ -373,12 +373,6 @@ class Test(unittest.TestCase):
         for a in ((1,1,1,2,2,3), [1,1,1,2,2,3]):
             splits = split(a, (3,5))
             self.assertEqual(len(splits), 3)
-            # np.testing.assert_array_equal(splits[0].execute(), (1,1,1))
-            # np.testing.assert_array_equal(splits[1].execute(), (2,2))
-            # np.testing.assert_array_equal(splits[2].execute(), (3,))
-            self.assertEqual(splits[0].shape, (3,))
-            self.assertEqual(splits[1].shape, (2,))
-            self.assertEqual(splits[2].shape, (1,))
 
     def testSqueeze(self):
         data = np.array([[[0], [1], [2]]])

--- a/mars/tensor/base/tests/test_base.py
+++ b/mars/tensor/base/tests/test_base.py
@@ -370,6 +370,13 @@ class Test(unittest.TestCase):
         self.assertTrue(splits[2].flags['F_CONTIGUOUS'])
         self.assertFalse(splits[0].flags['C_CONTIGUOUS'])
 
+        for a in ((1,1,1,2,2,3), [1,1,1,2,2,3]):
+            splits = split(a, (3,5))
+            self.assertEqual(len(splits), 3)
+            np.testing.assert_array_equal(splits[0].execute(), (1,1,1))
+            np.testing.assert_array_equal(splits[1].execute(), (2,2))
+            np.testing.assert_array_equal(splits[2].execute(), (3,))
+
     def testSqueeze(self):
         data = np.array([[[0], [1], [2]]])
         x = tensor(data)

--- a/mars/tensor/base/tests/test_base.py
+++ b/mars/tensor/base/tests/test_base.py
@@ -373,9 +373,12 @@ class Test(unittest.TestCase):
         for a in ((1,1,1,2,2,3), [1,1,1,2,2,3]):
             splits = split(a, (3,5))
             self.assertEqual(len(splits), 3)
-            np.testing.assert_array_equal(splits[0].execute(), (1,1,1))
-            np.testing.assert_array_equal(splits[1].execute(), (2,2))
-            np.testing.assert_array_equal(splits[2].execute(), (3,))
+            # np.testing.assert_array_equal(splits[0].execute(), (1,1,1))
+            # np.testing.assert_array_equal(splits[1].execute(), (2,2))
+            # np.testing.assert_array_equal(splits[2].execute(), (3,))
+            self.assertEqual(splits[0].shape, (3,))
+            self.assertEqual(splits[1].shape, (2,))
+            self.assertEqual(splits[2].shape, (1,))
 
     def testSqueeze(self):
         data = np.array([[[0], [1], [2]]])

--- a/mars/tensor/base/tests/test_base_execute.py
+++ b/mars/tensor/base/tests/test_base_execute.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from operator import concat
 import numpy as np
 import scipy.sparse as sps
 import pandas as pd

--- a/mars/tensor/base/tests/test_base_execute.py
+++ b/mars/tensor/base/tests/test_base_execute.py
@@ -444,6 +444,13 @@ class Test(TestBase):
         [np.testing.assert_equal(r, e) for r, e in zip(res, expected)]
 
     def testSplitExecution(self):
+        for a in ((1,1,1,2,2,3), [1,1,1,2,2,3]):
+            splits = split(a, (3,5))
+            self.assertEqual(len(splits), 3)
+            np.testing.assert_array_equal(splits[0].execute(), (1,1,1))
+            np.testing.assert_array_equal(splits[1].execute(), (2,2))
+            np.testing.assert_array_equal(splits[2].execute(), (3,))
+
         x = arange(48, chunk_size=3).reshape(2, 3, 8)
         ss = split(x, 4, axis=2)
 

--- a/mars/tensor/base/tests/test_base_execute.py
+++ b/mars/tensor/base/tests/test_base_execute.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from operator import concat
 import numpy as np
 import scipy.sparse as sps
 import pandas as pd
@@ -447,9 +448,12 @@ class Test(TestBase):
         for a in ((1,1,1,2,2,3), [1,1,1,2,2,3]):
             splits = split(a, (3,5))
             self.assertEqual(len(splits), 3)
-            np.testing.assert_array_equal(splits[0].execute(), (1,1,1))
-            np.testing.assert_array_equal(splits[1].execute(), (2,2))
-            np.testing.assert_array_equal(splits[2].execute(), (3,))
+            splits0 = self.executor.execute_tensor(splits[0], concat=True)[0]
+            np.testing.assert_array_equal(splits0, (1,1,1))
+            splits1 = self.executor.execute_tensor(splits[1], concat=True)[0]
+            np.testing.assert_array_equal(splits1, (2,2))
+            splits2 = self.executor.execute_tensor(splits[2], concat=True)[0]
+            np.testing.assert_array_equal(splits2, (3,))
 
         x = arange(48, chunk_size=3).reshape(2, 3, 8)
         ss = split(x, 4, axis=2)


### PR DESCRIPTION
## What do these changes do?

update `mt.split` to support list and tuple as first argument

## Related issue number

Fixes #1506 
