### PR TITLE
Add a threshold for `DataFrame.head` optimization

### DIFF
--- a/mars/config.py
+++ b/mars/config.py
@@ -377,6 +377,7 @@ default_options.register_option('worker.plasma_socket', '/tmp/plasma', validator
 default_options.register_option('optimize.min_stats_count', 10, validator=is_integer)
 default_options.register_option('optimize.stats_sufficient_ratio', 0.9, validator=is_float, serialize=True)
 default_options.register_option('optimize.default_disk_io_speed', 10 * 1024 ** 2, validator=is_integer)
+default_options.register_option('optimize.head_optimize_threshold', 1000, validator=is_integer)
 
 default_options.register_option('optimize_tileable_graph', True, validator=is_bool)
 

--- a/mars/dataframe/indexing/iloc.py
+++ b/mars/dataframe/indexing/iloc.py
@@ -212,9 +212,10 @@ class HeadTailOptimizedOperandMixin(DataFrameOperandMixin):
         params['chunks'] = chunks
         return new_op.new_tileables(op.inputs, kws=[params])
 
-    def is_head(self):
+    def can_be_optimized(self):
         return self._is_indexes_head_or_tail(self._indexes) and \
-               self._is_head(self._indexes[0])
+               self._is_head(self._indexes[0]) and \
+               self._indexes[0].stop <= options.optimize.head_optimize_threshold
 
     @classmethod
     def tile(cls, op):

--- a/mars/optimizes/runtime/dataframe.py
+++ b/mars/optimizes/runtime/dataframe.py
@@ -134,7 +134,7 @@ class DataSourceHeadRule(DataFrameRuntimeOptimizeRule):
         op = chunk.op
         inputs = graph.predecessors(chunk)
         if len(inputs) == 1 and isinstance(op, (DataFrameIlocGetItem, SeriesIlocGetItem)) and \
-                op.is_head() and isinstance(inputs[0].op, (DataFrameReadCSV, DataFrameReadSQL)) and \
+                op.can_be_optimized() and isinstance(inputs[0].op, (DataFrameReadCSV, DataFrameReadSQL)) and \
                 inputs[0].key not in keys:
             return True
         return False


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Expressions like `df.head(n)` will be optimized to reduce the memory usage, however, the strategy will even requires more memory when `n` is large, in this PR, we set a threshold 1000, if `n` greater than it, the optimization will be disabled.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1658.