### PR TITLE
Implements {DataFrame,Series}.explode

### DIFF
--- a/docs/source/reference/dataframe/frame.rst
+++ b/docs/source/reference/dataframe/frame.rst
@@ -161,6 +161,7 @@ Reshaping, sorting, transposing
 .. autosummary::
    :toctree: api/
 
+   DataFrame.explode
    DataFrame.melt
    DataFrame.sort_values
    DataFrame.sort_index

--- a/docs/source/reference/dataframe/series.rst
+++ b/docs/source/reference/dataframe/series.rst
@@ -154,6 +154,7 @@ Reshaping, sorting
 .. autosummary::
    :toctree: api/
 
+   Series.explode
    Series.sort_values
    Series.sort_index
 

--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 6, 0, 'b2')
+version_info = (0, 6, 0, 'rc1')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/dataframe/base/__init__.py
+++ b/mars/dataframe/base/__init__.py
@@ -38,6 +38,7 @@ from .select_dtypes import select_dtypes
 from .map_chunk import map_chunk
 from .rebalance import rebalance
 from .stack import stack
+from .explode import df_explode, series_explode
 
 
 def _install():
@@ -77,6 +78,7 @@ def _install():
         setattr(t, 'map_chunk', map_chunk)
         setattr(t, 'rebalance', rebalance)
         setattr(t, 'stack', stack)
+        setattr(t, 'explode', df_explode)
 
     for t in SERIES_TYPE:
         setattr(t, 'to_gpu', to_gpu)
@@ -105,6 +107,7 @@ def _install():
         setattr(t, 'memory_usage', series_memory_usage)
         setattr(t, 'map_chunk', map_chunk)
         setattr(t, 'rebalance', rebalance)
+        setattr(t, 'explode', series_explode)
 
     for t in INDEX_TYPE:
         setattr(t, 'rechunk', rechunk)

--- a/mars/dataframe/base/explode.py
+++ b/mars/dataframe/base/explode.py
@@ -1,0 +1,209 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+
+from ... import opcodes
+from ...core import OutputType
+from ...serialize import AnyField, BoolField
+from ..operands import DataFrameOperand, DataFrameOperandMixin
+from ..utils import parse_index, standardize_range_index
+
+
+class DataFrameExplode(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = opcodes.EXPLODE
+
+    _column = AnyField('column')
+    _ignore_index = BoolField('ignore_field')
+
+    def __init__(self, column=None, ignore_index=None, output_types=None, **kw):
+        super().__init__(_column=column, _ignore_index=ignore_index,
+                         _output_types=output_types, **kw)
+
+    @property
+    def column(self):
+        return self._column
+
+    @property
+    def ignore_index(self):
+        return self._ignore_index
+
+    def _rewrite_params(self, in_obj):
+        params = in_obj.params.copy()
+        new_shape = list(in_obj.shape)
+        new_shape[0] = np.nan
+        params['shape'] = tuple(new_shape)
+
+        if self.ignore_index:
+            params['index_value'] = parse_index(
+                pd.RangeIndex(-1), (in_obj.key, in_obj.index_value.key))
+        else:
+            params['index_value'] = parse_index(
+                None, (in_obj.key, in_obj.index_value.key))
+        return params
+
+    def __call__(self, df_or_series):
+        return self.new_tileable([df_or_series], **self._rewrite_params(df_or_series))
+
+    @classmethod
+    def tile(cls, op: "DataFrameExplode"):
+        in_obj = op.inputs[0]
+
+        if in_obj.ndim == 2 and in_obj.chunk_shape[1] > 1:
+            # make sure data's second dimension has only 1 chunk
+            in_obj = in_obj.rechunk({1: in_obj.shape[1]})._inplace_tile()
+
+        chunks = []
+        for chunk in in_obj.chunks:
+            new_op = op.copy().reset_key()
+            chunks.append(new_op.new_chunk([chunk], **op._rewrite_params(chunk)))
+
+        if op.ignore_index:
+            chunks = standardize_range_index(chunks)
+
+        new_op = op.copy().reset_key()
+        out_params = op.outputs[0].params
+        if in_obj.ndim == 2:
+            new_nsplits = ((np.nan,) * in_obj.chunk_shape[0], in_obj.nsplits[1])
+        else:
+            new_nsplits = ((np.nan,) * in_obj.chunk_shape[0],)
+        return new_op.new_tileable([in_obj], chunks=chunks, nsplits=new_nsplits, **out_params)
+
+    @classmethod
+    def execute(cls, ctx, op: "DataFrameExplode"):
+        in_data = ctx[op.inputs[0].key]
+        if in_data.ndim == 2:
+            ctx[op.outputs[0].key] = in_data.explode(op.column)
+        else:
+            ctx[op.outputs[0].key] = in_data.explode()
+
+
+def df_explode(df, column, ignore_index=False):
+    """
+    Transform each element of a list-like to a row, replicating index values.
+
+    Parameters
+    ----------
+    column : str or tuple
+        Column to explode.
+    ignore_index : bool, default False
+        If True, the resulting index will be labeled 0, 1, …, n - 1.
+
+    Returns
+    -------
+    DataFrame
+        Exploded lists to rows of the subset columns;
+        index will be duplicated for these rows.
+
+    Raises
+    ------
+    ValueError :
+        if columns of the frame are not unique.
+
+    See Also
+    --------
+    DataFrame.unstack : Pivot a level of the (necessarily hierarchical)
+        index labels.
+    DataFrame.melt : Unpivot a DataFrame from wide format to long format.
+    Series.explode : Explode a DataFrame from list-like columns to long format.
+
+    Notes
+    -----
+    This routine will explode list-likes including lists, tuples,
+    Series, and np.ndarray. The result dtype of the subset rows will
+    be object. Scalars will be returned unchanged. Empty list-likes will
+    result in a np.nan for that row.
+
+    Examples
+    --------
+    >>> import mars.tensor as mt
+    >>> import mars.dataframe as md
+    >>> df = md.DataFrame({'A': [[1, 2, 3], 'foo', [], [3, 4]], 'B': 1})
+    >>> df.execute()
+               A  B
+    0  [1, 2, 3]  1
+    1        foo  1
+    2         []  1
+    3     [3, 4]  1
+
+    >>> df.explode('A').execute()
+         A  B
+    0    1  1
+    0    2  1
+    0    3  1
+    1  foo  1
+    2  NaN  1
+    3    3  1
+    3    4  1
+    """
+    op = DataFrameExplode(column=column, ignore_index=ignore_index,
+                          output_types=[OutputType.dataframe])
+    return op(df)
+
+
+def series_explode(series, ignore_index=False):
+    """
+    Transform each element of a list-like to a row.
+
+    Parameters
+    ----------
+    ignore_index : bool, default False
+        If True, the resulting index will be labeled 0, 1, …, n - 1.
+
+    Returns
+    -------
+    Series
+        Exploded lists to rows; index will be duplicated for these rows.
+
+    See Also
+    --------
+    Series.str.split : Split string values on specified separator.
+    Series.unstack : Unstack, a.k.a. pivot, Series with MultiIndex
+        to produce DataFrame.
+    DataFrame.melt : Unpivot a DataFrame from wide format to long format.
+    DataFrame.explode : Explode a DataFrame from list-like
+        columns to long format.
+
+    Notes
+    -----
+    This routine will explode list-likes including lists, tuples,
+    Series, and np.ndarray. The result dtype of the subset rows will
+    be object. Scalars will be returned unchanged. Empty list-likes will
+    result in a np.nan for that row.
+
+    Examples
+    --------
+    >>> import mars.tensor as mt
+    >>> import mars.dataframe as md
+    >>> s = md.Series([[1, 2, 3], 'foo', [], [3, 4]])
+    >>> s.execute()
+    0    [1, 2, 3]
+    1          foo
+    2           []
+    3       [3, 4]
+    dtype: object
+
+    >>> s.explode().execute()
+    0      1
+    0      2
+    0      3
+    1    foo
+    2    NaN
+    3      3
+    3      4
+    dtype: object
+    """
+    op = DataFrameExplode(ignore_index=ignore_index, output_types=[OutputType.series])
+    return op(series)

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -1706,3 +1706,22 @@ class Test(TestBase):
                     pd.testing.assert_series_equal if expected.ndim == 1 \
                         else pd.testing.assert_frame_equal
                 assert_method(result, expected)
+
+    def testExplodeExecution(self):
+        raw = pd.DataFrame({'a': np.random.rand(10),
+                            'b': [np.random.rand(random.randint(1, 10)) for _ in range(10)],
+                            'c': np.random.rand(10),
+                            'd': np.random.rand(10)})
+        df = from_pandas_df(raw, chunk_size=(4, 2))
+
+        for ignore_index in [False, True]:
+            r = df.explode('b', ignore_index=ignore_index)
+            pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                          raw.explode('b', ignore_index=ignore_index))
+
+        series = from_pandas_series(raw.b, chunk_size=4)
+
+        for ignore_index in [False, True]:
+            r = series.explode(ignore_index=ignore_index)
+            pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                           raw.b.explode(ignore_index=ignore_index))

--- a/mars/serialize/dataserializer.py
+++ b/mars/serialize/dataserializer.py
@@ -217,6 +217,19 @@ def peek_file_header(file):
         file.seek(pos)
 
 
+_PANDAS_HAS_MGR = hasattr(pd.Series([0]), '_mgr')
+
+
+def _patch_pandas_mgr(pd_obj):  # pragma: no cover
+    """"""
+    if _PANDAS_HAS_MGR:
+        return pd_obj
+    if hasattr(pd_obj, '_mgr') and isinstance(pd_obj, (pd.DataFrame, pd.Series)):
+        pd_obj._data = pd_obj._mgr
+        del pd_obj._mgr
+    return pd_obj
+
+
 def load(file):
     header = read_file_header(file)
     file = open_decompression_file(file, header.compress)
@@ -230,7 +243,7 @@ def load(file):
     if header.type == SerialType.ARROW:
         return pyarrow.deserialize(memoryview(buf), mars_serialize_context())
     else:
-        return pickle.loads(buf)
+        return _patch_pandas_mgr(pickle.loads(buf))
 
 
 def loads(buf):
@@ -257,7 +270,7 @@ def loads(buf):
                             for idx in range(len(buffer_sizes))]
             return pyarrow.deserialize_components(meta, mars_serialize_context())
     else:
-        return pickle.loads(data)
+        return _patch_pandas_mgr(pickle.loads(data))
 
 
 def dump(obj, file, *, serial_type=None, compress=None, pickle_protocol=None):
@@ -322,7 +335,8 @@ def serialize(data):
 
 @_wrap_deprecates
 def deserialize(data):
-    return pyarrow.deserialize(data, mars_serialize_context())
+    result = pyarrow.deserialize(data, mars_serialize_context())
+    return _patch_pandas_mgr(result)
 
 
 _FreezeGrouping = namedtuple('_FreezeGrouping', 'name codes grouper ')

--- a/mars/serialize/dataserializer.py
+++ b/mars/serialize/dataserializer.py
@@ -241,9 +241,9 @@ def load(file):
             file.close()
 
     if header.type == SerialType.ARROW:
-        return pyarrow.deserialize(memoryview(buf), mars_serialize_context())
+        return deserialize(memoryview(buf))
     else:
-        return _patch_pandas_mgr(pickle.loads(buf))
+        return _patch_pandas_mgr(pickle.loads(buf))  # nosec
 
 
 def loads(buf):
@@ -268,9 +268,9 @@ def loads(buf):
             bounds = np.cumsum([4 + meta_block_size] + buffer_sizes)
             meta['data'] = [pyarrow.py_buffer(data_view[bounds[idx]:bounds[idx + 1]])
                             for idx in range(len(buffer_sizes))]
-            return pyarrow.deserialize_components(meta, mars_serialize_context())
+            return _patch_pandas_mgr(pyarrow.deserialize_components(meta, mars_serialize_context()))
     else:
-        return _patch_pandas_mgr(pickle.loads(data))
+        return _patch_pandas_mgr(pickle.loads(data))  # nosec
 
 
 def dump(obj, file, *, serial_type=None, compress=None, pickle_protocol=None):

--- a/mars/serialize/dataserializer.py
+++ b/mars/serialize/dataserializer.py
@@ -221,7 +221,9 @@ _PANDAS_HAS_MGR = hasattr(pd.Series([0]), '_mgr')
 
 
 def _patch_pandas_mgr(pd_obj):  # pragma: no cover
-    """"""
+    # as pandas prior to 1.1.0 use _data instead of _mgr to hold BlockManager,
+    # deserializing from high versions may produce mal-functioned pandas objects,
+    # thus the patch is needed
     if _PANDAS_HAS_MGR:
         return pd_obj
     if hasattr(pd_obj, '_mgr') and isinstance(pd_obj, (pd.DataFrame, pd.Series)):

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -365,6 +365,7 @@ message OperandDef {
         INSERT = 732;
         MAP_CHUNK = 733;
         REBALANCE = 734;
+        EXPLODE = 735;
 
         FUSE = 801;
 


### PR DESCRIPTION
## What do these changes do?

Implements {DataFrame,Series}.explode. Also fix pandas objects serialized from old versions.

## Related issue number

Fixes #1704
Fixes #1713