### PR TITLE
[BACKPORT] Fix wrong dtypes of DataFrame setitem chunks (#1690)

### DIFF
--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 5, 3)
+version_info = (0, 5, 4)
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/dataframe/indexing/setitem.py
+++ b/mars/dataframe/indexing/setitem.py
@@ -128,7 +128,7 @@ class DataFrameSetitem(DataFrameOperand, DataFrameOperandMixin):
                         value_chunk = value.cix[c.index[0], ]
                         chunk_inputs = [c, value_chunk]
 
-                    dtypes = c.dtypes
+                    dtypes = c.dtypes.copy(deep=True)
                     dtypes.loc[out.dtypes.index[-1]] = out.dtypes.iloc[-1]
                     chunk = chunk_op.new_chunk(chunk_inputs,
                                                shape=(c.shape[0], c.shape[1] + 1),

--- a/mars/dataframe/indexing/tests/test_indexing.py
+++ b/mars/dataframe/indexing/tests/test_indexing.py
@@ -650,6 +650,9 @@ class Test(TestBase):
         self.assertEqual(tiled.chunks[2].shape, (2, 3))
         pd.testing.assert_series_equal(tiled.inputs[0].dtypes, data.dtypes)
 
+        for c in tiled.chunks:
+            pd.testing.assert_series_equal(c.inputs[0].dtypes, data.dtypes)
+
     def testResetIndex(self):
         data = pd.DataFrame([('bird',    389.0),
                              ('bird',     24.0),


### PR DESCRIPTION
Backport of #1690.