### PR TITLE
Unifiy logics of modes including `eager`, `kernel` and `build`

### DIFF
--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -245,7 +245,7 @@ def tokenize_function(ob):
         return tokenize_function(ob.func), args, keywords
     else:
         try:
-            return pickle.dumps(ob, protocol=0)
+            return iterative_tokenize([pickle.dumps(ob, protocol=0), id(ob)])
         except:
             pass
         try:

--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -14,6 +14,7 @@
 
 import os
 import pickle
+import types
 import uuid
 from collections import deque
 from datetime import date, datetime, timedelta, tzinfo
@@ -245,7 +246,10 @@ def tokenize_function(ob):
         return tokenize_function(ob.func), args, keywords
     else:
         try:
-            return iterative_tokenize([pickle.dumps(ob, protocol=0), id(ob)])
+            if isinstance(ob, types.FunctionType):
+                return iterative_tokenize([pickle.dumps(ob, protocol=0), id(ob)])
+            else:
+                return pickle.dumps(ob, protocol=0)
         except:
             pass
         try:

--- a/mars/dataframe/arithmetic/__init__.py
+++ b/mars/dataframe/arithmetic/__init__.py
@@ -14,7 +14,7 @@
 
 import functools
 
-from ...core import build_mode
+from ...utils import is_build_mode
 from ..core import DATAFRAME_TYPE
 from ..utils import wrap_notimplemented_exception
 from ..ufunc.tensor import register_tensor_unary_ufunc
@@ -66,7 +66,7 @@ from .dot import dot
 def _wrap_eq():
     @functools.wraps(eq)
     def call(df, other, **kw):
-        if build_mode().is_build_mode:
+        if is_build_mode():
             return df._equals(other)
         return _wrap_comparison(eq)(df, other, **kw)
     return call

--- a/mars/dataframe/arithmetic/tests/test_comparison.py
+++ b/mars/dataframe/arithmetic/tests/test_comparison.py
@@ -19,8 +19,8 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 
-from mars.core import build_mode
 from mars.dataframe.initializer import DataFrame
+from mars.utils import enter_mode
 
 
 class Test(unittest.TestCase):
@@ -28,7 +28,7 @@ class Test(unittest.TestCase):
         df1 = DataFrame(pd.DataFrame(np.random.rand(4, 3)))
         df2 = DataFrame(pd.DataFrame(np.random.rand(4, 3)))
 
-        with build_mode():
+        with enter_mode(build=True):
             self.assertFalse(df1.data == df2.data)
             self.assertTrue(df1.data == df1.data)
 

--- a/mars/dataframe/arrays.py
+++ b/mars/dataframe/arrays.py
@@ -27,15 +27,10 @@ from pandas.api.types import pandas_dtype, is_scalar, \
     is_array_like, is_string_dtype, is_list_like
 from pandas.api.extensions import ExtensionArray, \
     ExtensionDtype, register_extension_dtype
+from pandas.arrays import StringArray as StringArrayBase
 from pandas.core import ops
 from pandas.core.algorithms import take
 from pandas.compat import set_function_name
-try:
-    from pandas.arrays import StringArray as StringArrayBase
-except ImportError:  # pragma: no cover
-    # for pandas < 1.0
-    StringArrayBase = ExtensionArray
-
 try:
     import pyarrow as pa
     pa_null = pa.NULL

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -27,7 +27,7 @@ from ..serialize import Serializable, ValueType, ProviderType, DataTypeField, An
     SeriesField, BoolField, Int32Field, StringField, ListField, SliceField, \
     TupleField, OneOfField, ReferenceField, NDArrayField, IntervalArrayField
 from ..utils import on_serialize_shape, on_deserialize_shape, on_serialize_numpy_type, \
-    build_mode, ceildiv
+    ceildiv, is_build_mode
 from .utils import fetch_corner_data, ReprSeries
 
 
@@ -411,7 +411,7 @@ class IndexData(HasShapeTileableData, _ToPandasMixin):
         }
 
     def _to_str(self, representation=False):
-        if build_mode().is_build_mode or len(self._executed_sessions) == 0:
+        if is_build_mode() or len(self._executed_sessions) == 0:
             # in build mode, or not executed, just return representation
             if representation:
                 return f'Index <op={type(self._op).__name__}, key={self.key}'
@@ -695,7 +695,7 @@ class BaseSeriesData(HasShapeTileableData, _ToPandasMixin):
         }
 
     def _to_str(self, representation=False):
-        if build_mode().is_build_mode or len(self._executed_sessions) == 0:
+        if is_build_mode() or len(self._executed_sessions) == 0:
             # in build mode, or not executed, just return representation
             if representation:
                 return f'{self._type_name} <op={type(self._op).__name__}, key={self.key}>'
@@ -1039,7 +1039,7 @@ class DataFrameData(BaseDataFrameData):
     _type_name = 'DataFrame'
 
     def _to_str(self, representation=False):
-        if build_mode().is_build_mode or len(self._executed_sessions) == 0:
+        if is_build_mode() or len(self._executed_sessions) == 0:
             # in build mode, or not executed, just return representation
             if representation:
                 return f'{self._type_name} <op={type(self._op).__name__}, key={self.key}>'
@@ -1453,7 +1453,7 @@ class DataFrameGroupByData(BaseDataFrameData):
 
     def _equal(self, o):
         # FIXME We need to implemented a true `==` operator for DataFrameGroupby
-        if build_mode().is_build_mode:
+        if is_build_mode():
             return self is o
         else:
             return self == o
@@ -1489,7 +1489,7 @@ class SeriesGroupByData(BaseSeriesData):
 
     def _equal(self, o):
         # FIXME We need to implemented a true `==` operator for DataFrameGroupby
-        if build_mode().is_build_mode:
+        if is_build_mode():
             return self is o
         else:
             return self == o
@@ -1617,7 +1617,7 @@ class CategoricalData(HasShapeTileableData, _ToPandasMixin):
         }
 
     def _to_str(self, representation=False):
-        if build_mode().is_build_mode or len(self._executed_sessions) == 0:
+        if is_build_mode() or len(self._executed_sessions) == 0:
             # in build mode, or not executed, just return representation
             if representation:
                 return f'{self._type_name} <op={type(self.op).__name__}, key={self.key}>'
@@ -1642,7 +1642,7 @@ class CategoricalData(HasShapeTileableData, _ToPandasMixin):
 
     def _equal(self, o):
         # FIXME We need to implemented a true `==` operator for DataFrameGroupby
-        if build_mode().is_build_mode:
+        if is_build_mode():
             return self is o
         else:  # pragma: no cover
             return self == o

--- a/mars/dataframe/tests/test_arrays.py
+++ b/mars/dataframe/tests/test_arrays.py
@@ -130,7 +130,6 @@ class Test(unittest.TestCase):
         self.assertEqual(array.dtype.value_type, np.int64)
         self.assertIsInstance(array._arrow_array, pa.ChunkedArray)
 
-    @unittest.skipIf(pd.__version__ < '1.0', 'pandas version should be at least 1.0')
     def testArrowStringArrayFunctions(self):
         lst = np.array(['abc', 'de', 'eee', '中文'], dtype=object)
         arrow_array = ArrowStringArray(lst)
@@ -364,7 +363,6 @@ class Test(unittest.TestCase):
         self.assertEqual(len(concatenated._arrow_array.chunks), 1)
         pd.testing.assert_series_equal(pd.Series(arrow_array5), pd.Series(concatenated))
 
-    @unittest.skipIf(pd.__version__ < '1.0', 'pandas version should be at least 1.0')
     def testToPandas(self):
         rs = np.random.RandomState(0)
         df = pd.DataFrame({'a': rs.rand(100),

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -35,8 +35,7 @@ from .optimizes.runtime.core import RuntimeOptimizer
 from .optimizes.tileable_graph import tileable_optimized, OptimizeIntegratedTileableGraphBuilder
 from .graph_builder import TileableGraphBuilder
 from .context import LocalContext
-from .utils import kernel_mode, enter_build_mode, build_fetch, calc_nsplits,\
-    has_unknown_shape, prune_chunk_graph
+from .utils import enter_mode, build_fetch, calc_nsplits, has_unknown_shape, prune_chunk_graph
 
 try:
     from numpy.core._exceptions import UFuncTypeError
@@ -432,6 +431,7 @@ class GraphExecution:
 
         return op_key_to_ops
 
+    @enter_mode(kernel=True)
     def _execute_operand(self, op):
         results = self._chunk_results
         ref_counts = self._chunk_key_ref_counts
@@ -696,8 +696,7 @@ class Executor(object):
             chunk_result.clear()
         return res
 
-    @kernel_mode
-    @enter_build_mode
+    @enter_mode(build=True, kernel=True)
     def execute_tileable(self, tileable, n_parallel=None, n_thread=None, concat=False,
                          print_progress=False, mock=False, compose=True):
         result_keys = []
@@ -760,8 +759,7 @@ class Executor(object):
         else:
             yield chunk_result
 
-    @kernel_mode
-    @enter_build_mode
+    @enter_mode(build=True, kernel=True)
     def execute_tileables(self, tileables, fetch=True, n_parallel=None, n_thread=None,
                           print_progress=False, mock=False, compose=True, name=None):
         # shallow copy chunk_result, prevent from any chunk key decref
@@ -952,7 +950,7 @@ class Executor(object):
             if not all(isinstance(ind, (slice, Integral)) for ind in indexes):
                 raise ValueError('Only support fetch data slices')
 
-    @kernel_mode
+    @enter_mode(kernel=True)
     def fetch_tileables(self, tileables, **kw):
         from .tensor.indexing import TensorIndex
         from .dataframe.indexing.iloc import DataFrameIlocGetItem, SeriesIlocGetItem

--- a/mars/graph_builder.py
+++ b/mars/graph_builder.py
@@ -17,7 +17,7 @@
 import itertools
 
 from .graph import DAG
-from .utils import kernel_mode, enter_build_mode
+from .utils import enter_mode
 
 
 class GraphBuilder(object):
@@ -69,8 +69,7 @@ class TileableGraphBuilder(GraphBuilder):
                          node_processor=node_processor,
                          inputs_selector=inputs_selector)
 
-    @kernel_mode
-    @enter_build_mode
+    @enter_mode(build=True, kernel=True)
     def build(self, tileables, tileable_graph=None):
         if tileable_graph is not None:  # pragma: no cover
             return tileable_graph

--- a/mars/optimizes/tileable_graph/core.py
+++ b/mars/optimizes/tileable_graph/core.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 
 from ...graph import DAG
 from ...graph_builder import TileableGraphBuilder
-from ...utils import copy_tileables, kernel_mode, enter_build_mode
+from ...utils import copy_tileables, enter_mode
 
 _rules = defaultdict(list)
 
@@ -114,8 +114,7 @@ class OptimizeIntegratedTileableGraphBuilder(TileableGraphBuilder):
         self._optimizer_context.update(replaced_tileables)
         return new_graph
 
-    @kernel_mode
-    @enter_build_mode
+    @enter_mode(build=True, kernel=True)
     def build(self, tileables, tileable_graph=None):
         self._optimizer_context.append_result_tileables(tileables)
         graph = super().build(tileables, tileable_graph=tileable_graph)

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -42,7 +42,7 @@ from ..tiles import handler, IterativeChunkGraphBuilder, \
     TileableGraphBuilder, get_tiled
 from ..utils import serialize_graph, deserialize_graph, log_unhandled, \
     build_exc_info, build_fetch_chunk, build_fetch_tileable, calc_nsplits, \
-    get_chunk_shuffle_key, enter_build_mode, has_unknown_shape
+    get_chunk_shuffle_key, enter_mode, has_unknown_shape
 from ..context import DistributedContext
 
 logger = logging.getLogger(__name__)
@@ -593,7 +593,7 @@ class GraphActor(SchedulerActor):
         logger.debug(f'Terminal chunk keys: {self._terminal_chunk_keys}')
 
     @log_unhandled
-    @enter_build_mode
+    @enter_mode(build=True)
     def prepare_graph(self, compose=True):
         """
         Tile and compose tileable graph into chunk graph
@@ -1204,7 +1204,7 @@ class GraphActor(SchedulerActor):
         return list(fetch_graph)[0]
 
     @log_unhandled
-    @enter_build_mode
+    @enter_mode(build=True)
     def fetch_tileable_result(self, tileable_key, _check=True):
         # this function is for test usage
         from ..executor import Executor

--- a/mars/tensor/arithmetic/__init__.py
+++ b/mars/tensor/arithmetic/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...core import build_mode
+from ...utils import is_build_mode
 from .add import add, TensorAdd, TensorTreeAdd
 from .subtract import subtract, TensorSubtract
 from .multiply import multiply, TensorMultiply, TensorTreeMultiply
@@ -141,7 +141,7 @@ def _install():
 
     def _wrap_equal(func):
         def eq(x1, x2, **kwargs):
-            if build_mode().is_build_mode:
+            if is_build_mode():
                 return astensor(x1)._equals(x2)
             return func(x1, x2, **kwargs)
         return eq

--- a/mars/tensor/arithmetic/tests/test_arithmetic.py
+++ b/mars/tensor/arithmetic/tests/test_arithmetic.py
@@ -24,8 +24,8 @@ from mars.tensor.arithmetic import add, subtract, truediv, log, frexp, around, \
     isclose, isfinite, negative, cos, TensorAdd, TensorSubtract, TensorLog, TensorIsclose, TensorGreaterThan
 from mars.tensor.linalg import matmul
 from mars.tensor.core import Tensor, SparseTensor
-from mars.core import build_mode
 from mars.tiles import get_tiled
+from mars.utils import enter_mode
 
 
 class Test(unittest.TestCase):
@@ -538,5 +538,5 @@ class Test(unittest.TestCase):
         t1 = ones((2, 3), chunk_size=2)
         self.assertTrue(t1 == 2)
 
-        with build_mode():
+        with enter_mode(build=True):
             self.assertFalse(t1 == 2)

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -24,10 +24,10 @@ from operator import attrgetter
 import numpy as np
 
 from ..core import Entity, HasShapeTileableEnity, ChunkData, Chunk, HasShapeTileableData, \
-    build_mode, Serializable, OutputType, register_output_types, _ExecuteAndFetchMixin
+    Serializable, OutputType, register_output_types, _ExecuteAndFetchMixin
 from ..serialize import ProviderType, ValueType, DataTypeField, ListField, TupleField, \
     BoolField, StringField, AnyField
-from ..utils import log_unhandled, on_serialize_shape, on_deserialize_shape
+from ..utils import log_unhandled, on_serialize_shape, on_deserialize_shape, is_build_mode
 from .utils import get_chunk_slices, fetch_corner_data
 
 logger = logging.getLogger(__name__)
@@ -84,7 +84,7 @@ class TensorChunkData(ChunkData):
         try:
             return self.shape[0]
         except IndexError:
-            if build_mode().is_build_mode:
+            if is_build_mode():
                 return 0
             raise TypeError('len() of unsized object')
 
@@ -154,7 +154,7 @@ class TensorData(HasShapeTileableData, _ExecuteAndFetchMixin):
         return super().cls(provider)
 
     def _to_str(self, representation=False):
-        if build_mode().is_build_mode or len(self._executed_sessions) == 0:
+        if is_build_mode() or len(self._executed_sessions) == 0:
             # in build mode, or not executed, just return representation
             if representation:
                 return f'Tensor <op={type(self._op).__name__}, shape={self._shape}, key={self._key}'

--- a/mars/tensor/datasource/tests/test_datasource.py
+++ b/mars/tensor/datasource/tests/test_datasource.py
@@ -27,7 +27,6 @@ except (ImportError, OSError):  # pragma: no cover
 
 from mars import dataframe as md
 from mars import opcodes
-from mars.core import build_mode
 from mars.graph import DAG
 from mars.tensor import ones, zeros, tensor, full, arange, diag, linspace, triu, tril, ones_like, dot
 from mars.tensor.datasource import array, fromtiledb, TensorTileDBDataSource, fromdense
@@ -41,7 +40,7 @@ from mars.tensor.core import Tensor, SparseTensor, TensorChunk
 from mars.tensor.datasource.from_dataframe import from_dataframe
 from mars.tests.core import TestBase
 from mars.tiles import get_tiled
-from mars.utils import build_fuse_chunk
+from mars.utils import build_fuse_chunk, enter_mode
 
 
 class Test(TestBase):
@@ -184,7 +183,7 @@ class Test(TestBase):
 
         serials = self._pb_serial(t2)
         dt = self._pb_deserial(serials)[t2.data]
-        with build_mode():
+        with enter_mode(build=True):
             self.assertIn(dt.op.indices_or_sections, dt.inputs)
 
     def testOnes(self):
@@ -632,7 +631,7 @@ class Test(TestBase):
         t3c = copy(t3)
         t3c.inputs = [t1c, t2c]
 
-        with build_mode():
+        with enter_mode(build=True):
             self.assertIs(t3c.op.input, t1c.data)
             self.assertIs(t3c.op.indexes[0], t2c.data)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR unified all modes including eager, kernel and build. Use enter_mode(kernel=None, build=None) as a unified way.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1529 .
