### PR TITLE
Fix error on fitting LGBMModel twice

### DIFF
--- a/mars/graph.pyx
+++ b/mars/graph.pyx
@@ -366,6 +366,8 @@ cdef class DirectedGraph:
         for node in self.iter_nodes():
             op = node.op
             op_name = type(op).__name__
+            if op.stage is not None:
+                op_name = f'{op_name}:{op.stage.name}'
             if op.key in visited:
                 continue
             for input_chunk in (op.inputs or []):

--- a/mars/learn/contrib/lightgbm/tests/integrated/test_distributed_lightgbm.py
+++ b/mars/learn/contrib/lightgbm/tests/integrated/test_distributed_lightgbm.py
@@ -55,6 +55,13 @@ class Test(LearnIntegrationTestBase):
             self.assertEqual(prediction.ndim, 1)
             self.assertEqual(prediction.shape[0], len(self.X))
 
+            # fi on fitted model shall work well
+            classifier.fit(X, y, session=sess, run_kwargs=run_kwargs)
+            prediction = classifier.predict(X, session=sess, run_kwargs=run_kwargs)
+
+            self.assertEqual(prediction.ndim, 1)
+            self.assertEqual(prediction.shape[0], len(self.X))
+
             self.assertIsInstance(prediction, mt.Tensor)
 
             classifier = LGBMClassifier(n_estimators=2)

--- a/mars/learn/contrib/lightgbm/train.py
+++ b/mars/learn/contrib/lightgbm/train.py
@@ -277,6 +277,8 @@ class LGBMTrain(MergeDictOperand):
             eval_init_score = eval_init_score or None
 
         params = op.params.copy()
+        # if model is trained, remove unsupported parameters
+        params.pop('out_dtype_', None)
         if ctx.running_mode == RunningMode.distributed:
             params['machines'] = ','.join(op.lgbm_endpoints)
             params['time_out'] = op.timeout

--- a/mars/learn/tests/integrated/base.py
+++ b/mars/learn/tests/integrated/base.py
@@ -75,6 +75,7 @@ class LearnIntegrationTestBase(unittest.TestCase):
                                            '-H', '127.0.0.1',
                                            '-p', scheduler_port,
                                            '-Dscheduler.default_cpu_usage=0',
+                                           '-Dscheduler.retry_delay=5',
                                            '--log-level', 'debug',
                                            '--log-format', 'SCH %(asctime)-15s %(message)s'])
         self.proc_scheduler = proc_scheduler


### PR DESCRIPTION
## What do these changes do?

Clear ``out_dtype_`` argument when fitting models. This will fix ValueError when a LGBMModel is fitted again.

## Related issue number

Fixes #1597