### PR TITLE
Implements `{DataFrame,Series}.rename_axis`

### DIFF
--- a/docs/source/locale/zh_CN/LC_MESSAGES/reference/dataframe/indexing.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/reference/dataframe/indexing.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mars 0.7.0a3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-31 15:22+0800\n"
+"POT-Creation-Date: 2021-01-06 00:44+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,127 +33,175 @@ msgstr ""
 msgid "Properties"
 msgstr "属性"
 
-#: ../../source/reference/dataframe/indexing.rst:24:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:25:<autosummary>:1
+msgid ":obj:`Index.name <mars.dataframe.Index.name>`\\"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:25:<autosummary>:1
+msgid ":obj:`Index.names <mars.dataframe.Index.names>`\\"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:25:<autosummary>:1
 msgid ":obj:`Index.ndim <mars.dataframe.Index.ndim>`\\"
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:24:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:25:<autosummary>:1
 msgid ":obj:`Index.size <mars.dataframe.Index.size>`\\"
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:24:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:25:<autosummary>:1
 msgid ""
 ":obj:`Index.memory_usage <mars.dataframe.Index.memory_usage>`\\ "
 "\\(\\[deep\\]\\)"
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:24:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:25:<autosummary>:1
 msgid "Memory usage of the values."
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:26
+#: ../../source/reference/dataframe/indexing.rst:27
 msgid "Modifying and computations"
 msgstr "修改和计算"
 
-#: ../../source/reference/dataframe/indexing.rst:32:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:38:<autosummary>:1
+msgid ":obj:`Index.all <mars.dataframe.Index.all>`\\ \\(\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:38:<autosummary>:1
+msgid ":obj:`Index.any <mars.dataframe.Index.any>`\\ \\(\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:38:<autosummary>:1
 msgid ""
 ":obj:`Index.drop <mars.dataframe.Index.drop>`\\ \\(labels\\[\\, "
 "errors\\]\\)"
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:32:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:38:<autosummary>:1
 msgid "Make new Index with passed list of labels deleted."
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:32:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:38:<autosummary>:1
 msgid ""
 ":obj:`Index.drop_duplicates <mars.dataframe.Index.drop_duplicates>`\\ "
 "\\(\\[keep\\, method\\]\\)"
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:32:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:38:<autosummary>:1
 msgid "Return Index with duplicate values removed."
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:34
-msgid "Missing values"
-msgstr "缺失值填充"
-
-#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
-msgid ""
-":obj:`Index.fillna <mars.dataframe.Index.fillna>`\\ \\(\\[value\\, "
-"downcast\\]\\)"
+#: ../../source/reference/dataframe/indexing.rst:38:<autosummary>:1
+msgid ":obj:`Index.max <mars.dataframe.Index.max>`\\ \\(\\[axis\\, skipna\\]\\)"
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
-msgid "Fill NA/NaN values with the specified value."
+#: ../../source/reference/dataframe/indexing.rst:38:<autosummary>:1
+msgid ":obj:`Index.min <mars.dataframe.Index.min>`\\ \\(\\[axis\\, skipna\\]\\)"
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
-msgid ":obj:`Index.dropna <mars.dataframe.Index.dropna>`\\ \\(\\[how\\]\\)"
-msgstr ""
-
-#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
-msgid "Return Index without NA/NaN values."
-msgstr ""
-
-#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
-msgid ":obj:`Index.isna <mars.dataframe.Index.isna>`\\ \\(\\)"
-msgstr ""
-
-#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
-msgid "Detect missing values."
-msgstr ""
-
-#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
-msgid ":obj:`Index.notna <mars.dataframe.Index.notna>`\\ \\(\\)"
-msgstr ""
-
-#: ../../source/reference/dataframe/indexing.rst:43:<autosummary>:1
-msgid "Detect existing (non-missing) values."
-msgstr ""
-
-#: ../../source/reference/dataframe/indexing.rst:45
-msgid "Conversion"
-msgstr "转换"
-
-#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
-msgid ""
-":obj:`Index.astype <mars.dataframe.Index.astype>`\\ \\(dtype\\[\\, "
-"copy\\]\\)"
-msgstr ""
-
-#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
-msgid "Create an Index with values cast to dtypes."
-msgstr ""
-
-#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:38:<autosummary>:1
 msgid ""
 ":obj:`Index.rename <mars.dataframe.Index.rename>`\\ \\(name\\[\\, "
 "inplace\\]\\)"
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:38:<autosummary>:1
 msgid "Alter Index or MultiIndex name."
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:40
+msgid "Compatibility with MultiIndex"
+msgstr "MultiIndex 兼容方法"
+
+#: ../../source/reference/dataframe/indexing.rst:46:<autosummary>:1
+msgid ""
+":obj:`Index.set_names <mars.dataframe.Index.set_names>`\\ \\(names\\[\\, "
+"level\\, inplace\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:46:<autosummary>:1
+msgid "Set Index or MultiIndex name."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:48
+msgid "Missing values"
+msgstr "缺失值填充"
+
+#: ../../source/reference/dataframe/indexing.rst:57:<autosummary>:1
+msgid ""
+":obj:`Index.fillna <mars.dataframe.Index.fillna>`\\ \\(\\[value\\, "
+"downcast\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:57:<autosummary>:1
+msgid "Fill NA/NaN values with the specified value."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:57:<autosummary>:1
+msgid ":obj:`Index.dropna <mars.dataframe.Index.dropna>`\\ \\(\\[how\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:57:<autosummary>:1
+msgid "Return Index without NA/NaN values."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:57:<autosummary>:1
+msgid ":obj:`Index.isna <mars.dataframe.Index.isna>`\\ \\(\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:57:<autosummary>:1
+msgid "Detect missing values."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:57:<autosummary>:1
+msgid ":obj:`Index.notna <mars.dataframe.Index.notna>`\\ \\(\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:57:<autosummary>:1
+msgid "Detect existing (non-missing) values."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:59
+msgid "Conversion"
+msgstr "转换"
+
+#: ../../source/reference/dataframe/indexing.rst:66:<autosummary>:1
+msgid ""
+":obj:`Index.astype <mars.dataframe.Index.astype>`\\ \\(dtype\\[\\, "
+"copy\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:66:<autosummary>:1
+msgid "Create an Index with values cast to dtypes."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:66:<autosummary>:1
+msgid ""
+":obj:`Index.map <mars.dataframe.Index.map>`\\ \\(mapper\\[\\, "
+"na\\_action\\, dtype\\, ...\\]\\)"
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:66:<autosummary>:1
+msgid "Map values using input correspondence (a dict, Series, or function)."
+msgstr ""
+
+#: ../../source/reference/dataframe/indexing.rst:66:<autosummary>:1
 msgid ""
 ":obj:`Index.to_frame <mars.dataframe.Index.to_frame>`\\ \\(\\[index\\, "
 "name\\]\\)"
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:66:<autosummary>:1
 msgid "Create a DataFrame with a column containing the Index."
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:66:<autosummary>:1
 msgid ""
 ":obj:`Index.to_series <mars.dataframe.Index.to_series>`\\ \\(\\[index\\, "
 "name\\]\\)"
 msgstr ""
 
-#: ../../source/reference/dataframe/indexing.rst:52:<autosummary>:1
+#: ../../source/reference/dataframe/indexing.rst:66:<autosummary>:1
 msgid "Create a Series with both index and values equal to the index keys."
 msgstr ""
 

--- a/docs/source/reference/dataframe/frame.rst
+++ b/docs/source/reference/dataframe/frame.rst
@@ -146,6 +146,7 @@ Reindexing / selection / label manipulation
    DataFrame.head
    DataFrame.reindex
    DataFrame.rename
+   DataFrame.rename_axis
    DataFrame.reset_index
    DataFrame.set_index
    DataFrame.tail

--- a/docs/source/reference/dataframe/indexing.rst
+++ b/docs/source/reference/dataframe/indexing.rst
@@ -36,6 +36,14 @@ Modifying and computations
    Index.min
    Index.rename
 
+Compatibility with MultiIndex
+-----------------------------
+.. autosummary::
+   :toctree: generated/
+
+   Index.set_names
+
+
 Missing values
 --------------
 .. autosummary::

--- a/docs/source/reference/dataframe/series.rst
+++ b/docs/source/reference/dataframe/series.rst
@@ -47,8 +47,10 @@ Indexing, iteration
    Series.iat
    Series.loc
    Series.iloc
-   Series.where
+   Series.items
+   Series.iteritems
    Series.mask
+   Series.where
 
 Binary operator functions
 -------------------------
@@ -140,6 +142,7 @@ Reindexing / selection / label manipulation
    Series.isin
    Series.reindex
    Series.rename
+   Series.rename_axis
    Series.reset_index
    Series.tail
 

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -571,6 +571,18 @@ class Index(HasShapeTileableEnity, _ToPandasMixin):
         if df_or_series is not None:
             df_or_series.rename_axis(value, axis=self._axis, inplace=True)
 
+    @property
+    def names(self):
+        return self._data.names
+
+    @names.setter
+    def names(self, value):
+        self.rename(value, inplace=True)
+
+        df_or_series = self._get_df_or_series()
+        if df_or_series is not None:
+            df_or_series.rename_axis(value, axis=self._axis, inplace=True)
+
     def to_frame(self, index: bool = True, name=None):
         """
         Create a DataFrame with a column containing the Index.

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import weakref
 from collections.abc import Iterable
 from io import StringIO
 from typing import Union
@@ -529,7 +530,7 @@ class IndexData(HasShapeTileableData, _ToPandasMixin):
 
 
 class Index(HasShapeTileableEnity, _ToPandasMixin):
-    __slots__ = ()
+    __slots__ = '_df_or_series', '_axis'
     _allow_data_type_ = (IndexData,)
 
     def __new__(cls, data: Union[pd.Index, IndexData], **_):
@@ -551,6 +552,24 @@ class Index(HasShapeTileableEnity, _ToPandasMixin):
 
     def __mars_tensor__(self, dtype=None, order='K'):
         return self._to_mars_tensor(dtype=dtype, order=order)
+
+    def _get_df_or_series(self):
+        obj = getattr(self, '_df_or_series', None)
+        if obj is not None:
+            return obj()
+        return None
+
+    @property
+    def name(self):
+        return self._data.name
+
+    @name.setter
+    def name(self, value):
+        self.rename(value, inplace=True)
+
+        df_or_series = self._get_df_or_series()
+        if df_or_series is not None:
+            df_or_series.rename_axis(value, axis=self._axis, inplace=True)
 
     def to_frame(self, index: bool = True, name=None):
         """
@@ -851,6 +870,12 @@ class SeriesData(_BatchedFetcher, BaseSeriesData):
             return SeriesDef
         return super().cls(provider)
 
+    def iteritems(self, batch_size=10000, session=None):
+        for batch_data in self.iterbatch(batch_size=batch_size, session=session):
+            yield from getattr(batch_data, 'iteritems')()
+
+    items = iteritems
+
 
 class Series(HasShapeTileableEnity, _ToPandasMixin):
     __slots__ = '_cache',
@@ -891,7 +916,10 @@ class Series(HasShapeTileableEnity, _ToPandasMixin):
         """
         The index (axis labels) of the Series.
         """
-        return self._data.index
+        idx = self._data.index
+        setattr(idx, '_df_or_series', weakref.ref(self))
+        setattr(idx, '_axis', 0)
+        return idx
 
     @property
     def name(self):
@@ -948,6 +976,38 @@ class Series(HasShapeTileableEnity, _ToPandasMixin):
         tensor = self._data.to_tensor()
         dtype = dtype if dtype is not None else tensor.dtype
         return tensor.astype(dtype=dtype, order=order, copy=False)
+
+    def iteritems(self, batch_size=10000, session=None):
+        """
+        Lazily iterate over (index, value) tuples.
+
+        This method returns an iterable tuple (index, value). This is
+        convenient if you want to create a lazy iterator.
+
+        Returns
+        -------
+        iterable
+            Iterable of tuples containing the (index, value) pairs from a
+            Series.
+
+        See Also
+        --------
+        DataFrame.items : Iterate over (column name, Series) pairs.
+        DataFrame.iterrows : Iterate over DataFrame rows as (index, Series) pairs.
+
+        Examples
+        --------
+        >>> import mars.dataframe as md
+        >>> s = md.Series(['A', 'B', 'C'])
+        >>> for index, value in s.items():
+        ...     print(f"Index : {index}, Value : {value}")
+        Index : 0, Value : A
+        Index : 1, Value : B
+        Index : 2, Value : C
+        """
+        return self._data.iteritems(batch_size=batch_size, session=session)
+
+    items = iteritems
 
     def to_frame(self, name=None):
         """
@@ -1270,11 +1330,17 @@ class DataFrame(HasShapeTileableEnity, _ToPandasMixin):
 
     @property
     def index(self):
-        return self._data.index
+        idx = self._data.index
+        setattr(idx, '_df_or_series', weakref.ref(self))
+        setattr(idx, '_axis', 0)
+        return idx
 
     @property
     def columns(self):
-        return self._data.columns
+        col = self._data.columns
+        setattr(col, '_df_or_series', weakref.ref(self))
+        setattr(col, '_axis', 1)
+        return col
 
     @columns.setter
     def columns(self, new_columns):

--- a/mars/dataframe/indexing/__init__.py
+++ b/mars/dataframe/indexing/__init__.py
@@ -23,6 +23,7 @@ def _install():
     from .insert import df_insert
     from .loc import loc
     from .rename import df_rename, series_rename, index_rename
+    from .rename_axis import rename_axis
     from .reset_index import df_reset_index, series_reset_index
     from .set_index import set_index
     from .setitem import dataframe_setitem
@@ -36,6 +37,7 @@ def _install():
         setattr(cls, 'at', cache_readonly(at))
         setattr(cls, 'reindex', reindex)
         setattr(cls, 'head', head)
+        setattr(cls, 'rename_axis', rename_axis)
         setattr(cls, 'tail', tail)
         setattr(cls, 'mask', mask)
         setattr(cls, 'where', where)

--- a/mars/dataframe/indexing/__init__.py
+++ b/mars/dataframe/indexing/__init__.py
@@ -22,7 +22,7 @@ def _install():
     from .iloc import iloc, head, tail
     from .insert import df_insert
     from .loc import loc
-    from .rename import df_rename, series_rename, index_rename
+    from .rename import df_rename, series_rename, index_rename, index_set_names
     from .rename_axis import rename_axis
     from .reset_index import df_reset_index, series_reset_index
     from .set_index import set_index
@@ -57,6 +57,7 @@ def _install():
 
     for cls in INDEX_TYPE:
         setattr(cls, 'rename', index_rename)
+        setattr(cls, 'set_names', index_set_names)
 
     # make sure operand is registered
     from .set_label import DataFrameSetLabel

--- a/mars/dataframe/indexing/rename.py
+++ b/mars/dataframe/indexing/rename.py
@@ -468,12 +468,13 @@ def index_set_names(index, names, level=None, inplace=False):
     ret = op(index)
 
     if inplace:
-        index.data = ret.data
-
         df_or_series = getattr(index, '_get_df_or_series', lambda: None)()
         if df_or_series is not None:
             from .rename_axis import rename_axis_with_level
             rename_axis_with_level(df_or_series, names, axis=index._axis,
                                    level=level, inplace=True)
+            index.data = df_or_series.axes[index._axis].data
+        else:
+            index.data = ret.data
     else:
         return ret

--- a/mars/dataframe/indexing/rename_axis.py
+++ b/mars/dataframe/indexing/rename_axis.py
@@ -1,0 +1,225 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ... import opcodes
+from ...core import OutputType
+from ...serialize import AnyField, BoolField
+from ..core import DATAFRAME_TYPE
+from ..operands import DataFrameOperand, DataFrameOperandMixin
+from ..utils import validate_axis, parse_index, build_df, build_series
+
+
+class DataFrameRenameAxis(DataFrameOperand, DataFrameOperandMixin):
+    _op_type_ = opcodes.RENAME_AXIS
+
+    _index = AnyField('index')
+    _columns = AnyField('columns')
+    _copy_value = BoolField('copy_value')
+
+    def __init__(self, index=None, columns=None, copy_value=None, **kw):
+        super().__init__(_index=index, _columns=columns, _copy_value=copy_value, **kw)
+
+    @property
+    def index(self):
+        return self._index
+
+    @property
+    def columns(self):
+        return self._columns
+
+    @property
+    def copy_value(self):
+        return self._copy_value
+
+    @staticmethod
+    def _update_params(params, obj, mapper, axis):
+        if obj.ndim == 2:
+            test_obj = build_df(obj).rename_axis(mapper, axis=axis)
+        else:
+            test_obj = build_series(obj).rename_axis(mapper, axis=axis)
+
+        if axis == 0:
+            params['index_value'] = parse_index(test_obj.index, store_data=False)
+        else:
+            params['dtypes'] = test_obj.dtypes
+            params['columns_value'] = parse_index(test_obj.columns, store_data=True)
+
+    def __call__(self, df_or_series):
+        params = df_or_series.params
+
+        if isinstance(df_or_series, DATAFRAME_TYPE):
+            self._output_types = [OutputType.dataframe]
+        else:
+            self._output_types = [OutputType.series]
+
+        if self.index is not None:
+            self._update_params(params, df_or_series, self.index, axis=0)
+        else:
+            self._update_params(params, df_or_series, self.columns, axis=1)
+
+        return self.new_tileable([df_or_series], **params)
+
+    @classmethod
+    def tile(cls, op: 'DataFrameRenameAxis'):
+        in_obj = op.inputs[0]
+        out_obj = op.outputs[0]
+
+        chunks = []
+        idx_cache = dict()
+        for c in in_obj.chunks:
+            params = c.params
+            if op.index is not None:
+                try:
+                    params['index_value'] = idx_cache[c.index[0]]
+                except KeyError:
+                    cls._update_params(params, c, op.index, axis=0)
+                    idx_cache[c.index[0]] = params['index_value']
+            else:
+                try:
+                    params['columns_value'] = idx_cache[c.index[1]]
+                except KeyError:
+                    cls._update_params(params, c, op.columns, axis=1)
+                    idx_cache[c.index[1]] = params['columns_value']
+
+            new_op = op.copy().reset_key()
+            chunks.append(new_op.new_chunk([c], **params))
+
+        new_op = op.copy().reset_key()
+        return new_op.new_tileables([in_obj], chunks=chunks, nsplits=in_obj.nsplits,
+                                    **out_obj.params)
+
+    @classmethod
+    def execute(cls, ctx, op: 'DataFrameRenameAxis'):
+        in_data = ctx[op.inputs[0].key]
+        if op.index is not None:
+            ctx[op.outputs[0].key] = in_data.rename_axis(
+                index=op.index, copy=op.copy_value)
+        else:
+            ctx[op.outputs[0].key] = in_data.rename_axis(
+                columns=op.columns, copy=op.copy_value)
+
+
+def rename_axis(df_or_series, mapper=None, index=None, columns=None, axis=0,
+                copy=True, inplace=False):
+    """
+    Set the name of the axis for the index or columns.
+
+    Parameters
+    ----------
+    mapper : scalar, list-like, optional
+        Value to set the axis name attribute.
+    index, columns : scalar, list-like, dict-like or function, optional
+        A scalar, list-like, dict-like or functions transformations to
+        apply to that axis' values.
+        Note that the ``columns`` parameter is not allowed if the
+        object is a Series. This parameter only apply for DataFrame
+        type objects.
+
+        Use either ``mapper`` and ``axis`` to
+        specify the axis to target with ``mapper``, or ``index``
+        and/or ``columns``.
+
+    axis : {0 or 'index', 1 or 'columns'}, default 0
+        The axis to rename.
+    copy : bool, default True
+        Also copy underlying data.
+    inplace : bool, default False
+        Modifies the object directly, instead of creating a new Series
+        or DataFrame.
+
+    Returns
+    -------
+    Series, DataFrame, or None
+        The same type as the caller or None if `inplace` is True.
+
+    See Also
+    --------
+    Series.rename : Alter Series index labels or name.
+    DataFrame.rename : Alter DataFrame index labels or name.
+    Index.rename : Set new names on index.
+
+    Notes
+    -----
+    ``DataFrame.rename_axis`` supports two calling conventions
+
+    * ``(index=index_mapper, columns=columns_mapper, ...)``
+    * ``(mapper, axis={'index', 'columns'}, ...)``
+
+    The first calling convention will only modify the names of
+    the index and/or the names of the Index object that is the columns.
+    In this case, the parameter ``copy`` is ignored.
+
+    The second calling convention will modify the names of the
+    the corresponding index if mapper is a list or a scalar.
+    However, if mapper is dict-like or a function, it will use the
+    deprecated behavior of modifying the axis *labels*.
+
+    We *highly* recommend using keyword arguments to clarify your
+    intent.
+
+    Examples
+    --------
+    **Series**
+
+    >>> import mars.dataframe as md
+    >>> s = md.Series(["dog", "cat", "monkey"])
+    >>> s.execute()
+    0       dog
+    1       cat
+    2    monkey
+    dtype: object
+    >>> s.rename_axis("animal").execute()
+    animal
+    0    dog
+    1    cat
+    2    monkey
+    dtype: object
+
+    **DataFrame**
+
+    >>> df = md.DataFrame({"num_legs": [4, 4, 2],
+    ...                    "num_arms": [0, 0, 2]},
+    ...                   ["dog", "cat", "monkey"])
+    >>> df.execute()
+            num_legs  num_arms
+    dog            4         0
+    cat            4         0
+    monkey         2         2
+    >>> df = df.rename_axis("animal")
+    >>> df.execute()
+            num_legs  num_arms
+    animal
+    dog            4         0
+    cat            4         0
+    monkey         2         2
+    >>> df = df.rename_axis("limbs", axis="columns")
+    >>> df.execute()
+    limbs   num_legs  num_arms
+    animal
+    dog            4         0
+    cat            4         0
+    monkey         2         2
+    """
+    axis = validate_axis(axis, df_or_series)
+    if mapper is not None:
+        if axis == 0:
+            index = mapper
+        else:
+            columns = mapper
+    op = DataFrameRenameAxis(index=index, columns=columns, copy_value=copy)
+    result = op(df_or_series)
+    if not inplace:
+        return result
+    else:
+        df_or_series.data = result.data

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -813,6 +813,41 @@ class Test(TestBase):
         pd.testing.assert_index_equal(self.executor.execute_dataframe(r, concat=True)[0],
                                       raw.rename(['C', 'D']))
 
+    def testRenameAxis(self):
+        rs = np.random.RandomState(0)
+
+        # test dataframe cases
+        raw = pd.DataFrame(rs.rand(10, 4), columns=['A', 'B', 'C', 'D'])
+        df = md.DataFrame(raw, chunk_size=3)
+
+        r = df.rename_axis('idx')
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                      raw.rename_axis('idx'))
+
+        r = df.rename_axis('cols', axis=1)
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                      raw.rename_axis('cols', axis=1))
+
+        df.rename_axis('c', axis=1, inplace=True)
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(df, concat=True)[0],
+                                      raw.rename_axis('c', axis=1))
+
+        df.columns.name = 'df_cols'
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(df, concat=True)[0],
+                                      raw.rename_axis('df_cols', axis=1))
+
+        # test series cases
+        raw = pd.Series(rs.rand(10))
+        s = md.Series(raw, chunk_size=3)
+
+        r = s.rename_axis('idx')
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                       raw.rename_axis('idx'))
+
+        s.index.name = 'series_idx'
+        pd.testing.assert_series_equal(self.executor.execute_dataframe(s, concat=True)[0],
+                                       raw.rename_axis('series_idx'))
+
     def testInsert(self):
         rs = np.random.RandomState(0)
         raw = pd.DataFrame(rs.rand(10, 4), columns=['A', 'B', 'C', 'D'])

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -813,6 +813,10 @@ class Test(TestBase):
         pd.testing.assert_index_equal(self.executor.execute_dataframe(r, concat=True)[0],
                                       raw.rename(['C', 'D']))
 
+        r = idx.set_names('C', level=0)
+        pd.testing.assert_index_equal(self.executor.execute_dataframe(r, concat=True)[0],
+                                      raw.set_names('C', level=0))
+
     def testRenameAxis(self):
         rs = np.random.RandomState(0)
 
@@ -835,6 +839,19 @@ class Test(TestBase):
         df.columns.name = 'df_cols'
         pd.testing.assert_frame_equal(self.executor.execute_dataframe(df, concat=True)[0],
                                       raw.rename_axis('df_cols', axis=1))
+
+        # test dataframe cases with MultiIndex
+        raw = pd.DataFrame(
+            rs.rand(10, 4), columns=pd.MultiIndex.from_tuples([('A', 1), ('B', 2), ('C', 3), ('D', 4)]))
+        df = md.DataFrame(raw, chunk_size=3)
+
+        df.columns.names = ['c1', 'c2']
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(df, concat=True)[0],
+                                      raw.rename_axis(['c1', 'c2'], axis=1))
+
+        df.columns.set_names('c2_1', level=1, inplace=True)
+        pd.testing.assert_frame_equal(self.executor.execute_dataframe(df, concat=True)[0],
+                                      raw.rename_axis(['c1', 'c2_1'], axis=1))
 
         # test series cases
         raw = pd.Series(rs.rand(10))

--- a/mars/serialize/protos/operand.proto
+++ b/mars/serialize/protos/operand.proto
@@ -374,6 +374,7 @@ message OperandDef {
         CARTESIAN_CHUNK = 734;
         EXPLODE = 735;
         REPLACE = 736;
+        RENAME_AXIS = 737;
 
         FUSE = 801;
 

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -618,7 +618,7 @@ class Test(unittest.TestCase):
         self.assertIn('Categorical', str(c))
         self.assertEqual(repr(c.execute()), repr(pd.qcut(range(5), 3)))
 
-    def testDataFrameIter(self):
+    def testIter(self):
         raw_data = pd.DataFrame(np.random.randint(1000, size=(20, 10)))
         df = md.DataFrame(raw_data, chunk_size=5)
 
@@ -641,6 +641,21 @@ class Test(unittest.TestCase):
         for result_tup, expect_tup in zip(df.itertuples(batch_size=10),
                                           raw_data.itertuples()):
             self.assertEqual(result_tup, expect_tup)
+            i += 1
+
+        self.assertEqual(i, len(raw_data))
+
+        raw_data = pd.Series(np.random.randint(1000, size=(20,)))
+        s = md.Series(raw_data, chunk_size=5)
+
+        for i, batch in enumerate(s.iterbatch(batch_size=15)):
+            pd.testing.assert_series_equal(batch, raw_data.iloc[i * 15: (i + 1) * 15])
+
+        i = 0
+        for result_item, expect_item in zip(s.iteritems(batch_size=15),
+                                            raw_data.iteritems()):
+            self.assertEqual(result_item[0], expect_item[0])
+            self.assertEqual(result_item[1], expect_item[1])
             i += 1
 
         self.assertEqual(i, len(raw_data))


### PR DESCRIPTION
## What do these changes do?

Implements `{DataFrame,Series}.rename_axis`. Also allows setting names of columns or indexes.

## Related issue number

Fixes #1665 
Part of #1840 is done (iteritems() and items() on series)