### PR TITLE
Unify groupby.agg() using ReductionCompiler

### DIFF
--- a/docs/source/reference/dataframe/api/mars.dataframe.groupby.GroupBy.kurt.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.groupby.GroupBy.kurt.rst
@@ -1,0 +1,6 @@
+﻿mars.dataframe.groupby.GroupBy.kurt
+===================================
+
+.. currentmodule:: mars.dataframe.groupby
+
+.. automethod:: GroupBy.kurt

--- a/docs/source/reference/dataframe/api/mars.dataframe.groupby.GroupBy.kurtosis.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.groupby.GroupBy.kurtosis.rst
@@ -1,0 +1,6 @@
+﻿mars.dataframe.groupby.GroupBy.kurtosis
+=======================================
+
+.. currentmodule:: mars.dataframe.groupby
+
+.. automethod:: GroupBy.kurtosis

--- a/docs/source/reference/dataframe/api/mars.dataframe.groupby.GroupBy.sem.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.groupby.GroupBy.sem.rst
@@ -1,0 +1,6 @@
+﻿mars.dataframe.groupby.GroupBy.sem
+==================================
+
+.. currentmodule:: mars.dataframe.groupby
+
+.. automethod:: GroupBy.sem

--- a/docs/source/reference/dataframe/api/mars.dataframe.groupby.GroupBy.skew.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.groupby.GroupBy.skew.rst
@@ -1,0 +1,6 @@
+﻿mars.dataframe.groupby.GroupBy.skew
+===================================
+
+.. currentmodule:: mars.dataframe.groupby
+
+.. automethod:: GroupBy.skew

--- a/docs/source/reference/dataframe/groupby.rst
+++ b/docs/source/reference/dataframe/groupby.rst
@@ -44,10 +44,14 @@ Computations / descriptive stats
    GroupBy.cummin
    GroupBy.cumprod
    GroupBy.cumsum
+   GroupBy.kurt
+   GroupBy.kurtosis
    GroupBy.max
    GroupBy.mean
    GroupBy.min
    GroupBy.size
+   GroupBy.sem
+   GroupBy.skew
    GroupBy.std
    GroupBy.sum
    GroupBy.var

--- a/mars/dataframe/groupby/__init__.py
+++ b/mars/dataframe/groupby/__init__.py
@@ -46,6 +46,10 @@ def _install():
         setattr(cls, 'std', lambda groupby, **kw: agg(groupby, 'std', **kw))
         setattr(cls, 'all', lambda groupby, **kw: agg(groupby, 'all', **kw))
         setattr(cls, 'any', lambda groupby, **kw: agg(groupby, 'any', **kw))
+        setattr(cls, 'skew', lambda groupby, **kw: agg(groupby, 'skew', **kw))
+        setattr(cls, 'kurt', lambda groupby, **kw: agg(groupby, 'kurt', **kw))
+        setattr(cls, 'kurtosis', lambda groupby, **kw: agg(groupby, 'kurtosis', **kw))
+        setattr(cls, 'sem', lambda groupby, **kw: agg(groupby, 'sem', **kw))
 
         setattr(cls, 'apply', groupby_apply)
         setattr(cls, 'transform', groupby_transform)

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -66,7 +66,7 @@ _series_col_name = 'col_name'
 def _patch_groupby_kurt():
     try:
         from pandas.core.groupby import DataFrameGroupBy, SeriesGroupBy
-        if not hasattr(DataFrameGroupBy, 'kurt'):
+        if not hasattr(DataFrameGroupBy, 'kurt'):  # pragma: no branch
             DataFrameGroupBy.kurt = lambda x: x.agg(pd.Series.kurt)
             SeriesGroupBy.kurt = lambda x: x.agg(pd.Series.kurt)
 
@@ -75,7 +75,7 @@ def _patch_groupby_kurt():
 
             DataFrameGroupBy.kurtosis = lambda x: x.agg(kurtosis)
             SeriesGroupBy.kurtosis = lambda x: x.agg(kurtosis)
-    except (AttributeError, ImportError):
+    except (AttributeError, ImportError):  # pragma: no cover
         pass
 
 
@@ -719,16 +719,8 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
                 cls._execute_combine(ctx, op)
             elif op.stage == OperandStage.agg:
                 cls._execute_agg(ctx, op)
-            elif op.raw_func == 'size':
-                xp = cp if op.gpu else np
-                ctx[op.outputs[0].key] = xp.array(ctx[op.inputs[0].key].agg(op.raw_func)) \
-                    .reshape(op.outputs[0].shape)
-            else:
-                xp = cp if op.gpu else np
-                result = ctx[op.inputs[0].key].agg(op.raw_func)
-                if op.output_types[0] == OutputType.tensor:
-                    result = xp.array(result)
-                ctx[op.outputs[0].key] = result
+            else:  # pragma: no cover
+                raise ValueError('Aggregation operand not executable')
         finally:
             pd.reset_option('mode.use_inf_as_na')
 

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -265,6 +265,10 @@ class Test(TestBase):
         self.assertEqual(r15.op.method, 'auto')
         self.assertTrue(all((not isinstance(c.op, ShuffleProxy)) for c in r15.build_graph(tiled=True)))
 
+        # r16 = mdf2.groupby('c2').agg(MockReduction2())
+        # pd.testing.assert_frame_equal(self.executor.execute_dataframe(r16, concat=True)[0],
+        #                               df2.groupby('c2').agg(MockReduction2()))
+
     def testSeriesGroupByAgg(self):
         rs = np.random.RandomState(0)
         series1 = pd.Series(rs.rand(10))

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -265,9 +265,9 @@ class Test(TestBase):
         self.assertEqual(r15.op.method, 'auto')
         self.assertTrue(all((not isinstance(c.op, ShuffleProxy)) for c in r15.build_graph(tiled=True)))
 
-        # r16 = mdf2.groupby('c2').agg(MockReduction2())
-        # pd.testing.assert_frame_equal(self.executor.execute_dataframe(r16, concat=True)[0],
-        #                               df2.groupby('c2').agg(MockReduction2()))
+        r16 = mdf2[['c1', 'c3']].groupby(mdf2['c2']).agg(MockReduction2())
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r16, concat=True)[0],
+                                      df2[['c1', 'c3']].groupby(df2['c2']).agg(MockReduction2()))
 
     def testSeriesGroupByAgg(self):
         rs = np.random.RandomState(0)
@@ -299,6 +299,10 @@ class Test(TestBase):
         r11 = ms1.groupby(lambda x: x % 2).agg(['cumsum', 'cumcount'], method='tree')
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(r11, concat=True)[0].sort_index(),
                                       series1.groupby(lambda x: x % 2).agg(['cumsum', 'cumcount']).sort_index())
+
+        r16 = ms1.groupby(lambda x: x % 2).agg(MockReduction2())
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r16, concat=True)[0],
+                                       series1.groupby(lambda x: x % 2).agg(MockReduction2()))
 
     @require_cudf
     def testGPUGroupByAgg(self):

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -315,9 +315,9 @@ class Test(TestBase):
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].to_pandas(),
                                       df1.groupby('a').sum())
 
-        r = mdf.groupby('a').var()
+        r = mdf.groupby('a').kurt()
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].to_pandas(),
-                                      df1.groupby('a').var())
+                                      df1.groupby('a').kurt())
 
         r = mdf.groupby('a').agg(['sum', 'var'])
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].to_pandas(),
@@ -332,9 +332,9 @@ class Test(TestBase):
         pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].to_pandas(),
                                        series1.groupby(level=0).sum())
 
-        r = ms.groupby(level=0).var()
+        r = ms.groupby(level=0).kurt()
         pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0].to_pandas(),
-                                       series1.groupby(level=0).var())
+                                       series1.groupby(level=0).kurt())
 
         r = ms.groupby(level=0).agg(['sum', 'var'])
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0].to_pandas(),

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -28,6 +28,22 @@ from mars.tests.core import TestBase, ExecutorForTest, assert_groupby_equal
 from mars.utils import arrow_array_to_objects
 
 
+class MockReduction1(md.CustomReduction):
+    def agg(self, v1):
+        return v1.sum()
+
+
+class MockReduction2(md.CustomReduction):
+    def pre(self, value):
+        return value + 1, value ** 2
+
+    def agg(self, v1, v2):
+        return v1.sum(), v2.prod()
+
+    def post(self, v1, v2):
+        return v1 + v2
+
+
 class Test(TestBase):
     def setUp(self):
         super().setUp()
@@ -179,41 +195,24 @@ class Test(TestBase):
                             'c3': rs.rand(10)})
         mdf2 = md.DataFrame(df2, chunk_size=2)
 
+        agg_funs = ['std', 'mean', 'var', 'max', 'count', 'size', 'all', 'any', 'skew', 'kurt', 'sem']
+
         for method in ['tree', 'shuffle']:
+
             r0 = mdf2.groupby('c2').agg('size', method=method)
             pd.testing.assert_series_equal(self.executor.execute_dataframe(r0, concat=True)[0],
                                            df2.groupby('c2').agg('size'))
 
-            r1 = mdf.groupby('a').agg('sum', method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r1, concat=True)[0],
-                                          df1.groupby('a').agg('sum'))
-            r2 = mdf.groupby('b').agg('min', method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r2, concat=True)[0],
-                                          df1.groupby('b').agg('min'))
+            for agg_fun in agg_funs:
+                if agg_fun == 'size':
+                    continue
+                r1 = mdf.groupby('a').agg(agg_fun, method=method)
+                pd.testing.assert_frame_equal(self.executor.execute_dataframe(r1, concat=True)[0],
+                                              df1.groupby('a').agg(agg_fun))
 
-            r1 = mdf2.groupby('c2').agg('prod', method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r1, concat=True)[0],
-                                          df2.groupby('c2').agg('prod'))
-            r2 = mdf2.groupby('c2').agg('max', method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r2, concat=True)[0],
-                                          df2.groupby('c2').agg('max'))
-            r3 = mdf2.groupby('c2').agg('count', method=method)
+            r3 = mdf2.groupby('c2').agg(agg_funs, method=method)
             pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                          df2.groupby('c2').agg('count'))
-            r4 = mdf2.groupby('c2').agg('mean', method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                          df2.groupby('c2').agg('mean'))
-            r5 = mdf2.groupby('c2').agg('var', method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r5, concat=True)[0],
-                                          df2.groupby('c2').agg('var'))
-            r6 = mdf2.groupby('c2').agg('std', method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r6, concat=True)[0],
-                                          df2.groupby('c2').agg('std'))
-
-            agg = ['std', 'mean', 'var', 'max', 'count', 'size', 'all', 'any']
-            r3 = mdf2.groupby('c2').agg(agg, method=method)
-            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                          df2.groupby('c2').agg(agg))
+                                          df2.groupby('c2').agg(agg_funs))
 
             agg = OrderedDict([('c1', ['min', 'mean']), ('c3', 'std')])
             r3 = mdf2.groupby('c2').agg(agg, method=method)
@@ -238,45 +237,12 @@ class Test(TestBase):
         pd.testing.assert_series_equal(self.executor.execute_dataframe(r8, concat=True)[0],
                                        df2.groupby('c2').size())
 
-        r4 = mdf2.groupby('c2').sum(method='tree')
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                      df2.groupby('c2').sum())
-
-        r5 = mdf2.groupby('c2').prod(method='tree')
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r5, concat=True)[0],
-                                      df2.groupby('c2').prod())
-
-        r6 = mdf2.groupby('c2').min(method='tree')
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r6, concat=True)[0],
-                                      df2.groupby('c2').min())
-
-        r7 = mdf2.groupby('c2').max(method='tree')
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r7, concat=True)[0],
-                                      df2.groupby('c2').max())
-
-        r8 = mdf2.groupby('c2').count(method='tree')
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r8, concat=True)[0],
-                                      df2.groupby('c2').count())
-
-        r9 = mdf2.groupby('c2').mean(method='tree')
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r9, concat=True)[0],
-                                      df2.groupby('c2').mean())
-
-        r10 = mdf2.groupby('c2').var(method='tree')
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r10, concat=True)[0],
-                                      df2.groupby('c2').var())
-
-        r11 = mdf2.groupby('c2').std(method='tree')
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r11, concat=True)[0],
-                                      df2.groupby('c2').std())
-
-        r10 = mdf2.groupby('c2').all(method='tree')
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r10, concat=True)[0],
-                                      df2.groupby('c2').all())
-
-        r11 = mdf2.groupby('c2').any(method='tree')
-        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r11, concat=True)[0],
-                                      df2.groupby('c2').any())
+        for agg_fun in agg_funs:
+            if agg_fun == 'size' or callable(agg_fun):
+                continue
+            r4 = getattr(mdf2.groupby('c2'), agg_fun)(method='tree')
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r4, concat=True)[0],
+                                          getattr(df2.groupby('c2'), agg_fun)())
 
         # test as_index=False
         r12 = mdf2.groupby('c2', as_index=False).agg('mean', method='tree')
@@ -304,90 +270,27 @@ class Test(TestBase):
         series1 = pd.Series(rs.rand(10))
         ms1 = md.Series(series1, chunk_size=3)
 
+        agg_funs = ['std', 'mean', 'var', 'max', 'count', 'size', 'all', 'any', 'skew', 'kurt', 'sem']
+
         for method in ['tree', 'shuffle']:
-            r0 = ms1.groupby(lambda x: x % 2).agg('size', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r0, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('size'))
+            for agg_fun in agg_funs:
+                r0 = ms1.groupby(lambda x: x % 2).agg(agg_fun, method=method)
+                pd.testing.assert_series_equal(self.executor.execute_dataframe(r0, concat=True)[0],
+                                               series1.groupby(lambda x: x % 2).agg(agg_fun))
 
-            r1 = ms1.groupby(lambda x: x % 2).agg('sum', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r1, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('sum'))
-            r2 = ms1.groupby(lambda x: x % 2).agg('min', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r2, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('min'))
-
-            r1 = ms1.groupby(lambda x: x % 2).agg('prod', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r1, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('prod'))
-            r2 = ms1.groupby(lambda x: x % 2).agg('max', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r2, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('max'))
-            r3 = ms1.groupby(lambda x: x % 2).agg('count', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('count'))
-            r4 = ms1.groupby(lambda x: x % 2).agg('mean', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('mean'))
-            r5 = ms1.groupby(lambda x: x % 2).agg('var', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r5, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('var'))
-            r6 = ms1.groupby(lambda x: x % 2).agg('std', method=method)
-            pd.testing.assert_series_equal(self.executor.execute_dataframe(r6, concat=True)[0],
-                                           series1.groupby(lambda x: x % 2).agg('std'))
-
-            agg = ['std', 'mean', 'var', 'max', 'count', 'size', 'all', 'any']
-            r3 = ms1.groupby(lambda x: x % 2).agg(agg, method=method)
+            r3 = ms1.groupby(lambda x: x % 2).agg(agg_funs, method=method)
             pd.testing.assert_frame_equal(self.executor.execute_dataframe(r3, concat=True)[0],
-                                          series1.groupby(lambda x: x % 2).agg(agg))
+                                          series1.groupby(lambda x: x % 2).agg(agg_funs))
 
             # test groupby series
             r3 = ms1.groupby(ms1).sum(method=method)
             pd.testing.assert_series_equal(self.executor.execute_dataframe(r3, concat=True)[0],
                                            series1.groupby(series1).sum())
 
-        r4 = ms1.groupby(lambda x: x % 2).size(method='tree')
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).size())
-
-        r4 = ms1.groupby(lambda x: x % 2).sum(method='tree')
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).sum())
-
-        r5 = ms1.groupby(lambda x: x % 2).prod(method='tree')
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r5, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).prod())
-
-        r6 = ms1.groupby(lambda x: x % 2).min(method='tree')
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r6, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).min())
-
-        r7 = ms1.groupby(lambda x: x % 2).max(method='tree')
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r7, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).max())
-
-        r8 = ms1.groupby(lambda x: x % 2).count(method='tree')
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r8, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).count())
-
-        r9 = ms1.groupby(lambda x: x % 2).mean(method='tree')
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r9, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).mean())
-
-        r10 = ms1.groupby(lambda x: x % 2).var(method='tree')
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r10, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).var())
-
-        r11 = ms1.groupby(lambda x: x % 2).std(method='tree')
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r11, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).std())
-
-        r10 = ms1.groupby(lambda x: x % 2).all(method='tree')
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r10, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).all())
-
-        r11 = ms1.groupby(lambda x: x % 2).any(method='tree')
-        pd.testing.assert_series_equal(self.executor.execute_dataframe(r11, concat=True)[0],
-                                       series1.groupby(lambda x: x % 2).any())
+        for agg_fun in agg_funs:
+            r4 = getattr(ms1.groupby(lambda x: x % 2), agg_fun)(method='tree')
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r4, concat=True)[0],
+                                           getattr(series1.groupby(lambda x: x % 2), agg_fun)())
 
         r11 = ms1.groupby(lambda x: x % 2).agg(['cumsum', 'cumcount'], method='tree')
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(r11, concat=True)[0].sort_index(),

--- a/mars/dataframe/reduction/nunique.py
+++ b/mars/dataframe/reduction/nunique.py
@@ -24,7 +24,8 @@ from ...config import options
 from ...serialize import BoolField
 from ...utils import lazy_import
 from ..arrays import ArrowListArray, ArrowListDtype
-from .core import DataFrameReductionOperand, DataFrameReductionMixin, CustomReduction
+from .core import DataFrameReductionOperand, DataFrameReductionMixin, \
+    CustomReduction
 
 cudf = lazy_import('cudf', globals=globals())
 


### PR DESCRIPTION
## What do these changes do?

This PR is a followup of #1705 by replacing implements of ``groupby.agg`` with newly-implemented ``ReductionCompiler``. ``skew``, ``kurt`` and ``CustomReduction`` are added, and those issues can be closed now.

## Performance tests

Under Intel 10700K with test data

```python
import numpy as np
import pandas as pd
import mars.dataframe as md
raw = pd.DataFrame(np.random.rand(1000, 10))
raw[0] = raw[0].map(lambda x: 'ABC'[int(x * 3)])
df = md.DataFrame(raw, chunk_size=20)
```

Tests with this PR patched:

```python
In[3]: %timeit df.groupby(0).sum()
6.74 ms ± 42.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
In[4]: %timeit df.groupby(0).var()
6.65 ms ± 7.27 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
In[5]: %timeit df.groupby(0).agg(['sum', 'var'])
15 ms ± 17.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Tests without this PR patched:

```python
In[3]: %timeit df.groupby(0).sum()
12.5 ms ± 67 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
In[4]: %timeit df.groupby(0).var()
12.5 ms ± 36 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
In[5]: %timeit df.groupby(0).agg(['sum', 'var'])
28.6 ms ± 748 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

## Related issue number

Fixes #1476 
Fixes #1311 
Fixes #1141