### PR TITLE
Add `errors` argument for groupby.sample to ignore errors when group size less than `n`

### DIFF
--- a/mars/deploy/kubernetes/client.py
+++ b/mars/deploy/kubernetes/client.py
@@ -277,6 +277,7 @@ class KubernetesCluster:
             'mars/service-type=' + MarsWorkersConfig.rc_name,
             'mars/service-type=' + MarsWebsConfig.rc_name,
             ]
+        logger.debug('Start waiting pods to be ready')
         wait_services_ready(selectors, limits,
                             lambda sel: self._get_ready_pod_count(sel),
                             timeout=self._timeout)

--- a/mars/deploy/kubernetes/core.py
+++ b/mars/deploy/kubernetes/core.py
@@ -173,6 +173,9 @@ class ReadinessActor(FunctionActor):
     """
     Dummy actor indicating service start
     """
+    def post_create(self):
+        logger.debug('ReadinessActor created as %s, pod should be ready by now.', self.uid)
+
     @classmethod
     def default_uid(cls):
         return f'k:0:{cls.__name__}'

--- a/mars/lib/groupby_wrapper.py
+++ b/mars/lib/groupby_wrapper.py
@@ -101,6 +101,10 @@ class GroupByWrapper:
             shape[1] = len(self.selection)
         return tuple(shape)
 
+    @property
+    def _selected_obj(self):
+        return getattr(self.groupby_obj, '_selected_obj')
+
     def to_tuple(self, truncate=False, pickle_function=False):
         if self.selection and truncate:
             if isinstance(self.selection, Iterable) and not isinstance(self.selection, str):


### PR DESCRIPTION
## What do these changes do?

Add `errors` argument for groupby.sample to ignore errors when group size less than `n`. This also adapts logic from pandas groupby.sample and then bugs of weighted sampling in pandas will not affect Mars.

## Related issue number

Fixes #2000 