### PR TITLE
Remove `prepare_inputs` property on operands

### DIFF
--- a/mars/operands.py
+++ b/mars/operands.py
@@ -89,7 +89,6 @@ class Operand(AttributeAsDictKey, metaclass=OperandMetaclass):
     _reassign_worker = BoolField('reassign_worker')
 
     _inputs = ListField('inputs', ValueType.key)
-    _prepare_inputs = ListField('prepare_inputs', ValueType.bool)
     _pure_depends = ListField('pure_depends', ValueType.bool)
     _outputs = ListField('outputs', ValueType.key, weak_ref=True)
 
@@ -185,13 +184,6 @@ class Operand(AttributeAsDictKey, metaclass=OperandMetaclass):
     @property
     def expect_worker(self):
         return getattr(self, '_expect_worker', None)
-
-    @property
-    def prepare_inputs(self):
-        val = getattr(self, '_prepare_inputs', None)
-        if not val:
-            return [True] * len(self.inputs or ())
-        return val
 
     @property
     def pure_depends(self):

--- a/mars/scheduler/graph.py
+++ b/mars/scheduler/graph.py
@@ -835,7 +835,6 @@ class GraphActor(SchedulerActor):
         input_chunk_keys = set()
         shared_input_chunk_keys = set()
         pure_dep_chunk_keys = set()
-        no_prepare_chunk_keys = set()
         chunk_keys = set()
         shuffle_keys = dict()
         predecessors_to_successors = dict()
@@ -848,10 +847,6 @@ class GraphActor(SchedulerActor):
                 input_chunk_keys.add(pn.key)
                 if graph.count_successors(pn) > 1:
                     shared_input_chunk_keys.add(pn.key)
-
-            for inp, prep in zip(c.op.inputs or (), c.op.prepare_inputs):
-                if not prep and inp.key in input_chunk_keys:
-                    no_prepare_chunk_keys.add(inp.key)
 
             for inp, is_dep in zip(c.op.inputs or (), c.op.pure_depends):
                 if is_dep and inp.key in input_chunk_keys:
@@ -873,7 +868,6 @@ class GraphActor(SchedulerActor):
             predecessors=list(predecessor_keys),
             successors=list(successor_keys),
             input_chunks=list(input_chunk_keys),
-            no_prepare_chunk_keys=list(no_prepare_chunk_keys),
             pure_dep_chunk_keys=list(pure_dep_chunk_keys),
             shared_input_chunks=list(shared_input_chunk_keys),
             chunks=list(chunk_keys),

--- a/mars/scheduler/tests/integrated/no_prepare_op.py
+++ b/mars/scheduler/tests/integrated/no_prepare_op.py
@@ -17,7 +17,7 @@ import numpy as np
 from mars.tensor.arithmetic import TensorAdd
 
 
-class NoPrepareOperand(TensorAdd):
+class PureDependsOperand(TensorAdd):
     _op_type_ = 9870104312
 
     @classmethod

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -31,7 +31,7 @@ from mars.errors import ExecutionFailed
 from mars.scheduler.custom_log import CustomLogMetaActor
 from mars.scheduler.resource import ResourceActor
 from mars.scheduler.tests.integrated.base import SchedulerIntegratedTest
-from mars.scheduler.tests.integrated.no_prepare_op import NoPrepareOperand
+from mars.scheduler.tests.integrated.no_prepare_op import PureDependsOperand
 from mars.session import new_session
 from mars.remote import spawn, ExecutableTuple
 from mars.tests.core import EtcdProcessHelper, require_cupy, require_cudf
@@ -258,7 +258,7 @@ class Test(SchedulerIntegratedTest):
         r = context.get_tileable_data(a.key, indexes)
         np.testing.assert_array_equal(raw1[[9, 1, 2, 0], [0, 0, 4, 4]], r)
 
-    def testOperandsWithoutPrepareInputs(self):
+    def testOperandsWithPureDepends(self):
         self.start_processes(etcd=False, modules=['mars.scheduler.tests.integrated.no_prepare_op'])
         sess = new_session(self.session_manager_ref.address)
 
@@ -271,11 +271,7 @@ class Test(SchedulerIntegratedTest):
         t2 = mt.random.rand(10)
         t2.op._expect_worker = worker_endpoints[1]
 
-        t = NoPrepareOperand().new_tileable([t1, t2])
-        t.op._prepare_inputs = [False, False]
-        t.execute(session=sess, timeout=self.timeout)
-
-        t = NoPrepareOperand().new_tileable([t1, t2])
+        t = PureDependsOperand().new_tileable([t1, t2])
         t.op._pure_depends = [True, True]
         t.execute(session=sess, timeout=self.timeout)
 

--- a/mars/tensor/base/shape.py
+++ b/mars/tensor/base/shape.py
@@ -29,9 +29,9 @@ class TensorGetShape(TensorOperand, TensorOperandMixin):
     _a = KeyField('a')
     _ndim = Int32Field('ndim')
 
-    def __init__(self, prepare_inputs=None, a=None, ndim=None, dtype=None, **kw):
+    def __init__(self, pure_depends=None, a=None, ndim=None, dtype=None, **kw):
         super().__init__(_dtype=dtype, _a=a, _ndim=ndim,
-                         _prepare_inputs=prepare_inputs, **kw)
+                         _pure_depends=pure_depends, **kw)
 
     @property
     def a(self):
@@ -70,7 +70,7 @@ class TensorGetShape(TensorOperand, TensorOperandMixin):
         a = op.a
         outs = op.outputs
 
-        chunk_op = TensorGetShape(prepare_inputs=[False] * len(a.chunks),
+        chunk_op = TensorGetShape(pure_depends=[True] * len(a.chunks),
                                   ndim=op.ndim)
         chunk_kws = []
         for out in outs:

--- a/mars/tensor/datastore/to_hdf5.py
+++ b/mars/tensor/datastore/to_hdf5.py
@@ -115,7 +115,7 @@ class TensorHDF5DataStore(TensorDataStore):
             chunk_op._lock = exclusive_chunk
             chunk_op._out_shape = in_tensor.shape
             chunk_op._axis_offsets = tuple(acc[ax][i] for ax, i in enumerate(chunk.index))
-            chunk_op._prepare_inputs = [True, False]
+            chunk_op._pure_depends = [False, True]
             out_chunk = chunk_op.new_chunk([chunk, exclusive_chunk], shape=(0,) * chunk.ndim,
                                            index=chunk.index)
             out_chunks.append(out_chunk)

--- a/mars/worker/calc.py
+++ b/mars/worker/calc.py
@@ -101,8 +101,8 @@ class BaseCalcActor(WorkerActor):
                 for k in chunk.op.to_fetch_keys:
                     fetch_keys.add((k, shuffle_key))
             else:
-                for inp, prepare_inp, is_dep in zip(chunk.inputs, chunk.op.prepare_inputs, chunk.op.pure_depends):
-                    if not prepare_inp or is_dep:
+                for inp, is_pure_dep in zip(chunk.inputs, chunk.op.pure_depends):
+                    if is_pure_dep:
                         exclude_fetch_keys.add(inp.key)
         return list(fetch_keys - exclude_fetch_keys)
 
@@ -174,8 +174,8 @@ class BaseCalcActor(WorkerActor):
         start_time = time.time()
 
         for chunk in graph:
-            for inp, prepare_inp, is_dep in zip(chunk.inputs, chunk.op.prepare_inputs, chunk.op.pure_depends):
-                if not prepare_inp or is_dep:
+            for inp, is_pure_dep in zip(chunk.inputs, chunk.op.pure_depends):
+                if is_pure_dep:
                     context_dict[inp.key] = None
 
         local_context_dict = DistributedDictContext(

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -43,8 +43,7 @@ class GraphExecutionRecord(object):
                  'state_time', 'mem_request', 'pinned_keys', 'mem_overhead_keys',
                  'est_finish_time', 'calc_actor_uid', 'send_addresses', 'retry_delay',
                  'retry_pending', 'finish_callbacks', 'stop_requested', 'calc_device',
-                 'preferred_data_device', 'resource_released', 'no_prepare_chunk_keys',
-                 'pure_dep_chunk_keys')
+                 'preferred_data_device', 'resource_released', 'pure_dep_chunk_keys')
 
     def __init__(self, graph_serialized, state, chunk_targets=None, data_targets=None,
                  io_meta=None, data_metas=None, mem_request=None, shared_input_chunks=None,
@@ -52,7 +51,7 @@ class GraphExecutionRecord(object):
                  calc_actor_uid=None, send_addresses=None, retry_delay=None,
                  finish_callbacks=None, stop_requested=False, calc_device=None,
                  preferred_data_device=None, resource_released=False,
-                 no_prepare_chunk_keys=None, pure_dep_chunk_keys=None):
+                 pure_dep_chunk_keys=None):
 
         self.graph_serialized = graph_serialized
         graph = self.graph = deserialize_graph(graph_serialized)
@@ -77,7 +76,6 @@ class GraphExecutionRecord(object):
         self.calc_device = calc_device
         self.preferred_data_device = preferred_data_device
         self.resource_released = resource_released
-        self.no_prepare_chunk_keys = no_prepare_chunk_keys or set()
         self.pure_dep_chunk_keys = pure_dep_chunk_keys or set()
 
         _, self.op_string = concat_operand_keys(graph)
@@ -259,8 +257,7 @@ class ExecutionActor(WorkerActor):
             overhead_keys_and_shapes = []
 
             if isinstance(op, Fetch):
-                if chunk.key in graph_record.no_prepare_chunk_keys \
-                        or chunk.key in graph_record.pure_dep_chunk_keys:
+                if chunk.key in chunk.key in graph_record.pure_dep_chunk_keys:
                     continue
                 # use actual size as potential allocation size
                 input_chunk_keys[chunk.key] = input_data_sizes.get(chunk.key) or calc_data_size(chunk)
@@ -513,7 +510,6 @@ class ExecutionActor(WorkerActor):
             finish_callbacks=all_callbacks,
             calc_device=calc_device,
             preferred_data_device=preferred_data_device,
-            no_prepare_chunk_keys=io_meta.get('no_prepare_chunk_keys') or set(),
             pure_dep_chunk_keys=io_meta.get('pure_dep_chunk_keys') or set(),
         )
 
@@ -623,8 +619,7 @@ class ExecutionActor(WorkerActor):
         for chunk in graph:
             op = chunk.op
             if isinstance(op, Fetch):
-                if chunk.key in graph_record.no_prepare_chunk_keys \
-                        or chunk.key in graph_record.pure_dep_chunk_keys:
+                if chunk.key in graph_record.pure_dep_chunk_keys:
                     continue
                 input_keys.add(op.to_fetch_key or chunk.key)
             elif isinstance(op, FetchShuffle):


### PR DESCRIPTION
## What do these changes do?

As all usages of `prepare_inputs` can be replaced with `pure_depends` without pains, the former property can be replaced.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
