### PR TITLE
Fix the KeyError in `estimate_fuse_size`

### DIFF
--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -261,11 +261,13 @@ class Test(unittest.TestCase):
             self.assertTrue(np.isscalar(res))
             self.assertLess(res, 10)
 
-            t = mt.random.rand(10)
-            r = t.sum() * 4 - 1
+            raw = np.random.rand(10)
+            t = mt.tensor(raw)
+            r = (mt.linalg.norm(t) * 4 - 1).sum()
 
             res = r.to_numpy()
-            self.assertLess(res, 39)
+            expected = (np.linalg.norm(raw) * 4 - 1).sum()
+            np.testing.assert_array_almost_equal(res, expected)
 
     def testMultipleOutputTensorExecute(self, *_):
         with new_cluster(scheduler_n_process=2, worker_n_process=2,

--- a/mars/tensor/fuse/core.py
+++ b/mars/tensor/fuse/core.py
@@ -30,6 +30,7 @@ class TensorFuseChunk(TensorFuse, TensorFuseChunkMixin):
 def estimate_fuse_size(ctx, op):
     from ...graph import DAG
     from ...executor import Executor
+    from ...utils import build_fetch_chunk
 
     chunk = op.outputs[0]
     dag = DAG()
@@ -40,6 +41,7 @@ def estimate_fuse_size(ctx, op):
         for inp in c.inputs:
             if inp.key not in keys:
                 size_ctx[inp.key] = ctx[inp.key]
+                inp = build_fetch_chunk(inp).data
             if inp not in dag:
                 dag.add_node(inp)
             dag.add_edge(inp, c)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
It has been fixed in master in #1541, this PR picks the related commit(https://github.com/mars-project/mars/pull/1541/commits/66be75170184919935ca06ceed2c526d30553bda) to backport to branch v0.5.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1698.