### PR TITLE
[BACKPORT] Implements reduction with `level` argument (#1779)

### DIFF
--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -535,10 +535,18 @@ class DataFrameUnaryOpMixin(DataFrameOperandMixin):
         out_df = op.outputs[0]
 
         out_chunks = []
+        index_dtypes_cache = dict()
         for in_chunk in in_df.chunks:
             out_op = op.copy().reset_key()
             if out_df.ndim == 2:
+                try:
+                    dtypes = index_dtypes_cache[in_chunk.index[1]]
+                except KeyError:
+                    dtypes = out_df.dtypes[in_chunk.columns_value.to_pandas()]
+                    index_dtypes_cache[in_chunk.index[1]] = dtypes
+
                 out_chunk = out_op.new_chunk([in_chunk], shape=in_chunk.shape,
+                                             dtypes=dtypes,
                                              index=in_chunk.index,
                                              index_value=in_chunk.index_value,
                                              columns_value=in_chunk.columns_value)

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -543,6 +543,10 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
         ndim = getattr(input_obj, 'ndim', None) or input_obj.obj.ndim
         if agg_func == 'str_concat':
             agg_func = lambda x: x.str.cat(**kwds)
+        elif isinstance(agg_func, str) and not kwds.get('skipna', True):
+            func_name = agg_func
+            agg_func = lambda x: getattr(x, func_name)(skipna=False)
+            agg_func.__name__ = func_name
 
         if ndim == 2:
             result = input_obj.agg([agg_func])

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -226,6 +226,9 @@ class TestReduction(TestBase):
         self.assertIsInstance(reduction_df.chunks[0].inputs[0].op, DataFrameConcat)
         self.assertEqual(len(reduction_df.chunks[0].inputs[0].inputs), 2)
 
+        with self.assertRaises(NotImplementedError):
+            getattr(from_pandas_df(data, chunk_size=3), self.func_name)(level=0, axis=1)
+
 
 cum_reduction_functions = dict(
     cummin=dict(func_name='cummin', op=DataFrameCummin, has_skipna=True),


### PR DESCRIPTION
Backport of #1779