### PR TITLE
Fix mars not working on ray cluster

### DIFF
--- a/mars/ray/tests/test_ray_execution.py
+++ b/mars/ray/tests/test_ray_execution.py
@@ -81,3 +81,10 @@ class Test(unittest.TestCase):
 
         for c1, c2 in zip(op.outputs, new_op.outputs):
             self.assertEqual(c1.key, c2.key)
+
+    def testRayClusterMode(self):
+        with new_session(backend='ray', _load_code_from_local=True).as_default():
+            t = mt.random.rand(100, 4, chunk_size=30)
+            df = md.DataFrame(t, columns=list('abcd'))
+            r = df.describe().execute()
+            self.assertEqual(r.shape, (8, 4))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

- Problem
  - mars on ray raises an exception when load code from local.
- Solution
  - Move nested type `RemoteMetaStore` outside the `RayStorage` class.

<!-- Please give a short brief about these changes. -->

## Related issue number

Fixes #1711

<!-- Are there any issues opened that will be resolved by merging this change? -->
