### PR TITLE
Support using compound agg function in lambda

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-16.04, macOS-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
         include:
           - { os: ubuntu-16.04, python-version: 3.6, python-abis: "cp36-cp36m" }
           - { os: ubuntu-16.04, python-version: 3.7, python-abis: "cp37-cp37m" }

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-16.04, macOS-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         include:
           - { os: ubuntu-16.04, python-version: 3.6, python-abis: "cp36-cp36m" }
           - { os: ubuntu-16.04, python-version: 3.7, python-abis: "cp37-cp37m" }

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-16.04]
-        python-version: [3.6, 3.7, 3.8, 3.8-cython]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.8-cython]
         include:
           - { os: ubuntu-16.04, python-version: 3.8-cython, no-common-tests: 1,
               no-deploy: 1, with-cython: 1, with-flake8: 1 }

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -36,6 +36,9 @@ jobs:
         source ./.github/workflows/reload-env.sh
         export DEFAULT_VENV=$VIRTUAL_ENV
 
+        # workaround
+        pip install scikit-learn\<0.24.0
+
         pip install -r requirements-dev.txt
         pip install -r requirements-extra.txt
         if [[ $UNAME == "windows" ]]; then

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-16.04]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.8-cython]
+        python-version: [3.6, 3.7, 3.8, 3.8-cython]
         include:
           - { os: ubuntu-16.04, python-version: 3.8-cython, no-common-tests: 1,
               no-deploy: 1, with-cython: 1, with-flake8: 1 }

--- a/.github/workflows/os-compat-ci.yml
+++ b/.github/workflows/os-compat-ci.yml
@@ -33,6 +33,9 @@ jobs:
         source ./.github/workflows/reload-env.sh
         export DEFAULT_VENV=$VIRTUAL_ENV
 
+        # workaround
+        pip install scikit-learn\<0.24.0
+
         pip install -r requirements-dev.txt
         pip install -r requirements-extra.txt
         if [[ $UNAME == "windows" ]]; then

--- a/mars/dataframe/reduction/aggregation.py
+++ b/mars/dataframe/reduction/aggregation.py
@@ -49,53 +49,6 @@ def where_function(cond, var1, var2):
             return np.where(cond, var1, var2).item()
 
 
-def mean_function(x, skipna=None):
-    return x.sum(skipna=skipna) / x.count()
-
-
-def var_function(x, skipna=None, ddof=1):
-    cnt = x.count()
-    if ddof == 0:
-        return (x ** 2).sum(skipna=skipna) / cnt - (x.sum(skipna=skipna) / cnt) ** 2
-    return ((x ** 2).sum(skipna=skipna) - x.sum(skipna=skipna) ** 2 / cnt) / (cnt - ddof)
-
-
-def sem_function(x, skipna=None, ddof=1):
-    var = var_function(x, skipna=skipna, ddof=ddof)
-    cnt = x.count()
-    return (var / cnt) ** 0.5
-
-
-def skew_function(x, skipna=None, bias=False):
-    cnt = x.count()
-    mean = x.sum(skipna=skipna) / cnt
-    divided = (x ** 3).sum(skipna=skipna) / cnt \
-        - 3 * (x ** 2).sum(skipna=skipna) / cnt * mean \
-        + 2 * mean ** 3
-    var = var_function(x, skipna=skipna, ddof=0)
-    val = where_function(var > 0, divided / var ** 1.5, np.nan)
-    if not bias:
-        val = where_function((var > 0) & (cnt > 2), val * ((cnt * (cnt - 1)) ** 0.5 / (cnt - 2)), np.nan)
-    return val
-
-
-def kurt_function(x, skipna=None, bias=False, fisher=True):
-    cnt = x.count()
-    mean = x.sum(skipna=skipna) / cnt
-    divided = (x ** 4).sum(skipna=skipna) / cnt \
-        - 4 * (x ** 3).sum(skipna=skipna) / cnt * mean \
-        + 6 * (x ** 2).sum(skipna=skipna) / cnt * mean ** 2 \
-        - 3 * mean ** 4
-    var = var_function(x, skipna=skipna, ddof=0)
-    val = where_function(var > 0, divided / var ** 2, np.nan)
-    if not bias:
-        val = where_function((var > 0) & (cnt > 3),
-                             (val * (cnt ** 2 - 1) - 3 * (cnt - 1) ** 2) / (cnt - 2) / (cnt - 3), np.nan)
-    if not fisher:
-        val += 3
-    return val
-
-
 _agg_functions = {
     'sum': lambda x, skipna=None: x.sum(skipna=skipna),
     'prod': lambda x, skipna=None: x.prod(skipna=skipna),
@@ -106,13 +59,13 @@ _agg_functions = {
     'any': lambda x, skipna=None: x.any(skipna=skipna),
     'count': lambda x: x.count(),
     'size': lambda x: x._reduction_size(),
-    'mean': mean_function,
-    'var': var_function,
-    'std': lambda x, skipna=None, ddof=1: var_function(x, skipna=skipna, ddof=ddof) ** 0.5,
-    'sem': sem_function,
-    'skew': skew_function,
-    'kurt': kurt_function,
-    'kurtosis': kurt_function,
+    'mean': lambda x, skipna=None: x.mean(skipna=skipna),
+    'var': lambda x, skipna=None, ddof=1: x.var(skipna=skipna, ddof=ddof),
+    'std': lambda x, skipna=None, ddof=1: x.std(skipna=skipna, ddof=ddof),
+    'sem': lambda x, skipna=None, ddof=1: x.sem(skipna=skipna, ddof=ddof),
+    'skew': lambda x, skipna=None, bias=False: x.skew(skipna=skipna, bias=bias),
+    'kurt': lambda x, skipna=None, bias=False: x.kurt(skipna=skipna, bias=bias),
+    'kurtosis': lambda x, skipna=None, bias=False: x.kurtosis(skipna=skipna, bias=bias),
 }
 
 

--- a/mars/dataframe/reduction/all.py
+++ b/mars/dataframe/reduction/all.py
@@ -22,6 +22,10 @@ class DataFrameAll(DataFrameReductionOperand, DataFrameReductionMixin):
     _op_type_ = OperandDef.ALL
     _func_name = 'all'
 
+    @property
+    def is_atomic(self):
+        return True
+
 
 def all_series(df, axis=None, bool_only=None, skipna=None, level=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na

--- a/mars/dataframe/reduction/any.py
+++ b/mars/dataframe/reduction/any.py
@@ -22,6 +22,10 @@ class DataFrameAny(DataFrameReductionOperand, DataFrameReductionMixin):
     _op_type_ = OperandDef.ANY
     _func_name = 'any'
 
+    @property
+    def is_atomic(self):
+        return True
+
 
 def any_series(df, axis=None, bool_only=None, skipna=None, level=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na

--- a/mars/dataframe/reduction/custom_reduction.py
+++ b/mars/dataframe/reduction/custom_reduction.py
@@ -32,6 +32,10 @@ class DataFrameCustomReduction(DataFrameReductionOperand, DataFrameReductionMixi
     def custom_reduction(self):
         return self._custom_reduction
 
+    @property
+    def is_atomic(self):
+        return True
+
     def get_reduction_args(self, axis=None):
         return dict()
 

--- a/mars/dataframe/reduction/kurtosis.py
+++ b/mars/dataframe/reduction/kurtosis.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
+import numpy as np
 
 from ... import opcodes
 from ...config import options
@@ -40,11 +40,27 @@ class DataFrameKurtosis(DataFrameReductionOperand, DataFrameReductionMixin):
         return self._fisher
 
     @classmethod
-    def _make_agg_object(cls, op):
-        from .aggregation import kurt_function
-        pf = functools.partial(kurt_function, bias=op.bias, skipna=op.skipna, fisher=op.fisher)
-        pf.__name__ = cls._func_name
-        return pf
+    def get_reduction_callable(cls, op):
+        from .aggregation import where_function
+        skipna, bias, fisher = op.skipna, op.bias, op.fisher
+
+        def kurt(x):
+            cnt = x.count()
+            mean = x.mean(skipna=skipna)
+            divided = (x ** 4).mean(skipna=skipna) \
+                - 4 * (x ** 3).mean(skipna=skipna) * mean \
+                + 6 * (x ** 2).mean(skipna=skipna) * mean ** 2 \
+                - 3 * mean ** 4
+            var = x.var(skipna=skipna, ddof=0)
+            val = where_function(var > 0, divided / var ** 2, np.nan)
+            if not bias:
+                val = where_function((var > 0) & (cnt > 3),
+                                     (val * (cnt ** 2 - 1) - 3 * (cnt - 1) ** 2) / (cnt - 2) / (cnt - 3), np.nan)
+            if not fisher:
+                val += 3
+            return val
+
+        return kurt
 
 
 def kurt_series(df, axis=None, skipna=None, level=None, combine_size=None, bias=False, fisher=True):

--- a/mars/dataframe/reduction/max.py
+++ b/mars/dataframe/reduction/max.py
@@ -22,6 +22,10 @@ class DataFrameMax(DataFrameReductionOperand, DataFrameReductionMixin):
     _op_type_ = OperandDef.MAX
     _func_name = 'max'
 
+    @property
+    def is_atomic(self):
+        return True
+
 
 def max_series(df, axis=None, skipna=None, level=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na

--- a/mars/dataframe/reduction/mean.py
+++ b/mars/dataframe/reduction/mean.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
-
 from ... import opcodes as OperandDef
 from ...config import options
 from ...core import OutputType
@@ -25,11 +23,12 @@ class DataFrameMean(DataFrameReductionOperand, DataFrameReductionMixin):
     _func_name = 'mean'
 
     @classmethod
-    def _make_agg_object(cls, op):
-        from .aggregation import mean_function
-        pf = functools.partial(mean_function, skipna=op.skipna)
-        pf.__name__ = cls._func_name
-        return pf
+    def get_reduction_callable(cls, op):
+        skipna = op.skipna
+
+        def mean(x):
+            return x.sum(skipna=skipna) / x.count()
+        return mean
 
 
 def mean_series(df, axis=None, skipna=None, level=None, combine_size=None):

--- a/mars/dataframe/reduction/min.py
+++ b/mars/dataframe/reduction/min.py
@@ -22,6 +22,10 @@ class DataFrameMin(DataFrameReductionOperand, DataFrameReductionMixin):
     _op_type_ = OperandDef.MIN
     _func_name = 'min'
 
+    @property
+    def is_atomic(self):
+        return True
+
 
 def min_series(df, axis=None, skipna=None, level=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na

--- a/mars/dataframe/reduction/nunique.py
+++ b/mars/dataframe/reduction/nunique.py
@@ -130,7 +130,7 @@ class DataFrameNunique(DataFrameReductionOperand, DataFrameReductionMixin):
         return self._use_arrow_dtype
 
     @classmethod
-    def _make_agg_object(cls, op):
+    def get_reduction_callable(cls, op):
         return NuniqueReduction(name=cls._func_name, axis=op.axis, dropna=op.dropna,
                                 use_arrow_dtype=op.use_arrow_dtype, is_gpu=op.is_gpu())
 

--- a/mars/dataframe/reduction/prod.py
+++ b/mars/dataframe/reduction/prod.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
-
 import numpy as np
 
 from ... import opcodes
@@ -23,22 +21,25 @@ from .aggregation import where_function
 from .core import DataFrameReductionOperand, DataFrameReductionMixin
 
 
-def _prod_with_count(value, skipna=True, min_count=0):
-    if min_count == 0:
-        return value.prod(skipna=skipna)
-    else:
-        return where_function(value.count() >= min_count, value.prod(skipna=skipna), np.nan)
-
-
 class DataFrameProd(DataFrameReductionOperand, DataFrameReductionMixin):
     _op_type_ = opcodes.PROD
     _func_name = 'prod'
 
+    @property
+    def is_atomic(self):
+        return self.min_count == 0
+
     @classmethod
-    def _make_agg_object(cls, op):
-        fn = functools.partial(_prod_with_count, skipna=op.skipna, min_count=op.min_count)
-        fn.__name__ = cls._func_name
-        return fn
+    def get_reduction_callable(cls, op):
+        skipna, min_count = op.skipna, op.min_count
+
+        def prod(value):
+            if min_count == 0:
+                return value.prod(skipna=skipna)
+            else:
+                return where_function(value.count() >= min_count, value.prod(skipna=skipna), np.nan)
+
+        return prod
 
 
 def prod_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):

--- a/mars/dataframe/reduction/reduction_size.py
+++ b/mars/dataframe/reduction/reduction_size.py
@@ -21,6 +21,10 @@ class DataFrameSize(DataFrameReductionOperand, DataFrameReductionMixin):
     _op_type_ = OperandDef.REDUCTION_SIZE
     _func_name = 'size'
 
+    @property
+    def is_atomic(self):
+        return True
+
 
 def size_series(df):
     op = DataFrameSize(output_types=[OutputType.scalar])

--- a/mars/dataframe/reduction/str_concat.py
+++ b/mars/dataframe/reduction/str_concat.py
@@ -39,8 +39,12 @@ class DataFrameStrConcat(DataFrameReductionOperand, DataFrameReductionMixin):
     def get_reduction_args(self, axis=None):
         return dict(sep=self._sep, na_rep=self._na_rep)
 
+    @property
+    def is_atomic(self):
+        return True
+
     @classmethod
-    def _make_agg_object(cls, op):
+    def get_reduction_callable(cls, op):
         sep, na_rep = op.sep, op.na_rep
 
         def str_concat(obj):

--- a/mars/dataframe/reduction/sum.py
+++ b/mars/dataframe/reduction/sum.py
@@ -12,33 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
-
 import numpy as np
 
 from ... import opcodes
 from ...config import options
 from ...core import OutputType
-from .aggregation import where_function
 from .core import DataFrameReductionOperand, DataFrameReductionMixin
-
-
-def _sum_with_count(value, skipna=True, min_count=0):
-    if min_count == 0:
-        return value.sum(skipna=skipna)
-    else:
-        return where_function(value.count() >= min_count, value.sum(skipna=skipna), np.nan)
 
 
 class DataFrameSum(DataFrameReductionOperand, DataFrameReductionMixin):
     _op_type_ = opcodes.SUM
     _func_name = 'sum'
 
+    @property
+    def is_atomic(self):
+        return self.min_count == 0
+
     @classmethod
-    def _make_agg_object(cls, op):
-        fn = functools.partial(_sum_with_count, skipna=op.skipna, min_count=op.min_count)
-        fn.__name__ = cls._func_name
-        return fn
+    def get_reduction_callable(cls, op):
+        from .aggregation import where_function
+        skipna, min_count = op.skipna, op.min_count
+
+        def sum(value):
+            if min_count == 0:
+                return value.sum(skipna=skipna)
+            else:
+                return where_function(value.count() >= min_count, value.sum(skipna=skipna), np.nan)
+
+        return sum
 
 
 def sum_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):

--- a/mars/dataframe/reduction/sum.py
+++ b/mars/dataframe/reduction/sum.py
@@ -33,13 +33,13 @@ class DataFrameSum(DataFrameReductionOperand, DataFrameReductionMixin):
         from .aggregation import where_function
         skipna, min_count = op.skipna, op.min_count
 
-        def sum(value):
+        def sum_(value):
             if min_count == 0:
                 return value.sum(skipna=skipna)
             else:
                 return where_function(value.count() >= min_count, value.sum(skipna=skipna), np.nan)
 
-        return sum
+        return sum_
 
 
 def sum_series(df, axis=None, skipna=None, level=None, min_count=0, combine_size=None):

--- a/mars/dataframe/reduction/unique.py
+++ b/mars/dataframe/reduction/unique.py
@@ -50,7 +50,7 @@ class DataFrameUnique(DataFrameReductionOperand, DataFrameReductionMixin):
         return self._method
 
     @classmethod
-    def _make_agg_object(cls, op):
+    def get_reduction_callable(cls, op):
         return UniqueReduction(name=cls._func_name, is_gpu=op.is_gpu())
 
     @classmethod

--- a/mars/deploy/kubernetes/core.py
+++ b/mars/deploy/kubernetes/core.py
@@ -96,6 +96,8 @@ class K8SPodsIPWatcher(object):
             if pod_ep is not None and not self._extract_pod_ready(el):
                 pod_ep = None
             result[name] = pod_ep
+        if not result:
+            logger.warning(repr(query))
         return result
 
     def _get_endpoints_by_service_type(self, service_type, update=False):

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -196,7 +196,7 @@ class Operand(AttributeAsDictKey, metaclass=OperandMetaclass):
 
     @property
     def memory_scale(self):
-        return getattr(self, '_memory_scale', None) or 1
+        return getattr(self, '_memory_scale', None)
 
     @property
     def stage(self) -> Union[None, "OperandStage"]:
@@ -510,6 +510,7 @@ class TileableOperandMixin(object):
                 pass
 
         exec_size = max(exec_size, total_out_size)
+        memory_scale = op.memory_scale or 1
         for out in outputs:
             if out.key in ctx:
                 continue
@@ -527,7 +528,7 @@ class TileableOperandMixin(object):
                 max_sparse_size = np.nan
             if not np.isnan(max_sparse_size):
                 store_size = min(store_size, max_sparse_size)
-            ctx[out.key] = (store_size, exec_size * op.memory_scale // len(outputs))
+            ctx[out.key] = (store_size, exec_size * memory_scale // len(outputs))
 
     @classmethod
     def concat_tileable_chunks(cls, tileable):

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -32,6 +32,9 @@ from mars.session import new_session, Session
 
 
 class Test(unittest.TestCase):
+    def setUp(self):
+        new_session().as_default()
+
     def testSessionExecute(self):
         a = mt.random.rand(10, 20)
         res = a.sum().to_numpy()

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -5,6 +5,6 @@ pyarrow>=0.11.0,!=0.16.*
 psutil>=4.0.0
 lz4>=1.0.0
 protobuf>=3.6
-gevent>=1.2.0
+gevent>=1.2.0,<20.12.0
 bokeh>=1.0.0
 jinja2>=2.0


### PR DESCRIPTION
## What do these changes do?

Allow calling compound aggregation functions, such as ``df.agg(lambda x: x.mean() + x.skew())`` in df.agg(). Also simplify definitions of builtin functions.

## Related issue number
