### PR TITLE
[BACKPORT] Mount /dev/shm on host to pods when starting Mars workers in Kubernetes (#1677)

### DIFF
--- a/mars/config.py
+++ b/mars/config.py
@@ -359,6 +359,7 @@ default_options.register_option('worker.spill_directory', None, validator=(is_nu
 default_options.register_option('worker.disk_compression', 'lz4', validator=is_string, serialize=True)
 default_options.register_option('worker.min_spill_size', '5%', validator=(is_string, is_integer))
 default_options.register_option('worker.max_spill_size', '95%', validator=(is_string, is_integer))
+default_options.register_option('worker.min_cache_mem_size', None, validator=(is_null, is_string, is_integer))
 default_options.register_option('worker.callback_preserve_time', 3600 * 24, validator=is_integer)
 default_options.register_option('worker.event_preserve_time', 3600 * 24, validator=(is_integer, is_float))
 default_options.register_option('worker.copy_block_size', 64 * 1024, validator=is_integer)

--- a/mars/deploy/kubernetes/client.py
+++ b/mars/deploy/kubernetes/client.py
@@ -69,6 +69,7 @@ class KubernetesCluster:
                  scheduler_num=1, scheduler_cpu=None, scheduler_mem=None,
                  worker_num=1, worker_cpu=None, worker_mem=None,
                  worker_spill_paths=None, worker_cache_mem=None, min_worker_num=None,
+                 worker_min_cache_mem=None,
                  web_num=1, web_cpu=None, web_mem=None, service_type=None,
                  timeout=None, **kwargs):
         from kubernetes import client as kube_client
@@ -121,6 +122,7 @@ class KubernetesCluster:
         self._worker_mem = worker_mem
         self._worker_spill_paths = worker_spill_paths
         self._worker_cache_mem = worker_cache_mem
+        self._worker_min_cache_men = worker_min_cache_mem
         self._min_worker_num = min_worker_num
         self._worker_extra_modules = _override_modules(kwargs.pop('worker_extra_modules', []))
         self._worker_extra_env = _override_envs(kwargs.pop('worker_extra_env', None))
@@ -232,6 +234,7 @@ class KubernetesCluster:
             memory=self._worker_mem, spill_volumes=self._worker_spill_paths,
             modules=self._worker_extra_modules, volumes=self._extra_volumes,
             worker_cache_mem=self._worker_cache_mem,
+            min_cache_mem=self._worker_min_cache_men,
             service_port=self._worker_service_port,
             pre_stop_command=self._pre_stop_command,
         )

--- a/mars/deploy/kubernetes/config.py
+++ b/mars/deploy/kubernetes/config.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from ... import __version__ as mars_version
 from ...utils import parse_readable_size
 
@@ -477,6 +479,7 @@ class MarsWorkersConfig(MarsReplicationControllerConfig):
         mount_shm = kwargs.pop('mount_shm', True)
         self._limit_resources = kwargs['limit_resources'] = kwargs.get('limit_resources', True)
         worker_cache_mem = kwargs.pop('worker_cache_mem', None)
+        min_cache_mem = kwargs.pop('min_cache_mem', None)
 
         super().__init__(*args, **kwargs)
 
@@ -493,9 +496,14 @@ class MarsWorkersConfig(MarsReplicationControllerConfig):
             self.add_env('MARS_SPILL_DIRS', ':'.join(self._spill_volumes))
 
         if mount_shm:
-            self.add_volume(EmptyDirVolumeConfig('shm-volume', '/dev/shm', True))
+            vol_host_path = '/tmp' if sys.platform == 'darwin' else '/dev/shm'
+            vol_cfg = HostPathVolumeConfig('shm-volume', '/dev/shm', vol_host_path, 'Directory')
+            self.add_volume(vol_cfg)
+            self.add_env('MARS_MOUNT_HOST_SHM', '1')
         if worker_cache_mem:
             self.add_env('MARS_CACHE_MEM_SIZE', worker_cache_mem)
+        if min_cache_mem:
+            self.add_env('MARS_MIN_CACHE_MEM_SIZE', min_cache_mem)
 
     def config_readiness_probe(self):
         readiness_cmd = [

--- a/mars/deploy/kubernetes/tests/test_config.py
+++ b/mars/deploy/kubernetes/tests/test_config.py
@@ -62,7 +62,8 @@ class Test(unittest.TestCase):
         worker_config_dict = MarsWorkersConfig(
             4, cpu=2, memory=10 * 1024 ** 3, limit_resources=False,
             spill_volumes=['/tmp/spill_vol', EmptyDirVolumeConfig('empty-dir', '/tmp/empty')],
-            worker_cache_mem='20%', modules='mars.test_mod', mount_shm=True).build()
+            worker_cache_mem='20%', min_cache_mem='10%', modules='mars.test_mod',
+            mount_shm=True).build()
         self.assertEqual(worker_config_dict['metadata']['name'], 'marsworker')
         self.assertEqual(worker_config_dict['spec']['replicas'], 4)
 
@@ -81,7 +82,7 @@ class Test(unittest.TestCase):
         volume_list = worker_config_dict['spec']['template']['spec']['volumes']
         volume_envs = dict((v['name'], v) for v in volume_list)
         self.assertIn('empty-dir', volume_envs)
-        self.assertEqual(volume_envs['shm-volume']['emptyDir']['medium'], 'Memory')
+        self.assertEqual(volume_envs['shm-volume']['hostPath']['type'], 'Directory')
         self.assertEqual(volume_envs['host-path-vol-0']['hostPath']['path'], '/tmp/spill_vol')
 
         volume_mounts = dict((v['name'], v) for v in container_dict['volumeMounts'])

--- a/mars/resource.py
+++ b/mars/resource.py
@@ -63,6 +63,8 @@ if not _shm_path:
 else:
     _shm_path = _shm_path[0]
 
+_host_shm_mounted = bool(int(os.environ.get('MARS_MOUNT_HOST_SHM', '0')))
+
 
 def _read_cgroup_stat_file():
     with open(CGROUP_MEM_STAT_FILE, 'r') as cg_file:
@@ -88,8 +90,11 @@ def virtual_memory():
         total = cgroup_mem_info['hierarchical_memory_limit']
         used = cgroup_mem_info['rss'] + cgroup_mem_info.get('swap', 0)
         if _shm_path:
-            shm_stats = psutil.disk_usage(_shm_path)
-            used += shm_stats.used
+            if _host_shm_mounted:
+                used += cgroup_mem_info['cache']
+            else:
+                shm_stats = psutil.disk_usage(_shm_path)
+                used += shm_stats.used
         available = free = total - used
         percent = 100.0 * (total - available) / total
         return _virt_memory_stat(total, available, percent, used, free)

--- a/mars/worker/__main__.py
+++ b/mars/worker/__main__.py
@@ -49,6 +49,7 @@ class WorkerApplication(BaseApplication):
         parser.add_argument('--ignore-avail-mem', action='store_true', help='ignore available memory')
         parser.add_argument('--cache-mem', help='cache memory size limit')
         parser.add_argument('--min-mem', help='minimal free memory required to start worker')
+        parser.add_argument('--min-cache-mem', help='minimal cache memory required to start worker')
         parser.add_argument('--spill-dir', help='spill directory')
         parser.add_argument('--io-parallel-num', help='make file io lock free, add this when using a mounted dfs')
         parser.add_argument('--disable-proc-recover', action='store_true',
@@ -78,6 +79,7 @@ class WorkerApplication(BaseApplication):
         args.plasma_dir = args.plasma_dir or environ.get('MARS_PLASMA_DIRS')
         args.spill_dir = args.spill_dir or environ.get('MARS_SPILL_DIRS')
         args.cache_mem = args.cache_mem or environ.get('MARS_CACHE_MEM_SIZE')
+        args.min_cache_mem = args.min_cache_mem or environ.get('MARS_MIN_CACHE_MEM_SIZE')
         args.disable_proc_recover = args.disable_proc_recover \
             or bool(int(environ.get('MARS_DISABLE_PROC_RECOVER', '0')))
         args.write_shuffle_to_disk = args.write_shuffle_to_disk \
@@ -114,6 +116,7 @@ class WorkerApplication(BaseApplication):
             cache_mem_limit=self.args.cache_mem,
             ignore_avail_mem=self.args.ignore_avail_mem,
             min_mem_size=self.args.min_mem,
+            min_cache_mem_size=self.args.min_cache_mem,
             disk_compression=self.args.disk_compression.lower(),
             transfer_compression=self.args.transfer_compression.lower(),
             plasma_dir=self.args.plasma_dir,

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -155,8 +155,6 @@ class BaseCalcActor(WorkerActor):
         def _handle_load_fail(*exc):
             if self._remove_intermediate:
                 storage_client.delete(session_id, keys_to_fetch, [self._calc_intermediate_device])
-            self._release_local_quotas(session_id, keys_to_fetch)
-
             context_dict.clear()
             raise exc[1].with_traceback(exc[2])
 
@@ -297,7 +295,6 @@ class BaseCalcActor(WorkerActor):
 
             if keys_to_delete:
                 self.storage_client.delete(session_id, keys_to_delete, [self._calc_intermediate_device])
-            self._release_local_quotas(session_id, keys_to_release)
             logger.debug('Finish calculating operand %s.', graph_key)
 
         return self._fetch_keys_to_process(session_id, keys_to_fetch) \

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -513,8 +513,11 @@ class ExecutionActor(WorkerActor):
             no_prepare_chunk_keys=io_meta.get('no_prepare_chunk_keys') or set(),
         )
 
+        _, long_op_string = concat_operand_keys(graph_record.graph, decompose=True)
+        if long_op_string != graph_record.op_string:
+            long_op_string = graph_record.op_string + ':' + long_op_string
         logger.debug('Worker graph %s(%s) targeting at %r accepted.', graph_key,
-                     graph_record.op_string, graph_record.chunk_targets)
+                     long_op_string, graph_record.chunk_targets)
         self._update_state(session_id, graph_key, ExecutionState.ALLOCATING)
 
         try:

--- a/mars/worker/tests/test_calc.py
+++ b/mars/worker/tests/test_calc.py
@@ -151,12 +151,6 @@ class Test(WorkerCase):
             self.assertTrue(all((id(obj), type(obj)) not in id_type_set
                                 for obj in gc.get_objects()))
 
-            quota_dump = quota_ref.dump_data()
-            self.assertEqual(len(quota_dump.allocations), 0)
-            self.assertEqual(len(quota_dump.requests), 0)
-            self.assertEqual(len(quota_dump.proc_sizes), 0)
-            self.assertEqual(len(quota_dump.hold_sizes), 0)
-
             self.assertEqual(sorted(storage_client.get_data_locations(session_id, [fetch_chunks[0].key])[0]),
                              [(0, DataStorageDevice.SHARED_MEMORY)])
             self.assertEqual(sorted(storage_client.get_data_locations(session_id, [fetch_chunks[1].key])[0]),

--- a/mars/worker/tests/test_service.py
+++ b/mars/worker/tests/test_service.py
@@ -42,6 +42,9 @@ class Test(unittest.TestCase):
         with self.assertRaises(MemoryError):
             WorkerService(soft_mem_limit='128m', cache_mem_limit='256m')
 
+        with self.assertRaises(MemoryError):
+            WorkerService(min_cache_mem_size='1g', cache_mem_limit='256m')
+
         svc = WorkerService(ignore_avail_mem=True, spill_dirs='/tmp/a')
         self.assertListEqual(svc._spill_dirs, ['/tmp/a'])
 

--- a/mars/worker/utils.py
+++ b/mars/worker/utils.py
@@ -186,10 +186,21 @@ class ExpiringCache(dict):
         self.pop(item, None)
 
 
-def concat_operand_keys(graph, sep=','):
+def concat_operand_keys(graph, sep=',', decompose=False):
     from ..operands import Fetch
     graph_op_dict = OrderedDict()
-    for c in graph:
+
+    if not decompose:
+        chunk_iter = graph
+    else:
+        def _iter_composed():
+            for c in graph:
+                chunks = getattr(c, 'composed', None) or [c]
+                for chunk in chunks:
+                    yield chunk
+        chunk_iter = _iter_composed()
+
+    for c in chunk_iter:
         if isinstance(c.op, Fetch):
             continue
         if c.op.stage is None:


### PR DESCRIPTION
Backport of #1677 .