### PR TITLE
Fix repeated execution of same code in distributed mode

### DIFF
--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -177,9 +177,9 @@ cdef inline _extract_range_index_attr(object range_index, str attr):
 
 
 cdef list tokenize_pandas_index(ob):
-    cdef int start
-    cdef int stop
-    cdef int end
+    cdef long long start
+    cdef long long stop
+    cdef long long end
     if isinstance(ob, pd.RangeIndex):
         start = _extract_range_index_attr(ob, 'start')
         stop = _extract_range_index_attr(ob, 'stop')

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -259,7 +259,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
                 output_types=[OutputType.dataframe_groupby])
             reduce_chunks.append(
                 reduce_op.new_chunk([proxy_chunk], shape=(np.nan, np.nan), index=out_idx,
-                                    index_value=op.outputs[0].index_value))
+                                    index_value=None))
 
         return reduce_chunks
 

--- a/mars/dataframe/indexing/iloc.py
+++ b/mars/dataframe/indexing/iloc.py
@@ -204,6 +204,7 @@ class HeadTailOptimizedOperandMixin(DataFrameOperandMixin):
                 chunk_op = op.copy().reset_key()
                 params = out.params
                 params['index'] = chunk_index
+                params['shape'] = in_chunks[0].shape if np.isnan(in_chunks[0].shape[0]) else out.shape
                 new_chunks.append(chunk_op.new_chunk([concat_chunk], kws=[params]))
             chunks = new_chunks
 

--- a/mars/dataframe/indexing/iloc.py
+++ b/mars/dataframe/indexing/iloc.py
@@ -184,6 +184,7 @@ class HeadTailOptimizedOperandMixin(DataFrameOperandMixin):
             chunk_op = op.copy().reset_key()
             params = out.params
             params['index'] = c.index
+            params['shape'] = c.shape if np.isnan(c.shape[0]) else out.shape
             new_chunks.append(chunk_op.new_chunk([c], kws=[params]))
         chunks = new_chunks
 

--- a/mars/scheduler/operands/common.py
+++ b/mars/scheduler/operands/common.py
@@ -93,6 +93,11 @@ class OperandActor(BaseOperandActor):
         if not self._is_terminal:
             self._is_terminal = op_info.get('is_terminal')
 
+        if self.state in OperandState.STORED_STATES:
+            metas = self.chunk_meta.batch_get_chunk_meta(self._session_id, self._io_meta.get('chunks'))
+            if any(meta is None for meta in metas):
+                self.state = OperandState.UNSCHEDULED
+
         if self.state not in OperandState.TERMINATED_STATES:
             for in_key in self._pred_keys:
                 self._get_operand_actor(in_key).remove_finished_successor(

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -110,89 +110,105 @@ class Test(SchedulerIntegratedTest):
         self.start_processes(etcd=False, scheduler_args=['-Dscheduler.aggressive_assign=true'])
         sess = new_session(self.session_manager_ref.address)
 
-        # test binary arithmetics with different indices
-        raw1 = pd.DataFrame(np.random.rand(10, 10))
-        df1 = md.DataFrame(raw1, chunk_size=5)
-        raw2 = pd.DataFrame(np.random.rand(10, 10))
-        df2 = md.DataFrame(raw2, chunk_size=6)
-        r = df1 + df2
-        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        pd.testing.assert_frame_equal(result, raw1 + raw2)
+        # # test binary arithmetics with different indices
+        # raw1 = pd.DataFrame(np.random.rand(10, 10))
+        # df1 = md.DataFrame(raw1, chunk_size=5)
+        # raw2 = pd.DataFrame(np.random.rand(10, 10))
+        # df2 = md.DataFrame(raw2, chunk_size=6)
+        # r = df1 + df2
+        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        # pd.testing.assert_frame_equal(result, raw1 + raw2)
+        #
+        # raw1 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(10),
+        #                     columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
+        # df1 = md.DataFrame(raw1, chunk_size=(10, 5))
+        # raw2 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(11, 1, -1),
+        #                     columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
+        # df2 = md.DataFrame(raw2, chunk_size=(10, 6))
+        # r = df1 + df2
+        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        # pd.testing.assert_frame_equal(result, raw1 + raw2)
+        #
+        # raw1 = pd.DataFrame(np.random.rand(10, 10), index=[0, 10, 2, 3, 4, 5, 6, 7, 8, 9],
+        #                     columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
+        # df1 = md.DataFrame(raw1, chunk_size=5)
+        # raw2 = pd.DataFrame(np.random.rand(10, 10), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3],
+        #                     columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
+        # df2 = md.DataFrame(raw2, chunk_size=6)
+        # r = df1 + df2
+        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        # pd.testing.assert_frame_equal(result, raw1 + raw2)
+        #
+        # # test sort_values
+        # raw1 = pd.DataFrame(np.random.rand(10, 10))
+        # raw1[0] = raw1[0].apply(str)
+        # raw1.columns = pd.MultiIndex.from_product([list('AB'), list('CDEFG')])
+        # df1 = md.DataFrame(raw1, chunk_size=5)
+        # r = df1.sort_values([('A', 'C')])
+        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        # pd.testing.assert_frame_equal(result, raw1.sort_values([('A', 'C')]))
+        #
+        # rs = np.random.RandomState(0)
+        # raw2 = pd.DataFrame({'a': rs.rand(10),
+        #                     'b': [f's{rs.randint(1000)}' for _ in range(10)]
+        #                     })
+        # raw2['b'] = raw2['b'].astype(md.ArrowStringDtype())
+        # mdf = md.DataFrame(raw2, chunk_size=4)
+        # filtered = mdf[mdf['a'] > 0.5]
+        # df2 = filtered.sort_values(by='b')
+        # result = df2.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        # expected = raw2[raw2['a'] > 0.5].sort_values(by='b')
+        # pd.testing.assert_frame_equal(result, expected)
+        #
+        # s1 = pd.Series(np.random.rand(10), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3])
+        # series1 = md.Series(s1, chunk_size=6)
+        # result = series1.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        # pd.testing.assert_series_equal(result, s1)
+        #
+        # # test reindex
+        # data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'c3', 'c4', 'c5'])
+        # df3 = md.DataFrame(data, chunk_size=4)
+        # r = df3.reindex(index=mt.arange(10, 1, -1, chunk_size=3))
+        #
+        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        # expected = data.reindex(index=np.arange(10, 1, -1))
+        # pd.testing.assert_frame_equal(result, expected)
+        #
+        # # test rebalance
+        # df4 = md.DataFrame(data)
+        # r = df4.rebalance()
+        #
+        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        # pd.testing.assert_frame_equal(result, data)
+        # chunk_metas = sess.get_tileable_chunk_metas(r.key)
+        # workers = list(set(itertools.chain(*(m.workers for m in chunk_metas.values()))))
+        # self.assertEqual(len(workers), 2)
+        #
+        # # test nunique
+        # data = pd.DataFrame(np.random.randint(0, 10, (100, 5)),
+        #                     columns=['c1', 'c2', 'c3', 'c4', 'c5'])
+        # df5 = md.DataFrame(data, chunk_size=4)
+        # r = df5.nunique()
+        #
+        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        # expected = data.nunique()
+        # pd.testing.assert_series_equal(result, expected)
 
-        raw1 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(10),
-                            columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
-        df1 = md.DataFrame(raw1, chunk_size=(10, 5))
-        raw2 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(11, 1, -1),
-                            columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
-        df2 = md.DataFrame(raw2, chunk_size=(10, 6))
-        r = df1 + df2
-        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        pd.testing.assert_frame_equal(result, raw1 + raw2)
-
-        raw1 = pd.DataFrame(np.random.rand(10, 10), index=[0, 10, 2, 3, 4, 5, 6, 7, 8, 9],
-                            columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
-        df1 = md.DataFrame(raw1, chunk_size=5)
-        raw2 = pd.DataFrame(np.random.rand(10, 10), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3],
-                            columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
-        df2 = md.DataFrame(raw2, chunk_size=6)
-        r = df1 + df2
-        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        pd.testing.assert_frame_equal(result, raw1 + raw2)
-
-        # test sort_values
-        raw1 = pd.DataFrame(np.random.rand(10, 10))
-        raw1[0] = raw1[0].apply(str)
-        raw1.columns = pd.MultiIndex.from_product([list('AB'), list('CDEFG')])
-        df1 = md.DataFrame(raw1, chunk_size=5)
-        r = df1.sort_values([('A', 'C')])
-        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        pd.testing.assert_frame_equal(result, raw1.sort_values([('A', 'C')]))
-
+        # test re-execute df.groupby().agg().sort_values()
         rs = np.random.RandomState(0)
-        raw2 = pd.DataFrame({'a': rs.rand(10),
-                            'b': [f's{rs.randint(1000)}' for _ in range(10)]
-                            })
-        raw2['b'] = raw2['b'].astype(md.ArrowStringDtype())
-        mdf = md.DataFrame(raw2, chunk_size=4)
-        filtered = mdf[mdf['a'] > 0.5]
-        df2 = filtered.sort_values(by='b')
-        result = df2.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        expected = raw2[raw2['a'] > 0.5].sort_values(by='b')
-        pd.testing.assert_frame_equal(result, expected)
-
-        s1 = pd.Series(np.random.rand(10), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3])
-        series1 = md.Series(s1, chunk_size=6)
-        result = series1.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        pd.testing.assert_series_equal(result, s1)
-
-        # test reindex
-        data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'c3', 'c4', 'c5'])
-        df3 = md.DataFrame(data, chunk_size=4)
-        r = df3.reindex(index=mt.arange(10, 1, -1, chunk_size=3))
-
-        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        expected = data.reindex(index=np.arange(10, 1, -1))
-        pd.testing.assert_frame_equal(result, expected)
-
-        # test rebalance
-        df4 = md.DataFrame(data)
-        r = df4.rebalance()
-
-        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        pd.testing.assert_frame_equal(result, data)
-        chunk_metas = sess.get_tileable_chunk_metas(r.key)
-        workers = list(set(itertools.chain(*(m.workers for m in chunk_metas.values()))))
-        self.assertEqual(len(workers), 2)
-
-        # test nunique
-        data = pd.DataFrame(np.random.randint(0, 10, (100, 5)),
-                            columns=['c1', 'c2', 'c3', 'c4', 'c5'])
-        df5 = md.DataFrame(data, chunk_size=4)
-        r = df5.nunique()
-
-        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        expected = data.nunique()
-        pd.testing.assert_series_equal(result, expected)
+        data = pd.DataFrame({'col1': rs.rand(100), 'col2': rs.randint(10, size=100)})
+        df6 = md.DataFrame(data, chunk_size=40)
+        grouped = df6.groupby('col2', as_index=False)['col2'].agg({"cnt": "count"}) \
+            .execute(session=sess, timeout=self.timeout)
+        r = grouped.sort_values(by='cnt').head().execute(session=sess, timeout=self.timeout)
+        result = r.fetch(session=sess)
+        expected = data.groupby('col2', as_index=False)['col2'].agg({"cnt": "count"}) \
+            .sort_values(by='cnt').head()
+        pd.testing.assert_frame_equal(result.reset_index(drop=True), expected.reset_index(drop=True))
+        r = df6.groupby('col2', as_index=False)['col2'].agg({"cnt": "count"}).sort_values(by='cnt').head() \
+            .execute(session=sess, timeout=self.timeout)
+        result = r.fetch(session=sess)
+        pd.testing.assert_frame_equal(result.reset_index(drop=True), expected.reset_index(drop=True))
 
     def testIterativeTilingWithoutEtcd(self):
         self.start_processes(etcd=False)

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -110,89 +110,89 @@ class Test(SchedulerIntegratedTest):
         self.start_processes(etcd=False, scheduler_args=['-Dscheduler.aggressive_assign=true'])
         sess = new_session(self.session_manager_ref.address)
 
-        # # test binary arithmetics with different indices
-        # raw1 = pd.DataFrame(np.random.rand(10, 10))
-        # df1 = md.DataFrame(raw1, chunk_size=5)
-        # raw2 = pd.DataFrame(np.random.rand(10, 10))
-        # df2 = md.DataFrame(raw2, chunk_size=6)
-        # r = df1 + df2
-        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        # pd.testing.assert_frame_equal(result, raw1 + raw2)
-        #
-        # raw1 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(10),
-        #                     columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
-        # df1 = md.DataFrame(raw1, chunk_size=(10, 5))
-        # raw2 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(11, 1, -1),
-        #                     columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
-        # df2 = md.DataFrame(raw2, chunk_size=(10, 6))
-        # r = df1 + df2
-        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        # pd.testing.assert_frame_equal(result, raw1 + raw2)
-        #
-        # raw1 = pd.DataFrame(np.random.rand(10, 10), index=[0, 10, 2, 3, 4, 5, 6, 7, 8, 9],
-        #                     columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
-        # df1 = md.DataFrame(raw1, chunk_size=5)
-        # raw2 = pd.DataFrame(np.random.rand(10, 10), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3],
-        #                     columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
-        # df2 = md.DataFrame(raw2, chunk_size=6)
-        # r = df1 + df2
-        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        # pd.testing.assert_frame_equal(result, raw1 + raw2)
-        #
-        # # test sort_values
-        # raw1 = pd.DataFrame(np.random.rand(10, 10))
-        # raw1[0] = raw1[0].apply(str)
-        # raw1.columns = pd.MultiIndex.from_product([list('AB'), list('CDEFG')])
-        # df1 = md.DataFrame(raw1, chunk_size=5)
-        # r = df1.sort_values([('A', 'C')])
-        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        # pd.testing.assert_frame_equal(result, raw1.sort_values([('A', 'C')]))
-        #
-        # rs = np.random.RandomState(0)
-        # raw2 = pd.DataFrame({'a': rs.rand(10),
-        #                     'b': [f's{rs.randint(1000)}' for _ in range(10)]
-        #                     })
-        # raw2['b'] = raw2['b'].astype(md.ArrowStringDtype())
-        # mdf = md.DataFrame(raw2, chunk_size=4)
-        # filtered = mdf[mdf['a'] > 0.5]
-        # df2 = filtered.sort_values(by='b')
-        # result = df2.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        # expected = raw2[raw2['a'] > 0.5].sort_values(by='b')
-        # pd.testing.assert_frame_equal(result, expected)
-        #
-        # s1 = pd.Series(np.random.rand(10), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3])
-        # series1 = md.Series(s1, chunk_size=6)
-        # result = series1.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        # pd.testing.assert_series_equal(result, s1)
-        #
-        # # test reindex
-        # data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'c3', 'c4', 'c5'])
-        # df3 = md.DataFrame(data, chunk_size=4)
-        # r = df3.reindex(index=mt.arange(10, 1, -1, chunk_size=3))
-        #
-        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        # expected = data.reindex(index=np.arange(10, 1, -1))
-        # pd.testing.assert_frame_equal(result, expected)
-        #
-        # # test rebalance
-        # df4 = md.DataFrame(data)
-        # r = df4.rebalance()
-        #
-        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        # pd.testing.assert_frame_equal(result, data)
-        # chunk_metas = sess.get_tileable_chunk_metas(r.key)
-        # workers = list(set(itertools.chain(*(m.workers for m in chunk_metas.values()))))
-        # self.assertEqual(len(workers), 2)
-        #
-        # # test nunique
-        # data = pd.DataFrame(np.random.randint(0, 10, (100, 5)),
-        #                     columns=['c1', 'c2', 'c3', 'c4', 'c5'])
-        # df5 = md.DataFrame(data, chunk_size=4)
-        # r = df5.nunique()
-        #
-        # result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
-        # expected = data.nunique()
-        # pd.testing.assert_series_equal(result, expected)
+        # test binary arithmetics with different indices
+        raw1 = pd.DataFrame(np.random.rand(10, 10))
+        df1 = md.DataFrame(raw1, chunk_size=5)
+        raw2 = pd.DataFrame(np.random.rand(10, 10))
+        df2 = md.DataFrame(raw2, chunk_size=6)
+        r = df1 + df2
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        pd.testing.assert_frame_equal(result, raw1 + raw2)
+
+        raw1 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(10),
+                            columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
+        df1 = md.DataFrame(raw1, chunk_size=(10, 5))
+        raw2 = pd.DataFrame(np.random.rand(10, 10), index=np.arange(11, 1, -1),
+                            columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
+        df2 = md.DataFrame(raw2, chunk_size=(10, 6))
+        r = df1 + df2
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        pd.testing.assert_frame_equal(result, raw1 + raw2)
+
+        raw1 = pd.DataFrame(np.random.rand(10, 10), index=[0, 10, 2, 3, 4, 5, 6, 7, 8, 9],
+                            columns=[4, 1, 3, 2, 10, 5, 9, 8, 6, 7])
+        df1 = md.DataFrame(raw1, chunk_size=5)
+        raw2 = pd.DataFrame(np.random.rand(10, 10), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3],
+                            columns=[5, 9, 12, 3, 11, 10, 6, 4, 1, 2])
+        df2 = md.DataFrame(raw2, chunk_size=6)
+        r = df1 + df2
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        pd.testing.assert_frame_equal(result, raw1 + raw2)
+
+        # test sort_values
+        raw1 = pd.DataFrame(np.random.rand(10, 10))
+        raw1[0] = raw1[0].apply(str)
+        raw1.columns = pd.MultiIndex.from_product([list('AB'), list('CDEFG')])
+        df1 = md.DataFrame(raw1, chunk_size=5)
+        r = df1.sort_values([('A', 'C')])
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        pd.testing.assert_frame_equal(result, raw1.sort_values([('A', 'C')]))
+
+        rs = np.random.RandomState(0)
+        raw2 = pd.DataFrame({'a': rs.rand(10),
+                            'b': [f's{rs.randint(1000)}' for _ in range(10)]
+                            })
+        raw2['b'] = raw2['b'].astype(md.ArrowStringDtype())
+        mdf = md.DataFrame(raw2, chunk_size=4)
+        filtered = mdf[mdf['a'] > 0.5]
+        df2 = filtered.sort_values(by='b')
+        result = df2.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        expected = raw2[raw2['a'] > 0.5].sort_values(by='b')
+        pd.testing.assert_frame_equal(result, expected)
+
+        s1 = pd.Series(np.random.rand(10), index=[11, 1, 2, 5, 7, 6, 8, 9, 10, 3])
+        series1 = md.Series(s1, chunk_size=6)
+        result = series1.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        pd.testing.assert_series_equal(result, s1)
+
+        # test reindex
+        data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'c3', 'c4', 'c5'])
+        df3 = md.DataFrame(data, chunk_size=4)
+        r = df3.reindex(index=mt.arange(10, 1, -1, chunk_size=3))
+
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        expected = data.reindex(index=np.arange(10, 1, -1))
+        pd.testing.assert_frame_equal(result, expected)
+
+        # test rebalance
+        df4 = md.DataFrame(data)
+        r = df4.rebalance()
+
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        pd.testing.assert_frame_equal(result, data)
+        chunk_metas = sess.get_tileable_chunk_metas(r.key)
+        workers = list(set(itertools.chain(*(m.workers for m in chunk_metas.values()))))
+        self.assertEqual(len(workers), 2)
+
+        # test nunique
+        data = pd.DataFrame(np.random.randint(0, 10, (100, 5)),
+                            columns=['c1', 'c2', 'c3', 'c4', 'c5'])
+        df5 = md.DataFrame(data, chunk_size=4)
+        r = df5.nunique()
+
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        expected = data.nunique()
+        pd.testing.assert_series_equal(result, expected)
 
         # test re-execute df.groupby().agg().sort_values()
         rs = np.random.RandomState(0)
@@ -205,9 +205,9 @@ class Test(SchedulerIntegratedTest):
         expected = data.groupby('col2', as_index=False)['col2'].agg({"cnt": "count"}) \
             .sort_values(by='cnt').head()
         pd.testing.assert_frame_equal(result.reset_index(drop=True), expected.reset_index(drop=True))
-        r = df6.groupby('col2', as_index=False)['col2'].agg({"cnt": "count"}).sort_values(by='cnt').head() \
+        r2 = df6.groupby('col2', as_index=False)['col2'].agg({"cnt": "count"}).sort_values(by='cnt').head() \
             .execute(session=sess, timeout=self.timeout)
-        result = r.fetch(session=sess)
+        result = r2.fetch(session=sess)
         pd.testing.assert_frame_equal(result.reset_index(drop=True), expected.reset_index(drop=True))
 
     def testIterativeTilingWithoutEtcd(self):

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -105,8 +105,8 @@ class Test(unittest.TestCase):
             mmp_array2 = np.memmap(filename, dtype=float, shape=(3, 4))
 
             try:
-                v = [1, 2.3, '456', u'789', b'101112', None, np.ndarray, [912, 'uvw'],
-                     np.arange(0, 10), np.array(10), np.array([b'\x01\x32\xff']),
+                v = [1, 2.3, '456', u'789', b'101112', 2147483649, None, np.ndarray,
+                     [912, 'uvw'], np.arange(0, 10), np.array(10), np.array([b'\x01\x32\xff']),
                      np.int64, TestEnum.VAL1]
                 copy_v = copy.deepcopy(v)
                 self.assertEqual(utils.tokenize(v + [mmp_array1], ext_data=1234),

--- a/mars/worker/storage/client.py
+++ b/mars/worker/storage/client.py
@@ -144,7 +144,7 @@ class StorageClient(object):
             return self.copy_to(session_id, [data_key], source_devices) \
                 .then(lambda *_: self.create_reader(session_id, data_key, source_devices, packed=packed))
         else:
-            raise IOError('Cannot return a non-promise result')
+            raise IOError(f'Cannot return a non-promise result for key {data_key}, stored_devs {stored_devs!r}')
 
     def create_writer(self, session_id, data_key, total_bytes, device_order, packed=False,
                       packed_compression=None, pin_token=None, _promise=True):


### PR DESCRIPTION
## What do these changes do?

Fix the case running in distributed mode:

```python
grouped = mdf.groupby('col2', as_index=False)['col2'].agg({"cnt":'count'}).execute()
grouped.sort_values(by='cnt').head().execute()
mdf.groupby('col2', as_index=False)['col2'].agg({"cnt":'count'}).sort_values(by='cnt').head().execute()
```

## Related issue number

Fixes #1741
Fixes #1752