### PR TITLE
Add memory estimation for `read_parquet` as well as `read_csv`

### DIFF
--- a/mars/dataframe/datasource/read_parquet.py
+++ b/mars/dataframe/datasource/read_parquet.py
@@ -292,8 +292,10 @@ class DataFrameReadParquet(DataFrameOperand, DataFrameOperandMixin):
             glob(op.path, storage_options=op.storage_options)
 
         for pth in paths:
-            row_num = get_engine(op.engine).get_row_num(pth)
             raw_bytes = file_size(pth, op.storage_options)
+            with open_file(pth, storage_options=op.storage_options) as f:
+                row_num = get_engine(op.engine).get_row_num(f)
+
             if op.groups_as_chunks:
                 num_row_groups = pq.ParquetFile(pth).num_row_groups
                 for group_idx in range(num_row_groups):

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -319,8 +319,11 @@ class Test(TestBase):
             df.to_csv(file_path)
 
             pdf = pd.read_csv(file_path, index_col=0)
-            mdf = self.executor.execute_dataframe(md.read_csv(file_path, index_col=0), concat=True)[0]
+            r = md.read_csv(file_path, index_col=0)
+            mdf = self.executor.execute_dataframe(r, concat=True)[0]
             pd.testing.assert_frame_equal(pdf, mdf)
+            size_res = self.executor.execute_dataframe(r, mock=True)
+            self.assertEqual(sum(s[0] for s in size_res), os.stat(file_path).st_size)
 
             mdf2 = self.executor.execute_dataframe(md.read_csv(file_path, index_col=0, chunk_bytes=10),
                                                    concat=True)[0]
@@ -805,6 +808,8 @@ class Test(TestBase):
             df = md.read_parquet(file_path)
             result = self.executor.execute_dataframe(df, concat=True)[0]
             pd.testing.assert_frame_equal(result, test_df)
+            size_res = self.executor.execute_dataframe(df, mock=True)
+            self.assertGreater(sum(s[0] for s in size_res), test_df.memory_usage(deep=True).sum())
 
         with tempfile.TemporaryDirectory() as tempdir:
             file_path = os.path.join(tempdir, 'test.csv')
@@ -859,3 +864,5 @@ class Test(TestBase):
             df = md.read_parquet(file_path, engine='fastparquet')
             result = self.executor.execute_dataframe(df, concat=True)[0]
             pd.testing.assert_frame_equal(result, test_df)
+            size_res = self.executor.execute_dataframe(df, mock=True)
+            self.assertGreater(sum(s[0] for s in size_res), test_df.memory_usage(deep=True).sum())

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1064,16 +1064,17 @@ class FixedSizeFileObject:
         return getattr(self._file_obj, item)
 
 
+def is_object_dtype(dtype):
+    try:
+        return np.issubdtype(dtype, np.object_) \
+               or np.issubdtype(dtype, np.unicode_) \
+               or np.issubdtype(dtype, np.bytes_)
+    except TypeError:  # pragma: no cover
+        return False
+
+
 def calc_object_overhead(chunk, shape):
     from .dataframe.core import DATAFRAME_CHUNK_TYPE, SERIES_CHUNK_TYPE, INDEX_CHUNK_TYPE
-
-    def is_object_dtype(dtype):
-        try:
-            return np.issubdtype(dtype, np.object_) \
-                   or np.issubdtype(dtype, np.unicode_) \
-                   or np.issubdtype(dtype, np.bytes_)
-        except TypeError:  # pragma: no cover
-            return False
 
     if not shape or np.isnan(shape[0]) or getattr(chunk, 'dtypes', None) is None:
         return 0


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR added memory estimation for `read_parquet` as well as `read_csv`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1809 .
