### PR TITLE
Fix `md.read_csv` for Ray executor

### DIFF
--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -202,11 +202,11 @@ class IndexValue(Serializable):
 
         def to_pandas(self):
             data = getattr(self, '_data', None)
+            sortorder = getattr(self, '_sortorder', None)
             if data is None:
-                sortorder = getattr(self, '_sortorder', None)
                 return pd.MultiIndex.from_arrays([np.array([], dtype=dtype) for dtype in self._dtypes],
                                                  sortorder=sortorder, names=self._names)
-            return pd.MultiIndex.from_tuples([tuple(d) for d in data], sortorder=self._sortorder,
+            return pd.MultiIndex.from_tuples([tuple(d) for d in data], sortorder=sortorder,
                                              names=self._names)
 
     _index_value = OneOfField('index_value', index=Index,

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -261,11 +261,13 @@ class Test(unittest.TestCase):
             self.assertTrue(np.isscalar(res))
             self.assertLess(res, 10)
 
-            t = mt.random.rand(10)
-            r = t.sum() * 4 - 1
+            raw = np.random.rand(10)
+            t = mt.tensor(raw)
+            r = (mt.linalg.norm(t) * 4 - 1).sum()
 
             res = r.to_numpy()
-            self.assertLess(res, 39)
+            expected = (np.linalg.norm(raw) * 4 - 1).sum()
+            np.testing.assert_array_almost_equal(res, expected)
 
     def testMultipleOutputTensorExecute(self, *_):
         with new_cluster(scheduler_n_process=2, worker_n_process=2,

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -976,12 +976,16 @@ class Executor(object):
                 del self._chunk_result[c.key]
         return result
 
+    @classmethod
+    def _get_chunk_shape(cls, chunk_key, chunk_result):
+        return chunk_result[chunk_key].shape
+
     def get_tileable_nsplits(self, tileable, chunk_result=None):
         chunk_idx_to_shape = OrderedDict()
         tiled = get_tiled(tileable, mapping=tileable_optimized)
         chunk_result = chunk_result if chunk_result is not None else self._chunk_result
         for chunk in tiled.chunks:
-            chunk_idx_to_shape[chunk.index] = chunk_result[chunk.key].shape
+            chunk_idx_to_shape[chunk.index] = self._get_chunk_shape(chunk.key, chunk_result)
         return calc_nsplits(chunk_idx_to_shape)
 
     def decref(self, *keys):

--- a/mars/ray/tests/test_ray_execution.py
+++ b/mars/ray/tests/test_ray_execution.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import tempfile
 import unittest
 
 import numpy as np
@@ -33,8 +35,8 @@ class Test(unittest.TestCase):
         with new_session(backend='ray').as_default():
             # test tensor task
             raw = np.random.rand(100, 100)
-            t = mt.tensor(raw, chunk_size=30).sum().to_numpy()
-            self.assertAlmostEqual(t, raw.sum())
+            t = (mt.tensor(raw, chunk_size=30) + 1).sum().to_numpy()
+            self.assertAlmostEqual(t, (raw + 1).sum())
 
             # test DataFrame task
             raw = pd.DataFrame(np.random.random((20, 4)), columns=list('abcd'))
@@ -45,10 +47,22 @@ class Test(unittest.TestCase):
             # test update shape
             raw = np.random.rand(100)
             t = mt.tensor(raw, chunk_size=30)
-            selected = t[t > 0.5].execute()
+            selected = (t[t > 0.5] + 1).execute()
             r = selected.to_numpy()
-            expected = raw[raw > 0.5]
+            expected = raw[raw > 0.5] + 1
             np.testing.assert_array_equal(r, expected)
+
+            with tempfile.TemporaryDirectory() as tempdir:
+                file_path = os.path.join(tempdir, 'test.csv')
+
+                df = pd.DataFrame(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.int64),
+                                  columns=['a', 'b', 'c'])
+                df.to_csv(file_path)
+
+                mdf = md.read_csv(file_path)
+                r = mdf.groupby('a').agg({'c': 'sum'}).to_pandas()
+                expected = df.groupby('a').agg({'c': 'sum'})
+                pd.testing.assert_frame_equal(r, expected)
 
     def testOperandSerialization(self):
         from mars.ray.core import operand_serializer, operand_deserializer

--- a/mars/ray/tests/test_ray_execution.py
+++ b/mars/ray/tests/test_ray_execution.py
@@ -57,7 +57,8 @@ class Test(unittest.TestCase):
         r = df.sort_values(by='a')
         op = r.op
 
-        new_op = operand_deserializer(operand_serializer(op))
+        new_op_wrapper = operand_deserializer(operand_serializer(op))
+        new_op = new_op_wrapper.op
 
         self.assertEqual(op.by, new_op.by)
         self.assertIsInstance(new_op, type(op))

--- a/mars/session.py
+++ b/mars/session.py
@@ -39,10 +39,11 @@ except ImportError:  # pragma: no cover
 
 class LocalSession(object):
     def __init__(self, **kwargs):
+        engine = kwargs.pop('engine', None)
         self._endpoint = None
         self._session_id = uuid.uuid4()
         self._context = LocalContext(self)
-        self._executor = Executor(storage=self._context)
+        self._executor = Executor(engine=engine, storage=self._context)
 
         self._mut_tensor = dict()
         self._mut_tensor_data = dict()

--- a/mars/session.py
+++ b/mars/session.py
@@ -439,6 +439,9 @@ class Session(object):
                     self._init_local_session(**kwargs)
         elif self._backend == 'ray':
             self._init_ray_session(**kwargs)
+        else:  # pragma: no cover
+            raise ValueError('Either endpoint or backend should '
+                             'be provided to create a session')
 
     def _init_local_session(self, **kwargs):
         self._sess = LocalSession(**kwargs)

--- a/mars/tensor/fuse/core.py
+++ b/mars/tensor/fuse/core.py
@@ -30,6 +30,7 @@ class TensorFuseChunk(TensorFuse, TensorFuseChunkMixin):
 def estimate_fuse_size(ctx, op):
     from ...graph import DAG
     from ...executor import Executor
+    from ...utils import build_fetch_chunk
 
     chunk = op.outputs[0]
     dag = DAG()
@@ -40,6 +41,7 @@ def estimate_fuse_size(ctx, op):
         for inp in c.inputs:
             if inp.key not in keys:
                 size_ctx[inp.key] = ctx[inp.key]
+                inp = build_fetch_chunk(inp).data
             if inp not in dag:
                 dag.add_node(inp)
             dag.add_edge(inp, c)

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,10 @@ from Cython.Build import cythonize
 from Cython.Distutils import build_ext
 
 try:
-    from numpy.distutils.ccompiler import CCompiler_compile
     import distutils.ccompiler
-    distutils.ccompiler.CCompiler.compile = CCompiler_compile
+    if sys.platform != 'win32':
+        from numpy.distutils.ccompiler import CCompiler_compile
+        distutils.ccompiler.CCompiler.compile = CCompiler_compile
 except ImportError:
     pass
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR did a few things.

1. Fix `md.read_csv` for Ray executor.
2. Disable numexpr fuse for Ray executor.
3. Optimize performance of RayStorage.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1542 .
