### PR TITLE
Support unknown shape for mt.reshape, mt.histogram and md.DataFrame

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,22 +1,23 @@
 # Each line is a component followed by one or more owners.
 
-*                        @qinxuye
-README.rst               @qinxuye
+*                        @qinxuye @wjsi @hekaisheng
 /.github                 @wjsi
 /bin                     @wjsi
 /docs                    @qinxuye @hekaisheng @wjsi
-/mars/                   @qinxuye
-/mars/actors             @qinxuye
-/mars/dataframe          @hekaisheng
-/mars/deploy             @wjsi
-/mars/learn              @qinxuye
-/mars/lib                @wjsi
-/mars/optimizes          @hekaisheng
-/mars/ray                @hekaisheng
-/mars/remote             @qinxuye
+/mars/                   @qinxuye @hekaisheng @wjsi
+/mars/tests              @qinxuye @hekaisheng @wjsi
+/mars/actors             @qinxuye @hekaisheng @wjsi
+/mars/dataframe          @hekaisheng @qinxuye @wjsi
+/mars/deploy             @wjsi @hekaisheng
+/mars/learn              @qinxuye @hekaisheng
+/mars/lib                @wjsi @qinxuye
+/mars/optimizes          @hekaisheng @qinxuye
+/mars/ray                @hekaisheng @qinxuye
+/mars/remote             @qinxuye @wjsi @hekaisheng
 /mars/scheduler          @wjsi
 /mars/serialize          @qinxuye @wjsi
-/mars/tensor             @hekaisheng
-/mars/tests              @wjsi @qinxuye
+/mars/serialize/protos   @qinxuye @wjsi @hekaisheng
+/mars/tensor             @hekaisheng @qinxuye @wjsi
+/mars/tests              @wjsi @qinxuye @qinxuye
 /mars/web                @wjsi @hekaisheng
 /mars/worker             @wjsi

--- a/mars/dataframe/base/cartesian_chunk.py
+++ b/mars/dataframe/base/cartesian_chunk.py
@@ -155,6 +155,7 @@ class DataFrameCartesianChunk(DataFrameOperand, DataFrameOperandMixin):
                                                    shape=shape,
                                                    index_value=index_value,
                                                    columns_value=out.columns_value,
+                                                   dtypes=out.dtypes,
                                                    index=(i, 0))
                     out_chunks.append(out_chunk)
                     nsplits[0].append(out_chunk.shape[0])
@@ -166,6 +167,7 @@ class DataFrameCartesianChunk(DataFrameOperand, DataFrameOperandMixin):
                     out_chunk = chunk_op.new_chunk([left_chunk, right_chunk],
                                                    shape=shape,
                                                    index_value=index_value,
+                                                   dtype=out.dtype,
                                                    name=out.name,
                                                    index=(i,))
                     out_chunks.append(out_chunk)

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -212,10 +212,10 @@ class Test(TestBase):
             # test from tensor with unknown shape
             tensor2 = tensor[tensor[:, 0] < 0.9]
             df = dataframe_from_tensor(tensor2)
+            df_result = self.executor.execute_dataframes([df])[0]
             tensor_res = self.executor.execute_tensors([tensor2])[0]
             pdf_expected = pd.DataFrame(tensor_res)
-            df_result = self.executor.execute_dataframes([df])[0]
-            pd.testing.assert_frame_equal(df_result, pdf_expected)
+            pd.testing.assert_frame_equal(df_result.reset_index(drop=True), pdf_expected)
 
         # test converted with specified index_value and columns
         tensor2 = mt.random.rand(2, 2, chunk_size=1)

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -208,6 +208,15 @@ class Test(TestBase):
         pd.testing.assert_index_equal(df_result.columns, pd.RangeIndex(0, 10))
         pd.testing.assert_frame_equal(df_result, pdf_expected)
 
+        with self.ctx:
+            # test from tensor with unknown shape
+            tensor2 = tensor[tensor[:, 0] < 0.9]
+            df = dataframe_from_tensor(tensor2)
+            tensor_res = self.executor.execute_tensors([tensor2])[0]
+            pdf_expected = pd.DataFrame(tensor_res)
+            df_result = self.executor.execute_dataframes([df])[0]
+            pd.testing.assert_frame_equal(df_result, pdf_expected)
+
         # test converted with specified index_value and columns
         tensor2 = mt.random.rand(2, 2, chunk_size=1)
         df2 = dataframe_from_tensor(tensor2, index=pd.Index(['a', 'b']), columns=pd.Index([3, 4]))

--- a/mars/ray/tests/test_ray_execution.py
+++ b/mars/ray/tests/test_ray_execution.py
@@ -24,6 +24,7 @@ import pandas as pd
 import mars.tensor as mt
 import mars.dataframe as md
 from mars.session import new_session
+from mars.tests.core import flaky
 from mars.utils import lazy_import
 
 ray_installed = lazy_import('ray', globals=globals()) is not None
@@ -82,6 +83,7 @@ class Test(unittest.TestCase):
         for c1, c2 in zip(op.outputs, new_op.outputs):
             self.assertEqual(c1.key, c2.key)
 
+    @flaky(max_runs=3)
     def testRayClusterMode(self):
         with new_session(backend='ray', _load_code_from_local=True).as_default():
             t = mt.random.RandomState(0).rand(100, 4, chunk_size=30)

--- a/mars/tensor/reshape/tests/test_reshape.py
+++ b/mars/tensor/reshape/tests/test_reshape.py
@@ -16,6 +16,8 @@
 
 import unittest
 
+import numpy as np
+
 from mars.operands import OperandStage
 from mars.tensor.datasource import ones
 from mars.tensor.reshape.reshape import TensorReshape
@@ -43,6 +45,15 @@ class Test(unittest.TestCase):
         a = a.tiles()
 
         self.assertEqual(tuple(sum(s) for s in a.nsplits), (10, 30, 20))
+
+        # test reshape unknown shape
+        c = a[a > 0]
+        d = c.reshape(10, 600)
+        self.assertEqual(d.shape, (10, 600))
+        d = c.reshape(-1, 10)
+        self.assertEqual(len(d.shape), 2)
+        self.assertTrue(np.isnan(d.shape[0]))
+        self.assertTrue(d.shape[1], 10)
 
         with self.assertRaises(TypeError):
             a.reshape((10, 30, 20), other_argument=True)

--- a/mars/tensor/statistics/histogram.py
+++ b/mars/tensor/statistics/histogram.py
@@ -503,7 +503,7 @@ class TensorHistogramBinEdges(TensorOperand, TensorOperandMixin):
             inputs.append(bins)
         if weights is not None:
             inputs.append(weights)
-        if a.size > 0 and \
+        if (a.size > 0 or np.isnan(a.size)) and \
                 (isinstance(bins, str) or mt.ndim(bins) == 0) and not range:
             # for bins that is str or integer,
             # requires min max calculated first

--- a/mars/tensor/statistics/tests/test_statistics_execute.py
+++ b/mars/tensor/statistics/tests/test_statistics_execute.py
@@ -251,6 +251,15 @@ class Test(TestBase):
                         expected = np.histogram(r, bins=[0, 4, 8], density=density)[0]
                         np.testing.assert_array_equal(result, expected)
 
+            # test unknown shape
+            raw4 = rs.rand(10)
+            d = tensor(raw4, chunk_size=3)
+            d = d[d < 0.9]
+            hist = histogram(d)
+            result = executor.execute_tensors(hist)[0]
+            expected = np.histogram(raw4[raw4 < 0.9])[0]
+            np.testing.assert_array_equal(result, expected)
+
     def testQuantileExecution(self):
         # test 1 chunk, 1-d
         raw = np.random.rand(20)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR added support for mt.reshape, mt.histogram and md.DataFrame when input tileable has unknown shape.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1868 
Fixes #1843 
