### PR TITLE
[BACKPORT] Update `mt.split` to support list and tuple (#1507)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -299,7 +299,7 @@ After all mars processes are started, users can run
 Getting involved
 ----------------
 
-- Read `contribution guide <https://docs.pymars.org/en/latest/contributing.html>`_.
+- Read `development guide <https://docs.pymars.org/en/latest/development/index.html>`_.
 - Join the mailing list: send an email to `mars-dev@googlegroups.com`_.
 - Please report bugs by submitting a `GitHub issue`_.
 - Submit contributions using `pull requests`_.

--- a/mars/tensor/base/split.py
+++ b/mars/tensor/base/split.py
@@ -21,6 +21,7 @@ from ...serialize import KeyField, AnyField, Int32Field
 from ...lib.sparse.core import get_array_module
 from ...core import ExecutableTuple
 from ..core import Tensor
+from ..datasource import tensor as astensor
 from ..utils import calc_sliced_size
 from ..operands import TensorHasInput, TensorOperandMixin
 
@@ -198,4 +199,4 @@ def split(ary, indices_or_sections, axis=0):
      array([], dtype=float64)]
 
     """
-    return _split(ary, indices_or_sections, axis=axis, is_split=True)
+    return _split(astensor(ary), indices_or_sections, axis=axis, is_split=True)

--- a/mars/tensor/base/tests/test_base.py
+++ b/mars/tensor/base/tests/test_base.py
@@ -370,6 +370,10 @@ class Test(unittest.TestCase):
         self.assertTrue(splits[2].flags['F_CONTIGUOUS'])
         self.assertFalse(splits[0].flags['C_CONTIGUOUS'])
 
+        for a in ((1,1,1,2,2,3), [1,1,1,2,2,3]):
+            splits = split(a, (3,5))
+            self.assertEqual(len(splits), 3)
+
     def testSqueeze(self):
         data = np.array([[[0], [1], [2]]])
         x = tensor(data)

--- a/mars/tensor/base/tests/test_base_execute.py
+++ b/mars/tensor/base/tests/test_base_execute.py
@@ -444,6 +444,16 @@ class Test(TestBase):
         [np.testing.assert_equal(r, e) for r, e in zip(res, expected)]
 
     def testSplitExecution(self):
+        for a in ((1,1,1,2,2,3), [1,1,1,2,2,3]):
+            splits = split(a, (3,5))
+            self.assertEqual(len(splits), 3)
+            splits0 = self.executor.execute_tensor(splits[0], concat=True)[0]
+            np.testing.assert_array_equal(splits0, (1,1,1))
+            splits1 = self.executor.execute_tensor(splits[1], concat=True)[0]
+            np.testing.assert_array_equal(splits1, (2,2))
+            splits2 = self.executor.execute_tensor(splits[2], concat=True)[0]
+            np.testing.assert_array_equal(splits2, (3,))
+
         x = arange(48, chunk_size=3).reshape(2, 3, 8)
         ss = split(x, 4, axis=2)
 


### PR DESCRIPTION
Backport of #1507