### PR TITLE
[BACKPORT] Fix the wrong dtypes of `DataFrameSetitem`'s inputs (#1623)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,13 +70,12 @@ jobs:
             fi
             if [[ $UNAME == "linux" ]] && [[ ! "$PYTHON" =~ "3.8" ]]; then
               conda install --quiet --yes -n test -c conda-forge --no-deps python=$PYTHON \
-                libxgboost py-xgboost xgboost lightgbm
+                libxgboost py-xgboost xgboost lightgbm tensorflow
             fi
             if [[ $UNAME == "linux" ]] && [[ "$PYTHON" =~ "3.6" ]]; then
               pip install torch==1.4.0 torchvision==0.5.0 faiss-cpu
             fi
             if [[ $UNAME == "linux" ]] && [[ ! "$PYTHON" =~ "3.8" ]]; then
-              pip install tensorflow\<2.3.0
               pip install torch torchvision
               pip install tsfresh
             fi

--- a/mars/dataframe/indexing/setitem.py
+++ b/mars/dataframe/indexing/setitem.py
@@ -79,7 +79,7 @@ class DataFrameSetitem(DataFrameOperand, DataFrameOperandMixin):
                                           'with different index for now')
 
         index_value = target.index_value
-        dtypes = target.dtypes
+        dtypes = target.dtypes.copy(deep=True)
         dtypes.loc[self._indexes] = value_dtype
         columns_value = parse_index(dtypes.index, store_data=True)
         ret = self.new_dataframe(inputs, shape=(target.shape[0], len(dtypes)),

--- a/mars/dataframe/indexing/tests/test_indexing.py
+++ b/mars/dataframe/indexing/tests/test_indexing.py
@@ -634,6 +634,22 @@ class Test(TestBase):
         self.assertEqual(result2.chunks[0].dtype, data.dtype)
         self.assertTrue(result2.chunks[0].op.labels, [['i2', 'i4']])
 
+    def testSetitem(self):
+        data = pd.DataFrame(np.random.rand(10, 2), columns=['c1', 'c2'])
+        df = md.DataFrame(data, chunk_size=4)
+
+        df['new'] = 1
+        self.assertEqual(df.shape, (10, 3))
+        pd.testing.assert_series_equal(df.inputs[0].dtypes, data.dtypes)
+
+        tiled = df.tiles()
+        self.assertEqual(tiled.chunks[0].shape, (4, 3))
+        pd.testing.assert_series_equal(tiled.inputs[0].dtypes, data.dtypes)
+        self.assertEqual(tiled.chunks[1].shape, (4, 3))
+        pd.testing.assert_series_equal(tiled.inputs[0].dtypes, data.dtypes)
+        self.assertEqual(tiled.chunks[2].shape, (2, 3))
+        pd.testing.assert_series_equal(tiled.inputs[0].dtypes, data.dtypes)
+
     def testResetIndex(self):
         data = pd.DataFrame([('bird',    389.0),
                              ('bird',     24.0),


### PR DESCRIPTION
Backport of #1623.