### PR TITLE
[BACKPORT] Fix wrongly raised error: Tileable object must be executed first before being fetched (#1872)

### DIFF
--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -445,12 +445,20 @@ class _BatchedFetcher:
         return self._iter(batch_size=batch_size, session=session)
 
     def fetch(self, session=None, **kw):
+        from .indexing.iloc import DataFrameIlocGetItem, SeriesIlocGetItem
+
         batch_size = kw.pop('batch_size', 1000)
         if len(kw) > 0:  # pragma: no cover
             raise TypeError(
                 f"'{next(iter(kw))}' is an invalid keyword argument for this function")
-        batches = list(self._iter(batch_size=batch_size, session=session))
-        return pd.concat(batches) if len(batches) > 1 else batches[0]
+
+        if isinstance(self.op, (DataFrameIlocGetItem, SeriesIlocGetItem)):
+            # see GH#1871
+            # already iloc, do not trigger batch fetch
+            return self._fetch(session=session, **kw)
+        else:
+            batches = list(self._iter(batch_size=batch_size, session=session))
+            return pd.concat(batches) if len(batches) > 1 else batches[0]
 
 
 class IndexData(HasShapeTileableData, _ToPandasMixin):

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -500,6 +500,13 @@ class Test(unittest.TestCase):
         r4 = sess.fetch(df1.iloc[0, 2])
         self.assertEqual(r4, r1.iloc[0, 2])
 
+        arr2 = mt.random.rand(10, 3, chunk_size=3)
+        df2 = md.DataFrame(arr2)
+        r5 = sess.run(df2)
+
+        r6 = df2.iloc[:4].fetch(batch_size=3, session=sess)
+        pd.testing.assert_frame_equal(r5.iloc[:4], r6)
+
     def testMultiOutputsOp(self):
         sess = new_session()
 


### PR DESCRIPTION
Backport of #1872 