### PR TITLE
Integrate `str.cat` into reduction and groupby-aggregation

### DIFF
--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -344,6 +344,27 @@ class Test(TestBase):
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
                                       series1.groupby(lambda x: x % 2).agg(col_var='var', col_skew='skew'))
 
+    def testGroupByAggStrCat(self):
+        agg_fun = lambda x: x.str.cat(sep='_', na_rep='NA')
+
+        rs = np.random.RandomState(0)
+        raw_df = pd.DataFrame({'a': rs.choice(['A', 'B', 'C'], size=(100,)),
+                               'b': rs.choice([None, 'alfa', 'bravo', 'charlie'], size=(100,))})
+
+        mdf = md.DataFrame(raw_df, chunk_size=13)
+
+        r = mdf.groupby('a').agg(agg_fun)
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                      raw_df.groupby('a').agg(agg_fun))
+
+        raw_series = pd.Series(rs.choice([None, 'alfa', 'bravo', 'charlie'], size=(100,)))
+
+        ms = md.Series(raw_series, chunk_size=13)
+
+        r = ms.groupby(lambda x: x % 2).agg(agg_fun)
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                       raw_series.groupby(lambda x: x % 2).agg(agg_fun))
+
     @require_cudf
     def testGPUGroupByAgg(self):
         rs = np.random.RandomState(0)

--- a/mars/dataframe/reduction/__init__.py
+++ b/mars/dataframe/reduction/__init__.py
@@ -28,6 +28,7 @@ from .skew import DataFrameSkew
 from .kurtosis import DataFrameKurtosis
 from .sem import DataFrameSem
 from .reduction_size import DataFrameSize
+from .str_concat import DataFrameStrConcat, build_str_concat_object
 from .custom_reduction import DataFrameCustomReduction
 
 from .cummax import DataFrameCummax
@@ -61,7 +62,6 @@ def _install():
     from .skew import skew_dataframe, skew_series
     from .kurtosis import kurt_dataframe, kurt_series
     from .reduction_size import size_dataframe, size_series
-    from .custom_reduction import custom_reduction_dataframe, custom_reduction_series
 
     funcs = [
         ('sum', sum_series, sum_dataframe),
@@ -88,7 +88,6 @@ def _install():
         ('kurtosis', kurt_series, kurt_dataframe),
         ('unique', unique, None),
         ('_reduction_size', size_dataframe, size_series),
-        ('_custom_reduction', custom_reduction_dataframe, custom_reduction_series),
     ]
     for func_name, series_func, df_func in funcs:
         if df_func is not None:  # pragma: no branch

--- a/mars/dataframe/reduction/tests/test_reduction_execute.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execute.py
@@ -21,11 +21,10 @@ try:
 except ImportError:  # pragma: no cover
     pa = None
 
+import mars.dataframe as md
 from mars.config import option_context
 from mars.dataframe import CustomReduction, NamedAgg
 from mars.dataframe.base import to_gpu
-from mars.dataframe.datasource.series import from_pandas as from_pandas_series
-from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df
 from mars.tests.core import TestBase, parameterized, ExecutorForTest, \
     require_cudf, require_cupy
 from mars.utils import lazy_import
@@ -57,144 +56,150 @@ class TestReduction(TestBase):
 
     def testSeriesReduction(self):
         data = pd.Series(np.random.randint(0, 8, (10,)), index=[str(i) for i in range(10)], name='a')
-        reduction_df1 = self.compute(from_pandas_series(data))
+        r = self.compute(md.Series(data))
         self.assertAlmostEqual(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_series(data, chunk_size=6))
+        r = self.compute(md.Series(data, chunk_size=6))
         self.assertAlmostEqual(
-            self.compute(data), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df3 = self.compute(from_pandas_series(data, chunk_size=3))
+        r = self.compute(md.Series(data, chunk_size=3))
         self.assertAlmostEqual(
-            self.compute(data), self.executor.execute_dataframe(reduction_df3, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df4 = self.compute(from_pandas_series(data, chunk_size=4), axis='index')
+        r = self.compute(md.Series(data, chunk_size=4), axis='index')
         self.assertAlmostEqual(
-            self.compute(data, axis='index'), self.executor.execute_dataframe(reduction_df4, concat=True)[0])
+            self.compute(data, axis='index'), self.executor.execute_dataframe(r, concat=True)[0])
+
+        r = self.compute(md.Series(data, chunk_size=4), axis='index')
+        self.assertAlmostEqual(
+            self.compute(data, axis='index'), self.executor.execute_dataframe(r, concat=True)[0])
 
         data = pd.Series(np.random.rand(20), name='a')
         data[0] = 0.1  # make sure not all elements are NAN
         data[data > 0.5] = np.nan
-        reduction_df1 = self.compute(from_pandas_series(data, chunk_size=3))
+        r = self.compute(md.Series(data, chunk_size=3))
         self.assertAlmostEqual(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_series(data, chunk_size=3), skipna=False)
+        r = self.compute(md.Series(data, chunk_size=3), skipna=False)
         self.assertTrue(
-            np.isnan(self.executor.execute_dataframe(reduction_df2, concat=True)[0]))
+            np.isnan(self.executor.execute_dataframe(r, concat=True)[0]))
 
         if self.has_min_count:
-            reduction_df3 = self.compute(from_pandas_series(data, chunk_size=3), skipna=False, min_count=2)
+            r = self.compute(md.Series(data, chunk_size=3), skipna=False, min_count=2)
             self.assertTrue(
-                np.isnan(self.executor.execute_dataframe(reduction_df3, concat=True)[0]))
+                np.isnan(self.executor.execute_dataframe(r, concat=True)[0]))
 
-            reduction_df4 = self.compute(from_pandas_series(data, chunk_size=3), min_count=1)
+            r = self.compute(md.Series(data, chunk_size=3), min_count=1)
             self.assertAlmostEqual(
                 self.compute(data, min_count=1),
-                self.executor.execute_dataframe(reduction_df4, concat=True)[0])
+                self.executor.execute_dataframe(r, concat=True)[0])
 
-            reduction_df5 = self.compute(from_pandas_series(data, chunk_size=3), min_count=21)
+            reduction_df5 = self.compute(md.Series(data, chunk_size=3), min_count=21)
             self.assertTrue(
                 np.isnan(self.executor.execute_dataframe(reduction_df5, concat=True)[0]))
 
     def testDataFrameReduction(self):
         data = pd.DataFrame(np.random.rand(20, 10))
-        reduction_df1 = self.compute(from_pandas_df(data))
+        r = self.compute(md.DataFrame(data))
         pd.testing.assert_series_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_df(data, chunk_size=3))
+        r = self.compute(md.DataFrame(data, chunk_size=3))
         pd.testing.assert_series_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df3 = self.compute(from_pandas_df(data, chunk_size=6), axis='index', numeric_only=True)
+        r = self.compute(md.DataFrame(data, chunk_size=6), axis='index', numeric_only=True)
         pd.testing.assert_series_equal(
             self.compute(data, axis='index', numeric_only=True),
-            self.executor.execute_dataframe(reduction_df3, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df4 = self.compute(from_pandas_df(data, chunk_size=3), axis=1)
+        r = self.compute(md.DataFrame(data, chunk_size=3), axis=1)
         pd.testing.assert_series_equal(
             self.compute(data, axis=1),
-            self.executor.execute_dataframe(reduction_df4, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
         # test null
         np_data = np.random.rand(20, 10)
         np_data[np_data > 0.6] = np.nan
         data = pd.DataFrame(np_data)
 
-        reduction_df1 = self.compute(from_pandas_df(data, chunk_size=3))
+        r = self.compute(md.DataFrame(data, chunk_size=3))
         pd.testing.assert_series_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_df(data, chunk_size=3), skipna=False)
+        r = self.compute(md.DataFrame(data, chunk_size=3), skipna=False)
         pd.testing.assert_series_equal(
-            self.compute(data, skipna=False), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data, skipna=False), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_df(data, chunk_size=3), skipna=False)
+        r = self.compute(md.DataFrame(data, chunk_size=3), skipna=False)
         pd.testing.assert_series_equal(
-            self.compute(data, skipna=False), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data, skipna=False), self.executor.execute_dataframe(r, concat=True)[0])
 
         if self.has_min_count:
-            reduction_df3 = self.compute(from_pandas_df(data, chunk_size=3), min_count=15)
+            r = self.compute(md.DataFrame(data, chunk_size=3), min_count=15)
             pd.testing.assert_series_equal(
                 self.compute(data, min_count=15),
-                self.executor.execute_dataframe(reduction_df3, concat=True)[0])
+                self.executor.execute_dataframe(r, concat=True)[0])
 
-            reduction_df4 = self.compute(from_pandas_df(data, chunk_size=3), min_count=3)
+            r = self.compute(md.DataFrame(data, chunk_size=3), min_count=3)
             pd.testing.assert_series_equal(
                 self.compute(data, min_count=3),
-                self.executor.execute_dataframe(reduction_df4, concat=True)[0])
+                self.executor.execute_dataframe(r, concat=True)[0])
 
-            reduction_df5 = self.compute(from_pandas_df(data, chunk_size=3), axis=1, min_count=3)
+            r = self.compute(md.DataFrame(data, chunk_size=3), axis=1, min_count=3)
             pd.testing.assert_series_equal(
                 self.compute(data, axis=1, min_count=3),
-                self.executor.execute_dataframe(reduction_df5, concat=True)[0])
+                self.executor.execute_dataframe(r, concat=True)[0])
 
-            reduction_df5 = self.compute(from_pandas_df(data, chunk_size=3), axis=1, min_count=8)
+            r = self.compute(md.DataFrame(data, chunk_size=3), axis=1, min_count=8)
             pd.testing.assert_series_equal(
                 self.compute(data, axis=1, min_count=8),
-                self.executor.execute_dataframe(reduction_df5, concat=True)[0])
+                self.executor.execute_dataframe(r, concat=True)[0])
 
         # test numeric_only
         data = pd.DataFrame(np.random.rand(10, 10), index=np.random.randint(-100, 100, size=(10,)),
                             columns=[np.random.bytes(10) for _ in range(10)])
-        reduction_df1 = self.compute(from_pandas_df(data, chunk_size=2))
+        r = self.compute(md.DataFrame(data, chunk_size=2))
         pd.testing.assert_series_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_df(data, chunk_size=6), axis='index', numeric_only=True)
+        r = self.compute(md.DataFrame(data, chunk_size=6), axis='index', numeric_only=True)
         pd.testing.assert_series_equal(
             self.compute(data, axis='index', numeric_only=True),
-            self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df3 = self.compute(from_pandas_df(data, chunk_size=3), axis='columns')
+        r = self.compute(md.DataFrame(data, chunk_size=3), axis='columns')
         pd.testing.assert_series_equal(
             self.compute(data, axis='columns'),
-            self.executor.execute_dataframe(reduction_df3, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
         data_dict = dict((str(i), np.random.rand(10)) for i in range(10))
         data_dict['string'] = [str(i) for i in range(10)]
         data_dict['bool'] = np.random.choice([True, False], (10,))
         data = pd.DataFrame(data_dict)
-        reduction_df = self.compute(from_pandas_df(data, chunk_size=3), axis='index', numeric_only=True)
+        r = self.compute(md.DataFrame(data, chunk_size=3), axis='index', numeric_only=True)
         pd.testing.assert_series_equal(
             self.compute(data, axis='index', numeric_only=True),
-            self.executor.execute_dataframe(reduction_df, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
         data1 = pd.DataFrame(np.random.rand(10, 10), columns=[str(i) for i in range(10)])
         data2 = pd.DataFrame(np.random.rand(10, 10), columns=[str(i) for i in range(10)])
-        df = from_pandas_df(data1, chunk_size=5) + from_pandas_df(data2, chunk_size=6)
-        reduction_df = self.compute(df)
+        df = md.DataFrame(data1, chunk_size=5) + md.DataFrame(data2, chunk_size=6)
+        r = self.compute(df)
         pd.testing.assert_series_equal(
             self.compute(data1 + data2).sort_index(),
-            self.executor.execute_dataframe(reduction_df, concat=True)[0].sort_index())
+            self.executor.execute_dataframe(r, concat=True)[0].sort_index())
 
-    @require_cudf
-    @require_cupy
+
+@require_cudf
+@require_cupy
+class TestGPUReduction(TestBase):
     def testGPUExecution(self):
         df_raw = pd.DataFrame(np.random.rand(30, 3), columns=list('abc'))
-        df = to_gpu(from_pandas_df(df_raw, chunk_size=6))
+        df = to_gpu(md.DataFrame(df_raw, chunk_size=6))
 
         r = df.sum()
         res = self.executor.execute_dataframe(r, concat=True)[0]
@@ -209,7 +214,7 @@ class TestReduction(TestBase):
         pd.testing.assert_frame_equal(res.to_pandas(), df_raw.agg(['sum', 'var']))
 
         s_raw = pd.Series(np.random.rand(30))
-        s = to_gpu(from_pandas_series(s_raw, chunk_size=6))
+        s = to_gpu(md.Series(s_raw, chunk_size=6))
 
         r = s.sum()
         res = self.executor.execute_dataframe(r, concat=True)[0]
@@ -225,7 +230,7 @@ class TestReduction(TestBase):
 
         s_raw = pd.Series(np.random.randint(0, 3, size=(30,))
                           * np.random.randint(0, 5, size=(30,)))
-        s = to_gpu(from_pandas_series(s_raw, chunk_size=6))
+        s = to_gpu(md.Series(s_raw, chunk_size=6))
 
         r = s.unique()
         res = self.executor.execute_dataframe(r, concat=True)[0]
@@ -248,98 +253,98 @@ class TestBoolReduction(TestBase):
 
     def testSeriesReduction(self):
         data = pd.Series(np.random.rand(10) > 0.5, index=[str(i) for i in range(10)], name='a')
-        reduction_df1 = self.compute(from_pandas_series(data))
+        r = self.compute(md.Series(data))
         self.assertEqual(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_series(data, chunk_size=6))
+        r = self.compute(md.Series(data, chunk_size=6))
         self.assertAlmostEqual(
-            self.compute(data), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df3 = self.compute(from_pandas_series(data, chunk_size=3))
+        r = self.compute(md.Series(data, chunk_size=3))
         self.assertAlmostEqual(
-            self.compute(data), self.executor.execute_dataframe(reduction_df3, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df4 = self.compute(from_pandas_series(data, chunk_size=4), axis='index')
+        r = self.compute(md.Series(data, chunk_size=4), axis='index')
         self.assertAlmostEqual(
-            self.compute(data, axis='index'), self.executor.execute_dataframe(reduction_df4, concat=True)[0])
+            self.compute(data, axis='index'), self.executor.execute_dataframe(r, concat=True)[0])
 
         data = pd.Series(np.random.rand(20), name='a')
         data[0] = 0.1  # make sure not all elements are NAN
         data[data > 0.5] = np.nan
-        reduction_df1 = self.compute(from_pandas_series(data, chunk_size=3))
+        r = self.compute(md.Series(data, chunk_size=3))
         self.assertEqual(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_series(data, chunk_size=3), skipna=False)
+        r = self.compute(md.Series(data, chunk_size=3), skipna=False)
         self.assertTrue(
-            self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
     def testDataFrameReduction(self):
         data = pd.DataFrame(np.random.rand(20, 10))
         data.iloc[:, :5] = data.iloc[:, :5] > 0.5
-        reduction_df1 = self.compute(from_pandas_df(data))
+        r = self.compute(md.DataFrame(data))
         pd.testing.assert_series_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_df(data, chunk_size=3))
+        r = self.compute(md.DataFrame(data, chunk_size=3))
         pd.testing.assert_series_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df3 = self.compute(from_pandas_df(data, chunk_size=6), axis='index', bool_only=True)
+        r = self.compute(md.DataFrame(data, chunk_size=6), axis='index', bool_only=True)
         pd.testing.assert_series_equal(
             self.compute(data, axis='index', bool_only=True),
-            self.executor.execute_dataframe(reduction_df3, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df4 = self.compute(from_pandas_df(data, chunk_size=3), axis=1)
+        r = self.compute(md.DataFrame(data, chunk_size=3), axis=1)
         pd.testing.assert_series_equal(
             self.compute(data, axis=1),
-            self.executor.execute_dataframe(reduction_df4, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
         # test null
         np_data = np.random.rand(20, 10)
         np_data[np_data > 0.6] = np.nan
         data = pd.DataFrame(np_data)
 
-        reduction_df1 = self.compute(from_pandas_df(data, chunk_size=3))
+        r = self.compute(md.DataFrame(data, chunk_size=3))
         pd.testing.assert_series_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_df(data, chunk_size=3), skipna=False)
+        r = self.compute(md.DataFrame(data, chunk_size=3), skipna=False)
         pd.testing.assert_series_equal(
-            self.compute(data, skipna=False), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data, skipna=False), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_df(data, chunk_size=3), skipna=False)
+        r = self.compute(md.DataFrame(data, chunk_size=3), skipna=False)
         pd.testing.assert_series_equal(
-            self.compute(data, skipna=False), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data, skipna=False), self.executor.execute_dataframe(r, concat=True)[0])
 
         # test bool_only
         data = pd.DataFrame(np.random.rand(10, 10), index=np.random.randint(-100, 100, size=(10,)),
                             columns=[np.random.bytes(10) for _ in range(10)])
         data.iloc[:, :5] = data.iloc[:, :5] > 0.5
         data.iloc[:5, 5:] = data.iloc[:5, 5:] > 0.5
-        reduction_df1 = self.compute(from_pandas_df(data, chunk_size=2))
+        r = self.compute(md.DataFrame(data, chunk_size=2))
         pd.testing.assert_series_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_df(data, chunk_size=6), axis='index', bool_only=True)
+        r = self.compute(md.DataFrame(data, chunk_size=6), axis='index', bool_only=True)
         pd.testing.assert_series_equal(
             self.compute(data, axis='index', bool_only=True),
-            self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df3 = self.compute(from_pandas_df(data, chunk_size=3), axis='columns')
+        r = self.compute(md.DataFrame(data, chunk_size=3), axis='columns')
         pd.testing.assert_series_equal(
             self.compute(data, axis='columns'),
-            self.executor.execute_dataframe(reduction_df3, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
         data_dict = dict((str(i), np.random.rand(10)) for i in range(10))
         data_dict['string'] = [str(i) for i in range(10)]
         data_dict['bool'] = np.random.choice([True, False], (10,))
         data = pd.DataFrame(data_dict)
-        reduction_df = self.compute(from_pandas_df(data, chunk_size=3), axis='index', bool_only=True)
+        r = self.compute(md.DataFrame(data, chunk_size=3), axis='index', bool_only=True)
         pd.testing.assert_series_equal(
             self.compute(data, axis='index', bool_only=True),
-            self.executor.execute_dataframe(reduction_df, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
 
 class TestCount(TestBase):
@@ -350,19 +355,19 @@ class TestCount(TestBase):
         array = np.random.rand(10)
         array[[2, 7, 9]] = np.nan
         data = pd.Series(array)
-        series = from_pandas_series(data)
+        series = md.Series(data)
 
         result = self.executor.execute_dataframe(series.count(), concat=True)[0]
         expected = data.count()
         self.assertEqual(result, expected)
 
-        series2 = from_pandas_series(data, chunk_size=1)
+        series2 = md.Series(data, chunk_size=1)
 
         result = self.executor.execute_dataframe(series2.count(), concat=True)[0]
         expected = data.count()
         self.assertEqual(result, expected)
 
-        series2 = from_pandas_series(data, chunk_size=3)
+        series2 = md.Series(data, chunk_size=3)
 
         result = self.executor.execute_dataframe(series2.count(), concat=True)[0]
         expected = data.count()
@@ -373,7 +378,7 @@ class TestCount(TestBase):
             "Person": ["John", "Myla", "Lewis", "John", "Myla"],
             "Age": [24., np.nan, 21., 33, 26],
             "Single": [False, True, True, True, False]})
-        df = from_pandas_df(data)
+        df = md.DataFrame(data)
 
         result = self.executor.execute_dataframe(df.count(), concat=True)[0]
         expected = data.count()
@@ -383,7 +388,7 @@ class TestCount(TestBase):
         expected = data.count(axis='columns')
         pd.testing.assert_series_equal(result, expected)
 
-        df2 = from_pandas_df(data, chunk_size=2)
+        df2 = md.DataFrame(data, chunk_size=2)
 
         result = self.executor.execute_dataframe(df2.count(), concat=True)[0]
         expected = data.count()
@@ -393,7 +398,7 @@ class TestCount(TestBase):
         expected = data.count(axis='columns')
         pd.testing.assert_series_equal(result, expected)
 
-        df3 = from_pandas_df(data, chunk_size=3)
+        df3 = md.DataFrame(data, chunk_size=3)
 
         result = self.executor.execute_dataframe(df3.count(numeric_only=True), concat=True)[0]
         expected = data.count(numeric_only=True)
@@ -406,12 +411,12 @@ class TestCount(TestBase):
     def testNunique(self):
         data1 = pd.Series(np.random.randint(0, 5, size=(20,)))
 
-        series = from_pandas_series(data1)
+        series = md.Series(data1)
         result = self.executor.execute_dataframe(series.nunique(), concat=True)[0]
         expected = data1.nunique()
         self.assertEqual(result, expected)
 
-        series = from_pandas_series(data1, chunk_size=6)
+        series = md.Series(data1, chunk_size=6)
         result = self.executor.execute_dataframe(series.nunique(), concat=True)[0]
         expected = data1.nunique()
         self.assertEqual(result, expected)
@@ -420,12 +425,12 @@ class TestCount(TestBase):
         data2 = data1.copy()
         data2[[2, 9, 18]] = np.nan
 
-        series = from_pandas_series(data2)
+        series = md.Series(data2)
         result = self.executor.execute_dataframe(series.nunique(), concat=True)[0]
         expected = data2.nunique()
         self.assertEqual(result, expected)
 
-        series = from_pandas_series(data2, chunk_size=3)
+        series = md.Series(data2, chunk_size=3)
         result = self.executor.execute_dataframe(series.nunique(dropna=False), concat=True)[0]
         expected = data2.nunique(dropna=False)
         self.assertEqual(result, expected)
@@ -433,22 +438,22 @@ class TestCount(TestBase):
         # test dataframe
         data1 = pd.DataFrame(np.random.randint(0, 6, size=(20, 20)),
                              columns=['c' + str(i) for i in range(20)])
-        df = from_pandas_df(data1)
+        df = md.DataFrame(data1)
         result = self.executor.execute_dataframe(df.nunique(), concat=True)[0]
         expected = data1.nunique()
         pd.testing.assert_series_equal(result, expected)
 
-        df = from_pandas_df(data1, chunk_size=6)
+        df = md.DataFrame(data1, chunk_size=6)
         result = self.executor.execute_dataframe(df.nunique(), concat=True)[0]
         expected = data1.nunique()
         pd.testing.assert_series_equal(result, expected)
 
-        df = from_pandas_df(data1)
+        df = md.DataFrame(data1)
         result = self.executor.execute_dataframe(df.nunique(axis=1), concat=True)[0]
         expected = data1.nunique(axis=1)
         pd.testing.assert_series_equal(result, expected)
 
-        df = from_pandas_df(data1, chunk_size=3)
+        df = md.DataFrame(data1, chunk_size=3)
         result = self.executor.execute_dataframe(df.nunique(axis=1), concat=True)[0]
         expected = data1.nunique(axis=1)
         pd.testing.assert_series_equal(result, expected)
@@ -457,17 +462,17 @@ class TestCount(TestBase):
         data2 = data1.copy()
         data2.iloc[[2, 9, 18], [2, 9, 18]] = np.nan
 
-        df = from_pandas_df(data2)
+        df = md.DataFrame(data2)
         result = self.executor.execute_dataframe(df.nunique(), concat=True)[0]
         expected = data2.nunique()
         pd.testing.assert_series_equal(result, expected)
 
-        df = from_pandas_df(data2, chunk_size=3)
+        df = md.DataFrame(data2, chunk_size=3)
         result = self.executor.execute_dataframe(df.nunique(dropna=False), concat=True)[0]
         expected = data2.nunique(dropna=False)
         pd.testing.assert_series_equal(result, expected)
 
-        df = from_pandas_df(data1, chunk_size=3)
+        df = md.DataFrame(data1, chunk_size=3)
         result = self.executor.execute_dataframe(df.nunique(axis=1), concat=True)[0]
         expected = data1.nunique(axis=1)
         pd.testing.assert_series_equal(result, expected)
@@ -482,7 +487,7 @@ class TestCount(TestBase):
             data1['d'] = data1['b'].copy()
             data1['e'] = data1['b'].copy()
 
-            df = from_pandas_df(data1, chunk_size=(3, 2))
+            df = md.DataFrame(data1, chunk_size=(3, 2))
             r = df.nunique(axis=0)
             result = self.executor.execute_dataframe(r, concat=True)[0]
             expected = data1.nunique(axis=0)
@@ -496,12 +501,12 @@ class TestCount(TestBase):
     def testUnique(self):
         data1 = pd.Series(np.random.randint(0, 5, size=(20,)))
 
-        series = from_pandas_series(data1)
+        series = md.Series(data1)
         result = self.executor.execute_dataframe(series.unique(), concat=True)[0]
         expected = data1.unique()
         np.testing.assert_array_equal(result, expected)
 
-        series = from_pandas_series(data1, chunk_size=6)
+        series = md.Series(data1, chunk_size=6)
         result = self.executor.execute_dataframe(series.unique(), concat=True)[0]
         expected = data1.unique()
         np.testing.assert_array_equal(result, expected)
@@ -509,12 +514,12 @@ class TestCount(TestBase):
         data2 = pd.Series([pd.Timestamp('20200101'), ] * 5 +
                           [pd.Timestamp('20200202')] +
                           [pd.Timestamp('20020101')] * 9)
-        series = from_pandas_series(data2)
+        series = md.Series(data2)
         result = self.executor.execute_dataframe(series.unique(), concat=True)[0]
         expected = data2.unique()
         np.testing.assert_array_equal(result, expected)
 
-        series = from_pandas_series(data2, chunk_size=6)
+        series = md.Series(data2, chunk_size=6)
         result = self.executor.execute_dataframe(series.unique(), concat=True)[0]
         expected = data2.unique()
         np.testing.assert_array_equal(result, expected)
@@ -538,76 +543,76 @@ class TestCumReduction(TestBase):
 
     def testSeriesCumReduction(self):
         data = pd.Series(np.random.rand(20), index=[str(i) for i in range(20)], name='a')
-        reduction_df1 = self.compute(from_pandas_series(data))
+        r = self.compute(md.Series(data))
         pd.testing.assert_series_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_series(data, chunk_size=6))
+        r = self.compute(md.Series(data, chunk_size=6))
         pd.testing.assert_series_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df3 = self.compute(from_pandas_series(data, chunk_size=3))
+        r = self.compute(md.Series(data, chunk_size=3))
         pd.testing.assert_series_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df3, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df4 = self.compute(from_pandas_series(data, chunk_size=4), axis='index')
+        r = self.compute(md.Series(data, chunk_size=4), axis='index')
         pd.testing.assert_series_equal(
-            self.compute(data, axis='index'), self.executor.execute_dataframe(reduction_df4, concat=True)[0])
+            self.compute(data, axis='index'), self.executor.execute_dataframe(r, concat=True)[0])
 
         data = pd.Series(np.random.rand(20), name='a')
         data[0] = 0.1  # make sure not all elements are NAN
         data[data > 0.5] = np.nan
-        reduction_df1 = self.compute(from_pandas_series(data, chunk_size=3))
+        r = self.compute(md.Series(data, chunk_size=3))
         pd.testing.assert_series_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_series(data, chunk_size=3), skipna=False)
+        r = self.compute(md.Series(data, chunk_size=3), skipna=False)
         pd.testing.assert_series_equal(
-            self.compute(data, skipna=False), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data, skipna=False), self.executor.execute_dataframe(r, concat=True)[0])
 
     def testDataFrameCumReduction(self):
         data = pd.DataFrame(np.random.rand(20, 10))
-        reduction_df1 = self.compute(from_pandas_df(data))
+        r = self.compute(md.DataFrame(data))
         pd.testing.assert_frame_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_df(data, chunk_size=3))
+        r = self.compute(md.DataFrame(data, chunk_size=3))
         pd.testing.assert_frame_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df4 = self.compute(from_pandas_df(data, chunk_size=3), axis=1)
+        r = self.compute(md.DataFrame(data, chunk_size=3), axis=1)
         pd.testing.assert_frame_equal(
             self.compute(data, axis=1),
-            self.executor.execute_dataframe(reduction_df4, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
         # test null
         np_data = np.random.rand(20, 10)
         np_data[np_data > 0.6] = np.nan
         data = pd.DataFrame(np_data)
 
-        reduction_df1 = self.compute(from_pandas_df(data, chunk_size=3))
+        r = self.compute(md.DataFrame(data, chunk_size=3))
         pd.testing.assert_frame_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_df(data, chunk_size=3), skipna=False)
+        r = self.compute(md.DataFrame(data, chunk_size=3), skipna=False)
         pd.testing.assert_frame_equal(
-            self.compute(data, skipna=False), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data, skipna=False), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df2 = self.compute(from_pandas_df(data, chunk_size=3), skipna=False)
+        r = self.compute(md.DataFrame(data, chunk_size=3), skipna=False)
         pd.testing.assert_frame_equal(
-            self.compute(data, skipna=False), self.executor.execute_dataframe(reduction_df2, concat=True)[0])
+            self.compute(data, skipna=False), self.executor.execute_dataframe(r, concat=True)[0])
 
         # test numeric_only
         data = pd.DataFrame(np.random.rand(10, 10), index=np.random.randint(-100, 100, size=(10,)),
                             columns=[np.random.bytes(10) for _ in range(10)])
-        reduction_df1 = self.compute(from_pandas_df(data, chunk_size=2))
+        r = self.compute(md.DataFrame(data, chunk_size=2))
         pd.testing.assert_frame_equal(
-            self.compute(data), self.executor.execute_dataframe(reduction_df1, concat=True)[0])
+            self.compute(data), self.executor.execute_dataframe(r, concat=True)[0])
 
-        reduction_df3 = self.compute(from_pandas_df(data, chunk_size=3), axis='columns')
+        r = self.compute(md.DataFrame(data, chunk_size=3), axis='columns')
         pd.testing.assert_frame_equal(
             self.compute(data, axis='columns'),
-            self.executor.execute_dataframe(reduction_df3, concat=True)[0])
+            self.executor.execute_dataframe(r, concat=True)[0])
 
 
 class TestAggregate(TestBase):
@@ -619,7 +624,7 @@ class TestAggregate(TestBase):
                     'mean', 'var', 'std', 'sem', 'skew', 'kurt']
         data = pd.DataFrame(np.random.rand(20, 20))
 
-        df = from_pandas_df(data)
+        df = md.DataFrame(data)
         result = df.agg(all_aggs)
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(result, concat=True)[0],
                                       data.agg(all_aggs))
@@ -636,7 +641,7 @@ class TestAggregate(TestBase):
             pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
                                            data.agg(func, axis=1))
 
-        df = from_pandas_df(data, chunk_size=3)
+        df = md.DataFrame(data, chunk_size=3)
 
         # will redirect to transform
         result = df.agg(['cumsum', 'cummax'])
@@ -681,7 +686,7 @@ class TestAggregate(TestBase):
         all_aggs = ['sum', 'prod', 'min', 'max', 'count', 'size',
                     'mean', 'var', 'std', 'sem', 'skew', 'kurt']
         data = pd.Series(np.random.rand(20), index=[str(i) for i in range(20)], name='a')
-        series = from_pandas_series(data)
+        series = md.Series(data)
 
         result = series.agg(all_aggs)
         pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
@@ -692,7 +697,7 @@ class TestAggregate(TestBase):
             self.assertAlmostEqual(self.executor.execute_dataframe(result, concat=True)[0],
                                    data.agg(func))
 
-        series = from_pandas_series(data, chunk_size=3)
+        series = md.Series(data, chunk_size=3)
 
         for func in all_aggs:
             result = series.agg(func)
@@ -710,6 +715,27 @@ class TestAggregate(TestBase):
         result = series.agg(col_var='var', col_skew='skew')
         pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
                                        data.agg(col_var='var', col_skew='skew'))
+
+    def testAggregateStrCat(self):
+        agg_fun = lambda x: x.str.cat(sep='_', na_rep='NA')
+
+        rs = np.random.RandomState(0)
+        raw_df = pd.DataFrame({'a': rs.choice(['A', 'B', 'C'], size=(100,)),
+                               'b': rs.choice([None, 'alfa', 'bravo', 'charlie'], size=(100,))})
+
+        mdf = md.DataFrame(raw_df, chunk_size=13)
+
+        r = mdf.agg(agg_fun)
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                       raw_df.agg(agg_fun))
+
+        raw_series = pd.Series(rs.choice([None, 'alfa', 'bravo', 'charlie'], size=(100,)))
+
+        ms = md.Series(raw_series, chunk_size=13)
+
+        r = ms.agg(agg_fun)
+        self.assertEqual(self.executor.execute_dataframe(r, concat=True)[0],
+                         raw_series.agg(agg_fun))
 
 
 class MockReduction1(CustomReduction):
@@ -735,7 +761,7 @@ class TestCustomAggregate(TestBase):
     def testDataFrameAggregate(self):
         data = pd.DataFrame(np.random.rand(30, 20))
 
-        df = from_pandas_df(data)
+        df = md.DataFrame(data)
         result = df.agg(MockReduction1())
         pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
                                        data.agg(MockReduction1()))
@@ -744,7 +770,7 @@ class TestCustomAggregate(TestBase):
         pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
                                        data.agg(MockReduction2()))
 
-        df = from_pandas_df(data, chunk_size=5)
+        df = md.DataFrame(data, chunk_size=5)
         result = df.agg(MockReduction2())
         pd.testing.assert_series_equal(self.executor.execute_dataframe(result, concat=True)[0],
                                        data.agg(MockReduction2()))
@@ -756,7 +782,7 @@ class TestCustomAggregate(TestBase):
     def testSeriesAggregate(self):
         data = pd.Series(np.random.rand(20))
 
-        s = from_pandas_series(data)
+        s = md.Series(data)
         result = s.agg(MockReduction1())
         self.assertEqual(self.executor.execute_dataframe(result, concat=True)[0],
                          data.agg(MockReduction1()))
@@ -765,7 +791,7 @@ class TestCustomAggregate(TestBase):
         self.assertEqual(self.executor.execute_dataframe(result, concat=True)[0],
                          data.agg(MockReduction2()))
 
-        s = from_pandas_series(data, chunk_size=5)
+        s = md.Series(data, chunk_size=5)
         result = s.agg(MockReduction2())
         self.assertAlmostEqual(self.executor.execute_dataframe(result, concat=True)[0],
                                data.agg(MockReduction2()))

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -262,6 +262,7 @@ message OperandDef {
         SKEW = 350;
         KURTOSIS = 351;
         SEM = 352;
+        STR_CONCAT = 353;
 
         // tensor operand
         RESHAPE = 401;


### PR DESCRIPTION
## What do these changes do?

Add ``str.cat`` as base aggregation method. Now users can call ``df.groupby('col').agg(lambda x: x.str.cat(sep='+')``.

## Related issue number

Fixes #1775 