### PR TITLE
Add `read_parquet` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         if [[ $UNAME == "windows" ]]; then
           pip install virtualenv flake8
         else
-          pip install virtualenv flake8 etcd-gevent ray
+          pip install virtualenv flake8 etcd-gevent ray fastparquet
           if [ -z "$NO_COMMON_TESTS" ]; then
             if [[ $UNAME == "linux" ]]; then
               pip install h5py zarr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,9 @@ jobs:
         if [[ $UNAME == "windows" ]]; then
           pip install virtualenv flake8
         else
-          pip install virtualenv flake8 etcd-gevent ray fastparquet
+          pip install virtualenv flake8 etcd-gevent ray
           if [ -z "$NO_COMMON_TESTS" ]; then
+            pip install fastparquet
             if [[ $UNAME == "linux" ]]; then
               pip install h5py zarr
               pip install matplotlib

--- a/mars/dataframe/__init__.py
+++ b/mars/dataframe/__init__.py
@@ -25,6 +25,7 @@ from .datasource.from_records import from_records
 from .datasource.from_vineyard import from_vineyard
 from .datasource.read_csv import read_csv
 from .datasource.read_sql import read_sql, read_sql_table, read_sql_query
+from .datasource.read_parquet import read_parquet
 from .datasource.date_range import date_range
 from .tseries.to_datetime import to_datetime
 from .merge import concat, merge

--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -25,9 +25,9 @@ from ...core import OutputType
 from ...utils import parse_readable_size, lazy_import, FixedSizeFileObject
 from ...serialize import StringField, DictField, ListField, Int32Field, Int64Field, BoolField, AnyField
 from ...filesystem import open_file, file_size, glob
-from ..arrays import ArrowStringDtype
 from ..core import IndexValue
-from ..utils import parse_index, build_empty_df, standardize_range_index, to_arrow_dtypes
+from ..utils import parse_index, build_empty_df, standardize_range_index, \
+    to_arrow_dtypes, contain_arrow_dtype
 from ..operands import DataFrameOperand, DataFrameOperandMixin
 
 try:
@@ -264,7 +264,7 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                 usecols = op.usecols if isinstance(op.usecols, list) else [op.usecols]
             else:
                 usecols = op.usecols
-            if cls._contains_arrow_dtype(dtypes):
+            if contain_arrow_dtype(dtypes):
                 # when keep_default_na is True which is default,
                 # will replace null value with np.nan,
                 # which will cause failure when converting to arrow string array
@@ -308,7 +308,7 @@ class DataFrameReadCSV(DataFrameOperand, DataFrameOperandMixin):
                 # As we specify names and dtype, we need to skip header rows
                 csv_kwargs['skiprows'] = 1 if op.header == 'infer' else op.header
                 dtypes = cls._validate_dtypes(op.outputs[0].dtypes, op.gpu)
-                if cls._contains_arrow_dtype(dtypes.values()):
+                if contain_arrow_dtype(dtypes.values()):
                     # when keep_default_na is True which is default,
                     # will replace null value with np.nan,
                     # which will cause failure when converting to arrow string array

--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -25,6 +25,7 @@ from ...core import OutputType
 from ...utils import parse_readable_size, lazy_import, FixedSizeFileObject
 from ...serialize import StringField, DictField, ListField, Int32Field, Int64Field, BoolField, AnyField
 from ...filesystem import open_file, file_size, glob
+from ..arrays import ArrowStringDtype
 from ..core import IndexValue
 from ..utils import parse_index, build_empty_df, standardize_range_index, \
     to_arrow_dtypes, contain_arrow_dtype

--- a/mars/dataframe/datasource/read_parquet.py
+++ b/mars/dataframe/datasource/read_parquet.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import numpy as np
+import pandas as pd
+
+try:
+    import pyarrow as pa
+    import fastparquet
+    import pyarrow.parquet as pq
+except ImportError:
+    pa = None
+    fastparquet = None
+
+from ... import opcodes as OperandDef
+from ...config import options
+from ...filesystem import open_file
+from ...serialize import AnyField, BoolField, DictField, ListField,\
+    StringField, Int32Field
+from ..arrays import ArrowStringDtype
+from ..operands import DataFrameOperandMixin, DataFrameOperand, OutputType
+from ..utils import parse_index, to_arrow_dtypes, contain_arrow_dtype
+
+
+def check_engine(engine):
+    if engine == 'auto':
+        if pa is not None:
+            return 'pyarrow'
+        elif fastparquet is not None:
+            return 'fastparquet'
+        else:
+            raise RuntimeError('Please install either pyarrow or fastparquet.')
+    elif engine == 'pyarrow':
+        if pa is None:
+            raise RuntimeError('Please install pyarrow fisrt.')
+        return engine
+    elif engine == 'fastparquet':
+        if fastparquet is None:
+            raise RuntimeError('Please install fastparquet first.')
+        return engine
+    else:
+        raise RuntimeError('Unsupported engine {} to read parquet.'.format(engine))
+
+
+def get_engine(engine):
+    if engine == 'pyarrow':
+        return ArrowEngine()
+    else:
+        raise RuntimeError('Unsupported engine {}'.format(engine))
+
+
+class ParqueEngine:
+    def read_dtypes(self, f, **kwargs):
+        raise NotImplementedError
+
+    def read_to_pandas(self, f, columns=None,
+                       use_arrow_dtype=None, **kwargs):
+        raise NotImplementedError
+
+    def read_group_to_pandas(self, f, group_index, columns=None,
+                             use_arrow_dtype=None, **kwargs):
+        raise NotImplementedError
+
+
+class ArrowEngine(ParqueEngine):
+    def read_dtypes(self, f, **kwargs):
+        file = pq.ParquetFile(f)
+        return file.schema_arrow.empty_table().to_pandas().dtypes
+
+    @classmethod
+    def _table_to_pandas(cls, t, use_arrow_dtype=None):
+        if use_arrow_dtype:
+            df = t.to_pandas(
+                types_mapper={pa.string(): ArrowStringDtype()}.get)
+        else:
+            df = t.to_pandas()
+        return df
+
+    def read_to_pandas(self, f, columns=None,
+                       use_arrow_dtype=None, **kwargs):
+        file = pq.ParquetFile(f)
+        t = file.read(columns=columns, **kwargs)
+        return self._table_to_pandas(t, use_arrow_dtype=use_arrow_dtype)
+
+    def read_group_to_pandas(self, f, group_index, columns=None,
+                             use_arrow_dtype=None, **kwargs):
+        file = pq.ParquetFile(f)
+        t = file.read_row_group(group_index, columns=columns)
+        return self._table_to_pandas(t, use_arrow_dtype=use_arrow_dtype)
+
+
+class DataFrameReadParquet(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = OperandDef.READ_PARQUET
+
+    _path = AnyField('path')
+    _engine = StringField('engine')
+    _columns = ListField('columns')
+    _use_arrow_dtype = BoolField('use_arrow_dtype')
+    _groups_as_chunks = BoolField('groups_as_chunks')
+    _group_index = Int32Field('group_index')
+    _read_kwargs = DictField('read_kwargs')
+    _storage_options = DictField('storage_options')
+
+    def __init__(self, path=None, engine=None, columns=None, use_arrow_dtype=None,
+                 groups_as_chunks=None, group_index=None,
+                 read_kwargs=None, storage_options=None, **kw):
+        super().__init__(_path=path, _engine=engine, _columns=columns,
+                         _use_arrow_dtype=use_arrow_dtype,
+                         _groups_as_chunks=groups_as_chunks,
+                         _group_index=group_index,
+                         _read_kwargs=read_kwargs,
+                         _storage_options=storage_options,
+                         _output_types=[OutputType.dataframe], **kw)
+
+    @property
+    def path(self):
+        return self._path
+
+    @property
+    def engine(self):
+        return self._engine
+
+    @property
+    def columns(self):
+        return self._columns
+
+    @property
+    def use_arrow_dtype(self):
+        return self._use_arrow_dtype
+
+    @property
+    def groups_as_chunks(self):
+        return self._groups_as_chunks
+
+    @property
+    def group_index(self):
+        return self._group_index
+
+    @property
+    def read_kwargs(self):
+        return self._read_kwargs
+
+    @property
+    def storage_options(self):
+        return self._storage_options
+
+    @classmethod
+    def tile(cls, op):
+        chunk_index = 0
+        out_chunks = []
+        out_df = op.outputs[0]
+
+        dtypes = out_df.dtypes
+        if op.use_arrow_dtype is None and not op.gpu and \
+                options.dataframe.use_arrow_dtype:  # pragma: no cover
+            # check if use_arrow_dtype set on the server side
+            dtypes = to_arrow_dtypes(out_df.dtypes)
+
+        shape = (np.nan, out_df.shape[1])
+        for pth in op.path:
+            if op.groups_as_chunks:
+                for group_idx in range(pq.ParquetFile(pth).num_row_groups):
+                    chunk_op = op.copy().reset_key()
+                    chunk_op._path = pth
+                    chunk_op._group_index = group_idx
+                    new_chunk = chunk_op.new_chunk(
+                        None, shape=shape, index=(chunk_index, 0),
+                        index_value=out_df.index_value,
+                        columns_value=out_df.columns_value,
+                        dtypes=dtypes)
+                    out_chunks.append(new_chunk)
+                    chunk_index += 1
+            else:
+                chunk_op = op.copy().reset_key()
+                chunk_op._path = pth
+                new_chunk = chunk_op.new_chunk(
+                    None, shape=shape, index=(chunk_index, 0),
+                    index_value=out_df.index_value,
+                    columns_value=out_df.columns_value,
+                    dtypes=dtypes)
+                out_chunks.append(new_chunk)
+                chunk_index += 1
+
+        new_op = op.copy()
+        nsplits = ((np.nan,) * len(out_chunks), (out_df.shape[1],))
+        return new_op.new_dataframes(None, out_df.shape, dtypes=dtypes,
+                                     index_value=out_df.index_value,
+                                     columns_value=out_df.columns_value,
+                                     chunks=out_chunks, nsplits=nsplits)
+
+    @classmethod
+    def execute(cls, ctx, op):
+        out = op.outputs[0]
+        path = op.path
+
+        engine = get_engine(op.engine)
+        with open_file(path, storage_options=op.storage_options) as f:
+            use_arrow_dtype = contain_arrow_dtype(out.dtypes)
+            if op.groups_as_chunks:
+                df = engine.read_group_to_pandas(f, op.group_index, columns=op.columns,
+                                                 use_arrow_dtype=use_arrow_dtype)
+            else:
+                df = engine.read_to_pandas(f, columns=op.columns,
+                                           use_arrow_dtype=use_arrow_dtype)
+
+            ctx[out.key] = df
+
+    def __call__(self, index_value=None, columns_value=None, dtypes=None):
+        shape = (np.nan, len(dtypes))
+        return self.new_dataframe(None, shape, dtypes=dtypes, index_value=index_value,
+                                  columns_value=columns_value)
+
+
+def read_parquet(path, engine: str = "auto", columns=None,
+                 groups_as_chunks=False, use_arrow_dtype=None,
+                 storage_options=None, **kwargs):
+    """
+    Load a parquet object from the file path, returning a DataFrame.
+    Parameters
+    ----------
+    path : str, path object or file-like object
+        Any valid string path is acceptable. The string could be a URL.
+        For file URLs, a host is expected. A local file could be:
+        ``file://localhost/path/to/table.parquet``.
+        A file URL can also be a path to a directory that contains multiple
+        partitioned parquet files. Both pyarrow and fastparquet support
+        paths to directories as well as file URLs. A directory path could be:
+        ``file://localhost/path/to/tables``.
+        By file-like object, we refer to objects with a ``read()`` method,
+        such as a file handler (e.g. via builtin ``open`` function)
+        or ``StringIO``.
+    engine : {'auto', 'pyarrow', 'fastparquet'}, default 'auto'
+        Parquet library to use. The default behavior is to try 'pyarrow',
+        falling back to 'fastparquet' if 'pyarrow' is unavailable.
+    columns : list, default=None
+        If not None, only these columns will be read from the file.
+    groups_as_chunks : bool, default False
+        if True, each row group correspond to a chunk.
+        if False, each file correspond to a chunk.
+    use_arrow_dtype: bool, default None
+        If True, use arrow dtype to store columns.
+    storage_options: dict, optional
+        Options for storage connection.
+    **kwargs
+        Any additional kwargs are passed to the engine.
+    Returns
+    -------
+    Mars DataFrame
+    """
+    if not isinstance(path, list):
+        path = [path]
+
+    engine_type = check_engine(engine)
+    engine = get_engine(engine_type)
+    with open_file(path[0], storage_options=storage_options) as f:
+        dtypes = engine.read_dtypes(f)
+
+    if columns:
+        dtypes = dtypes[columns]
+
+    index_value = parse_index(pd.RangeIndex(-1))
+    columns_value = parse_index(dtypes.index, store_data=True)
+    if use_arrow_dtype is None:
+        use_arrow_dtype = options.dataframe.use_arrow_dtype
+    if use_arrow_dtype:
+        dtypes = to_arrow_dtypes(dtypes)
+
+    op = DataFrameReadParquet(path=path, engine=engine_type, columns=columns,
+                              groups_as_chunks=groups_as_chunks,
+                              use_arrow_dtype=use_arrow_dtype,
+                              read_kwargs=kwargs,
+                              storage_options=storage_options)
+    return op(index_value=index_value, columns_value=columns_value,
+              dtypes=dtypes)

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -771,10 +771,10 @@ class Test(TestBase):
             df[100:200].to_parquet(file_paths[1], row_group_size=30)
             df[200:].to_parquet(file_paths[2])
 
-            mdf = md.read_parquet(f'{tempdir}/*.parquet', incremental_index=True)
+            mdf = md.read_parquet(f'{tempdir}/*.parquet')
             r = self.executor.execute_dataframe(mdf, concat=True)[0]
-            pd.testing.assert_frame_equal(df, r)
+            pd.testing.assert_frame_equal(df, r.sort_values('a').reset_index(drop=True))
 
             mdf = md.read_parquet(f'{tempdir}/*.parquet', groups_as_chunks=True)
             r = self.executor.execute_dataframe(mdf, concat=True)[0]
-            pd.testing.assert_frame_equal(df, r.reset_index(drop=True))
+            pd.testing.assert_frame_equal(df, r.sort_values('a').reset_index(drop=True))

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -987,6 +987,12 @@ def arrow_table_to_pandas_dataframe(arrow_table, use_arrow_dtype=True, **kw):
     return df
 
 
+def contain_arrow_dtype(dtypes):
+    from .arrays import ArrowStringDtype
+
+    return any(isinstance(dtype, ArrowStringDtype) for dtype in dtypes)
+
+
 def to_arrow_dtypes(dtypes, test_df=None):
     from .arrays import ArrowStringDtype
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Read a parquet file into DataFrame.

- [x] PyArrow engine
- [x] fastparquet engine

## Related issue number

Closes #1578.
<!-- Are there any issues opened that will be resolved by merging this change? -->
