### PR TITLE
Fix hang for rerun `DataFrame.groupby` in distributed mode

### DIFF
--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -601,8 +601,16 @@ class Test(unittest.TestCase):
             r4 = df.groupby('c2').transform(execute_with_session_check(
                 func, session.session_id)).to_pandas()
             expected4 = raw.groupby('c2').transform(func)
-            print(r4, expected4)
             pd.testing.assert_frame_equal(r4.sort_index(), expected4.sort_index())
+
+            # test rerun gropuby
+            df = md.DataFrame(raw.copy(), chunk_size=4)
+            r5 = session.run(df.groupby('c2').count(method='shuffle').max())
+            r6 = session.run(df.groupby('c2').count(method='shuffle').min())
+            expected5 = raw.groupby('c2').count().max()
+            expected6 = raw.groupby('c2').count().min()
+            pd.testing.assert_series_equal(r5, expected5)
+            pd.testing.assert_series_equal(r6, expected6)
 
     def testMultiSessionDecref(self, *_):
         with new_cluster(scheduler_n_process=2, worker_n_process=2,

--- a/mars/scheduler/operands/shuffle.py
+++ b/mars/scheduler/operands/shuffle.py
@@ -81,6 +81,13 @@ class ShuffleProxyActor(BaseOperandActor):
         if all(k in self._finish_preds for k in self._pred_keys):
             self._start_successors()
 
+    def append_graph(self, graph_key, op_info):
+        super().append_graph(graph_key, op_info)
+
+        io_meta = op_info['io_meta']
+        self._shuffle_keys_to_op = dict(zip(io_meta['shuffle_keys'], io_meta['successors']))
+        self._op_to_shuffle_keys = dict(zip(io_meta['successors'], io_meta['shuffle_keys']))
+
     def _start_successors(self):
         self._all_deps_built = True
         futures = []


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

When `ShuffleProxyActor` is reused, `io_meta` should be updated when append new graphs.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1661.