### PR TITLE
Fix __pre_destroy__ not called when actors are in main pool

### DIFF
--- a/mars/oscar/api.py
+++ b/mars/oscar/api.py
@@ -77,6 +77,10 @@ def setup_cluster(address_to_resources: Dict[str, Dict[str, Number]]):
 
 
 class Actor(_Actor):
+    @classmethod
+    def default_uid(cls):
+        return cls.__name__
+
     def __new__(cls, *args, **kwargs):
         try:
             return _actor_implementation[cls](*args, **kwargs)

--- a/mars/oscar/backends/mars/pool.py
+++ b/mars/oscar/backends/mars/pool.py
@@ -740,7 +740,7 @@ class MainActorPool(ActorPoolBase):
             return result
         real_actor_ref = result.result
         if real_actor_ref.address == self.external_address:
-            del self._actors[real_actor_ref.uid]
+            await super().destroy_actor(message)
             del self._allocated_actors[self.external_address][real_actor_ref]
             return ResultMessage(message.message_id, real_actor_ref.uid,
                                  protocol=message.protocol)

--- a/mars/oscar/core.pyx
+++ b/mars/oscar/core.pyx
@@ -132,7 +132,7 @@ cdef class ActorRefMethod:
             await asyncio.sleep(delay)
             await self.ref.__tell__((self.method_name, CALL_METHOD_DEFAULT, args, kwargs))
 
-        asyncio.create_task(delay_fun())
+        return asyncio.create_task(delay_fun())
 
 
 # The @cython.binding(True) is for ray getting members.


### PR DESCRIPTION
## What do these changes do?

Fix call `__pre_destroy__` when actors are in main pool.

## Related issue number

Fixes #2044 