### PR TITLE
Add an option to control writing shuffle data into disk

### DIFF
--- a/mars/config.py
+++ b/mars/config.py
@@ -358,6 +358,7 @@ default_options.register_option('worker.prepare_data_timeout', 600, validator=is
 default_options.register_option('worker.peer_blacklist_time', 3600, validator=is_numeric, serialize=True)
 default_options.register_option('worker.io_parallel_num', 1, validator=is_integer, serialize=True)
 default_options.register_option('worker.recover_dead_process', True, validator=is_bool, serialize=True)
+default_options.register_option('worker.write_shuffle_to_disk', False, validator=is_bool, serialize=True)
 
 default_options.register_option('worker.plasma_socket', '/tmp/plasma', validator=is_string)
 

--- a/mars/scheduler/resource.py
+++ b/mars/scheduler/resource.py
@@ -26,7 +26,6 @@ from .utils import SchedulerActor
 from ..config import options
 from ..utils import BlacklistSet
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mars/worker/__main__.py
+++ b/mars/worker/__main__.py
@@ -53,6 +53,8 @@ class WorkerApplication(BaseApplication):
         parser.add_argument('--io-parallel-num', help='make file io lock free, add this when using a mounted dfs')
         parser.add_argument('--disable-proc-recover', action='store_true',
                             help='disable recovering failed processes')
+        parser.add_argument('--write-shuffle-to-disk', action='store_true',
+                            help='write shuffled data to disk')
         parser.add_argument('--plasma-dir', help='path of plasma directory. When specified, the size '
                                                  'of plasma store will not be taken into account when '
                                                  'managing host memory')
@@ -78,6 +80,8 @@ class WorkerApplication(BaseApplication):
         args.cache_mem = args.cache_mem or environ.get('MARS_CACHE_MEM_SIZE')
         args.disable_proc_recover = args.disable_proc_recover \
             or bool(int(environ.get('MARS_DISABLE_PROC_RECOVER', '0')))
+        args.write_shuffle_to_disk = args.write_shuffle_to_disk \
+            or bool(int(environ.get('MARS_WRITE_SHUFFLE_TO_DISK', '0')))
         args.io_parallel_num = args.io_parallel_num \
             or int(environ.get('MARS_IO_PARALLEL_NUM', '1'))
         if args.io_parallel_num == 1 and bool(int(environ.get('MARS_LOCK_FREE_FILEIO', '0'))):
@@ -115,6 +119,7 @@ class WorkerApplication(BaseApplication):
             plasma_dir=self.args.plasma_dir,
             use_ext_plasma_dir=bool(self.args.plasma_dir),
             disable_proc_recover=self.args.disable_proc_recover,
+            write_shuffle_to_disk=self.args.write_shuffle_to_disk,
         )
         # start plasma
         self._service.start_plasma()

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -327,7 +327,8 @@ class BaseCalcActor(WorkerActor):
                 # delay destroying to allow requests to enter
                 self.ref().destroy_self(_tell=True, _delay=0.5)
 
-        dest_devices = self._calc_dest_devices if not isinstance(keys_to_store[0], tuple) \
+        dest_devices = self._calc_dest_devices \
+            if not isinstance(keys_to_store[0], tuple) or not options.worker.write_shuffle_to_disk \
             else [DataStorageDevice.DISK]
         return storage_client.copy_to(session_id, keys_to_store, dest_devices) \
             .then(_delete_keys) \

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -332,7 +332,9 @@ class BaseCalcActor(WorkerActor):
                 # delay destroying to allow requests to enter
                 self.ref().destroy_self(_tell=True, _delay=0.5)
 
-        return storage_client.copy_to(session_id, keys_to_store, self._calc_dest_devices) \
+        dest_devices = self._calc_dest_devices if not isinstance(keys_to_store[0], tuple) \
+            else [DataStorageDevice.DISK]
+        return storage_client.copy_to(session_id, keys_to_store, dest_devices) \
             .then(_delete_keys) \
             .then(lambda *_: meta_future.result()) \
             .then(lambda *_: self.tell_promise(callback),

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -239,8 +239,6 @@ class BaseCalcActor(WorkerActor):
                 'calc_speed.' + op_name, sum(apply_alloc_sizes) * 1.0 / (end_time - start_time),
                 _tell=True, _wait=False)
 
-        logger.debug('Finish calculating operand %s.', graph_key)
-
         return self.storage_client.put_objects(
             session_id, result_keys, result_values, [self._calc_intermediate_device],
             sizes=result_sizes, shapes=result_shapes) \
@@ -273,27 +271,24 @@ class BaseCalcActor(WorkerActor):
             if not self._marked_as_destroy:
                 self._dispatch_ref.register_free_slot(self.uid, self._slot_name, _tell=True, _wait=False)
 
-            keys_to_delete = []
-            keys_to_release = []
-
-            for k in keys_to_fetch:
-                if get_chunk_key(k) not in chunk_targets:
-                    if self._remove_intermediate:
-                        keys_to_delete.append(k)
-                    keys_to_release.append(k)
-
             if not exc_info:
                 self.tell_promise(callback, keys)
             else:
-                for k in chunk_targets:
-                    if self._remove_intermediate:
-                        keys_to_delete.append(k)
-                    keys_to_release.append(k)
                 self.tell_promise(callback, *exc_info, _accept=False)
+
+            keys_to_release = [k for k in keys_to_fetch if get_chunk_key(k) not in chunk_targets]
+            if exc_info:
+                keys_to_release.extend(chunk_targets)
+
+            if self._remove_intermediate:
+                keys_to_delete = keys_to_release
+            else:
+                keys_to_delete = []
 
             if keys_to_delete:
                 self.storage_client.delete(session_id, keys_to_delete, [self._calc_intermediate_device])
             self._release_local_quotas(session_id, keys_to_release)
+            logger.debug('Finish calculating operand %s.', graph_key)
 
         return self._fetch_keys_to_process(session_id, keys_to_fetch) \
             .then(lambda context_dict: _start_calc(context_dict)) \

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -653,7 +653,8 @@ class ExecutionActor(WorkerActor):
         promises = []
         graph_record = self._graph_records[(session_id, graph_key)]
         ensure_shared_keys = [k for k in copy_keys if k in graph_record.shared_input_chunks]
-        better_shared_keys = [k for k in copy_keys if k not in graph_record.shared_input_chunks]
+        better_shared_keys = [k for k in copy_keys if k not in graph_record.shared_input_chunks
+                              and not isinstance(k, tuple)]
 
         def _release_copied_keys(keys):
             actual_moved_keys = self._pin_shared_data_keys(session_id, graph_key, keys)

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -98,6 +98,7 @@ class WorkerService(object):
             options.worker.transfer_compression
         options.worker.io_parallel_num = kwargs.pop('io_parallel_num', None) or False
         options.worker.recover_dead_process = not (kwargs.pop('disable_proc_recover', None) or False)
+        options.worker.write_shuffle_to_disk = kwargs.pop('write_shuffle_to_disk', None) or False
 
         self._total_mem = kwargs.pop('total_mem', None)
         self._cache_mem_limit = kwargs.pop('cache_mem_limit', None)

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -586,7 +586,9 @@ class ReceiverWorkerActor(WorkerActor):
             self._data_metas[(session_id, chunk_key)] = ReceiverDataMeta(
                 start_time=time.time(), chunk_size=data_size, source_address=source_address)
 
-            use_device_order = [DataStorageDevice.DISK] if isinstance(chunk_key, tuple) else device_order
+            use_device_order = device_order \
+                if not isinstance(chunk_key, tuple) or not options.worker.write_shuffle_to_disk \
+                else [DataStorageDevice.DISK]
             if use_promise:
                 promises.append(self.storage_client.create_writer(
                     session_id, chunk_key, data_size, use_device_order, packed=True,


### PR DESCRIPTION
## What do these changes do?

This PR does things below:

1. Add an option to control writing shuffle data into disk. When switched on, all data produced in shuffle map will be stored in disk;
2. Spawn disk data deletion into threads to reduce greenlet block in the main process;
3. Optimize several batch operations.

## Related issue number

Fixes #1512 