### PR TITLE
Add support for batch interfaces for actors

### DIFF
--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -20,7 +20,7 @@ import pandas as pd
 import pytest
 
 import mars.oscar as mo
-from mars.utils import get_next_port, async_method
+from mars.utils import get_next_port, extensible
 
 
 class DummyActor(mo.Actor):
@@ -31,7 +31,7 @@ class DummyActor(mo.Actor):
             raise ValueError('value < 0')
         self.value = value
 
-    @async_method
+    @extensible
     async def add(self, value):
         if not isinstance(value, int):
             raise TypeError('add number must be int')
@@ -43,7 +43,7 @@ class DummyActor(mo.Actor):
         self.value += sum(v[0] for v in args_list)
         return self.value
 
-    @async_method
+    @extensible
     async def add_ret(self, value):
         return self.value + value
 

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -20,7 +20,7 @@ import pandas as pd
 import pytest
 
 import mars.oscar as mo
-from mars.utils import get_next_port
+from mars.utils import get_next_port, async_method
 
 
 class DummyActor(mo.Actor):
@@ -31,14 +31,26 @@ class DummyActor(mo.Actor):
             raise ValueError('value < 0')
         self.value = value
 
-    def add(self, value):
+    @async_method
+    async def add(self, value):
         if not isinstance(value, int):
             raise TypeError('add number must be int')
         self.value += value
         return self.value
 
-    def add_ret(self, value):
+    @add.batch
+    async def add(self, args_list, _kwargs_list):
+        self.value += sum(v[0] for v in args_list)
+        return self.value
+
+    @async_method
+    async def add_ret(self, value):
         return self.value + value
+
+    @add_ret.batch
+    async def add_ret(self, args_list, _kwargs_list):
+        sum_val = sum(v[0] for v in args_list)
+        return [self.value + sum_val for _ in args_list]
 
     async def create(self, actor_cls, *args, **kw):
         kw['address'] = self.address
@@ -273,6 +285,25 @@ async def test_mars_tell(actor_pool_context):
     # error needed when illegal uids are passed
     with pytest.raises(ValueError):
         await ref1.tell(await mo.actor_ref(set()), 'add', 3)
+
+
+@pytest.mark.asyncio
+async def test_mars_batch_method(actor_pool_context):
+    pool = actor_pool_context
+    ref1 = await mo.create_actor(DummyActor, 1, address=pool.external_address)
+    batch_result = await ref1.batch(
+        ref1.add_ret(1), ref1.add_ret(2), ref1.add_ret(3)
+    )
+    assert len(batch_result) == 3
+    assert all(r == 7 for r in batch_result)
+
+    await ref1.batch(
+        ref1.add.tell(1), ref1.add.tell(2), ref1.add.tell(3)
+    )
+    assert await ref1.get_value() == 7
+
+    with pytest.raises(ValueError):
+        await ref1.batch(ref1.add_ret(1), ref1.add(2))
 
 
 @pytest.mark.asyncio

--- a/mars/oscar/backends/mars/tests/test_pool.py
+++ b/mars/oscar/backends/mars/tests/test_pool.py
@@ -90,39 +90,39 @@ async def test_sub_actor_pool(notify_main_pool):
     assert (await pool.actor_ref(actor_ref_message)).result == actor_ref
 
     tell_message = TellMessage(
-        new_message_id(), actor_ref, ('add', 1, dict()))
+        new_message_id(), actor_ref, ('add', 0, (1,), dict()))
     message = await pool.tell(tell_message)
     assert message.result is None
 
     send_message = SendMessage(
-        new_message_id(), actor_ref, ('add', 3, dict()))
+        new_message_id(), actor_ref, ('add', 0, (3,), dict()))
     message = await pool.send(send_message)
     assert message.result == 4
 
     # test error message
     # type mismatch
     send_message = SendMessage(
-        new_message_id(), actor_ref, ('add', '3', dict()))
+        new_message_id(), actor_ref, ('add', 0, ('3',), dict()))
     result = await pool.send(send_message)
     assert result.message_type == MessageType.error
     assert isinstance(result.error, TypeError)
 
     send_message = SendMessage(
         new_message_id(), create_actor_ref(actor_ref.address, 'non_exist'),
-        ('add', 3, dict()))
+        ('add', 0, (3,), dict()))
     result = await pool.send(send_message)
     assert isinstance(result.error, ActorNotExist)
 
     # test processing message on background
     async with await pool.router.get_client(pool.external_address) as client:
         send_message = SendMessage(
-            new_message_id(), actor_ref, ('add', 5, dict()))
+            new_message_id(), actor_ref, ('add', 0, (5,), dict()))
         await client.send(send_message)
         result = await client.recv()
         assert result.result == 9
 
         send_message = SendMessage(
-            new_message_id(), actor_ref, ('add', '5', dict()))
+            new_message_id(), actor_ref, ('add', 0, ('5',), dict()))
         await client.send(send_message)
         result = await client.recv()
         assert isinstance(result.error, TypeError)
@@ -213,29 +213,29 @@ async def test_main_actor_pool():
 
         # tell
         tell_message = TellMessage(
-            new_message_id(), actor_ref1, ('add', 2, dict()))
+            new_message_id(), actor_ref1, ('add', 0, (2,), dict()))
         message = await pool.tell(tell_message)
         assert message.result is None
 
         # send
         send_message = SendMessage(
-            new_message_id(), actor_ref1, ('add', 4, dict()))
+            new_message_id(), actor_ref1, ('add', 0, (4,), dict()))
         assert (await pool.send(send_message)).result == 6
 
         # test error message
         # type mismatch
         send_message = SendMessage(
-            new_message_id(), actor_ref1, ('add', '3', dict()))
+            new_message_id(), actor_ref1, ('add', 0, ('3',), dict()))
         result = await pool.send(send_message)
         assert isinstance(result.error, TypeError)
 
         # send and tell to main process
         tell_message = TellMessage(
-            new_message_id(), actor_ref, ('add', 2, dict()))
+            new_message_id(), actor_ref, ('add', 0, (2,), dict()))
         message = await pool.tell(tell_message)
         assert message.result is None
         send_message = SendMessage(
-            new_message_id(), actor_ref, ('add', 4, dict()))
+            new_message_id(), actor_ref, ('add', 0, (4,), dict()))
         assert (await pool.send(send_message)).result == 6
 
         # destroy

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -497,7 +497,7 @@ async def test_async_batch_decorator():
             self.arg_list = []
             self.kwarg_list = []
 
-        @utils.async_method(False)
+        @utils.extensible(False)
         async def method1(self, *args, **kwargs):
             pass
 
@@ -507,13 +507,13 @@ async def test_async_batch_decorator():
             self.kwarg_list.extend(kwargs_list)
             return [len(self.kwarg_list)] * len(args_list)
 
-        @utils.async_method
+        @utils.extensible
         async def method2(self, *args, **kwargs):
             self.arg_list.append(tuple(a - 1 for a in args))
             self.kwarg_list.append({k: v - 1 for k, v in kwargs.items()})
             return len(self.kwarg_list)
 
-        @utils.async_method
+        @utils.extensible
         async def method3(self, *args, **kwargs):
             self.arg_list.append(tuple(a * 2 for a in args))
             self.kwarg_list.append({k: v * 2 for k, v in kwargs.items()})

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import copy
 import os
 import shutil
@@ -20,7 +21,6 @@ import sys
 import tempfile
 import textwrap
 import time
-import unittest
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from io import BytesIO
@@ -31,448 +31,521 @@ try:
     import pandas as pd
 except ImportError:  # pragma: no cover
     pd = None
+import pytest
 
 from mars import utils
 from mars.tensor.fetch import TensorFetch
 import mars.tensor as mt
 
 
-class Test(unittest.TestCase):
-    def testStringConversion(self):
-        s = None
-        self.assertIsNone(utils.to_binary(s))
-        self.assertIsNone(utils.to_str(s))
-        self.assertIsNone(utils.to_text(s))
+def test_string_conversion():
+    s = None
+    assert utils.to_binary(s) is None
+    assert utils.to_str(s) is None
+    assert utils.to_text(s) is None
 
-        s = 'abcdefg'
-        self.assertIsInstance(utils.to_binary(s), bytes)
-        self.assertEqual(utils.to_binary(s), b'abcdefg')
-        self.assertIsInstance(utils.to_str(s), str)
-        self.assertEqual(utils.to_str(s), 'abcdefg')
-        self.assertIsInstance(utils.to_text(s), str)
-        self.assertEqual(utils.to_text(s), u'abcdefg')
+    s = 'abcdefg'
+    assert isinstance(utils.to_binary(s), bytes)
+    assert utils.to_binary(s) == b'abcdefg'
+    assert isinstance(utils.to_str(s), str)
+    assert utils.to_str(s) == 'abcdefg'
+    assert isinstance(utils.to_text(s), str)
+    assert utils.to_text(s) == u'abcdefg'
 
-        ustr = type('ustr', (str,), {})
-        self.assertIsInstance(utils.to_str(ustr(s)), str)
-        self.assertEqual(utils.to_str(ustr(s)), 'abcdefg')
+    ustr = type('ustr', (str,), {})
+    assert isinstance(utils.to_str(ustr(s)), str)
+    assert utils.to_str(ustr(s)) == 'abcdefg'
 
-        s = b'abcdefg'
-        self.assertIsInstance(utils.to_binary(s), bytes)
-        self.assertEqual(utils.to_binary(s), b'abcdefg')
-        self.assertIsInstance(utils.to_str(s), str)
-        self.assertEqual(utils.to_str(s), 'abcdefg')
-        self.assertIsInstance(utils.to_text(s), str)
-        self.assertEqual(utils.to_text(s), u'abcdefg')
+    s = b'abcdefg'
+    assert isinstance(utils.to_binary(s), bytes)
+    assert utils.to_binary(s) == b'abcdefg'
+    assert isinstance(utils.to_str(s), str)
+    assert utils.to_str(s) == 'abcdefg'
+    assert isinstance(utils.to_text(s), str)
+    assert utils.to_text(s) == u'abcdefg'
 
-        ubytes = type('ubytes', (bytes,), {})
-        self.assertIsInstance(utils.to_binary(ubytes(s)), bytes)
-        self.assertEqual(utils.to_binary(ubytes(s)), b'abcdefg')
+    ubytes = type('ubytes', (bytes,), {})
+    assert isinstance(utils.to_binary(ubytes(s)), bytes)
+    assert utils.to_binary(ubytes(s)) == b'abcdefg'
 
-        s = u'abcdefg'
-        self.assertIsInstance(utils.to_binary(s), bytes)
-        self.assertEqual(utils.to_binary(s), b'abcdefg')
-        self.assertIsInstance(utils.to_str(s), str)
-        self.assertEqual(utils.to_str(s), 'abcdefg')
-        self.assertIsInstance(utils.to_text(s), str)
-        self.assertEqual(utils.to_text(s), u'abcdefg')
+    s = u'abcdefg'
+    assert isinstance(utils.to_binary(s), bytes)
+    assert utils.to_binary(s) == b'abcdefg'
+    assert isinstance(utils.to_str(s), str)
+    assert utils.to_str(s) == 'abcdefg'
+    assert isinstance(utils.to_text(s), str)
+    assert utils.to_text(s) == u'abcdefg'
 
-        uunicode = type('uunicode', (str,), {})
-        self.assertIsInstance(utils.to_text(uunicode(s)), str)
-        self.assertEqual(utils.to_text(uunicode(s)), u'abcdefg')
+    uunicode = type('uunicode', (str,), {})
+    assert isinstance(utils.to_text(uunicode(s)), str)
+    assert utils.to_text(uunicode(s)) == u'abcdefg'
 
-        with self.assertRaises(TypeError):
-            utils.to_binary(utils)
-        with self.assertRaises(TypeError):
-            utils.to_str(utils)
-        with self.assertRaises(TypeError):
-            utils.to_text(utils)
+    with pytest.raises(TypeError):
+        utils.to_binary(utils)
+    with pytest.raises(TypeError):
+        utils.to_str(utils)
+    with pytest.raises(TypeError):
+        utils.to_text(utils)
 
-    def testTokenize(self):
-        import shutil
-        import tempfile
 
-        class TestEnum(Enum):
-            VAL1 = 'val1'
+def test_tokenize():
+    import shutil
+    import tempfile
 
-        tempdir = tempfile.mkdtemp('mars_test_utils_')
+    class TestEnum(Enum):
+        VAL1 = 'val1'
+
+    tempdir = tempfile.mkdtemp('mars_test_utils_')
+    try:
+        filename = os.path.join(tempdir, 'test_npa.dat')
+        mmp_array = np.memmap(filename, dtype=float, mode='w+', shape=(3, 4))
+        mmp_array[:] = np.random.random((3, 4)).astype(float)
+        mmp_array.flush()
+        del mmp_array
+
+        mmp_array1 = np.memmap(filename, dtype=float, shape=(3, 4))
+        mmp_array2 = np.memmap(filename, dtype=float, shape=(3, 4))
+
         try:
-            filename = os.path.join(tempdir, 'test_npa.dat')
-            mmp_array = np.memmap(filename, dtype=float, mode='w+', shape=(3, 4))
-            mmp_array[:] = np.random.random((3, 4)).astype(float)
-            mmp_array.flush()
-            del mmp_array
-
-            mmp_array1 = np.memmap(filename, dtype=float, shape=(3, 4))
-            mmp_array2 = np.memmap(filename, dtype=float, shape=(3, 4))
-
-            try:
-                v = [1, 2.3, '456', u'789', b'101112', 2147483649, None, np.ndarray,
-                     [912, 'uvw'], np.arange(0, 10), np.array(10), np.array([b'\x01\x32\xff']),
-                     np.int64, TestEnum.VAL1]
-                copy_v = copy.deepcopy(v)
-                self.assertEqual(utils.tokenize(v + [mmp_array1], ext_data=1234),
-                                 utils.tokenize(copy_v + [mmp_array2], ext_data=1234))
-            finally:
-                del mmp_array1, mmp_array2
+            v = [1, 2.3, '456', u'789', b'101112', 2147483649, None, np.ndarray,
+                 [912, 'uvw'], np.arange(0, 10), np.array(10), np.array([b'\x01\x32\xff']),
+                 np.int64, TestEnum.VAL1]
+            copy_v = copy.deepcopy(v)
+            assert (utils.tokenize(v + [mmp_array1], ext_data=1234)
+                    == utils.tokenize(copy_v + [mmp_array2], ext_data=1234))
         finally:
-            shutil.rmtree(tempdir)
+            del mmp_array1, mmp_array2
+    finally:
+        shutil.rmtree(tempdir)
 
-        v = {'a', 'xyz', 'uvw'}
-        self.assertEqual(utils.tokenize(v), utils.tokenize(copy.deepcopy(v)))
+    v = {'a', 'xyz', 'uvw'}
+    assert utils.tokenize(v) == utils.tokenize(copy.deepcopy(v))
 
-        v = dict(x='abcd', y=98765)
-        self.assertEqual(utils.tokenize(v), utils.tokenize(copy.deepcopy(v)))
+    v = dict(x='abcd', y=98765)
+    assert utils.tokenize(v) == utils.tokenize(copy.deepcopy(v))
 
-        v = dict(x=dict(a=1, b=[1, 2, 3]), y=12345)
-        self.assertEqual(utils.tokenize(v), utils.tokenize(copy.deepcopy(v)))
+    v = dict(x=dict(a=1, b=[1, 2, 3]), y=12345)
+    assert utils.tokenize(v) == utils.tokenize(copy.deepcopy(v))
 
-        # pandas relative
-        if pd is not None:
-            df = pd.DataFrame([[utils.to_binary('测试'), utils.to_text('数据')]],
-                              index=['a'], columns=['中文', 'data'])
-            v = [df, df.index, df.columns, df['data'], pd.Categorical(list('ABCD'))]
-            self.assertEqual(utils.tokenize(v), utils.tokenize(copy.deepcopy(v)))
+    # pandas relative
+    if pd is not None:
+        df = pd.DataFrame([[utils.to_binary('测试'), utils.to_text('数据')]],
+                          index=['a'], columns=['中文', 'data'])
+        v = [df, df.index, df.columns, df['data'], pd.Categorical(list('ABCD'))]
+        assert utils.tokenize(v) == utils.tokenize(copy.deepcopy(v))
 
-        class NonTokenizableCls:
-            def __getstate__(self):
-                raise SystemError
+    class NonTokenizableCls:
+        def __getstate__(self):
+            raise SystemError
 
-        with self.assertRaises(TypeError):
-            utils.tokenize(NonTokenizableCls())
+    with pytest.raises(TypeError):
+        utils.tokenize(NonTokenizableCls())
 
-        class CustomizedTokenize(object):
-            def __mars_tokenize__(self):
-                return id(type(self)), id(NonTokenizableCls)
+    class CustomizedTokenize(object):
+        def __mars_tokenize__(self):
+            return id(type(self)), id(NonTokenizableCls)
 
-        self.assertEqual(utils.tokenize(CustomizedTokenize()),
-                         utils.tokenize(CustomizedTokenize()))
+    assert utils.tokenize(CustomizedTokenize()) == utils.tokenize(CustomizedTokenize())
 
-        v = lambda x: x + 1
-        self.assertEqual(utils.tokenize(v), utils.tokenize(copy.deepcopy(v)))
+    v = lambda x: x + 1
+    assert utils.tokenize(v) == utils.tokenize(copy.deepcopy(v))
 
-        def f(a, b):
-            return np.add(a, b)
-        self.assertEqual(utils.tokenize(f), utils.tokenize(copy.deepcopy(f)))
+    def f(a, b):
+        return np.add(a, b)
+    assert utils.tokenize(f) == utils.tokenize(copy.deepcopy(f))
 
-        partial_f = partial(f, 1, k=0)
-        partial_f2 = partial(f, 1, k=1)
-        self.assertEqual(utils.tokenize(partial_f), utils.tokenize(copy.deepcopy(partial_f)))
-        self.assertNotEqual(utils.tokenize(partial_f), utils.tokenize(partial_f2))
+    partial_f = partial(f, 1, k=0)
+    partial_f2 = partial(f, 1, k=1)
+    assert utils.tokenize(partial_f) == utils.tokenize(copy.deepcopy(partial_f))
+    assert utils.tokenize(partial_f) != utils.tokenize(partial_f2)
 
-    def testBuildTileableGraph(self):
-        a = mt.ones((10, 10), chunk_size=8)
-        b = mt.ones((10, 10), chunk_size=8)
-        c = (a + 1) * 2 + b
 
-        graph = utils.build_tileable_graph([c], set())
-        self.assertEqual(len(graph), 5)
-        a_data = next(n for n in graph if n.key == a.key)
-        self.assertEqual(graph.count_successors(a_data), 1)
-        self.assertEqual(graph.count_predecessors(a_data), 0)
-        c_data = next(n for n in graph if n.key == c.key)
-        self.assertEqual(graph.count_successors(c_data), 0)
-        self.assertEqual(graph.count_predecessors(c_data), 2)
+def test_build_tileable_graph():
+    a = mt.ones((10, 10), chunk_size=8)
+    b = mt.ones((10, 10), chunk_size=8)
+    c = (a + 1) * 2 + b
 
-        graph = utils.build_tileable_graph([a, b, c], set())
-        self.assertEqual(len(graph), 5)
+    graph = utils.build_tileable_graph([c], set())
+    assert len(graph) == 5
+    a_data = next(n for n in graph if n.key == a.key)
+    assert graph.count_successors(a_data) == 1
+    assert graph.count_predecessors(a_data) == 0
+    c_data = next(n for n in graph if n.key == c.key)
+    assert graph.count_successors(c_data) == 0
+    assert graph.count_predecessors(c_data) == 2
 
-        # test fetch replacement
-        a = mt.ones((10, 10), chunk_size=8)
-        b = mt.ones((10, 10), chunk_size=8)
-        c = (a + 1) * 2 + b
-        executed_keys = {a.key, b.key}
+    graph = utils.build_tileable_graph([a, b, c], set())
+    assert len(graph) == 5
 
-        graph = utils.build_tileable_graph([c], executed_keys)
-        self.assertEqual(len(graph), 5)
-        self.assertNotIn(a.data, graph)
-        self.assertNotIn(b.data, graph)
-        self.assertTrue(any(isinstance(n.op, TensorFetch) for n in graph))
-        c_data = next(n for n in graph if n.key == c.key)
-        self.assertEqual(graph.count_successors(c_data), 0)
-        self.assertEqual(graph.count_predecessors(c_data), 2)
+    # test fetch replacement
+    a = mt.ones((10, 10), chunk_size=8)
+    b = mt.ones((10, 10), chunk_size=8)
+    c = (a + 1) * 2 + b
+    executed_keys = {a.key, b.key}
 
-        executed_keys = {(a + 1).key}
-        graph = utils.build_tileable_graph([c], executed_keys)
-        self.assertTrue(any(isinstance(n.op, TensorFetch) for n in graph))
-        self.assertEqual(len(graph), 4)
+    graph = utils.build_tileable_graph([c], executed_keys)
+    assert len(graph) == 5
+    assert a.data not in graph
+    assert b.data not in graph
+    assert any(isinstance(n.op, TensorFetch) for n in graph)
+    c_data = next(n for n in graph if n.key == c.key)
+    assert graph.count_successors(c_data) == 0
+    assert graph.count_predecessors(c_data) == 2
 
-        executed_keys = {((a + 1) * 2).key}
-        graph = utils.build_tileable_graph([c], executed_keys)
-        self.assertTrue(any(isinstance(n.op, TensorFetch) for n in graph))
-        self.assertEqual(len(graph), 3)
+    executed_keys = {(a + 1).key}
+    graph = utils.build_tileable_graph([c], executed_keys)
+    assert any(isinstance(n.op, TensorFetch) for n in graph)
+    assert len(graph) == 4
 
-        executed_keys = {c.key}
-        graph = utils.build_tileable_graph([c], executed_keys)
-        self.assertTrue(any(isinstance(n.op, TensorFetch) for n in graph))
-        self.assertEqual(len(graph), 1)
+    executed_keys = {((a + 1) * 2).key}
+    graph = utils.build_tileable_graph([c], executed_keys)
+    assert any(isinstance(n.op, TensorFetch) for n in graph)
+    assert len(graph) == 3
 
-    def testEnterMode(self):
-        from mars.config import option_context, options
+    executed_keys = {c.key}
+    graph = utils.build_tileable_graph([c], executed_keys)
+    assert any(isinstance(n.op, TensorFetch) for n in graph)
+    assert len(graph) == 1
 
-        @utils.enter_mode(kernel=True)
-        def wrapped():
-            return utils.is_eager_mode()
 
-        self.assertFalse(options.eager_mode)
-        self.assertFalse(wrapped())
+def test_enter_mode():
+    from mars.config import option_context, options
 
+    @utils.enter_mode(kernel=True)
+    def wrapped():
+        return utils.is_eager_mode()
+
+    assert not options.eager_mode
+    assert not wrapped()
+
+    with option_context({'eager_mode': True}):
+        assert options.eager_mode
+        assert not wrapped()
+
+    @utils.enter_mode(kernel=True)
+    def wrapped2():
+        wrapped()
         with option_context({'eager_mode': True}):
-            self.assertTrue(options.eager_mode)
-            self.assertFalse(wrapped())
+            assert options.eager_mode
+            assert not utils.is_eager_mode()
+            with utils.enter_mode(kernel=False):
+                assert not utils.is_kernel_mode()
+            assert utils.is_kernel_mode()
 
-        @utils.enter_mode(kernel=True)
-        def wrapped2():
-            wrapped()
-            with option_context({'eager_mode': True}):
-                self.assertTrue(options.eager_mode)
-                self.assertFalse(utils.is_eager_mode())
-                with utils.enter_mode(kernel=False):
-                    self.assertFalse(utils.is_kernel_mode())
-                self.assertTrue(utils.is_kernel_mode())
+    wrapped2()
 
-        wrapped2()
+    assert not utils.is_kernel_mode()
+    assert not utils.is_build_mode()
 
-        self.assertFalse(utils.is_kernel_mode())
-        self.assertFalse(utils.is_build_mode())
-
-        @utils.enter_mode(kernel=False)
-        def wrapped3():
-            wrapped()
-            with option_context({'eager_mode': True}):
-                self.assertTrue(options.eager_mode)
-                self.assertFalse(utils.is_kernel_mode())
+    @utils.enter_mode(kernel=False)
+    def wrapped3():
+        wrapped()
+        with option_context({'eager_mode': True}):
+            assert options.eager_mode
+            assert not utils.is_kernel_mode()
+            with utils.enter_mode(kernel=True, build=True):
+                assert utils.is_kernel_mode()
+                assert utils.is_build_mode()
+            assert not utils.is_kernel_mode()
+            assert not utils.is_build_mode()
+            with pytest.raises(ValueError):
                 with utils.enter_mode(kernel=True, build=True):
-                    self.assertTrue(utils.is_kernel_mode())
-                    self.assertTrue(utils.is_build_mode())
-                self.assertFalse(utils.is_kernel_mode())
-                self.assertFalse(utils.is_build_mode())
-                with self.assertRaises(ValueError):
-                    with utils.enter_mode(kernel=True, build=True):
-                        raise ValueError('meant to raise error')
-                self.assertFalse(utils.is_kernel_mode())
-                self.assertFalse(utils.is_build_mode())
-
-                @utils.enter_mode(kernel=True)
-                def wrapped4():
                     raise ValueError('meant to raise error')
+            assert not utils.is_kernel_mode()
+            assert not utils.is_build_mode()
 
-                with self.assertRaises(ValueError):
-                    wrapped4()
-                self.assertFalse(utils.is_kernel_mode())
-                self.assertFalse(utils.is_build_mode())
+            @utils.enter_mode(kernel=True)
+            def wrapped4():
+                raise ValueError('meant to raise error')
 
-        wrapped3()
+            with pytest.raises(ValueError):
+                wrapped4()
+            assert not utils.is_kernel_mode()
+            assert not utils.is_build_mode()
 
-    def testBlacklistSet(self):
-        blset = utils.BlacklistSet(0.1)
-        blset.update([1, 2])
-        time.sleep(0.3)
-        blset.add(3)
+    wrapped3()
 
-        with self.assertRaises(KeyError):
-            blset.remove(2)
 
-        self.assertNotIn(1, blset)
-        self.assertNotIn(2, blset)
-        self.assertIn(3, blset)
+def test_blacklist_set():
+    blset = utils.BlacklistSet(0.1)
+    blset.update([1, 2])
+    time.sleep(0.3)
+    blset.add(3)
 
-        blset.add(4)
-        time.sleep(0.3)
-        blset.add(5)
-        blset.add(6)
+    with pytest.raises(KeyError):
+        blset.remove(2)
 
-        self.assertSetEqual({5, 6}, set(blset))
+    assert 1 not in blset
+    assert 2 not in blset
+    assert 3 in blset
 
-    def testLazyImport(self):
-        old_sys_path = sys.path
-        mock_mod = textwrap.dedent("""
-        __version__ = '0.1.0b1'
-        """.strip())
+    blset.add(4)
+    time.sleep(0.3)
+    blset.add(5)
+    blset.add(6)
 
-        temp_dir = tempfile.mkdtemp(prefix='mars-utils-test-')
-        sys.path += [temp_dir]
-        try:
-            with open(os.path.join(temp_dir, 'test_mod.py'), 'w') as outf:
-                outf.write(mock_mod)
+    assert {5, 6} == set(blset)
 
-            non_exist_mod = utils.lazy_import('non_exist_mod', locals=locals())
-            self.assertIsNone(non_exist_mod)
 
-            mod = utils.lazy_import(
-                'test_mod', globals=globals(), locals=locals(), rename='mod')
-            self.assertIsNotNone(mod)
-            self.assertEqual(mod.__version__, '0.1.0b1')
+def test_lazy_import():
+    old_sys_path = sys.path
+    mock_mod = textwrap.dedent("""
+    __version__ = '0.1.0b1'
+    """.strip())
 
-            glob = globals().copy()
-            mod = utils.lazy_import(
-                'test_mod', globals=glob, locals=locals(), rename='mod')
-            glob['mod'] = mod
-            self.assertIsNotNone(mod)
-            self.assertEqual(mod.__version__, '0.1.0b1')
-            self.assertEqual(type(glob['mod']).__name__, 'module')
-        finally:
-            shutil.rmtree(temp_dir)
-            sys.path = old_sys_path
+    temp_dir = tempfile.mkdtemp(prefix='mars-utils-test-')
+    sys.path += [temp_dir]
+    try:
+        with open(os.path.join(temp_dir, 'test_mod.py'), 'w') as outf:
+            outf.write(mock_mod)
 
-    def testChunksIndexer(self):
-        a = mt.ones((3, 4, 5), chunk_size=2)
+        non_exist_mod = utils.lazy_import('non_exist_mod', locals=locals())
+        assert non_exist_mod is None
+
+        mod = utils.lazy_import(
+            'test_mod', globals=globals(), locals=locals(), rename='mod')
+        assert mod is not None
+        assert mod.__version__ == '0.1.0b1'
+
+        glob = globals().copy()
+        mod = utils.lazy_import(
+            'test_mod', globals=glob, locals=locals(), rename='mod')
+        glob['mod'] = mod
+        assert mod is not None
+        assert mod.__version__ == '0.1.0b1'
+        assert type(glob['mod']).__name__ == 'module'
+    finally:
+        shutil.rmtree(temp_dir)
+        sys.path = old_sys_path
+
+
+def test_chunks_indexer():
+    a = mt.ones((3, 4, 5), chunk_size=2)
+    a = a.tiles()
+
+    assert a.chunk_shape == (2, 2, 3)
+
+    with pytest.raises(ValueError):
+        _ = a.cix[1]
+    with pytest.raises(ValueError):
+        _ = a.cix[1, :]
+
+    chunk_key = a.cix[0, 0, 0].key
+    expected = a.chunks[0].key
+    assert chunk_key == expected
+
+    chunk_key = a.cix[1, 1, 1].key
+    expected = a.chunks[9].key
+    assert chunk_key == expected
+
+    chunk_key = a.cix[1, 1, 2].key
+    expected = a.chunks[11].key
+    assert chunk_key == expected
+
+    chunk_key = a.cix[0, -1, -1].key
+    expected = a.chunks[5].key
+    assert chunk_key == expected
+
+    chunk_key = a.cix[0, -1, -1].key
+    expected = a.chunks[5].key
+    assert chunk_key == expected
+
+    chunk_keys = [c.key for c in a.cix[0, 0, :]]
+    expected = [c.key for c in [a.cix[0, 0, 0], a.cix[0, 0, 1], a.cix[0, 0, 2]]]
+    assert chunk_keys == expected
+
+    chunk_keys = [c.key for c in a.cix[:, 0, :]]
+    expected = [c.key for c in [a.cix[0, 0, 0], a.cix[0, 0, 1], a.cix[0, 0, 2],
+                                a.cix[1, 0, 0], a.cix[1, 0, 1], a.cix[1, 0, 2]]]
+    assert chunk_keys == expected
+
+    chunk_keys = [c.key for c in a.cix[:, :, :]]
+    expected = [c.key for c in a.chunks]
+    assert chunk_keys == expected
+
+
+def test_check_chunks_unknown_shape():
+    with pytest.raises(ValueError):
+        a = mt.random.rand(10, chunk_size=5)
+        mt.random.shuffle(a)
         a = a.tiles()
+        utils.check_chunks_unknown_shape([a], ValueError)
 
-        self.assertEqual(a.chunk_shape, (2, 2, 3))
 
-        with self.assertRaises(ValueError):
-            _ = a.cix[1]
-        with self.assertRaises(ValueError):
-            _ = a.cix[1, :]
+def test_insert_reversed_tuple():
+    assert utils.insert_reversed_tuple((), 9) == (9,)
+    assert utils.insert_reversed_tuple((7, 4, 3, 1), 9) == (9, 7, 4, 3, 1)
+    assert utils.insert_reversed_tuple((7, 4, 3, 1), 6) == (7, 6, 4, 3, 1)
+    assert utils.insert_reversed_tuple((7, 4, 3, 1), 4) == (7, 4, 3, 1)
+    assert utils.insert_reversed_tuple((7, 4, 3, 1), 0) == (7, 4, 3, 1, 0)
 
-        chunk_key = a.cix[0, 0, 0].key
-        expected = a.chunks[0].key
-        self.assertEqual(chunk_key, expected)
 
-        chunk_key = a.cix[1, 1, 1].key
-        expected = a.chunks[9].key
-        self.assertEqual(chunk_key, expected)
+def test_require_not_none():
+    @utils.require_not_none(1)
+    def should_exist():
+        pass
 
-        chunk_key = a.cix[1, 1, 2].key
-        expected = a.chunks[11].key
-        self.assertEqual(chunk_key, expected)
+    assert should_exist is not None
 
-        chunk_key = a.cix[0, -1, -1].key
-        expected = a.chunks[5].key
-        self.assertEqual(chunk_key, expected)
+    @utils.require_not_none(None)
+    def should_not_exist():
+        pass
 
-        chunk_key = a.cix[0, -1, -1].key
-        expected = a.chunks[5].key
-        self.assertEqual(chunk_key, expected)
+    assert should_not_exist is None
 
-        chunk_keys = [c.key for c in a.cix[0, 0, :]]
-        expected = [c.key for c in [a.cix[0, 0, 0], a.cix[0, 0, 1], a.cix[0, 0, 2]]]
-        self.assertEqual(chunk_keys, expected)
+    @utils.require_module('numpy.fft')
+    def should_exist_np():
+        pass
 
-        chunk_keys = [c.key for c in a.cix[:, 0, :]]
-        expected = [c.key for c in [a.cix[0, 0, 0], a.cix[0, 0, 1], a.cix[0, 0, 2],
-                                    a.cix[1, 0, 0], a.cix[1, 0, 1], a.cix[1, 0, 2]]]
-        self.assertEqual(chunk_keys, expected)
+    assert should_exist_np is not None
 
-        chunk_keys = [c.key for c in a.cix[:, :, :]]
-        expected = [c.key for c in a.chunks]
-        self.assertEqual(chunk_keys, expected)
+    @utils.require_module('numpy.fft_error')
+    def should_not_exist_np():
+        pass
 
-    def testCheckChunksUnknownShape(self):
-        with self.assertRaises(ValueError):
-            a = mt.random.rand(10, chunk_size=5)
-            mt.random.shuffle(a)
-            a = a.tiles()
-            utils.check_chunks_unknown_shape([a], ValueError)
+    assert should_not_exist_np is None
 
-    def testInsertReversedTuple(self):
-        self.assertTupleEqual(utils.insert_reversed_tuple((), 9), (9,))
-        self.assertTupleEqual(utils.insert_reversed_tuple((7, 4, 3, 1), 9), (9, 7, 4, 3, 1))
-        self.assertTupleEqual(utils.insert_reversed_tuple((7, 4, 3, 1), 6), (7, 6, 4, 3, 1))
-        self.assertTupleEqual(utils.insert_reversed_tuple((7, 4, 3, 1), 4), (7, 4, 3, 1))
-        self.assertTupleEqual(utils.insert_reversed_tuple((7, 4, 3, 1), 0), (7, 4, 3, 1, 0))
 
-    def testRequireNotNone(self):
-        @utils.require_not_none(1)
-        def should_exist():
-            pass
+def test_type_dispatcher():
+    dispatcher = utils.TypeDispatcher()
 
-        self.assertIsNotNone(should_exist)
+    type1 = type('Type1', (), {})
+    type2 = type('Type2', (type1,), {})
+    type3 = type('Type3', (), {})
 
-        @utils.require_not_none(None)
-        def should_not_exist():
-            pass
+    dispatcher.register(object, lambda x: 'Object')
+    dispatcher.register(type1, lambda x: 'Type1')
+    dispatcher.register('pandas.DataFrame', lambda x: 'DataFrame')
 
-        self.assertIsNone(should_not_exist)
+    assert 'Type1' == dispatcher(type2())
+    assert 'DataFrame' == dispatcher(pd.DataFrame())
+    assert 'Object' == dispatcher(type3())
 
-        @utils.require_module('numpy.fft')
-        def should_exist_np():
-            pass
 
-        self.assertIsNotNone(should_exist_np)
+def test_fixed_size_file_object():
+    arr = [str(i).encode() * 20 for i in range(10)]
+    bts = os.linesep.encode().join(arr)
+    bio = BytesIO(bts)
 
-        @utils.require_module('numpy.fft_error')
-        def should_not_exist_np():
-            pass
+    ref_bio = BytesIO(bio.read(100))
+    bio.seek(0)
+    ref_bio.seek(0)
+    fix_bio = utils.FixedSizeFileObject(bio, 100)
 
-        self.assertIsNone(should_not_exist_np)
+    assert ref_bio.readline() == fix_bio.readline()
+    assert ref_bio.tell() == fix_bio.tell()
+    pos = ref_bio.tell() + 10
+    assert ref_bio.seek(pos) == fix_bio.seek(pos)
+    assert ref_bio.read(5) == fix_bio.read(5)
+    assert ref_bio.readlines(25) == fix_bio.readlines(25)
+    assert list(ref_bio) == list(fix_bio)
 
-    def testTypeDispatcher(self):
-        dispatcher = utils.TypeDispatcher()
 
-        type1 = type('Type1', (), {})
-        type2 = type('Type2', (type1,), {})
-        type3 = type('Type3', (), {})
+def test_timer():
+    with utils.Timer() as timer:
+        time.sleep(0.1)
 
-        dispatcher.register(object, lambda x: 'Object')
-        dispatcher.register(type1, lambda x: 'Type1')
-        dispatcher.register('pandas.DataFrame', lambda x: 'DataFrame')
+    assert timer.duration >= 0.1
 
-        self.assertEqual('Type1', dispatcher(type2()))
-        self.assertEqual('DataFrame', dispatcher(pd.DataFrame()))
-        self.assertEqual('Object', dispatcher(type3()))
 
-    def testFixedSizeFileObject(self):
-        arr = [str(i).encode() * 20 for i in range(10)]
-        bts = os.linesep.encode().join(arr)
-        bio = BytesIO(bts)
+def test_quiet_stdio():
+    old_stdout, old_stderr = sys.stdout, sys.stderr
 
-        ref_bio = BytesIO(bio.read(100))
-        bio.seek(0)
-        ref_bio.seek(0)
-        fix_bio = utils.FixedSizeFileObject(bio, 100)
+    class _IOWrapper:
+        def __init__(self, name=None):
+            self.name = name
+            self.content = ''
 
-        self.assertEqual(ref_bio.readline(), fix_bio.readline())
-        self.assertEqual(ref_bio.tell(), fix_bio.tell())
-        pos = ref_bio.tell() + 10
-        self.assertEqual(ref_bio.seek(pos), fix_bio.seek(pos))
-        self.assertEqual(ref_bio.read(5), fix_bio.read(5))
-        self.assertEqual(ref_bio.readlines(25), fix_bio.readlines(25))
-        self.assertEqual(list(ref_bio), list(fix_bio))
+        @staticmethod
+        def writable():
+            return True
 
-    def testTimer(self):
-        with utils.Timer() as timer:
-            time.sleep(0.1)
+        def write(self, d):
+            self.content += d
+            return len(d)
 
-        self.assertGreaterEqual(timer.duration, 0.1)
+    stdout_w = _IOWrapper('stdout')
+    stderr_w = _IOWrapper('stderr')
+    executor = ThreadPoolExecutor(1)
+    try:
+        sys.stdout = stdout_w
+        sys.stderr = stderr_w
 
-    def testQuietStdio(self):
-        old_stdout, old_stderr = sys.stdout, sys.stderr
-
-        class _IOWrapper:
-            def __init__(self, name=None):
-                self.name = name
-                self.content = ''
-
-            @staticmethod
-            def writable():
-                return True
-
-            def write(self, d):
-                self.content += d
-                return len(d)
-
-        stdout_w = _IOWrapper('stdout')
-        stderr_w = _IOWrapper('stderr')
-        executor = ThreadPoolExecutor(1)
-        try:
-            sys.stdout = stdout_w
-            sys.stderr = stderr_w
-
+        with utils.quiet_stdio():
             with utils.quiet_stdio():
-                with utils.quiet_stdio():
-                    self.assertTrue(sys.stdout.writable())
-                    self.assertTrue(sys.stderr.writable())
+                assert sys.stdout.writable()
+                assert sys.stderr.writable()
 
-                    print('LINE 1', end='\n')
-                    print('LINE 2', file=sys.stderr, end='\n')
-                    executor.submit(print, 'LINE T').result()
-                print('LINE 3', end='\n')
+                print('LINE 1', end='\n')
+                print('LINE 2', file=sys.stderr, end='\n')
+                executor.submit(print, 'LINE T').result()
+            print('LINE 3', end='\n')
 
-            print('LINE 1', end='\n')
-            print('LINE 2', file=sys.stderr, end='\n')
-        finally:
-            sys.stdout, sys.stderr = old_stdout, old_stderr
+        print('LINE 1', end='\n')
+        print('LINE 2', file=sys.stderr, end='\n')
+    finally:
+        sys.stdout, sys.stderr = old_stdout, old_stderr
 
-        self.assertEqual(stdout_w.content, 'LINE T\nLINE 1\n')
-        self.assertEqual(stderr_w.content, 'LINE 2\n')
+    assert stdout_w.content == 'LINE T\nLINE 1\n'
+    assert stderr_w.content == 'LINE 2\n'
+
+
+@pytest.mark.asyncio
+async def test_async_batch_decorator():
+    class TestClass:
+        def __init__(self):
+            self.arg_list = []
+            self.kwarg_list = []
+
+        @utils.async_method(False)
+        async def method1(self, *args, **kwargs):
+            pass
+
+        @method1.batch
+        async def method1(self, args_list, kwargs_list):
+            self.arg_list.extend(args_list)
+            self.kwarg_list.extend(kwargs_list)
+            return [len(self.kwarg_list)] * len(args_list)
+
+        @utils.async_method
+        async def method2(self, *args, **kwargs):
+            self.arg_list.append(tuple(a - 1 for a in args))
+            self.kwarg_list.append({k: v - 1 for k, v in kwargs.items()})
+            return len(self.kwarg_list)
+
+        @utils.async_method
+        async def method3(self, *args, **kwargs):
+            self.arg_list.append(tuple(a * 2 for a in args))
+            self.kwarg_list.append({k: v * 2 for k, v in kwargs.items()})
+            return len(self.kwarg_list)
+
+        @method3.batch
+        async def method3(self, args_list, kwargs_list):
+            self.arg_list.extend([tuple(a * 2 + 1 for a in args) for args in args_list])
+            self.kwarg_list.extend([{k: v * 2 + 1 for k, v in kwargs.items()}
+                                    for kwargs in kwargs_list])
+            return [len(self.kwarg_list)] * len(args_list)
+
+    assert asyncio.iscoroutinefunction(TestClass.method1)
+
+    test_inst = TestClass()
+    ret = await test_inst.method1(12, kwarg=34)
+    assert ret == 1
+    assert test_inst.arg_list == [(12,)]
+    assert test_inst.kwarg_list == [{'kwarg': 34}]
+
+    test_inst = TestClass()
+    ret = await test_inst.method2.batch([(12,), (10,)],
+                                        [{'kwarg': 34}, {'kwarg': 33}])
+    assert ret == [1, 2]
+    assert test_inst.arg_list == [(11,), (9,)]
+    assert test_inst.kwarg_list == [{'kwarg': 33}, {'kwarg': 32}]
+
+    test_inst = TestClass()
+    ret = await test_inst.method3(15, kwarg=56)
+    assert ret == 1
+    ret = await test_inst.method3.batch([(16,), (17,)],
+                                        [{'kwarg': 57}, {'kwarg': 58}])
+    assert ret == [3, 3]
+    assert test_inst.arg_list == [(30,), (33,), (35,)]
+    assert test_inst.kwarg_list == [{'kwarg': 112}, {'kwarg': 115}, {'kwarg': 117}]

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1224,7 +1224,7 @@ def stringify_path(path: Union[str, os.PathLike]) -> str:
         raise TypeError("not a path-like object")
 
 
-class AsyncMethodWrapper:
+class ExtensibleWrapper:
     def __init__(self, instance, func, batch_func=None):
         self.instance = instance
         self.func = func
@@ -1244,7 +1244,7 @@ class AsyncMethodWrapper:
         )
 
 
-class AsyncMethodAccessor:
+class ExtensibleAccessor:
     def __init__(self, func, implemented=True):
         self.func = func
         self.batch_func = None
@@ -1261,14 +1261,14 @@ class AsyncMethodAccessor:
             if self.implemented else None
         batch_func = self.batch_func.__get__(instance, owner) \
             if self.batch_func is not None else None
-        return AsyncMethodWrapper(instance, func, batch_func)
+        return ExtensibleWrapper(instance, func, batch_func)
 
 
-def async_method(implemented):
+def extensible(implemented):
     if callable(implemented):
-        return AsyncMethodAccessor(implemented)
+        return ExtensibleAccessor(implemented)
 
     def deco_fun(func):
-        return AsyncMethodAccessor(func, implemented)
+        return ExtensibleAccessor(func, implemented)
 
     return deco_fun

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import functools
 import importlib
 import inspect
@@ -1221,3 +1222,53 @@ def stringify_path(path: Union[str, os.PathLike]) -> str:
         return path.__fspath__()
     except AttributeError:
         raise TypeError("not a path-like object")
+
+
+class AsyncMethodWrapper:
+    def __init__(self, instance, func, batch_func=None):
+        self.instance = instance
+        self.func = func
+        self._batch_func = batch_func
+
+    async def __call__(self, *args, **kwargs):
+        if self.func is not None:
+            return await self.func(*args, **kwargs)
+        else:
+            return (await self._batch_func([args], [kwargs]))[0]
+
+    async def batch(self, args_list, kwargs_list):
+        if self._batch_func is not None:
+            return await self._batch_func(args_list, kwargs_list)
+        return asyncio.gather(*[
+            self.func(*args, **kwargs) for args, kwargs in zip(args_list, kwargs_list)]
+        )
+
+
+class AsyncMethodAccessor:
+    def __init__(self, func, implemented=True):
+        self.func = func
+        self.batch_func = None
+        self.implemented = implemented
+
+    def batch(self, func):
+        self.batch_func = func
+        return self
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self.func
+        func = self.func.__get__(instance, owner) \
+            if self.implemented else None
+        batch_func = self.batch_func.__get__(instance, owner) \
+            if self.batch_func is not None else None
+        return AsyncMethodWrapper(instance, func, batch_func)
+
+
+def async_method(implemented):
+    if callable(implemented):
+        return AsyncMethodAccessor(implemented)
+
+    def deco_fun(func):
+        return AsyncMethodAccessor(func, implemented)
+
+    return deco_fun

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1239,7 +1239,7 @@ class AsyncMethodWrapper:
     async def batch(self, args_list, kwargs_list):
         if self._batch_func is not None:
             return await self._batch_func(args_list, kwargs_list)
-        return asyncio.gather(*[
+        return await asyncio.gather(*[
             self.func(*args, **kwargs) for args, kwargs in zip(args_list, kwargs_list)]
         )
 


### PR DESCRIPTION
## What do these changes do?

Add support for batch interfaces for actors. Actor writers can define actors as

```python
class TestActor(mo.Actor):
    @extensible
    def method(self, arg1, arg2):
        # implementation for single data

    @method.batch
    def method(self, args_list, kwargs_list):
        # implementation for batch data
```

and invoke as

```python
ref = await mp.actor_ref('TestActor', address='address')
await ref.batch(
    ref.method(val1_1, val2_1),
    ref.method(val1_2, val2_2),
)
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
