### PR TITLE
Fix sorting string columns with None value & sorting with empty chunks

### DIFF
--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -474,9 +474,9 @@ class IndexData(HasShapeTileableData, _ToPandasMixin):
                         on_deserialize=lambda x: [IndexChunk(it) for it in x] if x is not None else x)
 
     def __init__(self, op=None, shape=None, nsplits=None, dtype=None,
-                 name=None, index_value=None, chunks=None, **kw):
+                 name=None, names=None, index_value=None, chunks=None, **kw):
         super().__init__(_op=op, _shape=shape, _nsplits=nsplits, _dtype=dtype, _name=name,
-                         _index_value=index_value, _chunks=chunks, **kw)
+                         _names=names, _index_value=index_value, _chunks=chunks, **kw)
 
     @classmethod
     def cls(cls, provider):

--- a/mars/dataframe/datasource/index.py
+++ b/mars/dataframe/datasource/index.py
@@ -64,9 +64,10 @@ class IndexDataSource(DataFrameOperand, DataFrameOperandMixin):
         if inp is None:
             # create from pandas Index
             name = name if name is not None else self._data.name
+            names = names if names is not None else self._data.names
             return self.new_index(None, shape=shape, dtype=self._dtype,
                                   index_value=parse_index(self._data),
-                                  name=name, raw_chunk_size=chunk_size)
+                                  name=name, names=names, raw_chunk_size=chunk_size)
         elif hasattr(inp, 'index_value'):
             # get index from Mars DataFrame, Series or Index
             name = name if name is not None else inp.index_value.name
@@ -92,7 +93,7 @@ class IndexDataSource(DataFrameOperand, DataFrameOperandMixin):
                 self._dtype = pd_index.dtype
             return self.new_index([inp], shape=inp.shape, dtype=self._dtype,
                                   index_value=parse_index(pd_index, inp),
-                                  name=name)
+                                  name=name, names=names)
 
     @classmethod
     def _tile_from_pandas(cls, op):
@@ -210,7 +211,7 @@ def from_pandas(data, chunk_size=None, gpu=False, sparse=False):
     return op(shape=data.shape, chunk_size=chunk_size)
 
 
-def from_tileable(tileable, dtype=None, name=None):
+def from_tileable(tileable, dtype=None, name=None, names=None):
     op = IndexDataSource(gpu=tileable.op.gpu, sparse=tileable.issparse(),
                          dtype=dtype)
-    return op(inp=tileable, name=name)
+    return op(inp=tileable, name=name, names=names)

--- a/mars/dataframe/initializer.py
+++ b/mars/dataframe/initializer.py
@@ -137,7 +137,7 @@ class Index(_Index, metaclass=InitializerMeta):
         else:
             if isinstance(data, (Base, Entity)):
                 name = name if name is not None else getattr(data, 'name', None)
-                index = from_tileable_index(data, dtype=dtype, name=name)
+                index = from_tileable_index(data, dtype=dtype, name=name, names=names)
                 need_repart = num_partitions is not None
             else:
                 if not isinstance(data, pd.Index):

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -33,6 +33,21 @@ cudf = lazy_import('cudf', globals=globals())
 _PSRS_DISTINCT_COL = '__PSRS_TMP_DISTINCT_COL'
 
 
+class _Largest:
+    """
+    This util class resolve TypeError when
+    comparing strings with None values
+    """
+    def __lt__(self, other):
+        return False
+
+    def __gt__(self, other):
+        return self is not other
+
+
+_largest = _Largest()
+
+
 class DataFramePSRSOperandMixin(DataFrameOperandMixin, PSRSOperandMixin):
     @classmethod
     def _collect_op_properties(cls, op):
@@ -333,6 +348,11 @@ class DataFramePSRSSortRegularSample(DataFramePSRSChunkOperand, DataFrameOperand
         a = ctx[op.inputs[0].key]
         xdf = pd if isinstance(a, (pd.DataFrame, pd.Series)) else cudf
 
+        if len(a) == 0:
+            # when chunk is empty, return the empty chunk itself
+            ctx[op.outputs[0].key] = ctx[op.outputs[-1].key] = a
+            return
+
         if op.sort_type == 'sort_values':
             ctx[op.outputs[0].key] = res = execute_sort_values(a, op)
         else:
@@ -380,15 +400,20 @@ class DataFramePSRSConcatPivot(DataFramePSRSChunkOperand, DataFrameOperandMixin)
 
     @classmethod
     def execute(cls, ctx, op):
-        inputs = [ctx[c.key] for c in op.inputs]
+        inputs = [ctx[c.key] for c in op.inputs if len(ctx[c.key]) > 0]
+        if len(inputs) == 0:
+            # corner case: nothing sampled, we need to do nothing
+            ctx[op.outputs[-1].key] = ctx[op.inputs[0].key]
+            return
+
         xdf = pd if isinstance(inputs[0], (pd.DataFrame, pd.Series)) else cudf
 
         a = xdf.concat(inputs, axis=op.axis)
         p = len(inputs)
-        assert a.shape[op.axis] == p ** 2
+        assert a.shape[op.axis] == p * len(op.inputs)
 
         slc = np.linspace(p - 1, a.shape[op.axis] - 1,
-                          num=p - 1, endpoint=False).astype(int)
+                          num=len(op.inputs) - 1, endpoint=False).astype(int)
         if op.axis == 1:
             slc = (slice(None), slc)
         if op.sort_type == 'sort_values':
@@ -471,10 +496,27 @@ class DataFramePSRSShuffle(DataFrameMapReduceOperand, DataFrameOperandMixin):
     def output_limit(self):
         return 1
 
+    @staticmethod
+    def _calc_poses(src_cols, pivots, ascending=True):
+        records = src_cols.to_records(index=False)
+        p_records = pivots.to_records(index=False)
+        if ascending:
+            poses = records.searchsorted(p_records, side='right')
+        else:
+            poses = len(records) - records[::-1].searchsorted(p_records, side='right')
+        del records, p_records
+        return poses
+
     @classmethod
     def _execute_dataframe_map(cls, ctx, op):
         a, pivots = [ctx[c.key] for c in op.inputs]
         out = op.outputs[0]
+
+        if len(a) == 0:
+            # when the chunk is empty, no slices can be produced
+            for i in range(op.n_partition):
+                ctx[(out.key, str(i))] = a
+            return
 
         # use numpy.searchsorted to find split positions.
         by = op.by
@@ -484,13 +526,11 @@ class DataFramePSRSShuffle(DataFrameMapReduceOperand, DataFrameOperandMixin):
         if distinct_col in a.columns:
             by = list(by) + [distinct_col]
 
-        records = a[by].to_records(index=False)
-        p_records = pivots.to_records(index=False)
-        if op.ascending:
-            poses = records.searchsorted(p_records, side='right')
-        else:
-            poses = len(records) - records[::-1].searchsorted(p_records, side='right')
-        del records, p_records
+        try:
+            poses = cls._calc_poses(a[by], pivots, op.ascending)
+        except TypeError:
+            poses = cls._calc_poses(
+                a[by].fillna(_largest), pivots.fillna(_largest), op.ascending)
 
         poses = (None,) + tuple(poses) + (None,)
         for i in range(op.n_partition):

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -135,20 +135,20 @@ class Test(unittest.TestCase):
             pd.testing.assert_frame_equal(result, expected)
 
             # test None (issue #1885)
-            df = pd.DataFrame({
-                'col1': ['C', 'C', None, 'B', 'D', 'A'],
-                'col2': [2, 1, 9, np.nan, 7, 4],
-                'col3': [0, 1, 9, 4, 2, 3],
-            })
+            df = pd.DataFrame(np.random.rand(1000, 10))
+
+            df[0][df[0] < 0.5] = 'A'
+            df[0][df[0] != 'A'] = None
+
             mdf = DataFrame(df)
-            result = self.executor.execute_dataframe(mdf.sort_values(['col1']), concat=True)[0]
-            expected = df.sort_values(['col1'])
+            result = self.executor.execute_dataframe(mdf.sort_values([0, 1]), concat=True)[0]
+            expected = df.sort_values([0, 1])
 
             pd.testing.assert_frame_equal(result, expected)
 
-            mdf = DataFrame(df, chunk_size=3)
-            result = self.executor.execute_dataframe(mdf.sort_values(['col1']), concat=True)[0]
-            expected = df.sort_values(['col1'])
+            mdf = DataFrame(df, chunk_size=100)
+            result = self.executor.execute_dataframe(mdf.sort_values([0, 1]), concat=True)[0]
+            expected = df.sort_values([0, 1])
 
             pd.testing.assert_frame_equal(result, expected)
 

--- a/mars/tensor/base/tests/test_base_execute.py
+++ b/mars/tensor/base/tests/test_base_execute.py
@@ -1184,6 +1184,7 @@ class Test(TestBase):
         res = self.executor.execute_tensor(sx, concat=True)[0]
         np.testing.assert_array_equal(res, np.sort(raw, axis=0, order=['size', 'id']))
 
+        # test inplace sort
         raw = np.random.rand(10, 12)
         a = tensor(raw, chunk_size=(5, 4))
         a.sort(axis=1)


### PR DESCRIPTION
## What do these changes do?

This PR fixes two issues:

1. Fixes sorting string columns with None values with a largest object to make None comparable with strings.
2. Fixes sorting when there are empty chunks in data sources.

Similar bugs may exist in tensor sort and this PR does not fix them.

## Related issue number

Fixes #1885
Fixes #1890