### PR TITLE
Support `missing` argument for `tensor.tosparse()` and `fill_value` argument for `sparse_tensor.todense()`

### DIFF
--- a/mars/learn/contrib/lightgbm/_predict.py
+++ b/mars/learn/contrib/lightgbm/_predict.py
@@ -143,6 +143,7 @@ class LGBMPredict(LearnOperand, LearnOperandMixin):
     @classmethod
     def execute(cls, ctx, op: "LGBMPredict"):
         in_data = ctx[op.data.key]
+        in_data = in_data.spmatrix if hasattr(in_data, 'spmatrix') else in_data
         out = op.outputs[0]
 
         if op.data.shape[0] == 0:

--- a/mars/learn/contrib/lightgbm/_train.py
+++ b/mars/learn/contrib/lightgbm/_train.py
@@ -257,6 +257,8 @@ class LGBMTrain(MergeDictOperand):
         from lightgbm.basic import _safe_call, _LIB
 
         data_val = ctx[op.data.key]
+        data_val = data_val.spmatrix if hasattr(data_val, 'spmatrix') else data_val
+
         label_val = ctx[op.label.key]
         sample_weight_val = ctx[op.sample_weight.key] if op.sample_weight is not None else None
         init_score_val = ctx[op.init_score.key] if op.init_score is not None else None
@@ -266,7 +268,9 @@ class LGBMTrain(MergeDictOperand):
         else:
             eval_set, eval_sample_weight, eval_init_score = [], [], []
             for data, label in zip(op.eval_datas, op.eval_labels):
-                eval_set.append((ctx[data.key], ctx[label.key]))
+                data_eval = ctx[data.key]
+                data_eval = data_eval.spmatrix if hasattr(data_eval, 'spmatrix') else data_eval
+                eval_set.append((data_eval, ctx[label.key]))
             for weight in op.eval_sample_weights:
                 eval_sample_weight.append(ctx[weight.key] if weight is not None else None)
             for score in op.eval_init_scores:

--- a/mars/learn/contrib/xgboost/dmatrix.py
+++ b/mars/learn/contrib/xgboost/dmatrix.py
@@ -261,6 +261,7 @@ class ToDMatrix(LearnOperand, LearnOperandMixin):
         from xgboost import DMatrix
 
         data, label, weight, missing, feature_names, feature_types = tup
+        data = data.spmatrix if hasattr(data, 'spmatrix') else data
         return DMatrix(data, label=label, missing=missing, weight=weight,
                        feature_names=feature_names, feature_types=feature_types,
                        nthread=-1)

--- a/mars/learn/contrib/xgboost/predict.py
+++ b/mars/learn/contrib/xgboost/predict.py
@@ -129,6 +129,7 @@ class XGBPredict(LearnOperand, LearnOperandMixin):
         if isinstance(data, tuple):
             data = ToDMatrix.get_xgb_dmatrix(data)
         else:
+            data = data.spmatrix if hasattr(data, 'spmatrix') else data
             data = DMatrix(data)
         result = op.model.predict(data)
 

--- a/mars/learn/contrib/xgboost/tests/test_predict.py
+++ b/mars/learn/contrib/xgboost/tests/test_predict.py
@@ -41,6 +41,9 @@ class Test(unittest.TestCase):
         self.y = rs.rand(n_rows, chunk_size=chunk_size)
         self.X_df = md.DataFrame(self.X)
         self.y_series = md.Series(self.y)
+        x_sparse = np.random.rand(n_rows, n_columns)
+        x_sparse[np.arange(n_rows), np.random.randint(n_columns, size=n_rows)] = np.nan
+        self.X_sparse = mt.tensor(x_sparse, chunk_size=chunk_size).tosparse(missing=np.nan)
 
         self.session = new_session().as_default()
         self._old_executor = self.session._sess._executor
@@ -56,6 +59,9 @@ class Test(unittest.TestCase):
         self.assertIsInstance(booster, Booster)
 
         prediction = predict(booster, self.X)
+        self.assertIsInstance(prediction.to_numpy(), np.ndarray)
+
+        prediction = predict(booster, self.X_sparse)
         self.assertIsInstance(prediction.to_numpy(), np.ndarray)
 
         prediction = predict(booster, dtrain)

--- a/mars/learn/contrib/xgboost/tests/test_train.py
+++ b/mars/learn/contrib/xgboost/tests/test_train.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import numpy as np
+
 import mars.tensor as mt
 import mars.dataframe as md
 from mars.session import new_session
@@ -45,6 +47,9 @@ class Test(unittest.TestCase):
         self.X_df = md.DataFrame(self.X)
         self.y_series = md.Series(self.y)
         self.weight = rs.rand(n_rows, chunk_size=chunk_size)
+        x_sparse = np.random.rand(n_rows, n_columns)
+        x_sparse[np.arange(n_rows), np.random.randint(n_columns, size=n_rows)] = np.nan
+        self.X_sparse = mt.tensor(x_sparse, chunk_size=chunk_size).tosparse(missing=np.nan)
 
         self.session = new_session().as_default()
         self._old_executor = self.session._sess._executor
@@ -78,6 +83,11 @@ class Test(unittest.TestCase):
 
     def testLocalTrainTensor(self):
         dtrain = MarsDMatrix(self.X, self.y)
+        booster = train({}, dtrain, num_boost_round=2)
+        self.assertIsInstance(booster, Booster)
+
+    def testLocalTrainSparseTensor(self):
+        dtrain = MarsDMatrix(self.X_sparse, self.y)
         booster = train({}, dtrain, num_boost_round=2)
         self.assertIsInstance(booster, Booster)
 

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -226,19 +226,19 @@ class TensorData(HasShapeTileableData, _ExecuteAndFetchMixin):
 
     isscalar = is_scalar
 
-    def tosparse(self):
+    def tosparse(self, missing=None):
         if self.issparse():
             return self
 
         from .datasource import fromdense
-        return fromdense(self)
+        return fromdense(self, missing=missing)
 
-    def todense(self):
+    def todense(self, fill_value=None):
         if not self.issparse():
             return self
 
         from .datasource import fromsparse
-        return fromsparse(self)
+        return fromsparse(self, fill_value=fill_value)
 
     def transpose(self, *axes):
         from .base import transpose

--- a/mars/tensor/datasource/from_sparse.py
+++ b/mars/tensor/datasource/from_sparse.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ...serialize import KeyField, StringField
+from ...serialize import KeyField, StringField, AnyField
+from ..array_utils import as_same_device, device, get_array_module
 from ..utils import get_order
 from .core import TensorHasInput
 from .array import tensor
@@ -24,29 +25,50 @@ from .array import tensor
 class SparseToDense(TensorHasInput):
     _op_type_ = OperandDef.SPARSE_TO_DENSE
 
-    _input = KeyField('_input')
-    _order = StringField('_order')
+    _input = KeyField('input')
+    _order = StringField('order')
+    _fill_value = AnyField('fill_value')
 
-    def __init__(self, dtype=None, gpu=None, order=None, **kw):
-        super().__init__(_dtype=dtype, _gpu=gpu, _sparse=False, _order=order, **kw)
+    def __init__(self, dtype=None, fill_value=None, gpu=None, order=None, **kw):
+        super().__init__(_dtype=dtype, _fill_value=fill_value,
+                         _gpu=gpu, _sparse=False, _order=order, **kw)
 
     @property
     def order(self):
         return self._order
 
+    @property
+    def fill_value(self):
+        return self._fill_value
+
     @classmethod
     def execute(cls, ctx, op):
-        ctx[op.outputs[0].key] = \
-            ctx[op.inputs[0].key].toarray().astype(
-                op.outputs[0].dtype, order=op.order, copy=False)
+        fill_value = op.fill_value
+        out = op.outputs[0]
+        (inp,), device_id, xp = as_same_device(
+            [ctx[inp.key] for inp in op.inputs], device=op.device, ret_extra=True)
+
+        with device(device_id):
+            if fill_value is None:
+                ctx[out.key] = inp.toarray().astype(
+                    out.dtype, order=op.order, copy=False)
+            else:
+                xp = get_array_module(xp)
+                spmatrix = inp.spmatrix
+                inds = spmatrix.nonzero()
+                ret = xp.full(inp.shape, fill_value, dtype=out.dtype,
+                              order=op.order)
+                ret[inds] = spmatrix.data
+                ctx[out.key] = ret
 
 
-def fromsparse(a, order='C'):
+def fromsparse(a, order='C', fill_value=None):
     a = tensor(a)
     if not a.issparse():
         return a.astype(a.dtype, order=order, copy=False)
 
     tensor_order = get_order(order, None, available_options='CF',
                              err_msg="only 'C' or 'F' order is permitted")
-    op = SparseToDense(dtype=a.dtype, gpu=a.op.gpu, order=order)
+    op = SparseToDense(dtype=a.dtype, gpu=a.op.gpu,
+                       order=order, fill_value=fill_value)
     return op(a, order=tensor_order)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR support `missing` argument for `tensor.tosparse()` and `fill_value` argument for `sparse_tensor.todense()`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1795 .
