### PR TITLE
Unregister scheduler observer when destroying actors

### DIFF
--- a/mars/dataframe/arrays.py
+++ b/mars/dataframe/arrays.py
@@ -404,7 +404,7 @@ class ArrowArray(ExtensionArray):
             return pd.isna(self._arrow_array.to_pandas()).to_numpy()
 
     def take(self, indices, allow_fill=False, fill_value=None):
-        if allow_fill is False:
+        if allow_fill is False or (allow_fill and fill_value is self.dtype.na_value):
             return type(self)(self[indices], dtype=self._dtype)
 
         array = self._arrow_array.to_pandas().to_numpy()

--- a/mars/scheduler/assigner.py
+++ b/mars/scheduler/assigner.py
@@ -130,6 +130,7 @@ class AssignerActor(SchedulerActor):
 
     def pre_destroy(self):
         self._actual_ref.destroy()
+        self.unset_cluster_info_ref()
 
     def allocate_top_resources(self, max_allocates=None):
         self._allocate_requests.append(max_allocates)
@@ -266,6 +267,9 @@ class AssignEvaluationActor(SchedulerActor):
         self._resource_ref = self.get_actor_ref(ResourceActor.default_uid())
 
         self.periodical_allocate()
+
+    def pre_destroy(self):
+        self.unset_cluster_info_ref()
 
     def mark_metrics_expired(self):
         logger.debug('Metrics cache marked as expired.')

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -309,6 +309,7 @@ class GraphActor(SchedulerActor):
 
     def pre_destroy(self):
         super().pre_destroy()
+        self.unset_cluster_info_ref()
         self._graph_meta_ref.destroy()
 
     @contextlib.contextmanager

--- a/mars/scheduler/mutable.py
+++ b/mars/scheduler/mutable.py
@@ -72,6 +72,9 @@ class MutableTensorActor(SchedulerActor):
             nsplits=tensor.nsplits, key=tensor.key, chunks=tensor.chunks,
             chunk_eps=endpoints))
 
+    def pre_destroy(self):
+        self.unset_cluster_info_ref()
+
     def tensor_meta(self):
         # avoid built-in scalar dtypes are made into one-field record type.
         if self._dtype.fields:

--- a/mars/scheduler/operands/base.py
+++ b/mars/scheduler/operands/base.py
@@ -96,6 +96,9 @@ class BaseOperandActor(SchedulerActor):
 
         self.ref().start_operand(_tell=True)
 
+    def pre_destroy(self):
+        self.unset_cluster_info_ref()
+
     @property
     def state(self):
         return self._state

--- a/mars/scheduler/operands/tests/test_common_exec.py
+++ b/mars/scheduler/operands/tests/test_common_exec.py
@@ -49,6 +49,9 @@ class FakeExecutionActor(SchedulerActor):
         super().post_create()
         self.set_cluster_info_ref()
 
+    def pre_destroy(self):
+        self.unset_cluster_info_ref()
+
     @classmethod
     def gen_uid(cls, addr):
         return f's:h1:{cls.__name__}${addr}'

--- a/mars/scheduler/resource.py
+++ b/mars/scheduler/resource.py
@@ -84,6 +84,7 @@ class ResourceActor(SchedulerActor):
 
     def pre_destroy(self):
         self._heartbeat_ref.destroy()
+        self.unset_cluster_info_ref()
         super().pre_destroy()
 
     def heartbeat(self):

--- a/mars/scheduler/session.py
+++ b/mars/scheduler/session.py
@@ -71,6 +71,8 @@ class SessionActor(SchedulerActor):
 
     def pre_destroy(self):
         super().pre_destroy()
+        self.unset_cluster_info_ref()
+
         self._manager_ref.delete_session(self._session_id, _tell=True)
         self.ctx.destroy_actor(self._assigner_ref)
         for graph_ref in self._graph_refs.values():
@@ -234,6 +236,9 @@ class SessionManagerActor(SchedulerActor):
         logger.debug('Actor %s running in process %d', self.uid, os.getpid())
 
         self.set_cluster_info_ref()
+
+    def pre_destroy(self):
+        self.unset_cluster_info_ref()
 
     def get_sessions(self):
         return list(self._session_refs.keys())

--- a/mars/worker/dispatcher.py
+++ b/mars/worker/dispatcher.py
@@ -36,10 +36,6 @@ class DispatchActor(WorkerActor):
 
     def post_create(self):
         super().post_create()
-        try:
-            self.set_cluster_info_ref()
-        except ActorNotExist:
-            pass
 
         from .status import StatusActor
         self._status_ref = self.ctx.actor_ref(StatusActor.default_uid())

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -139,7 +139,6 @@ class ExecutionActor(WorkerActor):
         from .status import StatusActor
 
         super().post_create()
-        self.set_cluster_info_ref()
 
         self._dispatch_ref = self.promise_ref(DispatchActor.default_uid())
         self._mem_quota_ref = self.promise_ref(MemQuotaActor.default_uid())

--- a/mars/worker/utils.py
+++ b/mars/worker/utils.py
@@ -67,6 +67,12 @@ class WorkerActor(WorkerHasClusterInfoActor, PromiseActor):
         self._init_shared_store()
         self._proc_id = self.ctx.distributor.distribute(self.uid)
 
+    def pre_destroy(self):
+        try:
+            self.unset_cluster_info_ref()
+        except ActorNotExist:
+            pass
+
     def _init_shared_store(self):
         import pyarrow.plasma as plasma
         from .storage.sharedstore import PlasmaSharedStore, PlasmaKeyMapActor


### PR DESCRIPTION
## What do these changes do?

Allow unregistering scheduler observers when destroying actors. This will stop ActorNotExist errors after spawning graphs in mars.remote.

## Related issue number

Fixes #1524 
