### PR TITLE
Allow LightGBM wrapper to use numpy arrays

### DIFF
--- a/mars/learn/contrib/lightgbm/regressor.py
+++ b/mars/learn/contrib/lightgbm/regressor.py
@@ -38,6 +38,7 @@ if lightgbm:
         def predict(self, X, **kw):
             session = kw.pop('session', None)
             run_kwargs = kw.pop('run_kwargs', None)
+            X = self._convert_tileable(X)
             return predict(self, X, session=session, run_kwargs=run_kwargs, **kw)
 
         def to_local(self):

--- a/mars/learn/contrib/lightgbm/tests/test_regressor.py
+++ b/mars/learn/contrib/lightgbm/tests/test_regressor.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import pandas as pd
+
 import mars.tensor as mt
 from mars.session import new_session
 from mars.tests.core import ExecutorForTest
@@ -66,3 +68,25 @@ class Test(unittest.TestCase):
         self.assertEqual(prediction.shape[0], len(self.X))
         result = prediction.fetch()
         self.assertEqual(prediction.dtype, result.dtype)
+
+        # test numpy tensor
+        try:
+            from sklearn.datasets import make_classification
+            X_array, y_array = make_classification()
+            regressor = LGBMRegressor(n_estimators=2)
+            regressor.fit(X_array, y_array, verbose=True)
+            prediction = regressor.predict(X_array)
+
+            self.assertEqual(prediction.ndim, 1)
+            self.assertEqual(prediction.shape[0], len(X_array))
+
+            X_df = pd.DataFrame(X_array)
+            y_df = pd.Series(y_array)
+            regressor = LGBMRegressor(n_estimators=2)
+            regressor.fit(X_df, y_df, verbose=True)
+            prediction = regressor.predict(X_df)
+
+            self.assertEqual(prediction.ndim, 1)
+            self.assertEqual(prediction.shape[0], len(X_df))
+        except ImportError:
+            pass

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -732,7 +732,11 @@ def kill_process_tree(pid, include_parent=True):
         return
 
     plasma_sock_dir = None
-    children = proc.children(recursive=True)
+    try:
+        children = proc.children(recursive=True)
+    except psutil.NoSuchProcess:  # pragma: no cover
+        return
+
     if include_parent:
         children.append(proc)
     for p in children:

--- a/mars/worker/storage/objectholder.py
+++ b/mars/worker/storage/objectholder.py
@@ -71,6 +71,8 @@ class ObjectHolderActor(WorkerActor):
         self._storage_handler = self.storage_client.get_storage_handler(
             self._storage_device.build_location(self.proc_id))
 
+        self.ref().update_cache_status(_tell=True)
+
     def pre_destroy(self):
         for k in self._data_holder:
             self._data_holder[k] = None

--- a/mars/worker/storage/tests/test_objectholder.py
+++ b/mars/worker/storage/tests/test_objectholder.py
@@ -157,9 +157,13 @@ class Test(WorkerCase):
             manager_ref = pool.actor_ref(StorageManagerActor.default_uid())
             shared_holder_ref = pool.actor_ref(SharedHolderActor.default_uid())
             mock_runner_ref = pool.actor_ref(MockIORunnerActor.default_uid())
+            status_ref = pool.actor_ref(StatusActor.default_uid())
 
             storage_client = test_actor.storage_client
             shared_handler = storage_client.get_storage_handler((0, DataStorageDevice.SHARED_MEMORY))
+
+            cache_allocations = status_ref.get_cache_allocations()
+            self.assertGreater(cache_allocations['total'], 0)
 
             session_id = str(uuid.uuid4())
             data_list = [np.random.randint(0, 32767, (655360,), np.int16)


### PR DESCRIPTION
##  What do these changes do?

Convert all inputs into Mars tileables before running LightGBM wrapper.

## Related issue number

Fixes #1605