### PR TITLE
Fix `MarsDMatrix` when input tensor has unknown chunk shape

### DIFF
--- a/mars/dataframe/base/rechunk.py
+++ b/mars/dataframe/base/rechunk.py
@@ -111,11 +111,18 @@ def _get_chunk_size(a, chunk_size):
 
 def rechunk(a, chunk_size, threshold=None, chunk_size_limit=None, reassign_worker=False):
     if not any(pd.isna(s) for s in a.shape) and not a.is_coarse():
-        # do client check only when no unknown shape,
-        # real nsplits will be recalculated inside `tile`
-        chunk_size = _get_chunk_size(a, chunk_size)
-        if chunk_size == a.nsplits:
-            return a
+        try:
+            check_chunks_unknown_shape([a], ValueError)
+        except ValueError:
+            # due to reason that tileable has unknown chunk shape,
+            # just ignore to hand over to operand
+            pass
+        else:
+            # do client check only when no unknown shape,
+            # real nsplits will be recalculated inside `tile`
+            chunk_size = _get_chunk_size(a, chunk_size)
+            if chunk_size == a.nsplits:
+                return a
 
     op = DataFrameRechunk(chunk_size=chunk_size, threshold=threshold,
                           chunk_size_limit=chunk_size_limit,

--- a/mars/dataframe/base/tests/test_base.py
+++ b/mars/dataframe/base/tests/test_base.py
@@ -28,7 +28,7 @@ from mars.dataframe.datasource.index import from_pandas as from_pandas_index
 from mars.operands import OperandStage
 from mars.tensor.core import TENSOR_TYPE
 from mars.tests.core import TestBase
-from mars.tiles import get_tiled
+from mars.tiles import get_tiled, TilesError
 
 
 class Test(TestBase):
@@ -178,6 +178,13 @@ class Test(TestBase):
         series = get_tiled(series)
         self.assertEqual(series2.chunk_shape, series.chunk_shape)
         self.assertEqual(series2.nsplits, series.nsplits)
+
+        # test rechunk on DataFrame has known shape, but chunk's shape is unknown
+        data = pd.DataFrame({0: [1, 2], 1: [3, 4], 'a': [5, 6]})
+        df = from_pandas_df(data)
+        df = df[df[0] < 3]
+        with self.assertRaises(TilesError):
+            df.tiles().rechunk((np.nan, 3)).tiles()
 
     def testDataFrameApply(self):
         cols = [chr(ord('A') + i) for i in range(10)]

--- a/mars/learn/contrib/xgboost/classifier.py
+++ b/mars/learn/contrib/xgboost/classifier.py
@@ -63,10 +63,7 @@ if xgboost:
             session = kw.pop('session', None)
             run_kwargs = kw.pop('run_kwargs', dict())
             run = kw.pop('run', True)
-            if kw:
-                raise TypeError("predict got an unexpected "
-                                f"keyword argument '{next(iter(kw))}'")
-            prob = predict(self.get_booster(), data, run=False)
+            prob = predict(self.get_booster(), data, run=False, **kw)
             if prob.ndim > 1:
                 prediction = mt.argmax(prob, axis=1)
             else:

--- a/mars/learn/contrib/xgboost/regressor.py
+++ b/mars/learn/contrib/xgboost/regressor.py
@@ -50,8 +50,5 @@ if xgboost:
         def predict(self, data, **kw):
             session = kw.pop('session', None)
             run_kwargs = kw.pop('run_kwargs', None)
-            if kw:
-                raise TypeError("predict got an unexpected "
-                                f"keyword argument '{next(iter(kw))}'")
             return predict(self.get_booster(), data,
-                           session=session, run_kwargs=run_kwargs)
+                           session=session, run_kwargs=run_kwargs, **kw)

--- a/mars/tensor/rechunk/rechunk.py
+++ b/mars/tensor/rechunk/rechunk.py
@@ -92,11 +92,18 @@ class TensorRechunk(TensorHasInput, TensorOperandMixin):
 def rechunk(tensor, chunk_size, threshold=None, chunk_size_limit=None,
             reassign_worker=False):
     if not any(np.isnan(s) for s in tensor.shape) and not tensor.is_coarse():
-        # do client check only when tensor has no unknown shape,
-        # otherwise, recalculate chunk_size in `tile`
-        chunk_size = get_nsplits(tensor, chunk_size, tensor.dtype.itemsize)
-        if chunk_size == tensor.nsplits:
-            return tensor
+        try:
+            check_chunks_unknown_shape([tensor], ValueError)
+        except ValueError:
+            # due to reason that tensor has unknown chunk shape,
+            # just ignore to hand over to operand
+            pass
+        else:
+            # do client check only when tensor has no unknown shape,
+            # otherwise, recalculate chunk_size in `tile`
+            chunk_size = get_nsplits(tensor, chunk_size, tensor.dtype.itemsize)
+            if chunk_size == tensor.nsplits:
+                return tensor
 
     op = TensorRechunk(chunk_size, threshold, chunk_size_limit, reassign_worker=reassign_worker,
                        dtype=tensor.dtype, sparse=tensor.issparse())


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes `MarsDMatrix` when input tensor has unknown chunk shape. Extra arguments for predict are support as well.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1963 
Fixes #1965 
