### PR TITLE
Use ReductionCompiler to support function aggregation in `mars.dataframe.reduction`

### DIFF
--- a/docs/source/reference/dataframe/api/mars.dataframe.CustomReduction.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.CustomReduction.rst
@@ -1,0 +1,25 @@
+﻿mars.dataframe.CustomReduction
+==============================
+
+.. currentmodule:: mars.dataframe
+
+.. autoclass:: CustomReduction
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~CustomReduction.__init__
+      ~CustomReduction.agg
+      ~CustomReduction.post
+      ~CustomReduction.pre
+   
+   
+
+   
+   
+   

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.kurt.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.kurt.rst
@@ -1,0 +1,6 @@
+﻿mars.dataframe.DataFrame.kurt
+=============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.kurt

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.kurtosis.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.kurtosis.rst
@@ -1,0 +1,6 @@
+﻿mars.dataframe.DataFrame.kurtosis
+=================================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.kurtosis

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.rst
@@ -1,4 +1,4 @@
-mars.dataframe.DataFrame
+﻿mars.dataframe.DataFrame
 ========================
 
 .. currentmodule:: mars.dataframe
@@ -18,6 +18,8 @@ mars.dataframe.DataFrame
       ~DataFrame.add
       ~DataFrame.agg
       ~DataFrame.aggregate
+      ~DataFrame.all
+      ~DataFrame.any
       ~DataFrame.append
       ~DataFrame.apply
       ~DataFrame.astype
@@ -25,6 +27,8 @@ mars.dataframe.DataFrame
       ~DataFrame.copy
       ~DataFrame.copy_from
       ~DataFrame.copy_to
+      ~DataFrame.corr
+      ~DataFrame.corrwith
       ~DataFrame.count
       ~DataFrame.cummax
       ~DataFrame.cummin
@@ -51,11 +55,14 @@ mars.dataframe.DataFrame
       ~DataFrame.gt
       ~DataFrame.head
       ~DataFrame.insert
+      ~DataFrame.isin
       ~DataFrame.isna
       ~DataFrame.isnull
       ~DataFrame.iterrows
       ~DataFrame.itertuples
       ~DataFrame.join
+      ~DataFrame.kurt
+      ~DataFrame.kurtosis
       ~DataFrame.le
       ~DataFrame.lt
       ~DataFrame.map_chunk
@@ -94,8 +101,10 @@ mars.dataframe.DataFrame
       ~DataFrame.rsub
       ~DataFrame.rtruediv
       ~DataFrame.select_dtypes
+      ~DataFrame.sem
       ~DataFrame.set_index
       ~DataFrame.shift
+      ~DataFrame.skew
       ~DataFrame.sort_index
       ~DataFrame.sort_values
       ~DataFrame.stack
@@ -108,6 +117,7 @@ mars.dataframe.DataFrame
       ~DataFrame.to_csv
       ~DataFrame.to_gpu
       ~DataFrame.to_pandas
+      ~DataFrame.to_parquet
       ~DataFrame.to_sql
       ~DataFrame.to_tensor
       ~DataFrame.to_vineyard

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.sem.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.sem.rst
@@ -1,0 +1,6 @@
+﻿mars.dataframe.DataFrame.sem
+============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.sem

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.skew.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.skew.rst
@@ -1,0 +1,6 @@
+﻿mars.dataframe.DataFrame.skew
+=============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.skew

--- a/docs/source/reference/dataframe/api/mars.dataframe.Series.kurt.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.Series.kurt.rst
@@ -1,0 +1,6 @@
+﻿mars.dataframe.Series.kurt
+==========================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: Series.kurt

--- a/docs/source/reference/dataframe/api/mars.dataframe.Series.kurtosis.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.Series.kurtosis.rst
@@ -1,0 +1,6 @@
+﻿mars.dataframe.Series.kurtosis
+==============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: Series.kurtosis

--- a/docs/source/reference/dataframe/api/mars.dataframe.Series.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.Series.rst
@@ -18,13 +18,17 @@
       ~Series.add
       ~Series.agg
       ~Series.aggregate
+      ~Series.all
+      ~Series.any
       ~Series.append
       ~Series.apply
       ~Series.astype
+      ~Series.autocorr
       ~Series.bfill
       ~Series.copy
       ~Series.copy_from
       ~Series.copy_to
+      ~Series.corr
       ~Series.count
       ~Series.cummax
       ~Series.cummin
@@ -52,6 +56,8 @@
       ~Series.isin
       ~Series.isna
       ~Series.isnull
+      ~Series.kurt
+      ~Series.kurtosis
       ~Series.le
       ~Series.lt
       ~Series.map
@@ -87,7 +93,9 @@
       ~Series.rpow
       ~Series.rsub
       ~Series.rtruediv
+      ~Series.sem
       ~Series.shift
+      ~Series.skew
       ~Series.sort_index
       ~Series.sort_values
       ~Series.std

--- a/docs/source/reference/dataframe/api/mars.dataframe.Series.sem.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.Series.sem.rst
@@ -1,0 +1,6 @@
+﻿mars.dataframe.Series.sem
+=========================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: Series.sem

--- a/docs/source/reference/dataframe/api/mars.dataframe.Series.skew.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.Series.skew.rst
@@ -1,0 +1,6 @@
+﻿mars.dataframe.Series.skew
+==========================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: Series.skew

--- a/docs/source/reference/dataframe/frame.rst
+++ b/docs/source/reference/dataframe/frame.rst
@@ -120,6 +120,8 @@ Computations / descriptive stats
    DataFrame.cumprod
    DataFrame.cumsum
    DataFrame.describe
+   DataFrame.kurt
+   DataFrame.kurtosis
    DataFrame.max
    DataFrame.mean
    DataFrame.min
@@ -128,6 +130,8 @@ Computations / descriptive stats
    DataFrame.product
    DataFrame.quantile
    DataFrame.round
+   DataFrame.sem
+   DataFrame.skew
    DataFrame.std
    DataFrame.sum
    DataFrame.var

--- a/docs/source/reference/dataframe/general_functions.rst
+++ b/docs/source/reference/dataframe/general_functions.rst
@@ -39,4 +39,5 @@ Misc
 .. autosummary::
    :toctree: api/
 
+   CustomReduction
    ExecutableTuple

--- a/docs/source/reference/dataframe/series.rst
+++ b/docs/source/reference/dataframe/series.rst
@@ -112,6 +112,8 @@ Computations / descriptive stats
    Series.cumprod
    Series.cumsum
    Series.describe
+   Series.kurt
+   Series.kurtosis
    Series.max
    Series.mean
    Series.min
@@ -119,6 +121,8 @@ Computations / descriptive stats
    Series.product
    Series.quantile
    Series.round
+   Series.sem
+   Series.skew
    Series.std
    Series.sum
    Series.var

--- a/mars/core.py
+++ b/mars/core.py
@@ -93,8 +93,11 @@ class Base(HasKey):
             if (attr.startswith('__') and attr.endswith('__')) or attr in self._no_copy_attrs_:
                 # we don't copy id to identify that the copied one is new
                 continue
-            if hasattr(self, attr):
-                setattr(target, attr, getattr(self, attr))
+            try:
+                attr_val = getattr(self, attr)
+            except AttributeError:
+                continue
+            setattr(target, attr, attr_val)
 
         return target
 

--- a/mars/dataframe/__init__.py
+++ b/mars/dataframe/__init__.py
@@ -27,10 +27,10 @@ from .datasource.read_csv import read_csv
 from .datasource.read_sql import read_sql, read_sql_table, read_sql_query
 from .datasource.read_parquet import read_parquet
 from .datasource.date_range import date_range
-from .tseries.to_datetime import to_datetime
-from .merge import concat, merge
-from .reduction import unique
 from .fetch import DataFrameFetch, DataFrameFetchShuffle
+from .merge import concat, merge
+from .reduction import CustomReduction, unique
+from .tseries.to_datetime import to_datetime
 
 from . import arithmetic
 from . import base

--- a/mars/dataframe/arithmetic/__init__.py
+++ b/mars/dataframe/arithmetic/__init__.py
@@ -33,6 +33,7 @@ from .greater import gt, DataFrameGreater
 from .less_equal import le, DataFrameLessEqual
 from .greater_equal import ge, DataFrameGreaterEqual
 from .is_ufuncs import DataFrameIsNan, DataFrameIsInf, DataFrameIsFinite
+from .negative import DataFrameNegative, negative
 from .log import DataFrameLog
 from .log2 import DataFrameLog2
 from .log10 import DataFrameLog10
@@ -146,7 +147,7 @@ def _install():
         DataFrameCeil, DataFrameFloor, DataFrameAround,
         DataFrameExp, DataFrameExp2, DataFrameExpm1,
         DataFrameSqrt, DataFrameNot, DataFrameIsNan,
-        DataFrameIsInf, DataFrameIsFinite
+        DataFrameIsInf, DataFrameIsFinite, DataFrameNegative
     ]
     for unary_op in unary_ops:
         register_tensor_unary_ufunc(unary_op)
@@ -220,6 +221,8 @@ def _install():
 
         setattr(entity, '__xor__', wrap_notimplemented_exception(logical_xor))
         setattr(entity, '__rxor__', wrap_notimplemented_exception(logical_rxor))
+
+        setattr(entity, '__neg__', wrap_notimplemented_exception(negative))
 
     for entity in INDEX_TYPE:
         setattr(entity, '__eq__', _wrap_eq())

--- a/mars/dataframe/arithmetic/__init__.py
+++ b/mars/dataframe/arithmetic/__init__.py
@@ -32,6 +32,7 @@ from .less import lt, DataFrameLess
 from .greater import gt, DataFrameGreater
 from .less_equal import le, DataFrameLessEqual
 from .greater_equal import ge, DataFrameGreaterEqual
+from .is_ufuncs import DataFrameIsNan, DataFrameIsInf, DataFrameIsFinite
 from .log import DataFrameLog
 from .log2 import DataFrameLog2
 from .log10 import DataFrameLog10
@@ -144,7 +145,8 @@ def _install():
         DataFrameRadians, DataFrameDegrees,
         DataFrameCeil, DataFrameFloor, DataFrameAround,
         DataFrameExp, DataFrameExp2, DataFrameExpm1,
-        DataFrameSqrt, DataFrameNot,
+        DataFrameSqrt, DataFrameNot, DataFrameIsNan,
+        DataFrameIsInf, DataFrameIsFinite
     ]
     for unary_op in unary_ops:
         register_tensor_unary_ufunc(unary_op)

--- a/mars/dataframe/arithmetic/is_ufuncs.py
+++ b/mars/dataframe/arithmetic/is_ufuncs.py
@@ -1,0 +1,47 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameUnaryUfunc
+
+
+class DataFrameIsNan(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.ISNAN
+    _func_name = 'isnan'
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorIsNan
+        return TensorIsNan
+
+
+class DataFrameIsInf(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.ISINF
+    _func_name = 'isinf'
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorIsInf
+        return TensorIsInf
+
+
+class DataFrameIsFinite(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.ISFINITE
+    _func_name = 'isfinite'
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorIsFinite
+        return TensorIsFinite

--- a/mars/dataframe/arithmetic/negative.py
+++ b/mars/dataframe/arithmetic/negative.py
@@ -1,0 +1,32 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...utils import classproperty
+from .core import DataFrameUnaryUfunc
+
+
+class DataFrameNegative(DataFrameUnaryUfunc):
+    _op_type_ = OperandDef.NEGATIVE
+    _func_name = 'negative'
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorNegative
+        return TensorNegative
+
+
+def negative(df):
+    op = DataFrameNegative()
+    return op(df)

--- a/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
@@ -649,6 +649,14 @@ class TestUnary(TestBase):
         expected = ~data1
         pd.testing.assert_frame_equal(expected, result)
 
+    def testNegative(self):
+        data1 = pd.DataFrame(np.random.randint(low=0, high=100, size=(10, 10)))
+        df1 = from_pandas(data1, chunk_size=5)
+
+        result = self.executor.execute_dataframe(-df1, concat=True)[0]
+        expected = -data1
+        pd.testing.assert_frame_equal(expected, result)
+
     def testUfunc(self):
         df_raw = pd.DataFrame(np.random.uniform(size=(10, 10)),
                               index=pd.RangeIndex(9, -1, -1))
@@ -687,6 +695,7 @@ class TestUnary(TestBase):
             [np.isnan, mt.isnan],
             [np.isfinite, mt.isfinite],
             [np.isinf, mt.isinf],
+            [np.negative, mt.negative],
         ]
 
         for raw, data in [(df_raw, df), (series_raw, series)]:

--- a/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
@@ -683,7 +683,10 @@ class TestUnary(TestBase):
             [np.exp, mt.exp],
             [np.exp2, mt.exp2],
             [np.expm1, mt.expm1],
-            [np.sqrt, mt.sqrt]
+            [np.sqrt, mt.sqrt],
+            [np.isnan, mt.isnan],
+            [np.isfinite, mt.isfinite],
+            [np.isinf, mt.isinf],
         ]
 
         for raw, data in [(df_raw, df), (series_raw, series)]:

--- a/mars/dataframe/base/transform.py
+++ b/mars/dataframe/base/transform.py
@@ -198,7 +198,7 @@ class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
                         infer_df = test_df.agg(self._func, args=self.args, **self.kwds)
                     else:
                         infer_df = test_df.transform(self._func, convert_dtype=self.convert_dtype,
-                                                      args=self.args, **self.kwds)
+                                                     args=self.args, **self.kwds)
             except:  # noqa: E722
                 infer_df = None
 

--- a/mars/dataframe/reduction/__init__.py
+++ b/mars/dataframe/reduction/__init__.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .core import CustomReduction
+from .aggregation import DataFrameAggregate
+
 from .sum import DataFrameSum
 from .prod import DataFrameProd
 from .max import DataFrameMax
@@ -21,6 +24,11 @@ from .mean import DataFrameMean
 from .var import DataFrameVar
 from .all import DataFrameAll
 from .any import DataFrameAny
+from .skew import DataFrameSkew
+from .kurtosis import DataFrameKurtosis
+from .sem import DataFrameSem
+from .reduction_size import DataFrameSize
+from .custom_reduction import DataFrameCustomReduction
 
 from .cummax import DataFrameCummax
 from .cummin import DataFrameCummin
@@ -49,6 +57,11 @@ def _install():
     from .cumprod import cumprod
     from .cumsum import cumsum
     from .nunique import nunique_dataframe, nunique_series
+    from .sem import sem_dataframe, sem_series
+    from .skew import skew_dataframe, skew_series
+    from .kurtosis import kurt_dataframe, kurt_series
+    from .reduction_size import size_dataframe, size_series
+    from .custom_reduction import custom_reduction_dataframe, custom_reduction_series
 
     funcs = [
         ('sum', sum_series, sum_dataframe),
@@ -69,7 +82,13 @@ def _install():
         ('agg', aggregate, aggregate),
         ('aggregate', aggregate, aggregate),
         ('nunique', nunique_series, nunique_dataframe),
+        ('sem', sem_series, sem_dataframe),
+        ('skew', skew_series, skew_dataframe),
+        ('kurt', kurt_series, kurt_dataframe),
+        ('kurtosis', kurt_series, kurt_dataframe),
         ('unique', unique, None),
+        ('_reduction_size', size_dataframe, size_series),
+        ('_custom_reduction', custom_reduction_dataframe, custom_reduction_series),
     ]
     for func_name, series_func, df_func in funcs:
         if df_func is not None:  # pragma: no branch

--- a/mars/dataframe/reduction/aggregation.py
+++ b/mars/dataframe/reduction/aggregation.py
@@ -12,32 +12,106 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import namedtuple, OrderedDict
+import copy
+from collections import OrderedDict
 from collections.abc import Iterable
-from typing import Union, List, Dict
+from typing import List, Dict, Union
 
 import numpy as np
 import pandas as pd
 
-from ... import opcodes
+from ... import opcodes, tensor as mars_tensor
 from ...config import options
-from ...core import OutputType
+from ...core import OutputType, Base, Entity
+from ...custom_log import redirect_custom_log
 from ...operands import OperandStage
-from ...serialize import BoolField, AnyField, DictField
-from ...utils import tokenize, ceildiv, lazy_import
+from ...serialize import BoolField, AnyField, Int32Field, ListField
+from ...utils import ceildiv, lazy_import, enter_mode, enter_current_session
 from ..merge import DataFrameConcat
 from ..operands import DataFrameOperand, DataFrameOperandMixin
-from ..utils import build_df, build_series, parse_index, validate_axis
+from ..utils import build_df, build_empty_df, build_series, parse_index, validate_axis
+from .core import CustomReduction, ReductionCompiler, ReductionSteps, ReductionPreStep, \
+    ReductionAggStep, ReductionPostStep
 
 cp = lazy_import('cupy', globals=globals(), rename='cp')
 cudf = lazy_import('cudf', globals=globals())
 
-_builtin_aggregation_functions = {'sum', 'prod', 'min', 'max', 'count', 'size', 'mean', 'var', 'std',
-                                  'all', 'any'}
-_stage_info = namedtuple('_stage_info', ('map_groups', 'map_sources', 'combine_groups', 'combine_sources',
-                                         'agg_sources', 'agg_columns', 'agg_funcs', 'key_to_funcs',
-                                         'valid_columns'))
-_series_col_name = 'col_name'
+
+def where_function(cond, var1, var2):
+    if var1.ndim >= 1:
+        return var1.where(cond, var2)
+    else:
+        if isinstance(var1, (Base, Entity)):
+            return mars_tensor.where(cond, var1, var2)
+        else:
+            return np.where(cond, var1, var2).item()
+
+
+def mean_function(x, skipna=None):
+    return x.sum(skipna=skipna) / x.count()
+
+
+def var_function(x, skipna=None, ddof=1):
+    cnt = x.count()
+    if ddof == 0:
+        return (x ** 2).sum(skipna=skipna) / cnt - (x.sum(skipna=skipna) / cnt) ** 2
+    return ((x ** 2).sum(skipna=skipna) - x.sum(skipna=skipna) ** 2 / cnt) / (cnt - ddof)
+
+
+def sem_function(x, skipna=None, ddof=1):
+    var = var_function(x, skipna=skipna, ddof=ddof)
+    cnt = x.count()
+    return (var / cnt) ** 0.5
+
+
+def skew_function(x, skipna=None, bias=False):
+    cnt = x.count()
+    mean = x.sum(skipna=skipna) / cnt
+    divided = (x ** 3).sum(skipna=skipna) / cnt \
+        - 3 * (x ** 2).sum(skipna=skipna) / cnt * mean \
+        + 2 * mean ** 3
+    var = var_function(x, skipna=skipna, ddof=0)
+    val = where_function((var > 0) | np.isnan(var), divided / var ** 1.5, 0.0)
+    if not bias:
+        val = where_function((var > 0) & (cnt > 2), val * ((cnt * (cnt - 1)) ** 0.5 / (cnt - 2)), val)
+    return val
+
+
+def kurt_function(x, skipna=None, bias=False, fisher=True):
+    cnt = x.count()
+    mean = x.sum(skipna=skipna) / cnt
+    divided = (x ** 4).sum(skipna=skipna) / cnt \
+        - 4 * (x ** 3).sum(skipna=skipna) / cnt * mean \
+        + 6 * (x ** 2).sum(skipna=skipna) / cnt * mean ** 2 \
+        - 3 * mean ** 4
+    var = var_function(x, skipna=skipna, ddof=0)
+    val = where_function((var > 0) | np.isnan(var), divided / var ** 2, 0.0)
+    if not bias:
+        val = where_function((var > 0) & (cnt > 3),
+                             (val * (cnt ** 2 - 1) - 3 * (cnt - 1) ** 2) / (cnt - 2) / (cnt - 3), val)
+    if not fisher:
+        val += 3
+    return val
+
+
+_agg_functions = {
+    'sum': lambda x, skipna=None: x.sum(skipna=skipna),
+    'prod': lambda x, skipna=None: x.prod(skipna=skipna),
+    'product': lambda x, skipna=None: x.product(skipna=skipna),
+    'min': lambda x, skipna=None: x.min(skipna=skipna),
+    'max': lambda x, skipna=None: x.max(skipna=skipna),
+    'all': lambda x, skipna=None: x.all(skipna=skipna),
+    'any': lambda x, skipna=None: x.any(skipna=skipna),
+    'count': lambda x: x.count(),
+    'size': lambda x: x._reduction_size(),
+    'mean': mean_function,
+    'var': var_function,
+    'std': lambda x, skipna=None, ddof=1: var_function(x, skipna=skipna, ddof=ddof) ** 0.5,
+    'sem': sem_function,
+    'skew': skew_function,
+    'kurt': kurt_function,
+    'kurtosis': kurt_function,
+}
 
 
 class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
@@ -46,28 +120,25 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
     _func = AnyField('func')
     _raw_func = AnyField('raw_func')
     _axis = AnyField('axis')
+    _numeric_only = BoolField('numeric_only')
+    _bool_only = BoolField('bool_only')
     _use_inf_as_na = BoolField('use_inf_as_na')
 
-    _map_groups = DictField('map_groups')
-    _map_sources = DictField('map_sources')
-    _combine_groups = DictField('combine_groups')
-    _combine_sources = DictField('combine_sources')
-    _agg_sources = DictField('agg_sources')
-    _agg_columns = DictField('agg_columns')
-    _agg_funcs = DictField('agg_funcs')
-    _key_to_funcs = DictField('keys_to_funcs')
+    _combine_size = Int32Field('combine_size')
+    _pre_funcs = ListField('pre_funcs')
+    _agg_funcs = ListField('agg_funcs')
+    _post_funcs = ListField('post_funcs')
 
-    def __init__(self, func=None, raw_func=None, axis=None, use_inf_as_na=None, map_groups=None,
-                 map_sources=None, combine_groups=None, combine_sources=None, agg_sources=None,
-                 agg_columns=None, agg_funcs=None, key_to_funcs=None, output_types=None, stage=None, **kw):
+    def __init__(self, func=None, raw_func=None, axis=None, use_inf_as_na=None, numeric_only=None,
+                 bool_only=None, combine_size=None, pre_funcs=None, agg_funcs=None, post_funcs=None,
+                 output_types=None, stage=None, **kw):
         super().__init__(_func=func, _raw_func=raw_func, _axis=axis, _use_inf_as_na=use_inf_as_na,
-                         _map_groups=map_groups, _map_sources=map_sources, _combine_groups=combine_groups,
-                         _combine_sources=combine_sources, _agg_sources=agg_sources,
-                         _agg_columns=agg_columns, _agg_funcs=agg_funcs, _key_to_funcs=key_to_funcs,
-                         _stage=stage, _output_types=output_types, **kw)
+                         _numeric_only=numeric_only, _bool_only=bool_only, _combine_size=combine_size,
+                         _pre_funcs=pre_funcs, _agg_funcs=agg_funcs, _post_funcs=post_funcs, _stage=stage,
+                         _output_types=output_types, **kw)
 
     @property
-    def func(self):
+    def func(self) -> Union[List, Dict[str, List]]:
         return self._func
 
     @property
@@ -79,48 +150,59 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
         return self._axis
 
     @property
+    def numeric_only(self) -> bool:
+        return self._numeric_only
+
+    @property
+    def bool_only(self) -> bool:
+        return self._bool_only
+
+    @property
     def use_inf_as_na(self) -> int:
         return self._use_inf_as_na
 
     @property
-    def map_groups(self) -> Dict:
-        return self._map_groups
+    def combine_size(self) -> int:
+        return self._combine_size
 
     @property
-    def map_sources(self) -> Dict:
-        return self._map_sources
+    def pre_funcs(self) -> List[ReductionPreStep]:
+        return self._pre_funcs
 
     @property
-    def combine_groups(self) -> Dict:
-        return self._combine_groups
-
-    @property
-    def combine_sources(self) -> Dict:
-        return self._combine_sources
-
-    @property
-    def agg_sources(self) -> Dict:
-        return self._agg_sources
-
-    @property
-    def agg_columns(self) -> Dict:
-        return self._agg_columns
-
-    @property
-    def agg_funcs(self) -> Dict:
+    def agg_funcs(self) -> List[ReductionAggStep]:
         return self._agg_funcs
 
     @property
-    def key_to_funcs(self) -> Dict:
-        return self._key_to_funcs
+    def post_funcs(self) -> List[ReductionPostStep]:
+        return self._post_funcs
+
+    @staticmethod
+    def _filter_dtypes(op: "DataFrameAggregate", dtypes):
+        if not op.numeric_only and not op.bool_only:
+            return dtypes
+        empty_df = build_empty_df(dtypes)
+        return empty_df.select_dtypes([np.number, np.bool_] if op.numeric_only else [np.bool_]).dtypes
 
     def _calc_result_shape(self, df):
-        if self.output_types[0] == OutputType.dataframe:
-            test_obj = build_df(df, size=10)
-        else:
-            test_obj = build_series(df, size=10, name=df.name)
+        if df.ndim == 2:
+            if self._numeric_only:
+                df = df.select_dtypes([np.number, np.bool_])
+            elif self._bool_only:
+                df = df.select_dtypes([np.bool_])
 
-        result_df = test_obj.agg(self.func, axis=self.axis)
+        if self.output_types[0] == OutputType.dataframe:
+            test_obj = pd.concat([
+                build_df(df, size=2, fill_value=1),
+                build_df(df, size=2, fill_value=2),
+            ])
+        else:
+            test_obj = pd.concat([
+                build_series(df, size=2, fill_value=1, name=df.name),
+                build_series(df, size=2, fill_value=2, name=df.name),
+            ])
+
+        result_df = test_obj.agg(self.raw_func, axis=self.axis)
 
         if isinstance(result_df, pd.DataFrame):
             self.output_types = [OutputType.dataframe]
@@ -148,9 +230,24 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
         else:
             self._func = [self._func]
 
-    def __call__(self, df):
-        dtypes, index = self._calc_result_shape(df)
+        custom_idx = 0
+        if isinstance(self._func, list):
+            custom_iter = (f for f in self._func if isinstance(f, CustomReduction))
+        else:
+            custom_iter = (f for f in self._func.values() if isinstance(f, CustomReduction))
+        for r in custom_iter:
+            if r.name == '<custom>':
+                r.name = f'<custom_{custom_idx}>'
+                custom_idx += 1
+
+    def __call__(self, df, output_type=None, dtypes=None, index=None):
         self._normalize_funcs()
+        if output_type is None or dtypes is None:
+            with enter_mode(kernel=False, build=False):
+                dtypes, index = self._calc_result_shape(df)
+        else:
+            self.output_types = [output_type]
+
         if self.output_types[0] == OutputType.dataframe:
             if self.axis == 0:
                 new_shape = (len(index), len(dtypes))
@@ -161,14 +258,19 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
             return self.new_dataframe([df], shape=new_shape, dtypes=dtypes, index_value=new_index,
                                       columns_value=parse_index(dtypes.index, store_data=True))
         elif self.output_types[0] == OutputType.series:
-            if df.op.output_types[0] == OutputType.series:
+            if df.ndim == 1:
+                new_shape = (len(index),)
+                new_index = parse_index(index, store_data=True)
+            elif self.axis == 0:
                 new_shape = (len(index),)
                 new_index = parse_index(index, store_data=True)
             else:
-                new_shape = (df.shape[1 - self.axis],)
-                new_index = [df.columns_value, df.index_value][self.axis]
+                new_shape = (df.shape[0],)
+                new_index = df.index_value
             return self.new_series([df], shape=new_shape, dtype=dtypes[0], name=dtypes.index[0],
                                    index_value=new_index)
+        elif self.output_types[0] == OutputType.tensor:
+            return self.new_tileable([df], dtype=dtypes, shape=(np.nan,))
         else:
             return self.new_scalar([df], dtype=dtypes)
 
@@ -180,129 +282,52 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
             d[key].append(val)
 
     @classmethod
-    def _gen_chunk_stage_info(cls, op_func: Union[List, Dict], chunk_cols=None):
-        map_groups = OrderedDict()
-        map_sources = OrderedDict()
-        combine_groups = OrderedDict()
-        combine_sources = OrderedDict()
-        agg_sources = OrderedDict()
-        agg_columns = OrderedDict()
-        agg_funcs = OrderedDict()
-        key_to_funcs = OrderedDict()
-        valid_columns = []
-
-        def _clean_dict(d):
-            return OrderedDict((k, sorted(v) if v != [None] else None) for k, v in d.items())
-
-        def _fun_to_str(fun):
-            if isinstance(fun, str):
-                return fun
-            fun_str = tokenize(fun)
-            key_to_funcs[fun_str] = fun
-            return fun if isinstance(fun, str) else tokenize(fun)
-
-        def _add_column_to_functions(col, fun_name, mappers, combiners, aggregator):
-            sources = []
-            for mapper, combiner in zip(mappers, combiners):
-                mapper_str, combiner_str = _fun_to_str(mapper), _fun_to_str(combiner)
-                cls._safe_append(map_groups, mapper_str, col)
-                cls._safe_append(combine_groups, (mapper_str, combiner_str), col)
-                sources.append((mapper_str, combiner_str))
-
-            for mapper, combiner in zip(mappers, combiners):
-                if callable(combiner):
-                    combine_sources[(_fun_to_str(mapper), _fun_to_str(combiner))] = sources
-
-            agg_sources[fun_name] = sources
-            cls._safe_append(agg_columns, fun_name, col)
-            agg_funcs[fun_name] = _fun_to_str(aggregator)
-
-        chunk_cols = set(chunk_cols) if chunk_cols is not None else None
-        if isinstance(op_func, list):
-            op_func = {None: op_func}
-        for col, funcs in op_func.items():
-            if col is not None:
-                if chunk_cols is not None and col not in chunk_cols:
-                    continue
-                valid_columns.append(col)
-            for func in funcs:
-                if func in {'sum', 'prod', 'min', 'max', 'all', 'any'}:
-                    _add_column_to_functions(col, func, [func], [func], func)
-                elif func in {'count', 'size'}:
-                    _add_column_to_functions(col, func, [func], ['sum'], 'sum')
-                elif func == 'mean':
-                    def _mean(sum_data, count_data, axis=0):
-                        return sum_data.sum(axis=axis) / count_data.sum(axis=axis)
-
-                    _add_column_to_functions(col, func, ['sum', 'count'], ['sum', 'sum'], _mean)
-                elif func in {'var', 'std'}:
-                    def _reduce_var(sum_data, count_data, var_data, axis=0):
-                        reduced_cnt = count_data.sum(axis=axis)
-                        var_square = var_data * (count_data - 1)
-                        avg = sum_data.sum(axis=axis) / reduced_cnt
-                        avg_diff = (sum_data / count_data).subtract(avg, axis=1 - axis)
-                        var_square = var_square.sum(axis=axis) + (count_data * avg_diff ** 2).sum(axis=axis)
-                        return var_square / (reduced_cnt - 1)
-
-                    def _reduce_std(*args, **kwargs):
-                        return np.sqrt(_reduce_var(*args, **kwargs))
-
-                    _add_column_to_functions(col, func, ['sum', 'count', 'var'],
-                                             ['sum', 'sum', _reduce_var],
-                                             _reduce_var if func == 'var' else _reduce_std)
-                else:  # pragma: no cover
-                    raise NotImplementedError
-
-        return _stage_info(map_groups=_clean_dict(map_groups), map_sources=map_sources,
-                           combine_groups=_clean_dict(combine_groups), combine_sources=combine_sources,
-                           agg_sources=agg_sources, agg_columns=_clean_dict(agg_columns),
-                           agg_funcs=agg_funcs, key_to_funcs=key_to_funcs, valid_columns=valid_columns or None)
-
-    @classmethod
-    def _gen_map_chunks(cls, op, in_df, out_df, stage_infos: List[_stage_info],
+    def _gen_map_chunks(cls, op, in_df, out_df, func_infos: List[ReductionSteps],
                         input_index_to_output: Dict[int, int]):
         axis = op.axis
 
         if axis == 0:
-            agg_chunks_shape = (in_df.chunk_shape[0], len(stage_infos)) \
+            agg_chunks_shape = (in_df.chunk_shape[0], len(func_infos)) \
                                if len(in_df.chunk_shape) == 2 else (in_df.chunk_shape[0], 1)
         else:
-            agg_chunks_shape = (len(stage_infos), in_df.chunk_shape[1])
+            agg_chunks_shape = (len(func_infos), in_df.chunk_shape[1])
 
         agg_chunks = np.empty(agg_chunks_shape, dtype=np.object)
         for chunk in in_df.chunks:
             input_index = chunk.index[1 - axis] if len(chunk.index) > 1 else 0
             if input_index not in input_index_to_output:
                 continue
-            map_op = op.copy().reset_key()
+            map_op = op.copy().reset_key()  # type: "DataFrameAggregate"
             new_axis_index = input_index_to_output[input_index]
-            stage_info = stage_infos[new_axis_index]
+            func_info = func_infos[new_axis_index]
             # force as_index=True for map phase
-            map_op.output_types = [OutputType.dataframe]
+            map_op.output_types = [OutputType.dataframe] if chunk.ndim == 2 else [OutputType.series]
             map_op._stage = OperandStage.map
-            map_op._map_groups = stage_info.map_groups
-            map_op._map_sources = stage_info.map_sources
-            map_op._combine_groups = stage_info.combine_groups
-            map_op._key_to_funcs = stage_info.key_to_funcs
+            map_op._pre_funcs = func_info.pre_funcs
+            map_op._agg_funcs = func_info.agg_funcs
 
             if axis == 0:
                 new_index = (chunk.index[0], new_axis_index) if len(chunk.index) == 2 else (chunk.index[0], 0)
             else:
                 new_index = (new_axis_index, chunk.index[1])
 
-            if op.output_types[0] == OutputType.dataframe:
+            if map_op.output_types[0] == OutputType.dataframe:
                 if axis == 0:
-                    new_shape = (1, chunk.shape[1] if len(chunk.shape) > 1 else 1)
+                    shape = (1, out_df.shape[-1])
+                    if out_df.ndim == 2:
+                        columns_value = out_df.columns_value
+                        index_value = out_df.index_value
+                    else:
+                        columns_value = out_df.index_value
+                        index_value = parse_index(pd.Index([0]), out_df.key)
                 else:
-                    new_shape = (chunk.shape[1] if len(chunk.shape) > 1 else 1, 1)
-                agg_chunk = map_op.new_chunk(
-                    [chunk], shape=new_shape, index=new_index, index_value=chunk.index_value,
-                    columns_value=chunk.columns_value)
-            elif op.output_types[0] == OutputType.series:
-                agg_chunk = map_op.new_chunk([chunk], shape=(out_df.shape[0], 1), index=new_index,
-                                             index_value=out_df.index_value, name=out_df.name)
-            else:  # scalar target
-                agg_chunk = map_op.new_chunk([chunk], shape=(1, 1), index=new_index)
+                    shape = (out_df.shape[0], 1)
+                    columns_value = parse_index(pd.Index([0]), out_df.key, store_data=True)
+                    index_value = out_df.index_value
+                agg_chunk = map_op.new_chunk([chunk], shape=shape, index=new_index,
+                                             columns_value=columns_value, index_value=index_value)
+            else:
+                agg_chunk = map_op.new_chunk([chunk], shape=(1,), index=new_index)
             agg_chunks[agg_chunk.index] = agg_chunk
         return agg_chunks
 
@@ -319,12 +344,14 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
         elif op.output_types[0] == OutputType.series:
             chunk = chunk_op.new_chunk(in_df.chunks, index=(0,), shape=out_df.shape, dtype=out_df.dtype,
                                        index_value=out_df.index_value, name=out_df.name)
+        elif op.output_types[0] == OutputType.tensor:
+            chunk = chunk_op.new_chunk(in_df.chunks, index=(0,), dtype=out_df.dtype, shape=(np.nan,))
         else:
-            chunk = chunk_op.new_chunk(in_df.chunks, dtype=out_df.dtype, shape=())
+            chunk = chunk_op.new_chunk(in_df.chunks, dtype=out_df.dtype, index=(), shape=())
 
         tileable_op = op.copy().reset_key()
         kw = out_df.params.copy()
-        kw.update(dict(chunks=[chunk], nsplits=((x,) for x in out_df.shape)))
+        kw.update(dict(chunks=[chunk], nsplits=tuple((x,) for x in out_df.shape)))
         return tileable_op.new_tileables([in_df], **kw)
 
     @classmethod
@@ -344,32 +371,59 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
                                             shape=in_df.chunk_shape, dtype=out_df.dtype)
         return [tileable.sum()._inplace_tile()]
 
+    @staticmethod
+    def _add_functions(op: "DataFrameAggregate", compiler: ReductionCompiler,
+                       cols=None):
+        if isinstance(op.func, list):
+            func_iter = ((None, f) for f in op.func)
+            cols_set = set(cols) if cols is not None else None
+        else:
+            assert cols is not None
+            cols_set = set(cols) & set(op.func.keys())
+            if len(cols_set) == 0:
+                return False
+            func_iter = ((col, f) for col, funcs in op.func.items() for f in funcs)
+
+        for col, f in func_iter:
+            if cols_set is not None and col is not None and col not in cols_set:
+                continue
+            func_name = None
+            if isinstance(f, str):
+                f, func_name = _agg_functions[f], f
+            ndim = 1 if cols is None else 2
+            func_cols = [col] if col is not None else None
+            compiler.add_function(f, ndim, cols=func_cols, func_name=func_name)
+        return True
+
     @classmethod
     def _tile_tree(cls, op: "DataFrameAggregate"):
         in_df = op.inputs[0]
         out_df = op.outputs[0]
-        combine_size = options.combine_size
+        combine_size = op.combine_size
         axis = op.axis
 
         input_index_to_output = dict()
         output_index_to_input = []
-        axis_stage_infos = []
+        axis_func_infos = []
+        dtypes_list = []
         if len(in_df.chunk_shape) > 1:
             for col_idx in range(in_df.chunk_shape[1 - axis]):
+                compiler = ReductionCompiler(axis=op.axis)
                 idx_chunk = in_df.cix[0, col_idx] if axis == 0 else in_df.cix[col_idx, 0]
-                stage_info = cls._gen_chunk_stage_info(
-                    op.func, idx_chunk.dtypes.index if axis == 0 else None)
-                if not stage_info.map_groups:
+                new_dtypes = cls._filter_dtypes(op, idx_chunk.dtypes)
+                if not cls._add_functions(op, compiler, cols=list(new_dtypes.index)):
                     continue
-                input_index_to_output[col_idx] = len(axis_stage_infos)
+                input_index_to_output[col_idx] = len(axis_func_infos)
                 output_index_to_input.append(col_idx)
-                axis_stage_infos.append(stage_info)
+                axis_func_infos.append(compiler.compile())
+                dtypes_list.append(new_dtypes)
         else:
-            stage_info = cls._gen_chunk_stage_info(op.func, [_series_col_name])
+            compiler = ReductionCompiler(axis=op.axis)
+            cls._add_functions(op, compiler)
             input_index_to_output[0] = 0
-            axis_stage_infos.append(stage_info)
+            axis_func_infos.append(compiler.compile())
 
-        chunks = cls._gen_map_chunks(op, in_df, out_df, axis_stage_infos, input_index_to_output)
+        chunks = cls._gen_map_chunks(op, in_df, out_df, axis_func_infos, input_index_to_output)
         while chunks.shape[axis] > combine_size:
             if axis == 0:
                 new_chunks_shape = (ceildiv(chunks.shape[0], combine_size), chunks.shape[1])
@@ -379,13 +433,21 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
             new_chunks = np.empty(new_chunks_shape, dtype=np.object)
             for idx0, i in enumerate(range(0, chunks.shape[axis], combine_size)):
                 for idx1 in range(chunks.shape[1 - axis]):
-                    stage_info = axis_stage_infos[idx1]
+                    func_info = axis_func_infos[idx1]
                     if axis == 0:
                         chks = chunks[i: i + combine_size, idx1]
                         chunk_index = (idx0, idx1)
+                        if chks[0].ndim == 1:
+                            concat_shape = (len(chks),)
+                            agg_shape = (1,)
+                        else:
+                            concat_shape = (len(chks), chks[0].shape[1])
+                            agg_shape = (chks[0].shape[1], 1)
                     else:
                         chks = chunks[idx1, i: i + combine_size]
                         chunk_index = (idx1, idx0)
+                        concat_shape = (chks[0].shape[0], len(chks))
+                        agg_shape = (chks[0].shape[0], 1)
 
                     chks = chks.reshape((chks.shape[0],)).tolist()
                     if len(chks) == 1:
@@ -395,53 +457,57 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
                         # Change index for concatenate
                         for j, c in enumerate(chks):
                             c._index = (j, 0) if axis == 0 else (0, j)
-                        chk = concat_op.new_chunk(chks, dtypes=chks[0].dtypes)
+                        chk = concat_op.new_chunk(chks, dtypes=dtypes_list[idx1] if dtypes_list else None,
+                                                  shape=concat_shape, index_value=chks[0].index_value)
                     chunk_op = op.copy().reset_key()
                     chunk_op.output_types = [OutputType.dataframe]
                     chunk_op._stage = OperandStage.combine
-                    chunk_op._combine_groups = stage_info.combine_groups
-                    chunk_op._combine_sources = stage_info.combine_sources
-                    chunk_op._key_to_funcs = stage_info.key_to_funcs
+                    chunk_op._agg_funcs = func_info.agg_funcs
 
                     if axis == 0:
                         new_chunks[chunk_index] = chunk_op.new_chunk(
-                            [chk], index=chunk_index, shape=(np.nan, chks[0].shape[1]),
+                            [chk], index=chunk_index, shape=agg_shape,
                             index_value=chks[0].index_value)
                     else:
                         new_chunks[chunk_index] = chunk_op.new_chunk(
-                            [chk], index=chunk_index, shape=(chks[0].shape[0], np.nan),
+                            [chk], index=chunk_index, shape=agg_shape,
                             index_value=chks[0].columns_value)
             chunks = new_chunks
 
         agg_chunks = []
         for idx in range(chunks.shape[1 - axis]):
-            stage_info = axis_stage_infos[idx]
+            func_info = axis_func_infos[idx]
 
             concat_op = DataFrameConcat(output_types=[OutputType.dataframe], axis=axis)
             if axis == 0:
                 chks = chunks[:, idx]
+                if chks[0].ndim == 1:
+                    concat_shape = (len(chks),)
+                else:
+                    concat_shape = (len(chks), chks[0].shape[1])
             else:
                 chks = chunks[idx, :]
+                concat_shape = (chks[0].shape[0], len(chks))
             chks = chks.reshape((chks.shape[0],)).tolist()
-            chk = concat_op.new_chunk(chks, dtypes=chks[0].dtypes)
+            chk = concat_op.new_chunk(chks, dtypes=dtypes_list[idx] if dtypes_list else None,
+                                      shape=concat_shape, index_value=chks[0].index_value)
             chunk_op = op.copy().reset_key()
             chunk_op._stage = OperandStage.agg
-            chunk_op._combine_groups = stage_info.combine_groups
-            chunk_op._agg_columns = stage_info.agg_columns
-            chunk_op._agg_funcs = stage_info.agg_funcs
-            chunk_op._agg_sources = stage_info.agg_sources
-            chunk_op._key_to_funcs = stage_info.key_to_funcs
+            chunk_op._agg_funcs = func_info.agg_funcs
+            chunk_op._post_funcs = func_info.post_funcs
 
             kw = out_df.params.copy()
             if op.output_types[0] == OutputType.dataframe:
                 if axis == 0:
                     src_col_chunk = in_df.cix[0, output_index_to_input[idx]]
-                    if axis_stage_infos[idx].valid_columns is None:
+                    valid_cols = [c for pre in func_info.pre_funcs for c in pre.columns or ()]
+                    if not valid_cols:
                         columns_value = src_col_chunk.columns_value
                         shape_len = src_col_chunk.shape[1]
                     else:
-                        columns_value = parse_index(pd.Index(axis_stage_infos[idx].valid_columns), store_data=True)
-                        shape_len = len(axis_stage_infos[idx].valid_columns)
+                        col_index = pd.Index(valid_cols).unique()
+                        columns_value = parse_index(col_index, store_data=True)
+                        shape_len = len(col_index)
                     kw.update(dict(shape=(out_df.shape[0], shape_len), columns_value=columns_value,
                                    index=(0, idx), dtypes=out_df.dtypes[columns_value.to_pandas()]))
                 else:
@@ -451,16 +517,19 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
                                    dtypes=out_df.dtypes))
             else:
                 if op.output_types[0] == OutputType.series:
-                    if in_df.op.output_types[0] == OutputType.series:
+                    if in_df.ndim == 1:
                         index_value, shape = out_df.index_value, out_df.shape
                     elif axis == 0:
-                        src_chunk = in_df.cix[0, output_index_to_input[idx]]
-                        index_value, shape = src_chunk.columns_value, (src_chunk.shape[1],)
+                        out_dtypes = dtypes_list[idx]
+                        index_value = parse_index(out_dtypes.index, store_data=True)
+                        shape = (len(out_dtypes),)
                     else:
                         src_chunk = in_df.cix[output_index_to_input[idx], 0]
                         index_value, shape = src_chunk.index_value, (src_chunk.shape[0],)
                     kw.update(dict(name=out_df.name, dtype=out_df.dtype, index=(idx,),
                                    index_value=index_value, shape=shape))
+                elif op.output_types[0] == OutputType.tensor:
+                    kw.update(dict(index=(0,), shape=(np.nan,), dtype=out_df.dtype))
                 else:
                     kw.update(dict(index=(), shape=(), dtype=out_df.dtype))
             agg_chunks.append(chunk_op.new_chunk([chk], **kw))
@@ -478,6 +547,9 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
             nsplits = (tuple(c.shape[0] for c in agg_chunks),)
             return new_op.new_tileables(op.inputs, chunks=agg_chunks, nsplits=nsplits, dtype=out_df.dtype,
                                         shape=out_df.shape, index_value=out_df.index_value, name=out_df.name)
+        elif op.output_types[0] == OutputType.tensor:  # unique
+            return new_op.new_tileables(op.inputs, chunks=agg_chunks, dtype=out_df.dtype,
+                                        shape=out_df.shape, nsplits=((np.nan,),))
         else:  # scalar
             return new_op.new_tileables(op.inputs, chunks=agg_chunks, dtype=out_df.dtype,
                                         shape=(), nsplits=())
@@ -493,97 +565,160 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
         else:
             return cls._tile_tree(op)
 
-    @staticmethod
-    def _wrap_df(xdf, value, columns=None, transform=False):
-        if isinstance(value, (np.generic, int, float, complex)):
-            value = xdf.DataFrame([value], columns=columns)
+    @classmethod
+    def _wrap_df(cls, op, value, index=None):
+        xdf = cudf if op.gpu else pd
+        axis = op.axis
+        ndim = op.inputs[0].ndim
+
+        if ndim == 2:
+            if isinstance(value, (np.generic, int, float, complex)):
+                value = xdf.DataFrame([value], columns=index)
+            elif not isinstance(value, xdf.DataFrame):
+                value = xdf.DataFrame(value, columns=index)
+            else:
+                return value
+            return value.T if axis == 0 else value
         else:
-            value = xdf.DataFrame(value, columns=columns)
-        return value.T if transform else value
+            if isinstance(value, (np.generic, int, float, complex)):
+                value = xdf.Series([value], index=index)
+            elif isinstance(value, np.ndarray):
+                # assert value.ndim == 0
+                value = xdf.Series(value.tolist(), index=index)
+            return value
+
+    @staticmethod
+    def _pack_inputs(agg_funcs: List[ReductionAggStep], in_data):
+        pos = 0
+        out_dict = dict()
+        for step in agg_funcs:
+            if step.custom_reduction is None:
+                out_dict[step.output_key] = in_data[pos]
+            else:
+                out_dict[step.output_key] = tuple(in_data[pos:pos + step.output_limit])
+            pos += step.output_limit
+        return out_dict
 
     @classmethod
     def _execute_map(cls, ctx, op: "DataFrameAggregate"):
-        xdf = cudf if op.gpu else pd
         in_data = ctx[op.inputs[0].key]
         axis = op.axis
-        axis_index = op.outputs[0].index[axis]
+        axis_index = op.outputs[0].index[op.axis]
+
+        if in_data.ndim == 2:
+            if op.numeric_only:
+                in_data = in_data.select_dtypes([np.number, np.bool_])
+            elif op.bool_only:
+                in_data = in_data.select_dtypes([np.bool_])
 
         # map according to map groups
         ret_map_dfs = dict()
-        for map_func_str, cols in op.map_groups.items():
-            if cols is None:
-                src_df = in_data
+        for input_key, output_key, cols, func in op.pre_funcs:
+            src_df = in_data if cols is None else in_data[cols]
+            if input_key == output_key:
+                ret_map_dfs[output_key] = src_df
             else:
-                src_df = in_data[cols]
-            map_func = map_func_str if map_func_str != 'size' else (lambda x: x.size)
-            ret_map_dfs[map_func_str] = cls._wrap_df(xdf, src_df.agg(map_func, axis=axis),
-                                                     columns=[axis_index], transform=axis == 0)
+                ret_map_dfs[output_key] = func(src_df)
 
-        ret_combine_dfs = OrderedDict()
-        for func_strs, cols in op.combine_groups.items():
-            if cols is None:
-                ret_combine_dfs[func_strs] = ret_map_dfs[func_strs[0]]
+        agg_dfs = []
+        for input_key, map_func_name, _agg_func_name, custom_reduction, \
+                _output_key, _output_limit, kwds in op.agg_funcs:
+            input_obj = ret_map_dfs[input_key]
+            if map_func_name == 'custom_reduction':
+                pre_result = custom_reduction.pre(input_obj, **custom_reduction.kwds)
+                if not isinstance(pre_result, tuple):
+                    pre_result = (pre_result,)
+                agg_dfs.extend([cls._wrap_df(op, r, index=[axis_index]) for r in pre_result])
+            elif map_func_name == 'size':
+                agg_dfs.append(cls._wrap_df(op, input_obj.agg(lambda x: x.size, axis=axis),
+                                            index=[axis_index]))
             else:
-                ret_combine_dfs[func_strs] = ret_map_dfs[func_strs[0]][cols]
-        ctx[op.outputs[0].key] = tuple(ret_combine_dfs.values())
+                agg_dfs.append(cls._wrap_df(op, getattr(input_obj, map_func_name)(**kwds),
+                                            index=[axis_index]))
+        ctx[op.outputs[0].key] = tuple(agg_dfs)
 
     @classmethod
     def _execute_combine(cls, ctx, op: "DataFrameAggregate"):
-        xdf = cudf if op.gpu else pd
         in_data = ctx[op.inputs[0].key]
-        in_data_dict = dict(zip(op.combine_groups.keys(), in_data))
+        in_data_dict = cls._pack_inputs(op.agg_funcs, in_data)
         axis = op.axis
         axis_index = op.outputs[0].index[axis]
 
         combines = []
-        for fun_strs, df in zip(op.combine_groups.keys(), in_data):
-            if fun_strs[-1] in op.key_to_funcs:
-                func = op.key_to_funcs[fun_strs[-1]]
-                sources = [in_data_dict[fs] for fs in op.combine_sources[fun_strs]]
-                result = cls._wrap_df(xdf, func(*sources, axis=axis), columns=[axis_index],
-                                      transform=axis == 0)
+        for _input_key, _map_func_name, agg_func_name, custom_reduction, \
+                output_key, _output_limit, kwds in op.agg_funcs:
+            input_obj = in_data_dict[output_key]
+            if agg_func_name == 'custom_reduction':
+                agg_fun = custom_reduction.agg or custom_reduction.pre
+                pre_result = agg_fun(*input_obj, **custom_reduction.kwds)
+                if not isinstance(pre_result, tuple):
+                    pre_result = (pre_result,)
+                combines.extend([cls._wrap_df(op, r, index=[axis_index])
+                                 for r in pre_result])
             else:
-                result = cls._wrap_df(xdf, df.agg(fun_strs[-1], axis=axis), columns=[axis_index],
-                                      transform=axis == 0)
-            combines.append(result)
+                result = cls._wrap_df(op, getattr(input_obj, agg_func_name)(**kwds), index=[axis_index])
+                combines.append(result)
         ctx[op.outputs[0].key] = tuple(combines)
 
     @classmethod
     def _execute_agg(cls, ctx, op: "DataFrameAggregate"):
         xdf = cudf if op.gpu else pd
+        out = op.outputs[0]
         in_data = ctx[op.inputs[0].key]
-        in_data_dict = dict(zip(op.combine_groups.keys(), in_data))
+        in_data_dict = cls._pack_inputs(op.agg_funcs, in_data)
         axis = op.axis
 
+        for _input_key, _map_func_name, agg_func_name, custom_reduction, \
+                output_key, _output_limit, kwds in op.agg_funcs:
+            input_obj = in_data_dict[output_key]
+            if agg_func_name == 'custom_reduction':
+                pre_result = custom_reduction.agg(*input_obj, **custom_reduction.kwds)
+                if custom_reduction.post is None:
+                    in_data_dict[output_key] = pre_result
+                else:
+                    if not isinstance(pre_result, tuple):
+                        pre_result = (pre_result,)
+                    in_data_dict[output_key] = custom_reduction.post(*pre_result, **custom_reduction.kwds)
+            else:
+                in_data_dict[output_key] = getattr(input_obj, agg_func_name)(**kwds)
+
         aggs = []
-        for func_name, func_sources in op.agg_sources.items():
-            func_str = op.agg_funcs[func_name]
-            func_cols = op.agg_columns[func_name]
-            if func_cols is None:
-                func_inputs = [in_data_dict[src] for src in func_sources]
+        for input_keys, _output_key, func_name, cols, func in op.post_funcs:
+            if cols is None:
+                func_inputs = [in_data_dict[k] for k in input_keys]
             else:
-                func_inputs = [in_data_dict[src][func_cols] for src in func_sources]
+                func_inputs = [in_data_dict[k][cols] for k in input_keys]
 
-            if func_str in op.key_to_funcs:
-                func = op.key_to_funcs[func_str]
-                agg_series = func(*func_inputs, axis=axis)
-            else:
-                agg_series = func_inputs[0].agg(func_str, axis=axis)
+            agg_series = func(*func_inputs)
+            agg_series_ndim = getattr(agg_series, 'ndim', 0)
 
-            agg_series.name = func_name
-            aggs.append(cls._wrap_df(xdf, agg_series, transform=axis == 0))
+            ser_index = None
+            if agg_series_ndim == 0 and out.ndim == 1:
+                ser_index = [func_name]
+            elif agg_series_ndim == 1 and out.ndim == 2:
+                agg_series.name = func_name
+            aggs.append(cls._wrap_df(op, agg_series, index=ser_index))
 
-        concat_df = xdf.concat(aggs, axis=axis)
+        try:
+            concat_df = xdf.concat(aggs, axis=axis)
+        except TypeError:
+            raise
         if op.output_types[0] == OutputType.series:
-            if concat_df.shape[1] > 1:
-                concat_df = concat_df.iloc[0, :]
-            else:
-                concat_df = concat_df.iloc[:, 0]
+            if concat_df.ndim > 1:
+                if op.inputs[0].ndim == 2:
+                    if axis == 0:
+                        concat_df = concat_df.iloc[0, :]
+                    else:
+                        concat_df = concat_df.iloc[:, 0]
+                else:
+                    concat_df = concat_df.iloc[:, 0]
             concat_df.name = op.outputs[0].name
 
             concat_df = concat_df.astype(op.outputs[0].dtype, copy=False)
         elif op.output_types[0] == OutputType.scalar:
-            concat_df = concat_df.iloc[0, 0].astype(op.outputs[0].dtype)
+            concat_df = concat_df.iloc[0].astype(op.outputs[0].dtype)
+        elif op.output_types[0] == OutputType.tensor:
+            concat_df = concat_df.to_numpy(dtype=out.dtype)
         else:
             if axis == 0:
                 concat_df = concat_df.reindex(op.outputs[0].index_value.to_pandas())
@@ -594,6 +729,8 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
         ctx[op.outputs[0].key] = concat_df
 
     @classmethod
+    @redirect_custom_log
+    @enter_current_session
     def execute(cls, ctx, op: "DataFrameAggregate"):
         try:
             pd.set_option('mode.use_inf_as_na', op.use_inf_as_na)
@@ -608,12 +745,16 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
                 ctx[op.outputs[0].key] = xp.array(ctx[op.inputs[0].key].agg(op.raw_func, axis=op.axis)) \
                     .reshape(op.outputs[0].shape)
             else:
-                ctx[op.outputs[0].key] = ctx[op.inputs[0].key].agg(op.raw_func, axis=op.axis)
+                xp = cp if op.gpu else np
+                result = ctx[op.inputs[0].key].agg(op.raw_func, axis=op.axis)
+                if op.output_types[0] == OutputType.tensor:
+                    result = xp.array(result)
+                ctx[op.outputs[0].key] = result
         finally:
             pd.reset_option('mode.use_inf_as_na')
 
 
-def _is_funcs_agg(func):
+def _is_funcs_agg(func, ndim=2):
     to_check = []
     if isinstance(func, list):
         to_check.extend(func)
@@ -626,14 +767,25 @@ def _is_funcs_agg(func):
     else:
         to_check.append(func)
 
+    compiler = ReductionCompiler()
     for f in to_check:
-        if f not in _builtin_aggregation_functions:
+        if f in _agg_functions:
+            continue
+        elif callable(f):
+            try:
+                if ndim == 2:
+                    compiler.add_function(f, 2, cols=['A', 'B'])
+                else:
+                    compiler.add_function(f, 1)
+            except ValueError:
+                return False
+        else:
             return False
     return True
 
 
 def aggregate(df, func, axis=0, **kw):
-    if not _is_funcs_agg(func):
+    if not _is_funcs_agg(func, df.ndim):
         return df.transform(func, axis=axis, _call_agg=True)
 
     axis = validate_axis(axis, df)
@@ -641,6 +793,15 @@ def aggregate(df, func, axis=0, **kw):
     if (df.op.output_types[0] == OutputType.series or axis == 1) and isinstance(func, dict):
         raise NotImplementedError('Currently cannot aggregate dicts over axis=1 on %s'
                                   % type(df).__name__)
-    op = DataFrameAggregate(func=func, axis=axis, output_types=df.op.output_types,
+    combine_size = kw.get('combine_size') or options.combine_size
+    numeric_only = kw.get('numeric_only')
+    bool_only = kw.get('bool_only')
+
+    op = DataFrameAggregate(func=copy.deepcopy(func), axis=axis, output_types=df.op.output_types,
+                            combine_size=combine_size, numeric_only=numeric_only, bool_only=bool_only,
                             use_inf_as_na=use_inf_as_na)
-    return op(df)
+
+    output_type = kw.get('_output_type')
+    dtypes = kw.get('_dtypes')
+    index = kw.get('_index')
+    return op(df, output_type=output_type, dtypes=dtypes, index=index)

--- a/mars/dataframe/reduction/core.py
+++ b/mars/dataframe/reduction/core.py
@@ -180,7 +180,7 @@ class DataFrameReductionMixin(DataFrameOperandMixin):
         elif func_name == 'size':
             reduced_df = pd.Series(np.zeros(df.shape[1 - axis]), index=empty_df.columns if axis == 0 else None)
         elif func_name == 'custom_reduction':
-            reduced_df = getattr(self, 'custom_reduction').call_agg(empty_df)
+            reduced_df = getattr(self, 'custom_reduction').__call_agg__(empty_df)
         else:
             reduced_df = getattr(empty_df, func_name)(axis=axis, level=level, skipna=skipna,
                                                       numeric_only=numeric_only)
@@ -213,7 +213,7 @@ class DataFrameReductionMixin(DataFrameOperandMixin):
         elif func_name == 'size':
             reduced_series = empty_series.size
         elif func_name == 'custom_reduction':
-            reduced_series = getattr(self, 'custom_reduction').call_agg(empty_series)
+            reduced_series = getattr(self, 'custom_reduction').__call_agg__(empty_series)
         else:
             reduced_series = getattr(empty_series, func_name)(axis=axis, level=level, skipna=skipna,
                                                               numeric_only=numeric_only)
@@ -411,29 +411,16 @@ class DataFrameCumReductionMixin(DataFrameOperandMixin):
 
 
 class CustomReduction:
-    pre: Callable
-    agg: Union[Callable, None]
-    post: Union[Callable, None]
     name: Union[str, None]
     output_limit: Union[int, None]
     kwds: Dict
 
-    def __init__(self, pre, agg=None, post=None, name=None, output_limit=None,
-                 kwds=None, **kwargs):
-        self.pre = pre
-        self.agg = agg
-        self.post = post
+    # set to True when pre() already performs aggregation
+    pre_with_agg = False
+
+    def __init__(self, name=None):
         self.name = name or '<custom>'
-        self.output_limit = output_limit
-        kwargs.update(kwds or dict())
-        self.kwds = kwargs
-
-    def to_tuple(self):
-        return self.pre, self.agg, self.post, self.name, self.output_limit, self.kwds
-
-    @classmethod
-    def from_tuple(cls, tp):
-        return cls(*tp)
+        self.output_limit = 1
 
     @property
     def __name__(self):
@@ -442,24 +429,37 @@ class CustomReduction:
     def __call__(self, value):
         if is_build_mode():
             return value._custom_reduction(self)
-        return self.call_agg(value)
+        return self.__call_agg__(value)
 
-    def call_agg(self, value):
-        r = self.pre(value, **self.kwds)
+    def __call_agg__(self, value):
+        r = self.pre(value)
         if not isinstance(r, tuple):
             r = (r,)
+        # update output limit into actual size
         self.output_limit = len(r)
-        if self.post is not None:
-            r = self.post(*r, **self.kwds)
-        if isinstance(r, tuple):
-            if len(r) == 1:
-                r = r[0]
-            else:
-                raise ValueError('Need a post function to handle tuple output')
+
+        # only perform aggregation when pre() does not perform aggregation
+        if not self.pre_with_agg:
+            r = self.agg(*r)
+            if not isinstance(r, tuple):
+                r = (r,)
+
+        r = self.post(*r)
         return r
 
+    def pre(self, value):  # noqa: R0201  # pylint: disable=no-self-use
+        return value,
+
+    def agg(self, *values):  # noqa: R0201  # pylint: disable=no-self-use
+        raise NotImplementedError
+
+    def post(self, *value):  # noqa: R0201  # pylint: disable=no-self-use
+        assert len(value) == 1
+        return value[0]
+
     def __mars_tokenize__(self):
-        return [self.pre, self.agg, self.post, self.name, self.kwds]
+        import cloudpickle
+        return cloudpickle.dumps(self)
 
 
 class ReductionPreStep(NamedTuple):
@@ -493,17 +493,7 @@ class ReductionSteps(NamedTuple):
     post_funcs: List[ReductionPostStep]
 
 
-@functools.lru_cache(100)
-def _compile_expr_function(py_src):
-    from ... import tensor, dataframe
-    result_store = dict()
-    global_vars = globals()
-    global_vars.update(dict(mt=tensor, md=dataframe, array=np.array, nan=np.nan))
-    exec(py_src, globals(), result_store)  # noqa: W0122  # nosec  # pylint: disable=exec-used
-    fun = result_store['expr_function']
-    return fun
-
-
+# lookup table for numpy arithmetics in pandas
 _func_name_converts = dict(
     greater='gt',
     greater_equal='ge',
@@ -519,8 +509,10 @@ _func_compile_cache = dict()  # type: Dict[str, ReductionSteps]
 
 
 class ReductionCompiler:
-    def __init__(self, axis=0):
+    def __init__(self, axis=0, store_source=False):
         self._axis = axis
+        self._store_source = store_source
+
         self._key_to_tileable = dict()
         self._output_tileables = []
         self._lambda_counter = 0
@@ -542,13 +534,15 @@ class ReductionCompiler:
             return
 
         func_code = func.__code__
-        for var_name in func_code.co_names:
-            if isinstance(func.__globals__.get(var_name), (Base, Entity)):
-                raise ValueError(f'Global variable {var_name} used by {func.__name__} '
+        func_vars = {n: func.__globals__.get(n) for n in func_code.co_names}
+        if func.__closure__:
+            func_vars.update({n: cell.cell_contents for
+                              n, cell in zip(func_code.co_freevars, func.__closure__)})
+        # external Mars objects shall not be referenced
+        for var_name, val in func_vars.items():
+            if isinstance(val, (Base, Entity)):
+                raise ValueError(f'Variable {var_name} used by {func.__name__} '
                                  'cannot be a Mars object')
-        for cell in func.__closure__ or ():
-            if isinstance(cell.cell_contents, (Base, Entity)):
-                raise ValueError(f'Cannot reference Mars objects inside {func.__name__}')
 
     def add_function(self, func, ndim, cols=None, func_name=None):
         cols = cols if cols is not None and self._axis == 0 else None
@@ -582,6 +576,18 @@ class ReductionCompiler:
             self._output_key_to_post_steps[step.output_key] = step
             self._output_key_to_post_cols[step.output_key] = cols
 
+    @functools.lru_cache(100)
+    def _compile_expr_function(self, py_src):
+        from ... import tensor, dataframe
+        result_store = dict()
+        global_vars = globals()
+        global_vars.update(dict(mt=tensor, md=dataframe, array=np.array, nan=np.nan))
+        exec(py_src, global_vars, result_store)  # noqa: W0122  # nosec  # pylint: disable=exec-used
+        fun = result_store['expr_function']
+        if self._store_source:
+            fun.__source__ = py_src
+        return fun
+
     @enter_mode(build=True)
     def _compile_function(self, func, func_name=None, ndim=1) -> ReductionSteps:
         from . import DataFrameAll, DataFrameAny, DataFrameSum, DataFrameProd, \
@@ -599,7 +605,6 @@ class ReductionCompiler:
         if func_token in _func_compile_cache:
             return _func_compile_cache[func_token]
         custom_reduction = func if isinstance(func, CustomReduction) else None
-        output_limit = getattr(func, 'output_limit', None) or 1
 
         atomic_agg_op_types = (DataFrameAll, DataFrameAny, DataFrameSum, DataFrameProd,
                                DataFrameCount, DataFrameMin, DataFrameMax, DataFrameSize,
@@ -613,7 +618,11 @@ class ReductionCompiler:
             mock_obj = MarsDataFrame(mock_df)
 
         self._check_function_valid(func)
+
+        # calc target tileable to generate DAG
         func_ret = func(mock_obj)
+        output_limit = getattr(func, 'output_limit', None) or 1
+
         if not isinstance(func_ret, (Base, Entity)):
             raise ValueError(f'Custom function should return a Mars object, not {type(func_ret)}')
         if func_ret.ndim >= mock_obj.ndim:
@@ -621,31 +630,36 @@ class ReductionCompiler:
 
         agg_graph = func_ret.build_graph()
         agg_tileables = set(t for t in agg_graph if isinstance(t.op, atomic_agg_op_types))
+        # check operands before aggregation
         for t in agg_graph.dfs(list(agg_tileables), visit_predicate='all', reverse=True):
             if t not in agg_tileables and \
                     not isinstance(t.op, (DataFrameUnaryOp, DataFrameBinOp,
                                           TensorUnaryOp, TensorBinOp,
                                           TensorWhere, DataFrameWhere,
                                           DataFrameDataSource, SeriesDataSource)):
-                raise ValueError(f'Cannot support operand {type(t.op)} in custom aggregation')
+                raise ValueError(f'Cannot support operand {type(t.op)} in aggregation')
+        # check operands after aggregation
         for t in agg_graph.dfs(list(agg_tileables), visit_predicate='all'):
             if t not in agg_tileables and \
                     not isinstance(t.op, (DataFrameUnaryOp, DataFrameBinOp,
                                           TensorWhere, DataFrameWhere,
                                           TensorUnaryOp, TensorBinOp)):
-                raise ValueError(f'Cannot support operand {type(t.op)} in custom aggregation')
+                raise ValueError(f'Cannot support operand {type(t.op)} in aggregation')
 
         pre_funcs, agg_funcs, post_funcs = [], [], []
         visited_inputs = set()
+        # collect aggregations and their inputs
         for t in agg_tileables:
             agg_input_key = t.inputs[0].key
 
+            # collect agg names
             step_func_name = getattr(t.op, '_func_name')
             if step_func_name in ('count', 'size'):
                 map_func_name, agg_func_name = step_func_name, 'sum'
             else:
                 map_func_name, agg_func_name = step_func_name, step_func_name
 
+            # collect agg args
             func_args = dict(skipna=t.op.skipna)
             if t.inputs[0].ndim > 1:
                 func_args['axis'] = self._axis
@@ -654,10 +668,12 @@ class ReductionCompiler:
             if t.op.bool_only is not None:
                 func_args['bool_only'] = t.op.bool_only
 
+            # build agg description
             agg_funcs.append(ReductionAggStep(
                 agg_input_key, map_func_name, agg_func_name, custom_reduction, t.key, output_limit,
                 {k: v for k, v in func_args.items() if v is not None}
             ))
+            # collect agg input and build function
             if agg_input_key not in visited_inputs:
                 visited_inputs.add(agg_input_key)
                 initial_inputs = list(t.inputs[0].build_graph().iter_indep())
@@ -666,18 +682,22 @@ class ReductionCompiler:
 
                 func_str, _ = self._generate_function_str(t.inputs[0])
                 pre_funcs.append(ReductionPreStep(
-                    input_key, agg_input_key, None, _compile_expr_function(func_str)
+                    input_key, agg_input_key, None, self._compile_expr_function(func_str)
                 ))
+        # collect function output after agg
         func_str, input_keys = self._generate_function_str(func_ret)
         post_funcs.append(ReductionPostStep(
-            input_keys, func_ret.key, func_name, None, _compile_expr_function(func_str)
+            input_keys, func_ret.key, func_name, None, self._compile_expr_function(func_str)
         ))
-        if len(_func_compile_cache) > 100:
+        if len(_func_compile_cache) > 100:  # pragma: no cover
             _func_compile_cache.pop(next(iter(_func_compile_cache.keys())))
         result = _func_compile_cache[func_token] = ReductionSteps(pre_funcs, agg_funcs, post_funcs)
         return result
 
     def _generate_function_str(self, out_tileable):
+        """
+        Generate python code from tileable DAG
+        """
         from ...tensor.arithmetic.core import TensorBinOp, TensorUnaryOp
         from ...tensor.base import TensorWhere
         from ...tensor.datasource import Scalar
@@ -686,25 +706,52 @@ class ReductionCompiler:
         from ..datasource.series import SeriesDataSource
         from ..indexing.where import DataFrameWhere
 
-        input_key_to_arg = OrderedDict()
-        local_key_to_arg = dict()
+        input_key_to_var = OrderedDict()
+        local_key_to_var = dict()
+        ref_counts = dict()
+        ref_visited = set()
         local_lines = []
 
+        input_op_types = (DataFrameDataSource, SeriesDataSource, DataFrameReductionOperand)
+
+        def _calc_ref_counts(t):
+            # calculate object refcount for t, this reduces memory usage in functions
+            if t.key in ref_visited:
+                return
+            ref_visited.add(t.key)
+            for inp in t.inputs:
+                _calc_ref_counts(inp)
+
+                if not isinstance(inp.op, input_op_types):
+                    if inp.key not in ref_counts:
+                        ref_counts[inp.key] = 0
+                    ref_counts[inp.key] += 1
+
         def _gen_expr_str(t):
-            if t.key in local_key_to_arg:
+            # generate code for t
+            if t.key in local_key_to_var:
                 return
 
-            if isinstance(t.op, (DataFrameDataSource, SeriesDataSource, DataFrameReductionOperand)):
-                if t.key not in input_key_to_arg:
-                    input_key_to_arg[t.key] = local_key_to_arg[t.key] = f'invar{len(input_key_to_arg)}'
+            if isinstance(t.op, input_op_types):
+                # tileable is an input arg, build a function variable
+                if t.key not in input_key_to_var:  # pragma: no branch
+                    input_key_to_var[t.key] = local_key_to_var[t.key] = f'invar{len(input_key_to_var)}'
             else:
+                keys_to_del = []
                 for inp in t.inputs:
                     _gen_expr_str(inp)
 
-                var_name = local_key_to_arg[t.key] = f'var{len(local_key_to_arg)}'
-                keys_to_vars = {inp.key: local_key_to_arg[inp.key] for inp in t.inputs}
+                    if inp.key in ref_counts:
+                        ref_counts[inp.key] -= 1
+                        if ref_counts[inp.key] == 0:
+                            # the input is no longer referenced, a del statement will be produced
+                            keys_to_del.append(inp.key)
+
+                var_name = local_key_to_var[t.key] = f'var{len(local_key_to_var)}'
+                keys_to_vars = {inp.key: local_key_to_var[inp.key] for inp in t.inputs}
 
                 def _interpret_var(v):
+                    # get representation for variables
                     if hasattr(v, 'key'):
                         return keys_to_vars[v.key]
                     return v
@@ -712,11 +759,13 @@ class ReductionCompiler:
                 func_name = func_name_raw = getattr(t.op, '_func_name', None)
                 rfunc_name = getattr(t.op, '_rfunc_name', func_name)
 
+                # handle function name differences between numpy and pandas arithmetic ops
                 if func_name in _func_name_converts:
                     func_name = _func_name_converts[func_name]
                 if rfunc_name in _func_name_converts:
                     rfunc_name = 'r' + _func_name_converts[rfunc_name]
 
+                # build given different op types
                 if isinstance(t.op, (DataFrameUnaryOp, TensorUnaryOp)):
                     val = _interpret_var(t.inputs[0])
                     if isinstance(t.op, DataFrameUnaryUfunc):
@@ -742,36 +791,41 @@ class ReductionCompiler:
                         statements = [f'try:',
                                       f'    {var_name} = {rhs}.{rfunc_name}({lhs}, {axis_expr})',
                                       f'except AttributeError:',
-                                      f'    {var_name} = np.{func_name_raw}({lhs}, {rhs})']
+                                      f'    {var_name} = np.{func_name_raw}({rhs}, {lhs})']
                 elif isinstance(t.op, TensorWhere):
-                    inp = _interpret_var(t.op.condition)
+                    cond = _interpret_var(t.op.condition)
                     x = _interpret_var(t.op.x)
                     y = _interpret_var(t.op.y)
-                    statements = [f'{var_name} = np.where({inp}, {x}, {y})']
+                    statements = [f'{var_name} = np.where({cond}, {x}, {y})']
                 elif isinstance(t.op, DataFrameWhere):
                     func_name = 'mask' if t.op.replace_true else 'where'
                     inp = _interpret_var(t.op.input)
                     cond = _interpret_var(t.op.cond)
                     other = _interpret_var(t.op.other)
-                    op_axis = t.op.axis
-                    op_level = t.op.level
                     statements = [f'{var_name} = {inp}.{func_name}({cond}, {other}, '
-                                  f'axis={op_axis!r}, level={op_level!r})']
+                                  f'axis={t.op.axis!r}, level={t.op.level!r})']
                 elif isinstance(t.op, Scalar):
+                    # for scalar inputs of other operands
                     data = _interpret_var(t.op.data)
                     statements = [f'{var_name} = {data}']
-                else:
+                else:  # pragma: no cover
                     raise NotImplementedError(f'Does not support aggregating on {type(t.op)}')
+
+                # append del statements for used inputs
+                for key in keys_to_del:
+                    statements.append(f'del {local_key_to_var[key]}')
+
                 local_lines.extend(statements)
 
+        _calc_ref_counts(out_tileable)
         _gen_expr_str(out_tileable)
 
-        args_str = ', '.join(input_key_to_arg.values())
+        args_str = ', '.join(input_key_to_var.values())
         lines_str = '\n    '.join(local_lines)
         return f"def expr_function({args_str}):\n" \
                f"    {lines_str}\n" \
-               f"    return {local_key_to_arg[out_tileable.key]}", \
-            list(input_key_to_arg.keys())
+               f"    return {local_key_to_var[out_tileable.key]}", \
+            list(input_key_to_var.keys())
 
     def compile(self) -> ReductionSteps:
         pre_funcs, agg_funcs, post_funcs = [], [], []

--- a/mars/dataframe/reduction/custom_reduction.py
+++ b/mars/dataframe/reduction/custom_reduction.py
@@ -1,0 +1,48 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...config import options
+from ...core import OutputType
+from ...serialize import AnyField
+from .core import DataFrameReductionOperand, DataFrameReductionMixin, CustomReduction
+
+
+class DataFrameCustomReduction(DataFrameReductionOperand, DataFrameReductionMixin):
+    _op_type_ = OperandDef.CUSTOM_REDUCTION
+    _func_name = 'custom_reduction'
+
+    _custom_reduction = AnyField('custom_reduction', on_serialize=lambda x: x.to_tuple(),
+                                 on_deserialize=CustomReduction.from_tuple)
+
+    @property
+    def custom_reduction(self):
+        return self._custom_reduction
+
+    def __init__(self, custom_reduction=None, **kw):
+        super().__init__(_custom_reduction=custom_reduction, **kw)
+
+
+def custom_reduction_series(df, custom_reduction):
+    use_inf_as_na = options.dataframe.mode.use_inf_as_na
+    op = DataFrameCustomReduction(custom_reduction=custom_reduction, output_types=[OutputType.scalar],
+                                  use_inf_as_na=use_inf_as_na)
+    return op(df)
+
+
+def custom_reduction_dataframe(df, custom_reduction):
+    use_inf_as_na = options.dataframe.mode.use_inf_as_na
+    op = DataFrameCustomReduction(custom_reduction=custom_reduction, output_types=[OutputType.series],
+                                  use_inf_as_na=use_inf_as_na)
+    return op(df)

--- a/mars/dataframe/reduction/custom_reduction.py
+++ b/mars/dataframe/reduction/custom_reduction.py
@@ -16,15 +16,14 @@ from ... import opcodes as OperandDef
 from ...config import options
 from ...core import OutputType
 from ...serialize import AnyField
-from .core import DataFrameReductionOperand, DataFrameReductionMixin, CustomReduction
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 
 class DataFrameCustomReduction(DataFrameReductionOperand, DataFrameReductionMixin):
     _op_type_ = OperandDef.CUSTOM_REDUCTION
     _func_name = 'custom_reduction'
 
-    _custom_reduction = AnyField('custom_reduction', on_serialize=lambda x: x.to_tuple(),
-                                 on_deserialize=CustomReduction.from_tuple)
+    _custom_reduction = AnyField('custom_reduction')
 
     @property
     def custom_reduction(self):

--- a/mars/dataframe/reduction/kurtosis.py
+++ b/mars/dataframe/reduction/kurtosis.py
@@ -42,7 +42,7 @@ class DataFrameKurtosis(DataFrameReductionOperand, DataFrameReductionMixin):
     @classmethod
     def _make_agg_object(cls, op):
         from .aggregation import kurt_function
-        pf = functools.partial(kurt_function, bias=op.bias, skipna=op.skipna)
+        pf = functools.partial(kurt_function, bias=op.bias, skipna=op.skipna, fisher=op.fisher)
         pf.__name__ = cls._func_name
         return pf
 

--- a/mars/dataframe/reduction/kurtosis.py
+++ b/mars/dataframe/reduction/kurtosis.py
@@ -1,0 +1,64 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+from ... import opcodes
+from ...config import options
+from ...core import OutputType
+from ...serialize import BoolField
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
+
+
+class DataFrameKurtosis(DataFrameReductionOperand, DataFrameReductionMixin):
+    _op_type_ = opcodes.KURTOSIS
+    _func_name = 'kurt'
+
+    _bias = BoolField('bias')
+    _fisher = BoolField('fisher')
+
+    def __init__(self, bias=None, fisher=None, **kw):
+        super().__init__(_bias=bias, _fisher=fisher, **kw)
+
+    @property
+    def bias(self):
+        return self._bias
+
+    @property
+    def fisher(self):
+        return self._fisher
+
+    @classmethod
+    def _make_agg_object(cls, op):
+        from .aggregation import kurt_function
+        pf = functools.partial(kurt_function, bias=op.bias, skipna=op.skipna)
+        pf.__name__ = cls._func_name
+        return pf
+
+
+def kurt_series(df, axis=None, skipna=None, level=None, combine_size=None, bias=False, fisher=True):
+    use_inf_as_na = options.dataframe.mode.use_inf_as_na
+    op = DataFrameKurtosis(axis=axis, skipna=skipna, level=level, combine_size=combine_size,
+                           bias=bias, fisher=fisher, output_types=[OutputType.scalar],
+                           use_inf_as_na=use_inf_as_na)
+    return op(df)
+
+
+def kurt_dataframe(df, axis=None, skipna=None, level=None, numeric_only=None, combine_size=None,
+                   bias=False, fisher=True):
+    use_inf_as_na = options.dataframe.mode.use_inf_as_na
+    op = DataFrameKurtosis(axis=axis, skipna=skipna, level=level, numeric_only=numeric_only,
+                           bias=bias, fisher=fisher, combine_size=combine_size,
+                           output_types=[OutputType.series], use_inf_as_na=use_inf_as_na)
+    return op(df)

--- a/mars/dataframe/reduction/nunique.py
+++ b/mars/dataframe/reduction/nunique.py
@@ -24,10 +24,86 @@ from ...config import options
 from ...serialize import BoolField
 from ...utils import lazy_import
 from ..arrays import ArrowListArray, ArrowListDtype
-from .core import DataFrameReductionOperand, DataFrameReductionMixin
+from .core import DataFrameReductionOperand, DataFrameReductionMixin, CustomReduction
 
 
 cudf = lazy_import('cudf', globals=globals())
+
+
+def _drop_duplicates_to_arrow(v, explode=False):
+    if explode:
+        v = v.explode()
+    try:
+        return ArrowListArray([v.drop_duplicates().to_numpy()])
+    except pa.ArrowInvalid:
+        # fallback due to diverse dtypes
+        return [v.drop_duplicates().to_list()]
+
+
+def _nunique_pre_fun(in_data, axis=None, is_gpu=False, **kw):
+    xdf = cudf if is_gpu else pd
+    use_arrow_dtype = kw.get('use_arrow_dtype')
+    if isinstance(in_data, xdf.Series):
+        unique_values = in_data.drop_duplicates()
+        return xdf.Series(unique_values, name=in_data.name)
+    else:
+        if axis == 0:
+            data = dict()
+            for d, v in in_data.iteritems():
+                if not use_arrow_dtype or xdf is cudf:
+                    data[d] = [v.drop_duplicates().to_list()]
+                else:
+                    data[d] = _drop_duplicates_to_arrow(v)
+            df = xdf.DataFrame(data)
+        else:
+            df = xdf.DataFrame(columns=[0])
+            for d, v in in_data.iterrows():
+                if not use_arrow_dtype or xdf is cudf:
+                    df.loc[d] = [v.drop_duplicates().to_list()]
+                else:
+                    df.loc[d] = _drop_duplicates_to_arrow(v)
+        return df
+
+
+def _nunique_agg_fun(in_data, axis=None, is_gpu=False, **kw):
+    xdf = cudf if is_gpu else pd
+    use_arrow_dtype = kw.get('use_arrow_dtype')
+    if isinstance(in_data, xdf.Series):
+        unique_values = in_data.explode().drop_duplicates()
+        return xdf.Series(unique_values, name=in_data.name)
+    else:
+        if axis == 0:
+            data = dict()
+            for d, v in in_data.iteritems():
+                if not use_arrow_dtype or xdf is cudf:
+                    data[d] = [v.explode().drop_duplicates().to_list()]
+                else:
+                    v = pd.Series(v.to_numpy())
+                    data[d] = _drop_duplicates_to_arrow(v, explode=True)
+            df = xdf.DataFrame(data)
+        else:
+            df = xdf.DataFrame(columns=[0])
+            for d, v in in_data.iterrows():
+                if not use_arrow_dtype or xdf is cudf:
+                    df.loc[d] = [v.explode().drop_duplicates().to_list()]
+                else:
+                    df.loc[d] = _drop_duplicates_to_arrow(v, explode=True)
+        return df
+
+
+def _nunique_post_fun(in_data, axis=None, is_gpu=False, **kw):
+    xdf = cudf if is_gpu else pd
+    dropna = kw['dropna']
+    if isinstance(in_data, xdf.Series):
+        return in_data.explode().nunique(dropna=dropna)
+    else:
+        in_data_iter = in_data.iteritems() if axis == 0 else in_data.iterrows()
+        data = dict()
+        for d, v in in_data_iter:
+            if isinstance(v.dtype, ArrowListDtype):
+                v = xdf.Series(v.to_numpy())
+            data[d] = v.explode().nunique(dropna=dropna)
+        return xdf.Series(data)
 
 
 class DataFrameNunique(DataFrameReductionOperand, DataFrameReductionMixin):
@@ -50,101 +126,11 @@ class DataFrameNunique(DataFrameReductionOperand, DataFrameReductionMixin):
         return self._use_arrow_dtype
 
     @classmethod
-    def _if_use_arrow_dtype(cls, op):
-        use_arrow_dtype = op.use_arrow_dtype
-        if use_arrow_dtype is None:
-            # get options again,
-            # options may different when running
-            use_arrow_dtype = options.dataframe.use_arrow_dtype
-        return use_arrow_dtype
-
-    @classmethod
-    def _drop_duplicates_to_arrow(cls, v, explode=False):
-        if explode:
-            v = v.explode()
-        try:
-            return ArrowListArray([v.drop_duplicates().to_numpy()])
-        except pa.ArrowInvalid:
-            # fallback due to diverse dtypes
-            return [v.drop_duplicates().to_list()]
-
-    @classmethod
-    def _execute_map(cls, ctx, op: "DataFrameNunique"):
-        use_arrow_dtype = cls._if_use_arrow_dtype(op)
-
-        xdf = cudf if op.gpu else pd
-        in_data = ctx[op.inputs[0].key]
-        if isinstance(in_data, xdf.Series) or op.output_types[0] == OutputType.series:
-            unique_values = in_data.drop_duplicates()
-            ctx[op.outputs[0].key] = xdf.Series(unique_values, name=in_data.name)
-        else:
-            if op.axis == 0:
-                data = dict()
-                for d, v in in_data.iteritems():
-                    if not use_arrow_dtype or xdf is cudf:
-                        data[d] = [v.drop_duplicates().to_list()]
-                    else:
-                        data[d] = cls._drop_duplicates_to_arrow(v)
-                df = xdf.DataFrame(data)
-            else:
-                df = xdf.DataFrame(columns=[0])
-                for d, v in in_data.iterrows():
-                    if not use_arrow_dtype or xdf is cudf:
-                        df.loc[d] = [v.drop_duplicates().to_list()]
-                    else:
-                        df.loc[d] = cls._drop_duplicates_to_arrow(v)
-            ctx[op.outputs[0].key] = df
-
-    @classmethod
-    def _execute_combine(cls, ctx, op):
-        use_arrow_dtype = cls._if_use_arrow_dtype(op)
-
-        xdf = cudf if op.gpu else pd
-        in_data = ctx[op.inputs[0].key]
-        if isinstance(in_data, xdf.Series):
-            unique_values = in_data.explode().drop_duplicates()
-            ctx[op.outputs[0].key] = xdf.Series(unique_values, name=in_data.name)
-        else:
-            if op.axis == 0:
-                data = dict()
-                for d, v in in_data.iteritems():
-                    if not use_arrow_dtype or xdf is cudf:
-                        data[d] = [v.explode().drop_duplicates().to_list()]
-                    else:
-                        v = pd.Series(v.to_numpy())
-                        data[d] = cls._drop_duplicates_to_arrow(v, explode=True)
-                df = xdf.DataFrame(data)
-            else:
-                df = xdf.DataFrame(columns=[0])
-                for d, v in in_data.iterrows():
-                    if not use_arrow_dtype or xdf is cudf:
-                        df.loc[d] = [v.explode().drop_duplicates().to_list()]
-                    else:
-                        df.loc[d] = cls._drop_duplicates_to_arrow(v, explode=True)
-            ctx[op.outputs[0].key] = df
-
-    @classmethod
-    def _execute_agg(cls, ctx, op):
-        xdf = cudf if op.gpu else pd
-        in_data = ctx[op.inputs[0].key]
-        dropna = op.dropna
-        if isinstance(in_data, xdf.Series):
-            ctx[op.outputs[0].key] = in_data.explode().nunique(dropna=dropna)
-        else:
-            in_data_iter = in_data.iteritems() if op.axis == 0 else in_data.iterrows()
-            data = dict()
-            for d, v in in_data_iter:
-                if isinstance(v.dtype, ArrowListDtype):
-                    v = xdf.Series(v.to_numpy())
-                data[d] = v.explode().nunique(dropna=dropna)
-            ctx[op.outputs[0].key] = xdf.Series(data)
-
-    @classmethod
-    def _execute_reduction(cls, in_data, op, min_count=None, reduction_func=None):
-        kwargs = dict()
-        if op.axis is not None:
-            kwargs['axis'] = op.axis
-        return in_data.nunique(dropna=op.dropna, **kwargs)
+    def _make_agg_object(cls, op):
+        return CustomReduction(_nunique_pre_fun, _nunique_agg_fun, _nunique_post_fun,
+                               name=cls._func_name, output_limit=1, axis=op.axis,
+                               dropna=op.dropna, use_arrow_dtype=op.use_arrow_dtype,
+                               output_type=op.output_types[0], is_gpu=op.gpu)
 
 
 def nunique_dataframe(df, axis=0, dropna=True, combine_size=None):

--- a/mars/dataframe/reduction/prod.py
+++ b/mars/dataframe/reduction/prod.py
@@ -12,15 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ... import opcodes as OperandDef
+import functools
+
+import numpy as np
+
+from ... import opcodes
 from ...config import options
 from ...core import OutputType
+from .aggregation import where_function
 from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 
+def _prod_with_count(value, skipna=True, min_count=0):
+    if min_count == 0:
+        return value.prod(skipna=skipna)
+    else:
+        return where_function(value.count() >= min_count, value.prod(skipna=skipna), np.nan)
+
+
 class DataFrameProd(DataFrameReductionOperand, DataFrameReductionMixin):
-    _op_type_ = OperandDef.PROD
+    _op_type_ = opcodes.PROD
     _func_name = 'prod'
+
+    @classmethod
+    def _make_agg_object(cls, op):
+        fn = functools.partial(_prod_with_count, skipna=op.skipna, min_count=op.min_count)
+        fn.__name__ = cls._func_name
+        return fn
 
 
 def prod_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):

--- a/mars/dataframe/reduction/reduction_size.py
+++ b/mars/dataframe/reduction/reduction_size.py
@@ -1,0 +1,32 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes as OperandDef
+from ...core import OutputType
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
+
+
+class DataFrameSize(DataFrameReductionOperand, DataFrameReductionMixin):
+    _op_type_ = OperandDef.REDUCTION_SIZE
+    _func_name = 'size'
+
+
+def size_series(df):
+    op = DataFrameSize(output_types=[OutputType.scalar])
+    return op(df)
+
+
+def size_dataframe(df):
+    op = DataFrameSize(output_types=[OutputType.series])
+    return op(df)

--- a/mars/dataframe/reduction/sem.py
+++ b/mars/dataframe/reduction/sem.py
@@ -21,9 +21,9 @@ from ...serialize import Int32Field
 from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 
-class DataFrameVar(DataFrameReductionOperand, DataFrameReductionMixin):
-    _op_type_ = OperandDef.VAR
-    _func_name = 'var'
+class DataFrameSem(DataFrameReductionOperand, DataFrameReductionMixin):
+    _op_type_ = OperandDef.SEM
+    _func_name = 'sem'
 
     _ddof = Int32Field('ddof')
 
@@ -36,23 +36,23 @@ class DataFrameVar(DataFrameReductionOperand, DataFrameReductionMixin):
 
     @classmethod
     def _make_agg_object(cls, op):
-        from .aggregation import var_function
-        pf = functools.partial(var_function, ddof=op.ddof, skipna=op.skipna)
+        from .aggregation import sem_function
+        pf = functools.partial(sem_function, ddof=op.ddof, skipna=op.skipna)
         pf.__name__ = cls._func_name
         return pf
 
 
-def var_series(series, axis=None, skipna=None, level=None, ddof=1, combine_size=None):
+def sem_series(series, axis=None, skipna=None, level=None, ddof=1, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
-    op = DataFrameVar(axis=axis, skipna=skipna, level=level, ddof=ddof,
+    op = DataFrameSem(axis=axis, skipna=skipna, level=level, ddof=ddof,
                       combine_size=combine_size, output_types=[OutputType.scalar],
                       use_inf_as_na=use_inf_as_na)
     return op(series)
 
 
-def var_dataframe(df, axis=None, skipna=None, level=None, ddof=1, numeric_only=None, combine_size=None):
+def sem_dataframe(df, axis=None, skipna=None, level=None, ddof=1, numeric_only=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
-    op = DataFrameVar(axis=axis, skipna=skipna, level=level, ddof=ddof,
+    op = DataFrameSem(axis=axis, skipna=skipna, level=level, ddof=ddof,
                       numeric_only=numeric_only, combine_size=combine_size,
                       output_types=[OutputType.series], use_inf_as_na=use_inf_as_na)
     return op(df)

--- a/mars/dataframe/reduction/skew.py
+++ b/mars/dataframe/reduction/skew.py
@@ -1,0 +1,58 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+from ... import opcodes
+from ...config import options
+from ...core import OutputType
+from ...serialize import BoolField
+from .core import DataFrameReductionOperand, DataFrameReductionMixin
+
+
+class DataFrameSkew(DataFrameReductionOperand, DataFrameReductionMixin):
+    _op_type_ = opcodes.SKEW
+    _func_name = 'skew'
+
+    _bias = BoolField('bias')
+
+    def __init__(self, bias=None, **kw):
+        super().__init__(_bias=bias, **kw)
+
+    @property
+    def bias(self):
+        return self._bias
+
+    @classmethod
+    def _make_agg_object(cls, op):
+        from .aggregation import skew_function
+        pf = functools.partial(skew_function, bias=op.bias, skipna=op.skipna)
+        pf.__name__ = cls._func_name
+        return pf
+
+
+def skew_series(df, axis=None, skipna=None, level=None, combine_size=None, bias=False):
+    use_inf_as_na = options.dataframe.mode.use_inf_as_na
+    op = DataFrameSkew(axis=axis, skipna=skipna, level=level, combine_size=combine_size,
+                       bias=bias, output_types=[OutputType.scalar], use_inf_as_na=use_inf_as_na)
+    return op(df)
+
+
+def skew_dataframe(df, axis=None, skipna=None, level=None, numeric_only=None, combine_size=None,
+                   bias=False):
+    use_inf_as_na = options.dataframe.mode.use_inf_as_na
+    op = DataFrameSkew(axis=axis, skipna=skipna, level=level, numeric_only=numeric_only,
+                       bias=bias, combine_size=combine_size, output_types=[OutputType.series],
+                       use_inf_as_na=use_inf_as_na)
+    return op(df)

--- a/mars/dataframe/reduction/sum.py
+++ b/mars/dataframe/reduction/sum.py
@@ -12,15 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ... import opcodes as OperandDef
+import functools
+
+import numpy as np
+
+from ... import opcodes
 from ...config import options
 from ...core import OutputType
+from .aggregation import where_function
 from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 
+def _sum_with_count(value, skipna=True, min_count=0):
+    if min_count == 0:
+        return value.sum(skipna=skipna)
+    else:
+        return where_function(value.count() >= min_count, value.sum(skipna=skipna), np.nan)
+
+
 class DataFrameSum(DataFrameReductionOperand, DataFrameReductionMixin):
-    _op_type_ = OperandDef.SUM
+    _op_type_ = opcodes.SUM
     _func_name = 'sum'
+
+    @classmethod
+    def _make_agg_object(cls, op):
+        fn = functools.partial(_sum_with_count, skipna=op.skipna, min_count=op.min_count)
+        fn.__name__ = cls._func_name
+        return fn
 
 
 def sum_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -26,7 +26,8 @@ from mars.tensor import Tensor
 from mars.dataframe.core import DataFrame, IndexValue, Series, OutputType
 from mars.dataframe.reduction import DataFrameSum, DataFrameProd, DataFrameMin, \
     DataFrameMax, DataFrameCount, DataFrameMean, DataFrameVar, DataFrameAll, \
-    DataFrameAny, DataFrameCummin, DataFrameCummax, DataFrameCumprod, \
+    DataFrameAny, DataFrameSkew, DataFrameKurtosis, DataFrameSem, \
+    DataFrameAggregate, DataFrameCummin, DataFrameCummax, DataFrameCumprod, \
     DataFrameCumsum, DataFrameNunique
 from mars.dataframe.merge import DataFrameConcat
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
@@ -41,12 +42,15 @@ reduction_functions = dict(
     count=dict(func_name='count', op=DataFrameCount, has_skipna=False),
     mean=dict(func_name='mean', op=DataFrameMean),
     var=dict(func_name='var', op=DataFrameVar),
-    all=dict(func_name='all', op=DataFrameAll, has_numeric_only=False),
-    any=dict(func_name='any', op=DataFrameAny, has_numeric_only=False),
+    skew=dict(func_name='skew', op=DataFrameSkew),
+    kurt=dict(func_name='kurt', op=DataFrameKurtosis),
+    sem=dict(func_name='sem', op=DataFrameSem),
+    all=dict(func_name='all', op=DataFrameAll, has_numeric_only=False, has_bool_only=True),
+    any=dict(func_name='any', op=DataFrameAny, has_numeric_only=False, has_bool_only=True),
 )
 
 
-@parameterized(defaults=dict(has_skipna=True, has_numeric_only=True),
+@parameterized(defaults=dict(has_skipna=True, has_numeric_only=True, has_bool_only=False),
                **reduction_functions)
 class TestReduction(TestBase):
     @property
@@ -59,7 +63,7 @@ class TestReduction(TestBase):
             kwargs = dict(axis='index', skipna=False)
         else:
             kwargs = dict()
-        reduction_df = getattr(from_pandas_series(data), self.func_name)(**kwargs).tiles()
+        reduction_df = getattr(from_pandas_series(data, chunk_size=3), self.func_name)(**kwargs).tiles()
 
         # pb
         chunk = reduction_df.chunks[0]
@@ -69,14 +73,15 @@ class TestReduction(TestBase):
         self.assertEqual(tuple(pb.index), chunk.index)
         self.assertEqual(pb.key, chunk.key)
         self.assertEqual(tuple(pb.shape), chunk.shape)
-        self.assertEqual(int(op.type.split('.', 1)[1]), self.op_name)
+        self.assertEqual(int(op.type.split('.', 1)[1]), DataFrameAggregate._op_type_)
 
         chunk2 = self._pb_deserial(serials)[chunk.data]
 
         self.assertEqual(chunk.index, chunk2.index)
         self.assertEqual(chunk.key, chunk2.key)
         self.assertEqual(chunk.shape, chunk2.shape)
-        self.assertEqual(chunk.op.skipna, chunk2.op.skipna)
+        self.assertEqual(chunk.op.agg_funcs[0].kwds.get('skipna'),
+                         chunk2.op.agg_funcs[0].kwds.get('skipna'))
         self.assertEqual(chunk.op.axis, chunk2.op.axis)
 
         # json
@@ -88,7 +93,8 @@ class TestReduction(TestBase):
         self.assertEqual(chunk.index, chunk2.index)
         self.assertEqual(chunk.key, chunk2.key)
         self.assertEqual(chunk.shape, chunk2.shape)
-        self.assertEqual(chunk.op.skipna, chunk2.op.skipna)
+        self.assertEqual(chunk.op.agg_funcs[0].kwds.get('skipna'),
+                         chunk2.op.agg_funcs[0].kwds.get('skipna'))
         self.assertEqual(chunk.op.axis, chunk2.op.axis)
 
     def testSeriesReduction(self):
@@ -96,12 +102,13 @@ class TestReduction(TestBase):
         series = getattr(from_pandas_series(data, chunk_size=3), self.func_name)()
 
         self.assertIsInstance(series, Tensor)
+        self.assertIsInstance(series.op, self.op)
         self.assertEqual(series.shape, ())
 
         series = series.tiles()
 
         self.assertEqual(len(series.chunks), 1)
-        self.assertIsInstance(series.chunks[0].op, self.op)
+        self.assertIsInstance(series.chunks[0].op, DataFrameAggregate)
         self.assertIsInstance(series.chunks[0].inputs[0].op, DataFrameConcat)
         self.assertEqual(len(series.chunks[0].inputs[0].inputs), 2)
 
@@ -118,7 +125,7 @@ class TestReduction(TestBase):
         series = series.tiles()
 
         self.assertEqual(len(series.chunks), 1)
-        self.assertIsInstance(series.chunks[0].op, self.op)
+        self.assertIsInstance(series.chunks[0].op, DataFrameAggregate)
         self.assertIsInstance(series.chunks[0].inputs[0].op, DataFrameConcat)
         self.assertEqual(len(series.chunks[0].inputs[0].inputs), 4)
 
@@ -129,26 +136,30 @@ class TestReduction(TestBase):
             kwargs['skipna'] = False
         if self.has_numeric_only:
             kwargs['numeric_only'] = True
+        if self.has_bool_only:
+            kwargs['bool_only'] = True
         reduction_df = getattr(from_pandas_df(data, chunk_size=3), self.func_name)(**kwargs).tiles()
 
         # pb
         chunk = reduction_df.chunks[0]
         serials = self._pb_serial(chunk)
-        op, pb = serials[chunk.op, chunk.data]
+        chunk_op, chunk_pb = serials[chunk.op, chunk.data]
 
-        self.assertEqual(tuple(pb.index), chunk.index)
-        self.assertEqual(pb.key, chunk.key)
-        self.assertEqual(tuple(pb.shape), chunk.shape)
-        self.assertEqual(int(op.type.split('.', 1)[1]), self.op_name)
+        self.assertEqual(tuple(chunk_pb.index), chunk.index)
+        self.assertEqual(chunk_pb.key, chunk.key)
+        self.assertEqual(tuple(chunk_pb.shape), chunk.shape)
+        self.assertEqual(int(chunk_op.type.split('.', 1)[1]), DataFrameAggregate._op_type_)
 
         chunk2 = self._pb_deserial(serials)[chunk.data]
 
         self.assertEqual(chunk.index, chunk2.index)
         self.assertEqual(chunk.key, chunk2.key)
         self.assertEqual(chunk.shape, chunk2.shape)
-        self.assertEqual(chunk.op.skipna, chunk2.op.skipna)
+        self.assertEqual(chunk.op.agg_funcs[0].kwds.get('skipna'),
+                         chunk2.op.agg_funcs[0].kwds.get('skipna'))
         self.assertEqual(chunk.op.axis, chunk2.op.axis)
         self.assertEqual(chunk.op.numeric_only, chunk2.op.numeric_only)
+        self.assertEqual(chunk.op.bool_only, chunk2.op.bool_only)
         pd.testing.assert_index_equal(chunk2.index_value.to_pandas(), chunk.index_value.to_pandas())
 
         # json
@@ -160,9 +171,11 @@ class TestReduction(TestBase):
         self.assertEqual(chunk.index, chunk2.index)
         self.assertEqual(chunk.key, chunk2.key)
         self.assertEqual(chunk.shape, chunk2.shape)
-        self.assertEqual(chunk.op.skipna, chunk2.op.skipna)
+        self.assertEqual(chunk.op.agg_funcs[0].kwds.get('skipna'),
+                         chunk2.op.agg_funcs[0].kwds.get('skipna'))
         self.assertEqual(chunk.op.axis, chunk2.op.axis)
         self.assertEqual(chunk.op.numeric_only, chunk2.op.numeric_only)
+        self.assertEqual(chunk.op.bool_only, chunk2.op.bool_only)
         pd.testing.assert_index_equal(chunk2.index_value.to_pandas(), chunk.index_value.to_pandas())
 
     def testDataFrameReduction(self):
@@ -171,13 +184,14 @@ class TestReduction(TestBase):
         reduction_df = getattr(from_pandas_df(data, chunk_size=3), self.func_name)()
 
         self.assertIsInstance(reduction_df, Series)
+        self.assertIsInstance(reduction_df.op, self.op)
         self.assertIsInstance(reduction_df.index_value._index_value, IndexValue.Index)
         self.assertEqual(reduction_df.shape, (2,))
 
         reduction_df = reduction_df.tiles()
 
         self.assertEqual(len(reduction_df.chunks), 1)
-        self.assertIsInstance(reduction_df.chunks[0].op, self.op)
+        self.assertIsInstance(reduction_df.chunks[0].op, DataFrameAggregate)
         self.assertIsInstance(reduction_df.chunks[0].inputs[0].op, DataFrameConcat)
         self.assertEqual(len(reduction_df.chunks[0].inputs[0].inputs), 2)
 
@@ -192,7 +206,7 @@ class TestReduction(TestBase):
 
         self.assertEqual(len(reduction_df.chunks), 4)
         self.assertEqual(reduction_df.nsplits, ((3, 3, 3, 1),))
-        self.assertIsInstance(reduction_df.chunks[0].op, self.op)
+        self.assertIsInstance(reduction_df.chunks[0].op, DataFrameAggregate)
         self.assertIsInstance(reduction_df.chunks[0].inputs[0].op, DataFrameConcat)
         self.assertEqual(len(reduction_df.chunks[0].inputs[0].inputs), 2)
 
@@ -205,7 +219,7 @@ class TestReduction(TestBase):
 
         self.assertEqual(len(reduction_df.chunks), 5)
         self.assertEqual(reduction_df.nsplits, ((4,) * 5,))
-        self.assertIsInstance(reduction_df.chunks[0].op, self.op)
+        self.assertIsInstance(reduction_df.chunks[0].op, DataFrameAggregate)
         self.assertIsInstance(reduction_df.chunks[0].inputs[0].op, DataFrameConcat)
         self.assertEqual(len(reduction_df.chunks[0].inputs[0].inputs), 2)
 
@@ -374,6 +388,8 @@ class TestCumReduction(TestBase):
         self.assertEqual(reduction_df.chunks[-1].inputs[-1].op.stage, OperandStage.map)
         self.assertEqual(len(reduction_df.chunks[-1].inputs), 7)
 
+
+class TestNUnique(TestBase):
     def testNunique(self):
         data = pd.DataFrame(np.random.randint(0, 6, size=(20, 10)),
                             columns=['c' + str(i) for i in range(10)])
@@ -389,7 +405,7 @@ class TestCumReduction(TestBase):
         self.assertEqual(len(tiled.chunks), 4)
         self.assertEqual(tiled.nsplits, ((3, 3, 3, 1,),))
         self.assertEqual(tiled.chunks[0].op.stage, OperandStage.agg)
-        self.assertIsInstance(tiled.chunks[0].op, DataFrameNunique)
+        self.assertIsInstance(tiled.chunks[0].op, DataFrameAggregate)
 
         data2 = data.copy()
         df2 = from_pandas_df(data2, chunk_size=3)
@@ -404,13 +420,14 @@ class TestCumReduction(TestBase):
         self.assertEqual(len(tiled.chunks), 7)
         self.assertEqual(tiled.nsplits, ((3, 3, 3, 3, 3, 3, 2,),))
         self.assertEqual(tiled.chunks[0].op.stage, OperandStage.agg)
-        self.assertIsInstance(tiled.chunks[0].op, DataFrameNunique)
+        self.assertIsInstance(tiled.chunks[0].op, DataFrameAggregate)
 
 
 class TestAggregate(TestBase):
     def testDataFrameAggregate(self):
         data = pd.DataFrame(np.random.rand(20, 19))
-        agg_funcs = ['sum', 'min', 'max', 'mean', 'var', 'std', 'all', 'any']
+        agg_funcs = ['sum', 'min', 'max', 'mean', 'var', 'std', 'all', 'any',
+                     'skew', 'kurt', 'sem']
 
         df = from_pandas_df(data)
         result = df.agg(agg_funcs).tiles()
@@ -502,7 +519,8 @@ class TestAggregate(TestBase):
 
     def testSeriesAggregate(self):
         data = pd.Series(np.random.rand(20), index=[str(i) for i in range(20)], name='a')
-        agg_funcs = ['sum', 'min', 'max', 'mean', 'var', 'std', 'all', 'any']
+        agg_funcs = ['sum', 'min', 'max', 'mean', 'var', 'std', 'all', 'any',
+                     'skew', 'kurt', 'sem']
 
         series = from_pandas_series(data)
 

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import operator
 import unittest
 from functools import reduce
@@ -19,7 +20,7 @@ from functools import reduce
 import pandas as pd
 import numpy as np
 
-from mars import opcodes as OperandDef
+from mars import opcodes as OperandDef, dataframe as md
 from mars.operands import OperandStage
 from mars.tests.core import TestBase, parameterized
 from mars.tensor import Tensor
@@ -28,7 +29,9 @@ from mars.dataframe.reduction import DataFrameSum, DataFrameProd, DataFrameMin, 
     DataFrameMax, DataFrameCount, DataFrameMean, DataFrameVar, DataFrameAll, \
     DataFrameAny, DataFrameSkew, DataFrameKurtosis, DataFrameSem, \
     DataFrameAggregate, DataFrameCummin, DataFrameCummax, DataFrameCumprod, \
-    DataFrameCumsum, DataFrameNunique
+    DataFrameCumsum, DataFrameNunique, CustomReduction
+from mars.dataframe.reduction.aggregation import where_function
+from mars.dataframe.reduction.core import ReductionCompiler
 from mars.dataframe.merge import DataFrameConcat
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
 from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df
@@ -551,6 +554,136 @@ class TestAggregate(TestBase):
         self.assertEqual(agg_chunk.shape, (len(agg_funcs),))
         self.assertListEqual(list(agg_chunk.index_value.to_pandas()), agg_funcs)
         self.assertEqual(agg_chunk.op.stage, OperandStage.agg)
+
+
+class TestReductionCompiler(TestBase):
+    def testCompileFunction(self):
+        compiler = ReductionCompiler()
+        ms = md.Series([1, 2, 3])
+        # no Mars objects inside closures
+        with self.assertRaises(ValueError):
+            compiler.add_function(functools.partial(lambda x: (x + ms).sum()), ndim=2)
+        # function should return a Mars object
+        with self.assertRaises(ValueError):
+            compiler.add_function(lambda x: x is not None, ndim=2)
+        # function should perform some sort of reduction in dimensionality
+        with self.assertRaises(ValueError):
+            compiler.add_function(lambda x: x, ndim=2)
+        # function should only contain acceptable operands
+        with self.assertRaises(ValueError):
+            compiler.add_function(lambda x: x.sort_values().max(), ndim=1)
+        with self.assertRaises(ValueError):
+            compiler.add_function(lambda x: x.max().shift(1), ndim=2)
+
+        # test agg for all data
+        for ndim in [1, 2]:
+            compiler = ReductionCompiler(store_source=True)
+            compiler.add_function(lambda x: (x ** 2).count() + 1, ndim=ndim)
+            result = compiler.compile()
+            # check pre_funcs
+            self.assertEqual(len(result.pre_funcs), 1)
+            self.assertIn('pow', result.pre_funcs[0].func.__source__)
+            # check agg_funcs
+            self.assertEqual(len(result.agg_funcs), 1)
+            self.assertEqual(result.agg_funcs[0].map_func_name, 'count')
+            self.assertEqual(result.agg_funcs[0].agg_func_name, 'sum')
+            # check post_funcs
+            self.assertEqual(len(result.post_funcs), 1)
+            self.assertEqual(result.post_funcs[0].func_name, '<lambda_0>')
+            self.assertIn('add', result.post_funcs[0].func.__source__)
+
+            compiler.add_function(lambda x: -x.prod() ** 2 + (1 + (x ** 2).count()), ndim=ndim)
+            result = compiler.compile()
+            # check pre_funcs
+            self.assertEqual(len(result.pre_funcs), 2)
+            self.assertTrue('pow' in result.pre_funcs[0].func.__source__
+                            or 'pow' in result.pre_funcs[1].func.__source__)
+            self.assertTrue('pow' not in result.pre_funcs[0].func.__source__
+                            or 'pow' not in result.pre_funcs[1].func.__source__)
+            # check agg_funcs
+            self.assertEqual(len(result.agg_funcs), 2)
+            self.assertSetEqual(set(result.agg_funcs[i].map_func_name for i in range(2)),
+                                {'count', 'prod'})
+            self.assertSetEqual(set(result.agg_funcs[i].agg_func_name for i in range(2)),
+                                {'sum', 'prod'})
+            # check post_funcs
+            self.assertEqual(len(result.post_funcs), 2)
+            self.assertEqual(result.post_funcs[0].func_name, '<lambda_0>')
+            self.assertIn('add', result.post_funcs[0].func.__source__)
+            self.assertIn('add', result.post_funcs[1].func.__source__)
+
+            compiler = ReductionCompiler(store_source=True)
+            compiler.add_function(lambda x: where_function(x.all(), x.count(), 0), ndim=ndim)
+            result = compiler.compile()
+            # check pre_funcs
+            self.assertEqual(len(result.pre_funcs), 1)
+            self.assertEqual(result.pre_funcs[0].input_key, result.pre_funcs[0].output_key)
+            # check agg_funcs
+            self.assertEqual(len(result.agg_funcs), 2)
+            self.assertSetEqual(set(result.agg_funcs[i].map_func_name for i in range(2)),
+                                {'all', 'count'})
+            self.assertSetEqual(set(result.agg_funcs[i].agg_func_name for i in range(2)),
+                                {'sum', 'all'})
+            # check post_funcs
+            self.assertEqual(len(result.post_funcs), 1)
+            if ndim == 1:
+                self.assertIn('np.where', result.post_funcs[0].func.__source__)
+            else:
+                self.assertNotIn('np.where', result.post_funcs[0].func.__source__)
+                self.assertIn('.where', result.post_funcs[0].func.__source__)
+
+        # test agg for specific columns
+        compiler = ReductionCompiler(store_source=True)
+        compiler.add_function(lambda x: 1 + x.sum(), ndim=2, cols=['a', 'b'])
+        compiler.add_function(lambda x: -1 + x.sum(), ndim=2, cols=['b', 'c'])
+        result = compiler.compile()
+        # check pre_funcs
+        self.assertEqual(len(result.pre_funcs), 1)
+        self.assertSetEqual(set(result.pre_funcs[0].columns), set('abc'))
+        # check agg_funcs
+        self.assertEqual(len(result.agg_funcs), 1)
+        self.assertEqual(result.agg_funcs[0].map_func_name, 'sum')
+        self.assertEqual(result.agg_funcs[0].agg_func_name, 'sum')
+        # check post_funcs
+        self.assertEqual(len(result.post_funcs), 2)
+        self.assertSetEqual(set(''.join(sorted(result.post_funcs[i].columns)) for i in range(2)),
+                            {'ab', 'bc'})
+
+    def testCustomAggregation(self):
+        class MockReduction1(CustomReduction):
+            def agg(self, v1):
+                return v1.sum()
+
+        class MockReduction2(CustomReduction):
+            def pre(self, value):
+                return value + 1, value ** 2
+
+            def agg(self, v1, v2):
+                return v1.sum(), v2.prod()
+
+            def post(self, v1, v2):
+                return v1 + v2
+
+        for ndim in [1, 2]:
+            compiler = ReductionCompiler()
+            compiler.add_function(MockReduction1(), ndim=ndim)
+            result = compiler.compile()
+            # check agg_funcs
+            self.assertEqual(len(result.agg_funcs), 1)
+            self.assertEqual(result.agg_funcs[0].map_func_name, 'custom_reduction')
+            self.assertEqual(result.agg_funcs[0].agg_func_name, 'custom_reduction')
+            self.assertIsInstance(result.agg_funcs[0].custom_reduction, MockReduction1)
+            self.assertEqual(result.agg_funcs[0].output_limit, 1)
+
+            compiler = ReductionCompiler()
+            compiler.add_function(MockReduction2(), ndim=ndim)
+            result = compiler.compile()
+            # check agg_funcs
+            self.assertEqual(len(result.agg_funcs), 1)
+            self.assertEqual(result.agg_funcs[0].map_func_name, 'custom_reduction')
+            self.assertEqual(result.agg_funcs[0].agg_func_name, 'custom_reduction')
+            self.assertIsInstance(result.agg_funcs[0].custom_reduction, MockReduction2)
+            self.assertEqual(result.agg_funcs[0].output_limit, 2)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/mars/dataframe/reduction/tests/test_reduction_execute.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execute.py
@@ -36,6 +36,9 @@ reduction_functions = dict(
     mean=dict(func_name='mean', has_min_count=False),
     var=dict(func_name='var', has_min_count=False),
     std=dict(func_name='std', has_min_count=False),
+    sem=dict(func_name='sem', has_min_count=False),
+    skew=dict(func_name='skew', has_min_count=False),
+    kurt=dict(func_name='kurt', has_min_count=False),
 )
 
 
@@ -50,7 +53,7 @@ class TestReduction(TestBase):
     def testSeriesReduction(self):
         data = pd.Series(np.random.randint(0, 8, (10,)), index=[str(i) for i in range(10)], name='a')
         reduction_df1 = self.compute(from_pandas_series(data))
-        self.assertEqual(
+        self.assertAlmostEqual(
             self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
 
         reduction_df2 = self.compute(from_pandas_series(data, chunk_size=6))
@@ -576,7 +579,8 @@ class TestAggregate(TestBase):
         self.executor = ExecutorForTest()
 
     def testDataFrameAggregate(self):
-        all_aggs = ['sum', 'prod', 'min', 'max', 'count', 'size', 'mean', 'var', 'std']
+        all_aggs = ['sum', 'prod', 'min', 'max', 'count', 'size',
+                    'mean', 'var', 'std', 'sem', 'skew', 'kurt']
         data = pd.DataFrame(np.random.rand(20, 20))
 
         df = from_pandas_df(data)
@@ -632,7 +636,8 @@ class TestAggregate(TestBase):
                                       data.agg({0: ['sum', 'min', 'var'], 9: ['mean', 'var', 'std']}))
 
     def testSeriesAggregate(self):
-        all_aggs = ['sum', 'prod', 'min', 'max', 'count', 'size', 'mean', 'var', 'std']
+        all_aggs = ['sum', 'prod', 'min', 'max', 'count', 'size',
+                    'mean', 'var', 'std', 'sem', 'skew', 'kurt']
         data = pd.Series(np.random.rand(20), index=[str(i) for i in range(20)], name='a')
 
         series = from_pandas_series(data)

--- a/mars/dataframe/reduction/unique.py
+++ b/mars/dataframe/reduction/unique.py
@@ -27,12 +27,8 @@ cudf = lazy_import('cudf', globals=globals())
 
 
 class UniqueReduction(CustomReduction):
-    def __init__(self, name='unique', is_gpu=False):
-        super().__init__(name)
-        self._is_gpu = is_gpu
-
     def agg(self, data):  # noqa: W0221  # pylint: disable=arguments-differ
-        xdf = cudf if self._is_gpu else pd
+        xdf = cudf if self.is_gpu() else pd
         # convert to series data
         return xdf.Series(data.unique())
 
@@ -55,7 +51,7 @@ class DataFrameUnique(DataFrameReductionOperand, DataFrameReductionMixin):
 
     @classmethod
     def _make_agg_object(cls, op):
-        return UniqueReduction(name=cls._func_name, is_gpu=op.gpu)
+        return UniqueReduction(name=cls._func_name, is_gpu=op.is_gpu())
 
     @classmethod
     def tile(cls, op):

--- a/mars/dataframe/statistics/corr.py
+++ b/mars/dataframe/statistics/corr.py
@@ -116,8 +116,8 @@ class DataFrameCorr(DataFrameOperand, DataFrameOperandMixin):
     def _tile_pearson_cross(left, right, min_periods):
         left_tensor, right_tensor = left.fillna(0).to_tensor(), right.fillna(0).to_tensor()
 
-        nna_left = left.notna().to_tensor().astype(np.int_)
-        nna_right = right.notna().to_tensor().astype(np.int_)
+        nna_left = left.notna().to_tensor().astype(np.float_)
+        nna_right = right.notna().to_tensor().astype(np.float_)
 
         sum_left = left_tensor.T.dot(nna_right)
         sum_right = right_tensor.T.dot(nna_left)
@@ -136,8 +136,8 @@ class DataFrameCorr(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def _tile_pearson_align(cls, left, right, axis):
-        nna_left = left.notna().astype(np.int_)
-        nna_right = right.notna().astype(np.int_)
+        nna_left = left.notna().astype(np.float_)
+        nna_right = right.notna().astype(np.float_)
 
         left, right = left.fillna(0), right.fillna(0)
 

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -256,6 +256,11 @@ message OperandDef {
         CUMMIN = 345;
         CUMCOUNT = 346;
         CORR = 347;
+        REDUCTION_SIZE = 348;
+        CUSTOM_REDUCTION = 349;
+        SKEW = 350;
+        KURTOSIS = 351;
+        SEM = 352;
 
         // tensor operand
         RESHAPE = 401;

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -87,7 +87,7 @@ def parameterized(defaults=None, **params):
                 try:
                     fun(self, *args, **kwargs)
                 except:  # noqa: E722
-                    logger.error('Failed when running %s with param %s', fun.__name__, n)
+                    logger.error('Failed when running %s with param %s', fun.__qualname__, n)
                     raise
         return test_fun
 


### PR DESCRIPTION
## What do these changes do?

This PR adds a `ReductionCompiler` to `mars.dataframe.reduction` to handle function aggregations like

```python
df.agg(lambda x: (x ** 2).sum() + 1)
```

A graph is built for `(x ** 2).sum() + 1` with Mars tileable graph and separated with reduction operands into pre-process graphs and post-process graphs. Pre-handling functions and post-handling functions are then generated with a minimal codegen.

By doing this we successfully migrated implementations for `var` and `std` into function aggregations and supports for `skew` and `kurt` are also added.

To unify reduction functions in `mars.dataframe.reduction` such as `unique` and `nunique`, support for `CustonReduction` is also added.

Note that support for `mars.dataframe.groupby` is not added yet. This may rely on a refactor for `GroupbyWrapper` to fix potential bugs.

## Tests

Under Intel 10700K CPU and Python 3.8,

With the patch:
```python
In[1]: import mars.dataframe as md
In[2]: import numpy as np
In[3]: %%timeit
  ...: df = md.DataFrame(np.random.rand(100, 10), chunk_size=10)
  ...: df.sum().execute()
  ...: 
30.1 ms ± 218 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
In[4]: %%timeit
  ...: df = md.DataFrame(np.random.rand(100, 10), chunk_size=10)
  ...: df.sum().execute()
  ...: 
46 ms ± 272 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Without the patch:
```python
In[1]: import mars.dataframe as md
In[2]: import numpy as np
In[3]: %%timeit
  ...: df = md.DataFrame(np.random.rand(100, 10), chunk_size=10)
  ...: df.sum().execute()
  ...: 
36.1 ms ± 831 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
In[4]: %%timeit
  ...: df = md.DataFrame(np.random.rand(100, 10), chunk_size=10)
  ...: df.sum().execute()
  ...: 
54 ms ± 367 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

GPU cases are also tested with cudf. Now `var` and `agg` can be supported on Nvidia GPUs.

## Related issue number

(Note that none of these PRs fully fixed till `groupby` issue is resolved.)

#1476, #1311, #1141