### PR TITLE
[BACKPORT] Fix `md.concat` which may occupy huge amount of memory on client when all of DataFrames own large RangeIndex (#1649)

### DIFF
--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 5, 2)
+version_info = (0, 5, 3)
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/dataframe/merge/tests/test_merge.py
+++ b/mars/dataframe/merge/tests/test_merge.py
@@ -247,6 +247,38 @@ class Test(TestBase):
         for i, c in enumerate(tiled.chunks):
             self.assertEqual(c.index, (i, 0))
 
+        df3 = pd.DataFrame(np.random.rand(10, 4), columns=list('ABCD'),
+                           index=pd.RangeIndex(10, 20))
+
+        mdf3 = from_pandas(df3, chunk_size=4)
+        r = concat([mdf1, mdf3], axis='index')
+
+        self.assertEqual(r.shape, (20, 4))
+        pd.testing.assert_series_equal(r.dtypes, df1.dtypes)
+        pd.testing.assert_index_equal(r.index_value.to_pandas(), pd.RangeIndex(20))
+
+        df4 = pd.DataFrame(np.random.rand(10, 4), columns=list('ABCD'),
+                           index=np.random.permutation(np.arange(10)))
+
+        mdf4 = from_pandas(df4, chunk_size=4)
+        r = concat([mdf1, mdf4], axis='index')
+
+        self.assertEqual(r.shape, (20, 4))
+        pd.testing.assert_series_equal(r.dtypes, df1.dtypes)
+        pd.testing.assert_index_equal(r.index_value.to_pandas(), pd.Index([], dtype=np.int64))
+
+        r = concat([mdf4, mdf1], axis='index')
+
+        self.assertEqual(r.shape, (20, 4))
+        pd.testing.assert_series_equal(r.dtypes, df1.dtypes)
+        pd.testing.assert_index_equal(r.index_value.to_pandas(), pd.Index([], dtype=np.int64))
+
+        r = concat([mdf4, mdf4], axis='index')
+
+        self.assertEqual(r.shape, (20, 4))
+        pd.testing.assert_series_equal(r.dtypes, df1.dtypes)
+        pd.testing.assert_index_equal(r.index_value.to_pandas(), pd.Index([], dtype=np.int64))
+
         mdf1 = from_pandas(df1, chunk_size=3)
         mdf2 = from_pandas(df2, chunk_size=4)
         r = concat([mdf1, mdf2], axis='columns')


### PR DESCRIPTION
Backport of #1649 .