### PR TITLE
[BACKPORT] Fix ValueError when reducing tensors with empty chunks (#1978)

### DIFF
--- a/mars/lib/sparse/matrix.py
+++ b/mars/lib/sparse/matrix.py
@@ -124,6 +124,10 @@ class SparseMatrix(SparseArray):
     def shape(self):
         return self.spmatrix.shape
 
+    @property
+    def size(self):
+        return int(np.prod(self.shape))
+
     def transpose(self, axes=None):
         assert axes is None or tuple(axes) == (1, 0)
         return SparseMatrix(self.spmatrix.transpose())

--- a/mars/tensor/reduction/core.py
+++ b/mars/tensor/reduction/core.py
@@ -264,7 +264,10 @@ class TensorReductionMixin(TensorOperandMixin):
         reduce_func = getattr(xp, func_name)
         out = op.outputs[0]
         with device(device_id):
-            if "dtype" in inspect.getfullargspec(reduce_func).args:
+            if input_chunk.size == 0 and op.keepdims:
+                # input chunk is empty, when keepdims is True, return itself
+                ret = input_chunk
+            elif "dtype" in inspect.getfullargspec(reduce_func).args:
                 ret = reduce_func(input_chunk, axis=axis,
                                   dtype=op.dtype,
                                   keepdims=bool(op.keepdims))

--- a/mars/tensor/reduction/tests/test_reduction_execute.py
+++ b/mars/tensor/reduction/tests/test_reduction_execute.py
@@ -106,6 +106,13 @@ class Test(unittest.TestCase):
         a = tensor(list('abcdefghi'), dtype=object, chunk_size=2)
         self.assertEqual(self.executor.execute_tensor(a.max(), concat=True)[0], 'i')
 
+        # test empty chunks
+        raw = np.arange(3, 10)
+        arr = tensor(np.arange(0, 10), chunk_size=3)
+        arr = arr[arr >= 3]
+        self.assertEqual([raw.max()], self.executor.execute_tensor(arr.max()))
+        self.assertEqual([raw.min()], self.executor.execute_tensor(arr.min()))
+
     def testAllAnyExecution(self):
         raw1 = np.zeros((10, 15))
         raw2 = np.ones((10, 15))

--- a/mars/tensor/statistics/tests/test_statistics_execute.py
+++ b/mars/tensor/statistics/tests/test_statistics_execute.py
@@ -260,6 +260,14 @@ class Test(TestBase):
             expected = np.histogram(raw4[raw4 < 0.9])[0]
             np.testing.assert_array_equal(result, expected)
 
+            raw5 = np.arange(3, 10)
+            e = arange(10, chunk_size=3)
+            e = e[e >= 3]
+            hist = histogram(e)
+            result = executor.execute_tensors(hist)[0]
+            expected = np.histogram(raw5)[0]
+            np.testing.assert_array_equal(result, expected)
+
     def testQuantileExecution(self):
         # test 1 chunk, 1-d
         raw = np.random.rand(20)


### PR DESCRIPTION
Backport of #1978