### PR TITLE
Fix bug that explicit execute may be required for to_parquet and XGB predict

### DIFF
--- a/docs/source/reference/dataframe/api/mars.dataframe.CustomReduction.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.CustomReduction.rst
@@ -15,11 +15,18 @@
    
       ~CustomReduction.__init__
       ~CustomReduction.agg
+      ~CustomReduction.is_gpu
       ~CustomReduction.post
       ~CustomReduction.pre
    
    
 
    
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~CustomReduction.pre_with_agg
    
    

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.backfill.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.backfill.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.backfill
+=================================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.backfill

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.bfill.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.bfill.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.bfill
+==============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.bfill

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.explode.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.explode.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.explode
+================================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.explode

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.ffill.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.ffill.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.ffill
+==============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.ffill

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.isnull.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.isnull.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.isnull
+===============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.isnull

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.notnull.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.notnull.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.notnull
+================================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.notnull

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.pad.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.pad.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.pad
+============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.pad

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.replace.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.replace.rst
@@ -1,0 +1,6 @@
+mars.dataframe.DataFrame.replace
+================================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: DataFrame.replace

--- a/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.DataFrame.rst
@@ -23,7 +23,9 @@
       ~DataFrame.append
       ~DataFrame.apply
       ~DataFrame.astype
+      ~DataFrame.backfill
       ~DataFrame.bfill
+      ~DataFrame.cartesian_chunk
       ~DataFrame.copy
       ~DataFrame.copy_from
       ~DataFrame.copy_to
@@ -45,6 +47,7 @@
       ~DataFrame.ewm
       ~DataFrame.execute
       ~DataFrame.expanding
+      ~DataFrame.explode
       ~DataFrame.ffill
       ~DataFrame.fillna
       ~DataFrame.floordiv
@@ -80,6 +83,7 @@
       ~DataFrame.notna
       ~DataFrame.notnull
       ~DataFrame.nunique
+      ~DataFrame.pad
       ~DataFrame.pop
       ~DataFrame.pow
       ~DataFrame.prod
@@ -91,6 +95,7 @@
       ~DataFrame.rechunk
       ~DataFrame.reindex
       ~DataFrame.rename
+      ~DataFrame.replace
       ~DataFrame.reset_index
       ~DataFrame.rfloordiv
       ~DataFrame.rmod

--- a/docs/source/reference/dataframe/api/mars.dataframe.Series.explode.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.Series.explode.rst
@@ -1,0 +1,6 @@
+mars.dataframe.Series.explode
+=============================
+
+.. currentmodule:: mars.dataframe
+
+.. automethod:: Series.explode

--- a/docs/source/reference/dataframe/api/mars.dataframe.Series.rst
+++ b/docs/source/reference/dataframe/api/mars.dataframe.Series.rst
@@ -24,7 +24,9 @@
       ~Series.apply
       ~Series.astype
       ~Series.autocorr
+      ~Series.backfill
       ~Series.bfill
+      ~Series.cartesian_chunk
       ~Series.copy
       ~Series.copy_from
       ~Series.copy_to
@@ -45,6 +47,7 @@
       ~Series.ewm
       ~Series.execute
       ~Series.expanding
+      ~Series.explode
       ~Series.ffill
       ~Series.fillna
       ~Series.floordiv
@@ -74,6 +77,7 @@
       ~Series.notna
       ~Series.notnull
       ~Series.nunique
+      ~Series.pad
       ~Series.pow
       ~Series.prod
       ~Series.product
@@ -84,6 +88,7 @@
       ~Series.rechunk
       ~Series.reindex
       ~Series.rename
+      ~Series.replace
       ~Series.reset_index
       ~Series.rfloordiv
       ~Series.rmod

--- a/docs/source/reference/learn/generated/mars.learn.contrib.statsmodels.MarsDistributedModel.rst
+++ b/docs/source/reference/learn/generated/mars.learn.contrib.statsmodels.MarsDistributedModel.rst
@@ -1,0 +1,23 @@
+mars.learn.contrib.statsmodels.MarsDistributedModel
+===================================================
+
+.. currentmodule:: mars.learn.contrib.statsmodels
+
+.. autoclass:: MarsDistributedModel
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~MarsDistributedModel.__init__
+      ~MarsDistributedModel.fit
+   
+   
+
+   
+   
+   

--- a/docs/source/reference/learn/generated/mars.learn.contrib.statsmodels.MarsResults.rst
+++ b/docs/source/reference/learn/generated/mars.learn.contrib.statsmodels.MarsResults.rst
@@ -1,0 +1,29 @@
+mars.learn.contrib.statsmodels.MarsResults
+==========================================
+
+.. currentmodule:: mars.learn.contrib.statsmodels
+
+.. autoclass:: MarsResults
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~MarsResults.__init__
+      ~MarsResults.predict
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~MarsResults.model
+   
+   

--- a/mars/dataframe/datastore/tests/test_datastore_execute.py
+++ b/mars/dataframe/datastore/tests/test_datastore_execute.py
@@ -197,6 +197,11 @@ class Test(TestBase):
             result = result.sort_index()
             pd.testing.assert_frame_equal(result, raw)
 
+            # test read_parquet then to_parquet
+            read_df = md.read_parquet(path)
+            r = read_df.to_parquet(path)
+            self.executor.execute_dataframes([r])
+
             # test partition_cols
             path = os.path.join(base_path, 'out-partitioned')
             r = df.to_parquet(path, partition_cols=['col3'])

--- a/mars/dataframe/datastore/to_parquet.py
+++ b/mars/dataframe/datastore/to_parquet.py
@@ -20,6 +20,8 @@ from ... import opcodes as OperandDef
 from ...filesystem import open_file
 from ...serialize import KeyField, AnyField, StringField, ListField, \
     BoolField, DictField
+from ...tiles import TilesError
+from ...utils import check_chunks_unknown_shape
 from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index
 from ..datasource.read_parquet import check_engine
@@ -101,6 +103,7 @@ class DataFrameToParquet(DataFrameOperand, DataFrameOperandMixin):
         out_df = op.outputs[0]
 
         # make sure only 1 chunk on the column axis
+        check_chunks_unknown_shape([in_df], TilesError)
         in_df = in_df.rechunk({1: in_df.shape[1]})._inplace_tile()
 
         out_chunks = []

--- a/mars/learn/contrib/xgboost/predict.py
+++ b/mars/learn/contrib/xgboost/predict.py
@@ -60,9 +60,9 @@ class XGBPredict(LearnOperand, LearnOperandMixin):
         if num_class is not None:
             num_class = int(num_class)
         if num_class is not None:
-            shape = (len(self._data), num_class)
+            shape = (self._data.shape[0], num_class)
         else:
-            shape = (len(self._data),)
+            shape = (self._data.shape[0],)
         if self.output_types[0] == OutputType.tensor:
             # tensor
             return self.new_tileable([self._data], shape=shape, dtype=np.dtype(np.float32),
@@ -89,10 +89,10 @@ class XGBPredict(LearnOperand, LearnOperandMixin):
             chunk_op = op.copy().reset_key()
             chunk_index = (in_chunk.index[0],)
             if op.model.attr('num_class'):
-                chunk_shape = (len(in_chunk), int(op.model.attr('num_class')))
+                chunk_shape = (in_chunk.shape[0], int(op.model.attr('num_class')))
                 chunk_index += (0,)
             else:
-                chunk_shape = (len(in_chunk),)
+                chunk_shape = (in_chunk.shape[0],)
             if op.output_types[0] == OutputType.tensor:
                 out_chunk = chunk_op.new_chunk([in_chunk], shape=chunk_shape,
                                                dtype=out.dtype,

--- a/mars/learn/contrib/xgboost/tests/test_classifier.py
+++ b/mars/learn/contrib/xgboost/tests/test_classifier.py
@@ -105,6 +105,12 @@ class Test(unittest.TestCase):
         self.assertEqual(prediction.ndim, 1)
         self.assertEqual(prediction.shape[0], len(self.X))
 
+        # test predict data with unknown shape
+        X2 = X[X[:, 0] > 0.1].astype(mt.int32)
+        prediction = classifier.predict(X2)
+
+        self.assertEqual(prediction.ndim, 1)
+
         classifier = XGBClassifier(verbosity=1, n_estimators=2)
         with self.assertRaises(TypeError):
             classifier.fit(X, y, wrong_param=1)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes bug that explicit execute may be required for to_parquet and XGB predict.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1792 .
