### PR TITLE
Fix KeyError when comparing series

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 /mars/actors             @qinxuye @hekaisheng @wjsi
 /mars/dataframe          @hekaisheng @qinxuye @wjsi
 /mars/deploy             @wjsi @hekaisheng
-/mars/learn              @qinxuye @hekaisheng
+/mars/learn              @qinxuye @hekaisheng @wjsi
 /mars/lib                @wjsi @qinxuye
 /mars/optimizes          @hekaisheng @qinxuye
 /mars/ray                @hekaisheng @qinxuye

--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -18,14 +18,15 @@ import copy
 import numpy as np
 import pandas as pd
 
-from ...tensor.datasource import tensor as astensor
+from ...core import Base, Entity
 from ...serialize import AnyField, Float64Field
 from ...tensor.core import TENSOR_TYPE, ChunkData, Chunk
+from ...tensor.datasource import tensor as astensor
 from ...utils import classproperty
 from ..align import align_series_series, align_dataframe_series, align_dataframe_dataframe
 from ..core import DATAFRAME_TYPE, SERIES_TYPE, DATAFRAME_CHUNK_TYPE, SERIES_CHUNK_TYPE
-from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..initializer import Series, DataFrame
+from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..ufunc.tensor import TensorUfuncMixin
 from ..utils import parse_index, infer_dtypes, infer_dtype, infer_index_value, build_empty_df
 
@@ -533,7 +534,7 @@ class DataFrameBinOp(DataFrameOperand, DataFrameBinOpMixin):
             self._lhs = self._inputs[0]
             self._rhs = self._inputs[1]
         else:
-            if isinstance(self._lhs, (DATAFRAME_TYPE, SERIES_TYPE)):
+            if isinstance(self._lhs, (Base, Entity)):
                 self._lhs = self._inputs[0]
             elif pd.api.types.is_scalar(self._lhs):
                 self._rhs = self._inputs[0]

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -654,7 +654,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
         in_data_dict = cls._pack_inputs(op.agg_funcs, in_data_tuple)
 
         for _input_key, _map_func_name, agg_func_name, custom_reduction, \
-            output_key, _output_limit, kwds in op.agg_funcs:
+                output_key, _output_limit, kwds in op.agg_funcs:
             if agg_func_name == 'custom_reduction':
                 input_obj = tuple(cls._get_grouped(op, o, ctx) for o in in_data_dict[output_key])
                 in_data_dict[output_key] = cls._do_custom_agg(op, custom_reduction, *input_obj)[0]

--- a/mars/dataframe/groupby/cum.py
+++ b/mars/dataframe/groupby/cum.py
@@ -96,7 +96,7 @@ class GroupByCumReductionOperand(DataFrameOperandMixin, DataFrameOperand):
             else:
                 chunks.append(new_op.new_chunk(
                     [c], index=(c.index[0],), shape=(np.nan,), dtype=out_df.dtype,
-                    index_value=new_index))
+                    index_value=new_index, name=out_df.name))
 
         new_op = op.copy().reset_key()
         kw = out_df.params.copy()
@@ -110,22 +110,23 @@ class GroupByCumReductionOperand(DataFrameOperandMixin, DataFrameOperand):
     @classmethod
     def execute(cls, ctx, op: "GroupByCumReductionOperand"):
         in_data = ctx[op.inputs[0].key]
-        out_df = op.outputs[0]
+        out_chunk = op.outputs[0]
 
         if not in_data or in_data.empty:
-            ctx[out_df.key] = build_empty_df(out_df.dtypes) \
-                if op.output_types[0] == OutputType.dataframe else build_empty_series(out_df.dtype)
+            ctx[out_chunk.key] = build_empty_df(out_chunk.dtypes) \
+                if op.output_types[0] == OutputType.dataframe \
+                else build_empty_series(out_chunk.dtype, name=out_chunk.name)
             return
 
         func_name = getattr(op, '_func_name')
         if func_name == 'cumcount':
-            ctx[out_df.key] = in_data.cumcount(ascending=op.ascending)
+            ctx[out_chunk.key] = in_data.cumcount(ascending=op.ascending)
         else:
             result = getattr(in_data, func_name)(axis=op.axis)
             if result.ndim == 2:
-                ctx[out_df.key] = result.astype(out_df.dtypes, copy=False)
+                ctx[out_chunk.key] = result.astype(out_chunk.dtypes, copy=False)
             else:
-                ctx[out_df.key] = result.astype(out_df.dtype, copy=False)
+                ctx[out_chunk.key] = result.astype(out_chunk.dtype, copy=False)
 
 
 class GroupByCummin(GroupByCumReductionOperand):

--- a/mars/dataframe/groupby/transform.py
+++ b/mars/dataframe/groupby/transform.py
@@ -162,13 +162,19 @@ class GroupByTransform(DataFrameOperand, DataFrameOperandMixin):
 
         if op.call_agg:
             result = in_data.agg(op.func, *op.args, **op.kwds)
-        else:
+        elif in_data.shape[0] > 0:
+            # cannot perform groupby-transform over empty dataframe
             result = in_data.transform(op.func, *op.args, **op.kwds)
+        else:
+            if out_chunk.ndim == 2:
+                result = pd.DataFrame(columns=out_chunk.dtypes.index)
+            else:
+                result = pd.Series([], name=out_chunk.name, dtype=out_chunk.dtype)
 
         if result.ndim == 2:
-            result = result.astype(op.outputs[0].dtypes, copy=False)
+            result = result.astype(out_chunk.dtypes, copy=False)
         else:
-            result = result.astype(op.outputs[0].dtype, copy=False)
+            result = result.astype(out_chunk.dtype, copy=False)
         ctx[op.outputs[0].key] = result
 
 

--- a/mars/dataframe/missing/replace.py
+++ b/mars/dataframe/missing/replace.py
@@ -66,9 +66,9 @@ class DataFrameReplace(DataFrameOperand, DataFrameOperandMixin):
         super()._set_inputs(inputs)
         input_iter = iter(inputs)
         next(input_iter)
-        if isinstance(self.to_replace, SERIES_TYPE):
+        if isinstance(self.to_replace, (SERIES_TYPE, SERIES_CHUNK_TYPE)):
             self._to_replace = next(input_iter)
-        if isinstance(self.value, SERIES_TYPE):
+        if isinstance(self.value, (SERIES_TYPE, SERIES_CHUNK_TYPE)):
             self._value = next(input_iter)
         self._fill_chunks = list(input_iter)
 

--- a/mars/dataframe/statistics/quantile.py
+++ b/mars/dataframe/statistics/quantile.py
@@ -21,7 +21,7 @@ from ... import opcodes as OperandDef
 from ...core import Base, Entity
 from ...serialize import KeyField, AnyField, StringField, DataTypeField, \
     BoolField, Int32Field
-from ...tensor.core import TENSOR_TYPE
+from ...tensor.core import TENSOR_TYPE, TENSOR_CHUNK_TYPE
 from ...tensor.datasource import empty, tensor as astensor, \
     from_series as tensor_from_series, from_dataframe as tensor_from_dataframe
 from ...tensor.statistics.quantile import quantile as tensor_quantile
@@ -73,7 +73,7 @@ class DataFrameQuantile(DataFrameOperand, DataFrameOperandMixin):
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
         self._input = self._inputs[0]
-        if isinstance(self._q, TENSOR_TYPE):
+        if isinstance(self._q, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
             self._q = self._inputs[-1]
 
     def _calc_dtype_on_axis_1(self, a, dtypes):

--- a/mars/deploy/local/tests/test_cluster.py
+++ b/mars/deploy/local/tests/test_cluster.py
@@ -645,6 +645,19 @@ class Test(unittest.TestCase):
                                           s.index_value.to_pandas())
             pd.testing.assert_series_equal(s2.fetch(), raw['c1'])
 
+            # test series compare
+            raw_s = raw['c1'].copy()
+            raw_s[raw_s > 0.8] = np.inf
+            raw_s[raw_s < 0.2] = -np.inf
+
+            s2 = md.Series(raw_s) * 2 + 1
+            r = (s2 == np.inf) | (s2 == -np.inf)
+            raw_s = raw_s * 2 + 1
+            expected = (raw_s == np.inf) | (raw_s == -np.inf)
+            pd.testing.assert_series_equal(
+                r.execute(session=session).fetch(session=session),
+                expected)
+
     def testMultiSessionDecref(self, *_):
         with self.new_cluster(scheduler_n_process=2, worker_n_process=2,
                               shared_memory='20M', web=True) as cluster:

--- a/mars/learn/neighbors/tree.py
+++ b/mars/learn/neighbors/tree.py
@@ -16,7 +16,7 @@ import cloudpickle
 import numpy as np
 
 from ...context import RunningMode
-from ...core import Object, OBJECT_TYPE
+from ...core import Object, OBJECT_TYPE, OBJECT_CHUNK_TYPE
 from ...serialize import KeyField, Int32Field, DictField, AnyField, BoolField
 from ...tiles import TilesError
 from ...tensor.core import TensorOrder
@@ -154,7 +154,7 @@ class TreeQueryBase(LearnOperand, LearnOperandMixin):
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
         self._input = self._inputs[0]
-        if isinstance(self._tree, OBJECT_TYPE):
+        if isinstance(self._tree, (OBJECT_TYPE, OBJECT_CHUNK_TYPE)):
             self._tree = self._inputs[1]
 
     def _update_key(self):

--- a/mars/tensor/statistics/histogram.py
+++ b/mars/tensor/statistics/histogram.py
@@ -448,7 +448,7 @@ class TensorHistogramBinEdges(TensorOperand, TensorOperandMixin):
         super()._set_inputs(inputs)
         inputs_iter = iter(self._inputs)
         self._input = next(inputs_iter)
-        if isinstance(self._bins, TENSOR_TYPE):
+        if isinstance(self._bins, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
             self._bins = next(inputs_iter)
         if self._weights is not None:
             self._weights = next(inputs_iter)
@@ -801,7 +801,7 @@ class TensorHistogram(TensorOperand, TensorOperandMixin):
         super()._set_inputs(inputs)
         inputs_iter = iter(self._inputs)
         self._input = next(inputs_iter)
-        if isinstance(self._bins, TENSOR_TYPE):
+        if isinstance(self._bins, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
             self._bins = next(inputs_iter)
         if self._weights is not None:
             self._weights = next(inputs_iter)

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -384,7 +384,7 @@ def create_actor_pool(*args, **kwargs):
     raise OSError("Failed to create actor pool")
 
 
-def assert_groupby_equal(left, right, sort_keys=False, with_selection=False):
+def assert_groupby_equal(left, right, sort_keys=False, sort_index=True, with_selection=False):
     if hasattr(left, 'groupby_obj'):
         left = left.groupby_obj
     if hasattr(right, 'groupby_obj'):
@@ -400,6 +400,9 @@ def assert_groupby_equal(left, right, sort_keys=False, with_selection=False):
         right = sorted(right, key=lambda p: p[0])
     else:
         left, right = list(left), list(right)
+    if sort_index:
+        left = [(k, v.sort_index()) for k, v in left]
+        right = [(k, v.sort_index()) for k, v in right]
 
     if len(left) != len(right):
         raise AssertionError(f'Count of groupby keys not consistent: {len(left)} != {len(right)}')

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -300,7 +300,6 @@ def deserialize_graph(ser_graph, graph_cls=None):
     ser_graph_bin = to_binary(ser_graph)
     g = GraphDef()
     try:
-        ser_graph = ser_graph
         g.ParseFromString(ser_graph_bin)
         return graph_cls.from_pb(g)
     except DecodeError:


### PR DESCRIPTION
## What do these changes do?

1. Fix KeyError when comparing series. This is caused by fusing inputs of DataFrameBinOp and lhs / rhs not updated. Code base scanned manually and similar errors may not occur again.
2. Fix selecting column 0 after groupby and do aggregation. The cause is that value 0 is treated as None.

## Related issue number

Fixes #1918 
Fixes #1919