### PR TITLE
To vineyard: avoid copy when chunks are already in vineyard (vineyard is the backend).

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -91,13 +91,8 @@ jobs:
         run: |
           source ./.github/workflows/reload-env.sh
 
-          # pull vineyard image
-          echo "${{ github.token }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
-          sudo docker pull docker.pkg.github.com/alibaba/libvineyard/vineyardd:nightly
-
           # launch vineyardd
-          sudo docker run --rm -d --name vineyard --shm-size=3072m -v /tmp/vineyard:/var/run \
-              docker.pkg.github.com/alibaba/libvineyard/vineyardd:nightly
+          sudo docker run --rm -d --name vineyard --shm-size=3072m -v /tmp/vineyard:/var/run libvineyard/vineyardd:v0.1.6
 
           until [ -S /tmp/vineyard/vineyard.sock ]
           do

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -61,8 +61,8 @@ jobs:
               conda install -n test --quiet --yes -c conda-forge python=$PYTHON skein conda-pack
             fi
             if [ -n "$WITH_VINEYARD" ]; then
-              pip install https://github.com/alibaba/libvineyard/releases/download/latest/vineyard-0.1.5-cp38-cp38-manylinux2010_x86_64.whl
-              sudo docker pull libvineyard/vineyardd:latest
+              pip install vineyard==0.1.6
+              sudo docker pull libvineyard/vineyardd:v0.1.6
             fi
             if [ -n "$WITH_RAY" ]; then
               pip install ray

--- a/mars/config.py
+++ b/mars/config.py
@@ -415,7 +415,7 @@ default_options.register_option('client.serial_type', 'arrow', validator=is_stri
 default_options.register_option('custom_log_dir', None, validator=any_validator(is_null, is_string))
 
 # vineyard
-default_options.register_option('vineyard.socket', None)
+default_options.register_option('vineyard.socket', os.environ.get('VINEYARD_IPC_SOCKET', None))
 default_options.register_option('vineyard.enabled', os.environ.get('WITH_VINEYARD', None) is not None)
 
 _options_local = threading.local()

--- a/mars/context.py
+++ b/mars/context.py
@@ -316,7 +316,9 @@ class LocalContext(ContextBase, dict):
 class DistributedContext(ContextBase):
     def __init__(self, scheduler_address, session_id, actor_ctx=None,
                  is_distributed=None, resource_ref=None, **kw):
+        from .config import options
         from .worker.api import WorkerAPI
+        from .worker.storage.vineyardhandler import VineyardKeyMapActor
         from .scheduler.custom_log import CustomLogMetaActor
         from .scheduler.resource import ResourceActor
         from .scheduler.utils import SchedulerClusterInfoActor
@@ -350,6 +352,12 @@ class DistributedContext(ContextBase):
 
         self._address = kw.pop('address', None)
         self._extra_info = kw
+
+        if options.vineyard.enabled:
+            self._keymapper_ref = self._actor_ctx.actor_ref(
+                    VineyardKeyMapActor.default_uid(), address=self._address)
+        else:
+            self._keymapper_ref = None
 
     @property
     def meta_api(self):

--- a/mars/context.py
+++ b/mars/context.py
@@ -591,12 +591,10 @@ class DistributedContext(ContextBase):
         from .config import options
         from .worker.storage.vineyardhandler import VineyardKeyMapActor
 
-        if options.vineyard.enabled:
-            print('key mapper start: ', chunk_key)
+        if options.vineyard.enabled and self.running_mode != RunningMode.local:
             addr = self._cluster_info.get_scheduler((self._session_id, chunk_key))
             obj_id = self._actor_ctx.actor_ref(VineyardKeyMapActor.default_uid(), address=addr) \
                 .get(self._session_id, chunk_key)
-            print('key mapper returns: ', obj_id)
             return obj_id
         else:
             return None

--- a/mars/dataframe/datastore/to_vineyard.py
+++ b/mars/dataframe/datastore/to_vineyard.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...config import options
-from ...context import RunningMode
+from ...context import RunningMode, get_context
 from ...core import OutputType
 from ...serialize import TupleField, StringField
 from ...tiles import TilesError
@@ -35,8 +35,12 @@ class DataFrameToVineyardChunk(DataFrameOperand, DataFrameOperandMixin):
     # vineyard ipc socket
     _vineyard_socket = StringField('vineyard_socket')
 
+    # vineyard object id
+    _vineyard_object_id = StringField('vineyard_object_id')
+
     def __init__(self, vineyard_socket=None, dtypes=None, **kw):
-        super().__init__(_vineyard_socket=vineyard_socket, _dtypes=dtypes, _output_types=[OutputType.dataframe], **kw)
+        super().__init__(_vineyard_socket=vineyard_socket, _dtypes=dtypes,
+                         _output_types=[OutputType.dataframe], **kw)
 
     def __call__(self, df):
         return self.new_dataframe([df], shape=(0, 0), dtypes=df.dtypes,
@@ -45,6 +49,10 @@ class DataFrameToVineyardChunk(DataFrameOperand, DataFrameOperandMixin):
     @property
     def vineyard_socket(self):
         return self._vineyard_socket
+
+    @property
+    def vineyard_object_id(self):
+        return self._vineyard_object_id
 
     @classmethod
     def _get_out_chunk(cls, op, in_chunk):
@@ -70,9 +78,13 @@ class DataFrameToVineyardChunk(DataFrameOperand, DataFrameOperandMixin):
 
         in_df = op.inputs[0]
 
+        ctx = get_context()
+
         out_chunks = []
         for chunk in in_df.chunks:
             chunk_op = op.copy().reset_key()
+            if options.vineyard.enabled and ctx.running_mode != RunningMode.local:
+                chunk_op._vineyard_object_id = repr(ctx.get_vineyard_object_id(chunk.key))
             chunk = chunk_op.new_chunk([chunk], shape=chunk.shape, dtypes=chunk.dtypes,
                                        index_value=chunk.index_value,
                                        columns_value=chunk.columns_value,
@@ -105,9 +117,10 @@ class DataFrameToVineyardChunk(DataFrameOperand, DataFrameOperandMixin):
 
         if options.vineyard.enabled and ctx.running_mode != RunningMode.local:
             # the chunk already exists in vineyard
-            df_id = ctx._keymapper_ref.get(ctx._session_id, op.inputs[0].key)
+            df_id = vineyard.ObjectID(op.vineyard_object_id)
         else:
             df_id = client.put(ctx[op.inputs[0].key], partition_index=op.inputs[0].index)
+
         client.persist(df_id)
 
         # store the result object id to execution context

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -1317,3 +1317,30 @@ class VineyardEnabledTest(IntegrationTestBase, Test):
     @unittest.skip("FIXME: KeyError: 'Cannot find serializable class for type_id 1376787404'")
     def testTileContextInLocalCluster(self, *_):
         pass
+
+    def testTensorToVineyard(self, *_):
+        from mars.tensor.datastore.to_vineyard import tovineyard
+
+        with self.new_cluster(scheduler_n_process=2, worker_n_process=2,
+                              shared_memory='20M', web=True) as cluster:
+            session = cluster.session
+
+            a1 = mt.ones((10, 20), chunk_size=8) + 1
+            session.run(a1, timeout=_exec_timeout)
+
+            # test if `to_vineyard` works with vineyard as backend
+            session.run(tovineyard(a1))
+
+    def testDataFrameToVineyard(self, *_):
+        from mars.dataframe.datastore.to_vineyard import to_vineyard
+
+        with self.new_cluster(scheduler_n_process=2, worker_n_process=2,
+                              shared_memory='20M', web=True) as cluster:
+            session = cluster.session
+            a = mt.random.rand(10, 10, chunk_size=3)
+            df = md.DataFrame(a)
+
+            session.run(df)
+
+            # test if `to_vineyard` works with vineyard as backend
+            session.run(to_vineyard(df))

--- a/mars/tensor/datastore/to_vineyard.py
+++ b/mars/tensor/datastore/to_vineyard.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...config import options
-from ...context import RunningMode
+from ...context import RunningMode, get_context
 from ...serialize import TupleField, KeyField, StringField
 from ...tiles import TilesError
 from ...utils import check_chunks_unknown_shape
@@ -44,12 +44,19 @@ class TensorVineyardDataStoreChunk(TensorDataStore):
     # vineyard ipc socket
     _vineyard_socket = StringField('vineyard_socket')
 
+    # vineyard object id
+    _vineyard_object_id = StringField('vineyard_object_id')
+
     def __init__(self, vineyard_socket=None, dtype=None, sparse=None, **kw):
         super().__init__(_vineyard_socket=vineyard_socket, _dtype=dtype, _sparse=sparse, **kw)
 
     @property
     def vineyard_socket(self):
         return self._vineyard_socket
+
+    @property
+    def vineyard_object_id(self):
+        return self._vineyard_object_id
 
     @classmethod
     def _get_out_chunk(cls, op, in_chunk):
@@ -72,10 +79,20 @@ class TensorVineyardDataStoreChunk(TensorDataStore):
         # Not truely necessary, but putting a barrier here will make things simple
         check_chunks_unknown_shape(op.inputs, TilesError)
 
-        out = super().tile(op)[0]
+        ctx = get_context()
+
+        out_chunks = []
+        for chunk in op.inputs[0].chunks:
+            chunk_op = op.copy().reset_key()
+            if options.vineyard.enabled and ctx.running_mode != RunningMode.local:
+                chunk_op._vineyard_object_id = repr(ctx.get_vineyard_object_id(chunk.key))
+            out_chunk = chunk_op.new_chunk([chunk], dtype=chunk.dtype, shape=chunk.shape,
+                                           index=chunk.index)
+            out_chunks.append(out_chunk)
+
         new_op = op.copy().reset_key()
-        return new_op.new_tensors(out.inputs, shape=op.input.shape, dtype=out.dtype,
-                                  chunks=out.chunks, nsplits=((np.prod(op.input.chunk_shape),),))
+        return new_op.new_tensors(op.inputs, shape=op.input.shape, dtype=op.input.dtype,
+                                  chunks=out_chunks, nsplits=((np.prod(op.input.chunk_shape),),))
 
     @classmethod
     def execute(cls, ctx, op):
@@ -88,14 +105,14 @@ class TensorVineyardDataStoreChunk(TensorDataStore):
 
         if options.vineyard.enabled and ctx.running_mode != RunningMode.local:
             # the chunk already exists in vineyard
-            tensor_id = ctx._keymapper_ref.get(ctx._session_id, op.inputs[0].key)
+            tensor_id = vineyard.ObjectID(op.vineyard_object_id)
         else:
             tensor_id = client.put(ctx[op.inputs[0].key], numpy_ndarray_builder, partition_index=op.input.index)
 
         client.persist(tensor_id)
 
         # store the result object id to execution context
-        ctx[op.outputs[0].key] = (client.instance_id, repr(tensor_id))
+        ctx[op.outputs[0].key] = np.array([client.instance_id, repr(tensor_id)], dtype=object)
 
 
 class TensorVineyardDataStoreGlobalMeta(TensorDataStore):

--- a/mars/worker/storage/vineyardhandler.py
+++ b/mars/worker/storage/vineyardhandler.py
@@ -281,6 +281,7 @@ class VineyardHandler(StorageHandler, ObjectStorageMixin):
 
     def delete(self, session_id, data_keys, _tell=False):
         data_ids = self._batch_get_object_id(session_id, data_keys)
+        logger.debug('delete chunks from vineyard: %s', data_ids)
         try:
             self._client.delete(data_ids, deep=True)
         except vineyard._C.ObjectNotExistsException:


### PR DESCRIPTION
## What do these changes do?

+ Avoid copy chunks again when they are already in vineyard.
+ Use latest released vineyard in CI, rather than a hacked one.

## Related issue number

N/A