### PR TITLE
[BACKPORT] Fix issue that `output_type` does not take effect for `df.apply` (#1626)

### DIFF
--- a/mars/dataframe/base/map_chunk.py
+++ b/mars/dataframe/base/map_chunk.py
@@ -101,18 +101,19 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
                                    shape=shape, index_value=index_value,
                                    name=obj.name)
         else:
+            dtypes = dtypes if dtypes is not None else obj.dtypes
             # dataframe
             if obj.shape == test_obj.shape:
-                shape = (df_or_series.shape[0], obj.shape[1])
+                shape = (df_or_series.shape[0], len(dtypes))
             else:
-                shape = (np.nan, obj.shape[1])
-            columns_value = parse_index(obj.dtypes.index, store_data=True)
+                shape = (np.nan, len(dtypes))
+            columns_value = parse_index(dtypes.index, store_data=True)
             if index is None:
                 index = obj.index
             index_value = parse_index(index, df_or_series,
                                       self._func, self._args, self._kwargs)
             return self.new_dataframe([df_or_series], shape=shape,
-                                      dtypes=obj.dtypes, index_value=index_value,
+                                      dtypes=dtypes, index_value=index_value,
                                       columns_value=columns_value)
 
     @classmethod

--- a/mars/dataframe/base/tests/test_base.py
+++ b/mars/dataframe/base/tests/test_base.py
@@ -350,6 +350,12 @@ class Test(TestBase):
         finally:
             options.chunk_store_limit = old_chunk_store_limit
 
+        raw = pd.DataFrame({'a': [np.array([1, 2, 3]), np.array([4, 5, 6])]})
+        df = from_pandas_df(raw)
+        df2 = df.apply(lambda x: x['a'].astype(pd.Series), axis=1,
+                       output_type='dataframe', dtypes=pd.Series([np.dtype(float)] * 3))
+        self.assertEqual(df2.ndim, 2)
+
     def testSeriesApply(self):
         idxes = [chr(ord('A') + i) for i in range(20)]
         s_raw = pd.Series([i ** 2 for i in range(20)], index=idxes)
@@ -382,6 +388,37 @@ class Test(TestBase):
         self.assertEqual(r.op.output_types[0], OutputType.series)
         self.assertEqual(r.chunks[0].shape, (5,))
         self.assertEqual(r.chunks[0].inputs[0].shape, (5,))
+
+        s_raw2 = pd.Series([np.array([1, 2, 3]), np.array([4, 5, 6])])
+        series = from_pandas_series(s_raw2)
+
+        r = series.apply(np.sum)
+        self.assertEqual(r.dtype, np.dtype(object))
+
+        r = series.apply(lambda x: pd.Series([1]), output_type='dataframe')
+        expected = s_raw2.apply(lambda x: pd.Series([1]))
+        pd.testing.assert_series_equal(r.dtypes, expected.dtypes)
+
+        dtypes = pd.Series([np.dtype(float)] * 3)
+        r = series.apply(pd.Series, output_type='dataframe',
+                         dtypes=dtypes)
+        self.assertEqual(r.ndim, 2)
+        pd.testing.assert_series_equal(r.dtypes, dtypes)
+        self.assertEqual(r.shape, (2, 3))
+
+        r = series.apply(pd.Series, output_type='dataframe',
+                         dtypes=dtypes, index=pd.RangeIndex(2))
+        self.assertEqual(r.ndim, 2)
+        pd.testing.assert_series_equal(r.dtypes, dtypes)
+        self.assertEqual(r.shape, (2, 3))
+
+        with self.assertRaises(AttributeError) as cm:
+            series.apply('abc')
+        self.assertIn('abc', str(cm.exception))
+
+        with self.assertRaises(TypeError):
+            # dtypes not provided
+            series.apply(lambda x: x.tolist(), output_type='dataframe')
 
     def testTransform(self):
         cols = [chr(ord('A') + i) for i in range(10)]

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -495,6 +495,16 @@ class Test(TestBase):
         expected = s_raw.apply(lambda x: [x, x + 1], convert_dtype=False)
         pd.testing.assert_series_equal(result, expected)
 
+        s_raw2 = pd.Series([np.array([1, 2, 3]), np.array([4, 5, 6])])
+        series = from_pandas_series(s_raw2)
+
+        dtypes = pd.Series([np.dtype(float)] * 3)
+        r = series.apply(pd.Series, output_type='dataframe',
+                         dtypes=dtypes)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = s_raw2.apply(pd.Series)
+        pd.testing.assert_frame_equal(result, expected)
+
     @unittest.skipIf(pa is None, 'pyarrow not installed')
     def testApplyWithArrowDtypeExecution(self):
         df1 = pd.DataFrame({'a': [1, 2, 1],
@@ -1643,6 +1653,17 @@ class Test(TestBase):
                          dtypes=pd.Series([np.dtype(int), raw['b'].dtype], index=['a', 'b']))
         result = self.executor.execute_dataframe(r, concat=True)[0]
         expected = f4(raw)
+        pd.testing.assert_frame_equal(result, expected)
+
+        raw2 = pd.DataFrame({'a': [np.array([1, 2, 3]), np.array([4, 5, 6])]})
+        df2 = from_pandas_df(raw2)
+        dtypes = pd.Series([np.dtype(float)] * 3)
+        r = df2.map_chunk(lambda x: x['a'].apply(pd.Series), output_type='dataframe',
+                          dtypes=dtypes)
+        self.assertEqual(r.shape, (2, 3))
+        pd.testing.assert_series_equal(r.dtypes, dtypes)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = raw2.apply(lambda x: x['a'], axis=1, result_type='expand')
         pd.testing.assert_frame_equal(result, expected)
 
     def testRebalanceExecution(self):


### PR DESCRIPTION
Backport of #1626 .