### PR TITLE
Allow sync actor methods to be extensible

### DIFF
--- a/mars/services/scheduling/__init__.py
+++ b/mars/services/scheduling/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mars/services/scheduling/api.py
+++ b/mars/services/scheduling/api.py
@@ -1,0 +1,86 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC
+from typing import List, Tuple, Dict
+
+
+class AbstractSchedulingAPI(ABC):
+    async def submit_subtasks(self, subtasks: List, priorities: List[Tuple]):
+        """
+        Submit subtasks into scheduling service
+
+        Parameters
+        ----------
+        subtasks
+            list of subtasks to be submitted to service
+        priorities
+            list of priorities of subtasks
+        """
+
+    async def update_subtask_priorities(self, task_to_priorities: Dict[str, Tuple]):
+        """
+        Update priorities of subtasks
+
+        Parameters
+        ----------
+        task_to_priorities
+            mapping from subtask ids to priorities
+        """
+
+    async def cancel_subtasks(self, subtask_ids: List[str]):
+        """
+        Cancel pending and running subtasks.
+
+        Parameters
+        ----------
+        subtask_ids
+            ids of subtasks to cancel
+        """
+
+    async def finish_subtasks(self, subtask_ids: List[str]):
+        """
+        Mark subtasks as finished, letting scheduling service to schedule
+        next tasks in the ready queue
+
+        Parameters
+        ----------
+        subtask_ids
+            ids of subtasks to mark as finished
+        """
+
+    async def get_subtask_details(self, subtask_ids: List[str]) -> Dict[str, Dict]:
+        """
+        Get details of subtasks
+
+        Parameters
+        ----------
+        subtask_ids
+            ids of subtasks.
+
+        Returns
+        -------
+        out
+            mapping from subtask ids to details.
+        """
+
+    async def wait_subtasks(self, subtask_ids: List[str]):
+        """
+        Wait subtasks till all tasks finished
+
+        Parameters
+        ----------
+        subtask_ids
+            ids of subtasks to wait for.
+        """

--- a/mars/services/task/api.py
+++ b/mars/services/task/api.py
@@ -125,7 +125,7 @@ class AbstractTaskAPI(ABC):
     @abstractmethod
     async def list_subtasks(self,
                             task_id: str,
-                            offset: int = 0 ,
+                            offset: int = 0,
                             limit: int = None,
                             fields: List[str] = None) -> List[Dict]:
         """

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -542,6 +542,16 @@ async def test_batch_decorator(use_async):
         assert asyncio.iscoroutinefunction(TestClass.method1)
 
     test_inst = TestClass()
+
+    ret = test_inst.method1.batch([(12,), (10,)])
+    ret = await ret if use_async else ret
+    assert ret == [2, 2]
+    assert test_inst.arg_list == [(12,), (10,)]
+    assert test_inst.kwarg_list == [{}, {}]
+
+    test_inst.arg_list.clear()
+    test_inst.kwarg_list.clear()
+
     ret = test_inst.method1(12, kwarg=34)
     ret = await ret if use_async else ret
     assert ret == 1
@@ -551,7 +561,7 @@ async def test_batch_decorator(use_async):
     if sys.version_info[:2] > (3, 6):
         test_inst = TestClass()
         ret = test_inst.method2.batch([(12,), (10,)],
-                                            [{'kwarg': 34}, {'kwarg': 33}])
+                                      [{'kwarg': 34}, {'kwarg': 33}])
         ret = await ret if use_async else ret
         assert ret == [1, 2]
         assert test_inst.arg_list == [(11,), (9,)]
@@ -562,7 +572,7 @@ async def test_batch_decorator(use_async):
         ret = await ret if use_async else ret
         assert ret == 1
         ret = test_inst.method3.batch([(16,), (17,)],
-                                            [{'kwarg': 57}, {'kwarg': 58}])
+                                      [{'kwarg': 57}, {'kwarg': 58}])
         ret = await ret if use_async else ret
         assert ret == [3, 3]
         assert test_inst.arg_list == [(30,), (33,), (35,)]

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -491,62 +491,79 @@ def test_quiet_stdio():
 
 
 @pytest.mark.asyncio
-async def test_async_batch_decorator():
+@pytest.mark.parametrize('use_async', [False, True])
+async def test_batch_decorator(use_async):
+    def _wrap_async(func):
+        async def _wrapped(*args, **kwargs):
+            return func(*args, **kwargs)
+        _wrapped.__name__ = func.__name__
+        return _wrapped if use_async else func
+
     class TestClass:
         def __init__(self):
             self.arg_list = []
             self.kwarg_list = []
 
         @utils.extensible(False)
-        async def method1(self, *args, **kwargs):
+        @_wrap_async
+        def method1(self, *args, **kwargs):
             pass
 
         @method1.batch
-        async def method1(self, args_list, kwargs_list):
+        @_wrap_async
+        def method1(self, args_list, kwargs_list):
             self.arg_list.extend(args_list)
             self.kwarg_list.extend(kwargs_list)
             return [len(self.kwarg_list)] * len(args_list)
 
         @utils.extensible
-        async def method2(self, *args, **kwargs):
+        @_wrap_async
+        def method2(self, *args, **kwargs):
             self.arg_list.append(tuple(a - 1 for a in args))
             self.kwarg_list.append({k: v - 1 for k, v in kwargs.items()})
             return len(self.kwarg_list)
 
         @utils.extensible
-        async def method3(self, *args, **kwargs):
+        @_wrap_async
+        def method3(self, *args, **kwargs):
             self.arg_list.append(tuple(a * 2 for a in args))
             self.kwarg_list.append({k: v * 2 for k, v in kwargs.items()})
             return len(self.kwarg_list)
 
         @method3.batch
-        async def method3(self, args_list, kwargs_list):
+        @_wrap_async
+        def method3(self, args_list, kwargs_list):
             self.arg_list.extend([tuple(a * 2 + 1 for a in args) for args in args_list])
             self.kwarg_list.extend([{k: v * 2 + 1 for k, v in kwargs.items()}
                                     for kwargs in kwargs_list])
             return [len(self.kwarg_list)] * len(args_list)
 
-    assert asyncio.iscoroutinefunction(TestClass.method1)
+    if use_async:
+        assert asyncio.iscoroutinefunction(TestClass.method1)
 
     test_inst = TestClass()
-    ret = await test_inst.method1(12, kwarg=34)
+    ret = test_inst.method1(12, kwarg=34)
+    ret = await ret if use_async else ret
     assert ret == 1
     assert test_inst.arg_list == [(12,)]
     assert test_inst.kwarg_list == [{'kwarg': 34}]
 
     if sys.version_info[:2] > (3, 6):
         test_inst = TestClass()
-        ret = await test_inst.method2.batch([(12,), (10,)],
+        ret = test_inst.method2.batch([(12,), (10,)],
                                             [{'kwarg': 34}, {'kwarg': 33}])
+        ret = await ret if use_async else ret
         assert ret == [1, 2]
         assert test_inst.arg_list == [(11,), (9,)]
         assert test_inst.kwarg_list == [{'kwarg': 33}, {'kwarg': 32}]
 
         test_inst = TestClass()
-        ret = await test_inst.method3(15, kwarg=56)
+        ret = test_inst.method3(15, kwarg=56)
+        ret = await ret if use_async else ret
         assert ret == 1
-        ret = await test_inst.method3.batch([(16,), (17,)],
+        ret = test_inst.method3.batch([(16,), (17,)],
                                             [{'kwarg': 57}, {'kwarg': 58}])
+        ret = await ret if use_async else ret
         assert ret == [3, 3]
         assert test_inst.arg_list == [(30,), (33,), (35,)]
         assert test_inst.kwarg_list == [{'kwarg': 112}, {'kwarg': 115}, {'kwarg': 117}]

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1236,7 +1236,8 @@ class SyncExtensibleWrapper:
         else:
             return self._batch_func([args], [kwargs])[0]
 
-    def batch(self, args_list, kwargs_list):
+    def batch(self, args_list, kwargs_list=None):
+        kwargs_list = kwargs_list if kwargs_list is not None else [{} for _ in args_list]
         if self._batch_func is not None:
             return self._batch_func(args_list, kwargs_list)
         return [
@@ -1256,7 +1257,8 @@ class AsyncExtensibleWrapper:
         else:
             return (await self._batch_func([args], [kwargs]))[0]
 
-    async def batch(self, args_list, kwargs_list):
+    async def batch(self, args_list, kwargs_list=None):
+        kwargs_list = kwargs_list if kwargs_list is not None else [{} for _ in args_list]
         if self._batch_func is not None:
             return await self._batch_func(args_list, kwargs_list)
         return await asyncio.gather(*[


### PR DESCRIPTION
## What do these changes do?

Allow sync actor methods to be extensible. Scheduling APIs also added.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
