### PR TITLE
Fix `md.read_csv` when names and usecols specified

### DIFF
--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -628,6 +628,15 @@ def read_csv(path, names=None, sep=',', index_col=None, compression=None, header
             b = f.read(head_end - head_start)
         mini_df = pd.read_csv(BytesIO(b), sep=sep, index_col=index_col, dtype=dtype,
                               names=names, header=header)
+        if names is None:
+            names = list(mini_df.columns)
+        else:
+            # if names specified, header should be None
+            header = None
+        if usecols:
+            usecols = usecols if isinstance(usecols, list) else [usecols]
+            col_index = sorted(mini_df.columns.get_indexer(usecols))
+            mini_df = mini_df.iloc[:, col_index]
 
     if isinstance(mini_df.index, pd.RangeIndex):
         index_value = parse_index(pd.RangeIndex(-1))
@@ -636,7 +645,6 @@ def read_csv(path, names=None, sep=',', index_col=None, compression=None, header
     columns_value = parse_index(mini_df.columns, store_data=True)
     if index_col and not isinstance(index_col, int):
         index_col = list(mini_df.columns).index(index_col)
-    names = list(mini_df.columns)
     op = DataFrameReadCSV(path=path, names=names, sep=sep, header=header, index_col=index_col,
                           usecols=usecols, compression=compression, gpu=gpu,
                           incremental_index=incremental_index, use_arrow_dtype=use_arrow_dtype,

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -324,6 +324,33 @@ class Test(TestBase):
             mdf = self.executor.execute_dataframe(md.read_csv(file_path, index_col=0, nrows=1), concat=True)[0]
             pd.testing.assert_frame_equal(df[:1], mdf)
 
+        # test names and usecols
+        with tempfile.TemporaryDirectory() as tempdir:
+            file_path = os.path.join(tempdir, 'test.csv')
+            df = pd.DataFrame(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.int64),
+                              columns=['a', 'b', 'c'])
+            df.to_csv(file_path, index=False)
+
+            mdf = self.executor.execute_dataframe(md.read_csv(file_path,
+                                                              usecols=['c', 'b']), concat=True)[0]
+            pd.testing.assert_frame_equal(
+                pd.read_csv(file_path, usecols=['c', 'b']), mdf)
+
+            mdf = self.executor.execute_dataframe(md.read_csv(file_path, names=['a', 'b', 'c'],
+                                                              usecols=['c', 'b']), concat=True)[0]
+            pd.testing.assert_frame_equal(
+                pd.read_csv(file_path, names=['a', 'b', 'c'], usecols=['c', 'b']), mdf)
+
+            mdf = self.executor.execute_dataframe(md.read_csv(file_path, names=['a', 'b', 'c'],
+                                                              usecols=['a', 'c']), concat=True)[0]
+            pd.testing.assert_frame_equal(
+                pd.read_csv(file_path, names=['a', 'b', 'c'], usecols=['a', 'c']), mdf)
+
+            mdf = self.executor.execute_dataframe(
+                md.read_csv(file_path, usecols=['a', 'c']), concat=True)[0]
+            pd.testing.assert_frame_equal(
+                pd.read_csv(file_path, usecols=['a', 'c']), mdf)
+
         # test sep
         with tempfile.TemporaryDirectory() as tempdir:
             file_path = os.path.join(tempdir, 'test.csv')


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes `md.read_csv` when names and usecols specified.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1736 .
