### PR TITLE
Write into and read from merged files when data sizes are small

### DIFF
--- a/mars/config.py
+++ b/mars/config.py
@@ -386,8 +386,14 @@ default_options.register_option('worker.io_parallel_num', 1, validator=is_intege
 default_options.register_option('worker.recover_dead_process', True, validator=is_bool, serialize=True)
 default_options.register_option('worker.write_shuffle_to_disk', False, validator=is_bool, serialize=True)
 
+default_options.register_option('worker.filemerger.enabled', True, validator=is_bool, serialize=True)
+default_options.register_option('worker.filemerger.concurrency', 128, validator=is_integer, serialize=True)
+default_options.register_option('worker.filemerger.max_accept_size', 128 * 1024, validator=is_integer, serialize=True)
+default_options.register_option('worker.filemerger.max_file_size', 32 * 1024 ** 2, validator=is_integer, serialize=True)
+
 default_options.register_option('worker.plasma_dir', None, validator=(is_string, is_null))
 default_options.register_option('worker.plasma_limit', None, validator=(is_string, is_integer, is_null))
+
 default_options.register_option('worker.plasma_socket', '/tmp/plasma', validator=is_string)
 
 # optimization

--- a/mars/worker/storage/__init__.py
+++ b/mars/worker/storage/__init__.py
@@ -21,9 +21,10 @@ from .procmemhandler import ProcMemHandler
 from .sharedhandler import SharedStorageHandler
 from .vineyardhandler import VineyardHandler
 
+from .diskmerge import DiskFileMergerActor
 from .iorunner import IORunnerActor
 from .manager import StorageManagerActor
-from .sharedstore import PlasmaKeyMapActor
 from .objectholder import ObjectHolderActor, SharedHolderActor, InProcHolderActor, \
     CudaHolderActor
+from .sharedstore import PlasmaKeyMapActor
 from .vineyardhandler import VineyardKeyMapActor

--- a/mars/worker/storage/diskmerge.py
+++ b/mars/worker/storage/diskmerge.py
@@ -1,0 +1,137 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import random
+import time
+from collections import defaultdict, deque
+from typing import NamedTuple, Union
+
+from ...config import options
+from ...errors import SpillNotConfigured
+from ...utils import tokenize, mod_hash
+from ..utils import WorkerActor, parse_spill_dirs
+
+logger = logging.getLogger(__name__)
+
+
+def _build_file_path_by_name(session_id, filename):
+    dirs = options.worker.spill_directory
+    dir_name = dirs[mod_hash(filename, len(dirs))]
+    return os.path.join(dir_name, str(session_id), filename)
+
+
+class DataMeta(NamedTuple):
+    filename: str
+    start: int
+    end: Union[int, None]
+
+
+class DiskFileMergerActor(WorkerActor):
+    def __init__(self):
+        super().__init__()
+
+        dirs = options.worker.spill_directory = parse_spill_dirs(options.worker.spill_directory)
+        if not dirs:  # pragma: no cover
+            raise SpillNotConfigured
+
+        self._key_to_data_meta = dict()
+        self._file_to_sizes = defaultdict(lambda: 0)
+        self._file_to_keys = defaultdict(list)
+        self._available_files = []
+        self._concurrency = options.worker.filemerger.concurrency
+        self._max_file_size = options.worker.filemerger.max_file_size
+
+        self._reading_files = set()
+        self._writing_files = set()
+
+        self._pending_read_requests = deque()
+        self._pending_write_requests = deque()
+
+    def await_file_reader(self, session_id, data_key, with_lock=False, callback=None):
+        if with_lock and len(self._reading_files) >= self._concurrency:
+            self._pending_read_requests.append((session_id, data_key, callback))
+            return
+        self._reading_files.add((session_id, data_key))
+        self.tell_promise(callback)
+
+    def await_file_writer(self, session_id, with_lock=True, callback=None):
+        if with_lock and len(self._writing_files) >= self._concurrency:
+            self._pending_write_requests.append(callback)
+            return
+
+        if self._available_files:
+            filename = self._available_files.pop(-1)
+        else:
+            filename = _build_file_path_by_name(
+                session_id, tokenize(callback, time.time(), random.random()))
+
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        self._writing_files.add(filename)
+        self.tell_promise(callback, filename, self._file_to_sizes[filename])
+
+    def release_file_reader(self, session_id, data_key):
+        self._reading_files.difference_update([(session_id, data_key)])
+        if self._pending_read_requests:
+            session_id, data_key, callback = self._pending_read_requests.popleft()
+            self.await_file_reader(session_id, data_key, callback)
+
+    def release_file_writer(self, session_id, data_key, filename, start, end):
+        self._writing_files.remove(filename)
+        self._key_to_data_meta[(session_id, data_key)] = DataMeta(filename, start, end)
+        self._file_to_sizes[filename] = end
+        self._file_to_keys[filename].append((session_id, data_key))
+
+        if self._file_to_sizes[filename] >= self._max_file_size:
+            self._file_to_sizes.pop(filename)
+        else:
+            self._available_files.append(filename)
+
+        if self._pending_write_requests:
+            self.await_file_writer(session_id, callback=self._pending_write_requests.popleft())
+
+    def get_file_metas(self, session_id, data_keys):
+        metas = []
+        for key in data_keys:
+            meta = self._key_to_data_meta.get((session_id, key))
+            metas.append(meta)
+        return metas
+
+    def delete_file_metas(self, session_id, data_keys):
+        files_to_delete = []
+        filtered_keys = []
+        for key in data_keys:
+            meta = self._key_to_data_meta.pop((session_id, key), None)
+            if meta is None:  # pragma: no cover
+                continue
+            filtered_keys.append(key)
+            filename = meta.filename
+            keys_set = self._file_to_keys[filename]
+            keys_set.remove((session_id, key))
+            if not keys_set:
+                if filename in self._writing_files:
+                    continue
+                del self._file_to_keys[filename]
+                self._file_to_sizes.pop(filename, None)
+                files_to_delete.append(filename)
+
+        del_set = set(files_to_delete)
+        if del_set:
+            self._available_files = [f for f in self._available_files if f not in del_set]
+        return files_to_delete, filtered_keys
+
+    def dump_info(self):
+        return self._key_to_data_meta, self._file_to_sizes, self._file_to_keys, \
+            self._writing_files

--- a/mars/worker/storage/tests/test_disk_io.py
+++ b/mars/worker/storage/tests/test_disk_io.py
@@ -14,19 +14,22 @@
 
 import functools
 import os
+import random
 import uuid
 import weakref
 
 import numpy as np
 from numpy.testing import assert_allclose
 
+from mars import promise
+from mars.config import options
 from mars.errors import StorageDataExists
 from mars.serialize import dataserializer
 from mars.tests.core import patch_method
 from mars.utils import get_next_port
 from mars.worker import WorkerDaemonActor, QuotaActor, MemQuotaActor, StatusActor, EventsActor
 from mars.worker.storage import StorageHandler, StorageManagerActor, InProcHolderActor, \
-    PlasmaKeyMapActor, SharedHolderActor, DataStorageDevice
+    PlasmaKeyMapActor, SharedHolderActor, DiskFileMergerActor, DataStorageDevice
 from mars.worker.tests.base import WorkerCase
 from mars.worker.utils import WorkerClusterInfoActor
 
@@ -38,6 +41,11 @@ def mock_transfer_in_global_runner(self, session_id, data_key, src_handler, fall
 
 @patch_method(StorageHandler.transfer_in_runner, new=mock_transfer_in_global_runner)
 class Test(WorkerCase):
+    def tearDown(self):
+        options.worker.filemerger.max_file_size = 10 * 1024 ** 2
+        options.worker.filemerger.concurrency = 128
+        super().tearDown()
+
     @staticmethod
     def _get_compress_types():
         return {dataserializer.CompressType.NONE} \
@@ -188,6 +196,107 @@ class Test(WorkerCase):
                     .then(functools.partial(test_actor.set_result),
                           lambda *exc: test_actor.set_result(exc, accept=False))
                 assert_allclose(self.get_result(5), data1)
+
+    def testDiskReadAndWriteMerger(self):
+        import logging
+        logging.basicConfig(level=logging.DEBUG)
+
+        test_addr = f'127.0.0.1:{get_next_port()}'
+        options.worker.filemerger.max_file_size = 2400
+        options.worker.filemerger.concurrency = 16
+
+        with self.create_pool(n_process=1, address=test_addr) as pool, \
+                self.run_actor_test(pool) as test_actor:
+            pool.create_actor(WorkerClusterInfoActor, [test_addr],
+                              uid=WorkerClusterInfoActor.default_uid())
+            pool.create_actor(StatusActor, test_addr, uid=StatusActor.default_uid())
+            pool.create_actor(EventsActor, uid=EventsActor.default_uid())
+
+            disk_file_merger_ref = pool.create_actor(
+                DiskFileMergerActor, uid=DiskFileMergerActor.default_uid())
+
+            pool.create_actor(WorkerDaemonActor, uid=WorkerDaemonActor.default_uid())
+            storage_manager_ref = pool.create_actor(
+                StorageManagerActor, uid=StorageManagerActor.default_uid())
+
+            session_id = str(uuid.uuid4())
+            data_count = 30
+            data = [np.random.rand(random.randint(10, 30), random.randint(10, 30))
+                    for _ in range(data_count)]
+            ser_data = [dataserializer.serialize(d) for d in data]
+
+            storage_client = test_actor.storage_client
+            handler = storage_client.get_storage_handler((0, DataStorageDevice.DISK))
+
+            for handler._compress in self._get_compress_types():
+                data_keys = [str(uuid.uuid4()) for _ in range(data_count)]
+
+                promises = []
+                for idx in range(data_count):
+                    block_data = dataserializer.dumps(data[idx], compress=handler._compress)
+
+                    def _write_data(ser, writer):
+                        with writer:
+                            writer.write(ser)
+                        return writer.filename
+
+                    promises.append(
+                        handler.create_bytes_writer(session_id, data_keys[idx], ser_data[idx].total_bytes,
+                                                    packed=True, with_merger_lock=True, _promise=True)
+                            .then(functools.partial(_write_data, block_data))
+                    )
+                promise.all_(promises).then(lambda *_: test_actor.set_result(0),
+                                            lambda *exc: test_actor.set_result(exc, accept=False))
+                self.get_result(50)
+
+                for key in data_keys:
+                    self.assertEqual(sorted(storage_manager_ref.get_data_locations(session_id, [key])[0]),
+                                     [(0, DataStorageDevice.DISK)])
+
+                dump_result = disk_file_merger_ref.dump_info()
+                written_files = list(dump_result[2])
+                for fn in written_files:
+                    self.assertTrue(os.path.exists(fn))
+
+                data_store = [None] * len(data)
+                promises = []
+                for idx in range(data_count):
+                    def _read_data(reader, idx):
+                        with reader:
+                            data_store[idx] = dataserializer.loads(reader.read())
+
+                    promises.append(
+                        handler.create_bytes_reader(session_id, data_keys[idx],
+                                                    with_merger_lock=True, packed=True, _promise=True)
+                            .then(functools.partial(_read_data, idx=idx))
+                    )
+                promise.all_(promises).then(lambda *_: test_actor.set_result(0),
+                                            lambda *exc: test_actor.set_result(exc, accept=False))
+                self.get_result(50)
+                for true_data, read_data in zip(data, data_store):
+                    assert_allclose(true_data, read_data)
+
+                data_store = [None] * len(data)
+                promises = []
+                for idx in range(data_count):
+                    def _read_data(reader, idx):
+                        with reader:
+                            data_store[idx] = dataserializer.deserialize(reader.read())
+
+                    promises.append(
+                        handler.create_bytes_reader(session_id, data_keys[idx], _promise=True)
+                            .then(functools.partial(_read_data, idx=idx))
+                    )
+                promise.all_(promises).then(lambda *_: test_actor.set_result(0),
+                                            lambda *exc: test_actor.set_result(exc, accept=False))
+                self.get_result(50)
+                for true_data, read_data in zip(data, data_store):
+                    assert_allclose(true_data, read_data)
+
+                storage_client.delete(session_id, data_keys)
+                pool.sleep(0.1)
+                for fn in written_files:
+                    self.assertFalse(os.path.exists(fn))
 
     def testDiskLoad(self, *_):
         test_addr = f'127.0.0.1:{get_next_port()}'


### PR DESCRIPTION
## What do these changes do?

Write into  and read from merged files when data sizes are small. This reduces the number of inodes when using external storages.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
