### PR TITLE
Fix KeyError when column pruning is applied

### DIFF
--- a/mars/optimizes/tileable_graph/core.py
+++ b/mars/optimizes/tileable_graph/core.py
@@ -98,8 +98,16 @@ class OptimizeIntegratedTileableGraphBuilder(TileableGraphBuilder):
                     replaced_tileables[n] = new_node = self._optimizer_context[n]
                 else:
                     new_node = n
-            elif any(inp in replaced_tileables for inp in n.inputs):
-                new_inputs = [replaced_tileables.get(i, i) for i in n.inputs]
+            elif any(inp in replaced_tileables for inp in n.inputs) or \
+                    any(inp not in new_graph for inp in n.inputs):
+                new_inputs = []
+                for i in n.inputs:
+                    if i in replaced_tileables:
+                        new_inputs.append(replaced_tileables[i])
+                    elif i not in graph:
+                        new_inputs.append(self._optimizer_context[i])
+                    else:
+                        new_inputs.append(i)
                 new_tileables = copy_tileables(n.op.outputs, inputs=new_inputs)
                 for t, new_t in zip(n.op.outputs, new_tileables):
                     replaced_tileables[t] = new_t.data

--- a/mars/optimizes/tileable_graph/tests/test_head.py
+++ b/mars/optimizes/tileable_graph/tests/test_head.py
@@ -71,6 +71,11 @@ class Test(TestBase):
 
                 self.assertIn('cannot run iloc', str(cm.exception))
 
+            with self._raise_iloc():
+                s = mdf.head(5).sum()
+                expected = df.head(5).sum()
+                pd.testing.assert_series_equal(s.execute().fetch(), expected)
+
             pd.testing.assert_frame_equal(
                 mdf.head(99).execute().fetch().reset_index(drop=True), df.head(99))
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix KeyError when column pruning is applied, we need replace the inputs of optimized node.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1923 
