### PR TITLE
Optimize `mars.learn.cluster.KMeans` when `n_clusters` is relatively large

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
             if [[ $UNAME == "linux" ]] && [[ ! "$PYTHON" =~ "3.8" ]]; then
               pip install tensorflow\<2.3.0
               pip install torch torchvision
-              pip install tsfresh
+              pip install tsfresh statsmodels==0.11.1
             fi
             virtualenv testenv && source testenv/bin/activate
             pip install -r requirements.txt && pip install pytest pytest-timeout

--- a/mars/serialize/dataserializer.py
+++ b/mars/serialize/dataserializer.py
@@ -299,6 +299,11 @@ def serialize(data):
         if isinstance(data, (complex, np.complexfloating)):
             return pyarrow.serialize(_ComplexWrapper(data), mars_serialize_context())
         raise SerializationFailed(obj=data)
+    except pyarrow.lib.ArrowInvalid:
+        if isinstance(data, np.ndarray) and any(s < 0 for s in data.strides):
+            # pyarrow does not support negative strides for now
+            return pyarrow.serialize(data.copy(), mars_serialize_context())
+        raise SerializationFailed(obj=data)
 
 
 def deserialize(data):

--- a/mars/serialize/tests/test_serialize.py
+++ b/mars/serialize/tests/test_serialize.py
@@ -796,6 +796,12 @@ class Test(unittest.TestCase):
         self.assertIs(type(s), type(dest_s))
         self.assertEqual(s, dest_s)
 
+        # test ndarray with negative strides
+        arr = np.zeros((5, 6, 3))
+        arr2 = arr[:, :, ::-1]
+        dest_arr2 = dataserializer.loads(dataserializer.dumps(arr2))
+        np.testing.assert_array_equal(arr2, dest_arr2)
+
         # test ArrowArray
         df = pd.DataFrame({'a': ['s1', 's2', 's3'],
                            'b': [['s1', 's2'], ['s3'], ['s4', 's5']]})

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -164,6 +164,7 @@ class BaseCalcActor(WorkerActor):
             self._n_cpu = len(self._dispatch_ref.get_slots('cpu'))
         return self._n_cpu
 
+    @log_unhandled
     def _calc_results(self, session_id, graph_key, graph, context_dict, chunk_targets):
         _, op_name = concat_operand_keys(graph, '_')
 

--- a/mars/worker/quota.py
+++ b/mars/worker/quota.py
@@ -155,7 +155,8 @@ class QuotaActor(WorkerActor):
         :return: if request is returned immediately, return True, otherwise False
         """
         if delta > self._total_size:
-            raise ValueError('Cannot allocate size larger than the total capacity.')
+            raise ValueError(f'Cannot allocate size({delta}) '
+                             f'larger than the total capacity({self._total_size}).')
 
         if keys in self._requests:
             # already in request queue, store callback and quit


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR did two things to optimize `mars.learn.cluster.KMeans` when `n_clusters` is relatively large.

1. Do rechunk in `euclidean_distances` to prevent from potential large chunks.
2. Cut k-means++ iterations into pieces and trigger execution to reduce size of chunk graph.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1510 .
