### PR TITLE
Add more functionalities for `md.Index`

### DIFF
--- a/docs/source/locale/zh_CN/LC_MESSAGES/reference/dataframe/indexing.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/reference/dataframe/indexing.po
@@ -1,0 +1,159 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 1999-2020, The Alibaba Group Holding Ltd.
+# This file is distributed under the same license as the mars package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: mars 0.7.0a3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-12-31 15:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.0\n"
+
+#: ../../source/reference/dataframe/indexing.rst:3
+msgid "Index objects"
+msgstr "Index 对象"
+
+#: ../../source/reference/dataframe/indexing.rst:7
+msgid "Constructor"
+msgstr "构造函数"
+
+#: ../../source/reference/dataframe/indexing.rst:12:<autosummary>:1
+msgid ":obj:`Index <mars.dataframe.Index>`\\ \\(data\\, \\*\\*\\_\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:14
+msgid "Properties"
+msgstr "属性"
+
+#: ../../source/reference/dataframe/indexing.rst:24:<autosummary>:1
+msgid ":obj:`Index.ndim <mars.dataframe.Index.ndim>`\\"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:24:<autosummary>:1
+msgid ":obj:`Index.size <mars.dataframe.Index.size>`\\"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:24:<autosummary>:1
+msgid ""
+":obj:`Index.memory_usage <mars.dataframe.Index.memory_usage>`\\ "
+"\\(\\[deep\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:24:<autosummary>:1
+msgid "Memory usage of the values."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:26
+msgid "Modifying and computations"
+msgstr "修改和计算"
+
+#: ../../source/reference/dataframe/indexing.rst:32:<autosummary>:1
+msgid ""
+":obj:`Index.drop <mars.dataframe.Index.drop>`\\ \\(labels\\[\\, "
+"errors\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:32:<autosummary>:1
+msgid "Make new Index with passed list of labels deleted."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:32:<autosummary>:1
+msgid ""
+":obj:`Index.drop_duplicates <mars.dataframe.Index.drop_duplicates>`\\ "
+"\\(\\[keep\\, method\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:32:<autosummary>:1
+msgid "Return Index with duplicate values removed."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:34
+msgid "Missing values"
+msgstr "缺失值填充"
+
+#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
+msgid ""
+":obj:`Index.fillna <mars.dataframe.Index.fillna>`\\ \\(\\[value\\, "
+"downcast\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
+msgid "Fill NA/NaN values with the specified value."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
+msgid ":obj:`Index.dropna <mars.dataframe.Index.dropna>`\\ \\(\\[how\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
+msgid "Return Index without NA/NaN values."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
+msgid ":obj:`Index.isna <mars.dataframe.Index.isna>`\\ \\(\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
+msgid "Detect missing values."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
+msgid ":obj:`Index.notna <mars.dataframe.Index.notna>`\\ \\(\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
+msgid "Detect existing (non-missing) values."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:45
+msgid "Conversion"
+msgstr "转换"
+
+#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+msgid ""
+":obj:`Index.astype <mars.dataframe.Index.astype>`\\ \\(dtype\\[\\, "
+"copy\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+msgid "Create an Index with values cast to dtypes."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+msgid ""
+":obj:`Index.rename <mars.dataframe.Index.rename>`\\ \\(name\\[\\, "
+"inplace\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+msgid "Alter Index or MultiIndex name."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+msgid ""
+":obj:`Index.to_frame <mars.dataframe.Index.to_frame>`\\ \\(\\[index\\, "
+"name\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+msgid "Create a DataFrame with a column containing the Index."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+msgid ""
+":obj:`Index.to_series <mars.dataframe.Index.to_series>`\\ \\(\\[index\\, "
+"name\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+msgid "Create a Series with both index and values equal to the index keys."
+msgstr ""
+

--- a/docs/source/reference/dataframe/index.rst
+++ b/docs/source/reference/dataframe/index.rst
@@ -14,4 +14,5 @@ methods. All classes and functions exposed in ``mars.dataframe.*`` namespace are
    general_functions
    series
    frame
+   indexing
    groupby

--- a/docs/source/reference/dataframe/indexing.rst
+++ b/docs/source/reference/dataframe/indexing.rst
@@ -16,6 +16,7 @@ Properties
    :toctree: generated/
 
    Index.dtype
+   Index.inferred_type
    Index.name
    Index.names
    Index.ndim

--- a/docs/source/reference/dataframe/indexing.rst
+++ b/docs/source/reference/dataframe/indexing.rst
@@ -28,8 +28,13 @@ Modifying and computations
 .. autosummary::
    :toctree: generated/
 
+   Index.all
+   Index.any
    Index.drop
    Index.drop_duplicates
+   Index.max
+   Index.min
+   Index.rename
 
 Missing values
 --------------
@@ -49,6 +54,5 @@ Conversion
 
    Index.astype
    Index.map
-   Index.rename
    Index.to_frame
    Index.to_series

--- a/docs/source/reference/dataframe/indexing.rst
+++ b/docs/source/reference/dataframe/indexing.rst
@@ -1,0 +1,52 @@
+=============
+Index objects
+=============
+.. currentmodule:: mars.dataframe
+
+Constructor
+-----------
+.. autosummary::
+   :toctree: generated/
+
+   Index
+
+Properties
+----------
+.. autosummary::
+   :toctree: generated/
+
+   Index.dtype
+   Index.name
+   Index.names
+   Index.ndim
+   Index.size
+   Index.memory_usage
+
+Modifying and computations
+--------------------------
+.. autosummary::
+   :toctree: generated/
+
+   Index.drop
+   Index.drop_duplicates
+
+Missing values
+--------------
+.. autosummary::
+   :toctree: generated/
+
+   Index.fillna
+   Index.dropna
+   Index.isna
+   Index.notna
+
+
+Conversion
+----------
+.. autosummary::
+   :toctree: generated/
+
+   Index.astype
+   Index.rename
+   Index.to_frame
+   Index.to_series

--- a/docs/source/reference/dataframe/indexing.rst
+++ b/docs/source/reference/dataframe/indexing.rst
@@ -48,6 +48,7 @@ Conversion
    :toctree: generated/
 
    Index.astype
+   Index.map
    Index.rename
    Index.to_frame
    Index.to_series

--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -591,17 +591,23 @@ class DataFrameUnaryOp(DataFrameOperand, DataFrameUnaryOpMixin):
     def __init__(self, output_types=None, **kw):
         super().__init__(_output_types=output_types, **kw)
 
+    def _get_output_dtype(self, df):
+        if df.ndim == 2:
+            return df.dtypes
+        else:
+            return df.dtype
+
     def __call__(self, df):
         self.output_types = df.op.output_types
         if df.ndim == 2:
-            return self.new_dataframe([df], shape=df.shape, dtypes=df.dtypes,
+            return self.new_dataframe([df], shape=df.shape, dtypes=self._get_output_dtype(df),
                                       columns_value=df.columns_value,
                                       index_value=df.index_value)
         else:
             series = df
             return self.new_series([series], shape=series.shape, name=series.name,
                                    index_value=series.index_value,
-                                   dtype=series.dtype)
+                                   dtype=self._get_output_dtype(series))
 
 
 class DataFrameUnaryUfunc(DataFrameUnaryOp, TensorUfuncMixin):

--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -591,7 +591,8 @@ class DataFrameUnaryOp(DataFrameOperand, DataFrameUnaryOpMixin):
     def __init__(self, output_types=None, **kw):
         super().__init__(_output_types=output_types, **kw)
 
-    def _get_output_dtype(self, df):
+    @classmethod
+    def _get_output_dtype(cls, df):
         if df.ndim == 2:
             return df.dtypes
         else:

--- a/mars/dataframe/arithmetic/is_ufuncs.py
+++ b/mars/dataframe/arithmetic/is_ufuncs.py
@@ -21,7 +21,8 @@ from .core import DataFrameUnaryUfunc
 
 
 class DataFrameIsUFuncMixin:
-    def _get_output_dtype(self, df):
+    @classmethod
+    def _get_output_dtype(cls, df):
         if df.ndim == 2:
             return pd.Series(np.dtype(bool), index=df.dtypes.index)
         else:

--- a/mars/dataframe/arithmetic/is_ufuncs.py
+++ b/mars/dataframe/arithmetic/is_ufuncs.py
@@ -12,12 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import pandas as pd
+
 from ... import opcodes as OperandDef
 from ...utils import classproperty
 from .core import DataFrameUnaryUfunc
 
 
-class DataFrameIsNan(DataFrameUnaryUfunc):
+class DataFrameIsUFuncMixin:
+    def _get_output_dtype(self, df):
+        if df.ndim == 2:
+            return pd.Series(np.dtype(bool), index=df.dtypes.index)
+        else:
+            return np.dtype(bool)
+
+
+class DataFrameIsNan(DataFrameIsUFuncMixin, DataFrameUnaryUfunc):
     _op_type_ = OperandDef.ISNAN
     _func_name = 'isnan'
 
@@ -27,7 +38,7 @@ class DataFrameIsNan(DataFrameUnaryUfunc):
         return TensorIsNan
 
 
-class DataFrameIsInf(DataFrameUnaryUfunc):
+class DataFrameIsInf(DataFrameIsUFuncMixin, DataFrameUnaryUfunc):
     _op_type_ = OperandDef.ISINF
     _func_name = 'isinf'
 
@@ -37,7 +48,7 @@ class DataFrameIsInf(DataFrameUnaryUfunc):
         return TensorIsInf
 
 
-class DataFrameIsFinite(DataFrameUnaryUfunc):
+class DataFrameIsFinite(DataFrameIsUFuncMixin, DataFrameUnaryUfunc):
     _op_type_ = OperandDef.ISFINITE
     _func_name = 'isfinite'
 

--- a/mars/dataframe/base/__init__.py
+++ b/mars/dataframe/base/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .map import map_
+from .map import series_map, index_map
 from .to_gpu import to_gpu
 from .to_cpu import to_cpu
 from .rechunk import rechunk
@@ -75,7 +75,7 @@ def _install():
         setattr(t, 'to_gpu', to_gpu)
         setattr(t, 'to_cpu', to_cpu)
         setattr(t, 'rechunk', rechunk)
-        setattr(t, 'map', map_)
+        setattr(t, 'map', series_map)
         setattr(t, 'describe', describe)
         setattr(t, 'apply', series_apply)
         setattr(t, 'transform', series_transform)
@@ -94,6 +94,7 @@ def _install():
         setattr(t, 'explode', series_explode)
 
     for t in INDEX_TYPE:
+        setattr(t, 'map', index_map)
         setattr(t, 'rechunk', rechunk)
         setattr(t, 'rebalance', rebalance)
         setattr(t, 'drop', index_drop)

--- a/mars/dataframe/base/__init__.py
+++ b/mars/dataframe/base/__init__.py
@@ -25,7 +25,7 @@ from .qcut import qcut
 from .shift import shift, tshift
 from .diff import df_diff, series_diff
 from .value_counts import value_counts
-from .astype import astype
+from .astype import astype, index_astype
 from .drop import df_drop, df_pop, series_drop, index_drop
 from .drop_duplicates import df_drop_duplicates, \
     series_drop_duplicates, index_drop_duplicates
@@ -99,6 +99,8 @@ def _install():
         setattr(t, 'drop', index_drop)
         setattr(t, 'drop_duplicates', index_drop_duplicates)
         setattr(t, 'memory_usage', index_memory_usage)
+        setattr(t, 'astype', index_astype)
+        setattr(t, 'value_counts', value_counts)
 
     for method in _string_method_to_handlers:
         if not hasattr(StringAccessor, method):

--- a/mars/dataframe/base/cartesian_chunk.py
+++ b/mars/dataframe/base/cartesian_chunk.py
@@ -66,7 +66,7 @@ class DataFrameCartesianChunk(DataFrameOperand, DataFrameOperandMixin):
 
     @property
     def memory_scale(self):
-        return self._memory_scale or 2
+        return self._memory_scale or 2.0
 
     @property
     def tileable_op_key(self):

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -196,6 +196,14 @@ class Test(TestBase):
         expected = raw.map({'c': 'e'})
         pd.testing.assert_series_equal(result, expected)
 
+        # test map index
+        raw = pd.Index(np.random.rand(7))
+        idx = from_pandas_index(pd.Index(raw), chunk_size=2)
+        r = idx.map(f)
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = raw.map(lambda x: x + 1.)
+        pd.testing.assert_index_equal(result, expected)
+
     def testDescribeExecution(self):
         s_raw = pd.Series(np.random.rand(10))
 

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -1087,6 +1087,15 @@ class Test(TestBase):
         expected = s.astype('arrow_string')
         pd.testing.assert_series_equal(result, expected)
 
+        # test index
+        raw = pd.Index(rs.randint(5, size=20))
+        mix = from_pandas_index(raw)
+        r = mix.astype('int32')
+
+        result = self.executor.execute_dataframe(r, concat=True)[0]
+        expected = raw.astype('int32')
+        pd.testing.assert_index_equal(result, expected)
+
         # multiply chunks
         series = from_pandas_series(s, chunk_size=6)
         r = series.astype('str')

--- a/mars/dataframe/base/transform.py
+++ b/mars/dataframe/base/transform.py
@@ -368,9 +368,9 @@ def series_transform(series, func, convert_dtype=True, axis=0, *args, dtype=None
         Specify dtypes of returned DataFrames. See `Notes` for more details.
 
     *args
-    Positional arguments to pass to `func`.
+        Positional arguments to pass to `func`.
     **kwargs
-    Keyword arguments to pass to `func`.
+        Keyword arguments to pass to `func`.
 
     Returns
     -------

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -414,6 +414,7 @@ class IndexData(HasShapeTileableData, _ToPandasMixin):
     # optional field
     _dtype = DataTypeField('dtype')
     _name = AnyField('name')
+    _names = AnyField('names')
     _index_value = ReferenceField('index_value', IndexValue, on_deserialize=_on_deserialize_index_value)
     _chunks = ListField('chunks', ValueType.reference(IndexChunkData),
                         on_serialize=lambda x: [it.data for it in x] if x is not None else x,
@@ -465,6 +466,10 @@ class IndexData(HasShapeTileableData, _ToPandasMixin):
     @property
     def name(self):
         return self._name
+
+    @property
+    def names(self):
+        return getattr(self, '_names', None) or [self.name]
 
     @property
     def index_value(self) -> IndexValue:

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -88,6 +88,10 @@ class IndexValue(Serializable):
         def key(self):
             return self._key
 
+        @property
+        def inferred_type(self):
+            return None
+
         def to_pandas(self):
             kw = {field.tag_name(None): getattr(self, attr, None)
                   for attr, field in self._FIELDS.items()
@@ -126,10 +130,18 @@ class IndexValue(Serializable):
         _categories = ListField('categories')
         _ordered = BoolField('ordered')
 
+        @property
+        def inferred_type(self):
+            return 'categorical'
+
     class IntervalIndex(IndexBase):
         _name = AnyField('name')
         _data = IntervalArrayField('data')
         _closed = StringField('closed')
+
+        @property
+        def inferred_type(self):
+            return 'interval'
 
     class DatetimeIndex(IndexBase):
         _name = AnyField('name')
@@ -145,6 +157,10 @@ class IndexValue(Serializable):
         _yearfirst = BoolField('yearfirst')
 
         @property
+        def inferred_type(self):
+            return 'datetime64'
+
+        @property
         def freq(self):
             return getattr(self, '_freq', None)
 
@@ -157,6 +173,10 @@ class IndexValue(Serializable):
         _periods = AnyField('periods')
         _end = AnyField('end')
         _closed = AnyField('closed')
+
+        @property
+        def inferred_type(self):
+            return 'timedelta64'
 
     class PeriodIndex(IndexBase):
         _name = AnyField('name')
@@ -175,26 +195,46 @@ class IndexValue(Serializable):
         _tz = AnyField('tz')
         _dtype = DataTypeField('dtype')
 
+        @property
+        def inferred_type(self):
+            return 'period'
+
     class Int64Index(IndexBase):
         _name = AnyField('name')
         _data = NDArrayField('data')
         _dtype = DataTypeField('dtype')
+
+        @property
+        def inferred_type(self):
+            return 'integer'
 
     class UInt64Index(IndexBase):
         _name = AnyField('name')
         _data = NDArrayField('data')
         _dtype = DataTypeField('dtype')
 
+        @property
+        def inferred_type(self):
+            return 'integer'
+
     class Float64Index(IndexBase):
         _name = AnyField('name')
         _data = NDArrayField('data')
         _dtype = DataTypeField('dtype')
+
+        @property
+        def inferred_type(self):
+            return 'floating'
 
     class MultiIndex(IndexBase):
         _names = ListField('names', on_serialize=list)
         _dtypes = ListField('dtypes', on_serialize=list)
         _data = NDArrayField('data')
         _sortorder = Int32Field('sortorder')
+
+        @property
+        def inferred_type(self):
+            return 'mixed'
 
         @property
         def names(self) -> list:
@@ -279,6 +319,10 @@ class IndexValue(Serializable):
     @property
     def name(self):
         return getattr(self._index_value, '_name', None)
+
+    @property
+    def inferred_type(self):
+        return self._index_value.inferred_type
 
     def has_value(self):
         if isinstance(self._index_value, self.RangeIndex):
@@ -474,6 +518,10 @@ class IndexData(HasShapeTileableData, _ToPandasMixin):
     @property
     def index_value(self) -> IndexValue:
         return self._index_value
+
+    @property
+    def inferred_type(self):
+        return self._index_value.inferred_type
 
     def to_tensor(self, dtype=None, extract_multi_index=False):
         from ..tensor.datasource.from_dataframe import from_index
@@ -1148,6 +1196,12 @@ class DataFrameData(_BatchedFetcher, BaseDataFrameData):
             from ..serialize.protos.dataframe_pb2 import DataFrameDef
             return DataFrameDef
         return super().cls(provider)
+
+    def items(self):
+        for col_name in self.dtypes.index:
+            yield col_name, self[col_name]
+
+    iteritems = items
 
     def iterrows(self, batch_size=1000, session=None):
         for batch_data in self.iterbatch(batch_size=batch_size, session=session):

--- a/mars/dataframe/datasource/index.py
+++ b/mars/dataframe/datasource/index.py
@@ -59,7 +59,8 @@ class IndexDataSource(DataFrameOperand, DataFrameOperandMixin):
         if inputs is not None and len(inputs) > 0:
             self._input = self._inputs[0]
 
-    def __call__(self, shape=None, chunk_size=None, inp=None, name=None):
+    def __call__(self, shape=None, chunk_size=None, inp=None, name=None,
+                 names=None):
         if inp is None:
             # create from pandas Index
             name = name if name is not None else self._data.name
@@ -69,17 +70,18 @@ class IndexDataSource(DataFrameOperand, DataFrameOperandMixin):
         elif hasattr(inp, 'index_value'):
             # get index from Mars DataFrame, Series or Index
             name = name if name is not None else inp.index_value.name
+            names = names if names is not None else [name]
             if inp.index_value.has_value():
                 self._data = data = inp.index_value.to_pandas()
                 return self.new_index(None, shape=(inp.shape[0],), dtype=data.dtype,
-                                      index_value=parse_index(data),
-                                      name=name, raw_chunk_size=chunk_size)
+                                      index_value=parse_index(data), name=name,
+                                      names=names, raw_chunk_size=chunk_size)
             else:
                 if self._dtype is None:
                     self._dtype = inp.index_value.to_pandas().dtype
                 return self.new_index([inp], shape=(inp.shape[0],),
                                       dtype=self._dtype, index_value=inp.index_value,
-                                      name=name)
+                                      name=name, names=names)
         else:
             if inp.ndim != 1:
                 raise ValueError('Index data must be 1-dimensional')

--- a/mars/dataframe/missing/__init__.py
+++ b/mars/dataframe/missing/__init__.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .fillna import fillna, ffill, bfill
+from .fillna import fillna, ffill, bfill, index_fillna
 from .checkna import isna, notna, isnull, notnull
-from .dropna import df_dropna, series_dropna
+from .dropna import df_dropna, series_dropna, index_dropna
 from .replace import df_replace, series_replace
 
 
 def _install():
-    from ..core import DATAFRAME_TYPE, SERIES_TYPE
+    from ..core import DATAFRAME_TYPE, SERIES_TYPE, INDEX_TYPE
 
     for cls in DATAFRAME_TYPE + SERIES_TYPE:
         setattr(cls, 'fillna', fillna)
@@ -39,6 +39,12 @@ def _install():
     for cls in SERIES_TYPE:
         setattr(cls, 'dropna', series_dropna)
         setattr(cls, 'replace', series_replace)
+
+    for cls in INDEX_TYPE:
+        setattr(cls, 'fillna', index_fillna)
+        setattr(cls, 'dropna', index_dropna)
+        setattr(cls, 'isna', isna)
+        setattr(cls, 'notna', notna)
 
 
 _install()

--- a/mars/dataframe/missing/checkna.py
+++ b/mars/dataframe/missing/checkna.py
@@ -19,7 +19,8 @@ from ... import opcodes
 from ...config import options
 from ...core import OutputType
 from ...serialize import BoolField
-from ..operands import DataFrameOperand, DataFrameOperandMixin, DATAFRAME_TYPE
+from ..operands import DataFrameOperand, DataFrameOperandMixin, \
+    DATAFRAME_TYPE, SERIES_TYPE
 
 
 class DataFrameCheckNA(DataFrameOperand, DataFrameOperandMixin):
@@ -43,8 +44,10 @@ class DataFrameCheckNA(DataFrameOperand, DataFrameOperandMixin):
     def __call__(self, df):
         if isinstance(df, DATAFRAME_TYPE):
             self.output_types = [OutputType.dataframe]
-        else:
+        elif isinstance(df, SERIES_TYPE):
             self.output_types = [OutputType.series]
+        else:
+            self.output_types = [OutputType.tensor]
 
         params = df.params.copy()
         if self.output_types[0] == OutputType.dataframe:

--- a/mars/dataframe/missing/fillna.py
+++ b/mars/dataframe/missing/fillna.py
@@ -281,10 +281,10 @@ class FillNA(DataFrameOperand, DataFrameOperandMixin):
             out_chunks.append(out_chunk)
 
         new_op = op.copy()
-        return new_op.new_tileables(op.inputs, df.shape,
-                                    nsplits=tuple(tuple(ns) for ns in nsplits),
-                                    chunks=out_chunks, dtypes=df.dtypes,
-                                    index_value=df.index_value, columns_value=df.columns_value)
+        return new_op.new_dataframes(op.inputs, df.shape,
+                                     nsplits=tuple(tuple(ns) for ns in nsplits),
+                                     chunks=out_chunks, dtypes=df.dtypes,
+                                     index_value=df.index_value, columns_value=df.columns_value)
 
     @classmethod
     def _tile_dataframe_series(cls, op):
@@ -303,10 +303,10 @@ class FillNA(DataFrameOperand, DataFrameOperandMixin):
             out_chunks.append(out_chunk)
 
         new_op = op.copy().reset_key()
-        return new_op.new_tileables(op.inputs, df.shape,
-                                    nsplits=tuple(tuple(ns) for ns in nsplits),
-                                    chunks=out_chunks, dtypes=df.dtypes,
-                                    index_value=df.index_value, columns_value=df.columns_value)
+        return new_op.new_dataframes(op.inputs, df.shape,
+                                     nsplits=tuple(tuple(ns) for ns in nsplits),
+                                     chunks=out_chunks, dtypes=df.dtypes,
+                                     index_value=df.index_value, columns_value=df.columns_value)
 
     @classmethod
     def _tile_both_series(cls, op):
@@ -322,10 +322,10 @@ class FillNA(DataFrameOperand, DataFrameOperandMixin):
             out_chunks.append(out_chunk)
 
         new_op = op.copy()
-        return new_op.new_tileables(op.inputs, df.shape,
-                                    nsplits=tuple(tuple(ns) for ns in nsplits),
-                                    chunks=out_chunks, dtype=df.dtype,
-                                    index_value=df.index_value, name=df.name)
+        return new_op.new_seriess(op.inputs, df.shape,
+                                  nsplits=tuple(tuple(ns) for ns in nsplits),
+                                  chunks=out_chunks, dtype=df.dtype,
+                                  index_value=df.index_value, name=df.name)
 
     @classmethod
     def tile(cls, op):

--- a/mars/dataframe/reduction/__init__.py
+++ b/mars/dataframe/reduction/__init__.py
@@ -41,18 +41,18 @@ from .unique import DataFrameUnique, unique
 
 
 def _install():
-    from ..core import DATAFRAME_TYPE, SERIES_TYPE
+    from ..core import DATAFRAME_TYPE, SERIES_TYPE, INDEX_TYPE
     from .aggregation import aggregate
     from .sum import sum_series, sum_dataframe
     from .prod import prod_series, prod_dataframe
-    from .max import max_series, max_dataframe
-    from .min import min_series, min_dataframe
+    from .max import max_series, max_dataframe, max_index
+    from .min import min_series, min_dataframe, min_index
     from .count import count_series, count_dataframe
     from .mean import mean_series, mean_dataframe
     from .var import var_series, var_dataframe
     from .std import std_series, std_dataframe
-    from .all import all_series, all_dataframe
-    from .any import any_series, any_dataframe
+    from .all import all_series, all_dataframe, all_index
+    from .any import any_series, any_dataframe, any_index
     from .cummax import cummax
     from .cummin import cummin
     from .cumprod import cumprod
@@ -96,6 +96,14 @@ def _install():
         if series_func is not None:  # pragma: no branch
             for t in SERIES_TYPE:
                 setattr(t, func_name, series_func)
+
+    for t in INDEX_TYPE:
+        setattr(t, 'agg', aggregate)
+        setattr(t, 'aggregate', aggregate)
+        setattr(t, 'all', all_index)
+        setattr(t, 'any', any_index)
+        setattr(t, 'min', min_index)
+        setattr(t, 'max', max_index)
 
 
 _install()

--- a/mars/dataframe/reduction/all.py
+++ b/mars/dataframe/reduction/all.py
@@ -27,12 +27,12 @@ class DataFrameAll(DataFrameReductionOperand, DataFrameReductionMixin):
         return True
 
 
-def all_series(df, axis=None, bool_only=None, skipna=None, level=None, combine_size=None):
+def all_series(series, axis=None, bool_only=None, skipna=None, level=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameAll(axis=axis, skipna=skipna, level=level, bool_only=bool_only,
                       combine_size=combine_size, output_types=[OutputType.scalar],
                       use_inf_as_na=use_inf_as_na)
-    return op(df)
+    return op(series)
 
 
 def all_dataframe(df, axis=None, bool_only=None, skipna=None, level=None, combine_size=None):
@@ -41,3 +41,9 @@ def all_dataframe(df, axis=None, bool_only=None, skipna=None, level=None, combin
                       combine_size=combine_size, output_types=[OutputType.series],
                       use_inf_as_na=use_inf_as_na)
     return op(df)
+
+
+def all_index(idx):
+    use_inf_as_na = options.dataframe.mode.use_inf_as_na
+    op = DataFrameAll(output_types=[OutputType.scalar], use_inf_as_na=use_inf_as_na)
+    return op(idx)

--- a/mars/dataframe/reduction/any.py
+++ b/mars/dataframe/reduction/any.py
@@ -27,12 +27,12 @@ class DataFrameAny(DataFrameReductionOperand, DataFrameReductionMixin):
         return True
 
 
-def any_series(df, axis=None, bool_only=None, skipna=None, level=None, combine_size=None):
+def any_series(series, axis=None, bool_only=None, skipna=None, level=None, combine_size=None):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameAny(axis=axis, skipna=skipna, level=level, bool_only=bool_only,
                       combine_size=combine_size, output_types=[OutputType.scalar],
                       use_inf_as_na=use_inf_as_na)
-    return op(df)
+    return op(series)
 
 
 def any_dataframe(df, axis=None, bool_only=None, skipna=None, level=None, combine_size=None):
@@ -41,3 +41,9 @@ def any_dataframe(df, axis=None, bool_only=None, skipna=None, level=None, combin
                       combine_size=combine_size, output_types=[OutputType.series],
                       use_inf_as_na=use_inf_as_na)
     return op(df)
+
+
+def any_index(index):
+    use_inf_as_na = options.dataframe.mode.use_inf_as_na
+    op = DataFrameAny(output_types=[OutputType.scalar], use_inf_as_na=use_inf_as_na)
+    return op(index)

--- a/mars/dataframe/reduction/max.py
+++ b/mars/dataframe/reduction/max.py
@@ -40,3 +40,10 @@ def max_dataframe(df, axis=None, skipna=None, level=None, numeric_only=None, com
                       combine_size=combine_size, output_types=[OutputType.series],
                       use_inf_as_na=use_inf_as_na)
     return op(df)
+
+
+def max_index(df, axis=None, skipna=True):
+    use_inf_as_na = options.dataframe.mode.use_inf_as_na
+    op = DataFrameMax(axis=axis, skipna=skipna, output_types=[OutputType.scalar],
+                      use_inf_as_na=use_inf_as_na)
+    return op(df)

--- a/mars/dataframe/reduction/min.py
+++ b/mars/dataframe/reduction/min.py
@@ -40,3 +40,10 @@ def min_dataframe(df, axis=None, skipna=None, level=None, numeric_only=None, com
                       combine_size=combine_size, output_types=[OutputType.series],
                       use_inf_as_na=use_inf_as_na)
     return op(df)
+
+
+def min_index(df, axis=None, skipna=True):
+    use_inf_as_na = options.dataframe.mode.use_inf_as_na
+    op = DataFrameMin(axis=axis, skipna=skipna, output_types=[OutputType.scalar],
+                      use_inf_as_na=use_inf_as_na)
+    return op(df)

--- a/mars/dataframe/reduction/nunique.py
+++ b/mars/dataframe/reduction/nunique.py
@@ -182,7 +182,7 @@ def nunique_dataframe(df, axis=0, dropna=True, combine_size=None):
     return op(df)
 
 
-def nunique_series(df, dropna=True, combine_size=None):
+def nunique_series(series, dropna=True, combine_size=None):
     """
     Return number of unique elements in the object.
 
@@ -222,4 +222,4 @@ def nunique_series(df, dropna=True, combine_size=None):
     op = DataFrameNunique(dropna=dropna, combine_size=combine_size,
                           output_types=[OutputType.scalar],
                           use_arrow_dtype=options.dataframe.use_arrow_dtype)
-    return op(df)
+    return op(series)

--- a/mars/dataframe/reduction/tests/test_reduction_execute.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execute.py
@@ -678,6 +678,33 @@ class TestCount(TestBase):
         np.testing.assert_array_equal(result, expected)
 
 
+class TestIndexReduction(TestBase):
+    def setUp(self):
+        self.executor = ExecutorForTest()
+
+    def testIndexReduction(self):
+        rs = np.random.RandomState(0)
+        data = pd.Index(rs.randint(0, 5, (100,)))
+        data2 = pd.Index(rs.randint(1, 6, (100,)))
+
+        for method in ['min', 'max', 'all', 'any']:
+            idx = md.Index(data)
+            result = self.executor.execute_dataframe(getattr(idx, method)(), concat=True)[0]
+            self.assertEqual(result, getattr(data, method)())
+
+            idx = md.Index(data, chunk_size=10)
+            result = self.executor.execute_dataframe(getattr(idx, method)(), concat=True)[0]
+            self.assertEqual(result, getattr(data, method)())
+
+            idx = md.Index(data2)
+            result = self.executor.execute_dataframe(getattr(idx, method)(), concat=True)[0]
+            self.assertEqual(result, getattr(data2, method)())
+
+            idx = md.Index(data2, chunk_size=10)
+            result = self.executor.execute_dataframe(getattr(idx, method)(), concat=True)[0]
+            self.assertEqual(result, getattr(data2, method)())
+
+
 cum_reduction_functions = dict(
     cummax=dict(func_name='cummax'),
     cummin=dict(func_name='cummin'),

--- a/mars/dataframe/tests/test_utils.py
+++ b/mars/dataframe/tests/test_utils.py
@@ -23,7 +23,7 @@ import numpy as np
 import pandas as pd
 
 from mars.config import option_context
-from mars.dataframe.initializer import DataFrame
+from mars.dataframe.initializer import DataFrame, Index
 from mars.dataframe.core import IndexValue
 from mars.dataframe.utils import decide_dataframe_chunk_sizes, decide_series_chunk_size, \
     split_monotonic_index_min_max, build_split_idx_to_origin_idx, parse_index, filter_index_value, \
@@ -360,6 +360,10 @@ class Test(unittest.TestCase):
         self.assertIsInstance(oival.value, IndexValue.Index)
         self.assertNotEqual(oival.key, ival1.key)
         self.assertNotEqual(oival.key, ival2.key)
+
+    def testIndexInferredType(self):
+        self.assertEqual(Index(pd.Index([1, 2, 3, 4])).inferred_type, 'integer')
+        self.assertEqual(Index(pd.Index([1.2, 2.3, 4.5])).inferred_type, 'floating')
 
     def testValidateAxis(self):
         df = DataFrame(pd.DataFrame(np.random.rand(4, 3)))

--- a/mars/dataframe/tests/test_utils.py
+++ b/mars/dataframe/tests/test_utils.py
@@ -363,7 +363,16 @@ class Test(unittest.TestCase):
 
     def testIndexInferredType(self):
         self.assertEqual(Index(pd.Index([1, 2, 3, 4])).inferred_type, 'integer')
+        self.assertEqual(Index(pd.Index([1, 2, 3, 4]).astype('uint32')).inferred_type, 'integer')
         self.assertEqual(Index(pd.Index([1.2, 2.3, 4.5])).inferred_type, 'floating')
+        self.assertEqual(
+            Index(pd.IntervalIndex.from_tuples([(0, 1), (2, 3), (4, 5)])).inferred_type,
+            'interval'
+        )
+        self.assertEqual(
+            Index(pd.MultiIndex.from_tuples([('a', 1), ('b', 2)])).inferred_type,
+            'mixed'
+        )
 
     def testValidateAxis(self):
         df = DataFrame(pd.DataFrame(np.random.rand(4, 3)))

--- a/mars/operands.py
+++ b/mars/operands.py
@@ -26,7 +26,8 @@ from .core import Entity, Chunk, Tileable, AttributeAsDictKey, ExecutableTuple, 
     FuseChunkData, FuseChunk, OutputType, get_chunk_types, get_tileable_types, \
     register_fetch_class, get_fetch_class, get_output_types
 from .serialize import SerializableMetaclass, ValueType, ProviderType, IdentityField, \
-    ListField, DictField, Int32Field, BoolField, StringField, ReferenceField
+    ListField, DictField, Int32Field, Float32Field, BoolField, StringField, \
+    ReferenceField
 from .tiles import NotSupportTile
 from .utils import AttributeDict, to_str, calc_data_size, calc_object_overhead, \
     enter_mode, is_eager_mode
@@ -96,7 +97,7 @@ class Operand(AttributeAsDictKey, metaclass=OperandMetaclass):
                               on_serialize=OutputType.serialize_list,
                               on_deserialize=OutputType.deserialize_list)
 
-    _memory_scale = Int32Field('memory_scale')
+    _memory_scale = Float32Field('memory_scale')
 
     _stage = Int32Field('stage', on_serialize=lambda s: s.value if s is not None else s,
                         on_deserialize=lambda n: OperandStage(n) if n is not None else n)
@@ -510,7 +511,7 @@ class TileableOperandMixin(object):
                 pass
 
         exec_size = max(exec_size, total_out_size)
-        memory_scale = op.memory_scale or 1
+        memory_scale = op.memory_scale or 1.0
         for out in outputs:
             if out.key in ctx:
                 continue

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -622,6 +622,9 @@ class Test(unittest.TestCase):
         raw_data = pd.DataFrame(np.random.randint(1000, size=(20, 10)))
         df = md.DataFrame(raw_data, chunk_size=5)
 
+        for col, series in df.iteritems():
+            pd.testing.assert_series_equal(series.execute().fetch(), raw_data[col])
+
         for i, batch in enumerate(df.iterbatch(batch_size=15)):
             pd.testing.assert_frame_equal(batch, raw_data.iloc[i * 15: (i + 1) * 15])
 


### PR DESCRIPTION
## What do these changes do?

Add missing values methods for md.Index. Also add documentations for Mars index.

## Related issue number

Fixes #1832
Part of #1840 is done (``iteritems()`` and ``items()``)