### PR TITLE
Add `flush` method to `_LogWrapper`

### DIFF
--- a/mars/custom_log.py
+++ b/mars/custom_log.py
@@ -96,6 +96,9 @@ class _LogWrapper:
         # write into previous stdout
         self.stdout.write(data)
 
+    def flush(self):
+        self.stdout.flush()
+
 
 def gen_log_path(session_id, op_key):
     filename = f"{str(session_id).replace('-', '_')}_{op_key}"

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -369,6 +369,7 @@ class Test(SchedulerIntegratedTest):
             # test multiple functions
             def f1(size):
                 print('f1' * size)
+                sys.stdout.flush()
 
             fs = ExecutableTuple([spawn(f1, 30), spawn(f1, 40)])
             fs.execute(session=sess)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR added `flush` method to `_LogWrapper`, this prevents from AttributeError when users call `sys.stdout.flush()`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1645 .