### PR TITLE
Allow set verify_ssl to False for kubernetes configuration

### DIFF
--- a/mars/deploy/kubedl/client.py
+++ b/mars/deploy/kubedl/client.py
@@ -85,6 +85,9 @@ class KubeDLCluster:
             else extra_modules
         extra_envs = kwargs.pop('extra_env', None) or dict()
 
+        if not verify_ssl:
+            extra_envs['KUBE_VERIFY_SSL'] = '0'
+
         def _override_modules(updates):
             modules = set(extra_modules)
             updates = updates.split(',') if isinstance(updates, str) \

--- a/mars/deploy/kubernetes/core.py
+++ b/mars/deploy/kubernetes/core.py
@@ -41,6 +41,12 @@ class K8SPodsIPWatcher(object):
         else:
             self._k8s_config = config.load_incluster_config()
 
+        verify_ssl = bool(int(os.environ.get('KUBE_VERIFY_SSL', '1').strip('"')))
+        if not verify_ssl:
+            c = client.Configuration()
+            c.verify_ssl = False
+            client.Configuration.set_default(c)
+
         self._k8s_namespace = k8s_namespace or os.environ.get('MARS_K8S_POD_NAMESPACE') or 'default'
         self._full_label_selector = None
         self._client = client.CoreV1Api(client.ApiClient(self._k8s_config))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Add `KUBE_VERIFY_SSL` environment in kubernetes to ignore the certificate when connect to api server.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA