### PR TITLE
[oscar] Add cancel support, optimize error handling, add `kill_actor` API

### DIFF
--- a/mars/oscar/__init__.py
+++ b/mars/oscar/__init__.py
@@ -17,7 +17,7 @@ from ..lib import aio
 del aio
 
 from .api import actor_ref, create_actor, has_actor, destroy_actor, \
-    Actor, create_actor_pool
+    kill_actor, Actor, create_actor_pool
 from .errors import ActorNotExist, ActorAlreadyExist
 from .utils import create_actor_ref
 

--- a/mars/oscar/api.py
+++ b/mars/oscar/api.py
@@ -40,6 +40,11 @@ async def actor_ref(*args, **kwargs):
     return await ctx.actor_ref(*args, **kwargs)
 
 
+async def kill_actor(actor_ref):
+    ctx = get_context()
+    return await ctx.kill_actor(actor_ref)
+
+
 async def create_actor_pool(address: str,
                             n_process: int = None,
                             **kwargs):

--- a/mars/oscar/backends/mars/allocate_strategy.py
+++ b/mars/oscar/backends/mars/allocate_strategy.py
@@ -73,7 +73,8 @@ class MainPool(AllocateStrategy):
                               config: ActorPoolConfig,
                               allocated: allocated_type) -> str:
         # allocate to main process
-        return config.get_external_address(0)
+        main_process_index = config.get_process_indexes()[0]
+        return config.get_external_address(main_process_index)
 
 
 class RandomSubPool(AllocateStrategy):
@@ -84,6 +85,20 @@ class RandomSubPool(AllocateStrategy):
                               config: ActorPoolConfig,
                               allocated: allocated_type) -> str:
         return choice(config.get_external_addresses()[1:])
+
+
+class ProcessIndex(AllocateStrategy):
+    __slots__ = 'process_index',
+
+    def __init__(self, process_index: int):
+        self.process_index = process_index
+
+    @implements(AllocateStrategy.get_allocated_address)
+    def get_allocated_address(self,
+                              config: ActorPoolConfig,
+                              allocated: allocated_type) -> str:
+        actual_process_index = config.get_process_indexes()[self.process_index]
+        return config.get_pool_config(actual_process_index)['external_address'][0]
 
 
 class RandomLabel(AllocateStrategy):

--- a/mars/oscar/backends/mars/communication/__init__.py
+++ b/mars/oscar/backends/mars/communication/__init__.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 from .base import Client, Server, Channel
-from .core import get_client_type, get_server_type, gen_internal_address
+from .core import get_client_type, get_server_type, \
+    gen_internal_address, gen_local_address
 from .dummy import DummyClient, DummyServer, DummyChannel
 from .socket import SocketClient, SocketServer, UnixSocketClient, \
     UnixSocketServer, SocketChannel

--- a/mars/oscar/backends/mars/communication/core.py
+++ b/mars/oscar/backends/mars/communication/core.py
@@ -63,3 +63,7 @@ def get_server_type(address: str) -> Type[Server]:
 
 def gen_internal_address(process_index: int) -> str:
     return f'unixsocket:///{process_index}'
+
+
+def gen_local_address(process_index: int) -> str:
+    return f'dummy://{process_index}'

--- a/mars/oscar/backends/mars/communication/socket.py
+++ b/mars/oscar/backends/mars/communication/socket.py
@@ -176,8 +176,6 @@ class SocketServer(_BaseSocketServer):
         handle_channel = config.pop('handle_channel')
         if 'start_serving' not in config:
             config['start_serving'] = False
-        if 'reuse_port' not in config:
-            config['reuse_port'] = True
 
         async def handle_connection(reader, writer):
             # create a channel when client connected

--- a/mars/oscar/backends/mars/communication/socket.py
+++ b/mars/oscar/backends/mars/communication/socket.py
@@ -176,6 +176,8 @@ class SocketServer(_BaseSocketServer):
         handle_channel = config.pop('handle_channel')
         if 'start_serving' not in config:
             config['start_serving'] = False
+        if 'reuse_port' not in config:
+            config['reuse_port'] = True
 
         async def handle_connection(reader, writer):
             # create a channel when client connected
@@ -210,9 +212,12 @@ class SocketClient(Client):
         return SocketClient(local_address, dest_address, channel)
 
 
+TEMPDIR = tempfile.gettempdir()
+
+
 @lru_cache(100)
 def _gen_unix_socket_default_path(process_index):
-    return f'{tempfile.gettempdir()}/mars/' \
+    return f'{TEMPDIR}/mars/' \
            f'{md5(to_binary(str(process_index))).hexdigest()}'  # nosec
 
 

--- a/mars/oscar/backends/mars/communication/tests/test_comm.py
+++ b/mars/oscar/backends/mars/communication/tests/test_comm.py
@@ -15,7 +15,7 @@
 import asyncio
 import sys
 import multiprocessing
-from typing import Union
+from typing import Union, List, Tuple, Type, Dict
 
 import numpy as np
 import pytest
@@ -24,7 +24,7 @@ from mars.lib.aio import AioEvent
 from mars.oscar.backends.mars.communication import \
     SocketChannel, SocketServer, UnixSocketServer, \
     DummyChannel, DummyServer, get_client_type, \
-    SocketClient, UnixSocketClient, DummyClient
+    SocketClient, UnixSocketClient, DummyClient, Server
 from mars.utils import get_next_port
 
 
@@ -33,13 +33,13 @@ port = get_next_port()
 
 
 # server_type, config, con
-params = [
+params: List[Tuple[Type[Server], Dict, str]] = [
     (SocketServer, dict(host='127.0.0.1', port=port), f'127.0.0.1:{port}'),
 ]
 if sys.platform != 'win32':
     params.append((UnixSocketServer, dict(process_index='0'), f'unixsocket:///0'))
 local_params = params.copy()
-local_params.append((DummyServer, dict(), 'dummy://'))
+local_params.append((DummyServer, dict(), 'dummy://0'))
 
 
 @pytest.mark.parametrize(

--- a/mars/oscar/backends/mars/config.py
+++ b/mars/oscar/backends/mars/config.py
@@ -59,6 +59,13 @@ class ActorPoolConfig:
     def get_process_indexes(self):
         return list(self._conf['pools'])
 
+    def get_process_index(self, external_addrress):
+        for process_index, conf in self._conf['pools'].items():
+            if external_addrress in conf['external_address']:
+                return process_index
+        raise ValueError(f'Cannot get proces_index '
+                         f'for {external_addrress}')  # pragma: no cover
+
     def get_external_addresses(self, label=None) -> List[str]:
         result = []
         for c in self._conf['pools'].values():

--- a/mars/oscar/backends/mars/core.py
+++ b/mars/oscar/backends/mars/core.py
@@ -50,7 +50,11 @@ class ActorCaller:
                     message: _MessageBase = await client.recv()
                 except (EOFError, ConnectionError):
                     # remote server closed, close client and raise ServerClosed
-                    await client.close()
+                    try:
+                        await client.close()
+                    except ConnectionError:
+                        # close failed, ignore it
+                        pass
                     raise ServerClosed(f'Remote server {client.dest_address} closed')
                 future = self._client_to_message_futures[client].pop(message.message_id)
                 future.set_result(message)

--- a/mars/oscar/backends/mars/core.py
+++ b/mars/oscar/backends/mars/core.py
@@ -48,7 +48,7 @@ class ActorCaller:
             try:
                 try:
                     message: _MessageBase = await client.recv()
-                except EOFError:
+                except (EOFError, ConnectionError):
                     # remote server closed, close client and raise ServerClosed
                     await client.close()
                     raise ServerClosed(f'Remote server {client.dest_address} closed')

--- a/mars/oscar/backends/mars/message.py
+++ b/mars/oscar/backends/mars/message.py
@@ -42,6 +42,7 @@ class MessageType(Enum):
     actor_ref = 6
     send = 7
     tell = 8
+    cancel = 9
 
 
 class ControlMessageType(Enum):
@@ -86,10 +87,11 @@ class _MessageBase(ABC):
 
 
 class ControlMessage(_MessageBase):
-    __slots__ = 'control_message_type', 'content'
+    __slots__ = 'address', 'control_message_type', 'content'
 
     def __init__(self,
                  message_id: bytes,
+                 address: str,
                  control_message_type: ControlMessageType,
                  content: Any,
                  scoped_message_ids: List[bytes] = None,
@@ -97,6 +99,7 @@ class ControlMessage(_MessageBase):
         super().__init__(message_id,
                          scoped_message_ids=scoped_message_ids,
                          protocol=protocol)
+        self.address = address
         self.control_message_type = control_message_type
         self.content = content
 
@@ -256,10 +259,33 @@ class SendMessage(_MessageBase):
 
 
 class TellMessage(SendMessage):
+    __slots__ = ()
+
     @classproperty
     @implements(_MessageBase.message_type)
     def message_type(self) -> MessageType:
         return MessageType.tell
+
+
+class CancelMessage(_MessageBase):
+    __slots__ = 'address', 'cancel_message_id',
+
+    def __init__(self,
+                 message_id: bytes,
+                 address: str,
+                 cancel_message_id: bytes,
+                 scoped_message_ids: List[bytes] = None,
+                 protocol: int = None):
+        super().__init__(message_id,
+                         scoped_message_ids=scoped_message_ids,
+                         protocol=protocol)
+        self.address = address
+        self.cancel_message_id = cancel_message_id
+
+    @classproperty
+    @implements(_MessageBase.message_type)
+    def message_type(self) -> MessageType:
+        return MessageType.cancel
 
 
 class DesrializeMessageFailed(Exception):

--- a/mars/oscar/backends/mars/pool.py
+++ b/mars/oscar/backends/mars/pool.py
@@ -101,7 +101,7 @@ class AbstractActorPool(ABC):
         # actor id -> actor
         self._actors: Dict[bytes, Actor] = dict()
         # message id -> future
-        self._process_messages: Dict[bytes: asyncio.Future] = dict()
+        self._process_messages: Dict[bytes, asyncio.Future] = dict()
 
         # manage async actor callers
         self._caller = ActorCaller()
@@ -964,7 +964,7 @@ class MainActorPool(ActorPoolBase):
     async def _monitor_sub_pools(self):
         try:
             while not self._stopped.is_set():
-                for i, address in enumerate(self._sub_processes):
+                for address in self._sub_processes:
                     process = self._sub_processes[address]
                     if not process.is_alive():
                         self._recovered.clear()

--- a/mars/oscar/backends/mars/tests/test_pool.py
+++ b/mars/oscar/backends/mars/tests/test_pool.py
@@ -12,27 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import sys
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
 import pytest
 
 from mars.utils import get_next_port
-from mars.oscar import Actor
+from mars.oscar import Actor, kill_actor
 from mars.oscar.context import get_context
 from mars.oscar.backends.mars import create_actor_pool
 from mars.oscar.backends.mars.allocate_strategy import \
-    AddressSpecified, IdleLabel, MainPool, RandomSubPool
+    AddressSpecified, IdleLabel, MainPool, RandomSubPool, ProcessIndex
 from mars.oscar.backends.mars.config import ActorPoolConfig
 from mars.oscar.backends.mars.message import new_message_id, \
     CreateActorMessage, DestroyActorMessage, HasActorMessage, \
     ActorRefMessage, SendMessage, TellMessage, ControlMessage, \
-    ControlMessageType, MessageType
+    CancelMessage, ControlMessageType, MessageType
 from mars.oscar.backends.mars.pool import SubActorPool, MainActorPool
 from mars.oscar.backends.mars.router import Router
-from mars.oscar.errors import NoIdleSlot, ActorNotExist
+from mars.oscar.errors import NoIdleSlot, ActorNotExist, ServerClosed
 from mars.oscar.utils import create_actor_ref
-from mars.tests.core import mock
 
-
-# test create actor
 
 class _CannotBeUnpickled:
     def __getstate__(self):
@@ -50,6 +54,10 @@ class TestActor(Actor):
 
     def add(self, val):
         self.value += val
+        return self.value
+
+    async def sleep(self, second):
+        await asyncio.sleep(second)
         return self.value
 
     def return_cannot_unpickle(self):
@@ -113,6 +121,21 @@ async def test_sub_actor_pool(notify_main_pool):
     result = await pool.send(send_message)
     assert isinstance(result.error, ActorNotExist)
 
+    # test send message and cancel it
+    send_message = SendMessage(
+        new_message_id(), actor_ref, ('sleep', 0, (20,), dict()))
+    result_task = asyncio.create_task(pool.send(send_message))
+    await asyncio.sleep(0)
+    cancel_message = CancelMessage(
+        new_message_id(), actor_ref.address, send_message.message_id)
+    cancel_task = asyncio.create_task(pool.cancel(cancel_message))
+    result = await asyncio.wait_for(cancel_task, 3)
+    assert result.message_type == MessageType.result
+    assert result.result is True
+    result = await result_task
+    assert result.message_type == MessageType.error
+    assert isinstance(result.error, asyncio.CancelledError)
+
     # test processing message on background
     async with await pool.router.get_client(pool.external_address) as client:
         send_message = SendMessage(
@@ -142,24 +165,25 @@ async def test_sub_actor_pool(notify_main_pool):
     # test sync config
     config.add_pool_conf(1, 'sub', 'unixsocket:///1', f'127.0.0.1:{get_next_port()}')
     sync_config_message = ControlMessage(
-        new_message_id(), ControlMessageType.sync_config, config)
+        new_message_id(), '', ControlMessageType.sync_config, config)
     message = await pool.handle_control_command(sync_config_message)
     assert message.result is True
 
     # test get config
     get_config_message = ControlMessage(
-        new_message_id(), ControlMessageType.get_config, None)
+        new_message_id(), '', ControlMessageType.get_config, None)
     message = await pool.handle_control_command(get_config_message)
     config2 = message.result
     assert config.as_dict() == config2.as_dict()
 
+    assert pool.router._mapping == Router.get_instance()._mapping
+    assert pool.router._curr_external_addresses == \
+           Router.get_instance()._curr_external_addresses
+
     stop_message = ControlMessage(
-        new_message_id(), ControlMessageType.stop, None)
+        new_message_id(), '', ControlMessageType.stop, None)
     message = await pool.handle_control_command(stop_message)
     assert message.result is True
-
-    assert pool.router is Router.get_instance()
-    assert pool.external_address == pool.router.external_address
 
     await pool.join(.05)
     assert pool.stopped
@@ -238,6 +262,20 @@ async def test_main_actor_pool():
             new_message_id(), actor_ref, ('add', 0, (4,), dict()))
         assert (await pool.send(send_message)).result == 6
 
+        # send and cancel
+        send_message = SendMessage(
+            new_message_id(), actor_ref1, ('sleep', 0, (20,), dict()))
+        result_task = asyncio.create_task(pool.send(send_message))
+        cancel_message = CancelMessage(
+            new_message_id(), actor_ref1.address, send_message.message_id)
+        cancel_task = asyncio.create_task(pool.cancel(cancel_message))
+        result = await asyncio.wait_for(cancel_task, 3)
+        assert result.message_type == MessageType.result
+        assert result.result is True
+        result = await result_task
+        assert result.message_type == MessageType.error
+        assert isinstance(result.error, asyncio.CancelledError)
+
         # destroy
         destroy_actor_message = DestroyActorMessage(
             new_message_id(), actor_ref1)
@@ -253,6 +291,21 @@ async def test_main_actor_pool():
             result = await client.recv()
             assert result.result == actor_ref2.uid
 
+        # test sync config
+        config.add_pool_conf(3, 'sub', 'unixsocket:///3', f'127.0.0.1:{get_next_port()}')
+        sync_config_message = ControlMessage(
+            new_message_id(), pool.external_address, ControlMessageType.sync_config, config)
+        message = await pool.handle_control_command(sync_config_message)
+        assert message.result is True
+
+        # test get config
+        get_config_message = ControlMessage(
+            new_message_id(), config.get_external_addresses()[1],
+            ControlMessageType.get_config, None)
+        message = await pool.handle_control_command(get_config_message)
+        config2 = message.result
+        assert config.as_dict() == config2.as_dict()
+
     assert pool.stopped
 
 
@@ -261,6 +314,13 @@ async def test_create_actor_pool():
     pool = await create_actor_pool('127.0.0.1', n_process=2)
 
     async with pool:
+        # test global router
+        global_router = Router.get_instance()
+        # global router should not be the identical one with pool's router
+        assert global_router is not pool.router
+        assert pool.external_address in global_router._curr_external_addresses
+        assert pool.external_address in global_router._mapping
+
         ctx = get_context()
 
         # actor on main pool
@@ -270,6 +330,12 @@ async def test_create_actor_pool():
         assert await actor_ref.add(1) == 4
         assert (await ctx.has_actor(actor_ref)) is True
         assert (await ctx.actor_ref(actor_ref)) == actor_ref
+        # test cancel
+        task = asyncio.create_task(actor_ref.sleep(20))
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            print(await task)
         await ctx.destroy_actor(actor_ref)
         assert (await ctx.has_actor(actor_ref)) is False
 
@@ -284,8 +350,19 @@ async def test_create_actor_pool():
             await actor_ref2.return_cannot_unpickle()
         assert (await ctx.has_actor(actor_ref2)) is True
         assert (await ctx.actor_ref(actor_ref2)) == actor_ref2
+        # test cancel
+        task = asyncio.create_task(actor_ref2.sleep(20))
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
         await ctx.destroy_actor(actor_ref2)
         assert (await ctx.has_actor(actor_ref2)) is False
+
+    # after pool shutdown, global router must has been cleaned
+    global_router = Router.get_instance()
+    assert len(global_router._curr_external_addresses) == 0
+    assert len(global_router._mapping) == 0
 
 
 @pytest.mark.asyncio
@@ -300,3 +377,143 @@ async def test_errors():
     with pytest.raises(ValueError):
         _ = await create_actor_pool('127.0.0.1', n_process=1,
                                     ports=[get_next_port()])
+
+
+@pytest.mark.asyncio
+async def test_server_closed():
+    start_method = 'fork' if sys.platform != 'win32' else None
+    ports = [get_next_port() for _ in range(3)]
+    pool = await create_actor_pool('127.0.0.1', n_process=2,
+                                   ports=ports,
+                                   subprocess_start_method=start_method,
+                                   auto_recover=False)
+
+    ctx = get_context()
+
+    async with pool:
+        actor_ref = await ctx.create_actor(
+            TestActor, address=pool.external_address,
+            allocate_strategy=ProcessIndex(1))
+
+        # check if error raised normally when subprocess killed
+        task = asyncio.create_task(actor_ref.sleep(10))
+        await asyncio.sleep(0)
+
+        # kill subprocess 1
+        process = list(pool._sub_processes.values())[0]
+        process.kill()
+
+        with pytest.raises(ServerClosed):
+            # process already been killed,
+            # ServerClosed will be raised
+            await task
+
+        assert not process.is_alive()
+
+    with pytest.raises(RuntimeError):
+        await pool.start()
+
+    # create a new pool with same address
+    pool = await create_actor_pool('127.0.0.1', n_process=2,
+                                   ports=ports,
+                                   subprocess_start_method=start_method)
+    async with pool:
+        # test client that is new
+        assert await ctx.has_actor(actor_ref) is False
+
+    # test server unreachable
+    with pytest.raises(ConnectionError):
+        await ctx.has_actor(actor_ref)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'auto_rover',
+    [False, True, 'actor', 'process']
+)
+async def test_auto_recover(auto_rover):
+    start_method = 'fork' if sys.platform != 'win32' else None
+
+    pool = await create_actor_pool('127.0.0.1', n_process=2,
+                                   subprocess_start_method=start_method,
+                                   auto_recover=auto_rover)
+
+    async with pool:
+        ctx = get_context()
+
+        # create actor on main
+        actor_ref = await ctx.create_actor(
+            TestActor, address=pool.external_address,
+            allocate_strategy=MainPool())
+
+        with pytest.raises(ValueError):
+            # cannot kill actors on main pool
+            await kill_actor(actor_ref)
+
+        # create actor
+        actor_ref = await ctx.create_actor(
+            TestActor, address=pool.external_address,
+            allocate_strategy=ProcessIndex(1))
+        # kill_actor will cause kill corresponding process
+        await ctx.kill_actor(actor_ref)
+
+        if auto_rover:
+            # process must have been killed
+            await asyncio.sleep(.5)
+
+            assert not pool._recovered.is_set()
+            await pool._recovered.wait()
+
+            expect_has_actor = True if auto_rover in ['actor', True] else False
+            assert await ctx.has_actor(actor_ref) is expect_has_actor
+        else:
+            with pytest.raises(ServerClosed):
+                await ctx.has_actor(actor_ref)
+
+
+@pytest.mark.asyncio
+async def test_two_pools():
+    start_method = 'fork' if sys.platform != 'win32' else None
+
+    ctx = get_context()
+
+    pool1 = await create_actor_pool('127.0.0.1', n_process=2,
+                                    subprocess_start_method=start_method)
+    pool2 = await create_actor_pool('127.0.0.1', n_process=2,
+                                    subprocess_start_method=start_method)
+
+    try:
+        actor_ref1 = await ctx.create_actor(
+            TestActor, address=pool1.external_address,
+            allocate_strategy=MainPool())
+        assert actor_ref1.address == pool1.external_address
+        assert await actor_ref1.add(1) == 1
+        assert Router.get_instance().get_internal_address(
+            actor_ref1.address).startswith('dummy://')
+
+        actor_ref2 = await ctx.create_actor(
+            TestActor, address=pool1.external_address,
+            allocate_strategy=RandomSubPool())
+        assert actor_ref2.address in pool1._config.get_external_addresses()[1:]
+        assert await actor_ref2.add(3) == 3
+        assert Router.get_instance().get_internal_address(
+            actor_ref2.address).startswith('unixsocket://')
+
+        actor_ref3 = await ctx.create_actor(
+            TestActor, address=pool2.external_address,
+            allocate_strategy=MainPool())
+        assert actor_ref3.address == pool2.external_address
+        assert await actor_ref3.add(5) == 5
+        assert Router.get_instance().get_internal_address(
+            actor_ref3.address).startswith('dummy://')
+
+        actor_ref4 = await ctx.create_actor(
+            TestActor, address=pool2.external_address,
+            allocate_strategy=RandomSubPool())
+        assert actor_ref4.address in pool2._config.get_external_addresses()[1:]
+        assert await actor_ref4.add(7) == 7
+        assert Router.get_instance().get_internal_address(
+            actor_ref4.address).startswith('unixsocket://')
+    finally:
+        await pool1.stop()
+        await pool2.stop()

--- a/mars/oscar/backends/mars/tests/test_pool.py
+++ b/mars/oscar/backends/mars/tests/test_pool.py
@@ -382,9 +382,7 @@ async def test_errors():
 @pytest.mark.asyncio
 async def test_server_closed():
     start_method = 'fork' if sys.platform != 'win32' else None
-    ports = [get_next_port() for _ in range(3)]
     pool = await create_actor_pool('127.0.0.1', n_process=2,
-                                   ports=ports,
                                    subprocess_start_method=start_method,
                                    auto_recover=False)
 
@@ -412,14 +410,6 @@ async def test_server_closed():
 
     with pytest.raises(RuntimeError):
         await pool.start()
-
-    # create a new pool with same address
-    pool = await create_actor_pool('127.0.0.1', n_process=2,
-                                   ports=ports,
-                                   subprocess_start_method=start_method)
-    async with pool:
-        # test client that is new
-        assert await ctx.has_actor(actor_ref) is False
 
     # test server unreachable
     with pytest.raises(ConnectionError):

--- a/mars/oscar/backends/ray/context.pyx
+++ b/mars/oscar/backends/ray/context.pyx
@@ -58,6 +58,10 @@ cdef class RayActorContext(BaseActorContext):
         ray.kill(actor_handle)
         return actor_ref.uid
 
+    async def kill_actor(self, ActorRef actor_ref):
+        # for Ray, kill == destroy.
+        return await self.destroy_actor(actor_ref)
+
     async def send(self, ActorRef actor_ref, object message, bint wait_response=True):
         try:
             actor_handle = ray.get_actor(actor_ref.uid)

--- a/mars/oscar/context.pyx
+++ b/mars/oscar/context.pyx
@@ -84,6 +84,23 @@ cdef class BaseActorContext:
         """
         raise NotImplementedError
 
+    async def kill_actor(self, ActorRef actor_ref):
+        """
+        Force to kill an actor, take care this is a dangerous operation,
+        it may lead to the result that other actors are killed as well.
+        Hence, unless you are knowing what you are doing and know how
+        to recover possible effected actors, DO NOT USE this method!
+
+        Parameters
+        ----------
+        actor_ref : ActorRef
+            Reference to an actor
+
+        Returns
+        -------
+        bool
+        """
+
     async def send(self, ActorRef actor_ref, object message, bint wait_response=True):
         """
         Send a message to given actor by its reference
@@ -150,6 +167,10 @@ cdef class ClientActorContext(BaseActorContext):
     def destroy_actor(self, ActorRef actor_ref):
         context = self._get_backend_context(actor_ref.address)
         return context.destroy_actor(actor_ref)
+
+    def kill_actor(self, ActorRef actor_ref):
+        context = self._get_backend_context(actor_ref.address)
+        return context.kill_actor(actor_ref)
 
     def actor_ref(self, *args, **kwargs):
         from .utils import create_actor_ref

--- a/mars/oscar/errors.py
+++ b/mars/oscar/errors.py
@@ -29,3 +29,7 @@ class ActorAlreadyExist(Exception):
 
 class NoIdleSlot(Exception):
     pass
+
+
+class ServerClosed(Exception):
+    pass


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR did a few things:

1. Add cancel support, now an actor operation can be cancelled. 
2. Error handling is optimized.
3. Actor pool now can auto recovering when process is done, if `auto_recover` is specified as True or 'actor', the actors created on the process will be created automatically.
4. `kill_actor` API is added to make sure an Actor can be destroyed even if it's blocked, but remember this is a dangerous operation that it actually did it by killing a process, make sure the actors that created in the same process are stateless.
5. Now more than 1 pools can be created.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA
