### PR TITLE
Fix inferring dtype for `series.map`

### DIFF
--- a/mars/dataframe/base/map.py
+++ b/mars/dataframe/base/map.py
@@ -26,6 +26,7 @@ from ...tiles import TilesError
 from ...utils import check_chunks_unknown_shape, enter_current_session
 from ..core import SERIES_TYPE
 from ..operands import DataFrameOperand, DataFrameOperandMixin
+from ..utils import build_series
 
 
 class DataFrameMap(DataFrameOperand, DataFrameOperandMixin):
@@ -76,6 +77,13 @@ class DataFrameMap(DataFrameOperand, DataFrameOperandMixin):
                 return_type = sig.return_annotation
                 if return_type is not inspect._empty:
                     inferred_dtype = np.dtype(return_type)
+                else:
+                    try:
+                        # try to infer dtype by calling the function
+                        inferred_dtype = build_series(series).map(
+                            self._arg, na_action=self._na_action).dtype
+                    except:  # noqa: E722  # nosec
+                        pass
             else:
                 if isinstance(self._arg, MutableMapping):
                     inferred_dtype = pd.Series(self._arg).dtype

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -1214,7 +1214,7 @@ class Test(TestBase):
 
     def testValueCountsExecution(self):
         rs = np.random.RandomState(0)
-        s = pd.Series(rs.randint(5, size=100))
+        s = pd.Series(rs.randint(5, size=100), name='s')
         s[rs.randint(100)] = np.nan
 
         ctx, executor = self._create_test_context(self.executor)

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -160,6 +160,15 @@ class Test(TestBase):
         expected = raw.map(lambda x: x + 1.)
         pd.testing.assert_series_equal(result, expected)
 
+        def f(x: int):
+            return x + 1.
+
+        # dtype can be inferred for function
+        r = s.map(f)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = raw.map(lambda x: x + 1.)
+        pd.testing.assert_series_equal(result, expected)
+
         # test arg is a md.Series
         raw2 = pd.Series([10], index=[5])
         s2 = from_pandas_series(raw2)

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -97,14 +97,14 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
     def build_mock_groupby(self, **kwargs):
         in_df = self.inputs[0]
         if self.is_dataframe_obj:
-            empty_df = build_df(in_df, size=2)
+            empty_df = build_df(in_df, size=1)
             obj_dtypes = in_df.dtypes[in_df.dtypes == np.dtype('O')]
             empty_df[obj_dtypes.index] = 'O'
         else:
             if in_df.dtype == np.dtype('O'):
                 empty_df = pd.Series('O', index=pd.RangeIndex(2), name=in_df.name, dtype=np.dtype('O'))
             else:
-                empty_df = build_series(in_df, size=2, name=in_df.name)
+                empty_df = build_series(in_df, size=1, name=in_df.name)
 
         new_kw = self.groupby_params
         new_kw.update(kwargs)
@@ -114,7 +114,7 @@ class DataFrameGroupByOperand(DataFrameMapReduceOperand, DataFrameOperandMixin):
             new_by = []
             for v in new_kw['by']:
                 if isinstance(v, (Base, Entity)):
-                    new_by.append(build_series(v, size=2, name=v.name))
+                    new_by.append(build_series(v, size=1, name=v.name))
                 else:
                     new_by.append(v)
             new_kw['by'] = new_by

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -253,12 +253,14 @@ class DataFrameIndex(DataFrameOperand, DataFrameOperandMixin):
                                        name=self._col_names)
         else:
             if isinstance(self.mask, (SERIES_TYPE, DATAFRAME_TYPE)):
-                index_value = parse_index(pd.Index([], dtype=df.index_value.to_pandas().dtype),
+                index_value = parse_index(pd.Index([], dtype=df.index_value.to_pandas().dtype,
+                                                   name=df.index_value.name),
                                           df, self._mask)
                 return self.new_dataframe([df, self._mask], shape=(np.nan, df.shape[1]), dtypes=df.dtypes,
                                           index_value=index_value, columns_value=df.columns_value)
             else:
-                index_value = parse_index(pd.Index([], dtype=df.index_value.to_pandas().dtype),
+                index_value = parse_index(pd.Index([], dtype=df.index_value.to_pandas().dtype,
+                                                   name=df.index_value.name),
                                           df, self._mask)
                 return self.new_dataframe([df], shape=(np.nan, df.shape[1]), dtypes=df.dtypes,
                                           index_value=index_value, columns_value=df.columns_value)

--- a/mars/dataframe/indexing/set_index.py
+++ b/mars/dataframe/indexing/set_index.py
@@ -117,7 +117,11 @@ class DataFrameSetIndex(DataFrameOperand, DataFrameOperandMixin):
                                                         verify_integrity=op.verify_integrity)
 
 
-def set_index(df, keys, drop=True, append=False, verify_integrity=False, **kw):
+def set_index(df, keys, drop=True, append=False, inplace=False, verify_integrity=False):
     op = DataFrameSetIndex(keys=keys, drop=drop, append=append,
-                           verify_integrity=verify_integrity, output_types=[OutputType.dataframe], **kw)
-    return op(df)
+                           verify_integrity=verify_integrity, output_types=[OutputType.dataframe])
+    result = op(df)
+    if not inplace:
+        return result
+    else:
+        df.data = result.data

--- a/mars/dataframe/indexing/tests/test_indexing.py
+++ b/mars/dataframe/indexing/tests/test_indexing.py
@@ -566,7 +566,9 @@ class Test(TestBase):
             self.assertEqual(c.shape, (2, 1))
 
     def testDataFrameGetitemBool(self):
-        data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'c3', 'c4', 'c5'])
+        data = pd.DataFrame(np.random.rand(10, 5),
+                            columns=['c1', 'c2', 'c3', 'c4', 'c5'],
+                            index=pd.RangeIndex(10, name='i'))
         df = md.DataFrame(data, chunk_size=2)
 
         mask_data1 = data.c1 > 0.5
@@ -582,6 +584,7 @@ class Test(TestBase):
         self.assertNotEqual(r1.index_value.key, mask1.index_value.key)
         self.assertEqual(r1.columns_value.key, df.columns_value.key)
         self.assertIs(r1.columns_value, df.columns_value)
+        self.assertEqual(r1.index_value.name, 'i')
 
         self.assertNotEqual(r1.index_value.key, r2.index_value.key)
         self.assertEqual(r1.columns_value.key, r2.columns_value.key)

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -48,6 +48,11 @@ class Test(TestBase):
         pd.testing.assert_frame_equal(
             expected, self.executor.execute_dataframe(df4, concat=True)[0])
 
+        expected = df1.set_index('y')
+        df2.set_index('y', inplace=True)
+        pd.testing.assert_frame_equal(
+            expected, self.executor.execute_dataframe(df2, concat=True)[0])
+
     def testILocGetItem(self):
         df1 = pd.DataFrame([[1, 3, 3], [4, 2, 6], [7, 8, 9]],
                            index=['a1', 'a2', 'a3'], columns=['x', 'y', 'z'])

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -243,6 +243,7 @@ def parse_index(index_value, *args, store_data=False, key=None):
     def _serialize_index(index):
         tp = getattr(IndexValue, type(index).__name__)
         properties = _extract_property(index, tp, store_data)
+        properties['_name'] = index.name
         return tp(**properties)
 
     def _serialize_range_index(index):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes:

1. Infer dtype correctly for `series.map`.
2. Pass index name for bool indexing.
3. Eliminate index name for `series.value_counts` which is consistent to pandas.
4. Fix `build_mock_groupby` which may raise error `ValueError: cannot reindex from a duplicate axis`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1717 .
Fixes #1718 .
