### PR TITLE
Create Fetch operands given output types

### DIFF
--- a/mars/dataframe/fetch/core.py
+++ b/mars/dataframe/fetch/core.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ...core import OutputType, register_fetch_class
 from ...serialize.core import TupleField, ValueType
 from ...operands import Fetch, FetchShuffle, FetchMixin
 from ...utils import on_serialize_shape, on_deserialize_shape
@@ -53,3 +54,11 @@ class DataFrameFetchShuffle(FetchShuffle, DataFrameFetchMixin):
         super().__init__(
             _to_fetch_keys=to_fetch_keys, _to_fetch_idxes=to_fetch_idxes,
             _output_types=output_types, **kw)
+
+
+register_fetch_class(OutputType.dataframe, DataFrameFetch, DataFrameFetchShuffle)
+register_fetch_class(OutputType.dataframe_groupby, DataFrameFetch, DataFrameFetchShuffle)
+register_fetch_class(OutputType.series, DataFrameFetch, DataFrameFetchShuffle)
+register_fetch_class(OutputType.series_groupby, DataFrameFetch, DataFrameFetchShuffle)
+register_fetch_class(OutputType.index, DataFrameFetch, DataFrameFetchShuffle)
+register_fetch_class(OutputType.categorical, DataFrameFetch, DataFrameFetchShuffle)

--- a/mars/dataframe/operands.py
+++ b/mars/dataframe/operands.py
@@ -239,19 +239,6 @@ class DataFrameOperandMixin(TileableOperandMixin):
         index_value = parse_index(pd_index)
         return {'dtype': chunks[0].dtype, 'index_value': index_value}
 
-    def get_fetch_op_cls(self, _):
-        from ..operands import ShuffleProxy
-        from .fetch import DataFrameFetchShuffle, DataFrameFetch
-        if isinstance(self, ShuffleProxy):
-            cls = DataFrameFetchShuffle
-        else:
-            cls = DataFrameFetch
-
-        def _inner(**kw):
-            return cls(output_types=self.output_types, **kw)
-
-        return _inner
-
     def get_fuse_op_cls(self, _):
         return DataFrameFuseChunk
 

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -1019,6 +1019,13 @@ class Test(unittest.TestCase):
             r2 = web_session.run(merge(df1, df2, how='inner', on=['a', 'b']), timeout=_exec_timeout)
             pd.testing.assert_frame_equal(sort_dataframe_inplace(r1, 0), sort_dataframe_inplace(r2, 0))
 
+            df3 = from_pandas_df(data1, chunk_size=2)
+            df3 = df3.execute()
+            with tempfile.TemporaryDirectory() as tempdir:
+                csv_path = os.path.join(tempdir, 'test_out.csv')
+                df3.to_csv(csv_path).execute()
+                self.assertTrue(os.path.exists(csv_path))
+
     @require_cudf
     def testCudaCluster(self, *_):
         from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df

--- a/mars/learn/operands.py
+++ b/mars/learn/operands.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..operands import Operand, TileableOperandMixin, Fetch, FetchMixin, \
-    Fuse, FuseChunkMixin, MapReduceOperand, ShuffleProxy, OutputType
+from ..operands import Operand, TileableOperandMixin, Fuse, FuseChunkMixin, \
+    MapReduceOperand, ShuffleProxy, OutputType
 from ..tensor.core import TENSOR_TYPE, TENSOR_CHUNK_TYPE
 from ..tensor.operands import TensorOperandMixin
 from ..tensor.fuse import TensorFuseChunk
-from ..tensor.fetch import TensorFetch
-from ..dataframe.core import SERIES_TYPE, SERIES_CHUNK_TYPE, TILEABLE_TYPE as DATAFRAME_TYPE, \
+from ..dataframe.core import TILEABLE_TYPE as DATAFRAME_TYPE, \
     CHUNK_TYPE as DATAFRAME_CHUNK_TYPE
 from ..dataframe.operands import DataFrameOperandMixin, DataFrameFuseChunk
-from ..dataframe.fetch import DataFrameFetch
 
 
 LearnOperand = Operand
@@ -53,24 +51,6 @@ class LearnOperandMixin(TileableOperandMixin):
             # op has to implement its logic of `create_tileable_from_chunks`
             raise NotImplementedError
 
-    def get_fetch_op_cls(self, obj):
-        # Shuffle proxy should be tensor or dataframe
-        if isinstance(obj, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
-            return TensorFetch
-        elif isinstance(obj, (DATAFRAME_TYPE, DATAFRAME_CHUNK_TYPE)):
-            def _inner(**kw):
-                output_types = [OutputType.series] \
-                    if isinstance(obj, (SERIES_TYPE, SERIES_CHUNK_TYPE)) else \
-                    [OutputType.dataframe]
-                return DataFrameFetch(output_types=output_types, **kw)
-
-            return _inner
-        else:
-            def _inner(**kw):
-                return LearnObjectFetch(output_types=[OutputType.object], **kw)
-
-            return _inner
-
     def get_fuse_op_cls(self, obj):
         if isinstance(obj, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
             return TensorFuseChunk
@@ -78,25 +58,6 @@ class LearnOperandMixin(TileableOperandMixin):
             return DataFrameFuseChunk
         else:
             return LearnObjectFuseChunk
-
-
-class LearnObjectFetchMixin(LearnOperandMixin, FetchMixin):
-    __slots__ = ()
-
-
-class LearnObjectFetch(Fetch, LearnObjectFetchMixin):
-    def __init__(self, to_fetch_key=None, output_types=None, **kw):
-        super().__init__(_to_fetch_key=to_fetch_key, _output_types=output_types, **kw)
-
-    def _new_chunks(self, inputs, kws=None, **kw):
-        if '_key' in kw and self._to_fetch_key is None:
-            self._to_fetch_key = kw['_key']
-        return super()._new_chunks(inputs, kws=kws, **kw)
-
-    def _new_tileables(self, inputs, kws=None, **kw):
-        if '_key' in kw and self._to_fetch_key is None:
-            self._to_fetch_key = kw['_key']
-        return super()._new_tileables(inputs, kws=kws, **kw)
 
 
 class LearnObjectFuseChunkMixin(FuseChunkMixin, LearnOperandMixin):

--- a/mars/tensor/fetch/core.py
+++ b/mars/tensor/fetch/core.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ...core import register_fetch_class
 from ...operands import Fetch, FetchShuffle, FetchMixin, OutputType
 from ...serialize import DataTypeField
 from ..operands import TensorOperandMixin
@@ -26,6 +27,8 @@ class TensorFetch(TensorFetchMixin, Fetch):
     _dtype = DataTypeField('dtype')
 
     def __init__(self, dtype=None, to_fetch_key=None, sparse=False, **kw):
+        kw.pop('output_types', None)
+        kw.pop('_output_types', None)
         super().__init__(
             _dtype=dtype, _to_fetch_key=to_fetch_key, _sparse=sparse, **kw)
 
@@ -48,9 +51,15 @@ class TensorFetchShuffle(TensorFetchMixin, FetchShuffle):
     _dtype = DataTypeField('dtype')
 
     def __init__(self, dtype=None, to_fetch_keys=None, to_fetch_idxes=None, **kw):
+        kw.pop('output_types', None)
+        kw.pop('_output_types', None)
         super().__init__(
             _dtype=dtype, _to_fetch_keys=to_fetch_keys, _to_fetch_idxes=to_fetch_idxes, **kw)
 
     @property
     def dtype(self):
         return getattr(self, '_dtype', None)
+
+
+register_fetch_class(OutputType.tensor, TensorFetch, TensorFetchShuffle)
+register_fetch_class(OutputType.scalar, TensorFetch, TensorFetchShuffle)

--- a/mars/tensor/operands.py
+++ b/mars/tensor/operands.py
@@ -55,15 +55,6 @@ class TensorOperandMixin(TileableOperandMixin):
         return op.new_tensor(inputs, shape=shape, chunks=chunks,
                              nsplits=nsplits, dtype=chunks[0].dtype, **kw)
 
-    def get_fetch_op_cls(self, _):
-        from ..operands import ShuffleProxy
-        from .fetch import TensorFetchShuffle, TensorFetch
-
-        if isinstance(self, ShuffleProxy):
-            return TensorFetchShuffle
-        else:
-            return TensorFetch
-
     def get_fuse_op_cls(self, _):
         from .fuse import TensorFuseChunk
 


### PR DESCRIPTION
## What do these changes do?

Create Fetch operands given output types, not operand types. This resolves errors caused by fetching tensors generated by DataFrame operands with DataFrameFetch.

## Related issue number

Fixes #1664 