### PR TITLE
Fix rechunk when input tileable has unknown shape

### DIFF
--- a/mars/dataframe/datastore/to_csv.py
+++ b/mars/dataframe/datastore/to_csv.py
@@ -176,7 +176,7 @@ class DataFrameToCSV(DataFrameOperand, DataFrameOperandMixin):
         in_df = op.input
         out_df = op.outputs[0]
 
-        if in_df.ndim == 2:
+        if in_df.ndim == 2 and in_df.chunk_shape[1] > 1:
             # make sure only 1 chunk on the column axis
             in_df = in_df.rechunk({1: in_df.shape[1]})._inplace_tile()
 

--- a/mars/learn/contrib/xgboost/tests/test_classifier.py
+++ b/mars/learn/contrib/xgboost/tests/test_classifier.py
@@ -117,6 +117,17 @@ class Test(unittest.TestCase):
 
         self.assertEqual(prediction.ndim, 1)
 
+        # test train with unknown shape
+        cond = X[:, 0] > 0
+        X3 = X[cond]
+        y3 = y[cond]
+        classifier = XGBClassifier(verbosity=1, n_estimators=2)
+        classifier.fit(X3, y3)
+        prediction = classifier.predict(X)
+
+        self.assertEqual(prediction.ndim, 1)
+        self.assertEqual(prediction.shape[0], len(self.X))
+
         classifier = XGBClassifier(verbosity=1, n_estimators=2)
         with self.assertRaises(TypeError):
             classifier.fit(X, y, wrong_param=1)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes rechunk when input tileable has unknown shape.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1901 
Fixes #1910 