### PR TITLE
Fix the failure of DataFrame reduction operators

### DIFF
--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -27,7 +27,7 @@ from ..core import DATAFRAME_TYPE, SERIES_TYPE, DATAFRAME_CHUNK_TYPE, SERIES_CHU
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..initializer import Series, DataFrame
 from ..ufunc.tensor import TensorUfuncMixin
-from ..utils import parse_index, infer_dtypes, infer_dtype, infer_index_value
+from ..utils import parse_index, infer_dtypes, infer_dtype, infer_index_value, build_empty_df
 
 
 class DataFrameBinOp(DataFrameOperand):
@@ -301,7 +301,7 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
             if x2 is None:
                 dtypes = x1.dtypes
             elif pd.api.types.is_scalar(x2):
-                dtypes = infer_dtypes(x1.dtypes, pd.Series(np.array(x2).dtype), cls._operator)
+                dtypes = cls._operator(build_empty_df(x1.dtypes), x2).dtypes
             elif x1.dtypes is not None and isinstance(x2, TENSOR_TYPE):
                 dtypes = pd.Series(
                     [infer_dtype(dt, x2.dtype, cls._operator) for dt in x1.dtypes],

--- a/mars/dataframe/arithmetic/tests/test_arithmetic.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic.py
@@ -1058,6 +1058,10 @@ class TestBinary(TestBase):
         result3 = getattr(df, self.rfunc_name)(1)
         result4 = self.func(df, 1)
         result5 = self.func(1, df)
+
+        expected = self.func(data, 2)
+        pd.testing.assert_series_equal(result.dtypes, expected.dtypes)
+
         pd.testing.assert_index_equal(result.columns_value.to_pandas(), data.columns)
         self.assertIsInstance(result.index_value.value, IndexValue.Int64Index)
 

--- a/mars/dataframe/datasource/read_parquet.py
+++ b/mars/dataframe/datasource/read_parquet.py
@@ -268,6 +268,7 @@ def read_parquet(path, engine: str = "auto", columns=None,
                  **kwargs):
     """
     Load a parquet object from the file path, returning a DataFrame.
+
     Parameters
     ----------
     path : str, path object or file-like object
@@ -298,10 +299,12 @@ def read_parquet(path, engine: str = "auto", columns=None,
         Options for storage connection.
     **kwargs
         Any additional kwargs are passed to the engine.
+
     Returns
     -------
     Mars DataFrame
     """
+
     if not isinstance(path, list):
         file_path = glob(path, storage_options=storage_options)[0]
     else:

--- a/mars/dataframe/reduction/tests/test_reduction_execute.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execute.py
@@ -174,6 +174,14 @@ class TestReduction(TestBase):
             self.compute(data, axis='index', numeric_only=True),
             self.executor.execute_dataframe(reduction_df, concat=True)[0])
 
+        data1 = pd.DataFrame(np.random.rand(10, 10), columns=[str(i) for i in range(10)])
+        data2 = pd.DataFrame(np.random.rand(10, 10), columns=[str(i) for i in range(10)])
+        df = from_pandas_df(data1, chunk_size=5) + from_pandas_df(data2, chunk_size=6)
+        reduction_df = self.compute(df)
+        pd.testing.assert_series_equal(
+            self.compute(data1 + data2).sort_index(),
+            self.executor.execute_dataframe(reduction_df, concat=True)[0].sort_index())
+
     @require_cudf
     def testGPUExecution(self):
         pdf = pd.DataFrame(np.random.rand(30, 3), columns=list('abc'))

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -476,14 +476,15 @@ def build_df(df_obj, fill_value=1, size=1):
     empty_df = build_empty_df(df_obj.dtypes, index=df_obj.index_value.to_pandas()[:0])
     dtypes = empty_df.dtypes
     record = [_generate_value(dtype, fill_value) for dtype in dtypes]
-    if isinstance(empty_df.index, pd.MultiIndex):
-        index = tuple(_generate_value(level.dtype, fill_value) for level in empty_df.index.levels)
-        empty_df = empty_df.reindex(
-            index=pd.MultiIndex.from_tuples([index], names=empty_df.index.names))
-        empty_df.iloc[0] = record
-    else:
-        index = _generate_value(empty_df.index.dtype, fill_value)
-        empty_df.loc[index] = record
+    if len(record) != 0:  # columns is empty in some cases
+        if isinstance(empty_df.index, pd.MultiIndex):
+            index = tuple(_generate_value(level.dtype, fill_value) for level in empty_df.index.levels)
+            empty_df = empty_df.reindex(
+                index=pd.MultiIndex.from_tuples([index], names=empty_df.index.names))
+            empty_df.iloc[0] = record
+        else:
+            index = _generate_value(empty_df.index.dtype, fill_value)
+            empty_df.loc[index] = record
 
     empty_df = pd.concat([empty_df] * size)
     # make sure dtypes correct for MultiIndex


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
When the one of the input chunk's columns is empty, reduction operations will raise a ValueError. Small fixes in function `build_df` will resolve it.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1586.
Fixes #1590.