### PR TITLE
Support string dtype for tensor reductions

### DIFF
--- a/mars/tensor/reduction/all.py
+++ b/mars/tensor/reduction/all.py
@@ -102,5 +102,9 @@ def all(a, axis=None, out=None, keepdims=None, combine_size=None):
 
     """
     a = astensor(a)
-    op = TensorAll(axis=axis, dtype=np.dtype(bool), keepdims=keepdims, combine_size=combine_size)
+    if a.dtype == np.object_:
+        dtype = a.dtype
+    else:
+        dtype = np.dtype(bool)
+    op = TensorAll(axis=axis, dtype=dtype, keepdims=keepdims, combine_size=combine_size)
     return op(a, out=out)

--- a/mars/tensor/reduction/any.py
+++ b/mars/tensor/reduction/any.py
@@ -104,5 +104,9 @@ def any(a, axis=None, out=None, keepdims=None, combine_size=None):
 
     """
     a = astensor(a)
-    op = TensorAny(axis=axis, dtype=np.dtype(bool), keepdims=keepdims, combine_size=combine_size)
+    if a.dtype == np.object_:
+        dtype = a.dtype
+    else:
+        dtype = np.dtype(bool)
+    op = TensorAny(axis=axis, dtype=dtype, keepdims=keepdims, combine_size=combine_size)
     return op(a, out=out)

--- a/mars/tensor/reduction/sum.py
+++ b/mars/tensor/reduction/sum.py
@@ -122,7 +122,10 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=None, combine_size=None):
     """
     a = astensor(a)
     if dtype is None:
-        dtype = np.empty((1,), dtype=a.dtype).sum().dtype
+        if a.dtype == np.object_:
+            dtype = a.dtype
+        else:
+            dtype = np.empty((1,), dtype=a.dtype).sum().dtype
     else:
         dtype = np.dtype(dtype)
     op = TensorSum(axis=axis, dtype=dtype, keepdims=keepdims, combine_size=combine_size)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR added string dtype support for tensor reductions.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1743 .
