### PR TITLE
Optimize generating mock DataFrames

### DIFF
--- a/mars/dataframe/reduction/core.py
+++ b/mars/dataframe/reduction/core.py
@@ -208,8 +208,10 @@ class DataFrameReductionMixin(DataFrameOperandMixin):
             return self._call_groupby_level(df[list(reduced_df.columns)], level)
 
         reduced_shape = (df.shape[0],) if axis == 1 else reduced_df.shape
+        index_value = parse_index(reduced_df.index, store_data=True) \
+            if axis == 0 else parse_index(pd.RangeIndex(-1))
         return self.new_series([df], shape=reduced_shape, dtype=reduced_df.dtype,
-                               index_value=parse_index(reduced_df.index, store_data=axis == 0))
+                               index_value=index_value)
 
     def _call_series(self, series):
         level = getattr(self, 'level', None)


### PR DESCRIPTION
## What do these changes do?

Optimize generating mock DataFrames when num of columns is large.

Test results:

```python
import mars.tensor as mt, mars.dataframe as md
a = mt.random.randint(low=1, high=1000, size=(20000, 40000))
```

```python
%%time
df = md.DataFrame(a)
_ = df.min()
```

```
Before:
CPU times: user 28.2 s, sys: 302 ms, total: 28.5 s
Wall time: 28.5 s
After: 
CPU times: user 4.44 s, sys: 55.4 ms, total: 4.5 s
Wall time: 4.52 s
```

```python
from mars.dataframe.utils import build_empty_df
%time _ = build_empty_df(df.dtypes)
```

```
Before:
CPU times: user 28.4 s, sys: 297 ms, total: 28.7 s
Wall time: 28.7 s
After:
CPU times: user 4.36 s, sys: 39 ms, total: 4.4 s
Wall time: 4.4 s
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
