### PR TITLE
Add preliminary statsmodels support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             fi
             if [[ $UNAME == "linux" ]] && [[ ! "$PYTHON" =~ "3.8" ]]; then
               conda install --quiet --yes -n test -c conda-forge --no-deps python=$PYTHON \
-                libxgboost py-xgboost xgboost lightgbm tensorflow
+                libxgboost py-xgboost xgboost lightgbm tensorflow statsmodels
             fi
             if [[ $UNAME == "linux" ]] && [[ "$PYTHON" =~ "3.6" ]]; then
               pip install torch==1.4.0 torchvision==0.5.0 faiss-cpu

--- a/docs/source/reference/learn/reference.rst
+++ b/docs/source/reference/learn/reference.rst
@@ -200,12 +200,12 @@ Utilities
    utils.validation.check_is_fitted
    utils.validation.column_or_1d
 
-.. _tensorflow_ref:
+.. _lightgbm_ref:
 
-TensorFlow Integration
-======================
+LightGBM Integration
+====================
 
-.. automodule:: mars.learn.contrib.tensorflow
+.. automodule:: mars.learn.contrib.lightgbm
    :no-members:
    :no-inherited-members:
 
@@ -214,7 +214,9 @@ TensorFlow Integration
 .. autosummary::
    :toctree: generated/
 
-   contrib.tensorflow.run_tensorflow_script
+   contrib.lightgbm.LGBMClassifier
+   contrib.lightgbm.LGBMRegressor
+   contrib.lightgbm.LGBMRanker
 
 .. _pytorch_ref:
 
@@ -235,6 +237,39 @@ PyTorch Integration
    contrib.pytorch.MarsDistributedSampler
    contrib.pytorch.MarsRandomSampler
 
+.. _statsmodels_ref:
+
+StatsModels Integration
+=======================
+
+.. automodule:: mars.learn.contrib.statsmodels
+   :no-members:
+   :no-inherited-members:
+
+.. currentmodule:: mars.learn
+
+.. autosummary::
+   :toctree: generated/
+
+   contrib.statsmodels.MarsDistributedModel
+   contrib.statsmodels.MarsResults
+
+.. _tensorflow_ref:
+
+TensorFlow Integration
+======================
+
+.. automodule:: mars.learn.contrib.tensorflow
+   :no-members:
+   :no-inherited-members:
+
+.. currentmodule:: mars.learn
+
+.. autosummary::
+   :toctree: generated/
+
+   contrib.tensorflow.run_tensorflow_script
+
 .. _xgboost_ref:
 
 XGBoost Integration
@@ -254,21 +289,3 @@ XGBoost Integration
    contrib.xgboost.predict
    contrib.xgboost.XGBClassifier
    contrib.xgboost.XGBRegressor
-
-.. _lightgbm_ref:
-
-LightGBM Integration
-====================
-
-.. automodule:: mars.learn.contrib.lightgbm
-   :no-members:
-   :no-inherited-members:
-
-.. currentmodule:: mars.learn
-
-.. autosummary::
-   :toctree: generated/
-
-   contrib.lightgbm.LGBMClassifier
-   contrib.lightgbm.LGBMRegressor
-   contrib.lightgbm.LGBMRanker

--- a/docs/source/user_guide/learn/index.rst
+++ b/docs/source/user_guide/learn/index.rst
@@ -12,6 +12,7 @@ can be obtained in the :ref:`API reference <learn_api>`.
 .. toctree::
    :maxdepth: 2
 
+   lightgbm
+   statsmodels
    tensorflow
    xgboost
-   lightgbm

--- a/docs/source/user_guide/learn/statsmodels.rst
+++ b/docs/source/user_guide/learn/statsmodels.rst
@@ -1,0 +1,159 @@
+.. _statsmodels:
+
+**************************
+Integrate with StatsModels
+**************************
+
+.. currentmodule:: mars.learn.contrib.statsmodels
+
+This is an introduction about how to use StatsModels for model fitting and
+prediction in Mars.
+
+Installation
+------------
+
+If you are trying to use Mars on a single machine e.g. on your laptop, make
+sure StatsModels is installed.
+
+You can install StatsModels via pip:
+
+.. code-block:: bash
+
+    pip install statsmodels
+
+Visit `installation guide for StatsModels
+<https://www.statsmodels.org/stable/install.html>`_ for more information.
+
+On the other hand, if you are using Mars on a cluster, make sure StatsModels is
+installed on each worker.
+
+Prepare data
+------------
+
+First, we use scikit-learn to load the Boston Housing dataset.
+
+.. code-block:: ipython
+
+   In [1]: from sklearn.datasets import load_boston
+   In [2]: boston = load_boston()
+
+Then create Mars DataFrame from the dataset.
+
+.. code-block:: ipython
+
+   In [3]: import mars.dataframe as md
+   In [4]: data = md.DataFrame(boston.data, columns=boston.feature_names)
+
+Explore the top 5 rows data of the DataFrame.
+
+.. code-block:: ipython
+
+   In [5]: data.head().execute()
+   Out[5]:
+         CRIM    ZN  INDUS  CHAS    NOX  ...  RAD    TAX  PTRATIO       B  LSTAT
+   0  0.00632  18.0   2.31   0.0  0.538  ...  1.0  296.0     15.3  396.90   4.98
+   1  0.02731   0.0   7.07   0.0  0.469  ...  2.0  242.0     17.8  396.90   9.14
+   2  0.02729   0.0   7.07   0.0  0.469  ...  2.0  242.0     17.8  392.83   4.03
+   3  0.03237   0.0   2.18   0.0  0.458  ...  3.0  222.0     18.7  394.63   2.94
+   4  0.06905   0.0   2.18   0.0  0.458  ...  3.0  222.0     18.7  396.90   5.33
+
+   [5 rows x 13 columns]
+
+:meth:`mars.dataframe.DataFrame.describe` gives summary statistics of the columns.
+
+.. code-block:: ipython
+
+   In [6]: data.describe().execute()
+   Out[6]:
+                CRIM          ZN       INDUS  ...     PTRATIO           B       LSTAT
+   count  506.000000  506.000000  506.000000  ...  506.000000  506.000000  506.000000
+   mean     3.613524   11.363636   11.136779  ...   18.455534  356.674032   12.653063
+   std      8.601545   23.322453    6.860353  ...    2.164946   91.294864    7.141062
+   min      0.006320    0.000000    0.460000  ...   12.600000    0.320000    1.730000
+   25%      0.082045    0.000000    5.190000  ...   17.400000  375.377500    6.950000
+   50%      0.256510    0.000000    9.690000  ...   19.050000  391.440000   11.360000
+   75%      3.677083   12.500000   18.100000  ...   20.200000  396.225000   16.955000
+   max     88.976200  100.000000   27.740000  ...   22.000000  396.900000   37.970000
+
+   [8 rows x 13 columns]
+
+We can shuffle the sequence of the data, and separate the data into train and
+test parts.
+
+.. code-block:: ipython
+
+   In [7]: from mars.learn.model_selection import train_test_split
+   In [8]: X_train, X_test, y_train, y_test = \
+      ...:     train_test_split(data, boston.target, train_size=0.7, random_state=0)
+
+Training
+--------
+
+We can fit a model with API similar to the `distributed estimation API
+<https://www.statsmodels.org/stable/examples/notebooks/generated/distributed_estimation.html>`_
+implemented in StatsModels.
+
+.. code-block:: ipython
+
+   In [9]: from mars.learn.contrib import statsmodels as msm
+   In [10]: model = msm.MarsDistributedModel(num_partitions=5)
+   In [11]: results = model.fit(y_train, X_train, alpha=0.2)
+   In [12]: results
+   Out[12]: <mars.learn.contrib.statsmodels.api.MarsResults at 0x7fd47a118f70>
+
+Arguments for ``DistributedModel`` like ``model_class``, ``estimation_method``
+and ``join_method`` can be added to the constructor of
+``MarsDistributedModel``.
+
+Prediction
+----------
+
+For prediction,
+
+.. code-block:: ipython
+
+   In [13]: results.predict(X_test)
+   Out[13]:
+   377    20.475695
+   218    20.792441
+   216    23.158081
+   78     19.912593
+   467    14.290641
+            ...
+   94     24.798897
+   120    22.196336
+   53     23.714524
+   165    19.824247
+   319    22.138279
+   Length: 152, dtype: float64
+
+Distributed fitting and prediction
+-----------------------------------
+
+Refer to :ref:`deploy` section for deployment, or :ref:`k8s` section for
+running Mars on Kubernetes.
+
+Once a cluster exists, you can either set the session as default, the fitting
+and prediction shown above will be submitted to the cluster, or you can specify
+``session=***`` explicitly as well.
+
+Take :meth:`MarsDistributedModel.fit` as an example.
+
+.. code-block:: python
+
+   # A cluster has been configured, and web UI is started on <web_ip>:<web_port>
+   from mars.session import new_session
+   # set the session as the default one
+   sess = new_session('http://<web_ip>:<web_port>').as_default()
+
+   # specify partition number
+   model = msm.MarsDistributedModel(num_partitions=5)
+   # or specify factor for cluster size,
+   # num_partitions will be int(factor * num_cores)
+   model = msm.MarsDistributedModel(factor=1.2)
+
+   # fitting will submitted to cluster by default
+   results = model.fit(y_train, X_train, alpha=1.2)
+
+   # Or, session could be specified as well
+   results = model.fit(y_train, X_train, alpha=1.2, session=sess)

--- a/mars/learn/contrib/statsmodels/__init__.py
+++ b/mars/learn/contrib/statsmodels/__init__.py
@@ -12,18 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# register operands
-# import torch first, or some issue emerges,
-# see https://github.com/pytorch/pytorch/issues/2575
-from .contrib import pytorch, tensorflow, xgboost, lightgbm, statsmodels
-from .metrics import pairwise
-from . import cluster
-from . import preprocessing
-from . import proxima
-from . import neighbors
-from . import utils
+from .api import MarsDistributedModel, MarsResults
 
-for _mod in [xgboost, tensorflow, pytorch, lightgbm, proxima, neighbors, statsmodels]:
-    _mod.register_op()
 
-del _mod, pairwise, preprocessing, utils
+def register_op():
+    from . import train, predict
+    del train, predict

--- a/mars/learn/contrib/statsmodels/api.py
+++ b/mars/learn/contrib/statsmodels/api.py
@@ -1,0 +1,73 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pickle  # nosec  # pylint: disable=import_pickle
+
+from .train import StatsModelsTrain
+from .predict import StatsModelsPredict
+
+try:
+    from statsmodels.base.distributed_estimation import DistributedModel
+except ImportError:
+    DistributedModel = None
+
+
+class MarsDistributedModel:
+    def __init__(self, factor=None, num_partitions=None, model_class=None,
+                 init_kwds=None, estimation_method=None, estimation_kwds=None,
+                 join_method=None, join_kwds=None, results_class=None, results_kwds=None):
+        self._factor = factor
+        self._sm_model = DistributedModel(
+            num_partitions or 10, model_class=model_class, init_kwds=init_kwds,
+            estimation_method=estimation_method, estimation_kwds=estimation_kwds,
+            join_method=join_method, join_kwds=join_kwds, results_class=results_class,
+            results_kwds=results_kwds
+        )
+
+    def fit(self, endog, exog, session=None, **kwargs):
+        num_partitions = None if self._factor is not None else self._sm_model.partitions
+        run_kwargs = kwargs.pop('run_kwargs', dict())
+        op = StatsModelsTrain(
+            endog=endog, exog=exog, num_partitions=num_partitions, factor=self._factor,
+            model_class=self._sm_model.model_class, init_kwds=self._sm_model.init_kwds,
+            fit_kwds=kwargs, estimation_method=self._sm_model.estimation_method,
+            estimation_kwds=self._sm_model.estimation_kwds,
+            join_method=self._sm_model.join_method, join_kwds=self._sm_model.join_kwds,
+            results_class=self._sm_model.results_class,
+            results_kwds=self._sm_model.results_kwds)
+        result = op(exog, endog).execute(session=session, **run_kwargs).fetch(session=session)
+        return MarsResults(pickle.loads(result))  # nosec
+
+
+class MarsResults:
+    def __init__(self, model):
+        self._model = model
+
+    @property
+    def model(self):
+        return self._model
+
+    def __getattr__(self, item):
+        if item == '_model':
+            raise AttributeError
+        return getattr(self._model, item)
+
+    def __mars_tokenize__(self):
+        return pickle.dumps(self.model)
+
+    def predict(self, exog, *args, **kwargs):
+        session = kwargs.pop('session', None)
+        run_kwargs = kwargs.pop('run_kwargs', dict())
+        op = StatsModelsPredict(model_results=self, predict_args=args, predict_kwargs=kwargs)
+        return op(exog).execute(session=session, **run_kwargs)

--- a/mars/learn/contrib/statsmodels/predict.py
+++ b/mars/learn/contrib/statsmodels/predict.py
@@ -1,0 +1,101 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pickle  # nosec  # pylint: disable=import_pickle
+
+import numpy as np
+
+from .... import opcodes
+from ....dataframe.core import DATAFRAME_TYPE, SERIES_TYPE
+from ....serialize import BytesField, DictField, TupleField
+from ....core import OutputType
+from ...operands import LearnOperand, LearnOperandMixin
+
+
+class StatsModelsPredict(LearnOperand, LearnOperandMixin):
+    _op_code_ = opcodes.STATSMODELS_PREDICT
+
+    _model_results = BytesField('model_results', on_serialize=pickle.dumps,
+                                on_deserialize=pickle.loads)
+    _predict_args = TupleField('predict_args')
+    _predict_kwargs = DictField('predict_kwargs')
+
+    def __init__(self, model_results=None, predict_args=None, predict_kwargs=None, **kw):
+        super().__init__(_model_results=model_results, _predict_args=predict_args,
+                         _predict_kwargs=predict_kwargs, **kw)
+
+    @property
+    def model_results(self):
+        return self._model_results
+
+    @property
+    def predict_args(self) -> tuple:
+        return self._predict_args
+
+    @property
+    def predict_kwargs(self) -> dict:
+        return self._predict_kwargs
+
+    def __call__(self, exog):
+        if isinstance(exog, (DATAFRAME_TYPE, SERIES_TYPE)):
+            self._output_types = [OutputType.series]
+            kwargs = dict(
+                shape=exog.shape[:1],
+                index_value=exog.index_value,
+                dtype=np.dtype('float'),
+            )
+        else:
+            self._output_types = [OutputType.tensor]
+            kwargs = dict(
+                shape=exog.shape[:1],
+                dtype=np.dtype('float'),
+            )
+        return self.new_tileable([exog], **kwargs)
+
+    @classmethod
+    def tile(cls, op: 'StatsModelsPredict'):
+        exog = op.inputs[0]
+        out = op.outputs[0]
+
+        if exog.ndim > 1 and exog.chunk_shape[1] > 1:
+            exog = exog.rechunk({1: exog.shape[1]})._inplace_tile()
+
+        chunks = []
+        for in_chunk in exog.chunks:
+            if isinstance(exog, (DATAFRAME_TYPE, SERIES_TYPE)):
+                kwargs = dict(
+                    index=in_chunk.index[:1],
+                    shape=in_chunk.shape[:1],
+                    index_value=in_chunk.index_value,
+                    dtype=out.dtype,
+                )
+            else:
+                kwargs = dict(
+                    index=in_chunk.index[:1],
+                    shape=in_chunk.shape[:1],
+                    dtype=out.dtype,
+                )
+
+            new_op = op.copy().reset_key()
+            chunks.append(new_op.new_chunk([in_chunk], **kwargs))
+
+        new_op = op.copy().reset_key()
+        return new_op.new_tileables([exog], chunks=chunks, nsplits=(exog.nsplits[0],),
+                                    **out.params)
+
+    @classmethod
+    def execute(cls, ctx, op: 'StatsModelsPredict'):
+        in_data = ctx[op.inputs[0].key]
+        ctx[op.outputs[0].key] = op.model_results.model.predict(
+            in_data, *op.predict_args, **op.predict_kwargs)

--- a/mars/learn/contrib/statsmodels/tests/__init__.py
+++ b/mars/learn/contrib/statsmodels/tests/__init__.py
@@ -11,19 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# register operands
-# import torch first, or some issue emerges,
-# see https://github.com/pytorch/pytorch/issues/2575
-from .contrib import pytorch, tensorflow, xgboost, lightgbm, statsmodels
-from .metrics import pairwise
-from . import cluster
-from . import preprocessing
-from . import proxima
-from . import neighbors
-from . import utils
-
-for _mod in [xgboost, tensorflow, pytorch, lightgbm, proxima, neighbors, statsmodels]:
-    _mod.register_op()
-
-del _mod, pairwise, preprocessing, utils

--- a/mars/learn/contrib/statsmodels/tests/integrated/__init__.py
+++ b/mars/learn/contrib/statsmodels/tests/integrated/__init__.py
@@ -11,19 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# register operands
-# import torch first, or some issue emerges,
-# see https://github.com/pytorch/pytorch/issues/2575
-from .contrib import pytorch, tensorflow, xgboost, lightgbm, statsmodels
-from .metrics import pairwise
-from . import cluster
-from . import preprocessing
-from . import proxima
-from . import neighbors
-from . import utils
-
-for _mod in [xgboost, tensorflow, pytorch, lightgbm, proxima, neighbors, statsmodels]:
-    _mod.register_op()
-
-del _mod, pairwise, preprocessing, utils

--- a/mars/learn/contrib/statsmodels/tests/integrated/test_distributed_statsmodels.py
+++ b/mars/learn/contrib/statsmodels/tests/integrated/test_distributed_statsmodels.py
@@ -1,0 +1,58 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from mars.learn.tests.integrated.base import LearnIntegrationTestBase
+import mars.tensor as mt
+from mars.session import new_session
+
+try:
+    import statsmodels
+    from mars.learn.contrib.statsmodels import MarsDistributedModel, MarsResults
+except ImportError:  # pragma: no cover
+    statsmodels = MarsDistributedModel = MarsResults = None
+
+
+@unittest.skipIf(statsmodels is None, 'statsmodels not installed')
+class Test(LearnIntegrationTestBase):
+    def setUp(self):
+        n_rows = 1000
+        n_columns = 10
+        chunk_size = 20
+        rs = mt.random.RandomState(0)
+        X = rs.rand(n_rows, n_columns, chunk_size=chunk_size)
+        y = rs.rand(n_rows, chunk_size=chunk_size)
+        filter = rs.rand(n_rows, chunk_size=chunk_size) < 0.8
+        self.X = X[filter]
+        self.y = y[filter]
+        super().setUp()
+
+    def testDistributedStatsModels(self):
+        service_ep = 'http://127.0.0.1:' + self.web_port
+        timeout = 120 if 'CI' in os.environ else -1
+        with new_session(service_ep) as sess:
+            run_kwargs = {'timeout': timeout}
+
+            X, y = self.X, self.y
+            y = (y * 10).astype(mt.int32)
+            model = MarsDistributedModel(factor=1.2)
+            result = model.fit(y, X, alpha=0.2, session=sess, run_kwargs=run_kwargs)
+            prediction = result.predict(X, session=sess, run_kwargs=run_kwargs)
+
+            X.execute(session=sess)
+
+            self.assertEqual(prediction.ndim, 1)
+            self.assertEqual(prediction.shape[0], len(self.X))

--- a/mars/learn/contrib/statsmodels/tests/test_statsmodels.py
+++ b/mars/learn/contrib/statsmodels/tests/test_statsmodels.py
@@ -35,8 +35,8 @@ class Test(unittest.TestCase):
         rs = mt.random.RandomState(0)
         self.X = rs.rand(n_rows, n_columns, chunk_size=chunk_size)
         self.y = rs.rand(n_rows, chunk_size=chunk_size)
-        self.X_df = md.DataFrame(self.X)
-        self.y_s = md.Series(self.y)
+        self.X_df = md.DataFrame(self.X, chunk_size=(100, 5))
+        self.y_s = md.Series(self.y, chunk_size=100)
 
         self.session = new_session().as_default()
         self._old_executor = self.session._sess._executor

--- a/mars/learn/contrib/statsmodels/tests/test_statsmodels.py
+++ b/mars/learn/contrib/statsmodels/tests/test_statsmodels.py
@@ -1,0 +1,59 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import mars.tensor as mt
+import mars.dataframe as md
+from mars.session import new_session
+from mars.tests.core import ExecutorForTest
+
+try:
+    import statsmodels
+    from mars.learn.contrib.statsmodels import MarsDistributedModel, MarsResults
+except ImportError:  # pragma: no cover
+    statsmodels = MarsDistributedModel = MarsResults = None
+
+
+@unittest.skipIf(statsmodels is None, 'statsmodels not installed')
+class Test(unittest.TestCase):
+    def setUp(self):
+        n_rows = 1000
+        n_columns = 10
+        chunk_size = 20
+        rs = mt.random.RandomState(0)
+        self.X = rs.rand(n_rows, n_columns, chunk_size=chunk_size)
+        self.y = rs.rand(n_rows, chunk_size=chunk_size)
+        self.X_df = md.DataFrame(self.X)
+        self.y_s = md.Series(self.y)
+
+        self.session = new_session().as_default()
+        self._old_executor = self.session._sess._executor
+        self.executor = self.session._sess._executor = \
+            ExecutorForTest('numpy', storage=self.session._sess._context)
+
+    def testLocalTrainPredict(self):
+        model = MarsDistributedModel(num_partitions=10)
+        result = model.fit(self.y, self.X, alpha=0.2, session=self.session)
+        self.assertIsInstance(result, MarsResults)
+        predict_tensor = result.predict(self.X, session=self.session)
+        predicted = predict_tensor.fetch(session=self.session)
+        self.assertEqual(predicted.shape, self.y.shape)
+
+        model = MarsDistributedModel(num_partitions=10)
+        result = model.fit(self.y_s, self.X_df, alpha=0.2, session=self.session)
+        self.assertIsInstance(result, MarsResults)
+        predict_tensor = result.predict(self.X_df, session=self.session)
+        predicted = predict_tensor.fetch(session=self.session)
+        self.assertEqual(predicted.shape, self.y.shape)

--- a/mars/learn/contrib/statsmodels/train.py
+++ b/mars/learn/contrib/statsmodels/train.py
@@ -1,0 +1,199 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pickle  # nosec  # pylint: disable=import_pickle
+
+import cloudpickle
+
+from .... import opcodes
+from ....context import get_context
+from ....operands import OutputType, OperandStage, MergeDictOperand
+from ....serialize import KeyField, BytesField, DictField, Int32Field, \
+    Float32Field, FunctionField
+from ....tiles import TilesError
+from ....utils import check_chunks_unknown_shape
+
+
+class StatsModelsTrain(MergeDictOperand):
+    _op_type_ = opcodes.STATSMODELS_TRAIN
+
+    _exog = KeyField('exog')  # exogenous
+    _endog = KeyField('endog')  # endogenous
+
+    _num_partitions = Int32Field('num_partitions')
+    _partition_id = Int32Field('partition_id')
+    _factor = Float32Field('factor')
+    _model_class = BytesField('model_class', on_serialize=cloudpickle.dumps,
+                              on_deserialize=cloudpickle.loads)
+    _init_kwds = DictField('init_kwds')
+    _fit_kwds = DictField('fit_kwds')
+    _estimation_method = FunctionField('estimation_method')
+    _estimation_kwds = DictField('estimation_kwds')
+    _join_method = FunctionField('join_method')
+    _join_kwds = DictField('join_kwds')
+    _results_class = BytesField('results_class', on_serialize=cloudpickle.dumps,
+                                on_deserialize=cloudpickle.loads)
+    _results_kwds = DictField('results_kwds')
+
+    def __init__(self, exog=None, endog=None, num_partitions=None, partition_id=None,
+                 factor=None, model_class=None, init_kwds=None, fit_kwds=None,
+                 estimation_method=None, estimation_kwds=None, join_method=None,
+                 join_kwds=None, results_class=None, results_kwds=None, stage=None, **kw):
+        super().__init__(_exog=exog, _endog=endog, _num_partitions=num_partitions,
+                         _partition_id=partition_id, _factor=factor,
+                         _model_class=model_class, _init_kwds=init_kwds,
+                         _fit_kwds=fit_kwds, _estimation_method=estimation_method,
+                         _estimation_kwds=estimation_kwds, _join_method=join_method,
+                         _join_kwds=join_kwds, _results_class=results_class,
+                         _results_kwds=results_kwds, _stage=stage, **kw)
+
+    @property
+    def exog(self):
+        return self._exog
+
+    @property
+    def endog(self):
+        return self._endog
+
+    @property
+    def num_partitions(self):
+        return self._num_partitions
+
+    @property
+    def partition_id(self):
+        return self._partition_id
+
+    @property
+    def factor(self):
+        return self._factor
+
+    @property
+    def model_class(self):
+        return self._model_class
+
+    @property
+    def init_kwds(self) -> dict:
+        return self._init_kwds
+
+    @property
+    def fit_kwds(self) -> dict:
+        return self._fit_kwds
+
+    @property
+    def estimation_method(self):
+        return self._estimation_method
+
+    @property
+    def estimation_kwds(self) -> dict:
+        return self._estimation_kwds
+
+    @property
+    def join_method(self):
+        return self._join_method
+
+    @property
+    def join_kwds(self) -> dict:
+        return self._join_kwds
+
+    @property
+    def results_class(self):
+        return self._results_class
+
+    @property
+    def results_kwds(self) -> dict:
+        return self._results_kwds
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        inputs_iter = iter(inputs)
+        self._exog = next(inputs_iter)
+        self._endog = next(inputs_iter)
+
+    def __call__(self, exog, endog):
+        self._output_types = [OutputType.object]
+        return self.new_tileable([exog, endog])
+
+    @classmethod
+    def tile(cls, op: "StatsModelsTrain"):
+        if op.factor is not None:
+            ctx = get_context()
+            cluster_cpu_count = ctx.get_total_ncores()
+            assert cluster_cpu_count > 0
+            num_partitions = int(cluster_cpu_count * op.factor)
+        else:
+            num_partitions = op.num_partitions
+
+        check_chunks_unknown_shape([op.exog, op.endog], TilesError)
+
+        exog = op.exog
+        if exog.ndim > 1:
+            exog = exog.rechunk({1: exog.shape[1]})._inplace_tile()
+        exog = exog.rebalance(num_partitions=num_partitions)._inplace_tile()
+        endog = op.endog.rebalance(num_partitions=num_partitions)._inplace_tile()
+
+        assert len(exog.chunks) == len(endog.chunks)
+
+        # generate map stage
+        map_chunks = []
+        for part_id, (exog_chunk, endog_chunk) in enumerate(zip(exog.chunks, endog.chunks)):
+            new_op = op.copy().reset_key()
+            new_op._factor = None
+            new_op._partition_id = part_id
+            new_op._num_partitions = num_partitions
+            new_op._stage = OperandStage.map
+
+            map_chunks.append(new_op.new_chunk(
+                [exog_chunk, endog_chunk], index=exog_chunk.index))
+
+        # generate combine (join) stage
+        new_op = op.copy().reset_key()
+        new_op._factor = None
+        new_op._num_partitions = num_partitions
+        new_op._stage = OperandStage.combine
+
+        combine_chunk = new_op.new_chunk(map_chunks, index=(0,))
+
+        # generate tileable
+        new_op = op.copy().reset_key()
+        return new_op.new_tileables(op.inputs, chunks=[combine_chunk])
+
+    @classmethod
+    def _execute_map(cls, ctx, op: "StatsModelsTrain"):
+        endog = ctx[op.endog.key]
+        exog = ctx[op.exog.key]
+
+        # code from statsmodels.base.distributed_estimation::_helper_fit_partition
+        model = op.model_class(endog, exog, **op.init_kwds)
+        results = op.estimation_method(model, op.partition_id, op.num_partitions,
+                                       fit_kwds=op.fit_kwds, **op.estimation_kwds)
+        ctx[op.outputs[0].key] = pickle.dumps(results)
+
+    @classmethod
+    def _execute_combine(cls, ctx, op: "StatsModelsTrain"):
+        # code from statsmodels.base.distributed_estimation::DistributedModel.fit
+        results_list = [pickle.loads(ctx[inp.key]) for inp in op.inputs]  # nosec
+        params = op.join_method(results_list, **op.join_kwds)
+        res_mod = op.model_class([0], [0], **op.init_kwds)
+        result = op.results_class(res_mod, params, **op.results_kwds)
+
+        ctx[op.outputs[0].key] = pickle.dumps(result)
+
+    @classmethod
+    def execute(cls, ctx, op: "StatsModelsTrain"):
+        if op.merge:
+            super().execute(ctx, op)
+        elif op.stage == OperandStage.combine:
+            cls._execute_combine(ctx, op)
+        else:
+            cls._execute_map(ctx, op)

--- a/mars/learn/contrib/statsmodels/train.py
+++ b/mars/learn/contrib/statsmodels/train.py
@@ -137,7 +137,7 @@ class StatsModelsTrain(MergeDictOperand):
         check_chunks_unknown_shape([op.exog, op.endog], TilesError)
 
         exog = op.exog
-        if exog.ndim > 1:
+        if exog.ndim > 1 and exog.chunk_shape[1] > 1:
             exog = exog.rechunk({1: exog.shape[1]})._inplace_tile()
         exog = exog.rebalance(num_partitions=num_partitions)._inplace_tile()
         endog = op.endog.rebalance(num_partitions=num_partitions)._inplace_tile()
@@ -191,7 +191,7 @@ class StatsModelsTrain(MergeDictOperand):
 
     @classmethod
     def execute(cls, ctx, op: "StatsModelsTrain"):
-        if op.merge:
+        if op.merge:  # pragma: no cover
             super().execute(ctx, op)
         elif op.stage == OperandStage.combine:
             cls._execute_combine(ctx, op)

--- a/mars/scheduler/analyzer.py
+++ b/mars/scheduler/analyzer.py
@@ -363,7 +363,7 @@ class GraphAnalyzer(object):
                 cur = sorted_candidates.pop()
                 while cur.op.key in cur_assigns:
                     cur = sorted_candidates.pop()
-            except IndexError:
+            except IndexError:  # pragma: no cover
                 break
             self._assign_by_bfs(cur, worker, worker_quotas, spread_ranges, op_keys,
                                 cur_assigns, graph=graph)

--- a/mars/scheduler/analyzer.py
+++ b/mars/scheduler/analyzer.py
@@ -359,9 +359,12 @@ class GraphAnalyzer(object):
         sorted_candidates = [v for v in chunks_to_assign]
         while max(worker_quotas.values()):
             worker = max(worker_quotas, key=lambda k: worker_quotas[k])
-            cur = sorted_candidates.pop()
-            while cur.op.key in cur_assigns:
+            try:
                 cur = sorted_candidates.pop()
+                while cur.op.key in cur_assigns:
+                    cur = sorted_candidates.pop()
+            except IndexError:
+                break
             self._assign_by_bfs(cur, worker, worker_quotas, spread_ranges, op_keys,
                                 cur_assigns, graph=graph)
 

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -501,6 +501,10 @@ message OperandDef {
         // PyTorch
         RUN_PYTORCH = 3011;
 
+        // statsmodels
+        STATSMODELS_TRAIN = 3012;
+        STATSMODELS_PREDICT = 3013;
+
         // learn
         // checks
         CHECK_NON_NEGATIVE = 3300;


### PR DESCRIPTION
## What do these changes do?

Add distributed model for statsmodels library. As statsmodels does not support model analysis for `RegularizedResults` generated from `DistributedModel`, it is not implemented either.

## Related issue number

Fixes #1734 