### PR TITLE
Add an extra sort key in PSRS to make distinct pivot

### DIFF
--- a/mars/dataframe/sort/sort_values.py
+++ b/mars/dataframe/sort/sort_values.py
@@ -16,7 +16,7 @@ import pandas as pd
 
 from ... import opcodes as OperandDef
 from ...core import OutputType
-from ...serialize import ListField, ValueType
+from ...serialize import ListField
 from ...tensor.base.sort import _validate_sort_psrs_kinds
 from ..utils import parse_index, validate_axis, build_concatenated_rows_frame
 from ..core import IndexValue
@@ -27,7 +27,7 @@ from .psrs import DataFramePSRSOperandMixin, execute_sort_values
 class DataFrameSortValues(DataFrameSortOperand, DataFramePSRSOperandMixin):
     _op_type_ = OperandDef.SORT_VALUES
 
-    _by = ListField('by', ValueType.string)
+    _by = ListField('by')
 
     def __init__(self, by=None, output_types=None, **kw):
         super(DataFrameSortValues, self).__init__(_by=by, _output_types=output_types, **kw)

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -66,6 +66,16 @@ class Test(unittest.TestCase):
 
         pd.testing.assert_frame_equal(result, expected)
 
+        # test multiindex
+        df2 = df.copy(deep=True)
+        df2.columns = pd.MultiIndex.from_product([list('AB'), list('CDEFG')])
+        mdf = DataFrame(df2, chunk_size=10)
+
+        result = self.executor.execute_dataframe(mdf.sort_values([('A', 'C')]), concat=True)[0]
+        expected = df2.sort_values([('A', 'C')])
+
+        pd.testing.assert_frame_equal(result, expected)
+
         # test rechunk
         mdf = DataFrame(df, chunk_size=3)
         result = self.executor.execute_dataframe(mdf.sort_values('a0'), concat=True)[0]

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -140,10 +140,11 @@ class Test(SchedulerIntegratedTest):
 
         raw1 = pd.DataFrame(np.random.rand(10, 10))
         raw1[0] = raw1[0].apply(str)
+        raw1.columns = pd.MultiIndex.from_product([list('AB'), list('CDEFG')])
         df1 = md.DataFrame(raw1, chunk_size=5)
-        r = df1.sort_values(0)
+        r = df1.sort_values([('A', 'C')])
         result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        pd.testing.assert_frame_equal(result, raw1.sort_values(0))
+        pd.testing.assert_frame_equal(result, raw1.sort_values([('A', 'C')]))
 
         rs = np.random.RandomState(0)
         raw2 = pd.DataFrame({'a': rs.rand(10),

--- a/mars/worker/prochelper.py
+++ b/mars/worker/prochelper.py
@@ -48,11 +48,7 @@ class ProcessHelperActor(WorkerActor):
         """
         Free MKL buffer
         """
-        from ..lib.mkl_interface import mkl_free_buffers, mkl_mem_stat
+        from ..lib.mkl_interface import mkl_free_buffers
         if mkl_free_buffers is None:
             return
-
-        size_before = mkl_mem_stat()
         mkl_free_buffers()
-        size_after = mkl_mem_stat()
-        logger.debug('free_mkl_buffers() called, %r -> %r', size_before, size_after)

--- a/mars/worker/quota.py
+++ b/mars/worker/quota.py
@@ -155,8 +155,8 @@ class QuotaActor(WorkerActor):
         :return: if request is returned immediately, return True, otherwise False
         """
         if delta > self._total_size:
-            raise ValueError(f'Cannot allocate size({delta}) '
-                             f'larger than the total capacity({self._total_size}).')
+            raise ValueError(f'Cannot allocate quota size {delta} '
+                             f'larger than total capacity {self._total_size}.')
 
         if keys in self._requests:
             # already in request queue, store callback and quit


### PR DESCRIPTION
## What do these changes do?

Add (chunk_key, row_id) as an extra sort key to resolve value bias in PSRS sort algorithm.

## Related issue number

Fixes #1611 