### PR TITLE
Fix rechunk when chunks have different dtypes that cannot compare

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,23 +1,23 @@
 # Each line is a component followed by one or more owners.
 
 *                        @qinxuye @wjsi @hekaisheng
-/.github                 @wjsi
-/bin                     @wjsi
+/.github                 @wjsi @qinxuye
+/bin                     @wjsi @qinxuye
 /docs                    @qinxuye @hekaisheng @wjsi
 /mars/                   @qinxuye @hekaisheng @wjsi
 /mars/tests              @qinxuye @hekaisheng @wjsi
 /mars/actors             @qinxuye @hekaisheng @wjsi
 /mars/dataframe          @hekaisheng @qinxuye @wjsi
-/mars/deploy             @wjsi @hekaisheng
+/mars/deploy             @wjsi @hekaisheng @qinxuye
 /mars/learn              @qinxuye @hekaisheng @wjsi
 /mars/lib                @wjsi @qinxuye
 /mars/optimizes          @hekaisheng @qinxuye
 /mars/ray                @hekaisheng @qinxuye
 /mars/remote             @qinxuye @wjsi @hekaisheng
-/mars/scheduler          @wjsi
+/mars/scheduler          @wjsi @qinxuye
 /mars/serialize          @qinxuye @wjsi
 /mars/serialize/protos   @qinxuye @wjsi @hekaisheng
 /mars/tensor             @hekaisheng @qinxuye @wjsi
 /mars/tests              @wjsi @qinxuye @qinxuye
-/mars/web                @wjsi @hekaisheng
-/mars/worker             @wjsi
+/mars/web                @wjsi @hekaisheng @qinxuye
+/mars/worker             @wjsi @qinxuye

--- a/mars/_version.py
+++ b/mars/_version.py
@@ -15,7 +15,7 @@
 import subprocess
 import os
 
-version_info = (0, 7, 0, 'a4')
+version_info = (0, 7, 0, 'a5')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/dataframe/base/rechunk.py
+++ b/mars/dataframe/base/rechunk.py
@@ -109,7 +109,7 @@ def _get_chunk_size(a, chunk_size):
 
 
 def rechunk(a, chunk_size, threshold=None, chunk_size_limit=None, reassign_worker=False):
-    if not any(pd.isna(s) for s in a.shape):
+    if not any(pd.isna(s) for s in a.shape) and not a.is_coarse():
         # do client check only when no unknown shape,
         # real nsplits will be recalculated inside `tile`
         chunk_size = _get_chunk_size(a, chunk_size)

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -116,6 +116,13 @@ class Test(TestBase):
         res = self.executor.execute_dataframe(index2, concat=True)[0]
         pd.testing.assert_index_equal(data, res)
 
+        # test rechunk on mixed typed columns
+        data = pd.DataFrame({0: [1, 2], 1: [3, 4], 'a': [5, 6]})
+        df = from_pandas_df(data)
+        df = df.rechunk((2, 2)).rechunk({1: 3})
+        res = self.executor.execute_dataframe(df, concat=True)[0]
+        pd.testing.assert_frame_equal(data, res)
+
     def testSeriesMapExecution(self):
         raw = pd.Series(np.arange(10))
         s = from_pandas_series(raw, chunk_size=7)

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -732,9 +732,14 @@ def merge_index_value(to_merge_index_values, store_data=False):
         else:
             index_value = index_value.append(chunk_index_value.to_pandas())
             if chunk_index_value.min_val is not None:
-                if min_val is None or min_val > chunk_index_value.min_val:
-                    min_val = chunk_index_value.min_val
-                    min_val_close = chunk_index_value.min_val_close
+                try:
+                    if min_val is None or min_val > chunk_index_value.min_val:
+                        min_val = chunk_index_value.min_val
+                        min_val_close = chunk_index_value.min_val_close
+                except TypeError:
+                    # min_value has different types that cannot compare
+                    # just stop compare
+                    continue
             if chunk_index_value.max_val is not None:
                 if max_val is None or max_val < chunk_index_value.max_val:
                     max_val = chunk_index_value.max_val

--- a/mars/tensor/rechunk/rechunk.py
+++ b/mars/tensor/rechunk/rechunk.py
@@ -74,7 +74,7 @@ class TensorRechunk(TensorHasInput, TensorOperandMixin):
         if chunk_size == tensor.nsplits:
             return [tensor]
 
-        new_chunk_size = op.chunk_size
+        new_chunk_size = chunk_size
         steps = plan_rechunks(op.inputs[0], new_chunk_size, op.inputs[0].dtype.itemsize,
                               threshold=op.threshold,
                               chunk_size_limit=op.chunk_size_limit)
@@ -91,7 +91,7 @@ class TensorRechunk(TensorHasInput, TensorOperandMixin):
 
 def rechunk(tensor, chunk_size, threshold=None, chunk_size_limit=None,
             reassign_worker=False):
-    if not any(np.isnan(s) for s in tensor.shape):
+    if not any(np.isnan(s) for s in tensor.shape) and not tensor.is_coarse():
         # do client check only when tensor has no unknown shape,
         # otherwise, recalculate chunk_size in `tile`
         chunk_size = get_nsplits(tensor, chunk_size, tensor.dtype.itemsize)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes rechunk when chunks have different dtypes that cannot compare

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1908 .