### PR TITLE
Allow internal serialization to use JSON

### DIFF
--- a/mars/config.py
+++ b/mars/config.py
@@ -314,6 +314,7 @@ default_options.register_option('tcp_timeout', 30, validator=is_integer)
 default_options.register_option('verbose', False, validator=is_bool)
 default_options.register_option('kv_store', ':inproc:', validator=is_string)
 default_options.register_option('check_interval', 20, validator=is_integer)
+default_options.register_option('serialize_method', 'json')
 
 # dataframe-related options
 default_options.register_option('dataframe.mode.use_inf_as_na', False, validator=is_bool)

--- a/mars/scheduler/tests/test_graph.py
+++ b/mars/scheduler/tests/test_graph.py
@@ -221,7 +221,7 @@ class Test(unittest.TestCase):
             graph_key = str(uuid.uuid4())
             expr = mt.random.random((8, 2), chunk_size=2) + 1
             graph = expr.build_graph(compose=False)
-            serialized_graph = serialize_graph(graph)
+            serialized_graph = serialize_graph(graph, serialize_method='pb')
 
             graph_ref = pool.create_actor(GraphActor, session_id, graph_key, serialized_graph,
                                           uid=GraphActor.gen_uid(session_id, graph_key))

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -278,9 +278,15 @@ def lazy_import(name, package=None, globals=None, locals=None, rename=None):
         return None
 
 
-def serialize_graph(graph, compress=False, data_serial_type=None, pickle_protocol=None):
-    ser_graph = graph.to_pb(data_serial_type=data_serial_type,
-                            pickle_protocol=pickle_protocol).SerializeToString()
+def serialize_graph(graph, compress=False, data_serial_type=None, pickle_protocol=None,
+                    serialize_method=None):
+    serialize_method = serialize_method or options.serialize_method
+    if serialize_method == 'json':
+        ser_graph = json.dumps(graph.to_json(data_serial_type=data_serial_type,
+                                             pickle_protocol=pickle_protocol))
+    else:
+        ser_graph = graph.to_pb(data_serial_type=data_serial_type,
+                                pickle_protocol=pickle_protocol).SerializeToString()
     if compress:
         ser_graph = zlib.compress(ser_graph)
     return ser_graph

--- a/mars/worker/execution.py
+++ b/mars/worker/execution.py
@@ -354,8 +354,7 @@ class ExecutionActor(WorkerActor):
                     return
 
                 raise exc[1].with_traceback(exc[2])
-            except (BrokenPipeError, ConnectionRefusedError, TimeoutError,
-                    WorkerDead, promise.PromiseTimeout):
+            except (BrokenPipeError, ConnectionRefusedError, WorkerDead):
                 self._resource_ref.detach_dead_workers([remote_addr], _tell=True, _wait=False)
                 raise DependencyMissing((session_id, chunk_key))
 


### PR DESCRIPTION
## What do these changes do?

As it is quite slow to construct protobuf objects in Python due to type checks, we change serialization method into JSON and make serialization methods configurable.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
