### PR TITLE
Eliminate TimeoutError when there are running nodes

### DIFF
--- a/.github/workflows/install-minikube.sh
+++ b/.github/workflows/install-minikube.sh
@@ -15,6 +15,8 @@ K8S_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/
 if [[ "$K8S_VERSION" == *"alpha"* ]] || [[ "$K8S_VERSION" == *"beta"* ]] || [[ "$K8S_VERSION" == *"rc"* ]]; then
   K8S_VERSION=$(get_latest_release "kubernetes/kubernetes")
 fi
+# temporary fix version to avoid CI failure
+K8S_VERSION="v1.19.2"
 
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$K8S_VERSION/bin/linux/amd64/kubectl && \
   chmod +x kubectl && sudo mv kubectl /usr/local/bin/

--- a/mars/scheduler/assigner.py
+++ b/mars/scheduler/assigner.py
@@ -406,7 +406,12 @@ class AssignEvaluationActor(SchedulerActor):
                 rejects.append(worker_ep)
 
         if timeout_on_fail:
-            raise TimeoutError(f'Assign resources to operand {op_key} timed out')
+            running_ops = sum(len(metrics.get('progress', dict()).get(str(session_id), dict()))
+                              for metrics in self._worker_metrics.values())
+            if running_ops == 0:
+                raise TimeoutError(f'Assign resources to operand {op_key} timed out')
+            else:
+                self._session_last_assigns[session_id] = time.time()
         return None, rejects
 
     def _get_chunks_meta(self, session_id, keys):

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -735,6 +735,11 @@ class GraphActor(SchedulerActor):
         ext_chunks_to_inputs = analyzer.collect_external_input_chunks(initial=True)
         input_chunk_metas = self._collect_external_input_metas(ext_chunks_to_inputs)
 
+        invalid_keys = [k for k, v in input_chunk_metas.items() if v is None]
+        if invalid_keys:
+            raise KeyError(f'Input metas for data chunks {invalid_keys!r} missing when '
+                           f'executing graph {self._graph_key}')
+
         def _do_assign():
             # do placements
             return self.assign_operand_workers(


### PR DESCRIPTION
## What do these changes do?

Eliminate TimeoutError when there are running nodes. This resolves the issue when the job is constructed with time-consuming nodes.

## Related issue number

Fixes #1636 