### PR TITLE
Allow returning None when using groupby.apply

### DIFF
--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -397,11 +397,15 @@ class Test(TestBase):
 
         mdf = md.DataFrame(df1, chunk_size=3)
 
+        applied = mdf.groupby('b').apply(lambda df: None)
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(applied, concat=True)[0],
+                                      df1.groupby('b').apply(lambda df: None))
+
         applied = mdf.groupby('b').apply(apply_df)
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(applied, concat=True)[0].sort_index(),
                                       df1.groupby('b').apply(apply_df).sort_index())
 
-        applied = mdf.groupby('b').apply(lambda df: df.a)
+        applied = mdf.groupby('b').apply(lambda df: df.a, output_type='series')
         pd.testing.assert_series_equal(self.executor.execute_dataframe(applied, concat=True)[0].sort_index(),
                                        df1.groupby('b').apply(lambda df: df.a).sort_index())
 
@@ -411,6 +415,10 @@ class Test(TestBase):
 
         series1 = pd.Series([3, 4, 5, 3, 5, 4, 1, 2, 3])
         ms1 = md.Series(series1, chunk_size=3)
+
+        applied = ms1.groupby(lambda x: x % 3).apply(lambda df: None)
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(applied, concat=True)[0],
+                                       series1.groupby(lambda x: x % 3).apply(lambda df: None))
 
         applied = ms1.groupby(lambda x: x % 3).apply(apply_series)
         pd.testing.assert_series_equal(self.executor.execute_dataframe(applied, concat=True)[0].sort_index(),

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -835,6 +835,16 @@ def validate_axis_style_args(data, args, kwargs, arg_name, method_name):  # prag
     return out
 
 
+def validate_output_types(**kwargs):
+    from ..core import OutputType
+
+    output_type = kwargs.pop('object_type', None) or kwargs.pop('output_type', None)
+    output_types = kwargs.pop('output_types', None) \
+        or ([output_type] if output_type is not None else None)
+    return [getattr(OutputType, v.lower()) if isinstance(v, str) else v for v in output_types] \
+        if output_types else None
+
+
 def standardize_range_index(chunks, axis=0):
     from .base.standardize_range_index import ChunkStandardizeRangeIndex
 

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -1027,11 +1027,13 @@ class Test(unittest.TestCase):
             def g(x, y):
                 return x * y
 
-            a = mr.spawn(f, 3)
-            b = mr.spawn(f, 4)
-            c = mr.spawn(g, (a, b))
+            def f1():
+                a = mr.spawn(f, 3)
+                b = mr.spawn(f, 4)
+                c = mr.spawn(g, (a, b))
+                return c.execute().fetch()
 
-            r = session.run(c, timeout=_exec_timeout)
+            r = session.run(mr.spawn(f1), timeout=_exec_timeout)
             self.assertEqual(r, 20)
 
             e = mr.spawn(f, mr.spawn(f, 2))


### PR DESCRIPTION
## What do these changes do?

Support executing ``df.groupby(xxx).apply(fun)`` where ``fun`` returns nothing.

## Related issue number

Fixes #1543 