### PR TITLE
Fix xgboost and lightgbm on DataFrames

### DIFF
--- a/mars/dataframe/initializer.py
+++ b/mars/dataframe/initializer.py
@@ -29,7 +29,12 @@ from .datasource.from_tensor import dataframe_from_tensor, series_from_tensor, \
 from .fetch import DataFrameFetch
 
 
-class DataFrame(_Frame):
+class InitializerMeta(type):
+    def __instancecheck__(cls, instance):
+        return isinstance(instance, (cls.__base__,) + getattr(cls, '_allow_data_type_'))
+
+
+class DataFrame(_Frame, metaclass=InitializerMeta):
     def __init__(self, data=None, index=None, columns=None, dtype=None, copy=False,
                  chunk_size=None, gpu=None, sparse=None, num_partitions=None):
         # make sure __getattr__ does not result in stack overflow
@@ -73,7 +78,7 @@ class DataFrame(_Frame):
         super().__init__(df.data)
 
 
-class Series(_Series):
+class Series(_Series, metaclass=InitializerMeta):
     def __init__(self, data=None, index=None, dtype=None, name=None, copy=False,
                  chunk_size=None, gpu=None, sparse=None, num_partitions=None):
         # make sure __getattr__ does not result in stack overflow
@@ -108,7 +113,7 @@ class Series(_Series):
         super().__init__(series.data)
 
 
-class Index(_Index):
+class Index(_Index, metaclass=InitializerMeta):
     def __new__(cls, data, **_):
         # just return cls always until we support other Index's initializers
         return object.__new__(cls)

--- a/mars/dataframe/merge/concat.py
+++ b/mars/dataframe/merge/concat.py
@@ -211,9 +211,7 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
             if len(inputs) == 1:
                 ret = inputs[0]
             else:
-                max_rows = max(inp.index[0] for inp in chunk.inputs)
-                min_rows = min(inp.index[0] for inp in chunk.inputs)
-                n_rows = max_rows - min_rows + 1
+                n_rows = len(set(inp.index[0] for inp in chunk.inputs))
                 n_cols = int(len(inputs) // n_rows)
                 assert n_rows * n_cols == len(inputs)
 

--- a/mars/dataframe/operands.py
+++ b/mars/dataframe/operands.py
@@ -223,11 +223,13 @@ class DataFrameOperandMixin(TileableOperandMixin):
     @classmethod
     def _calc_dataframe_params(cls, chunk_index_to_chunks, chunk_shape):
         dtypes = pd.concat([chunk_index_to_chunks[0, i].dtypes
-                            for i in range(chunk_shape[1])])
+                            for i in range(chunk_shape[1])
+                            if (0, i) in chunk_index_to_chunks])
         columns_value = parse_index(dtypes.index, store_data=True)
-        pd_indxes = [chunk_index_to_chunks[i, 0].index_value.to_pandas()
-                     for i in range(chunk_shape[0])]
-        pd_index = reduce(lambda x, y: x.append(y), pd_indxes)
+        pd_indexes = [chunk_index_to_chunks[i, 0].index_value.to_pandas()
+                      for i in range(chunk_shape[0])
+                      if (i, 0) in chunk_index_to_chunks]
+        pd_index = reduce(lambda x, y: x.append(y), pd_indexes)
         index_value = parse_index(pd_index)
         return {'dtypes': dtypes, 'columns_value': columns_value,
                 'index_value': index_value}

--- a/mars/dataframe/tests/test_initializer.py
+++ b/mars/dataframe/tests/test_initializer.py
@@ -65,6 +65,10 @@ class Test(TestBase):
         self.assertEqual(len(results), 10)
         pd.testing.assert_frame_equal(pd.concat(results), raw)
 
+        # test check instance
+        r = r * 2
+        self.assertIsInstance(r, md.DataFrame)
+
     def testSeriesInitializer(self):
         # from tensor
         raw = np.random.rand(100)
@@ -100,6 +104,10 @@ class Test(TestBase):
         results = self.executor.execute_dataframe(r)
         self.assertEqual(len(results), 10)
         pd.testing.assert_series_equal(pd.concat(results), raw)
+
+        # test check instance
+        r = r * 2
+        self.assertIsInstance(r, md.Series)
 
     def testIndexInitializer(self):
         def _concat_idx(results):

--- a/mars/learn/contrib/lightgbm/tests/integrated/test_distributed_lightgbm.py
+++ b/mars/learn/contrib/lightgbm/tests/integrated/test_distributed_lightgbm.py
@@ -15,7 +15,10 @@
 import os
 import unittest
 
+import numpy as np
+
 from mars.learn.tests.integrated.base import LearnIntegrationTestBase
+import mars.dataframe as md
 import mars.tensor as mt
 from mars.session import new_session
 
@@ -72,3 +75,13 @@ class Test(LearnIntegrationTestBase):
             self.assertEqual(prediction.shape[0], len(self.X))
 
             self.assertIsInstance(prediction, mt.Tensor)
+
+            X = md.DataFrame(np.random.rand(100, 20), chunk_size=20)
+            y = md.DataFrame(np.random.randint(0, 2, (100, 1)), chunk_size=20)
+            classifier = LGBMClassifier(n_estimators=2)
+            classifier.fit(X, y, session=sess, run_kwargs=run_kwargs)
+            prediction = classifier.predict(X, session=sess, run_kwargs=run_kwargs)
+
+            self.assertEqual(prediction.ndim, 1)
+            self.assertEqual(prediction.shape[0], len(X))
+            self.assertIsInstance(prediction, md.Series)

--- a/mars/learn/contrib/xgboost/tests/integrated/test_distributed_xgboost.py
+++ b/mars/learn/contrib/xgboost/tests/integrated/test_distributed_xgboost.py
@@ -70,3 +70,6 @@ class Test(LearnIntegrationTestBase):
             classifier = XGBClassifier(verbosity=1, n_estimators=2)
             classifier.fit(X, y, session=sess, run_kwargs=run_kwargs)
             prediction = classifier.predict(X, session=sess, run_kwargs=run_kwargs)
+
+            self.assertIsInstance(prediction, md.Series)
+            self.assertEqual(prediction.shape[0], len(X))

--- a/mars/learn/contrib/xgboost/tests/integrated/test_distributed_xgboost.py
+++ b/mars/learn/contrib/xgboost/tests/integrated/test_distributed_xgboost.py
@@ -15,6 +15,9 @@
 import os
 import unittest
 
+import numpy as np
+
+import mars.dataframe as md
 import mars.tensor as mt
 from mars.session import new_session
 from mars.learn.contrib.xgboost import XGBClassifier
@@ -61,3 +64,9 @@ class Test(LearnIntegrationTestBase):
             self.assertEqual(list(history['validation_0'])[0], 'merror')
             self.assertEqual(len(history['validation_0']), 1)
             self.assertEqual(len(history['validation_0']['merror']), 2)
+
+            X = md.DataFrame(np.random.rand(100, 20), chunk_size=20)
+            y = md.DataFrame(np.random.randint(0, 2, (100, 1)), chunk_size=20)
+            classifier = XGBClassifier(verbosity=1, n_estimators=2)
+            classifier.fit(X, y, session=sess, run_kwargs=run_kwargs)
+            prediction = classifier.predict(X, session=sess, run_kwargs=run_kwargs)

--- a/mars/scheduler/__main__.py
+++ b/mars/scheduler/__main__.py
@@ -16,6 +16,7 @@ import logging
 import os
 
 from .. import resource
+from ..config import options
 from ..base_app import BaseApplication
 from ..distributor import MarsDistributor
 from .service import SchedulerService
@@ -42,6 +43,7 @@ class SchedulerApplication(BaseApplication):
         environ = environ or os.environ
         args.disable_failover = args.disable_failover \
             or bool(int(environ.get('MARS_DISABLE_FAILOVER', '0')))
+        options.scheduler.dump_graph_data = bool(int(environ.get('MARS_DUMP_GRAPH_DATA', '0')))
         return args
 
     def create_pool(self, *args, **kwargs):

--- a/mars/scheduler/tests/integrated/test_normal_execution.py
+++ b/mars/scheduler/tests/integrated/test_normal_execution.py
@@ -80,6 +80,12 @@ class Test(SchedulerIntegratedTest):
         result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
         np.testing.assert_array_equal(result, raw[raw.argmin(axis=1), np.arange(10)])
 
+        raw = np.random.RandomState(0).rand(1000)
+        a = mt.tensor(raw, chunk_size=100)
+        r = mt.median(a)
+        result = r.execute(session=sess, timeout=self.timeout).fetch(session=sess)
+        np.testing.assert_array_equal(result, np.median(raw))
+
     @unittest.skipIf('CI' not in os.environ and not EtcdProcessHelper().is_installed(),
                      'does not run without etcd')
     def testMainTensorWithEtcd(self):


### PR DESCRIPTION
## What do these changes do?

Allow non-consecutive indices when concatenating df objects. This resolves training issues for xgboost and lightgbm.

## Related issue number

Fixes #1740