### PR TITLE
Fix errors when calling where() on reshape results

### DIFF
--- a/mars/deploy/kubernetes/config.py
+++ b/mars/deploy/kubernetes/config.py
@@ -465,7 +465,7 @@ class MarsSchedulersConfig(MarsReplicationControllerConfig):
         readiness_cmd = [
             '/srv/entrypoint.sh', self.get_local_app_module('probe'),
         ]
-        return ExecProbeConfig(readiness_cmd, timeout=5, failure_thresh=3)
+        return ExecProbeConfig(readiness_cmd, timeout=60, failure_thresh=10)
 
     def build_container_command(self):
         cmd = [
@@ -515,7 +515,7 @@ class MarsWorkersConfig(MarsReplicationControllerConfig):
         readiness_cmd = [
             '/srv/entrypoint.sh', self.get_local_app_module('probe'),
         ]
-        return ExecProbeConfig(readiness_cmd, timeout=60, failure_thresh=3)
+        return ExecProbeConfig(readiness_cmd, timeout=60, failure_thresh=10)
 
     def build_container_command(self):
         cmd = [
@@ -534,7 +534,7 @@ class MarsWebsConfig(MarsReplicationControllerConfig):
 
     def config_readiness_probe(self):
         if self._service_port:
-            return TcpProbeConfig(self._service_port, timeout=60, failure_thresh=3)
+            return TcpProbeConfig(self._service_port, timeout=60, failure_thresh=10)
 
     def build_container_command(self):
         cmd = [

--- a/mars/deploy/kubernetes/core.py
+++ b/mars/deploy/kubernetes/core.py
@@ -174,7 +174,8 @@ class ReadinessActor(FunctionActor):
     Dummy actor indicating service start
     """
     def post_create(self):
-        logger.debug('ReadinessActor created as %s, pod should be ready by now.', self.uid)
+        logger.debug('ReadinessActor created as %s, pod %s should be ready by now.',
+                     self.uid, os.environ['MARS_K8S_POD_NAME'])
 
     @classmethod
     def default_uid(cls):

--- a/mars/tensor/arithmetic/core.py
+++ b/mars/tensor/arithmetic/core.py
@@ -42,7 +42,7 @@ class TensorElementWise(TensorOperandMixin):
         out_chunk_shape = broadcast_shape(*chunk_shapes)
 
         out_chunks = [list() for _ in op.outputs]
-        nsplits = [[None] * shape for shape in out_chunk_shape]
+        nsplits = [[np.nan] * shape for shape in out_chunk_shape]
         get_index = lambda idx, t: tuple(0 if t.nsplits[i] == (1,) else ix for i, ix in enumerate(idx))
         for out_index in itertools.product(*(map(range, out_chunk_shape))):
             in_chunks = [t.cix[get_index(out_index[-t.ndim:], t)] if t.ndim != 0 else t.chunks[0]

--- a/mars/tensor/base/copyto.py
+++ b/mars/tensor/base/copyto.py
@@ -126,7 +126,7 @@ class TensorCopyTo(TensorOperand, TensorOperandMixin):
         out_chunk_shape = broadcast_shape(*chunk_shapes)
 
         out_chunks = []
-        nsplits = [[None] * shape for shape in out_chunk_shape]
+        nsplits = [[np.nan] * shape for shape in out_chunk_shape]
         get_index = lambda idx, t: tuple(0 if t.nsplits[i] == (1,) else ix
                                          for i, ix in enumerate(idx))
         for out_idx in itertools.product(*(map(range, out_chunk_shape))):

--- a/mars/tensor/base/tests/test_base_execute.py
+++ b/mars/tensor/base/tests/test_base_execute.py
@@ -284,6 +284,13 @@ class Test(TestBase):
         self.assertTrue(np.array_equal(res.toarray(),
                                        np.where(raw_cond.toarray(), raw_x.toarray(), raw_y.toarray())))
 
+        # GH 2009
+        raw_x = np.arange(9.).reshape(3, 3)
+        x = arange(9.).reshape(3, 3)
+        arr = where(x < 5, 2, -1)
+        res = self.executor.execute_tensor(arr, concat=True)[0]
+        np.testing.assert_array_equal(res, np.where(raw_x < 5, 2, -1))
+
     def testReshapeExecution(self):
         raw_data = np.random.rand(10, 20, 30)
         x = tensor(raw_data, chunk_size=6)

--- a/mars/tensor/base/where.py
+++ b/mars/tensor/base/where.py
@@ -59,7 +59,7 @@ class TensorWhere(TensorOperand, TensorOperandMixin):
         self._y = self._inputs[2]
 
     def __call__(self, condition, x, y, shape=None):
-        shape = shape or broadcast_shape(x.shape, y.shape)
+        shape = shape or broadcast_shape(condition.shape, x.shape, y.shape)
         return self.new_tensor([condition, x, y], shape)
 
     @classmethod
@@ -72,12 +72,12 @@ class TensorWhere(TensorOperand, TensorOperandMixin):
         output = op.outputs[0]
 
         out_chunks = []
-        nsplits = [[None] * shape for shape in out_chunk_shape]
+        nsplits = [[np.nan] * shape for shape in out_chunk_shape]
         get_index = lambda idx, t: tuple(0 if t.nsplits[i] == (1,) else ix for i, ix in enumerate(idx))
         for out_index in itertools.product(*(map(range, out_chunk_shape))):
             in_chunks = [t.cix[get_index(out_index[-t.ndim:], t)] if t.ndim != 0 else t.chunks[0]
                          for t in inputs]
-            chunk_shape = broadcast_shape(*(c.shape for c in in_chunks[1:]))
+            chunk_shape = broadcast_shape(*(c.shape for c in in_chunks))
             out_chunk = op.copy().reset_key().new_chunk(in_chunks, shape=chunk_shape,
                                                         index=out_index, order=output.order)
             out_chunks.append(out_chunk)

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -719,9 +719,9 @@ def check_chunks_unknown_shape(tileables, error_cls):
 def has_unknown_shape(tiled):
     if getattr(tiled, 'shape', None) is None:
         return False
-    if any(np.isnan(s) for s in tiled.shape):
+    if any(pd.isnull(s) for s in tiled.shape):
         return True
-    if any(np.isnan(s) for s in itertools.chain(*tiled.nsplits)):
+    if any(pd.isnull(s) for s in itertools.chain(*tiled.nsplits)):
         return True
     return False
 


### PR DESCRIPTION
## What do these changes do?

This PR does things below:

1. Fix TypeError caused by `None`s in shapes
2. Fix shape inconsistency when x and y in `where` are all scalars
3. Fix CI failure for kubernetes

## Related issue number

Fixes #2009