### PR TITLE
Fix creating Mars DataFrame from an empty pandas DataFrame

### DIFF
--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -41,6 +41,19 @@ class Test(TestBase):
         self.ctx, self.executor = self._create_test_context()
 
     def testFromPandasDataFrameExecution(self):
+        # test empty dataframe
+        pdf = pd.DataFrame()
+        df = from_pandas_df(pdf)
+
+        result = self.executor.execute_dataframe(df, concat=True)[0]
+        pd.testing.assert_frame_equal(pdf, result)
+
+        pdf = pd.DataFrame(columns=list('ab'))
+        df = from_pandas_df(pdf)
+
+        result = self.executor.execute_dataframe(df, concat=True)[0]
+        pd.testing.assert_frame_equal(pdf, result)
+
         pdf = pd.DataFrame(np.random.rand(20, 30), index=[np.arange(20), np.arange(20, 0, -1)])
         df = from_pandas_df(pdf, chunk_size=(13, 21))
 

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -41,7 +41,7 @@ class Test(TestBase):
         self.ctx, self.executor = self._create_test_context()
 
     def testFromPandasDataFrameExecution(self):
-        # test empty dataframe
+        # test empty DataFrame
         pdf = pd.DataFrame()
         df = from_pandas_df(pdf)
 
@@ -61,6 +61,13 @@ class Test(TestBase):
         pd.testing.assert_frame_equal(pdf, result)
 
     def testFromPandasSeriesExecution(self):
+        # test empty Series
+        ps = pd.Series(name='a')
+        series = from_pandas_series(ps, chunk_size=13)
+
+        result = self.executor.execute_dataframe(series, concat=True)[0]
+        pd.testing.assert_series_equal(ps, result)
+
         ps = pd.Series(np.random.rand(20), index=[np.arange(20), np.arange(20, 0, -1)], name='a')
         series = from_pandas_series(ps, chunk_size=13)
 

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -183,7 +183,7 @@ def decide_series_chunk_size(shape, chunk_size, memory_usage):
     from ..config import options
 
     chunk_size = dictify_chunk_size(shape, chunk_size)
-    average_memory_usage = memory_usage / shape[0]
+    average_memory_usage = memory_usage / shape[0] if shape[0] != 0 else memory_usage
 
     if len(chunk_size) == len(shape):
         return normalize_chunk_sizes(shape, chunk_size[0])

--- a/mars/tensor/utils.py
+++ b/mars/tensor/utils.py
@@ -69,8 +69,11 @@ def normalize_chunk_sizes(shape, chunk_size):
         else:
             assert isinstance(chunk, int)
 
-            sizes = tuple(chunk for _ in range(int(size / chunk))) + \
-                (tuple() if size % chunk == 0 else (size % chunk,))
+            if size == 0:
+                sizes = (0,)
+            else:
+                sizes = tuple(chunk for _ in range(int(size / chunk))) + \
+                    (tuple() if size % chunk == 0 else (size % chunk,))
             chunk_sizes.append(sizes)
 
     return tuple(chunk_sizes)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Fix `decide_dataframe_chunk_sizes` to make it works when input DataFrame is empty.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1521.