### PR TITLE
Support `df.groupby().count()` for arrow dtype with and without pyarrow installed

### DIFF
--- a/mars/config.py
+++ b/mars/config.py
@@ -298,6 +298,7 @@ default_options.register_option('check_interval', 20, validator=is_integer)
 # dataframe-related options
 default_options.register_option('dataframe.mode.use_inf_as_na', False, validator=is_bool)
 default_options.register_option('dataframe.use_arrow_dtype', None, validator=any_validator(is_null, is_bool))
+default_options.register_option('dataframe.arrow_array.pandas_only', None, validator=any_validator(is_null, is_bool))
 
 # learn options
 assume_finite = os.environ.get('SKLEARN_ASSUME_FINITE')

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -192,6 +192,7 @@ class IndexValue(Serializable):
 
     class MultiIndex(IndexBase):
         _names = ListField('names', on_serialize=list)
+        _dtypes = ListField('dtypes', on_serialize=list)
         _data = NDArrayField('data')
         _sortorder = Int32Field('sortorder')
 
@@ -203,7 +204,7 @@ class IndexValue(Serializable):
             data = getattr(self, '_data', None)
             if data is None:
                 sortorder = getattr(self, '_sortorder', None)
-                return pd.MultiIndex.from_arrays([[] for _ in range(len(self._names))],
+                return pd.MultiIndex.from_arrays([np.array([], dtype=dtype) for dtype in self._dtypes],
                                                  sortorder=sortorder, names=self._names)
             return pd.MultiIndex.from_tuples([tuple(d) for d in data], sortorder=self._sortorder,
                                              names=self._names)

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -15,12 +15,17 @@
 import os
 import tempfile
 import time
+import unittest
 from collections import OrderedDict
 from datetime import datetime
 from string import printable
 
 import numpy as np
 import pandas as pd
+try:
+    import pyarrow as pa
+except ImportError:  # pragma: no cover
+    pa = None
 
 import mars.tensor as mt
 import mars.dataframe as md
@@ -421,6 +426,7 @@ class Test(TestBase):
                 md.read_csv(f'{tempdir}/*.csv', index_col=0, chunk_bytes=50), concat=True)[0]
             pd.testing.assert_frame_equal(df, mdf2.sort_index())
 
+    @unittest.skipIf(pa is None, 'pyarrow not installed')
     def testReadCSVUseArrowDtype(self):
         df = pd.DataFrame({
             'col1': np.random.rand(100),
@@ -600,6 +606,7 @@ class Test(TestBase):
             finally:
                 engine.dispose()
 
+    @unittest.skipIf(pa is None, 'pyarrow not installed')
     def testReadSQLUseArrowDtype(self):
         test_df = pd.DataFrame({'a': np.arange(10).astype(np.int64, copy=False),
                                 'b': [f's{i}' for i in range(10)],

--- a/mars/dataframe/groupby/apply.py
+++ b/mars/dataframe/groupby/apply.py
@@ -19,7 +19,7 @@ from ... import opcodes
 from ...core import OutputType
 from ...serialize import TupleField, DictField, FunctionField
 from ..operands import DataFrameOperandMixin, DataFrameOperand
-from ..utils import build_empty_df, build_empty_series, parse_index
+from ..utils import build_df, build_empty_df, build_series, build_empty_series, parse_index
 
 
 class GroupByApply(DataFrameOperand, DataFrameOperandMixin):
@@ -100,16 +100,16 @@ class GroupByApply(DataFrameOperand, DataFrameOperandMixin):
 
         try:
             if in_df.op.output_types[0] == OutputType.dataframe:
-                empty_df = build_empty_df(in_df.dtypes, index=pd.RangeIndex(2))
+                test_df = build_df(in_df, size=2)
             else:
-                empty_df = build_empty_series(in_df.dtype, index=pd.RangeIndex(2), name=in_df.name)
+                test_df = build_series(in_df, size=2, name=in_df.name)
 
             selection = getattr(in_groupby.op, 'selection', None)
             if selection:
-                empty_df = empty_df[selection]
+                test_df = test_df[selection]
 
             with np.errstate(all='ignore'):
-                infer_df = self.func(empty_df, *self.args, **self.kwds)
+                infer_df = self.func(test_df, *self.args, **self.kwds)
 
             # todo return proper index when sort=True is implemented
             index_value = parse_index(None, in_df.key, self.func)

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -28,7 +28,7 @@ from ..align import align_dataframe_series, align_series_series
 from ..initializer import Series as asseries
 from ..core import SERIES_TYPE, SERIES_CHUNK_TYPE
 from ..utils import build_concatenated_rows_frame, hash_dataframe_on, \
-    build_empty_df, build_empty_series, parse_index
+    build_df, build_series, parse_index
 from ..operands import DataFrameOperandMixin, DataFrameMapReduceOperand, DataFrameShuffleProxy
 
 
@@ -97,14 +97,14 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
     def build_mock_groupby(self, **kwargs):
         in_df = self.inputs[0]
         if self.is_dataframe_obj:
-            empty_df = build_empty_df(in_df.dtypes, index=pd.RangeIndex(2))
+            empty_df = build_df(in_df, size=2)
             obj_dtypes = in_df.dtypes[in_df.dtypes == np.dtype('O')]
             empty_df[obj_dtypes.index] = 'O'
         else:
             if in_df.dtype == np.dtype('O'):
                 empty_df = pd.Series('O', index=pd.RangeIndex(2), name=in_df.name, dtype=np.dtype('O'))
             else:
-                empty_df = build_empty_series(in_df.dtype, index=pd.RangeIndex(2), name=in_df.name)
+                empty_df = build_series(in_df, size=2, name=in_df.name)
 
         new_kw = self.groupby_params
         new_kw.update(kwargs)
@@ -114,7 +114,7 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
             new_by = []
             for v in new_kw['by']:
                 if isinstance(v, (Base, Entity)):
-                    new_by.append(build_empty_series(v.dtype, index=pd.RangeIndex(2), name=v.name))
+                    new_by.append(build_series(v, size=2, name=v.name))
                 else:
                     new_by.append(v)
             new_kw['by'] = new_by

--- a/mars/dataframe/reduction/aggregation.py
+++ b/mars/dataframe/reduction/aggregation.py
@@ -27,7 +27,7 @@ from ...serialize import BoolField, AnyField, DictField
 from ...utils import tokenize, ceildiv, lazy_import
 from ..merge import DataFrameConcat
 from ..operands import DataFrameOperand, DataFrameOperandMixin
-from ..utils import build_empty_df, build_empty_series, parse_index, validate_axis
+from ..utils import build_df, build_series, parse_index, validate_axis
 
 cp = lazy_import('cupy', globals=globals(), rename='cp')
 cudf = lazy_import('cudf', globals=globals())
@@ -115,11 +115,11 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
 
     def _calc_result_shape(self, df):
         if self.output_types[0] == OutputType.dataframe:
-            empty_obj = build_empty_df(df.dtypes, index=pd.RangeIndex(0, 10))
+            test_obj = build_df(df, size=10)
         else:
-            empty_obj = build_empty_series(df.dtype, index=pd.RangeIndex(0, 10), name=df.name)
+            test_obj = build_series(df, size=10, name=df.name)
 
-        result_df = empty_obj.agg(self.func, axis=self.axis)
+        result_df = test_obj.agg(self.func, axis=self.axis)
 
         if isinstance(result_df, pd.DataFrame):
             self.output_types = [OutputType.dataframe]

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -88,7 +88,7 @@ class TestReduction(TestBase):
         self.assertEqual(chunk.op.axis, chunk2.op.axis)
 
     def testSeriesReduction(self):
-        data = pd.Series({'a': list(range(20))}, index=[str(i) for i in range(20)])
+        data = pd.Series(range(20), index=[str(i) for i in range(20)])
         series = getattr(from_pandas_series(data, chunk_size=3), self.func_name)()
 
         self.assertIsInstance(series, Tensor)

--- a/mars/dataframe/reduction/tests/test_reduction_execute.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execute.py
@@ -16,6 +16,10 @@ import unittest
 
 import pandas as pd
 import numpy as np
+try:
+    import pyarrow as pa
+except ImportError:  # pragma: no cover
+    pa = None
 
 from mars.config import option_context
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
@@ -300,6 +304,7 @@ class TestCount(TestBase):
         expected = data1.nunique(axis=1)
         pd.testing.assert_series_equal(result, expected)
 
+    @unittest.skipIf(pa is None, 'pyarrow not installed')
     def testUseArrowDtypeNUnique(self):
         with option_context({'dataframe.use_arrow_dtype': True, 'combine_size': 2}):
             rs = np.random.RandomState(0)

--- a/mars/dataframe/tests/test_arrays.py
+++ b/mars/dataframe/tests/test_arrays.py
@@ -21,9 +21,11 @@ try:
 except ImportError:
     pa = None
 
+from mars.config import option_context
 from mars.dataframe import ArrowStringDtype, ArrowStringArray, ArrowListDtype, ArrowListArray
 from mars.dataframe.utils import arrow_table_to_pandas_dataframe
 from mars.serialize import dataserializer
+from mars.utils import enter_mode
 
 
 @unittest.skipIf(pa is None, 'pyarrow not installed')
@@ -130,238 +132,265 @@ class Test(unittest.TestCase):
         self.assertEqual(array.dtype.value_type, np.int64)
         self.assertIsInstance(array._arrow_array, pa.ChunkedArray)
 
+        # test pandas_only
+        with option_context({'dataframe.arrow_array.pandas_only': True}):
+            array = ArrowListArray._from_sequence([[1, 2], [3, 4], [5]])
+            self.assertIsInstance(array.dtype, ArrowListDtype)
+            self.assertIsInstance(array._ndarray, np.ndarray)
+
+        # test pandas_only and in kernel mode
+        with enter_mode(kernel=True), \
+             option_context({'dataframe.arrow_array.pandas_only': True}), \
+             self.assertRaises(ImportError):
+            ArrowListArray._from_sequence([[1, 2], [3, 4], [5]])
+
     def testArrowStringArrayFunctions(self):
         lst = np.array(['abc', 'de', 'eee', '中文'], dtype=object)
-        arrow_array = ArrowStringArray(lst)
         # leverage string array to get the right answer
         string_array = pd.arrays.StringArray(lst)
         has_na_arrow_array = ArrowStringArray(['abc', None, 'eee', '中文'])
         has_na_string_array = pd.arrays.StringArray(
             np.array(['abc', pd.NA, 'eee', '中文'], dtype=object))
 
-        # getitem, scalar
-        self.assertEqual(arrow_array[1], string_array[1])
-        self.assertEqual(arrow_array[-1], string_array[-1])
-        # getitem, slice
-        self.assertListEqual(list(arrow_array[:2]), list(string_array[:2]))
-        self.assertListEqual(list(arrow_array[1:-1]), list(string_array[1:-1]))
-        self.assertListEqual(list(arrow_array[::2]), list(string_array[::2]))
-        # getitem, boolean index
-        cond = np.array([len(c) > 2 for c in lst])
-        self.assertListEqual(list(arrow_array[cond]), list(string_array[cond]))
-        # getitem, fancy index
-        selection = [3, 1, 2]
-        self.assertListEqual(list(arrow_array[selection]), list(string_array[selection]))
-        selection = [3, -1, 2, -4]
-        self.assertListEqual(list(arrow_array[selection]), list(string_array[selection]))
-        selection = np.array([3, -1, 2, -4])
-        self.assertListEqual(list(arrow_array[selection]), list(string_array[selection]))
+        for pandas_only in [False, True]:
+            with option_context({'dataframe.arrow_array.pandas_only': pandas_only}):
+                arrow_array = ArrowStringArray(lst)
 
-        # setitem
-        arrow_array2 = arrow_array.copy()
-        string_array2 = string_array.copy()
-        arrow_array2[0] = 'ss'
-        string_array2[0] = 'ss'
-        self.assertListEqual(list(arrow_array2), list(string_array2))
-        arrow_array2[1: 3] = ['ss1', 'ss2']
-        string_array2[1: 3] = ['ss1', 'ss2']
-        self.assertListEqual(list(arrow_array2), list(string_array2))
-        arrow_array2[1: 3] = arrow_array2[2: 4]
-        string_array2[1: 3] = string_array2[2: 4]
-        self.assertListEqual(list(arrow_array2), list(string_array2))
-        arrow_array2[2:] = pd.Series(['ss3', 'ss4'])
-        string_array2[2:] = pd.Series(['ss3', 'ss4'])
-        self.assertListEqual(list(arrow_array2), list(string_array2))
-        with self.assertRaises(ValueError):
-            arrow_array2[0] = ['a', 'b']
-        arrow_array2[-1] = None
-        string_array2[-1] = None
-        self.assertListEqual(list(arrow_array2)[:-1], list(string_array2)[:-1])
-        self.assertTrue(pd.isna(list(arrow_array2)[-1]))
-        with self.assertRaises(ValueError):
-            arrow_array2[0] = 2
-        with self.assertRaises(ValueError):
-            arrow_array2[:2] = [1, 2]
+                # getitem, scalar
+                self.assertEqual(arrow_array[1], string_array[1])
+                self.assertEqual(arrow_array[-1], string_array[-1])
+                # getitem, slice
+                self.assertListEqual(list(arrow_array[:2]), list(string_array[:2]))
+                self.assertListEqual(list(arrow_array[1:-1]), list(string_array[1:-1]))
+                self.assertListEqual(list(arrow_array[::2]), list(string_array[::2]))
+                # getitem, boolean index
+                cond = np.array([len(c) > 2 for c in lst])
+                self.assertListEqual(list(arrow_array[cond]), list(string_array[cond]))
+                # getitem, fancy index
+                selection = [3, 1, 2]
+                self.assertListEqual(list(arrow_array[selection]), list(string_array[selection]))
+                selection = [3, -1, 2, -4]
+                self.assertListEqual(list(arrow_array[selection]), list(string_array[selection]))
+                selection = np.array([3, -1, 2, -4])
+                self.assertListEqual(list(arrow_array[selection]), list(string_array[selection]))
 
-        # test to_numpy
-        np.testing.assert_array_equal(arrow_array.to_numpy(), string_array.to_numpy())
-        np.testing.assert_array_equal(arrow_array.to_numpy(copy=True),
-                                      string_array.to_numpy(copy=True))
-        np.testing.assert_array_equal(has_na_arrow_array.to_numpy(copy=True, na_value='ss'),
-                                      has_na_string_array.to_numpy(copy=True, na_value='ss'))
+                # setitem
+                arrow_array2 = arrow_array.copy()
+                string_array2 = string_array.copy()
+                arrow_array2[0] = 'ss'
+                string_array2[0] = 'ss'
+                self.assertListEqual(list(arrow_array2), list(string_array2))
+                arrow_array2[1: 3] = ['ss1', 'ss2']
+                string_array2[1: 3] = ['ss1', 'ss2']
+                self.assertListEqual(list(arrow_array2), list(string_array2))
+                arrow_array2[1: 3] = arrow_array2[2: 4]
+                string_array2[1: 3] = string_array2[2: 4]
+                self.assertListEqual(list(arrow_array2), list(string_array2))
+                arrow_array2[2:] = pd.Series(['ss3', 'ss4'])
+                string_array2[2:] = pd.Series(['ss3', 'ss4'])
+                self.assertListEqual(list(arrow_array2), list(string_array2))
+                with self.assertRaises(ValueError):
+                    arrow_array2[0] = ['a', 'b']
+                arrow_array2[-1] = None
+                string_array2[-1] = None
+                self.assertListEqual(list(arrow_array2)[:-1], list(string_array2)[:-1])
+                self.assertTrue(pd.isna(list(arrow_array2)[-1]))
+                with self.assertRaises(ValueError):
+                    arrow_array2[0] = 2
+                with self.assertRaises(ValueError):
+                    arrow_array2[:2] = [1, 2]
 
-        # test fillna
-        arrow_array3 = has_na_arrow_array.fillna('filled')
-        string_array3 = has_na_string_array.fillna('filled')
-        self.assertListEqual(list(arrow_array3), list(string_array3))
+                # test to_numpy
+                np.testing.assert_array_equal(arrow_array.to_numpy(), string_array.to_numpy())
+                np.testing.assert_array_equal(arrow_array.to_numpy(copy=True),
+                                              string_array.to_numpy(copy=True))
+                np.testing.assert_array_equal(has_na_arrow_array.to_numpy(copy=True, na_value='ss'),
+                                              has_na_string_array.to_numpy(copy=True, na_value='ss'))
 
-        # test astype
-        arrow_array4 = ArrowStringArray(['1', '10', '100'])
-        # leverage string array to get the right answer
-        string_array4 = pd.arrays.StringArray(np.array(['1', '10', '100'],
-                                                       dtype=object))
-        np.testing.assert_array_equal(arrow_array4.astype(np.int64),
-                                      string_array4.astype(np.int64))
-        np.testing.assert_almost_equal(arrow_array4.astype(float),
-                                       string_array4.astype(float))
-        self.assertListEqual(list(arrow_array4.astype(ArrowStringDtype(), copy=False)),
-                             list(string_array4.astype(pd.StringDtype(), copy=False)))
-        self.assertListEqual(list(arrow_array4.astype(ArrowStringDtype(), copy=True)),
-                             list(string_array4.astype(pd.StringDtype(), copy=True)))
+                # test fillna
+                arrow_array3 = has_na_arrow_array.fillna('filled')
+                string_array3 = has_na_string_array.fillna('filled')
+                self.assertListEqual(list(arrow_array3), list(string_array3))
 
-        # test factorize
-        codes, unique = arrow_array.factorize()
-        codes2, unique2 = string_array.factorize()
-        self.assertListEqual(list(codes), list(codes2))
-        self.assertListEqual(list(unique), list(unique2))
+                # test astype
+                arrow_array4 = ArrowStringArray(['1', '10', '100'])
+                # leverage string array to get the right answer
+                string_array4 = pd.arrays.StringArray(np.array(['1', '10', '100'],
+                                                               dtype=object))
+                np.testing.assert_array_equal(arrow_array4.astype(np.int64),
+                                              string_array4.astype(np.int64))
+                np.testing.assert_almost_equal(arrow_array4.astype(float),
+                                               string_array4.astype(float))
+                self.assertListEqual(list(arrow_array4.astype(ArrowStringDtype(), copy=False)),
+                                     list(string_array4.astype(pd.StringDtype(), copy=False)))
+                self.assertListEqual(list(arrow_array4.astype(ArrowStringDtype(), copy=True)),
+                                     list(string_array4.astype(pd.StringDtype(), copy=True)))
 
-        # test nbytes
-        self.assertLess(arrow_array.nbytes,
-                        pd.Series(string_array).memory_usage(deep=True))
+                # test factorize
+                codes, unique = arrow_array.factorize()
+                codes2, unique2 = string_array.factorize()
+                self.assertListEqual(list(codes), list(codes2))
+                self.assertListEqual(list(unique), list(unique2))
 
-        # test memory_usage
-        self.assertEqual(arrow_array.memory_usage(deep=True),
-                         arrow_array.nbytes)
+                # test nbytes
+                self.assertLess(arrow_array.nbytes,
+                                pd.Series(string_array.astype(object)).memory_usage(
+                                    deep=True, index=False))
 
-        # test isna
-        np.testing.assert_array_equal(has_na_arrow_array.isna(),
-                                      has_na_string_array.isna())
-        has_na_arrow_array2 = has_na_arrow_array.copy()
-        has_na_arrow_array2._force_use_pandas = True
-        np.testing.assert_array_equal(has_na_arrow_array2.isna(),
-                                      has_na_string_array.isna())
+                # test memory_usage
+                if pandas_only:
+                    self.assertEqual(arrow_array.memory_usage(deep=False),
+                                     pd.Series(string_array).memory_usage(index=False))
+                else:
+                    self.assertEqual(arrow_array.memory_usage(deep=True),
+                                     arrow_array.nbytes)
 
-        # test take
-        self.assertListEqual(list(arrow_array.take([1, 2, -1])),
-                             list(string_array.take([1, 2, -1])))
-        self.assertListEqual(list(arrow_array.take([1, 2, -1],
-                                                   allow_fill=True).fillna('aa')),
-                             list(string_array.take([1, 2, -1],
-                                                    allow_fill=True).fillna('aa')))
-        self.assertListEqual(list(arrow_array.take([1, 2, -1],
-                                                   allow_fill=True,
-                                                   fill_value='aa')),
-                             list(string_array.take([1, 2, -1],
-                                                    allow_fill=True,
-                                                    fill_value='aa')))
+                # test isna
+                np.testing.assert_array_equal(has_na_arrow_array.isna(),
+                                              has_na_string_array.isna())
+                has_na_arrow_array2 = has_na_arrow_array.copy()
+                has_na_arrow_array2._force_use_pandas = True
+                np.testing.assert_array_equal(has_na_arrow_array2.isna(),
+                                              has_na_string_array.isna())
 
-        # test shift
-        self.assertListEqual(list(arrow_array.shift(2, fill_value='aa')),
-                             list(string_array.shift(2, fill_value='aa')))
+                # test take
+                self.assertListEqual(list(arrow_array.take([1, 2, -1])),
+                                     list(string_array.take([1, 2, -1])))
+                self.assertListEqual(list(arrow_array.take([1, 2, -1],
+                                                           allow_fill=True).fillna('aa')),
+                                     list(string_array.take([1, 2, -1],
+                                                            allow_fill=True).fillna('aa')))
+                self.assertListEqual(list(arrow_array.take([1, 2, -1],
+                                                           allow_fill=True,
+                                                           fill_value='aa')),
+                                     list(string_array.take([1, 2, -1],
+                                                            allow_fill=True,
+                                                            fill_value='aa')))
 
-        # test value_counts
-        self.assertListEqual(list(arrow_array.value_counts()),
-                             list(string_array.value_counts()))
-        self.assertListEqual(list(has_na_arrow_array.value_counts(dropna=True)),
-                             list(has_na_string_array.value_counts(dropna=True)))
+                # test shift
+                self.assertListEqual(list(arrow_array.shift(2, fill_value='aa')),
+                                     list(string_array.shift(2, fill_value='aa')))
 
-        # test all any
-        self.assertEqual(arrow_array.all(), string_array.all())
-        self.assertEqual(arrow_array.any(), string_array.any())
+                # test value_counts
+                self.assertListEqual(list(arrow_array.value_counts()),
+                                     list(string_array.value_counts()))
+                self.assertListEqual(list(has_na_arrow_array.value_counts(dropna=True)),
+                                     list(has_na_string_array.value_counts(dropna=True)))
 
-        # test arithmetic
-        self.assertListEqual(list(arrow_array + 's'),
-                             list(string_array + 's'))
-        self.assertListEqual(list((arrow_array + has_na_arrow_array).fillna('ss')),
-                             list((string_array + has_na_string_array).fillna('ss')))
+                # test all any
+                self.assertEqual(arrow_array.all(), string_array.all())
+                self.assertEqual(arrow_array.any(), string_array.any())
 
-        # test comparison
-        np.testing.assert_array_equal(arrow_array < 's', string_array < 's')
-        pd.testing.assert_series_equal(pd.Series(arrow_array < has_na_arrow_array),
-                                       pd.Series(string_array < has_na_string_array))
+                # test arithmetic
+                self.assertListEqual(list(arrow_array + 's'),
+                                     list(string_array + 's'))
+                self.assertListEqual(list((arrow_array + has_na_arrow_array).fillna('ss')),
+                                     list((string_array + has_na_string_array).fillna('ss')))
 
-        # test repr
-        self.assertIn('ArrowStringArray', repr(arrow_array))
+                # test comparison
+                np.testing.assert_array_equal(arrow_array < 's', string_array < 's')
+                pd.testing.assert_series_equal(pd.Series(arrow_array < has_na_arrow_array),
+                                               pd.Series(string_array < has_na_string_array))
 
-        # test concat empty
-        arrow_array5 = ArrowStringArray(pa.chunked_array([], type=pa.string()))
-        concatenated = ArrowStringArray._concat_same_type([arrow_array5, arrow_array5])
-        self.assertEqual(len(concatenated._arrow_array.chunks), 1)
-        pd.testing.assert_series_equal(pd.Series(arrow_array5), pd.Series(concatenated))
+                # test repr
+                self.assertIn('ArrowStringArray', repr(arrow_array))
+
+                # test concat empty
+                arrow_array5 = ArrowStringArray(pa.chunked_array([], type=pa.string()))
+                concatenated = ArrowStringArray._concat_same_type([arrow_array5, arrow_array5])
+                if not pandas_only:
+                    self.assertEqual(len(concatenated._arrow_array.chunks), 1)
+                pd.testing.assert_series_equal(pd.Series(arrow_array5), pd.Series(concatenated))
 
     def testArrowListFunctions(self):
         lst = np.array([['a, bc'], ['de'], ['e', 'ee'], ['中文', '中文2']], dtype=object)
-        arrow_array = ArrowListArray(lst)
         has_na_lst = lst.copy()
         has_na_lst[1] = None
-        has_na_arrow_array = ArrowListArray(has_na_lst)
 
-        # getitem, scalar
-        self.assertEqual(arrow_array[1], lst[1])
-        self.assertEqual(arrow_array[-1], lst[-1])
-        # getitem, slice
-        np.testing.assert_array_equal(arrow_array[:2].to_numpy(), lst[:2])
+        for pandas_only in [False, True]:
+            with option_context({'dataframe.arrow_array.pandas_only': pandas_only}):
+                arrow_array = ArrowListArray(lst)
+                has_na_arrow_array = ArrowListArray(has_na_lst)
 
-        # setitem
-        arrow_array2 = arrow_array.copy()
-        lst2 = lst.copy()
-        for s in [['ss'], pd.Series(['ss'])]:
-            arrow_array2[0] = s
-            lst2[0] = ['ss']
-            np.testing.assert_array_equal(arrow_array2.to_numpy(), lst2)
-        arrow_array2[0] = None
-        lst2[0] = None
-        np.testing.assert_array_equal(arrow_array2.to_numpy(), lst2)
-        with self.assertRaises(ValueError):
-            # must set list like object
-            arrow_array2[0] = 'ss'
+                # getitem, scalar
+                self.assertEqual(arrow_array[1], lst[1])
+                self.assertEqual(list(arrow_array[-1]), lst[-1])
+                # getitem, slice
+                np.testing.assert_array_equal(arrow_array[:2].to_numpy(), lst[:2])
 
-        # test to_numpy
-        np.testing.assert_array_equal(arrow_array.to_numpy(), lst)
-        np.testing.assert_array_equal(arrow_array.to_numpy(copy=True), lst)
-        np.testing.assert_array_equal(has_na_arrow_array.to_numpy(na_value=1),
-                                      pd.Series(has_na_lst).fillna(1).to_numpy())
+                # setitem
+                arrow_array2 = arrow_array.copy()
+                lst2 = lst.copy()
+                for s in [['ss'], pd.Series(['ss'])]:
+                    arrow_array2[0] = s
+                    lst2[0] = ['ss']
+                    np.testing.assert_array_equal(arrow_array2.to_numpy(), lst2)
+                arrow_array2[0] = None
+                lst2[0] = None
+                np.testing.assert_array_equal(arrow_array2.to_numpy(), lst2)
+                with self.assertRaises(ValueError):
+                    # must set list like object
+                    arrow_array2[0] = 'ss'
 
-        # test fillna
-        arrow_array3 = has_na_arrow_array.fillna(lst[1])
-        np.testing.assert_array_equal(arrow_array3.to_numpy(), lst)
+                # test to_numpy
+                np.testing.assert_array_equal(arrow_array.to_numpy(), lst)
+                np.testing.assert_array_equal(arrow_array.to_numpy(copy=True), lst)
+                np.testing.assert_array_equal(has_na_arrow_array.to_numpy(na_value=1),
+                                              pd.Series(has_na_lst).fillna(1).to_numpy())
 
-        # test astype
-        with self.assertRaises(TypeError):
-            arrow_array.astype(np.int64)
-        with self.assertRaises(TypeError):
-            arrow_array.astype(ArrowListDtype(np.int64))
-        arrow_array4 = ArrowListArray([[1, 2], [3]])
-        expected = np.array([['1', '2'], ['3']], dtype=object)
-        np.testing.assert_array_equal(arrow_array4.astype(ArrowListDtype(str)),
-                                      expected)
-        np.testing.assert_array_equal(arrow_array4.astype(ArrowListDtype(arrow_array4.dtype)),
-                                      arrow_array4)
-        np.testing.assert_array_equal(arrow_array4.astype(ArrowListDtype(arrow_array4.dtype), copy=False),
-                                      arrow_array4)
+                # test fillna
+                if not pandas_only:
+                    arrow_array3 = has_na_arrow_array.fillna(lst[1])
+                    np.testing.assert_array_equal(arrow_array3.to_numpy(), lst)
 
-        # test nbytes
-        self.assertLess(arrow_array.nbytes,
-                        pd.Series(lst).memory_usage(deep=True))
+                # test astype
+                with self.assertRaises(TypeError):
+                    arrow_array.astype(np.int64)
+                with self.assertRaises(TypeError):
+                    arrow_array.astype(ArrowListDtype(np.int64))
+                arrow_array4 = ArrowListArray([[1, 2], [3]])
+                expected = np.array([['1', '2'], ['3']], dtype=object)
+                np.testing.assert_array_equal(arrow_array4.astype(ArrowListDtype(str)),
+                                              expected)
+                np.testing.assert_array_equal(arrow_array4.astype(ArrowListDtype(arrow_array4.dtype)),
+                                              arrow_array4)
+                np.testing.assert_array_equal(arrow_array4.astype(ArrowListDtype(arrow_array4.dtype), copy=False),
+                                              arrow_array4)
 
-        # test memory_usage
-        self.assertEqual(arrow_array.memory_usage(deep=True),
-                         arrow_array.nbytes)
+                # test nbytes
+                self.assertLess(arrow_array.nbytes,
+                                pd.Series(lst).memory_usage(deep=True))
 
-        # test isna
-        np.testing.assert_array_equal(has_na_arrow_array.isna(),
-                                      pd.Series(has_na_lst).isna())
+                # test memory_usage
+                if not pandas_only:
+                    self.assertEqual(arrow_array.memory_usage(deep=True),
+                                     arrow_array.nbytes)
 
-        # test take
-        self.assertListEqual(list(arrow_array.take([1, 2, -1])),
-                             list(pd.Series(lst).take([1, 2, -1])))
+                # test isna
+                np.testing.assert_array_equal(has_na_arrow_array.isna(),
+                                              pd.Series(has_na_lst).isna())
 
-        # test shift
-        self.assertListEqual(list(arrow_array.shift(2, fill_value=['aa'])),
-                             [['aa']] * 2 + lst[:-2].tolist())
+                # test take
+                self.assertListEqual(list(arrow_array.take([1, 2, -1])),
+                                     list(pd.Series(lst).take([1, 2, -1])))
 
-        # test all any
-        self.assertEqual(arrow_array.all(), lst.all())
-        self.assertEqual(arrow_array.any(), lst.any())
+                # test shift
+                self.assertListEqual(list(arrow_array.shift(2, fill_value=['aa'])),
+                                     [['aa']] * 2 + lst[:-2].tolist())
 
-        # test repr
-        self.assertIn('ArrowListArray', repr(arrow_array))
+                # test all any
+                self.assertEqual(arrow_array.all(), lst.all())
+                self.assertEqual(arrow_array.any(), lst.any())
 
-        # test concat empty
-        arrow_array5 = ArrowListArray(pa.chunked_array([], type=pa.list_(pa.string())))
-        concatenated = ArrowListArray._concat_same_type([arrow_array5, arrow_array5])
-        self.assertEqual(len(concatenated._arrow_array.chunks), 1)
-        pd.testing.assert_series_equal(pd.Series(arrow_array5), pd.Series(concatenated))
+                # test repr
+                self.assertIn('ArrowListArray', repr(arrow_array))
+
+                # test concat empty
+                arrow_array5 = ArrowListArray(pa.chunked_array([], type=pa.list_(pa.string())))
+                concatenated = ArrowListArray._concat_same_type([arrow_array5, arrow_array5])
+                if not pandas_only:
+                    self.assertEqual(len(concatenated._arrow_array.chunks), 1)
+                pd.testing.assert_series_equal(pd.Series(arrow_array5), pd.Series(concatenated))
 
     def testToPandas(self):
         rs = np.random.RandomState(0)

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -269,6 +269,7 @@ def parse_index(index_value, *args, store_data=False, key=None):
     def _serialize_multi_index(index):
         kw = _extract_property(index, IndexValue.MultiIndex, store_data)
         kw['_sortorder'] = index.sortorder
+        kw['_dtypes'] = [lev.dtype for lev in index.levels]
         return IndexValue.MultiIndex(**kw)
 
     if index_value is None:
@@ -448,6 +449,10 @@ def _generate_value(dtype, fill_value):
     dispatch = {
         np.datetime64: pd.Timestamp,
         np.timedelta64: pd.Timedelta,
+        pd.CategoricalDtype.type: lambda x: pd.CategoricalDtype([x]),
+        # for object, we do not know the actual dtype,
+        # just convert to str for common usage
+        np.object_: lambda x: str(fill_value),
     }
     # otherwise, just use dtype.type itself to convert
     convert = dispatch.get(dtype.type, dtype.type)
@@ -459,8 +464,10 @@ def build_empty_df(dtypes, index=None):
     # duplicate column may exist,
     # so use RangeIndex first
     df = pd.DataFrame(columns=pd.RangeIndex(len(columns)), index=index)
+    length = len(index) if index is not None else 0
     for i, d in enumerate(dtypes):
-        df[i] = pd.Series(dtype=d, index=index)
+        df[i] = pd.Series([_generate_value(d, 1) for _ in range(length)],
+                          dtype=d, index=index)
     df.columns = columns
     return df
 
@@ -468,10 +475,12 @@ def build_empty_df(dtypes, index=None):
 def build_df(df_obj, fill_value=1, size=1):
     empty_df = build_empty_df(df_obj.dtypes, index=df_obj.index_value.to_pandas()[:0])
     dtypes = empty_df.dtypes
-    record = [_generate_value(dtype, fill_value) for dtype in empty_df.dtypes]
+    record = [_generate_value(dtype, fill_value) for dtype in dtypes]
     if isinstance(empty_df.index, pd.MultiIndex):
         index = tuple(_generate_value(level.dtype, fill_value) for level in empty_df.index.levels)
-        empty_df.loc[index, :] = record
+        empty_df = empty_df.reindex(
+            index=pd.MultiIndex.from_tuples([index], names=empty_df.index.names))
+        empty_df.iloc[0] = record
     else:
         index = _generate_value(empty_df.index.dtype, fill_value)
         empty_df.loc[index] = record
@@ -480,21 +489,26 @@ def build_df(df_obj, fill_value=1, size=1):
     # make sure dtypes correct for MultiIndex
     for i, dtype in enumerate(dtypes.tolist()):
         s = empty_df.iloc[:, i]
-        if s.dtype != dtype:
+        if not pd.api.types.is_dtype_equal(s.dtype, dtype):
             empty_df.iloc[:, i] = s.astype(dtype)
     return empty_df
 
 
 def build_empty_series(dtype, index=None, name=None):
-    return pd.Series(dtype=dtype, index=index, name=name)
+    length = len(index) if index is not None else 0
+    return pd.Series([_generate_value(dtype, 1) for _ in range(length)],
+                     dtype=dtype, index=index, name=name)
 
 
-def build_series(series_obj, fill_value=1, size=1):
-    empty_series = build_empty_series(series_obj.dtype, index=series_obj.index_value.to_pandas()[:0])
+def build_series(series_obj, fill_value=1, size=1, name=None):
+    empty_series = build_empty_series(series_obj.dtype, name=name,
+                                      index=series_obj.index_value.to_pandas()[:0])
     record = _generate_value(series_obj.dtype, fill_value)
     if isinstance(empty_series.index, pd.MultiIndex):
         index = tuple(_generate_value(level.dtype, fill_value) for level in empty_series.index.levels)
-        empty_series.loc[index, ] = record
+        empty_series = empty_series.reindex(
+            index=pd.MultiIndex.from_tuples([index], names=empty_series.index.names))
+        empty_series.iloc[0] = record
     else:
         if isinstance(empty_series.index.dtype, pd.CategoricalDtype):
             index = None

--- a/mars/dataframe/window/aggregation.py
+++ b/mars/dataframe/window/aggregation.py
@@ -26,7 +26,7 @@ from ...utils import tokenize
 from ..core import DATAFRAME_TYPE
 from ..merge import DataFrameConcat
 from ..operands import DataFrameOperand, DataFrameOperandMixin
-from ..utils import build_empty_df, parse_index, build_empty_series, \
+from ..utils import build_df, parse_index, build_empty_series, \
     filter_dtypes_by_index
 
 _stage_info = namedtuple('_stage_info', ('map_groups', 'map_sources', 'combine_sources',
@@ -129,9 +129,7 @@ class BaseDataFrameExpandingAgg(DataFrameOperand, DataFrameOperandMixin):
         self._normalize_funcs()
 
         if isinstance(inp, DATAFRAME_TYPE):
-            pd_index = inp.index_value.to_pandas()
-
-            empty_df = build_empty_df(inp.dtypes, index=pd_index[:1])
+            empty_df = build_df(inp)
             for c, t in empty_df.dtypes.items():
                 if t == np.dtype('O'):
                     empty_df[c] = 'O'

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -27,7 +27,8 @@ from .core import Entity, Chunk, Tileable, AttributeAsDictKey, ExecutableTuple, 
 from .serialize import SerializableMetaclass, ValueType, ProviderType, IdentityField, \
     ListField, DictField, Int32Field, BoolField, StringField, ReferenceField
 from .tiles import NotSupportTile
-from .utils import AttributeDict, to_str, calc_data_size, is_eager_mode, calc_object_overhead
+from .utils import AttributeDict, to_str, calc_data_size, calc_object_overhead, \
+    enter_mode, is_eager_mode
 
 
 operand_type_to_oprand_cls = {}
@@ -38,6 +39,11 @@ T = TypeVar('T')
 
 class OperandMetaclass(SerializableMetaclass):
     def __new__(mcs, name, bases, kv):
+        if '__call__' in kv:
+            # if __call__ is specified for an operand,
+            # make sure that entering user space
+            kv['__call__'] = enter_mode(kernel=False)(kv['__call__'])
+
         cls = super().__new__(mcs, name, bases, kv)
 
         for base in bases:

--- a/mars/serialize/protos/indexvalue.proto
+++ b/mars/serialize/protos/indexvalue.proto
@@ -204,6 +204,7 @@ message IndexValue {
         repeated Value names = 1;
         Value data = 2;
         int32 sortorder = 3;
+        repeated Value dtypes = 4;
         // public fields
         string key = 51;
         bool is_monotonic_increasing = 52;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR mainly introduced:

1. Support `df.groupby().count()` for arrow dtype with and without pyarrow installed
2. Make `ArrowArray` work even when pyarrow not installed and not in kernel mode. If pyarrow not installed and in kernel mode(for instance, inside tile or execute), an ImportError will be raised.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1514 .
