### PR TITLE
Fix wrong dtypes of DataFrame setitem chunks

### DIFF
--- a/mars/dataframe/indexing/setitem.py
+++ b/mars/dataframe/indexing/setitem.py
@@ -128,7 +128,7 @@ class DataFrameSetitem(DataFrameOperand, DataFrameOperandMixin):
                         value_chunk = value.cix[c.index[0], ]
                         chunk_inputs = [c, value_chunk]
 
-                    dtypes = c.dtypes
+                    dtypes = c.dtypes.copy(deep=True)
                     dtypes.loc[out.dtypes.index[-1]] = out.dtypes.iloc[-1]
                     chunk = chunk_op.new_chunk(chunk_inputs,
                                                shape=(c.shape[0], c.shape[1] + 1),

--- a/mars/dataframe/indexing/tests/test_indexing.py
+++ b/mars/dataframe/indexing/tests/test_indexing.py
@@ -650,6 +650,9 @@ class Test(TestBase):
         self.assertEqual(tiled.chunks[2].shape, (2, 3))
         pd.testing.assert_series_equal(tiled.inputs[0].dtypes, data.dtypes)
 
+        for c in tiled.chunks:
+            pd.testing.assert_series_equal(c.inputs[0].dtypes, data.dtypes)
+
     def testResetIndex(self):
         data = pd.DataFrame([('bird',    389.0),
                              ('bird',     24.0),


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Changes in #1623 only fixed tileable's dtypes, fix wrong dtypes of chunks in this PR.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1622.