### PR TITLE
Fix getitem on DataFrames with unknown index

### DIFF
--- a/mars/api.py
+++ b/mars/api.py
@@ -239,6 +239,7 @@ class MarsAPI(object):
 
     def fetch_data(self, session_id, tileable_key, index_obj=None, serial=True,
                    serial_type=None, compressions=None, pickle_protocol=None):
+        logger.debug('Fetching tileable data %s', tileable_key)
         session_uid = SessionActor.gen_uid(session_id)
         session_ref = self.get_actor_ref(session_uid)
         graph_ref = self.actor_client.actor_ref(
@@ -252,8 +253,11 @@ class MarsAPI(object):
         endpoints = self.chunk_meta_client.get_workers(session_id, chunk_key)
         if endpoints is None:
             raise KeyError(f'Chunk key {chunk_key} not exist in cluster')
+
+        source_endpoint = random.choice(endpoints)
+        logger.debug('Fetching chunk %s from worker %s', chunk_key, source_endpoint)
         sender_ref = self.actor_client.actor_ref(ResultSenderActor.default_uid(),
-                                                 address=random.choice(endpoints))
+                                                 address=source_endpoint)
         return sender_ref.fetch_data(session_id, chunk_key, index_obj, _wait=False)
 
     def get_chunk_metas(self, session_id, chunk_keys):

--- a/mars/dataframe/align.py
+++ b/mars/dataframe/align.py
@@ -443,8 +443,6 @@ def _get_monotonic_chunk_index_min_max(index, index_chunks):
 
 def _need_align_map(input_chunk, index_min_max, column_min_max,
                     dummy_index_splits=False, dummy_column_splits=False):
-    # if not dummy_index_splits:
-    #     assert not index_min_max[0] is None and not index_min_max[2] is None
     if isinstance(input_chunk, SERIES_CHUNK_TYPE):
         if input_chunk.index_value is None:
             return True

--- a/mars/dataframe/align.py
+++ b/mars/dataframe/align.py
@@ -420,8 +420,9 @@ def _get_chunk_index_min_max(index_chunks):
         max_val = chunk.max_val
         max_val_close = chunk.max_val_close
         if min_val is None or max_val is None:
-            return
-        chunk_index_min_max.append((min_val, min_val_close, max_val, max_val_close))
+            chunk_index_min_max.append((None, True, None, True))
+        else:
+            chunk_index_min_max.append((min_val, min_val_close, max_val, max_val_close))
     return chunk_index_min_max
 
 
@@ -442,8 +443,8 @@ def _get_monotonic_chunk_index_min_max(index, index_chunks):
 
 def _need_align_map(input_chunk, index_min_max, column_min_max,
                     dummy_index_splits=False, dummy_column_splits=False):
-    if not dummy_index_splits:
-        assert not index_min_max[0] is None and not index_min_max[2] is None
+    # if not dummy_index_splits:
+    #     assert not index_min_max[0] is None and not index_min_max[2] is None
     if isinstance(input_chunk, SERIES_CHUNK_TYPE):
         if input_chunk.index_value is None:
             return True

--- a/mars/dataframe/arithmetic/__init__.py
+++ b/mars/dataframe/arithmetic/__init__.py
@@ -17,9 +17,12 @@ import functools
 from ...utils import is_build_mode
 from ..core import DATAFRAME_TYPE
 from ..utils import wrap_notimplemented_exception
-from ..ufunc.tensor import register_tensor_unary_ufunc
+from ..ufunc.tensor import register_tensor_ufunc
 from .abs import abs_, DataFrameAbs
 from .add import add, radd, DataFrameAdd
+from .bitwise_and import bitand, rbitand, DataFrameAnd
+from .bitwise_or import bitor, rbitor, DataFrameOr
+from .bitwise_xor import bitxor, rbitxor, DataFrameXor
 from .subtract import subtract, rsubtract, DataFrameSubtract
 from .multiply import mul, rmul, DataFrameMul
 from .floordiv import floordiv, rfloordiv, DataFrameFloorDiv
@@ -32,15 +35,12 @@ from .less import lt, DataFrameLess
 from .greater import gt, DataFrameGreater
 from .less_equal import le, DataFrameLessEqual
 from .greater_equal import ge, DataFrameGreaterEqual
+from .invert import invert, DataFrameNot
 from .is_ufuncs import DataFrameIsNan, DataFrameIsInf, DataFrameIsFinite
 from .negative import DataFrameNegative, negative
 from .log import DataFrameLog
 from .log2 import DataFrameLog2
 from .log10 import DataFrameLog10
-from .logical_and import logical_and, logical_rand, DataFrameAnd
-from .logical_not import logical_not, DataFrameNot
-from .logical_or import logical_or, logical_ror, DataFrameOr
-from .logical_xor import logical_xor, logical_rxor, DataFrameXor
 from .sin import DataFrameSin
 from .cos import DataFrameCos
 from .tan import DataFrameTan
@@ -136,8 +136,9 @@ def _install():
             call = None
         return _register_method(cls, name, func, wrapper=call)
 
-    # register mars unary ufuncs
-    unary_ops = [
+    # register mars tensor ufuncs
+    ufunc_ops = [
+        # unary
         DataFrameAbs, DataFrameLog, DataFrameLog2, DataFrameLog10,
         DataFrameSin, DataFrameCos, DataFrameTan,
         DataFrameSinh, DataFrameCosh, DataFrameTanh,
@@ -147,16 +148,22 @@ def _install():
         DataFrameCeil, DataFrameFloor, DataFrameAround,
         DataFrameExp, DataFrameExp2, DataFrameExpm1,
         DataFrameSqrt, DataFrameNot, DataFrameIsNan,
-        DataFrameIsInf, DataFrameIsFinite, DataFrameNegative
+        DataFrameIsInf, DataFrameIsFinite, DataFrameNegative,
+        # binary
+        DataFrameAdd, DataFrameEqual, DataFrameFloorDiv,
+        DataFrameGreater, DataFrameGreaterEqual, DataFrameLess,
+        DataFrameLessEqual, DataFrameAnd, DataFrameOr, DataFrameXor,
+        DataFrameMod, DataFrameMul, DataFrameNotEqual, DataFramePower,
+        DataFrameSubtract, DataFrameTrueDiv,
     ]
-    for unary_op in unary_ops:
-        register_tensor_unary_ufunc(unary_op)
+    for ufunc_op in ufunc_ops:
+        register_tensor_ufunc(ufunc_op)
 
     for entity in DATAFRAME_TYPE + SERIES_TYPE:
         setattr(entity, '__abs__', abs_)
         setattr(entity, 'abs', abs_)
         _register_method(entity, 'round', around)
-        setattr(entity, '__invert__', logical_not)
+        setattr(entity, '__invert__', invert)
 
         setattr(entity, '__add__', wrap_notimplemented_exception(add))
         setattr(entity, '__radd__', wrap_notimplemented_exception(radd))
@@ -213,14 +220,14 @@ def _install():
         setattr(entity, '__matmul__', dot)
         _register_method(entity, 'dot', dot)
 
-        setattr(entity, '__and__', wrap_notimplemented_exception(logical_and))
-        setattr(entity, '__rand__', wrap_notimplemented_exception(logical_rand))
+        setattr(entity, '__and__', wrap_notimplemented_exception(bitand))
+        setattr(entity, '__rand__', wrap_notimplemented_exception(rbitand))
 
-        setattr(entity, '__or__', wrap_notimplemented_exception(logical_or))
-        setattr(entity, '__ror__', wrap_notimplemented_exception(logical_ror))
+        setattr(entity, '__or__', wrap_notimplemented_exception(bitor))
+        setattr(entity, '__ror__', wrap_notimplemented_exception(rbitor))
 
-        setattr(entity, '__xor__', wrap_notimplemented_exception(logical_xor))
-        setattr(entity, '__rxor__', wrap_notimplemented_exception(logical_rxor))
+        setattr(entity, '__xor__', wrap_notimplemented_exception(bitxor))
+        setattr(entity, '__rxor__', wrap_notimplemented_exception(rbitxor))
 
         setattr(entity, '__neg__', wrap_notimplemented_exception(negative))
 

--- a/mars/dataframe/arithmetic/add.py
+++ b/mars/dataframe/arithmetic/add.py
@@ -16,11 +16,11 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_arithmetic_doc
 
 
-class DataFrameAdd(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameAdd(DataFrameBinopUfunc):
     _op_type_ = OperandDef.ADD
 
     _func_name = 'add'
@@ -29,6 +29,11 @@ class DataFrameAdd(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return operator.add
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorAdd
+        return TensorAdd
 
 
 _add_example = """

--- a/mars/dataframe/arithmetic/bitwise_and.py
+++ b/mars/dataframe/arithmetic/bitwise_and.py
@@ -16,25 +16,30 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 
 
-class DataFrameXor(DataFrameBinOp, DataFrameBinOpMixin):
-    _op_type_ = OperandDef.XOR
+class DataFrameAnd(DataFrameBinopUfunc):
+    _op_type_ = OperandDef.AND
 
-    _func_name = '__xor__'
-    _rfunc_name = '__rxor__'
+    _func_name = '__and__'
+    _rfunc_name = '__rand__'
 
     @classproperty
     def _operator(self):
-        return operator.xor
+        return operator.and_
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorBitand
+        return TensorBitand
 
 
-def logical_xor(df, other, axis='columns', level=None, fill_value=None):
-    op = DataFrameXor(axis=axis, level=level, fill_value=fill_value, lhs=df, rhs=other)
+def bitand(df, other, axis='columns', level=None, fill_value=None):
+    op = DataFrameAnd(axis=axis, level=level, fill_value=fill_value, lhs=df, rhs=other)
     return op(df, other)
 
 
-def logical_rxor(df, other, axis='columns', level=None, fill_value=None):
-    op = DataFrameXor(axis=axis, level=level, fill_value=fill_value, lhs=other, rhs=df)
+def rbitand(df, other, axis='columns', level=None, fill_value=None):
+    op = DataFrameAnd(axis=axis, level=level, fill_value=fill_value, lhs=other, rhs=df)
     return op.rcall(df, other)

--- a/mars/dataframe/arithmetic/bitwise_or.py
+++ b/mars/dataframe/arithmetic/bitwise_or.py
@@ -16,10 +16,10 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 
 
-class DataFrameOr(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameOr(DataFrameBinopUfunc):
     _op_type_ = OperandDef.OR
 
     _func_name = '__or__'
@@ -29,12 +29,17 @@ class DataFrameOr(DataFrameBinOp, DataFrameBinOpMixin):
     def _operator(self):
         return operator.or_
 
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorBitor
+        return TensorBitor
 
-def logical_or(df, other, axis='columns', level=None, fill_value=None):
+
+def bitor(df, other, axis='columns', level=None, fill_value=None):
     op = DataFrameOr(axis=axis, level=level, fill_value=fill_value, lhs=df, rhs=other)
     return op(df, other)
 
 
-def logical_ror(df, other, axis='columns', level=None, fill_value=None):
+def rbitor(df, other, axis='columns', level=None, fill_value=None):
     op = DataFrameOr(axis=axis, level=level, fill_value=fill_value, lhs=other, rhs=df)
     return op.rcall(df, other)

--- a/mars/dataframe/arithmetic/bitwise_xor.py
+++ b/mars/dataframe/arithmetic/bitwise_xor.py
@@ -16,25 +16,30 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 
 
-class DataFrameAnd(DataFrameBinOp, DataFrameBinOpMixin):
-    _op_type_ = OperandDef.AND
+class DataFrameXor(DataFrameBinopUfunc):
+    _op_type_ = OperandDef.XOR
 
-    _func_name = '__and__'
-    _rfunc_name = '__rand__'
+    _func_name = '__xor__'
+    _rfunc_name = '__rxor__'
 
     @classproperty
     def _operator(self):
-        return operator.and_
+        return operator.xor
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorBitxor
+        return TensorBitxor
 
 
-def logical_and(df, other, axis='columns', level=None, fill_value=None):
-    op = DataFrameAnd(axis=axis, level=level, fill_value=fill_value, lhs=df, rhs=other)
+def bitxor(df, other, axis='columns', level=None, fill_value=None):
+    op = DataFrameXor(axis=axis, level=level, fill_value=fill_value, lhs=df, rhs=other)
     return op(df, other)
 
 
-def logical_rand(df, other, axis='columns', level=None, fill_value=None):
-    op = DataFrameAnd(axis=axis, level=level, fill_value=fill_value, lhs=other, rhs=df)
+def rbitxor(df, other, axis='columns', level=None, fill_value=None):
+    op = DataFrameXor(axis=axis, level=level, fill_value=fill_value, lhs=other, rhs=df)
     return op.rcall(df, other)

--- a/mars/dataframe/arithmetic/equal.py
+++ b/mars/dataframe/arithmetic/equal.py
@@ -14,11 +14,11 @@
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_compare_doc
 
 
-class DataFrameEqual(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameEqual(DataFrameBinopUfunc):
     _op_type_ = OperandDef.EQ
 
     _func_name = 'eq'
@@ -27,6 +27,11 @@ class DataFrameEqual(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return lambda lhs, rhs: lhs.eq(rhs)
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorEqual
+        return TensorEqual
 
 
 _eq_example = """

--- a/mars/dataframe/arithmetic/floordiv.py
+++ b/mars/dataframe/arithmetic/floordiv.py
@@ -16,11 +16,11 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_arithmetic_doc
 
 
-class DataFrameFloorDiv(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameFloorDiv(DataFrameBinopUfunc):
     _op_type_ = OperandDef.FLOORDIV
 
     _func_name = 'floordiv'
@@ -29,6 +29,11 @@ class DataFrameFloorDiv(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return operator.floordiv
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorFloorDiv
+        return TensorFloorDiv
 
 
 _floordiv_example = """

--- a/mars/dataframe/arithmetic/greater.py
+++ b/mars/dataframe/arithmetic/greater.py
@@ -14,11 +14,11 @@
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_compare_doc
 
 
-class DataFrameGreater(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameGreater(DataFrameBinopUfunc):
     _op_type_ = OperandDef.GT
 
     _func_name = 'gt'
@@ -27,6 +27,11 @@ class DataFrameGreater(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return lambda lhs, rhs: lhs.gt(rhs)
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorGreaterThan
+        return TensorGreaterThan
 
 
 _gt_example = """

--- a/mars/dataframe/arithmetic/greater_equal.py
+++ b/mars/dataframe/arithmetic/greater_equal.py
@@ -14,11 +14,11 @@
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_compare_doc
 
 
-class DataFrameGreaterEqual(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameGreaterEqual(DataFrameBinopUfunc):
     _op_type_ = OperandDef.GE
 
     _func_name = 'ge'
@@ -27,6 +27,11 @@ class DataFrameGreaterEqual(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return lambda lhs, rhs: lhs.ge(rhs)
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorGreaterEqual
+        return TensorGreaterEqual
 
 
 _ge_example = """

--- a/mars/dataframe/arithmetic/invert.py
+++ b/mars/dataframe/arithmetic/invert.py
@@ -27,6 +27,6 @@ class DataFrameNot(DataFrameUnaryUfunc):
         return TensorNot
 
 
-def logical_not(df):
+def invert(df):
     op = DataFrameNot()
     return op(df)

--- a/mars/dataframe/arithmetic/less.py
+++ b/mars/dataframe/arithmetic/less.py
@@ -15,11 +15,11 @@
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_compare_doc
 
 
-class DataFrameLess(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameLess(DataFrameBinopUfunc):
     _op_type_ = OperandDef.LT
 
     _func_name = 'lt'
@@ -28,6 +28,11 @@ class DataFrameLess(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return lambda lhs, rhs: lhs.lt(rhs)
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorLessThan
+        return TensorLessThan
 
 
 _lt_example = """

--- a/mars/dataframe/arithmetic/less_equal.py
+++ b/mars/dataframe/arithmetic/less_equal.py
@@ -14,11 +14,11 @@
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_compare_doc
 
 
-class DataFrameLessEqual(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameLessEqual(DataFrameBinopUfunc):
     _op_type_ = OperandDef.LE
 
     _func_name = 'le'
@@ -27,6 +27,11 @@ class DataFrameLessEqual(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return lambda lhs, rhs: lhs.le(rhs)
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorLessEqual
+        return TensorLessEqual
 
 
 _le_example = """

--- a/mars/dataframe/arithmetic/mod.py
+++ b/mars/dataframe/arithmetic/mod.py
@@ -16,11 +16,11 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_arithmetic_doc
 
 
-class DataFrameMod(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameMod(DataFrameBinopUfunc):
     _op_type_ = OperandDef.MOD
 
     _func_name = 'mod'
@@ -29,6 +29,11 @@ class DataFrameMod(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return operator.mod
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorMod
+        return TensorMod
 
 
 _mod_example = """

--- a/mars/dataframe/arithmetic/multiply.py
+++ b/mars/dataframe/arithmetic/multiply.py
@@ -16,11 +16,11 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_arithmetic_doc
 
 
-class DataFrameMul(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameMul(DataFrameBinopUfunc):
     _op_type_ = OperandDef.MUL
 
     _func_name = 'mul'
@@ -29,6 +29,11 @@ class DataFrameMul(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return operator.mul
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorMultiply
+        return TensorMultiply
 
 
 _mul_example = """

--- a/mars/dataframe/arithmetic/not_equal.py
+++ b/mars/dataframe/arithmetic/not_equal.py
@@ -14,11 +14,11 @@
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_compare_doc
 
 
-class DataFrameNotEqual(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameNotEqual(DataFrameBinopUfunc):
     _op_type_ = OperandDef.NE
 
     _func_name = 'ne'
@@ -27,6 +27,11 @@ class DataFrameNotEqual(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return lambda lhs, rhs: lhs.ne(rhs)
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorNotEqual
+        return TensorNotEqual
 
 
 _ne_example = """

--- a/mars/dataframe/arithmetic/power.py
+++ b/mars/dataframe/arithmetic/power.py
@@ -16,11 +16,11 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_arithmetic_doc
 
 
-class DataFramePower(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFramePower(DataFrameBinopUfunc):
     _op_type_ = OperandDef.POW
 
     _func_name = 'pow'
@@ -29,6 +29,11 @@ class DataFramePower(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return operator.pow
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorPower
+        return TensorPower
 
 
 _pow_example = """

--- a/mars/dataframe/arithmetic/subtract.py
+++ b/mars/dataframe/arithmetic/subtract.py
@@ -16,11 +16,11 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_arithmetic_doc
 
 
-class DataFrameSubtract(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameSubtract(DataFrameBinopUfunc):
     _op_type_ = OperandDef.SUB
 
     _func_name = 'sub'
@@ -29,6 +29,11 @@ class DataFrameSubtract(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return operator.sub
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorSubtract
+        return TensorSubtract
 
 
 _sub_example = """

--- a/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
@@ -735,6 +735,19 @@ class TestUnary(TestBase):
                    (df_raw['c'] < pd.to_datetime('2021-01-01'))
         pd.testing.assert_series_equal(result, expected)
 
+    def testSeriesAndTensor(self):
+        rs = np.random.RandomState(0)
+        s_raw = pd.Series(rs.rand(10)) < 0.5
+        a_raw = rs.rand(10) < 0.5
+
+        series = from_pandas_series(s_raw, chunk_size=5)
+        t = mt.tensor(a_raw, chunk_size=5)
+
+        r = t | series
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = a_raw | s_raw
+        pd.testing.assert_series_equal(result, expected)
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/mars/dataframe/arithmetic/truediv.py
+++ b/mars/dataframe/arithmetic/truediv.py
@@ -16,11 +16,11 @@ import operator
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
-from .core import DataFrameBinOpMixin, DataFrameBinOp
+from .core import DataFrameBinopUfunc
 from .docstring import bin_arithmetic_doc
 
 
-class DataFrameTrueDiv(DataFrameBinOp, DataFrameBinOpMixin):
+class DataFrameTrueDiv(DataFrameBinopUfunc):
     _op_type_ = OperandDef.DIV
 
     _func_name = 'truediv'
@@ -29,6 +29,11 @@ class DataFrameTrueDiv(DataFrameBinOp, DataFrameBinOpMixin):
     @classproperty
     def _operator(self):
         return operator.truediv
+
+    @classproperty
+    def tensor_op_type(self):
+        from ...tensor.arithmetic import TensorTrueDiv
+        return TensorTrueDiv
 
 
 _truediv_example = """

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -22,7 +22,7 @@ from ... import opcodes as OperandDef
 from ...config import options
 from ...core import Base, Entity, OutputType
 from ...serialize import AnyField, Int32Field, BoolField
-from ...tensor.core import TENSOR_TYPE
+from ...tensor.core import TENSOR_TYPE, TENSOR_CHUNK_TYPE
 from ...tensor.datasource import tensor as astensor
 from ...utils import check_chunks_unknown_shape
 from ...tiles import TilesError
@@ -252,7 +252,7 @@ class DataFrameIndex(DataFrameOperand, DataFrameOperandMixin):
                 return self.new_series([df], shape=(df.shape[0],), dtype=dtype, index_value=df.index_value,
                                        name=self._col_names)
         else:
-            if isinstance(self.mask, (SERIES_TYPE, DATAFRAME_TYPE)):
+            if isinstance(self.mask, (SERIES_TYPE, DATAFRAME_TYPE, TENSOR_TYPE)):
                 index_value = parse_index(pd.Index([], dtype=df.index_value.to_pandas().dtype,
                                                    name=df.index_value.name),
                                           df, self._mask)
@@ -279,15 +279,22 @@ class DataFrameIndex(DataFrameOperand, DataFrameOperandMixin):
 
         out_chunks = []
 
-        if isinstance(op.mask, (SERIES_TYPE, DATAFRAME_TYPE)):
+        if isinstance(op.mask, (SERIES_TYPE, DATAFRAME_TYPE, TENSOR_TYPE)):
             mask = op.inputs[1]
 
             if isinstance(op.mask, SERIES_TYPE):
                 nsplits, out_shape, df_chunks, mask_chunks = \
                     align_dataframe_series(in_df, mask, axis='index')
-            else:
+            elif isinstance(op.mask, DATAFRAME_TYPE):
                 nsplits, out_shape, df_chunks, mask_chunks = \
                     align_dataframe_dataframe(in_df, mask)
+            else:
+                # tensor
+                nsplits = in_df.nsplits
+                mask = mask.rechunk(nsplits[:mask.ndim])._inplace_tile()
+                out_shape = in_df.chunk_shape
+                df_chunks = in_df.chunks
+                mask_chunks = mask.chunks
             out_chunk_indexes = itertools.product(*(range(s) for s in out_shape))
 
             out_chunks = []
@@ -383,11 +390,13 @@ class DataFrameIndex(DataFrameOperand, DataFrameOperandMixin):
             ctx[op.outputs[0].key] = df[op.col_names]
         else:
             df = ctx[op.inputs[0].key]
-            if isinstance(op.mask, (SERIES_CHUNK_TYPE, DATAFRAME_CHUNK_TYPE)):
+            if isinstance(op.mask, (SERIES_CHUNK_TYPE, DATAFRAME_CHUNK_TYPE,
+                                    TENSOR_CHUNK_TYPE)):
                 mask = ctx[op.inputs[1].key]
             else:
                 mask = op.mask
-            mask = mask.reindex_like(df).fillna(False)
+            if hasattr(mask, 'reindex_like'):
+                mask = mask.reindex_like(df).fillna(False)
             if mask.ndim == 2:
                 mask = mask[df.columns.tolist()]
             ctx[op.outputs[0].key] = df[mask]

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -303,8 +303,6 @@ class DataFrameIndex(DataFrameOperand, DataFrameOperandMixin):
                                                             index_value=index_value,
                                                             columns_value=df_chunk.columns_value)
                 out_chunks.append(out_chunk)
-
-            nsplits = ((np.nan,) * len(nsplits[0]), nsplits[1])
         else:
             check_chunks_unknown_shape([in_df], TilesError)
             nsplits_acc = np.cumsum((0,) + in_df.nsplits[0])

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -437,6 +437,11 @@ class Test(TestBase):
         result = self.executor.execute_dataframe(r, concat=True)[0]
         pd.testing.assert_frame_equal(result, data[data > 0.5])
 
+        # getitem by tensor mask
+        r = df[(df['c1'] > 0.5).to_tensor()]
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        pd.testing.assert_frame_equal(result, data[data['c1'] > 0.5])
+
     def testDataFrameGetitemUsingAttr(self):
         data = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'key', 'dtypes', 'size'])
         df = md.DataFrame(data, chunk_size=2)

--- a/mars/dataframe/missing/dropna.py
+++ b/mars/dataframe/missing/dropna.py
@@ -115,6 +115,7 @@ class DataFrameDropNA(DataFrameOperand, DataFrameOperandMixin):
         in_df = op.inputs[0]
         out_df = op.outputs[0]
 
+        # series tiling will go here
         if len(in_df.chunk_shape) == 1 or in_df.chunk_shape[1] == 1:
             return cls._tile_drop_directly(op)
 
@@ -129,7 +130,7 @@ class DataFrameDropNA(DataFrameOperand, DataFrameOperandMixin):
         out_chunks = []
         for out_idx, df_chunk in zip(out_chunk_indexes, left_chunks):
             series_chunk = right_chunks[out_idx[0]]
-            kw = dict(shape=(np.nan, nsplits[1][out_idx[1]]),
+            kw = dict(shape=(np.nan, nsplits[1][out_idx[1]]), dtypes=df_chunk.dtypes,
                       index_value=df_chunk.index_value, columns_value=df_chunk.columns_value)
 
             new_op = op.copy().reset_key()

--- a/mars/dataframe/ufunc/tensor.py
+++ b/mars/dataframe/ufunc/tensor.py
@@ -18,7 +18,7 @@ from ...utils import classproperty
 _tensor_op_to_df_op = dict()
 
 
-def register_tensor_unary_ufunc(op):
+def register_tensor_ufunc(op):
     _tensor_op_to_df_op[op.tensor_op_type] = op
 
 

--- a/mars/learn/contrib/xgboost/tests/integrated/test_distributed_xgboost.py
+++ b/mars/learn/contrib/xgboost/tests/integrated/test_distributed_xgboost.py
@@ -61,9 +61,11 @@ class Test(LearnIntegrationTestBase):
             self.assertIsInstance(history, dict)
 
             self.assertEqual(list(history)[0], 'validation_0')
-            self.assertEqual(list(history['validation_0'])[0], 'merror')
+            # default metrics may differ, see https://github.com/dmlc/xgboost/pull/6183
+            eval_metric = list(history['validation_0'])[0]
+            self.assertIn(eval_metric, ('merror', 'mlogloss'))
             self.assertEqual(len(history['validation_0']), 1)
-            self.assertEqual(len(history['validation_0']['merror']), 2)
+            self.assertEqual(len(history['validation_0'][eval_metric]), 2)
 
             X = md.DataFrame(np.random.rand(100, 20), chunk_size=20)
             y = md.DataFrame(np.random.randint(0, 2, (100, 1)), chunk_size=20)

--- a/mars/learn/contrib/xgboost/tests/test_classifier.py
+++ b/mars/learn/contrib/xgboost/tests/test_classifier.py
@@ -61,9 +61,11 @@ class Test(unittest.TestCase):
         self.assertIsInstance(history, dict)
 
         self.assertEqual(list(history)[0], 'validation_0')
-        self.assertEqual(list(history['validation_0'])[0], 'merror')
+        # default metrics may differ, see https://github.com/dmlc/xgboost/pull/6183
+        eval_metric = list(history['validation_0'])[0]
+        self.assertIn(eval_metric, ('merror', 'mlogloss'))
         self.assertEqual(len(history['validation_0']), 1)
-        self.assertEqual(len(history['validation_0']['merror']), 2)
+        self.assertEqual(len(history['validation_0'][eval_metric]), 2)
 
         prob = classifier.predict_proba(X)
         self.assertEqual(prob.shape, X.shape)

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -441,6 +441,14 @@ class Test(unittest.TestCase):
             result = sess.run(r)
             pd.testing.assert_series_equal(result, raw.loc['2020-1-2'])
 
+            df = md.DataFrame(raw, chunk_size=chunk_size)
+            df2 = df[[0, 2]].dropna().head(4).copy()
+            df3 = df2[df2[0] > 0.5]
+            result = sess.run(df3)
+            expected = raw[[0, 2]].dropna().head(4).copy()
+            expected = expected[expected[0] > 0.5]
+            pd.testing.assert_frame_equal(result, expected)
+
     @unittest.skipIf(pa is not None, 'this test aims to test usage of ArrowDtype '
                                      'when pyarrow not installed')
     def testDataFrameWithArrowDtypeExecution(self):

--- a/mars/worker/transfer.py
+++ b/mars/worker/transfer.py
@@ -819,6 +819,7 @@ class ResultSenderActor(WorkerActor):
         return results
 
     def fetch_data(self, session_id, chunk_key, index_obj=None, compression_type=None):
+        logger.debug('Sending data %s from %s', chunk_key, self.uid)
         if compression_type is None:
             compression_type = dataserializer.CompressType(options.worker.transfer_compression)
         if index_obj is None:


### PR DESCRIPTION
## What do these changes do?

This PR include fixes:

1. Fix getitem on DataFrames with unknown index.
2. Return series if tensor | series.
3. Support tensor for getitem, e.g. df[bool_tensor].

## Related issue number

Fixes #1771 