### PR TITLE
[BACKPORT] Remove unnecessary iterative tiling when predicting via XGBoost and data from/to parquet (#1818)

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -110,8 +110,7 @@ jobs:
 
           if [ -n "$WITH_HADOOP" ]; then
             source $CONDA/bin/activate test
-            pytest $PYTEST_CONFIG --cov-config .coveragerc-threaded mars/dataframe/datasource/tests/test_hdfs.py \
-            mars/deploy/yarn
+            pytest $PYTEST_CONFIG --cov-config .coveragerc-threaded -m hadoop
             coverage report
           fi
           if [ -n "$WITH_KUBERNETES" ]; then

--- a/mars/dataframe/datasource/from_tensor.py
+++ b/mars/dataframe/datasource/from_tensor.py
@@ -182,9 +182,6 @@ class DataFrameFromTensor(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def tile(cls, op):
-        # make sure all tensor have known chunk shapes
-        check_chunks_unknown_shape(op.inputs, TilesError)
-
         if isinstance(op.input, dict):
             return cls._tile_input_1d_tileables(op)
         else:
@@ -192,6 +189,9 @@ class DataFrameFromTensor(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def _tile_input_1d_tileables(cls, op):
+        # make sure all tensor have known chunk shapes
+        check_chunks_unknown_shape(op.inputs, TilesError)
+
         out_df = op.outputs[0]
         in_tensors = op.inputs
         in_tensors = unify_chunks(*in_tensors)
@@ -249,6 +249,7 @@ class DataFrameFromTensor(DataFrameOperand, DataFrameOperandMixin):
 
         if op.index is not None:
             # rechunk index if it's a tensor
+            check_chunks_unknown_shape(op.inputs, TilesError)
             index_tensor = op.index.rechunk([nsplits[0]])._inplace_tile()
         else:
             index_tensor = None

--- a/mars/dataframe/datasource/tests/test_datasource_hdfs.py
+++ b/mars/dataframe/datasource/tests/test_datasource_hdfs.py
@@ -12,23 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import random
-import unittest
 from io import BytesIO, StringIO
 
 import pandas as pd
 import numpy as np
 
 import mars.dataframe as md
-from mars.tests.core import TestBase
+from mars.tests.core import TestBase, require_hadoop
 
 
 TEST_DIR = '/tmp/test'
 
 
-@unittest.skipIf(not os.environ.get('WITH_HADOOP'), 'Only run when hdfs is installed')
-class TestHDFS(TestBase):
+@require_hadoop
+class Test(TestBase):
     def setUp(self):
         super().setUp()
 

--- a/mars/dataframe/datastore/tests/test_datastore_hdfs.py
+++ b/mars/dataframe/datastore/tests/test_datastore_hdfs.py
@@ -1,0 +1,58 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+import numpy as np
+
+import mars.dataframe as md
+from mars.tests.core import TestBase, require_hadoop
+
+
+TEST_DIR = '/tmp/test'
+
+
+@require_hadoop
+class Test(TestBase):
+    def setUp(self):
+        super().setUp()
+
+        import pyarrow
+        self.hdfs = pyarrow.hdfs.connect(host="localhost", port=8020)
+        if self.hdfs.exists(TEST_DIR):
+            self.hdfs.rm(TEST_DIR, recursive=True)
+
+    def tearDown(self):
+        if self.hdfs.exists(TEST_DIR):
+            self.hdfs.rm(TEST_DIR, recursive=True)
+
+    def testToParquetExecution(self):
+        test_df = pd.DataFrame({'a': np.arange(10).astype(np.int64, copy=False),
+                                'b': [f's{i}' for i in range(10)],
+                                'c': np.random.rand(10), })
+        df = md.DataFrame(test_df, chunk_size=5)
+
+        dir_name = f'hdfs://localhost:8020{TEST_DIR}/test_to_parquet/'
+        self.hdfs.mkdir(dir_name)
+        df.to_parquet(dir_name).execute()
+
+        result = md.read_parquet(dir_name).to_pandas()
+        pd.testing.assert_frame_equal(result.reset_index(drop=True), test_df)
+
+        # test wildcard
+        dir_name = f'hdfs://localhost:8020{TEST_DIR}/test_to_parquet2/*.parquet'
+        self.hdfs.mkdir(dir_name.rsplit('/', 1)[0])
+        df.to_parquet(dir_name).execute()
+
+        result = md.read_parquet(dir_name.rsplit('/', 1)[0]).to_pandas()
+        pd.testing.assert_frame_equal(result.reset_index(drop=True), test_df)

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -36,22 +36,24 @@ class Test(TestBase):
     def testSetIndex(self):
         df1 = pd.DataFrame([[1, 3, 3], [4, 2, 6], [7, 8, 9]],
                            index=['a1', 'a2', 'a3'], columns=['x', 'y', 'z'])
-        df2 = md.DataFrame(df1, chunk_size=2)
 
-        expected = df1.set_index('y', drop=True)
-        df3 = df2.set_index('y', drop=True)
-        pd.testing.assert_frame_equal(
-            expected, self.executor.execute_dataframe(df3, concat=True)[0])
+        for chunk_size in [2, (2, 3)]:
+            df2 = md.DataFrame(df1, chunk_size=chunk_size)
 
-        expected = df1.set_index('y', drop=False)
-        df4 = df2.set_index('y', drop=False)
-        pd.testing.assert_frame_equal(
-            expected, self.executor.execute_dataframe(df4, concat=True)[0])
+            expected = df1.set_index('y', drop=True)
+            df3 = df2.set_index('y', drop=True)
+            pd.testing.assert_frame_equal(
+                expected, self.executor.execute_dataframe(df3, concat=True)[0])
 
-        expected = df1.set_index('y')
-        df2.set_index('y', inplace=True)
-        pd.testing.assert_frame_equal(
-            expected, self.executor.execute_dataframe(df2, concat=True)[0])
+            expected = df1.set_index('y', drop=False)
+            df4 = df2.set_index('y', drop=False)
+            pd.testing.assert_frame_equal(
+                expected, self.executor.execute_dataframe(df4, concat=True)[0])
+
+            expected = df1.set_index('y')
+            df2.set_index('y', inplace=True)
+            pd.testing.assert_frame_equal(
+                expected, self.executor.execute_dataframe(df2, concat=True)[0])
 
     def testILocGetItem(self):
         df1 = pd.DataFrame([[1, 3, 3], [4, 2, 6], [7, 8, 9]],

--- a/mars/dataframe/initializer.py
+++ b/mars/dataframe/initializer.py
@@ -46,6 +46,9 @@ class DataFrame(_Frame, metaclass=InitializerMeta):
                 data = data.rechunk(chunk_size)
             df = dataframe_from_tensor(data, index=index, columns=columns, gpu=gpu, sparse=sparse)
             need_repart = num_partitions is not None
+        elif isinstance(data, SERIES_TYPE):
+            df = data.to_frame()
+            need_repart = num_partitions is not None
         elif isinstance(data, DATAFRAME_TYPE):
             if not hasattr(data, 'data'):
                 # DataFrameData

--- a/mars/dataframe/tests/test_initializer.py
+++ b/mars/dataframe/tests/test_initializer.py
@@ -65,6 +65,14 @@ class Test(TestBase):
         self.assertEqual(len(results), 10)
         pd.testing.assert_frame_equal(pd.concat(results), raw)
 
+        # from mars series
+        raw_s = np.random.rand(100)
+        s = md.Series(raw_s, chunk_size=20)
+        r = md.DataFrame(s, num_partitions=10)
+        results = self.executor.execute_dataframe(r)
+        self.assertEqual(len(results), 10)
+        pd.testing.assert_frame_equal(pd.concat(results), pd.DataFrame(raw_s))
+
         # test check instance
         r = r * 2
         self.assertIsInstance(r, md.DataFrame)

--- a/mars/deploy/yarn/tests/test_yarn.py
+++ b/mars/deploy/yarn/tests/test_yarn.py
@@ -28,14 +28,14 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 import mars.tensor as mt
-from mars.tests.core import flaky
+from mars.tests.core import flaky, require_hadoop
 from mars.deploy.yarn import new_cluster
 
 logger = logging.getLogger(__name__)
 MARS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(mt.__file__)))
 
 
-@unittest.skipIf(not os.environ.get('HADOOP_HOME'), 'Only run when hadoop is installed')
+@require_hadoop
 @flaky(max_runs=3)
 class Test(unittest.TestCase):
     def tearDown(self):

--- a/mars/learn/contrib/lightgbm/core.py
+++ b/mars/learn/contrib/lightgbm/core.py
@@ -96,3 +96,8 @@ class LGBMScikitLearnBase:
 
     def predict_proba(self, X, **kwargs):
         raise NotImplementedError
+
+    def load_model(self, model):
+        self.set_params(**self.get_params())
+        self._copy_extra_params(model, self)
+        return self

--- a/mars/learn/contrib/xgboost/classifier.py
+++ b/mars/learn/contrib/xgboost/classifier.py
@@ -61,6 +61,7 @@ if xgboost:
         def predict(self, data, **kw):
             session = kw.pop('session', None)
             run_kwargs = kw.pop('run_kwargs', dict())
+            run = kw.pop('run', True)
             if kw:
                 raise TypeError("predict got an unexpected "
                                 f"keyword argument '{next(iter(kw))}'")
@@ -69,7 +70,8 @@ if xgboost:
                 prediction = mt.argmax(prob, axis=1)
             else:
                 prediction = (prob > 0.5).astype(mt.int64)
-            prediction.execute(session=session, **run_kwargs)
+            if run:
+                prediction.execute(session=session, **run_kwargs)
             return prediction
 
         def predict_proba(self, data, ntree_limit=None, **kw):

--- a/mars/learn/contrib/xgboost/predict.py
+++ b/mars/learn/contrib/xgboost/predict.py
@@ -22,7 +22,8 @@ from ....serialize import KeyField, BytesField
 from ....dataframe.core import SERIES_CHUNK_TYPE, DATAFRAME_CHUNK_TYPE
 from ....dataframe.utils import parse_index
 from ....tensor.core import TENSOR_TYPE, TensorOrder
-from ....utils import register_tokenizer
+from ....tiles import TilesError
+from ....utils import register_tokenizer, check_chunks_unknown_shape
 from ...operands import LearnOperand, LearnOperandMixin, OutputType
 from .dmatrix import ToDMatrix, check_data
 
@@ -84,6 +85,7 @@ class XGBPredict(LearnOperand, LearnOperandMixin):
         out_chunks = []
         data = op.data
         if data.chunk_shape[1] > 1:
+            check_chunks_unknown_shape([op.data], TilesError)
             data = data.rechunk({1: op.data.shape[1]})._inplace_tile()
         for in_chunk in data.chunks:
             chunk_op = op.copy().reset_key()

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -352,6 +352,13 @@ def require_cudf(func):
     return func
 
 
+def require_hadoop(func):
+    if pytest:
+        func = pytest.mark.hadoop(func)
+    func = unittest.skipIf(not os.environ.get('WITH_HADOOP'), 'Only run when hadoop is installed')(func)
+    return func
+
+
 def create_actor_pool(*args, **kwargs):
     import gevent.socket
     from mars.actors import create_actor_pool as new_actor_pool


### PR DESCRIPTION
Backport of #1818