### PR TITLE
Fix `build_faiss_index` when some index type cannot be merged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,7 @@ jobs:
                 libxgboost py-xgboost xgboost lightgbm
             fi
             if [[ $UNAME == "linux" ]] && [[ "$PYTHON" =~ "3.6" ]]; then
-              pip install torch==1.4.0 torchvision==0.5.0
-              conda install -n test --quiet --yes -c pytorch python=$PYTHON faiss-cpu
+              pip install torch==1.4.0 torchvision==0.5.0 faiss-cpu
             fi
             if [[ $UNAME == "linux" ]] && [[ ! "$PYTHON" =~ "3.8" ]]; then
               pip install tensorflow\<2.3.0


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes `build_faiss_index` when some index type cannot be merged.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1608 .
