### PR TITLE
docs: fix simple typo, parititioned -> partitioned

### DIFF
--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -544,7 +544,7 @@ class Tensor(HasShapeTileableEnity):
 
         See Also
         --------
-        mt.partition : Return a parititioned copy of an tensor.
+        mt.partition : Return a partitioned copy of an tensor.
         argpartition : Indirect partition.
         sort : Full sort.
 


### PR DESCRIPTION
There is a small typo in mars/tensor/core.py.

Should read `partitioned` rather than `parititioned`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md