### PR TITLE
Support `num_partitions` argument for DataFrame initializers

### DIFF
--- a/mars/dataframe/base/__init__.py
+++ b/mars/dataframe/base/__init__.py
@@ -111,6 +111,7 @@ def _install():
 
     for t in INDEX_TYPE:
         setattr(t, 'rechunk', rechunk)
+        setattr(t, 'rebalance', rebalance)
         setattr(t, 'drop', index_drop)
         setattr(t, 'drop_duplicates', index_drop_duplicates)
         setattr(t, 'memory_usage', index_memory_usage)

--- a/mars/dataframe/base/apply.py
+++ b/mars/dataframe/base/apply.py
@@ -26,7 +26,7 @@ from ...serialize import StringField, AnyField, BoolField, \
 from ...utils import enter_current_session
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..utils import build_df, build_series, parse_index, validate_axis, \
-    validate_output_types
+    validate_output_types, suspend_stdio
 
 
 class ApplyOperand(DataFrameOperand, DataFrameOperandMixin):
@@ -205,7 +205,7 @@ class ApplyOperand(DataFrameOperand, DataFrameOperandMixin):
 
         try:
             empty_df = build_df(df, size=2)
-            with np.errstate(all='ignore'):
+            with np.errstate(all='ignore'), suspend_stdio():
                 infer_df = empty_df.apply(self._func, axis=self._axis, raw=self._raw,
                                           result_type=self._result_type, args=self.args, **self.kwds)
             if index_value is None:
@@ -265,7 +265,7 @@ class ApplyOperand(DataFrameOperand, DataFrameOperandMixin):
         if self._convert_dtype:
             try:
                 test_series = build_series(series, size=2, name=series.name)
-                with np.errstate(all='ignore'):
+                with np.errstate(all='ignore'), suspend_stdio():
                     infer_series = test_series.apply(self._func, args=self.args, **self.kwds)
             except:  # noqa: E722  # nosec  # pylint: disable=bare-except
                 infer_series = None

--- a/mars/dataframe/base/apply.py
+++ b/mars/dataframe/base/apply.py
@@ -26,7 +26,7 @@ from ...serialize import StringField, AnyField, BoolField, \
 from ...utils import enter_current_session
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..utils import build_df, build_series, parse_index, validate_axis, \
-    validate_output_types, suspend_stdio
+    validate_output_types, quiet_stdio
 
 
 class ApplyOperand(DataFrameOperand, DataFrameOperandMixin):
@@ -205,7 +205,7 @@ class ApplyOperand(DataFrameOperand, DataFrameOperandMixin):
 
         try:
             empty_df = build_df(df, size=2)
-            with np.errstate(all='ignore'), suspend_stdio():
+            with np.errstate(all='ignore'), quiet_stdio():
                 infer_df = empty_df.apply(self._func, axis=self._axis, raw=self._raw,
                                           result_type=self._result_type, args=self.args, **self.kwds)
             if index_value is None:
@@ -265,7 +265,7 @@ class ApplyOperand(DataFrameOperand, DataFrameOperandMixin):
         if self._convert_dtype:
             try:
                 test_series = build_series(series, size=2, name=series.name)
-                with np.errstate(all='ignore'), suspend_stdio():
+                with np.errstate(all='ignore'), quiet_stdio():
                     infer_series = test_series.apply(self._func, args=self.args, **self.kwds)
             except:  # noqa: E722  # nosec  # pylint: disable=bare-except
                 infer_series = None

--- a/mars/dataframe/base/map.py
+++ b/mars/dataframe/base/map.py
@@ -26,7 +26,7 @@ from ...tiles import TilesError
 from ...utils import check_chunks_unknown_shape, enter_current_session
 from ..core import SERIES_TYPE
 from ..operands import DataFrameOperand, DataFrameOperandMixin
-from ..utils import build_series
+from ..utils import build_series, suspend_stdio
 
 
 class DataFrameMap(DataFrameOperand, DataFrameOperandMixin):
@@ -79,9 +79,10 @@ class DataFrameMap(DataFrameOperand, DataFrameOperandMixin):
                     inferred_dtype = np.dtype(return_type)
                 else:
                     try:
-                        # try to infer dtype by calling the function
-                        inferred_dtype = build_series(series).map(
-                            self._arg, na_action=self._na_action).dtype
+                        with suspend_stdio():
+                            # try to infer dtype by calling the function
+                            inferred_dtype = build_series(series).map(
+                                self._arg, na_action=self._na_action).dtype
                     except:  # noqa: E722  # nosec
                         pass
             else:

--- a/mars/dataframe/base/map.py
+++ b/mars/dataframe/base/map.py
@@ -26,7 +26,7 @@ from ...tiles import TilesError
 from ...utils import check_chunks_unknown_shape, enter_current_session
 from ..core import SERIES_TYPE
 from ..operands import DataFrameOperand, DataFrameOperandMixin
-from ..utils import build_series, suspend_stdio
+from ..utils import build_series, quiet_stdio
 
 
 class DataFrameMap(DataFrameOperand, DataFrameOperandMixin):
@@ -79,7 +79,7 @@ class DataFrameMap(DataFrameOperand, DataFrameOperandMixin):
                     inferred_dtype = np.dtype(return_type)
                 else:
                     try:
-                        with suspend_stdio():
+                        with quiet_stdio():
                             # try to infer dtype by calling the function
                             inferred_dtype = build_series(series).map(
                                 self._arg, na_action=self._na_action).dtype

--- a/mars/dataframe/base/rechunk.py
+++ b/mars/dataframe/base/rechunk.py
@@ -156,7 +156,7 @@ def compute_rechunk(a, chunk_size):
                                                    output_types=a.op.output_types)
                 merge_chunk = merge_chunk_op.new_chunk([old_chunk], shape=merge_chunk_shape,
                                                        index=merge_idx, index_value=new_index_value,
-                                                       dtype=old_chunk.dtype)
+                                                       dtype=old_chunk.dtype, name=old_chunk.name)
             to_merge.append(merge_chunk)
         if len(to_merge) == 1:
             chunk_op = to_merge[0].op.copy()
@@ -183,7 +183,8 @@ def compute_rechunk(a, chunk_size):
                 index_value = _concat_series_index(to_merge)
                 out_chunk = chunk_op.new_chunk(to_merge, shape=chunk_shape,
                                                index=idx, index_value=index_value,
-                                               dtype=to_merge[0].dtype)
+                                               dtype=to_merge[0].dtype,
+                                               name=to_merge[0].name)
             result_chunks.append(out_chunk)
 
     if is_dataframe:
@@ -197,4 +198,4 @@ def compute_rechunk(a, chunk_size):
         else:
             f = op.new_series
         return f([a], a.shape, dtype=a.dtype, index_value=a.index_value,
-                 nsplits=chunk_size, chunks=result_chunks)
+                 nsplits=chunk_size, chunks=result_chunks, name=a.name)

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -1679,13 +1679,21 @@ class Test(TestBase):
         raw = pd.DataFrame(np.random.rand(10, 3), columns=list('abc'))
         df = from_pandas_df(raw)
 
-        df2 = df.rebalance()
+        r = df.rebalance(num_partitions=3)
+        results = self.executor.execute_dataframe(r)
+        self.assertEqual(len(results), 3)
+        pd.testing.assert_frame_equal(pd.concat(results), raw)
+
+        r = df.rebalance(factor=1.5)
+        results = self.executor.execute_dataframe(r)
+        pd.testing.assert_frame_equal(results[0], raw)
 
         self.ctx.set_ncores(2)
         with self.ctx:
-            result = self.executor.execute_dataframe(df2)
-            self.assertEqual(len(result), 2)
-            pd.testing.assert_frame_equal(pd.concat(result), raw)
+            r = df.rebalance()
+            results = self.executor.execute_dataframe(r)
+            self.assertEqual(len(results), 2)
+            pd.testing.assert_frame_equal(pd.concat(results), raw)
 
     def testStackExecution(self):
         raw = pd.DataFrame(np.random.rand(10, 3), columns=list('abc'),

--- a/mars/dataframe/base/transform.py
+++ b/mars/dataframe/base/transform.py
@@ -24,7 +24,7 @@ from ...utils import enter_current_session
 from ..core import DATAFRAME_CHUNK_TYPE, DATAFRAME_TYPE
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..utils import build_df, build_series, validate_axis, \
-    parse_index, filter_dtypes_by_index
+    parse_index, filter_dtypes_by_index, suspend_stdio
 
 
 class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
@@ -183,7 +183,7 @@ class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
         if self.output_types[0] == OutputType.dataframe:
             test_df = build_df(df, fill_value=1, size=2)
             try:
-                with np.errstate(all='ignore'):
+                with np.errstate(all='ignore'), suspend_stdio():
                     if self.call_agg:
                         infer_df = test_df.agg(self._func, axis=self._axis, *self.args, **self.kwds)
                     else:
@@ -193,7 +193,7 @@ class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
         else:
             test_df = build_series(df, size=2, name=df.name)
             try:
-                with np.errstate(all='ignore'):
+                with np.errstate(all='ignore'), suspend_stdio():
                     if self.call_agg:
                         infer_df = test_df.agg(self._func, args=self.args, **self.kwds)
                     else:

--- a/mars/dataframe/base/transform.py
+++ b/mars/dataframe/base/transform.py
@@ -24,7 +24,7 @@ from ...utils import enter_current_session
 from ..core import DATAFRAME_CHUNK_TYPE, DATAFRAME_TYPE
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..utils import build_df, build_series, validate_axis, \
-    parse_index, filter_dtypes_by_index, suspend_stdio
+    parse_index, filter_dtypes_by_index, quiet_stdio
 
 
 class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
@@ -183,7 +183,7 @@ class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
         if self.output_types[0] == OutputType.dataframe:
             test_df = build_df(df, fill_value=1, size=2)
             try:
-                with np.errstate(all='ignore'), suspend_stdio():
+                with np.errstate(all='ignore'), quiet_stdio():
                     if self.call_agg:
                         infer_df = test_df.agg(self._func, axis=self._axis, *self.args, **self.kwds)
                     else:
@@ -193,7 +193,7 @@ class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
         else:
             test_df = build_series(df, size=2, name=df.name)
             try:
-                with np.errstate(all='ignore'), suspend_stdio():
+                with np.errstate(all='ignore'), quiet_stdio():
                     if self.call_agg:
                         infer_df = test_df.agg(self._func, args=self.args, **self.kwds)
                     else:

--- a/mars/dataframe/datasource/from_tensor.py
+++ b/mars/dataframe/datasource/from_tensor.py
@@ -350,9 +350,13 @@ def dataframe_from_tensor(tensor, index=None, columns=None, gpu=None, sparse=Fal
 
 
 def dataframe_from_1d_tileables(d, index=None, columns=None, gpu=None, sparse=False):
-    tileables = list(d.values())
-    columns = list(d.keys()) if columns is None else columns
-    gpu = next(t.op.gpu for t in tileables if hasattr(t, 'op')) if gpu is None else gpu
+    if columns is not None:
+        tileables = [d.get(c) for c in columns]
+    else:
+        columns = list(d.keys())
+        tileables = list(d.values())
+
+    gpu = next((t.op.gpu for t in tileables if hasattr(t, 'op')), False) if gpu is None else gpu
     dtypes = pd.Series([t.dtype if hasattr(t, 'dtype') else pd.Series(t).dtype
                         for t in tileables], index=columns)
     op = DataFrameFromTensor(input_=d, dtypes=dtypes,

--- a/mars/dataframe/groupby/apply.py
+++ b/mars/dataframe/groupby/apply.py
@@ -22,7 +22,7 @@ from ...serialize import TupleField, DictField, FunctionField, StringField
 from ...utils import enter_current_session
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..utils import build_df, build_empty_df, build_series, build_empty_series, \
-    parse_index, validate_output_types, suspend_stdio
+    parse_index, validate_output_types, quiet_stdio
 
 
 class GroupByApply(DataFrameOperand, DataFrameOperandMixin):
@@ -157,7 +157,7 @@ class GroupByApply(DataFrameOperand, DataFrameOperandMixin):
         while in_df.op.output_types[0] not in (OutputType.dataframe, OutputType.series):
             in_df = in_df.inputs[0]
 
-        with suspend_stdio():
+        with quiet_stdio():
             dtypes, index_value = self._infer_df_func_returns(groupby, in_df, dtypes, index)
         if index_value is None:
             index_value = parse_index(None, (in_df.key, in_df.index_value.key))

--- a/mars/dataframe/groupby/apply.py
+++ b/mars/dataframe/groupby/apply.py
@@ -22,7 +22,7 @@ from ...serialize import TupleField, DictField, FunctionField, StringField
 from ...utils import enter_current_session
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..utils import build_df, build_empty_df, build_series, build_empty_series, \
-    parse_index, validate_output_types
+    parse_index, validate_output_types, suspend_stdio
 
 
 class GroupByApply(DataFrameOperand, DataFrameOperandMixin):
@@ -157,7 +157,8 @@ class GroupByApply(DataFrameOperand, DataFrameOperandMixin):
         while in_df.op.output_types[0] not in (OutputType.dataframe, OutputType.series):
             in_df = in_df.inputs[0]
 
-        dtypes, index_value = self._infer_df_func_returns(groupby, in_df, dtypes, index)
+        with suspend_stdio():
+            dtypes, index_value = self._infer_df_func_returns(groupby, in_df, dtypes, index)
         if index_value is None:
             index_value = parse_index(None, (in_df.key, in_df.index_value.key))
         for arg, desc in zip((self.output_types, dtypes), ('output_types', 'dtypes')):

--- a/mars/dataframe/groupby/transform.py
+++ b/mars/dataframe/groupby/transform.py
@@ -21,7 +21,7 @@ from ...custom_log import redirect_custom_log
 from ...serialize import BoolField, TupleField, DictField, AnyField, StringField
 from ...utils import enter_current_session
 from ..operands import DataFrameOperandMixin, DataFrameOperand
-from ..utils import build_empty_df, build_empty_series, parse_index
+from ..utils import build_empty_df, build_empty_series, parse_index, suspend_stdio
 
 
 class GroupByTransform(DataFrameOperand, DataFrameOperandMixin):
@@ -70,7 +70,7 @@ class GroupByTransform(DataFrameOperand, DataFrameOperandMixin):
 
         try:
             empty_groupby = in_groupby.op.build_mock_groupby()
-            with np.errstate(all='ignore'):
+            with np.errstate(all='ignore'), suspend_stdio():
                 if self.call_agg:
                     infer_df = empty_groupby.agg(self.func, *self.args, **self.kwds)
                 else:

--- a/mars/dataframe/groupby/transform.py
+++ b/mars/dataframe/groupby/transform.py
@@ -21,7 +21,7 @@ from ...custom_log import redirect_custom_log
 from ...serialize import BoolField, TupleField, DictField, AnyField, StringField
 from ...utils import enter_current_session
 from ..operands import DataFrameOperandMixin, DataFrameOperand
-from ..utils import build_empty_df, build_empty_series, parse_index, suspend_stdio
+from ..utils import build_empty_df, build_empty_series, parse_index, quiet_stdio
 
 
 class GroupByTransform(DataFrameOperand, DataFrameOperandMixin):
@@ -70,7 +70,7 @@ class GroupByTransform(DataFrameOperand, DataFrameOperandMixin):
 
         try:
             empty_groupby = in_groupby.op.build_mock_groupby()
-            with np.errstate(all='ignore'), suspend_stdio():
+            with np.errstate(all='ignore'), quiet_stdio():
                 if self.call_agg:
                     infer_df = empty_groupby.agg(self.func, *self.args, **self.kwds)
                 else:

--- a/mars/dataframe/initializer.py
+++ b/mars/dataframe/initializer.py
@@ -17,6 +17,7 @@ import pandas as pd
 from ..core import Base, Entity, OutputType
 from ..tensor import tensor as astensor
 from ..tensor.core import TENSOR_TYPE
+from ..utils import ceildiv
 from .core import DATAFRAME_TYPE, SERIES_TYPE, INDEX_TYPE, DataFrame as _Frame, \
     Series as _Series, Index as _Index
 from .datasource.dataframe import from_pandas as from_pandas_df
@@ -30,21 +31,28 @@ from .fetch import DataFrameFetch
 
 class DataFrame(_Frame):
     def __init__(self, data=None, index=None, columns=None, dtype=None, copy=False,
-                 chunk_size=None, gpu=None, sparse=None):
+                 chunk_size=None, gpu=None, sparse=None, num_partitions=None):
+        # make sure __getattr__ does not result in stack overflow
+        self._data = None
+
+        need_repart = False
         if isinstance(data, TENSOR_TYPE):
             if chunk_size is not None:
                 data = data.rechunk(chunk_size)
             df = dataframe_from_tensor(data, index=index, columns=columns, gpu=gpu, sparse=sparse)
+            need_repart = num_partitions is not None
         elif isinstance(data, DATAFRAME_TYPE):
             if not hasattr(data, 'data'):
                 # DataFrameData
                 df = _Frame(data)
             else:
                 df = data
+            need_repart = num_partitions is not None
         elif isinstance(data, dict) and any(isinstance(v, (Base, Entity)) for v in data.values()):
             # data is a dict and some value is tensor
             df = dataframe_from_1d_tileables(
                 data, index=index, columns=columns, gpu=gpu, sparse=sparse)
+            need_repart = num_partitions is not None
         elif isinstance(index, (INDEX_TYPE, SERIES_TYPE)):
             if isinstance(data, dict):
                 data = {k: astensor(v, chunk_size=chunk_size) for k, v in data.items()}
@@ -53,31 +61,50 @@ class DataFrame(_Frame):
             else:
                 df = dataframe_from_tensor(astensor(data, chunk_size=chunk_size), index=index,
                                            columns=columns, gpu=gpu, sparse=sparse)
+            need_repart = num_partitions is not None
         else:
             pdf = pd.DataFrame(data, index=index, columns=columns, dtype=dtype, copy=copy)
+            if num_partitions is not None:
+                chunk_size = ceildiv(len(pdf), num_partitions)
             df = from_pandas_df(pdf, chunk_size=chunk_size, gpu=gpu, sparse=sparse)
+
+        if need_repart:
+            df = df.rebalance(num_partitions=num_partitions)
         super().__init__(df.data)
 
 
 class Series(_Series):
     def __init__(self, data=None, index=None, dtype=None, name=None, copy=False,
-                 chunk_size=None, gpu=None, sparse=None):
-        if isinstance(data, TENSOR_TYPE):
+                 chunk_size=None, gpu=None, sparse=None, num_partitions=None):
+        # make sure __getattr__ does not result in stack overflow
+        self._data = None
+
+        need_repart = False
+        if isinstance(data, (TENSOR_TYPE, INDEX_TYPE)):
             if chunk_size is not None:
                 data = data.rechunk(chunk_size)
+            name = name or getattr(data, 'name', None)
             series = series_from_tensor(data, index=index, name=name, gpu=gpu, sparse=sparse)
+            need_repart = num_partitions is not None
         elif isinstance(index, INDEX_TYPE):
             series = series_from_tensor(astensor(data, chunk_size=chunk_size), index=index,
                                         name=name, gpu=gpu, sparse=sparse)
+            need_repart = num_partitions is not None
         elif isinstance(data, SERIES_TYPE):
             if not hasattr(data, 'data'):
                 # SeriesData
                 series = _Series(data)
             else:
                 series = data
+            need_repart = num_partitions is not None
         else:
             pd_series = pd.Series(data, index=index, dtype=dtype, name=name, copy=copy)
+            if num_partitions is not None:
+                chunk_size = ceildiv(len(pd_series), num_partitions)
             series = from_pandas_series(pd_series, chunk_size=chunk_size, gpu=gpu, sparse=sparse)
+
+        if need_repart:
+            series = series.rebalance(num_partitions=num_partitions)
         super().__init__(series.data)
 
 
@@ -87,24 +114,38 @@ class Index(_Index):
         return object.__new__(cls)
 
     def __init__(self, data=None, dtype=None, copy=False, name=None, tupleize_cols=True,
-                 chunk_size=None, gpu=None, sparse=None, names=None):
+                 chunk_size=None, gpu=None, sparse=None, names=None, num_partitions=None):
+        # make sure __getattr__ does not result in stack overflow
+        self._data = None
+
+        need_repart = False
         if isinstance(data, INDEX_TYPE):
             if not hasattr(data, 'data'):
                 # IndexData
                 index = _Index(data)
             else:
                 index = data
+            need_repart = num_partitions is not None
         else:
             if isinstance(data, (Base, Entity)):
+                name = name if name is not None else getattr(data, 'name', None)
                 index = from_tileable_index(data, dtype=dtype, name=name)
+                need_repart = num_partitions is not None
             else:
                 if not isinstance(data, pd.Index):
+                    name = name if name is not None else getattr(data, 'name', None)
                     pd_index = pd.Index(data=data, dtype=dtype, copy=copy, name=name,
                                         tupleize_cols=tupleize_cols)
                 else:
                     pd_index = data
+
+                if num_partitions is not None:
+                    chunk_size = ceildiv(len(pd_index), num_partitions)
                 index = from_pandas_index(pd_index, chunk_size=chunk_size,
                                           gpu=gpu, sparse=sparse)
+
+        if need_repart:
+            index = index.rebalance(num_partitions=num_partitions)
         super().__init__(index.data)
 
 

--- a/mars/dataframe/tests/test_initializer.py
+++ b/mars/dataframe/tests/test_initializer.py
@@ -1,0 +1,138 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+
+import mars.dataframe as md
+import mars.tensor as mt
+from mars.tests.core import TestBase
+
+
+class Test(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.ctx, self.executor = self._create_test_context()
+
+    def testDataFrameInitializer(self):
+        # from tensor
+        raw = np.random.rand(100, 10)
+        tensor = mt.tensor(raw, chunk_size=7)
+        r = md.DataFrame(tensor)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        pd.testing.assert_frame_equal(result, pd.DataFrame(raw))
+
+        r = md.DataFrame(tensor, chunk_size=13)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        pd.testing.assert_frame_equal(result, pd.DataFrame(raw))
+
+        # from Mars dataframe
+        raw = pd.DataFrame(np.random.rand(100, 10), columns=list('ABCDEFGHIJ'))
+        df = md.DataFrame(raw, chunk_size=15) * 2
+        r = md.DataFrame(df, num_partitions=11)
+        results = self.executor.execute_dataframe(r)
+        self.assertEqual(len(results), 10)
+        pd.testing.assert_frame_equal(pd.concat(results), raw * 2)
+
+        # from tileable dict
+        raw_dict = {
+            'C': np.random.choice(['u', 'v', 'w'], size=(100,)),
+            'A': pd.Series(np.random.rand(100)),
+            'B': np.random.randint(0, 10, size=(100,)),
+        }
+        m_dict = raw_dict.copy()
+        m_dict['A'] = md.Series(m_dict['A'])
+        m_dict['B'] = mt.tensor(m_dict['B'])
+        r = md.DataFrame(m_dict, columns=list('ABC'))
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        pd.testing.assert_frame_equal(result, pd.DataFrame(raw_dict, columns=list('ABC')))
+
+        # from raw pandas initializer
+        raw = pd.DataFrame(np.random.rand(100, 10), columns=list('ABCDEFGHIJ'))
+        r = md.DataFrame(raw, num_partitions=10)
+        results = self.executor.execute_dataframe(r)
+        self.assertEqual(len(results), 10)
+        pd.testing.assert_frame_equal(pd.concat(results), raw)
+
+    def testSeriesInitializer(self):
+        # from tensor
+        raw = np.random.rand(100)
+        tensor = mt.tensor(raw, chunk_size=7)
+        r = md.Series(tensor)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        pd.testing.assert_series_equal(result, pd.Series(raw))
+
+        r = md.Series(tensor, chunk_size=13)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        pd.testing.assert_series_equal(result, pd.Series(raw))
+
+        # from index
+        raw = np.arange(100)
+        np.random.shuffle(raw)
+        raw = pd.Index(raw, name='idx_name')
+        idx = md.Index(raw, chunk_size=7)
+        r = md.Series(idx)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        pd.testing.assert_series_equal(result, pd.Series(raw))
+
+        # from Mars series
+        raw = pd.Series(np.random.rand(100), name='series_name')
+        ms = md.Series(raw, chunk_size=15) * 2
+        r = md.Series(ms, num_partitions=11)
+        results = self.executor.execute_dataframe(r)
+        self.assertEqual(len(results), 10)
+        pd.testing.assert_series_equal(pd.concat(results), raw * 2)
+
+        # from raw pandas initializer
+        raw = pd.Series(np.random.rand(100), name='series_name')
+        r = md.Series(raw, num_partitions=10)
+        results = self.executor.execute_dataframe(r)
+        self.assertEqual(len(results), 10)
+        pd.testing.assert_series_equal(pd.concat(results), raw)
+
+    def testIndexInitializer(self):
+        def _concat_idx(results):
+            s_results = [pd.Series(idx) for idx in results]
+            return pd.Index(pd.concat(s_results))
+
+        # from tensor
+        raw = np.arange(100)
+        np.random.shuffle(raw)
+        tensor = mt.tensor(raw)
+        r = md.Index(tensor, chunk_size=7)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        pd.testing.assert_index_equal(result, pd.Index(raw))
+
+        # from Mars index
+        raw = np.arange(100)
+        np.random.shuffle(raw)
+        idx = md.Index(raw, chunk_size=7)
+        r = md.Index(idx, num_partitions=11)
+        results = self.executor.execute_dataframe(r)
+        self.assertEqual(len(results), 10)
+        pd.testing.assert_index_equal(_concat_idx(results), pd.Index(raw))
+
+        # from pandas initializer
+        raw = np.arange(100)
+        np.random.shuffle(raw)
+        raw_ser = pd.Series(raw, name='series_name')
+        r = md.Index(raw_ser, chunk_size=7)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        pd.testing.assert_index_equal(result, pd.Index(raw_ser))
+
+        raw_idx = pd.Index(raw, name='idx_name')
+        r = md.Index(raw_idx, num_partitions=10)
+        results = self.executor.execute_dataframe(r)
+        self.assertEqual(len(results), 10)
+        pd.testing.assert_index_equal(_concat_idx(results), pd.Index(raw_idx))

--- a/mars/dataframe/tests/test_utils.py
+++ b/mars/dataframe/tests/test_utils.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-from numbers import Integral
 import operator
+import sys
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from numbers import Integral
 
 import numpy as np
 import pandas as pd
@@ -24,7 +26,7 @@ from mars.dataframe.initializer import DataFrame
 from mars.dataframe.core import IndexValue
 from mars.dataframe.utils import decide_dataframe_chunk_sizes, decide_series_chunk_size, \
     split_monotonic_index_min_max, build_split_idx_to_origin_idx, parse_index, filter_index_value, \
-    infer_dtypes, infer_index_value, validate_axis, fetch_corner_data
+    infer_dtypes, infer_index_value, validate_axis, fetch_corner_data, suspend_stdio
 from mars.session import new_session
 
 
@@ -412,3 +414,42 @@ class Test(unittest.TestCase):
             self.assertEqual(corner.to_string(max_rows=corner_max_rows, min_rows=min_rows),
                              pdf.to_string(max_rows=max_rows, min_rows=min_rows),
                              f'failed when row == {row}')
+
+    def testSuspendStdio(self):
+        old_stdout, old_stderr = sys.stdout, sys.stderr
+
+        class _IOWrapper:
+            def __init__(self, name=None):
+                self.name = name
+                self.content = ''
+
+            @staticmethod
+            def writable():
+                return True
+
+            def write(self, d):
+                self.content += d
+                return len(d)
+
+        stdout_w = _IOWrapper('stdout')
+        stderr_w = _IOWrapper('stderr')
+        executor = ThreadPoolExecutor(1)
+        try:
+            sys.stdout = stdout_w
+            sys.stderr = stderr_w
+
+            with suspend_stdio(), suspend_stdio():
+                self.assertTrue(sys.stdout.writable())
+                self.assertTrue(sys.stderr.writable())
+
+                print('LINE 1', end='\n')
+                print('LINE 2', file=sys.stderr, end='\n')
+                executor.submit(print, 'LINE T').result()
+
+            print('LINE 1', end='\n')
+            print('LINE 2', file=sys.stderr, end='\n')
+        finally:
+            sys.stdout, sys.stderr = old_stdout, old_stderr
+
+        self.assertEqual(stdout_w.content, 'LINE T\nLINE 1\n')
+        self.assertEqual(stderr_w.content, 'LINE 2\n')

--- a/mars/dataframe/tests/test_utils.py
+++ b/mars/dataframe/tests/test_utils.py
@@ -26,7 +26,7 @@ from mars.dataframe.initializer import DataFrame
 from mars.dataframe.core import IndexValue
 from mars.dataframe.utils import decide_dataframe_chunk_sizes, decide_series_chunk_size, \
     split_monotonic_index_min_max, build_split_idx_to_origin_idx, parse_index, filter_index_value, \
-    infer_dtypes, infer_index_value, validate_axis, fetch_corner_data, suspend_stdio
+    infer_dtypes, infer_index_value, validate_axis, fetch_corner_data, quiet_stdio
 from mars.session import new_session
 
 
@@ -415,7 +415,7 @@ class Test(unittest.TestCase):
                              pdf.to_string(max_rows=max_rows, min_rows=min_rows),
                              f'failed when row == {row}')
 
-    def testSuspendStdio(self):
+    def testQuietStdio(self):
         old_stdout, old_stderr = sys.stdout, sys.stderr
 
         class _IOWrapper:
@@ -438,13 +438,15 @@ class Test(unittest.TestCase):
             sys.stdout = stdout_w
             sys.stderr = stderr_w
 
-            with suspend_stdio(), suspend_stdio():
-                self.assertTrue(sys.stdout.writable())
-                self.assertTrue(sys.stderr.writable())
+            with quiet_stdio():
+                with quiet_stdio():
+                    self.assertTrue(sys.stdout.writable())
+                    self.assertTrue(sys.stderr.writable())
 
-                print('LINE 1', end='\n')
-                print('LINE 2', file=sys.stderr, end='\n')
-                executor.submit(print, 'LINE T').result()
+                    print('LINE 1', end='\n')
+                    print('LINE 2', file=sys.stderr, end='\n')
+                    executor.submit(print, 'LINE T').result()
+                print('LINE 3', end='\n')
 
             print('LINE 1', end='\n')
             print('LINE 2', file=sys.stderr, end='\n')


### PR DESCRIPTION
## What do these changes do?

1. Support `num_partitions` argument for DataFrame initializers
2. Fixes column order when creating DataFrames from dicts
3. Allow creating Series from Index
4. Suspend standard outputs when inferring output dtypes

## Related issue number

Fixes #1314 
Fixes #1726
Fixes #1728 