### PR TITLE
[BACKPORT] Fix IndexError in `Series.sort_values` when some chunk is empty (#1999)

### DIFF
--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -225,6 +225,25 @@ class Test(unittest.TestCase):
 
             pd.testing.assert_series_equal(result, expected)
 
+            # test empty series
+            series = pd.Series(list(range(10)), name='a')
+            mseries = Series(series, chunk_size=4)
+            filtered = mseries[mseries > 100]
+            result = self.executor.execute_dataframe(filtered.sort_values(), concat=True)[0]
+
+            pd.testing.assert_series_equal(result, series[series > 100].sort_values())
+
+            # test series with None
+            series = pd.Series(np.arange(1000,))
+
+            series[series < 500] = 'A'
+            series[series != 'A'] = None
+
+            mseries = Series(series, chunk_size=100)
+            result = self.executor.execute_dataframe(mseries.sort_values(), concat=True)[0]
+            expected = series.sort_values()
+            pd.testing.assert_series_equal(result.reset_index(drop=True), expected.reset_index(drop=True))
+
     def testSortIndexExecution(self):
         raw = pd.DataFrame(np.random.rand(100, 20), index=np.random.rand(100))
 


### PR DESCRIPTION
Backport of #1999