### PR TITLE
Fix stuck of threaded actor operations in gevent==20.12.0

### DIFF
--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -5,6 +5,6 @@ pyarrow>=0.11.0,!=0.16.*
 psutil>=4.0.0
 lz4>=1.0.0
 protobuf>=3.6
-gevent>=1.2.0,<20.12.0
+gevent>=1.2.0
 bokeh>=1.0.0
 jinja2>=2.0


### PR DESCRIPTION
## What do these changes do?

Use cross-thread semaphores (gevent>20.5.1 required) to resolve stuck of threaded actor operations in gevent==20.12.0.

## Related issue number

Fixes #1816