### PR TITLE
Fix sort functions of DataFrames on CUDA

### DIFF
--- a/mars/dataframe/sort/core.py
+++ b/mars/dataframe/sort/core.py
@@ -27,14 +27,12 @@ class DataFrameSortOperand(DataFrameOperand):
     _parallel_kind = StringField('parallel_kind')
     _psrs_kinds = ListField('psrs_kinds', ValueType.string)
 
-    def __init__(self, axis=None, ascending=None, inplace=None, kind=None,
-                 na_position=None, ignore_index=None, parallel_kind=None, psrs_kinds=None, **kw):
-        super(DataFrameSortOperand, self).__init__(_axis=axis, _ascending=ascending,
-                                                   _inplace=inplace, _kind=kind,
-                                                   _na_position=na_position,
-                                                   _ignore_index=ignore_index,
-                                                   _parallel_kind=parallel_kind,
-                                                   _psrs_kinds=psrs_kinds, **kw)
+    def __init__(self, axis=None, ascending=None, inplace=None, kind=None, na_position=None,
+                 ignore_index=None, parallel_kind=None, psrs_kinds=None, gpu=False, **kw):
+        super().__init__(_axis=axis, _ascending=ascending, _inplace=inplace, _kind=kind,
+                         _na_position=na_position, _ignore_index=ignore_index,
+                         _parallel_kind=parallel_kind, _psrs_kinds=psrs_kinds,
+                         _gpu=gpu, **kw)
 
     @property
     def axis(self):

--- a/mars/dataframe/sort/sort_index.py
+++ b/mars/dataframe/sort/sort_index.py
@@ -183,7 +183,7 @@ def sort_index(a, axis=0, level=None, ascending=True, inplace=False, kind='quick
     op = DataFrameSortIndex(level=level, axis=axis, ascending=ascending, inplace=inplace,
                             kind=kind, na_position=na_position, sort_remaining=sort_remaining,
                             ignore_index=ignore_index, parallel_kind=parallel_kind,
-                            psrs_kinds=psrs_kinds)
+                            psrs_kinds=psrs_kinds, gpu=a.op.is_gpu())
     sorted_a = op(a)
     if inplace:
         a.data = sorted_a.data

--- a/mars/dataframe/sort/sort_values.py
+++ b/mars/dataframe/sort/sort_values.py
@@ -217,7 +217,7 @@ def dataframe_sort_values(df, by, axis=0, ascending=True, inplace=False, kind='q
     by = by if isinstance(by, (list, tuple)) else [by]
     op = DataFrameSortValues(by=by, axis=axis, ascending=ascending, inplace=inplace, kind=kind,
                              na_position=na_position, ignore_index=ignore_index, parallel_kind=parallel_kind,
-                             psrs_kinds=psrs_kinds, output_types=[OutputType.dataframe])
+                             psrs_kinds=psrs_kinds, gpu=df.op.is_gpu(), output_types=[OutputType.dataframe])
     sorted_df = op(df)
     if inplace:
         df.data = sorted_df.data
@@ -312,7 +312,7 @@ def series_sort_values(series, axis=0, ascending=True, inplace=False, kind='quic
     op = DataFrameSortValues(axis=axis, ascending=ascending, inplace=inplace, kind=kind,
                              na_position=na_position, ignore_index=ignore_index,
                              parallel_kind=parallel_kind, psrs_kinds=psrs_kinds,
-                             output_types=[OutputType.series])
+                             output_types=[OutputType.series], gpu=series.op.is_gpu())
     sorted_series = op(series)
     if inplace:
         series.data = sorted_series.data


### PR DESCRIPTION
## What do these changes do?

Fix `sort_index` and `sort_values` of DataFrames on CUDA. cuDF 0.16 is needed.

## Related issue number

Fixes #1720 