### PR TITLE
Fix `md.concat` which may occupy huge amount of memory on client when all of DataFrames own large RangeIndex

### DIFF
--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 6, 0, 'a3')
+version_info = (0, 6, 0, 'b1')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/dataframe/merge/tests/test_merge.py
+++ b/mars/dataframe/merge/tests/test_merge.py
@@ -247,6 +247,32 @@ class Test(TestBase):
         for i, c in enumerate(tiled.chunks):
             self.assertEqual(c.index, (i, 0))
 
+        df3 = pd.DataFrame(np.random.rand(10, 4), columns=list('ABCD'),
+                           index=pd.RangeIndex(10, 20))
+
+        mdf3 = from_pandas(df3, chunk_size=4)
+        r = concat([mdf1, mdf3], axis='index')
+
+        self.assertEqual(r.shape, (20, 4))
+        pd.testing.assert_series_equal(r.dtypes, df1.dtypes)
+        pd.testing.assert_index_equal(r.index_value.to_pandas(), pd.RangeIndex(20))
+
+        df4 = pd.DataFrame(np.random.rand(10, 4), columns=list('ABCD'),
+                           index=np.random.permutation(np.arange(10)))
+
+        mdf4 = from_pandas(df4, chunk_size=4)
+        r = concat([mdf1, mdf4], axis='index')
+
+        self.assertEqual(r.shape, (20, 4))
+        pd.testing.assert_series_equal(r.dtypes, df1.dtypes)
+        pd.testing.assert_index_equal(r.index_value.to_pandas(), pd.Index([], dtype=np.int64))
+
+        r = concat([mdf4, mdf1], axis='index')
+
+        self.assertEqual(r.shape, (20, 4))
+        pd.testing.assert_series_equal(r.dtypes, df1.dtypes)
+        pd.testing.assert_index_equal(r.index_value.to_pandas(), pd.Index([], dtype=np.int64))
+
         mdf1 = from_pandas(df1, chunk_size=3)
         mdf2 = from_pandas(df2, chunk_size=4)
         r = concat([mdf1, mdf2], axis='columns')

--- a/mars/dataframe/merge/tests/test_merge.py
+++ b/mars/dataframe/merge/tests/test_merge.py
@@ -273,6 +273,12 @@ class Test(TestBase):
         pd.testing.assert_series_equal(r.dtypes, df1.dtypes)
         pd.testing.assert_index_equal(r.index_value.to_pandas(), pd.Index([], dtype=np.int64))
 
+        r = concat([mdf4, mdf4], axis='index')
+
+        self.assertEqual(r.shape, (20, 4))
+        pd.testing.assert_series_equal(r.dtypes, df1.dtypes)
+        pd.testing.assert_index_equal(r.index_value.to_pandas(), pd.Index([], dtype=np.int64))
+
         mdf1 = from_pandas(df1, chunk_size=3)
         mdf2 = from_pandas(df2, chunk_size=4)
         r = concat([mdf1, mdf2], axis='columns')


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes `md.concat` which may occupy huge amount of memory on client when all of DataFrames own large RangeIndex.

Master branch:

```python
In [1]: import mars.tensor as mt                                                                                                                                                                            

In [2]: import mars.dataframe as md                                                                                                                                                                         

In [3]: df = md.DataFrame(mt.random.rand(1000_0000, 10))                                                                                                                                                    

In [4]: df2 = md.DataFrame(mt.random.rand(1000_0000, 10))                                                                                                                                                   

In [5]: import ipython_memory_usage                                                                                                                                                                         

In [6]: %ipython_memory_usage_start                                                                                                                                                                         
Out[6]: 'memory profile enabled'
In [6] used 0.4336 MiB RAM in 3.64s, peaked 0.00 MiB above current, total RAM usage 126.13 MiB

In [7]: md.concat([df, df2])                                                                                                                                                                                
Out[7]: DataFrame <op=DataFrameConcat, key=570c63e8d6d1e426717fad9a6ae57d0d>
In [7] used 491.3359 MiB RAM in 1.76s, peaked 152.72 MiB above current, total RAM usage 617.46 MiB
```

This PR:

```python
In [1]: import mars.tensor as mt                                                                                                                                                                            

In [2]: import mars.dataframe as md                                                                                                                                                                         

In [3]: df = md.DataFrame(mt.random.rand(1000_0000, 10))                                                                                                                                                    

In [4]: df2 = md.DataFrame(mt.random.rand(1000_0000, 10))                                                                                                                                                   

In [5]: import ipython_memory_usage                                                                                                                                                                         

In [6]: %ipython_memory_usage_start                                                                                                                                                                         
Out[6]: 'memory profile enabled'
In [6] used 0.0508 MiB RAM in 4.65s, peaked 0.00 MiB above current, total RAM usage 124.11 MiB

In [7]: md.concat([df, df2])                                                                                                                                                                                
Out[7]: DataFrame <op=DataFrameConcat, key=a5577f6cebc7caa266be6eedddf65ee5>
In [7] used 0.3984 MiB RAM in 0.12s, peaked 0.00 MiB above current, total RAM usage 124.51 MiB
```

**Memory costs down from 491.3359 MiB to 0.3984 MiB**.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1647 .
