### PR TITLE
Fix reading partitioned parquet files in HDFS

### DIFF
--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -24,3 +24,4 @@ For now, distributed version is only available for Linux and Mac OS.
    install
    deploy
    kubernetes
+   yarn

--- a/docs/source/installation/kubernetes.rst
+++ b/docs/source/installation/kubernetes.rst
@@ -79,8 +79,8 @@ Customizing cluster
 -------------------
 ``new_cluster`` function provides several keyword arguments for users to define
 the cluster. You may use the argument ``image`` to specify the image for all
-Mars pods, and the argument ``timeout`` to specify timeout of cluster creation.
-Arguments for scaling up and out of the cluster are also available.
+Mars pods, or use the argument ``timeout`` to specify timeout of cluster
+creation.  Arguments for scaling up and out of the cluster are also available.
 
 Arguments for schedulers:
 

--- a/docs/source/installation/yarn.rst
+++ b/docs/source/installation/yarn.rst
@@ -1,0 +1,165 @@
+.. _yarn:
+
+Run on Yarn
+===========
+
+Mars can be deployed on `YARN
+<https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html>`_
+clusters. You can use ``mars.deploy.yarn`` to start Mars clusters in Hadoop
+environments.
+
+Basic steps
+-----------
+
+Mars uses `Skein <https://jcrist.github.io/skein/>`_ to deploy itself into YARN
+clusters.  This library bridges Java interfaces of YARN applications and Python
+interfaces.
+
+Before starting Mars in YARN, you need to check your environments first. As
+Skein supports Linux only, you need to work on a Linux client, otherwise you
+need to fix and compile a number of packages yourself. Skein library is also
+needed on client side. You may install Skein with conda
+
+.. code-block:: bash
+
+    conda install -c conda-forge skein
+
+or install with pip
+
+.. code-block:: bash
+
+    pip install skein
+
+Then you need to check Python environment inside your cluster. If you have a
+Python environment installed within your YARN nodes with every required
+packages installed, it will save a lot of time for you to start your cluster.
+Otherwise you need to pack your local environment and specify it to Mars.
+
+You may use `conda-pack <https://conda.github.io/conda-pack/>`_ to pack your
+environment when you are using Conda:
+
+.. code-block:: bash
+
+    conda activate local-env
+    conda install -c conda-forge conda-pack
+    conda-pack
+
+or use `venv-pack <https://jcrist.github.io/venv-pack/>`_ to pack your
+environment when you are using virtual environments:
+
+.. code-block:: bash
+
+    source local-env/bin/activate
+    pip install venv-pack
+    venv-pack
+
+Both commands will create a ``tar.gz`` archive, and you can use it when
+deploying your Mars cluster.
+
+Then it is time to start your Mars cluster. Select different lines when you are
+starting from existing a conda environment, virtual environment, Python
+executable or pre-packed environment archive:
+
+.. code-block:: python
+
+    import os
+    from mars.deploy.yarn import new_cluster
+
+    # specify location of Hadoop and JDK on client side
+    os.environ['JAVA_HOME'] = '/usr/lib/jvm/java-1.8.0-openjdk'
+    os.environ['HADOOP_HOME'] = '/usr/local/hadoop'
+
+    # use a conda environment at /path/to/remote/conda/env
+    cluster = new_cluster(enviromnent='conda:///path/to/remote/conda/env')
+
+    # use a virtual environment at /path/to/remote/virtual/env
+    cluster = new_cluster(enviromnent='venv:///path/to/remote/virtual/env')
+
+    # use a remote python executable
+    cluster = new_cluster(enviromnent='python:///path/to/remote/python')
+
+    # use a local packed environment archive
+    cluster = new_cluster(enviromnent='path/to/local/env/pack.tar.gz')
+
+    # get web endpoint, may be used elsewhere
+    from mars.session import Session
+    print(Session.default_or_local().endpoint)
+
+    # new cluster will start a session and set it as default one
+    # execute will then run in the local cluster
+    a = mt.random.rand(10, 10)
+    a.dot(a.T).execute()
+
+    # after all jobs executed, you can turn off the cluster
+    cluster.stop()
+
+Customizing cluster
+-------------------
+``new_cluster`` function provides several keyword arguments for users to define
+the cluster. You may use the argument ``app_name`` to customize the name of the
+Yarn application, or use the argument ``timeout`` to specify timeout of cluster
+creation.  Arguments for scaling up and out of the cluster are also available.
+
+Arguments for schedulers:
+
++------------------+----------------------------------------------------------------+
+| Argument         | Description                                                    |
++==================+================================================================+
+| scheduler_num    | Number of schedulers in the cluster, 1 by default              |
++------------------+----------------------------------------------------------------+
+| scheduler_cpu    | Number of CPUs for every scheduler                             |
++------------------+----------------------------------------------------------------+
+| scheduler_mem    | Memory size for schedulers in the cluster, in bytes or size    |
+|                  | units like ``1g``                                              |
++------------------+----------------------------------------------------------------+
+
+Arguments for workers:
+
++--------------------+----------------------------------------------------------------+
+| Argument           | Description                                                    |
++====================+================================================================+
+| worker_num         | Number of workers in the cluster, 1 by default                 |
++--------------------+----------------------------------------------------------------+
+| worker_cpu         | Number of CPUs for every worker                                |
++--------------------+----------------------------------------------------------------+
+| worker_mem         | Memory size for workers in the cluster, in bytes or size units |
+|                    | like ``1g``                                                    |
++--------------------+----------------------------------------------------------------+
+| worker_spill_paths | List of spill paths for worker pods on hosts                   |
++--------------------+----------------------------------------------------------------+
+| worker_cache_mem   | Size or ratio of shared memory for every worker. Details about |
+|                    | memory management of Mars workers can be found in :ref:`memory |
+|                    | tuning <worker_memory_tuning>` section.                        |
++--------------------+----------------------------------------------------------------+
+| min_worker_num     | Minimal number of ready workers for ``new_cluster`` to return, |
+|                    | ``worker_num`` by default                                      |
++--------------------+----------------------------------------------------------------+
+
+Arguments for web services:
+
++------------------+----------------------------------------------------------------+
+| Argument         | Description                                                    |
++==================+================================================================+
+| web_num          | Number of web services in the cluster, 1 by default            |
++------------------+----------------------------------------------------------------+
+| web_cpu          | Number of CPUs for every web service                           |
++------------------+----------------------------------------------------------------+
+| web_mem          | Memory size for web services in the cluster, in bytes or size  |
+|                  | units like ``1g``                                              |
++------------------+----------------------------------------------------------------+
+
+For instance, if you want to create a Mars cluster with 1 scheduler, 1 web
+service and 100 workers, each worker has 4 cores and 16GB memory, and stop
+waiting when 95 workers are ready, we can use the code below:
+
+.. code-block:: python
+
+    import os
+    from mars.deploy.yarn import new_cluster
+
+    os.environ['JAVA_HOME'] = '/usr/lib/jvm/java-1.8.0-openjdk'
+    os.environ['HADOOP_HOME'] = '/usr/local/hadoop'
+
+    cluster = new_cluster('path/to/env/pack.tar.gz', scheduler_num=1, web_num=1,
+                          worker_num=100, worker_cpu=4, worker_mem='16g',
+                          min_worker_num=95)

--- a/mars/dataframe/datasource/read_parquet.py
+++ b/mars/dataframe/datasource/read_parquet.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import pickle
 from urllib.parse import urlparse
 
@@ -219,7 +220,7 @@ class DataFrameReadParquet(DataFrameOperand, DataFrameOperandMixin):
         dataset = pq.ParquetDataset(op.path)
 
         parsed_path = urlparse(op.path)
-        if parsed_path.scheme is not None:
+        if not os.path.exists(op.path) and parsed_path.scheme:
             path_prefix = f'{parsed_path.scheme}://{parsed_path.netloc}'
         else:
             path_prefix = ''

--- a/mars/dataframe/datasource/read_parquet.py
+++ b/mars/dataframe/datasource/read_parquet.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import pickle
+from urllib.parse import urlparse
 
 import numpy as np
 import pandas as pd
@@ -33,7 +33,7 @@ except ImportError:
 
 from ... import opcodes as OperandDef
 from ...config import options
-from ...filesystem import open_file, glob
+from ...filesystem import get_fs, open_file, glob
 from ...serialize import AnyField, BoolField, DictField, ListField,\
     StringField, Int32Field, BytesField
 from ..arrays import ArrowStringDtype
@@ -218,11 +218,17 @@ class DataFrameReadParquet(DataFrameOperand, DataFrameOperandMixin):
         dtypes = cls._to_arrow_dtypes(out_df.dtypes, op)
         dataset = pq.ParquetDataset(op.path)
 
+        parsed_path = urlparse(op.path)
+        if parsed_path.scheme is not None:
+            path_prefix = f'{parsed_path.scheme}://{parsed_path.netloc}'
+        else:
+            path_prefix = ''
+
         chunk_index = 0
         out_chunks = []
         for piece in dataset.pieces:
             chunk_op = op.copy().reset_key()
-            chunk_op._path = piece.path
+            chunk_op._path = path_prefix + piece.path
             chunk_op._partitions = pickle.dumps(dataset.partitions)
             chunk_op._partition_keys = piece.partition_keys
             new_chunk = chunk_op.new_chunk(
@@ -288,7 +294,7 @@ class DataFrameReadParquet(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def tile(cls, op):
-        if os.path.isdir(op.path):
+        if get_fs(op.path, op.storage_options).isdir(op.path):
             return cls._tile_partitioned(op)
         else:
             return cls._tile_no_partitioned(op)
@@ -376,7 +382,7 @@ def read_parquet(path, engine: str = "auto", columns=None,
     engine_type = check_engine(engine)
     engine = get_engine(engine_type)
 
-    if os.path.isdir(path):
+    if get_fs(path, storage_options).isdir(path):
         # If path is a directory, we will read as a partitioned datasets.
         if engine_type != 'pyarrow':
             raise TypeError('Only support pyarrow engine when reading from'

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -478,6 +478,28 @@ class Test(TestBase):
                 md.read_csv(f'{tempdir}/*.csv', index_col=0, chunk_bytes=50), concat=True)[0]
             pd.testing.assert_frame_equal(df, mdf2.sort_index())
 
+        # test read directory
+        with tempfile.TemporaryDirectory() as tempdir:
+            testdir = os.path.join(tempdir, 'test_dir')
+            os.makedirs(testdir, exist_ok=True)
+
+            df = pd.DataFrame(np.random.rand(300, 3), columns=['a', 'b', 'c'])
+
+            file_paths = [os.path.join(testdir, f'test{i}.csv') for i in range(3)]
+            df[:100].to_csv(file_paths[0])
+            df[100:200].to_csv(file_paths[1])
+            df[200:].to_csv(file_paths[2])
+
+            # As we can not guarantee the order in which these files are processed,
+            # the result may not keep the original order.
+            mdf = self.executor.execute_dataframe(
+                md.read_csv(testdir, index_col=0), concat=True)[0]
+            pd.testing.assert_frame_equal(df, mdf.sort_index())
+
+            mdf2 = self.executor.execute_dataframe(
+                md.read_csv(testdir, index_col=0, chunk_bytes=50), concat=True)[0]
+            pd.testing.assert_frame_equal(df, mdf2.sort_index())
+
     @unittest.skipIf(pa is None, 'pyarrow not installed')
     def testReadCSVUseArrowDtype(self):
         df = pd.DataFrame({


### PR DESCRIPTION
## What do these changes do?

Fix reading partitioned parquet files in HDFS by using ``mars.filesystem`` methods instead of built-in ``os`` package.

## Related issue number

Fixes #1780 