### PR TITLE
Implements serializables based on new serialization mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ bin/etcd*
 # cython compiled files
 mars/*.c*
 mars/*.h*
+mars/_core/**/*.c*
 mars/lib/*.c*
 mars/actors/*.c*
 mars/actors/pool/*.c*

--- a/mars/_core/__init__.py
+++ b/mars/_core/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .graph import DirectedGraph, DAG, GraphContainsCycleError, \
+    TileableGraph, ChunkGraph, TileableGraphBuilder, ChunkGraphBuilder

--- a/mars/_core/graph/__init__.py
+++ b/mars/_core/graph/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .builder import TileableGraphBuilder, ChunkGraphBuilder
+from .core import DirectedGraph, DAG, GraphContainsCycleError
+from .entity import TileableGraph, ChunkGraph

--- a/mars/_core/graph/builder.py
+++ b/mars/_core/graph/builder.py
@@ -1,0 +1,218 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import weakref
+from abc import ABC, abstractmethod
+from typing import Callable, List, Set, Union, Tuple, Iterable
+
+from ...core import EntityType, Tileable, TileableData
+from ...operands import Operand
+from ...utils import enter_mode, copy_tileables
+from .entity import EntityGraph, TileableGraph, ChunkGraph
+
+
+def _default_inputs_selector(inputs: List[EntityType]) -> List[EntityType]:
+    return inputs
+
+
+class AbstractGraphBuilder(ABC):
+    _graph: EntityGraph
+    _node_processor: Callable[[EntityType], EntityType]
+    _inputs_selector: Callable[[List], List]
+
+    def __init__(self,
+                 graph: EntityGraph,
+                 node_processor: Callable[[EntityType], EntityType] = None,
+                 inputs_selector: Callable[[List[EntityType]], List[EntityType]] = None,
+                 ):
+        self._graph = graph
+        self._node_processor = node_processor
+        self._inputs_selector = inputs_selector or _default_inputs_selector
+
+    def _add_nodes(self,
+                   graph: Union[ChunkGraph, TileableGraph],
+                   nodes: List[EntityType],
+                   visited: Set):
+        # update visited
+        visited.update(nodes)
+
+        while len(nodes) > 0:
+            node = nodes.pop()
+            if self._node_processor:
+                # if node processor registered, process the node first
+                node = self._node_processor(node)
+
+            # mark node as visited
+            visited.add(node)
+
+            # add node to graph if possible
+            if not graph.contains(node):
+                graph.add_node(node)
+
+            children = self._inputs_selector(node.inputs or [])
+            for c in children:
+                if self._node_processor:
+                    # process if node processor registered
+                    c = self._node_processor(c)
+                if not graph.contains(c):
+                    graph.add_node(c)
+                if not graph.has_successor(c, node):
+                    graph.add_edge(c, node)
+                for out in c.op.outputs:
+                    if out not in visited:
+                        nodes.append(out)
+
+    @abstractmethod
+    def build(self) -> Iterable[Union[EntityGraph, ChunkGraph]]:
+        """
+        Build a entity graph.
+
+        Returns
+        -------
+        graph : EntityGraph
+            Entity graph.
+        """
+
+
+class TileableGraphBuilder(AbstractGraphBuilder):
+    _graph: TileableGraph
+
+    def __init__(self,
+                 graph: TileableGraph,
+                 node_processor: Callable[[EntityType], EntityType] = None,
+                 inputs_selector: Callable[[List[EntityType]], List[EntityType]] = None,
+                 ):
+        super().__init__(graph=graph,
+                         node_processor=node_processor,
+                         inputs_selector=inputs_selector)
+
+    @enter_mode(build=True, kernel=True)
+    def build(self) -> Iterable[Union[TileableGraph, ChunkGraph]]:
+        self._add_nodes(self._graph, self._graph.result_tileables, set())
+        yield self._graph
+
+
+_tileable_data_to_tiled = weakref.WeakKeyDictionary()
+_op_to_copied = weakref.WeakKeyDictionary()
+
+
+class ChunkGraphBuilder(AbstractGraphBuilder):
+    _graph: TileableGraph
+
+    def __init__(self,
+                 graph: TileableGraph,
+                 node_process: Callable[[EntityType], EntityType] = None,
+                 inputs_selector: Callable[[List[EntityType]], List[EntityType]] = None,
+                 on_tile: Callable[[List[Tileable], List[Tileable]], List[Tileable]] = None,
+                 on_tile_success: Callable[[Tileable, Tileable], Tileable] = None,
+                 on_tile_failure: Callable[[Operand, Tuple], List[Tileable]] = None,
+                 fuse_enabled: bool = True,
+                 ):
+        super().__init__(graph=graph, node_processor=node_process,
+                         inputs_selector=inputs_selector)
+        self._fuse_enabled = fuse_enabled
+        self._on_tile = on_tile
+        self._on_tile_success = on_tile_success
+        self._on_tile_failure = on_tile_failure
+
+    @property
+    def fused_enabled(self):
+        return self._fuse_enabled
+
+    def _tile(self,
+              tileable_data: TileableData) -> List[Tileable]:
+        cache = _tileable_data_to_tiled
+        on_tile = self._on_tile
+
+        if tileable_data in cache:
+            return [cache[o] for o in tileable_data.op.outputs]
+
+        # copy tileable
+        if tileable_data.op in _op_to_copied:
+            tds = _op_to_copied[tileable_data.op]
+        else:
+            tds = copy_tileables(tileable_data.op.outputs,
+                                 inputs=[cache[inp] for inp in tileable_data.inputs],
+                                 copy_key=True, copy_id=False)
+            _op_to_copied[tileable_data.op] = tds
+        if not tileable_data.is_coarse():
+            # the tileable is already tiled
+            # could only happen when executor.execute_tileable(tileable.tiles())
+            for o, t in zip(tileable_data.op.outputs, tds):
+                t._chunks = o.chunks
+                t._nsplits = o.nsplits
+        elif on_tile is None:
+            tds[0]._inplace_tile()
+        else:
+            tds = on_tile(tileable_data.op.outputs, tds)
+            if not isinstance(tds, (list, tuple)):
+                tds = [tds]
+            assert len(tileable_data.op.outputs) == len(tds)
+        for t, td in zip(tileable_data.op.outputs, tds):
+            cache[t] = td.data if hasattr(td, 'data') else td
+        return tds
+
+    @enter_mode(build=True, kernel=True)
+    def build(self) -> Iterable[Union[TileableGraph, ChunkGraph]]:
+        tileable_graph = self._graph
+        tileables = tileable_graph.result_tileables
+
+        result_chunks = []
+        graph = ChunkGraph(result_chunks)
+
+        # do tiles and add nodes or edges to chunk graph
+        tileables_set = set(tileables)
+        keys = list()
+        visited = set()
+        tiled_op = set()
+        for tileable_data in tileable_graph.topological_iter():
+            nodes = list()
+            # do tiling
+            if tileable_data.op in tiled_op:
+                continue
+            try:
+                tiled = self._tile(tileable_data)
+                tiled_op.add(tileable_data.op)
+                for t, td in zip(tileable_data.op.outputs, tiled):
+                    if self._on_tile_success is not None:
+                        td = self._on_tile_success(t, td)
+                        if td is None:
+                            # if return None after calling `on_tile_success`,
+                            # the chunks will not be added into chunk graph any more
+                            continue
+                    nodes.extend(c.data for c in td.chunks)
+                    if t in tileables_set:
+                        result_chunks.extend(td.chunks)
+                        keys.extend(c.key for c in td.chunks)
+                    self._add_nodes(graph, nodes, visited)
+            except:  # noqa: E722  # nosec  # pylint: disable=bare-except  # pragma: no cover
+                exc_info = sys.exc_info()
+                if self._on_tile_failure:
+                    # partial tiled chunks can be returned
+                    # here they will be added to the chunk graph
+                    # for further execution
+                    partial_tiled_chunks = \
+                        self._on_tile_failure(tileable_data.op, exc_info)
+                    if partial_tiled_chunks is not None and \
+                            len(partial_tiled_chunks) > 0:
+                        self._add_nodes(graph, partial_tiled_chunks, visited)
+                    tiled_op.add(tileable_data.op)
+                else:
+                    raise
+
+        if self._fuse_enabled:
+            graph.compose(keys=keys)
+
+        yield graph

--- a/mars/_core/graph/core.pyx
+++ b/mars/_core/graph/core.pyx
@@ -1,0 +1,435 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+from collections import deque
+from io import StringIO
+
+
+logger = logging.getLogger(__name__)
+
+
+cdef class DirectedGraph:
+    cdef readonly:
+        dict _nodes
+        dict _predecessors
+        dict _successors
+
+    def __init__(self):
+        self._nodes = dict()
+        self._predecessors = dict()
+        self._successors = dict()
+
+    def __iter__(self):
+        return iter(self._nodes)
+
+    def __contains__(self, n):
+        return n in self._nodes
+
+    def __len__(self):
+        return len(self._nodes)
+
+    def __getitem__(self, n):
+        return self._successors[n]
+
+    def contains(self, node):
+        return node in self._nodes
+
+    def add_node(self, node, node_attr=None, **node_attrs):
+        if node_attr is None:
+            node_attr = node_attrs
+        else:
+            try:
+                node_attr.update(node_attrs)
+            except AttributeError:
+                raise TypeError('The node_attr argument must be a dictionary')
+        self._add_node(node, node_attr)
+
+    cdef inline _add_node(self, node, dict node_attr=None):
+        if node_attr is None:
+            node_attr = dict()
+        if node not in self._nodes:
+            self._nodes[node] = node_attr
+            self._successors[node] = dict()
+            self._predecessors[node] = dict()
+        else:
+            self._nodes[node].update(node_attr)
+
+    def remove_node(self, node):
+        if node not in self._nodes:
+            raise KeyError(f'Node {node} does not exist '
+                           f'in the directed graph')
+
+        del self._nodes[node]
+
+        for succ in self._successors[node]:
+            del self._predecessors[succ][node]
+        del self._successors[node]
+
+        for pred in self._predecessors[node]:
+            del self._successors[pred][node]
+        del self._predecessors[node]
+
+    def add_edge(self, u, v, edge_attr=None, **edge_attrs):
+        if edge_attr is None:
+            edge_attr = edge_attrs
+        else:
+            try:
+                edge_attr.update(edge_attrs)
+            except AttributeError:
+                raise TypeError('The edge_attr argument must be a dictionary')
+        self._add_edge(u, v, edge_attr)
+
+    cdef inline _add_edge(self, u, v, edge_attr=None):
+        cdef:
+            dict u_succ, v_pred
+
+        if u not in self._nodes:
+            raise KeyError(f'Node {u} does not exist in the directed graph')
+        if v not in self._nodes:
+            raise KeyError(f'Node {v} does not exist in the directed graph')
+
+        if edge_attr is None:
+            edge_attr = dict()
+
+        u_succ = self._successors[u]
+        if v in u_succ:
+            u_succ[v].update(edge_attr)
+        else:
+            u_succ[v] = edge_attr
+
+        v_pred = self._predecessors[v]
+        if u not in v_pred:
+            # `update` is not necessary, as they point to the same object
+            v_pred[u] = edge_attr
+
+    def remove_edge(self, u, v):
+        try:
+            del self._successors[u][v]
+            del self._predecessors[v][u]
+        except KeyError:
+            raise KeyError(f'Edge {u}->{v} does not exist in the directed graph')
+
+    def has_successor(self, u, v):
+        return (u in self._successors) and (v in self._successors[u])
+
+    def has_predecessor(self, u, v):
+        return (u in self._predecessors) and (v in self._predecessors[u])
+
+    def iter_nodes(self, data=False):
+        if data:
+            return iter(self._nodes.items())
+        return iter(self._nodes)
+
+    def iter_successors(self, n):
+        try:
+            return iter(self._successors[n])
+        except KeyError:
+            raise KeyError(f'Node {n} does not exist in the directed graph')
+
+    cpdef list successors(self, n):
+        try:
+            return list(self._successors[n])
+        except KeyError:
+            return KeyError(f'Node {n} does not exist in the directed graph')
+
+    def iter_predecessors(self, n):
+        try:
+            return iter(self._predecessors[n])
+        except KeyError:
+            raise KeyError(f'Node {n} does not exist in the directed graph')
+
+    cpdef list predecessors(self, n):
+        try:
+            return list(self._predecessors[n])
+        except KeyError:
+            raise KeyError(f'Node {n} does not exist in the directed graph')
+
+    cpdef int count_successors(self, n):
+        return len(self._successors[n])
+
+    cpdef int count_predecessors(self, n):
+        return len(self._predecessors[n])
+
+    def iter_indep(self, bint reverse=False):
+        cdef dict preds
+        preds = self._predecessors if not reverse else self._successors
+        for n, p in preds.items():
+            if len(p) == 0:
+                yield n
+
+    cpdef int count_indep(self, reverse=False):
+        cdef:
+            dict preds
+            int result = 0
+        preds = self._predecessors if not reverse else self._successors
+        for n, p in preds.items():
+            if len(p) == 0:
+                result += 1
+        return result
+
+    def dfs(self, start=None, visit_predicate=None, successors=None, reverse=False):
+        cdef:
+            set visited = set()
+            list stack
+            bint visit_all = False
+
+        if reverse:
+            pred_fun, succ_fun = self.successors, self.predecessors
+        else:
+            pred_fun, succ_fun = self.predecessors, self.successors
+
+        if start:
+            if not isinstance(start, (list, tuple)):
+                start = [start]
+            stack = list(start)
+        else:
+            stack = list(self.iter_indep(reverse=reverse))
+
+        def _default_visit_predicate(n, visited):
+            cdef list preds
+            preds = pred_fun(n)
+            return not preds or all(pred in visited for pred in preds)
+
+        successors = successors or succ_fun
+        visit_all = (visit_predicate == 'all')
+        visit_predicate = visit_predicate or _default_visit_predicate
+
+        while stack:
+            node = stack.pop()
+            if node in visited:
+                continue
+            preds = self.predecessors(node)
+            if visit_all or visit_predicate(node, visited):
+                yield node
+                visited.add(node)
+                stack.extend(n for n in successors(node) if n not in visited)
+            else:
+                stack.append(node)
+                stack.extend(n for n in preds if n not in visited)
+
+    def bfs(self, start=None, visit_predicate=None, successors=None, reverse=False):
+        cdef:
+            object queue
+            object node
+            set visited = set()
+            bint visit_all = False
+
+        if reverse:
+            pred_fun, succ_fun = self.successors, self.predecessors
+        else:
+            pred_fun, succ_fun = self.predecessors, self.successors
+
+        if start is not None:
+            if not isinstance(start, (list, tuple)):
+                start = [start]
+            queue = deque(start)
+        else:
+            queue = deque(self.iter_indep(reverse=reverse))
+
+        def _default_visit_predicate(n, visited):
+            preds = pred_fun(n)
+            return not preds or all(pred in visited for pred in preds)
+
+        successors = successors or succ_fun
+        visit_all = (visit_predicate == 'all')
+        visit_predicate = visit_predicate or _default_visit_predicate
+
+        while queue:
+            node = queue.popleft()
+            if node in visited:
+                continue
+            preds = pred_fun(node)
+            if visit_all or visit_predicate(node, visited):
+                yield node
+                visited.add(node)
+                queue.extend(n for n in successors(node) if n not in visited)
+            else:
+                queue.append(node)
+                queue.extend(n for n in preds if n not in visited)
+
+    def copy(self):
+        cdef DirectedGraph graph = type(self)()
+        for n in self:
+            if n not in graph._nodes:
+                graph._add_node(n)
+            for succ in self.iter_successors(n):
+                if succ not in graph._nodes:
+                    graph._add_node(succ)
+                graph._add_edge(n, succ)
+        return graph
+
+    def copyto(self, DirectedGraph other_graph):
+        if other_graph is self:
+            return
+
+        other_graph._nodes = self._nodes.copy()
+        other_graph._predecessors = self._predecessors.copy()
+        other_graph._successors = self._successors.copy()
+
+    def build_undirected(self):
+        cdef DirectedGraph graph = DirectedGraph()
+        for n in self:
+            if n not in graph._nodes:
+                graph._add_node(n)
+            for succ in self._successors[n]:
+                if succ not in graph._nodes:
+                    graph._add_node(succ)
+                graph._add_edge(n, succ)
+                graph._add_edge(succ, n)
+        return graph
+
+    def build_reversed(self):
+        cdef DirectedGraph graph = type(self)()
+        for n in self:
+            if n not in graph._nodes:
+                graph._add_node(n)
+            for succ in self._successors[n]:
+                if succ not in graph._nodes:
+                    graph._add_node(succ)
+                graph._add_edge(succ, n)
+        return graph
+
+    @classmethod
+    def _repr_in_dot(cls, val):
+        if isinstance(val, bool):
+            return 'true' if val else 'false'
+        if isinstance(val, str):
+            return f'"{val}"'
+        return val
+
+    def to_dot(self, graph_attrs=None, node_attrs=None, trunc_key=5, result_chunk_keys=None):
+        sio = StringIO()
+        sio.write('digraph {\n')
+        sio.write('splines=curved\n')
+        sio.write('rankdir=BT\n')
+
+        if graph_attrs:
+            sio.write('graph [{0}];\n'.format(
+                ' '.join(f'{k}={self._repr_in_dot(v)}' for k, v in graph_attrs.items())))
+        if node_attrs:
+            sio.write('node [{0}];\n'.format(
+                ' '.join(f'{k}={self._repr_in_dot(v)}' for k, v in node_attrs.items())))
+
+        chunk_style = '[shape=box]'
+        operand_style = '[shape=circle]'
+
+        visited = set()
+        for node in self.iter_nodes():
+            op = node.op
+            op_name = type(op).__name__
+            if op.stage is not None:
+                op_name = f'{op_name}:{op.stage.name}'
+            if op.key in visited:
+                continue
+            for input_chunk in (op.inputs or []):
+                if input_chunk.key not in visited:
+                    sio.write(f'"Chunk:{input_chunk.key[:trunc_key]}" {chunk_style}\n')
+                    visited.add(input_chunk.key)
+                if op.key not in visited:
+                    sio.write(f'"{op_name}:{op.key[:trunc_key]}" {operand_style}\n')
+                    visited.add(op.key)
+                sio.write(f'"Chunk:{input_chunk.key[:trunc_key]}" -> "{op_name}:{op.key[:5]}"\n')
+
+            for output_chunk in (op.outputs or []):
+                if output_chunk.key not in visited:
+                    tmp_chunk_style = chunk_style
+                    if result_chunk_keys and output_chunk.key in result_chunk_keys:
+                        tmp_chunk_style = '[shape=box,style=filled,fillcolor=cadetblue1]'
+                    sio.write(f'"Chunk:{output_chunk.key[:trunc_key]}" {tmp_chunk_style}\n')
+                    visited.add(output_chunk.key)
+                if op.key not in visited:
+                    sio.write(f'"{op_name}:{op.key[:trunc_key]}" {operand_style}\n')
+                    visited.add(op.key)
+                sio.write(f'"{op_name}:{op.key[:trunc_key]}" -> "Chunk:{output_chunk.key[:5]}"\n')
+
+        sio.write('}')
+        return sio.getvalue()
+
+    def _repr_svg_(self):  # pragma: no cover
+        from graphviz import Source
+        return Source(self.to_dot())._repr_svg_()
+
+    def compose(self, list keys=None):
+        from ...optimizes.chunk_graph.fuse import Fusion
+
+        return Fusion(self).compose(keys=keys)
+
+    def decompose(self, nodes=None):
+        from ...optimizes.chunk_graph.fuse import Fusion
+
+        Fusion(self).decompose(nodes=nodes)
+
+    def view(self, filename='default', graph_attrs=None, node_attrs=None, result_chunk_keys=None):  # pragma: no cover
+        from graphviz import Source
+
+        g = Source(self.to_dot(graph_attrs, node_attrs, result_chunk_keys=result_chunk_keys))
+        g.view(filename=filename, cleanup=True)
+
+    def to_dag(self):
+        dag = DAG()
+        dag._nodes = self._nodes.copy()
+        dag._predecessors = self._predecessors.copy()
+        dag._successors = self._successors.copy()
+        return dag
+
+
+class GraphContainsCycleError(Exception):
+    pass
+
+
+cdef class DAG(DirectedGraph):
+    def to_dag(self):
+        return self
+
+    def topological_iter(self, succ_checker=None, reverse=False):
+        cdef:
+            dict preds, succs
+            set visited = set()
+            list stack
+
+        if len(self) == 0:
+            return
+
+        if reverse:
+            preds, succs = self._successors, self._predecessors
+        else:
+            preds, succs = self._predecessors, self._successors
+
+        # copy predecessors and successors
+        succs = dict((k, set(v)) for k, v in succs.items())
+        preds = dict((k, set(v)) for k, v in preds.items())
+
+        def _default_succ_checker(_, predecessors):
+            return len(predecessors) == 0
+
+        succ_checker = succ_checker or _default_succ_checker
+
+        stack = list((p for p, l in preds.items() if len(l) == 0))
+        if not stack:
+            raise GraphContainsCycleError
+        while stack:
+            node = stack.pop()
+            yield node
+            visited.add(node)
+            for succ in succs.get(node, {}):
+                if succ in visited:
+                    raise GraphContainsCycleError
+                succ_preds = preds[succ]
+                succ_preds.remove(node)
+                if succ_checker(succ, succ_preds):
+                    stack.append(succ)
+        if len(visited) != len(self):
+            raise GraphContainsCycleError

--- a/mars/_core/graph/entity.py
+++ b/mars/_core/graph/entity.py
@@ -1,0 +1,100 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Dict, Union
+
+from ...core import Tileable, Chunk
+from ...serialization.serializables import Serializable, DictField, ListField, BoolField
+from ...serialization.serializables.core import SerializableSerializer
+from .core import DAG
+
+
+class EntityGraph(DAG):
+    pass
+
+
+class TileableGraph(EntityGraph):
+    _result_tileables: List[Tileable]
+
+    def __init__(self, result_tileables: List[Tileable]):
+        super().__init__()
+        self._result_tileables = result_tileables
+
+    @property
+    def result_tileables(self):
+        return self._result_tileables
+
+    @property
+    def results(self):
+        return self._result_tileables
+
+
+class ChunkGraph(EntityGraph):
+    _result_chunks: List[Chunk]
+
+    def __init__(self, result_chunks: List[Chunk]):
+        super().__init__()
+        self._result_chunks = result_chunks
+
+    @property
+    def result_chunks(self):
+        return self._result_chunks
+
+    @property
+    def results(self):
+        return self._result_chunks
+
+
+class SerializableGraph(Serializable):
+    _is_chunk = BoolField('is_chunk')
+    _nodes = DictField('nodes')
+    _predecessors = DictField('predecessors')
+    _successors = DictField('successors')
+    _results = ListField('results')
+
+    @classmethod
+    def from_graph(cls, graph: Union[TileableGraph, ChunkGraph]):
+        is_chunk = isinstance(graph, ChunkGraph)
+        return SerializableGraph(
+            _is_chunk=is_chunk,
+            _nodes=graph._nodes,
+            _predecessors=graph._predecessors,
+            _successors=graph._successors,
+            _results=graph.results
+        )
+
+    def to_graph(self) -> Union[TileableGraph, ChunkGraph]:
+        graph_cls = ChunkGraph if self._is_chunk else TileableGraph
+        graph = graph_cls(self._results)
+        graph._nodes.update(self._nodes)
+        graph._predecessors.update(self._predecessors)
+        graph._successors.update(self._successors)
+        return graph
+
+
+class GraphSerializer(SerializableSerializer):
+    serializer_name = 'graph'
+
+    def serialize(self, obj: Union[TileableGraph, ChunkGraph]):
+        serializable_graph = SerializableGraph.from_graph(obj)
+        return super().serialize(serializable_graph)
+
+    def deserialize(self, header: Dict, buffers: List) \
+            -> Union[TileableGraph, ChunkGraph]:
+        serializable_graph: SerializableGraph = \
+            super().deserialize(header, buffers)
+        return serializable_graph.to_graph()
+
+
+GraphSerializer.register(EntityGraph)

--- a/mars/_core/graph/entity.py
+++ b/mars/_core/graph/entity.py
@@ -86,14 +86,14 @@ class SerializableGraph(Serializable):
 class GraphSerializer(SerializableSerializer):
     serializer_name = 'graph'
 
-    def serialize(self, obj: Union[TileableGraph, ChunkGraph]):
+    def serialize(self, obj: Union[TileableGraph, ChunkGraph], context: Dict):
         serializable_graph = SerializableGraph.from_graph(obj)
-        return super().serialize(serializable_graph)
+        return super().serialize(serializable_graph, context)
 
-    def deserialize(self, header: Dict, buffers: List) \
+    def deserialize(self, header: Dict, buffers: List, context: Dict) \
             -> Union[TileableGraph, ChunkGraph]:
         serializable_graph: SerializableGraph = \
-            super().deserialize(header, buffers)
+            super().deserialize(header, buffers, context)
         return serializable_graph.to_graph()
 
 

--- a/mars/_core/graph/tests/__init__.py
+++ b/mars/_core/graph/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mars/_core/graph/tests/test_graph.py
+++ b/mars/_core/graph/tests/test_graph.py
@@ -1,0 +1,147 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from typing import List, Union
+
+import mars.tensor as mt
+from mars._core.graph import DAG, GraphContainsCycleError, TileableGraph, ChunkGraph, \
+    TileableGraphBuilder, ChunkGraphBuilder
+from mars.core import Tileable
+from mars.serialization import serialize, deserialize
+from mars.serialization.serializables import Serializable, Int32Field
+from mars.utils import enter_mode
+
+
+@enter_mode(kernel=True)
+def _build_graph(tileables: List[Tileable],
+                 tiled: bool = False,
+                 fuse_enabled: bool = True,
+                 **chunk_graph_build_kwargs) -> Union[TileableGraph, ChunkGraph]:
+    tileable_graph = TileableGraph(tileables)
+    tileable_graph_builder = TileableGraphBuilder(tileable_graph)
+    tileable_graph = next(tileable_graph_builder.build())
+    if not tiled:
+        return tileable_graph
+    chunk_graph_builder = ChunkGraphBuilder(
+        tileable_graph, fuse_enabled=fuse_enabled,
+        **chunk_graph_build_kwargs)
+    return next(chunk_graph_builder.build())
+
+
+class MySerializable(Serializable):
+    _id = Int32Field('id')
+
+    def __hash__(self):
+        return hash((type(self), self._id))
+
+    def __eq__(self, other):
+        return isinstance(other, MySerializable) and self._id == other._id
+
+
+def test_dag():
+    r"""
+    1 --- 4
+    2 --- 6
+      \  /
+       5
+     /
+    3
+    """
+
+    dag = DAG()
+    [dag.add_node(i) for i in range(1, 7)]
+    dag.add_edge(1, 4)
+    dag.add_edge(2, 6)
+    dag.add_edge(2, 5)
+    dag.add_edge(5, 6)
+    dag.add_edge(3, 5)
+
+    with pytest.raises(KeyError):
+        dag.add_edge(1, 10)
+    with pytest.raises(KeyError):
+        dag.add_edge(10, 1)
+
+    assert set(dag[2]) == {5, 6}
+    assert list(dag.topological_iter()) == [3, 2, 5, 6, 1, 4]
+
+    assert list(dag.dfs()) == [3, 2, 5, 6, 1, 4]
+    assert list(dag.bfs()) == [1, 2, 3, 4, 5, 6]
+
+    dag.add_edge(6, 1)
+    dag.add_edge(1, 2)
+
+    with pytest.raises(KeyError):
+        for _ in dag.iter_predecessors(-1):
+            pass
+
+    with pytest.raises(KeyError):
+        for _ in dag.iter_successors(-1):
+            pass
+
+    with pytest.raises(GraphContainsCycleError):
+        _ = list(dag.topological_iter())
+
+    dag.remove_edge(2, 5)
+    assert dag.has_successor(2, 5) is False
+    with pytest.raises(KeyError):
+        dag.remove_edge(2, 5)
+
+    rev_dag = dag.build_reversed()
+    for n in dag:
+        assert n in rev_dag
+        assert all(rev_dag.has_successor(n, pred)
+                   for pred in dag.predecessors(n)) is True
+
+    undigraph = dag.build_undirected()
+    for n in dag:
+        assert n in undigraph
+        assert all(undigraph.has_predecessor(pred, n)
+                   for pred in dag.predecessors(n)) is True
+        assert all(undigraph.has_successor(n, pred)
+                   for pred in dag.predecessors(n)) is True
+
+    dag_copy = dag.copy()
+    for n in dag:
+        assert n in dag_copy
+        assert all(dag_copy.has_successor(pred, n)
+                   for pred in dag_copy.predecessors(n)) is True
+
+
+def test_to_dot():
+    arr = mt.random.randint(10, size=(10, 8), chunk_size=4)
+    arr_add = mt.random.randint(10, size=(10, 8), chunk_size=4)
+    arr2 = arr + arr_add
+    graph = _build_graph([arr2], fuse_enabled=False, tiled=True)
+
+    dot = str(graph.to_dot(trunc_key=5))
+    assert all(str(n.op.key)[5] in dot for n in graph) is True
+
+
+@pytest.mark.parametrize(
+    'graph_type',
+    [TileableGraph, ChunkGraph]
+)
+def test_dag_serialization(graph_type):
+    n1 = MySerializable(_id=1)
+    n2 = MySerializable(_id=2)
+    graph = graph_type([n2])
+    graph.add_node(n1)
+    graph.add_node(n2)
+    graph.add_edge(n1, n2)
+
+    header, buffers = serialize(graph)
+    graph2 = deserialize(header, buffers)
+
+    assert len(graph) == len(graph2) > 0

--- a/mars/core.py
+++ b/mars/core.py
@@ -38,6 +38,12 @@ class Base(HasKey):
     _init_update_key_ = True
 
     def __init__(self, *args, **kwargs):
+        for slot, arg in zip(self.__slots__, args):
+            object.__setattr__(self, slot, arg)
+
+        for key, val in kwargs.items():
+            object.__setattr__(self, key, val)
+
         if self._init_update_key_ and (not hasattr(self, '_key') or not self._key):
             self._update_key()
         if not hasattr(self, '_id') or not self._id:

--- a/mars/dataframe/base/rechunk.py
+++ b/mars/dataframe/base/rechunk.py
@@ -174,14 +174,14 @@ def compute_rechunk(a, chunk_size):
             new_index_value = indexing_index_value(old_chunk.index_value, chunk_slice[0])
             if is_dataframe:
                 new_columns_value = indexing_index_value(old_chunk.columns_value, chunk_slice[1], store_data=True)
-                merge_chunk_op = DataFrameIlocGetItem(chunk_slice, sparse=old_chunk.op.sparse,
+                merge_chunk_op = DataFrameIlocGetItem(list(chunk_slice), sparse=old_chunk.op.sparse,
                                                       output_types=[OutputType.dataframe])
                 merge_chunk = merge_chunk_op.new_chunk([old_chunk], shape=merge_chunk_shape,
                                                        index=merge_idx, index_value=new_index_value,
                                                        columns_value=new_columns_value,
                                                        dtypes=old_chunk.dtypes.iloc[chunk_slice[1]])
             else:
-                merge_chunk_op = SeriesIlocGetItem(chunk_slice, sparse=old_chunk.op.sparse,
+                merge_chunk_op = SeriesIlocGetItem(list(chunk_slice), sparse=old_chunk.op.sparse,
                                                    output_types=a.op.output_types)
                 merge_chunk = merge_chunk_op.new_chunk([old_chunk], shape=merge_chunk_shape,
                                                        index=merge_idx, index_value=new_index_value,

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -26,7 +26,8 @@ from ..core import ChunkData, Chunk, TileableEntity, HasShapeTileableData, \
     HasShapeTileableEnity, OutputType, register_output_types, _ExecuteAndFetchMixin
 from ..serialize import Serializable, ValueType, ProviderType, DataTypeField, AnyField, \
     SeriesField, BoolField, Int32Field, StringField, ListField, SliceField, \
-    TupleField, OneOfField, ReferenceField, NDArrayField, IntervalArrayField
+    TupleField, OneOfField, ReferenceField, NDArrayField, IntervalArrayField, \
+    _ENABLE_NEW_SERIALIZATION
 from ..utils import on_serialize_shape, on_deserialize_shape, on_serialize_numpy_type, \
     ceildiv, is_build_mode, tokenize
 from .utils import fetch_corner_data, ReprSeries
@@ -94,9 +95,14 @@ class IndexValue(Serializable):
             return None
 
         def to_pandas(self):
-            kw = {field.tag_name(None): getattr(self, attr, None)
-                  for attr, field in self._FIELDS.items()
-                  if attr not in super(type(self), self)._FIELDS}
+            if _ENABLE_NEW_SERIALIZATION:
+                kw = {field.tag: getattr(self, attr, None)
+                      for attr, field in self._FIELDS.items()
+                      if attr not in super(type(self), self)._FIELDS}
+            else:
+                kw = {field.tag_name(None): getattr(self, attr, None)
+                      for attr, field in self._FIELDS.items()
+                      if attr not in super(type(self), self)._FIELDS}
             kw = {k: v for k, v in kw.items() if v is not None}
             if kw.get('data') is None:
                 kw['data'] = []

--- a/mars/dataframe/indexing/iloc.py
+++ b/mars/dataframe/indexing/iloc.py
@@ -23,7 +23,7 @@ from pandas.core.indexing import IndexingError
 from ... import opcodes as OperandDef
 from ...core import Entity, Base, OutputType
 from ...config import options
-from ...serialize import AnyField, KeyField, ListField
+from ...serialize import AnyField, KeyField, TupleField
 from ...tensor import asarray
 from ...tensor.datasource.empty import empty
 from ...tensor.indexing.core import calc_shape
@@ -229,7 +229,7 @@ class DataFrameIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
     _op_type_ = OperandDef.DATAFRAME_ILOC_GETITEM
 
     _input = KeyField('input')
-    _indexes = ListField('indexes')
+    _indexes = TupleField('indexes')
 
     def __init__(self, indexes=None, gpu=False, sparse=False, output_types=None, **kw):
         super().__init__(_indexes=indexes, _gpu=gpu, _sparse=sparse, _output_types=output_types, **kw)
@@ -361,7 +361,7 @@ class DataFrameIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
 class DataFrameIlocSetItem(DataFrameOperand, DataFrameOperandMixin):
     _op_type_ = OperandDef.DATAFRAME_ILOC_SETITEM
 
-    _indexes = ListField('indexes')
+    _indexes = TupleField('indexes')
     _value = AnyField('value')
 
     def __init__(self, indexes=None, value=None, gpu=False, sparse=False,
@@ -427,7 +427,7 @@ class SeriesIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
     _op_type_ = OperandDef.DATAFRAME_ILOC_GETITEM
 
     _input = KeyField('input')
-    _indexes = ListField('indexes')
+    _indexes = TupleField('indexes')
 
     def __init__(self, indexes=None, gpu=False, sparse=False, output_types=None, **kw):
         super().__init__(_indexes=indexes, _gpu=gpu, _sparse=sparse, _output_types=output_types, **kw)
@@ -495,7 +495,7 @@ class SeriesIlocSetItem(DataFrameOperand, DataFrameOperandMixin):
     _op_module_ = 'series'
     _op_type_ = OperandDef.DATAFRAME_ILOC_SETITEM
 
-    _indexes = ListField('indexes')
+    _indexes = TupleField('indexes')
     _value = AnyField('value')
 
     def __init__(self, indexes=None, value=None, gpu=False, sparse=False, **kw):
@@ -555,7 +555,7 @@ class IndexIlocGetItem(DataFrameOperand, DataFrameOperandMixin):
     _op_type_ = OperandDef.DATAFRAME_ILOC_GETITEM
 
     _input = KeyField('input')
-    _indexes = ListField('indexes')
+    _indexes = TupleField('indexes')
 
     def __init__(self, indexes=None, gpu=False, sparse=False, output_types=None, **kw):
         super().__init__(_indexes=indexes, _gpu=gpu, _sparse=sparse, _output_types=output_types, **kw)

--- a/mars/dataframe/indexing/iloc.py
+++ b/mars/dataframe/indexing/iloc.py
@@ -23,7 +23,7 @@ from pandas.core.indexing import IndexingError
 from ... import opcodes as OperandDef
 from ...core import Entity, Base, OutputType
 from ...config import options
-from ...serialize import AnyField, KeyField, TupleField
+from ...serialize import AnyField, KeyField, ListField
 from ...tensor import asarray
 from ...tensor.datasource.empty import empty
 from ...tensor.indexing.core import calc_shape
@@ -229,7 +229,7 @@ class DataFrameIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
     _op_type_ = OperandDef.DATAFRAME_ILOC_GETITEM
 
     _input = KeyField('input')
-    _indexes = TupleField('indexes')
+    _indexes = ListField('indexes')
 
     def __init__(self, indexes=None, gpu=False, sparse=False, output_types=None, **kw):
         super().__init__(_indexes=indexes, _gpu=gpu, _sparse=sparse, _output_types=output_types, **kw)
@@ -254,7 +254,7 @@ class DataFrameIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
                 indexes.append(next(inputs_iter))
             else:
                 indexes.append(index)
-        self._indexes = tuple(indexes)
+        self._indexes = indexes
 
     def __call__(self, df):
         # Note [Fancy Index of Numpy and Pandas]
@@ -361,7 +361,7 @@ class DataFrameIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
 class DataFrameIlocSetItem(DataFrameOperand, DataFrameOperandMixin):
     _op_type_ = OperandDef.DATAFRAME_ILOC_SETITEM
 
-    _indexes = TupleField('indexes')
+    _indexes = ListField('indexes')
     _value = AnyField('value')
 
     def __init__(self, indexes=None, value=None, gpu=False, sparse=False,
@@ -402,7 +402,7 @@ class DataFrameIlocSetItem(DataFrameOperand, DataFrameOperandMixin):
             else:
                 chunk_op = op.copy().reset_key()
                 index_chunk, column_chunk = chunk_mapping[chunk.index]
-                chunk_op._indexes = (index_chunk.op.indexes[0], column_chunk.op.indexes[0])
+                chunk_op._indexes = [index_chunk.op.indexes[0], column_chunk.op.indexes[0]]
                 chunk_op._value = op.value
                 out_chunk = chunk_op.new_chunk([chunk],
                                                shape=chunk.shape, index=chunk.index, dtypes=chunk.dtypes,
@@ -427,7 +427,7 @@ class SeriesIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
     _op_type_ = OperandDef.DATAFRAME_ILOC_GETITEM
 
     _input = KeyField('input')
-    _indexes = TupleField('indexes')
+    _indexes = ListField('indexes')
 
     def __init__(self, indexes=None, gpu=False, sparse=False, output_types=None, **kw):
         super().__init__(_indexes=indexes, _gpu=gpu, _sparse=sparse, _output_types=output_types, **kw)
@@ -454,7 +454,7 @@ class SeriesIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
                 indexes.append(next(inputs_iter))
             else:
                 indexes.append(index)
-        self._indexes = tuple(indexes)
+        self._indexes = indexes
 
     @classmethod
     def tile(cls, op):
@@ -495,7 +495,7 @@ class SeriesIlocSetItem(DataFrameOperand, DataFrameOperandMixin):
     _op_module_ = 'series'
     _op_type_ = OperandDef.DATAFRAME_ILOC_SETITEM
 
-    _indexes = TupleField('indexes')
+    _indexes = ListField('indexes')
     _value = AnyField('value')
 
     def __init__(self, indexes=None, value=None, gpu=False, sparse=False, **kw):
@@ -555,7 +555,7 @@ class IndexIlocGetItem(DataFrameOperand, DataFrameOperandMixin):
     _op_type_ = OperandDef.DATAFRAME_ILOC_GETITEM
 
     _input = KeyField('input')
-    _indexes = TupleField('indexes')
+    _indexes = ListField('indexes')
 
     def __init__(self, indexes=None, gpu=False, sparse=False, output_types=None, **kw):
         super().__init__(_indexes=indexes, _gpu=gpu, _sparse=sparse, _output_types=output_types, **kw)
@@ -582,7 +582,7 @@ class IndexIlocGetItem(DataFrameOperand, DataFrameOperandMixin):
                 indexes.append(next(inputs_iter))
             else:
                 indexes.append(index)
-        self._indexes = tuple(indexes)
+        self._indexes = indexes
 
     @classmethod
     def tile(cls, op):

--- a/mars/dataframe/indexing/tests/test_indexing.py
+++ b/mars/dataframe/indexing/tests/test_indexing.py
@@ -84,8 +84,8 @@ class Test(TestBase):
         self.assertEqual(df3.chunk_shape, (2,))
         self.assertEqual(df3.chunks[0].shape, (2,))
         self.assertEqual(df3.chunks[1].shape, (1,))
-        self.assertEqual(df3.chunks[0].op.indexes, (1, slice(None, None, None)))
-        self.assertEqual(df3.chunks[1].op.indexes, (1, slice(None, None, None)))
+        self.assertEqual(df3.chunks[0].op.indexes, [1, slice(None, None, None)])
+        self.assertEqual(df3.chunks[1].op.indexes, [1, slice(None, None, None)])
         self.assertEqual(df3.chunks[0].inputs[0].index, (0, 0))
         self.assertEqual(df3.chunks[0].inputs[0].shape, (2, 2))
         self.assertEqual(df3.chunks[1].inputs[0].index, (0, 1))
@@ -107,8 +107,8 @@ class Test(TestBase):
         pd.testing.assert_series_equal(df4.chunks[1].dtypes, df1.dtypes[2:3])
         self.assertNotEqual(df4.chunks[0].index_value.key, df4.chunks[1].index_value.key)
         self.assertIsInstance(df4.chunks[1].index_value.to_pandas(), type(df1.index))
-        self.assertEqual(df4.chunks[0].op.indexes, (slice(None, None, None), slice(None, None, None)))
-        self.assertEqual(df4.chunks[1].op.indexes, (slice(None, None, None), slice(None, None, None)))
+        self.assertEqual(df4.chunks[0].op.indexes, [slice(None, None, None), slice(None, None, None)])
+        self.assertEqual(df4.chunks[1].op.indexes, [slice(None, None, None), slice(None, None, None)])
         self.assertEqual(df4.chunks[0].inputs[0].index, (0, 1))
         self.assertEqual(df4.chunks[0].inputs[0].shape, (2, 1))
         self.assertEqual(df4.chunks[1].inputs[0].index, (1, 1))
@@ -175,7 +175,7 @@ class Test(TestBase):
         self.assertEqual(df7.chunk_shape, ())
         self.assertEqual(df7.chunks[0].dtype, df7.dtype)
         self.assertEqual(df7.chunks[0].shape, ())
-        self.assertEqual(df7.chunks[0].op.indexes, (1, 0))
+        self.assertEqual(df7.chunks[0].op.indexes, [1, 0])
         self.assertEqual(df7.chunks[0].inputs[0].index, (0, 1))
         self.assertEqual(df7.chunks[0].inputs[0].shape, (2, 1))
 
@@ -190,9 +190,9 @@ class Test(TestBase):
         self.assertEqual(len(series.chunks), 2)
         self.assertEqual(series.chunks[0].shape, (2,))
         self.assertEqual(series.chunks[0].index, (0,))
-        self.assertEqual(series.chunks[0].op.indexes, (slice(1, 3, 1),))
+        self.assertEqual(series.chunks[0].op.indexes, [slice(1, 3, 1),])
         self.assertEqual(series.chunks[1].shape, (2,))
-        self.assertEqual(series.chunks[1].op.indexes, (slice(0, 2, 1),))
+        self.assertEqual(series.chunks[1].op.indexes, [slice(0, 2, 1),])
         self.assertEqual(series.chunks[1].index, (1,))
 
         # fancy index
@@ -234,8 +234,8 @@ class Test(TestBase):
                 self.assertEqual(c1.key, c2.inputs[0].key)
             else:
                 self.assertEqual(c1.key, c2.key)
-        self.assertEqual(df3.chunks[0].op.indexes, (1, slice(None, None, None)))
-        self.assertEqual(df3.chunks[1].op.indexes, (1, slice(None, None, None)))
+        self.assertEqual(df3.chunks[0].op.indexes, [1, slice(None, None, None)])
+        self.assertEqual(df3.chunks[1].op.indexes, [1, slice(None, None, None)])
 
         # # slice index
         df4 = md.DataFrame(df1, chunk_size=2)
@@ -253,8 +253,8 @@ class Test(TestBase):
                 self.assertEqual(c1.key, c2.inputs[0].key)
             else:
                 self.assertEqual(c1.key, c2.key)
-        self.assertEqual(df4.chunks[1].op.indexes, (slice(None, None, None), slice(None, None, None)))
-        self.assertEqual(df4.chunks[3].op.indexes, (slice(None, None, None), slice(None, None, None)))
+        self.assertEqual(df4.chunks[1].op.indexes, [slice(None, None, None), slice(None, None, None)])
+        self.assertEqual(df4.chunks[3].op.indexes, [slice(None, None, None), slice(None, None, None)])
 
         # plain fancy index
         df5 = md.DataFrame(df1, chunk_size=2)
@@ -318,7 +318,7 @@ class Test(TestBase):
                 self.assertEqual(c1.key, c2.inputs[0].key)
             else:
                 self.assertEqual(c1.key, c2.key)
-        self.assertEqual(df7.chunks[1].op.indexes, (1, 0))
+        self.assertEqual(df7.chunks[1].op.indexes, [1, 0])
 
         # test Series
 

--- a/mars/serialization/core.py
+++ b/mars/serialization/core.py
@@ -151,7 +151,7 @@ class CollectionSerializer(Serializer):
             obj_type = pickle.loads(header['obj_type'])
         if hasattr(obj_type, '_fields'):
             # namedtuple
-            return obj_type(*self._iter_deserial(header['headers'], buffers))
+            return obj_type(*self._iter_deserial(header['headers'], buffers, context))
         else:
             return obj_type(self._iter_deserial(header['headers'], buffers, context))
 

--- a/mars/serialization/core.py
+++ b/mars/serialization/core.py
@@ -149,7 +149,11 @@ class CollectionSerializer(Serializer):
         obj_type = self.obj_type
         if 'obj_type' in header:
             obj_type = pickle.loads(header['obj_type'])
-        return obj_type(self._iter_deserial(header['headers'], buffers, context))
+        if hasattr(obj_type, '_fields'):
+            # namedtuple
+            return obj_type(*self._iter_deserial(header['headers'], buffers))
+        else:
+            return obj_type(self._iter_deserial(header['headers'], buffers, context))
 
 
 class ListSerializer(CollectionSerializer):

--- a/mars/serialization/serializables/__init__.py
+++ b/mars/serialization/serializables/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .core import Serializable, SerializableMeta
+from .field import AnyField, IdentityField, BoolField, \
+    Int8Field, Int16Field, Int32Field, Int64Field, \
+    UInt8Field, UInt16Field, UInt32Field, UInt64Field, \
+    Float16Field, Float32Field, Float64Field, Complex64Field, Complex128Field, \
+    StringField, BytesField, KeyField, NDArrayField, \
+    Datetime64Field, Timedelta64Field, DataTypeField, \
+    IndexField, SeriesField, DataFrameField, IntervalArrayField, \
+    SliceField, FunctionField, NamedTupleField, TZInfoField, \
+    ListField, TupleField, DictField, ReferenceField, OneOfField
+from .field_type import FieldTypes

--- a/mars/serialization/serializables/core.py
+++ b/mars/serialization/serializables/core.py
@@ -40,14 +40,17 @@ class SerializableMeta(type):
             v._attr_name = k
 
         properties['_FIELDS'] = property_to_fields
-        properties['__slots__'] = tuple(properties.pop('__slots__', ()))
+        slots = set(properties.pop('__slots__', set()))
+        if property_to_fields:
+            slots.add(_STORE_VALUE_PROPERTY)
+        properties['__slots__'] = tuple(slots)
 
         clz = type.__new__(mcs, name, bases, properties)
         return clz
 
 
 class Serializable(metaclass=SerializableMeta):
-    __slots__ = _STORE_VALUE_PROPERTY,
+    __slots__ = ()
 
     _FIELDS: Dict[str, Field]
     _STORE_VALUE_PROPERTY: Dict[str, Any]

--- a/mars/serialization/serializables/core.py
+++ b/mars/serialization/serializables/core.py
@@ -37,6 +37,7 @@ class SerializableMeta(type):
 
             property_to_fields[k] = v
             properties[k] = v
+            v._attr_name = k
 
         properties['_FIELDS'] = property_to_fields
         properties['__slots__'] = tuple(properties.pop('__slots__', ()))

--- a/mars/serialization/serializables/core.py
+++ b/mars/serialization/serializables/core.py
@@ -1,0 +1,118 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cloudpickle
+from typing import Dict, Tuple, List, Type, Any
+
+from ..core import DictSerializer
+from .field import _STORE_VALUE_PROPERTY, Field, FunctionField, OneOfField
+
+
+class SerializableMeta(type):
+    def __new__(mcs,
+                name: str,
+                bases: Tuple[Type],
+                properties: Dict):
+        properties = properties.copy()
+        for base in bases:
+            if hasattr(base, '_FIELDS'):
+                properties.update(base._FIELDS)
+
+        property_to_fields = dict()
+        # filter out all fields
+        for k, v in properties.items():
+            if not isinstance(v, Field):
+                continue
+
+            property_to_fields[k] = v
+            properties[k] = v
+
+        properties['_FIELDS'] = property_to_fields
+        properties['__slots__'] = tuple(properties.pop('__slots__', ()))
+
+        clz = type.__new__(mcs, name, bases, properties)
+        return clz
+
+
+class Serializable(metaclass=SerializableMeta):
+    __slots__ = _STORE_VALUE_PROPERTY,
+
+    _FIELDS: Dict[str, Field]
+    _STORE_VALUE_PROPERTY: Dict[str, Any]
+
+    def __init__(self, *args, **kwargs):
+        setattr(self, _STORE_VALUE_PROPERTY, dict())
+
+        for slot, arg in zip(self.__slots__, args):  # pragma: no cover
+            object.__setattr__(self, slot, arg)
+
+        for key, val in kwargs.items():
+            object.__setattr__(self, key, val)
+
+
+class SerializableSerializer(DictSerializer):
+    """
+    Leverage DictSerializer to perform serde.
+    """
+    serializer_name = 'serializable'
+
+    def serialize(self, obj: Serializable):
+        fields = obj._FIELDS
+        tag_to_values = getattr(obj, _STORE_VALUE_PROPERTY).copy()
+
+        for field in fields.values():
+            tag = field.tag
+            try:
+                value = tag_to_values[tag]
+            except KeyError:
+                continue
+            if field.on_serialize:
+                value = tag_to_values[tag] = field.on_serialize(value)
+            if isinstance(field, FunctionField):
+                tag_to_values[tag] = cloudpickle.dumps(value)
+
+        header, buffers = super().serialize(tag_to_values)
+        header['class'] = type(obj)
+        return header, buffers
+
+    def deserialize(self, header: Dict, buffers: List) -> Serializable:
+        obj_class: Type[Serializable] = header.pop('class')
+        tag_to_values = super().deserialize(header, buffers)
+
+        property_to_values = dict()
+        for property_name, field in obj_class._FIELDS.items():
+            if isinstance(field, OneOfField):
+                value = None
+                for ref_field in field.reference_fields:
+                    try:
+                        value = tag_to_values.pop(ref_field.tag)
+                    except KeyError:
+                        continue
+                if value is None:
+                    continue
+            else:
+                try:
+                    value = tag_to_values[field.tag]
+                except KeyError:
+                    continue
+            if field.on_deserialize:
+                value = field.on_deserialize(value)
+            if isinstance(field, FunctionField):
+                value = cloudpickle.loads(value)
+            property_to_values[property_name] = value
+
+        return obj_class(**property_to_values)
+
+
+SerializableSerializer.register(Serializable)

--- a/mars/serialization/serializables/field.py
+++ b/mars/serialization/serializables/field.py
@@ -87,14 +87,11 @@ class Field(ABC):
         field_type = self.field_type
         try:
             to_check_value = value
-            if self._on_serialize:
+            if to_check_value is not None and self._on_serialize:
                 to_check_value = self._on_serialize(to_check_value)
             field_type.validate(to_check_value)
         except (TypeError, ValueError) as e:
-            if not self._attr_name:
-                raise
-            else:
-                raise type(e)(f'Failed to set `{self._attr_name}`: {str(e)}')
+            raise type(e)(f'Failed to set `{self._attr_name}`: {str(e)}')
         getattr(instance, _STORE_VALUE_PROPERTY)[self._tag] = value
 
     def __delete__(self, instance):
@@ -461,8 +458,8 @@ class ReferenceField(Field):
             field_type = self.get_field_type(instance)
             try:
                 to_check_value = value
-                if self.on_serialize:
-                    to_check_value = self.on_serialize(to_check_value)
+                if to_check_value is not None and self._on_serialize:
+                    to_check_value = self._on_serialize(to_check_value)
                 field_type.validate(to_check_value)
             except (TypeError, ValueError) as e:
                 if not self._attr_name:
@@ -507,8 +504,8 @@ class OneOfField(Field):
         for reference_field in self._reference_fields:
             try:
                 to_check_value = value
-                if self.on_serialize:
-                    to_check_value = self.on_serialize(to_check_value)
+                if to_check_value is not None and self._on_serialize:
+                    to_check_value = self._on_serialize(to_check_value)
                 reference_field.get_field_type(instance).validate(to_check_value)
                 field_values[reference_field.tag] = value
                 return

--- a/mars/serialization/serializables/field.py
+++ b/mars/serialization/serializables/field.py
@@ -1,0 +1,508 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import importlib
+import inspect
+from abc import ABC, ABCMeta, abstractmethod
+from typing import Any, Callable, Type, Union
+
+from .field_type import AbstractFieldType, FieldTypes, \
+    ListType, TupleType, DictType, ReferenceType
+
+
+_STORE_VALUE_PROPERTY = '_FIELD_VALUES'
+
+
+class Field(ABC):
+    __slots__ = '_tag', '_default_value', '_on_serialize', '_on_deserialize'
+
+    _tag: str
+    _default_value: Any
+
+    def __init__(self,
+                 tag: str,
+                 default: Any = None,
+                 on_serialize: Callable[[Any], Any] = None,
+                 on_deserialize: Callable[[Any], Any] = None):
+        self._tag = tag
+        self._default_value = default
+        self._on_serialize = on_serialize
+        self._on_deserialize = on_deserialize
+
+    @property
+    def tag(self):
+        return self._tag
+
+    @property
+    def on_serialize(self):
+        return self._on_serialize
+
+    @property
+    def on_deserialize(self):
+        return self._on_deserialize
+
+    @property
+    @abstractmethod
+    def field_type(self) -> AbstractFieldType:
+        """
+        Field type.
+
+        Returns
+        -------
+        field_type : AbstractFieldType
+             Field type.
+        """
+
+    def __get__(self, instance, owner):
+        tag_to_values = getattr(instance, _STORE_VALUE_PROPERTY)
+        if self._default_value is not None:
+            return tag_to_values.get(self._tag, self._default_value)
+        else:
+            try:
+                return tag_to_values[self._tag]
+            except KeyError:
+                raise AttributeError(f"'{type(instance)}' has no attribute")
+
+    def __set__(self, instance, value):
+        field_type = self.field_type
+        field_type.validate(value)
+        getattr(instance, _STORE_VALUE_PROPERTY)[self._tag] = value
+
+    def __delete__(self, instance):
+        del getattr(instance, _STORE_VALUE_PROPERTY)[self._tag]
+
+
+class AnyField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.any
+
+
+class IdentityField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.int32
+
+
+class BoolField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.bool
+
+
+class Int8Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.int8
+
+
+class Int16Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.int16
+
+
+class Int32Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.int32
+
+
+class Int64Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.int64
+
+
+class UInt8Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.uint8
+
+
+class UInt16Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.uint16
+
+
+class UInt32Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.uint32
+
+
+class UInt64Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.uint64
+
+
+class Float16Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.float16
+
+
+class Float32Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.float32
+
+
+class Float64Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.float64
+
+
+class Complex64Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.complex64
+
+
+class Complex128Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.complex128
+
+
+class StringField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.string
+
+
+class BytesField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.bytes
+
+
+class KeyField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.key
+
+
+class NDArrayField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.ndarray
+
+
+class Datetime64Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.datetime
+
+
+class Timedelta64Field(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.timedelta
+
+
+class DataTypeField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.dtype
+
+
+class IndexField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.index
+
+
+class SeriesField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.series
+
+
+class DataFrameField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.dataframe
+
+
+class SliceField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.slice
+
+
+class FunctionField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.function
+
+
+class NamedTupleField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.namedtuple
+
+
+class TZInfoField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.tzinfo
+
+
+class IntervalArrayField(Field):
+    __slots__ = ()
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return FieldTypes.interval_array
+
+
+class _CollectionField(Field, metaclass=ABCMeta):
+    __slots__ = '_field_type',
+
+    def __init__(self,
+                 tag: str,
+                 field_type: AbstractFieldType = None,
+                 default: Any = None,
+                 on_serialize: Callable[[Any], Any] = None,
+                 on_deserialize: Callable[[Any], Any] = None):
+        super().__init__(tag, default=default, on_serialize=on_serialize,
+                         on_deserialize=on_deserialize)
+        if not isinstance(field_type, ListType):
+            field_type = self._collection_type()(field_type, ...)
+        self._field_type = field_type
+
+    @classmethod
+    @abstractmethod
+    def _collection_type(cls) -> AbstractFieldType:
+        """
+        Collection type.
+
+        Returns
+        -------
+        collection_type
+        """
+
+    @property
+    def field_type(self) -> Type[AbstractFieldType]:
+        return self._field_type
+
+
+class ListField(_CollectionField):
+    __slots__ = ()
+
+    @classmethod
+    def _collection_type(cls) -> Type[AbstractFieldType]:
+        return ListType
+
+
+class TupleField(_CollectionField):
+    __slots__ = ()
+
+    @classmethod
+    def _collection_type(cls) -> Type[AbstractFieldType]:
+        return TupleType
+
+
+class DictField(Field):
+    __slots__ = '_field_type',
+
+    def __init__(self,
+                 tag: str,
+                 key_type: AbstractFieldType = None,
+                 value_type: AbstractFieldType = None,
+                 default: Any = None,
+                 on_serialize: Callable[[Any], Any] = None,
+                 on_deserialize: Callable[[Any], Any] = None):
+        super().__init__(tag, default=default, on_serialize=on_serialize,
+                         on_deserialize=on_deserialize)
+        self._field_type = DictType(key_type, value_type)
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return self._field_type
+
+
+class ReferenceField(Field):
+    __slots__ = '_reference_type', '_field_type'
+
+    def __init__(self,
+                 tag: str,
+                 reference_type: Union[str, Type] = None,
+                 default: Any = None,
+                 on_serialize: Callable[[Any], Any] = None,
+                 on_deserialize: Callable[[Any], Any] = None):
+        super().__init__(tag, default=default, on_serialize=on_serialize,
+                         on_deserialize=on_deserialize)
+        self._reference_type = reference_type
+
+        if not isinstance(reference_type, str):
+            self._field_type = ReferenceType(reference_type)
+        else:
+            # need to bind dynamically
+            self._field_type = None
+
+    @property
+    def field_type(self) -> AbstractFieldType:
+        return self._field_type
+
+    def get_field_type(self, instance):
+        if self._field_type is None:
+            # bind dynamically
+            if self._reference_type == 'self':
+                reference_type = type(instance)
+            elif isinstance(self._reference_type, str) and \
+                    '.' in self._reference_type:
+                module, name = self._reference_type.rsplit('.', 1)
+                reference_type = getattr(importlib.import_module(module), name)
+            else:
+                module = inspect.getmodule(instance)
+                reference_type = getattr(module, self._reference_type)
+            return ReferenceType(reference_type)
+        else:
+            return self.field_type
+
+    def __set__(self, instance, value):
+        if self._field_type is None:
+            field_type = self.get_field_type(instance)
+            field_type.validate(value)
+            getattr(instance, _STORE_VALUE_PROPERTY)[self._tag] = value
+        else:
+            super().__set__(instance, value)
+
+
+class OneOfField(Field):
+    __slots__ = '_reference_fields'
+
+    def __init__(self,
+                 tag: str,
+                 default: Any = None,
+                 on_serialize: Callable[[Any], Any] = None,
+                 on_deserialize: Callable[[Any], Any] = None,
+                 **tag_to_reference_types):
+        super().__init__(
+            tag, default=default, on_serialize=on_serialize,
+            on_deserialize=on_deserialize)
+        self._reference_fields = [
+            ReferenceField(t, ref_type) for t, ref_type
+            in tag_to_reference_types.items()]
+
+    @property
+    def reference_fields(self):
+        return self._reference_fields
+
+    @property
+    def field_type(self) -> AbstractFieldType:  # pragma: no cover
+        # takes no effect here, just return AnyType()
+        # we will do check in __set__ instead
+        return FieldTypes.any
+
+    def __set__(self, instance, value):
+        field_values = getattr(instance, _STORE_VALUE_PROPERTY)
+        for reference_field in self._reference_fields:
+            try:
+                reference_field.get_field_type(instance).validate(value)
+                field_values[reference_field.tag] = value
+                return
+            except TypeError:
+                continue
+        valid_types = list(itertools.chain(*[r.get_field_type(instance).valid_types
+                                             for r in self._reference_fields]))
+        raise TypeError(f'cannot set value, type of instance cannot '
+                        f'match any of {valid_types}, got {type(value)}')
+
+    def __get__(self, instance, owner):
+        field_values = getattr(instance, _STORE_VALUE_PROPERTY)
+        for reference_field in self._reference_fields:
+            try:
+                return field_values[reference_field.tag]
+            except KeyError:
+                continue
+        raise AttributeError('cannot get attribute, '
+                             'maybe value not set before')
+
+    def __delete__(self, instance):
+        field_values = getattr(instance, _STORE_VALUE_PROPERTY)
+        for reference_field in self._reference_fields:
+            try:
+                del field_values[reference_field.tag]
+                return
+            except KeyError:
+                continue
+        raise AttributeError('cannot delete attribute, '
+                             'maybe value not set before')

--- a/mars/serialization/serializables/field_type.py
+++ b/mars/serialization/serializables/field_type.py
@@ -98,7 +98,7 @@ class AbstractFieldType(ABC):
         """
 
     def validate(self, value):
-        if not isinstance(value, self.valid_types):
+        if value is not None and not isinstance(value, self.valid_types):
             raise TypeError(f'value needs to be instance '
                             f'of {self.valid_types}, got {type(value)}')
 
@@ -352,6 +352,8 @@ class _CollectionType(AbstractFieldType, metaclass=ABCMeta):
                (len(self._field_types) == 2 and self._field_types[1] is Ellipsis)
 
     def validate(self, value):
+        if value is None:
+            return
         if not isinstance(value, self.valid_types):
             raise TypeError(f'value should be instance of {self.valid_types}, '
                             f'got f{type(value)}')

--- a/mars/serialization/serializables/field_type.py
+++ b/mars/serialization/serializables/field_type.py
@@ -1,0 +1,524 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, ABCMeta, abstractmethod
+from datetime import datetime, timedelta, tzinfo
+from enum import Enum
+from typing import Tuple, Type
+
+import numpy as np
+import pandas as pd
+
+
+class PrimitiveType(Enum):
+    bool = 1
+    int8 = 2
+    int16 = 3
+    int32 = 4
+    int64 = 5
+    uint8 = 6
+    uint16 = 7
+    uint32 = 8
+    uint64 = 9
+    float16 = 10
+    float32 = 11
+    float64 = 12
+    bytes = 13
+    string = 14
+    complex64 = 24
+    complex128 = 25
+
+
+_primitive_type_to_valid_types = {
+    PrimitiveType.bool: (bool, np.bool_),
+    PrimitiveType.int8: (int, np.int8),
+    PrimitiveType.int16: (int, np.int16),
+    PrimitiveType.int32: (int, np.int32),
+    PrimitiveType.int64: (int, np.int64),
+    PrimitiveType.uint8: (int, np.uint8),
+    PrimitiveType.uint16: (int, np.uint16),
+    PrimitiveType.uint32: (int, np.uint32),
+    PrimitiveType.uint64: (int, np.uint64),
+    PrimitiveType.float16: (float, np.float16),
+    PrimitiveType.float32: (float, np.float32),
+    PrimitiveType.float64: (float, np.float64),
+    PrimitiveType.bytes: (bytes, np.bytes_),
+    PrimitiveType.string: (str, np.unicode_),
+    PrimitiveType.complex64: (complex, np.complex64),
+    PrimitiveType.complex128: (complex, np.complex128),
+}
+
+
+class AbstractFieldType(ABC):
+    __slots__ = ()
+
+    @property
+    @abstractmethod
+    def type_name(self) -> str:
+        """
+        Type name.
+
+        Returns
+        -------
+        type_name : str
+        """
+
+    @property
+    def name(self) -> str:
+        """
+        Name of field type instance.
+
+        Returns
+        -------
+        name : str
+        """
+        return self.type_name.capitalize()
+
+    @property
+    @abstractmethod
+    def valid_types(self) -> Tuple[Type, ...]:
+        """
+        Valid types.
+
+        Returns
+        -------
+        valid_types: tuple
+            Valid types.
+        """
+
+    def validate(self, value):
+        if not isinstance(value, self.valid_types):
+            raise TypeError(f'value needs to be instance '
+                            f'of {self.valid_types}, got {type(value)}')
+
+    def __call__(self, *args, **kwargs):
+        return type(self)(*args, **kwargs)
+
+
+class SingletonFieldType(AbstractFieldType, metaclass=ABCMeta):
+    __slots__ = ()
+
+    _instance = None
+
+    def __new__(cls, *args, **kw):
+        if cls._instance is None:
+            inst = super().__new__(cls, *args, **kw)
+            cls._instance = inst
+        return cls._instance
+
+
+class PrimitiveFieldType(AbstractFieldType):
+    __slots__ = 'type',
+
+    _type_to_instances = dict()
+
+    def __new__(cls, *args, **kwargs):
+        primitive_type = args[0]
+        try:
+            return cls._type_to_instances[primitive_type]
+        except KeyError:
+            inst = cls._type_to_instances[primitive_type] = \
+                super().__new__(cls)
+            return inst
+
+    def __init__(self, primitive_type: PrimitiveType):
+        self.type = primitive_type
+
+    @property
+    def type_name(self) -> str:
+        return self.type.name
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return _primitive_type_to_valid_types[self.type]
+
+
+class SliceType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'slice'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return slice,
+
+
+class NDArrayType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'ndarray'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return np.ndarray,
+
+
+class DtypeType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'dtype'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return np.dtype, pd.api.extensions.ExtensionDtype
+
+
+class KeyType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'dtype'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        from ...core import HasKey
+        return HasKey,
+
+
+class DatetimeType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'datetime'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return datetime, pd.Timestamp
+
+
+class TimedeltaType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'timedelta'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return timedelta, pd.Timedelta
+
+
+class IndexType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'index'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return pd.Index,
+
+
+class SeriesType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'series'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return pd.Series,
+
+
+class DataFrameType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'dataframe'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return pd.DataFrame,
+
+
+class FunctionType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'function'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:  # pragma: no cover
+        return ()
+
+    def validate(self, value):
+        if not callable(value):
+            raise TypeError(f'value should be a function, '
+                            f'got {type(value)}')
+
+
+class NamedtupleType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'namedtuple'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return tuple,
+
+    def validate(self, value):
+        if not (isinstance(value, self.valid_types) and hasattr(value, '_fields')):
+            raise TypeError(f'value should be instance of namedtuple, '
+                            f'got {type(value)}')
+
+
+class TZInfoType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'tzinfo'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return tzinfo,
+
+
+class IntervalArrayType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'interval_array'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return pd.arrays.IntervalArray,
+
+
+class AnyType(SingletonFieldType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'any'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:  # pragma: no cover
+        return ()
+
+    def validate(self, value):
+        # any type is valid
+        return
+
+
+class _CollectionType(AbstractFieldType, metaclass=ABCMeta):
+    __slots__ = '_field_types',
+
+    def __init__(self, *field_types):
+        self._field_types = field_types
+        if len(field_types) == 0:
+            self._field_types = (AnyType(), Ellipsis)
+
+    @property
+    def name(self) -> str:
+        base_name = super().name
+        if self.is_homogeneous():
+            if isinstance(self._field_types[0], AnyType):
+                return base_name
+            else:
+                return f'{base_name}[{self._field_types[0].name}, ...]'
+        else:
+            field_type_names = ', '.join([ft.name for ft in self._field_types])
+            return f'{base_name}[{field_type_names}]'
+
+    def is_homogeneous(self):
+        return len(self._field_types) == 1 or \
+               (len(self._field_types) == 2 and self._field_types[1] is Ellipsis)
+
+    def validate(self, value):
+        if not isinstance(value, self.valid_types):
+            raise TypeError(f'value should be instance of {self.valid_types}, '
+                            f'got f{type(value)}')
+        if self.is_homogeneous():
+            field_type: AbstractFieldType = self._field_types[0]
+            if not isinstance(field_type, AnyType):
+                for item in value:
+                    try:
+                        field_type.validate(item)
+                    except TypeError:
+                        raise TypeError(f'item should be instance of '
+                                        f'{field_type.valid_types}, '
+                                        f'got f{type(item)}')
+        else:
+            if len(value) != len(self._field_types):
+                raise ValueError(f'value should own {len(self._field_types)} items, '
+                                 f'got {len(value)} items')
+            for expect_field_type, item in zip(self._field_types, value):
+                try:
+                    expect_field_type.validate(item)
+                except TypeError:
+                    raise TypeError(f'item should be instance of '
+                                    f'{expect_field_type.valid_types}, '
+                                    f'got f{type(item)}')
+
+
+class ListType(_CollectionType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'list'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return list,
+
+
+class TupleType(_CollectionType):
+    __slots__ = ()
+
+    @property
+    def type_name(self) -> str:
+        return 'tuple'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return tuple,
+
+
+class DictType(AbstractFieldType):
+    __slots__ = 'key_type', 'value_type'
+
+    key_type: AbstractFieldType
+    value_type: AbstractFieldType
+
+    def __init__(self,
+                 key_type: AbstractFieldType = None,
+                 value_type: AbstractFieldType = None):
+        if key_type is None:
+            key_type = AnyType()
+        if value_type is None:
+            value_type = AnyType()
+        self.key_type = key_type
+        self.value_type = value_type
+
+    @property
+    def type_name(self) -> str:
+        return 'dict'
+
+    @property
+    def name(self) -> str:
+        if isinstance(self.key_type, AnyType) and isinstance(self.value_type, AnyType):
+            return 'Dict'
+        else:
+            return f'Dict[{self.key_type.name}, {self.value_type.name}]'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return dict,
+
+    def validate(self, value):
+        super().validate(value)
+        for k, v in value.items():
+            try:
+                self.key_type.validate(k)
+            except TypeError:
+                raise TypeError(f'key should be instance of '
+                                f'{self.key_type.valid_types}, got {type(k)}')
+            try:
+                self.value_type.validate(v)
+            except TypeError:
+                raise TypeError(f'value should be instance of '
+                                f'{self.value_type.valid_types}, got {type(v)}')
+
+
+class ReferenceType(AbstractFieldType):
+    __slots__ = 'reference_type',
+
+    reference_type: Type
+
+    def __init__(self, reference_type: Type = None):
+        if reference_type is None:
+            reference_type = object
+        self.reference_type = reference_type
+
+    @property
+    def type_name(self) -> str:
+        return 'reference'
+
+    @property
+    def valid_types(self) -> Tuple[Type, ...]:
+        return self.reference_type,
+
+
+class FieldTypes:
+    # primitive type
+    bool = PrimitiveFieldType(PrimitiveType.bool)
+    int8 = PrimitiveFieldType(PrimitiveType.int8)
+    int16 = PrimitiveFieldType(PrimitiveType.int16)
+    int32 = PrimitiveFieldType(PrimitiveType.int32)
+    int64 = PrimitiveFieldType(PrimitiveType.int64)
+    uint8 = PrimitiveFieldType(PrimitiveType.uint8)
+    uint16 = PrimitiveFieldType(PrimitiveType.uint16)
+    uint32 = PrimitiveFieldType(PrimitiveType.uint32)
+    uint64 = PrimitiveFieldType(PrimitiveType.uint64)
+    float16 = PrimitiveFieldType(PrimitiveType.float16)
+    float32 = PrimitiveFieldType(PrimitiveType.float32)
+    float64 = PrimitiveFieldType(PrimitiveType.float64)
+    complex64 = PrimitiveFieldType(PrimitiveType.complex64)
+    complex128 = PrimitiveFieldType(PrimitiveType.complex128)
+    bytes = PrimitiveFieldType(PrimitiveType.bytes)
+    string = PrimitiveFieldType(PrimitiveType.string)
+
+    key = KeyType()
+
+    # Python types
+    slice = SliceType()
+    datetime = DatetimeType()
+    # alias of datetime
+    datatime64 = DatetimeType()
+    timedelta = TimedeltaType()
+    # alias of timedelta
+    timedelta64 = TimedeltaType()
+    tzinfo = TZInfoType()
+    function = FunctionType()
+    namedtuple = NamedtupleType()
+    reference = ReferenceType()
+    any = AnyType()
+    # equivalent to any
+    pickled = AnyType()
+
+    # collection
+    list = ListType()
+    tuple = TupleType()
+    dict = DictType()
+
+    # numpy
+    ndarray = NDArrayType()
+    # alias of ndarray
+    arr = NDArrayType()
+    dtype = DtypeType()
+
+    # pandas
+    index = IndexType()
+    series = SeriesType()
+    dataframe = DataFrameType()
+    interval_array = IntervalArrayType()
+    # alias of interval_array
+    interval_arr = IntervalArrayType()

--- a/mars/serialization/serializables/field_type.py
+++ b/mars/serialization/serializables/field_type.py
@@ -437,6 +437,8 @@ class DictType(AbstractFieldType):
 
     def validate(self, value):
         super().validate(value)
+        if value is None:
+            return
         for k, v in value.items():
             try:
                 self.key_type.validate(k)

--- a/mars/serialization/serializables/tests/__init__.py
+++ b/mars/serialization/serializables/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mars/serialization/serializables/tests/test_field_type.py
+++ b/mars/serialization/serializables/tests/test_field_type.py
@@ -1,0 +1,104 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import namedtuple
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mars.core import HasKey
+from mars.serialization.serializables import FieldTypes
+
+
+class MyClass(HasKey):
+    __slots__ = ()
+
+    @staticmethod
+    def my_func():
+        """
+        Test function
+        """
+
+
+my_named_tuple = namedtuple('my_named_tuple', 'a b')
+
+
+fields_values = [
+    # field_type, valid values, invalid values
+    [FieldTypes.bool, [True, np.bool(False)], [1]],
+    [FieldTypes.int8, [8, np.int8(8)], [8.]],
+    [FieldTypes.int16, [16, np.int16(16)], [16.]],
+    [FieldTypes.int32, [32, np.int32(32)], [64.]],
+    [FieldTypes.uint8, [8, np.uint8(8)], [8.]],
+    [FieldTypes.uint16, [16, np.uint16(16)], [16.]],
+    [FieldTypes.uint32, [32, np.uint32(32)], [32.]],
+    [FieldTypes.uint64, [64, np.uint64(64)], [64.]],
+    [FieldTypes.float16, [16., np.float16(16)], [16]],
+    [FieldTypes.float32, [32., np.float32(32)], [32]],
+    [FieldTypes.float64, [64., np.float64(64)], [64]],
+    [FieldTypes.complex64, [1+2j, np.complex64(1+2j)], [64]],
+    [FieldTypes.complex128, [1+2j, np.complex128(1+2j)], [128]],
+    [FieldTypes.bytes, [b'abc', np.bytes_('abc')], ['abc']],
+    [FieldTypes.string, ['abc', np.str_('abc')], [b'abc']],
+    [FieldTypes.ndarray, [np.array([1, 2, 3])], [object()]],
+    [FieldTypes.dtype, [np.dtype(np.int32), pd.StringDtype()], [object()]],
+    [FieldTypes.key, [MyClass()], [object()]],
+    [FieldTypes.slice, [slice(1, 10), slice('a', 'b')], [object()]],
+    [FieldTypes.datetime, [datetime.now(), pd.Timestamp(0)], [object()]],
+    [FieldTypes.timedelta, [timedelta(days=1), pd.Timedelta(days=1)], [object()]],
+    [FieldTypes.tzinfo, [timezone.utc], [object()]],
+    [FieldTypes.index, [pd.RangeIndex(10), pd.Index([1, 2])], [object()]],
+    [FieldTypes.series, [pd.Series([1, 2, 3])], [object()]],
+    [FieldTypes.dataframe, [pd.DataFrame({'a': [1, 2]})], [object()]],
+    [FieldTypes.interval_array, [pd.arrays.IntervalArray([])], [object()]],
+    [FieldTypes.function, [MyClass.my_func], [object()]],
+    [FieldTypes.namedtuple, [my_named_tuple(a=1, b=2)], [tuple()]],
+    [FieldTypes.reference(MyClass), [MyClass()], [object()]],
+    [FieldTypes.tuple(FieldTypes.int64, ...), [tuple(), tuple([1, 2])], [list(), tuple([1, 2.])]],
+    [FieldTypes.list(FieldTypes.int64, FieldTypes.float64), [[1, 1.]], [tuple(), [1, 1]]],
+    [FieldTypes.dict(FieldTypes.string, FieldTypes.int64), [{'a': 1}], [{1: 'a'}, {'a': 1.}]],
+    [FieldTypes.any, [object()], []],
+]
+
+
+@pytest.mark.parametrize(
+    'field_type, valid_values, invalid_values',
+    fields_values
+)
+def test_field_type(field_type, valid_values, invalid_values):
+    assert isinstance(field_type.type_name, str)
+    assert isinstance(field_type.name, str)
+
+    for valid_value in valid_values:
+        field_type.validate(valid_value)
+
+    for invalid_value in invalid_values:
+        with pytest.raises(TypeError):
+            field_type.validate(invalid_value)
+
+
+def test_collction_field_error():
+    with pytest.raises(ValueError):
+        FieldTypes.tuple(FieldTypes.int64, FieldTypes.float32).validate(tuple([1, 3., 3.]))
+
+
+def test_field_name():
+    assert FieldTypes.list().name == 'List'
+    assert FieldTypes.list(FieldTypes.int64, FieldTypes.float32).name == 'List[Int64, Float32]'
+    assert FieldTypes.tuple(FieldTypes.int8, ...).name == 'Tuple[Int8, ...]'
+    assert FieldTypes.tuple(FieldTypes.int8).name == 'Tuple[Int8, ...]'
+    assert FieldTypes.dict().name == 'Dict'
+    assert FieldTypes.dict(FieldTypes.int8, FieldTypes.float64).name == 'Dict[Int8, Float64]'

--- a/mars/serialization/serializables/tests/test_serializable.py
+++ b/mars/serialization/serializables/tests/test_serializable.py
@@ -33,7 +33,7 @@ my_namedtuple = namedtuple('my_namedtuple', 'a, b')
 
 
 class MyHasKey(HasKey):
-    __slots__ = ()
+    __slots__ = '_key', '_id'
 
     def __init__(self, key):
         self._key = key
@@ -95,7 +95,7 @@ class MySerializable(Serializable):
 
 def test_serializable():
     my_serializable = MySerializable(
-        _id=1,
+        _id='1',
         _any_val='any_value',
         _bool_val=True,
         _int8_val=-8,
@@ -130,7 +130,7 @@ def test_serializable():
         _tuple_val=('a', 'b'),
         _dict_val={'a': b'bytes_value'},
         _ref_val=MySerializable(),
-        _oneof_val=MySerializable(_id=2)
+        _oneof_val=MySerializable(_id='2')
     )
 
     header, buffers = serialize(my_serializable)
@@ -164,10 +164,14 @@ def _assert_serializable_eq(my_serializable, my_serializable2):
 
 def test_fields_errors():
     my_simple = MySimpleSerializable(
-        _id=1, _ref_val=MySimpleSerializable(_id=2))
+        _id='1', _ref_val=MySimpleSerializable(_id='2'))
     my_serializeble = MySerializable(
         _oneof_val=my_simple
     )
+
+    with pytest.raises(TypeError) as exc_info:
+        my_simple._int_val = '10'
+    assert '_int_val' in str(exc_info.value)
 
     del my_simple._ref_val
     with pytest.raises(AttributeError):
@@ -183,7 +187,7 @@ def test_fields_errors():
     with pytest.raises(AttributeError):
         _ = my_serializeble._oneof_val
 
-    my_serializeble._ref_val2 = MySimpleSerializable(_id=3)
+    my_serializeble._ref_val2 = MySimpleSerializable(_id='3')
     del my_serializeble._ref_val2
     with pytest.raises(AttributeError):
         _ = my_serializeble._ref_val2

--- a/mars/serialization/serializables/tests/test_serializable.py
+++ b/mars/serialization/serializables/tests/test_serializable.py
@@ -1,0 +1,198 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import namedtuple
+from datetime import timezone
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mars.core import HasKey
+from mars.serialization import serialize, deserialize
+from mars.serialization.serializables import Serializable, FieldTypes, \
+    IdentityField, BoolField, AnyField, Int8Field, Int16Field, Int32Field, Int64Field, \
+    UInt8Field, UInt16Field, UInt32Field, UInt64Field, Float16Field, Float32Field, Float64Field, \
+    Complex64Field, Complex128Field, StringField, BytesField, KeyField, NDArrayField, \
+    Datetime64Field, Timedelta64Field, DataTypeField, IndexField, SeriesField, DataFrameField, \
+    IntervalArrayField, SliceField, FunctionField, NamedTupleField, TZInfoField, \
+    ListField, TupleField, DictField, ReferenceField, OneOfField
+
+my_namedtuple = namedtuple('my_namedtuple', 'a, b')
+
+
+class MyHasKey(HasKey):
+    __slots__ = ()
+
+    def __init__(self, key):
+        self._key = key
+        self._id = 1
+
+    def __eq__(self, other):
+        return isinstance(other, MyHasKey) and other._key == self._key
+
+
+class MySimpleSerializable(Serializable):
+    _id = IdentityField('id')
+    _int_val = Int64Field('int_val', default=1000)
+    _ref_val = ReferenceField('ref_val', 'MySimpleSerializable')
+
+
+class MySerializable(Serializable):
+    _id = IdentityField('id')
+    _any_val = AnyField('any_val')
+    _bool_val = BoolField('bool_val')
+    _int8_val = Int8Field('int8_val')
+    _int16_val = Int16Field('int16_val')
+    _int32_val = Int32Field('int32_val')
+    _int64_val = Int64Field('int64_val')
+    _uint8_val = UInt8Field('uint8_val')
+    _uint16_val = UInt16Field('uint16_val')
+    _uint32_val = UInt32Field('uint32_val')
+    _uint64_val = UInt64Field('uint64_val')
+    _float16_val = Float16Field('float16_val')
+    _float32_val = Float32Field('float32_val',
+                                on_serialize=lambda x: x + 1,
+                                on_deserialize=lambda x: x - 1)
+    _float64_val = Float64Field('float64_val')
+    _complex64_val = Complex64Field('complex64_val')
+    _complex128_val = Complex128Field('complex128_val')
+    _string_val = StringField('string_val')
+    _bytes_val = BytesField('bytes_val')
+    _key_val = KeyField('key_val')
+    _ndarray_val = NDArrayField('ndarray_val')
+    _datetime64_val = Datetime64Field('datetime64_val')
+    _timedelta64_val = Timedelta64Field('timedelta64_val')
+    _datatype_val = DataTypeField('datatype_val')
+    _index_val = IndexField('index_val')
+    _series_val = SeriesField('series_val')
+    _dataframe_val = DataFrameField('dataframe_val')
+    _interval_array_val = IntervalArrayField('interval_array_val')
+    _slice_val = SliceField('slice_val')
+    _function_val = FunctionField('function_val')
+    _named_tuple_val = NamedTupleField('named_tuple_val')
+    _tzinfo_val = TZInfoField('tzinfo_val')
+    _list_val = ListField('list_val', FieldTypes.int64)
+    _tuple_val = TupleField('tuple_val', FieldTypes.string)
+    _dict_val = DictField('dict_val', FieldTypes.string, FieldTypes.bytes)
+    _ref_val = ReferenceField('ref_val', 'self')
+    _ref_val2 = ReferenceField('ref_val2', MySimpleSerializable)
+    _oneof_val = OneOfField('ref_val',
+                            oneof1_val=f'{__name__}.MySerializable',
+                            oneof2_val=MySimpleSerializable)
+
+
+def test_serializable():
+    my_serializable = MySerializable(
+        _id=1,
+        _any_val='any_value',
+        _bool_val=True,
+        _int8_val=-8,
+        _int16_val=np.int16(-16),
+        _int32_val=-32,
+        _int64_val=-64,
+        _uint8_val=8,
+        _uint16_val=16,
+        _uint32_val=np.uint32(32),
+        _uint64_val=64,
+        _float16_val=1.,
+        _float32_val=np.float32(2.),
+        _float64_val=2.,
+        _complex64_val=np.complex64(1+2j),
+        _complex128_val=1+2j,
+        _string_val='string_value',
+        _bytes_val=b'bytes_value',
+        _key_val=MyHasKey('aaa'),
+        _ndarray_val=np.random.rand(4, 3),
+        _datetime64_val=pd.Timestamp(123),
+        _timedelta64_val=pd.Timedelta(days=1),
+        _datatype_val=np.dtype(np.int32),
+        _index_val=pd.Index([1, 2]),
+        _series_val=pd.Series(['a', 'b']),
+        _dataframe_val=pd.DataFrame({'a': [1, 2, 3]}),
+        _interval_array_val=pd.arrays.IntervalArray([]),
+        _slice_val=slice(1, 10, 2),
+        _function_val=lambda x: x + 1,
+        _named_tuple_val=my_namedtuple(a=1, b=2),
+        _tzinfo_val=timezone.utc,
+        _list_val=[1, 2],
+        _tuple_val=('a', 'b'),
+        _dict_val={'a': b'bytes_value'},
+        _ref_val=MySerializable(),
+        _oneof_val=MySerializable(_id=2)
+    )
+
+    header, buffers = serialize(my_serializable)
+    my_serializable2 = deserialize(header, buffers)
+    _assert_serializable_eq(my_serializable, my_serializable2)
+
+
+def _assert_serializable_eq(my_serializable, my_serializable2):
+    for field_name, field in my_serializable._FIELDS.items():
+        if field.tag not in my_serializable._FIELD_VALUES:
+            continue
+        expect_value = getattr(my_serializable, field_name)
+        actual_value = getattr(my_serializable2, field_name)
+        if isinstance(expect_value, np.ndarray):
+            np.testing.assert_array_equal(expect_value, actual_value)
+        elif isinstance(expect_value, pd.DataFrame):
+            pd.testing.assert_frame_equal(expect_value, actual_value)
+        elif isinstance(expect_value, pd.Series):
+            pd.testing.assert_series_equal(expect_value, actual_value)
+        elif isinstance(expect_value, pd.Index):
+            pd.testing.assert_index_equal(expect_value, actual_value)
+        elif isinstance(expect_value, pd.api.extensions.ExtensionArray):
+            pd.testing.assert_extension_array_equal(expect_value, actual_value)
+        elif isinstance(expect_value, (MySimpleSerializable, MySerializable)):
+            _assert_serializable_eq(expect_value, actual_value)
+        elif callable(expect_value):
+            assert expect_value(1) == actual_value(1)
+        else:
+            assert expect_value == actual_value
+
+
+def test_fields_errors():
+    my_simple = MySimpleSerializable(
+        _id=1, _ref_val=MySimpleSerializable(_id=2))
+    my_serializeble = MySerializable(
+        _oneof_val=my_simple
+    )
+
+    del my_simple._ref_val
+    with pytest.raises(AttributeError):
+        _ = my_simple._ref_val
+
+    del my_simple._id
+    with pytest.raises(AttributeError):
+        _ = my_simple._id
+
+    assert my_simple._int_val == 1000
+
+    del my_serializeble._oneof_val
+    with pytest.raises(AttributeError):
+        _ = my_serializeble._oneof_val
+
+    my_serializeble._ref_val2 = MySimpleSerializable(_id=3)
+    del my_serializeble._ref_val2
+    with pytest.raises(AttributeError):
+        _ = my_serializeble._ref_val2
+
+    with pytest.raises(TypeError):
+        my_serializeble._ref_val = my_simple
+
+    with pytest.raises(TypeError):
+        my_serializeble._oneof_val = 1
+
+    with pytest.raises(AttributeError):
+        del my_serializeble._oneof_val

--- a/mars/serialize/__init__.py
+++ b/mars/serialize/__init__.py
@@ -14,14 +14,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+from .core import HasKey, HasData
 # noinspection PyUnresolvedReferences
-from .core import HasKey, HasData, ValueType, Serializable, SerializableMetaclass, AttributeAsDict, \
-    serializes, deserializes, ProviderType, Provider, \
-    AnyField, IdentityField, BoolField, Int8Field, Int16Field, Int32Field, Int64Field, \
-    UInt8Field, UInt16Field, UInt32Field, UInt64Field, Float16Field, Float32Field, Float64Field, \
-    StringField, BytesField, UnicodeField, KeyField, NDArrayField, DataTypeField, \
-    SliceField, IndexField, SeriesField, DataFrameField, ListField, TupleField, DictField, \
-    FunctionField, TZInfoField, IntervalArrayField, ReferenceField, OneOfField
+from .core import serializes, deserializes, ProviderType, Provider
+
+_ENABLE_NEW_SERIALIZATION = os.environ.get('enable_new_serialization', '0') == '1'
+if _ENABLE_NEW_SERIALIZATION:
+    # noinspection PyUnresolvedReferences
+    from ..serialization.serializables import FieldTypes as ValueType, \
+        SerializableMeta as SerializableMetaclass, Serializable as AttributeAsDict
+    # noinspection PyUnresolvedReferences
+    from ..serialization.serializables import Serializable, \
+        AnyField, IdentityField, BoolField, Int8Field, Int16Field, Int32Field, Int64Field, \
+        UInt8Field, UInt16Field, UInt32Field, UInt64Field, Float16Field, Float32Field, Float64Field, \
+        StringField, BytesField, KeyField, NDArrayField, DataTypeField, \
+        SliceField, IndexField, SeriesField, DataFrameField, ListField, TupleField, DictField, \
+        FunctionField, TZInfoField, IntervalArrayField, ReferenceField, OneOfField
+else:
+    # noinspection PyUnresolvedReferences
+    from .core import ValueType, Serializable, SerializableMetaclass, AttributeAsDict, \
+        AnyField, IdentityField, BoolField, Int8Field, Int16Field, Int32Field, Int64Field, \
+        UInt8Field, UInt16Field, UInt32Field, UInt64Field, Float16Field, Float32Field, Float64Field, \
+        StringField, BytesField, UnicodeField, KeyField, NDArrayField, DataTypeField, \
+        SliceField, IndexField, SeriesField, DataFrameField, ListField, TupleField, DictField, \
+        FunctionField, TZInfoField, IntervalArrayField, ReferenceField, OneOfField
 from .jsonserializer import JsonSerializeProvider
 try:
     from .pbserializer import ProtobufSerializeProvider

--- a/mars/serialize/core.pyx
+++ b/mars/serialize/core.pyx
@@ -758,7 +758,7 @@ class AttributeAsDict(Serializable):
 
 
 class HasKey(object):
-    __slots__ = '_key', '_id'
+    __slots__ = ()
 
 
 class HasData(object):

--- a/mars/tensor/indexing/tests/test_indexing.py
+++ b/mars/tensor/indexing/tests/test_indexing.py
@@ -291,7 +291,7 @@ class Test(unittest.TestCase):
         t[1:3] = np.arange(5)
         t = t.tiles()
         slices_op = t.cix[0, 0].op.value.op
-        self.assertEqual(slices_op.slices, (slice(None, None, None), slice(None, 3, None)))
+        self.assertEqual(slices_op.slices, [slice(None, None, None), slice(None, 3, None)])
         broadcast_op = slices_op.inputs[0].op.inputs[0].op
         self.assertIsInstance(broadcast_op, TensorBroadcastTo)
         self.assertEqual(broadcast_op.shape, (2, 5))
@@ -301,7 +301,7 @@ class Test(unittest.TestCase):
         t[2:4] = np.arange(10).reshape(2, 5)
         t = t.tiles()
         slices_op = t.cix[0, 0].op.value.op
-        self.assertEqual(slices_op.slices, (slice(None, 1, None), slice(None, 3, None)))
+        self.assertEqual(slices_op.slices, [slice(None, 1, None), slice(None, 3, None)])
         np.testing.assert_array_equal(slices_op.inputs[0].op.inputs[0].op.data, np.arange(10).reshape(2, 5))
 
     def testChoose(self):

--- a/mars/tensor/random/beta.py
+++ b/mars/tensor/random/beta.py
@@ -21,10 +21,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorRandBeta(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_a', '_b', '_size'
     _input_fields_ = ['_a', '_b']
     _op_type_ = OperandDef.RAND_BETA
 
+    _fields_ = '_a', '_b', '_size'
     _a = AnyField('a')
     _b = AnyField('b')
     _func_name = 'beta'

--- a/mars/tensor/random/binomial.py
+++ b/mars/tensor/random/binomial.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorBinomial(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_n', '_p', '_size'
     _input_fields_ = ['_n', '_p']
     _op_type_ = OperandDef.RAND_BINOMIAL
 
+    _fields_ = '_n', '_p', '_size'
     _n = AnyField('n')
     _p = AnyField('p')
     _func_name = 'binomial'

--- a/mars/tensor/random/chisquare.py
+++ b/mars/tensor/random/chisquare.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorChisquareDist(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_df', '_size'
     _input_fields_ = ['_df']
     _op_type_ = OperandDef.RAND_CHISQUARE
 
+    _fields_ = '_df', '_size'
     _df = AnyField('df')
     _func_name = 'chisquare'
 

--- a/mars/tensor/random/core.py
+++ b/mars/tensor/random/core.py
@@ -308,8 +308,11 @@ class TensorSeedOperandMixin(object):
 
     @property
     def args(self):
-        return [slot for slot in self.__slots__
-                if slot not in set(TensorRandomOperand.__slots__)]
+        if hasattr(self, '_fields_'):
+            return self._fields_
+        else:
+            return [field for field in self._FIELDS
+                    if field not in TensorRandomOperand._FIELDS]
 
     def _update_key(self):
         self._key = tokenize(type(self).__name__,

--- a/mars/tensor/random/dirichlet.py
+++ b/mars/tensor/random/dirichlet.py
@@ -27,9 +27,9 @@ from .core import TensorRandomOperandMixin, TensorDistribution
 
 
 class TensorDirichlet(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_alpha', '_size'
     _op_type_ = OperandDef.RAND_DIRICHLET
 
+    _fields_ = '_alpha', '_size'
     _alpha = TupleField('alpha')
     _func_name = 'dirichlet'
 

--- a/mars/tensor/random/exponential.py
+++ b/mars/tensor/random/exponential.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorExponential(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_scale', '_size'
     _input_fields_ = ['_scale']
     _op_type_ = OperandDef.RAND_EXPONENTIAL
 
+    _fields_ = '_scale', '_size'
     _scale = AnyField('scale')
     _func_name = 'exponential'
 

--- a/mars/tensor/random/f.py
+++ b/mars/tensor/random/f.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorF(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_dfnum', '_dfden', '_size'
     _input_fields_ = ['_dfnum', '_dfden']
     _op_type_ = OperandDef.RAND_F
 
+    _fields_ = '_dfnum', '_dfden', '_size'
     _dfnum = AnyField('dfnum')
     _dfden = AnyField('dfden')
     _func_name = 'f'

--- a/mars/tensor/random/gamma.py
+++ b/mars/tensor/random/gamma.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorRandGamma(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_shape', '_scale', '_size'
     _input_fields_ = ['_shape', '_scale']
     _op_type_ = OperandDef.RAND_GAMMA
 
+    _fields_ = '_shape', '_scale', '_size'
     _shape = AnyField('shape')
     _scale = AnyField('scale')
     _func_name = 'gamma'

--- a/mars/tensor/random/geometric.py
+++ b/mars/tensor/random/geometric.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorGeometric(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_p', '_size'
     _input_fields_ = ['_p']
     _op_type_ = OperandDef.RAND_GEOMETRIC
 
+    _fields_ = '_p', '_size'
     _p = AnyField('p')
     _func_name = 'geometric'
 

--- a/mars/tensor/random/gumbel.py
+++ b/mars/tensor/random/gumbel.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorGumbel(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_loc', '_scale', '_size'
     _input_fields_ = ['_loc', '_scale']
     _op_type_ = OperandDef.RAND_GUMBEL
 
+    _fields_ = '_loc', '_scale', '_size'
     _loc = AnyField('loc')
     _scale = AnyField('scale')
     _func_name = 'gumbel'

--- a/mars/tensor/random/hypergeometric.py
+++ b/mars/tensor/random/hypergeometric.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorHypergeometric(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_ngood', '_nbad', '_nsample', '_size'
     _input_fields_ = ['_ngood', '_nbad', '_nsample']
     _op_type_ = OperandDef.RAND_HYPERGEOMETRIC
 
+    _fields_ = '_ngood', '_nbad', '_nsample', '_size'
     _ngood = AnyField('ngood')
     _nbad = AnyField('nbad')
     _nsample = AnyField('nsample')

--- a/mars/tensor/random/laplace.py
+++ b/mars/tensor/random/laplace.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorLaplace(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_loc', '_scale', '_size'
     _input_fields_ = ['_loc', '_scale']
     _op_type_ = OperandDef.RAND_LAPLACE
 
+    _fields_ = '_loc', '_scale', '_size'
     _loc = AnyField('loc')
     _scale = AnyField('scale')
     _func_name = 'laplace'

--- a/mars/tensor/random/logistic.py
+++ b/mars/tensor/random/logistic.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorLogistic(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_loc', '_scale', '_size'
     _input_fields_ = ['_loc', '_scale']
     _op_type_ = OperandDef.RAND_LOGISTIC
 
+    _fields_ = '_loc', '_scale', '_size'
     _loc = AnyField('loc')
     _scale = AnyField('scale')
     _func_name = 'logistic'

--- a/mars/tensor/random/lognormal.py
+++ b/mars/tensor/random/lognormal.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorLognormal(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_mean', '_sigma', '_size'
     _input_fields_ = ['_mean', '_sigma']
     _op_type_ = OperandDef.RAND_LOGNORMAL
 
+    _fields_ = '_mean', '_sigma', '_size'
     _mean = AnyField('mean')
     _sigma = AnyField('sigma')
     _func_name = 'lognormal'

--- a/mars/tensor/random/logseries.py
+++ b/mars/tensor/random/logseries.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorLogseries(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_p', '_size'
     _input_fields_ = ['_p']
     _op_type_ = OperandDef.RAND_LOGSERIES
 
+    _fields_ = '_p', '_size'
     _p = AnyField('p')
     _func_name = 'logseries'
 

--- a/mars/tensor/random/multinomial.py
+++ b/mars/tensor/random/multinomial.py
@@ -22,9 +22,9 @@ from .core import TensorRandomOperandMixin, TensorDistribution
 
 
 class TensorMultinomial(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_n', '_pvals', '_size'
     _op_type_ = OperandDef.RAND_MULTINOMIAL
 
+    _fields_ = '_n', '_pvals', '_size'
     _n = Int64Field('n')
     _pvals = TupleField('pvals', ValueType.float64)
     _func_name = 'multinomial'

--- a/mars/tensor/random/multivariate_normal.py
+++ b/mars/tensor/random/multivariate_normal.py
@@ -27,9 +27,9 @@ from .core import TensorRandomOperandMixin, TensorDistribution, TENSOR_CHUNK_TYP
 
 
 class TensorMultivariateNormal(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_mean', '_cov', '_size', '_check_valid', '_tol'
     _op_type_ = OperandDef.RAND_MULTIVARIATE_NORMAL
 
+    _fields_ = '_mean', '_cov', '_size', '_check_valid', '_tol'
     _mean = NDArrayField('mean')
     _cov = NDArrayField('cov')
     _check_valid = StringField('check_valid')

--- a/mars/tensor/random/negative_binomial.py
+++ b/mars/tensor/random/negative_binomial.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorNegativeBinomial(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_n', '_p', '_size'
     _input_fields_ = ['_n', '_p']
     _op_type_ = OperandDef.RAND_NEGATIVE_BINOMIAL
 
+    _fields_ = '_n', '_p', '_size'
     _n = AnyField('n')
     _p = AnyField('p')
     _func_name = 'negative_binomial'

--- a/mars/tensor/random/noncentral_chisquare.py
+++ b/mars/tensor/random/noncentral_chisquare.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorNoncentralChisquare(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_df', '_nonc', '_size'
     _input_fields_ = ['_df', '_nonc']
     _op_type_ = OperandDef.RAND_NONCENTRAL_CHISQURE
 
+    _fields_ = '_df', '_nonc', '_size'
     _df = AnyField('df')
     _nonc = AnyField('nonc')
     _func_name = 'noncentral_chisquare'

--- a/mars/tensor/random/noncentral_f.py
+++ b/mars/tensor/random/noncentral_f.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorNoncentralF(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_dfnum', '_dfden', '_nonc', '_size'
     _input_fields_ = ['_dfnum', '_dfden', '_nonc']
     _op_type_ = OperandDef.RAND_NONCENTRAL_F
 
+    _fields_ = '_dfnum', '_dfden', '_nonc', '_size'
     _dfnum = AnyField('dfnum')
     _dfden = AnyField('dfden')
     _nonc = AnyField('nonc')

--- a/mars/tensor/random/normal.py
+++ b/mars/tensor/random/normal.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorNormal(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_loc', '_scale', '_size'
     _input_fields_ = ['_loc', '_scale']
     _op_type_ = OperandDef.RAND_NORMAL
 
+    _fields_ = '_loc', '_scale', '_size'
     _loc = AnyField('loc')
     _scale = AnyField('scale')
     _func_name = 'normal'

--- a/mars/tensor/random/pareto.py
+++ b/mars/tensor/random/pareto.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorPareto(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_a', '_size'
     _input_fields_ = ['_a']
     _op_type_ = OperandDef.RAND_PARETO
 
+    _fields_ = '_a', '_size'
     _a = AnyField('a')
     _func_name = 'pareto'
 

--- a/mars/tensor/random/poisson.py
+++ b/mars/tensor/random/poisson.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorPoisson(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_lam', '_size'
     _input_fields_ = ['_lam']
     _op_type_ = OperandDef.RAND_POSSION
 
+    _fields_ = '_lam', '_size'
     _lam = AnyField('lam')
     _func_name = 'poisson'
 

--- a/mars/tensor/random/power.py
+++ b/mars/tensor/random/power.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorRandomPower(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_a', '_size'
     _input_fields_ = ['_a']
     _op_type_ = OperandDef.RAND_POWER
 
+    _fields_ = '_a', '_size'
     _a = AnyField('a')
     _func_name = 'power'
 

--- a/mars/tensor/random/randint.py
+++ b/mars/tensor/random/randint.py
@@ -23,9 +23,9 @@ from .core import TensorRandomOperandMixin, TensorSimpleRandomData
 
 
 class TensorRandint(TensorSimpleRandomData, TensorRandomOperandMixin):
-    __slots__ = '_low', '_high', '_density', '_size'
     _op_type_ = OperandDef.RAND_RANDINT
 
+    _fields_ = '_low', '_high', '_density', '_size'
     _low = Int64Field('low')
     _high = Int64Field('high')
     _density = Float64Field('density')

--- a/mars/tensor/random/random_integers.py
+++ b/mars/tensor/random/random_integers.py
@@ -22,9 +22,9 @@ from .core import TensorRandomOperandMixin, TensorSimpleRandomData
 
 
 class TensorRandomIntegers(TensorSimpleRandomData, TensorRandomOperandMixin):
-    __slots__ = '_low', '_high', '_size'
     _op_type_ = OperandDef.RAND_RANDOM_INTEGERS
 
+    _fields_ = '_low', '_high', '_size'
     _low = Int64Field('low')
     _high = Int64Field('high')
     _func_name = 'random_integers'

--- a/mars/tensor/random/random_sample.py
+++ b/mars/tensor/random/random_sample.py
@@ -21,8 +21,9 @@ from .core import TensorRandomOperandMixin, TensorSimpleRandomData
 
 
 class TensorRandomSample(TensorSimpleRandomData, TensorRandomOperandMixin):
-    __slots__ = '_size',
     _op_type_ = OperandDef.RAND_RANDOM_SAMPLE
+
+    _fields_ = '_size',
     _func_name = 'random_sample'
 
     def __init__(self, state=None, size=None, dtype=None,

--- a/mars/tensor/random/rayleigh.py
+++ b/mars/tensor/random/rayleigh.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorRayleigh(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_scale', '_size'
     _input_fields_ = ['_scale']
     _op_type_ = OperandDef.RAND_RAYLEIGH
 
+    _fields_ = '_scale', '_size'
     _scale = AnyField('scale')
     _func_name = 'rayleigh'
 

--- a/mars/tensor/random/standard_cauchy.py
+++ b/mars/tensor/random/standard_cauchy.py
@@ -21,9 +21,9 @@ from .core import TensorRandomOperandMixin, TensorDistribution
 
 
 class TensorStandardCauchy(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_size',
     _op_type_ = OperandDef.RAND_STANDARD_CAUCHY
     _func_name = 'standard_cauchy'
+    _fields_ = '_size',
 
     def __init__(self, size=None, state=None, dtype=None, gpu=None, **kw):
         dtype = np.dtype(dtype) if dtype is not None else dtype

--- a/mars/tensor/random/standard_exponential.py
+++ b/mars/tensor/random/standard_exponential.py
@@ -21,9 +21,9 @@ from .core import TensorRandomOperandMixin, TensorDistribution
 
 
 class TensorStandardExponential(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_size',
     _op_type_ = OperandDef.RAND_STANDARD_EXPONENTIAL
     _func_name = 'standard_exponential'
+    _fields_ = '_size',
 
     def __init__(self, size=None, state=None, dtype=None, gpu=None, **kw):
         dtype = np.dtype(dtype) if dtype is not None else dtype

--- a/mars/tensor/random/standard_gamma.py
+++ b/mars/tensor/random/standard_gamma.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorStandardGamma(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_shape', '_size'
     _input_fields_ = ['_shape']
     _op_type_ = OperandDef.RAND_STANDARD_GAMMMA
 
+    _fields_ = '_shape', '_size'
     _shape = AnyField('shape')
     _func_name = 'standard_gamma'
 

--- a/mars/tensor/random/standard_normal.py
+++ b/mars/tensor/random/standard_normal.py
@@ -21,9 +21,9 @@ from .core import TensorRandomOperandMixin, TensorDistribution
 
 
 class TensorStandardNormal(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_size',
     _op_type_ = OperandDef.RAND_STANDARD_NORMAL
     _func_name = 'standard_normal'
+    _fields_ = '_size',
 
     def __init__(self, size=None, state=None, dtype=None, gpu=None, **kw):
         dtype = np.dtype(dtype) if dtype is not None else dtype

--- a/mars/tensor/random/standard_t.py
+++ b/mars/tensor/random/standard_t.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorStandardT(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_df', '_size'
     _input_fields_ = ['_df']
     _op_type_ = OperandDef.RAND_STANDARD_T
 
+    _fields_ = '_df', '_size'
     _df = AnyField('df')
     _func_name = 'standard_t'
 

--- a/mars/tensor/random/triangular.py
+++ b/mars/tensor/random/triangular.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorTriangular(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_left', '_mode', '_right', '_size'
     _input_fields_ = ['_left', '_mode', '_right']
     _op_type_ = OperandDef.RAND_TRIANGULAR
 
+    _fields_ = '_left', '_mode', '_right', '_size'
     _left = AnyField('left')
     _mode = AnyField('mode')
     _right = AnyField('right')

--- a/mars/tensor/random/uniform.py
+++ b/mars/tensor/random/uniform.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorUniform(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_low', '_high', '_size'
     _input_fields_ = ['_low', '_high']
     _op_type_ = OperandDef.RAND_UNIFORM
 
+    _fields_ = '_low', '_high', '_size'
     _low = AnyField('low')
     _high = AnyField('high')
     _func_name = 'uniform'

--- a/mars/tensor/random/vonmises.py
+++ b/mars/tensor/random/vonmises.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorVonmises(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_mu', '_kappa', '_size'
     _input_fields_ = ['_mu', '_kappa']
     _op_type_ = OperandDef.RAND_VONMISES
 
+    _fields_ = '_mu', '_kappa', '_size'
     _mu = AnyField('mu')
     _kappa = AnyField('kappa')
     _func_name = 'vonmises'

--- a/mars/tensor/random/wald.py
+++ b/mars/tensor/random/wald.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorWald(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_mean', '_scale', '_size'
     _input_fields_ = ['_mean', '_scale']
     _op_type_ = OperandDef.RAND_WALD
 
+    _fields_ = '_mean', '_scale', '_size'
     _mean = AnyField('mean')
     _scale = AnyField('scale')
     _func_name = 'wald'

--- a/mars/tensor/random/weibull.py
+++ b/mars/tensor/random/weibull.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorWeibull(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_a', '_size'
     _input_fields_ = ['_a']
     _op_type_ = OperandDef.RAND_WEIBULL
 
+    _fields_ = '_a', '_size'
     _a = AnyField('a')
     _func_name = 'weibull'
 

--- a/mars/tensor/random/zipf.py
+++ b/mars/tensor/random/zipf.py
@@ -22,10 +22,10 @@ from .core import TensorRandomOperandMixin, handle_array, TensorDistribution
 
 
 class TensorZipf(TensorDistribution, TensorRandomOperandMixin):
-    __slots__ = '_a', '_size'
     _input_fields_ = ['_a']
     _op_type_ = OperandDef.RAND_ZIPF
 
+    _fields_ = '_a', '_size'
     _a = AnyField('a')
     _func_name = 'zipf'
 

--- a/mars/tensor/rechunk/rechunk.py
+++ b/mars/tensor/rechunk/rechunk.py
@@ -126,7 +126,7 @@ def compute_rechunk(tensor, chunk_size):
             chunk_index, chunk_slice = zip(*index_slices)
             old_chunk = tensor.cix[chunk_index]
             merge_chunk_shape = tuple(calc_sliced_size(s, chunk_slice[0]) for s in old_chunk.shape)
-            merge_chunk_op = TensorSlice(chunk_slice, dtype=old_chunk.dtype, sparse=old_chunk.op.sparse)
+            merge_chunk_op = TensorSlice(list(chunk_slice), dtype=old_chunk.dtype, sparse=old_chunk.op.sparse)
             merge_chunk = merge_chunk_op.new_chunk([old_chunk], shape=merge_chunk_shape,
                                                    index=merge_idx, order=tensor.order)
             to_merge.append(merge_chunk)

--- a/mars/tensor/rechunk/tests/test_rechunk.py
+++ b/mars/tensor/rechunk/tests/test_rechunk.py
@@ -33,16 +33,16 @@ class Test(unittest.TestCase):
         self.assertIsInstance(new_tensor.chunks[0].inputs[0].op, TensorSlice)
         self.assertIs(new_tensor.chunks[0].inputs[0].inputs[0], tensor.chunks[0].data)
         self.assertEqual(new_tensor.chunks[0].inputs[0].op.slices,
-                         (slice(None, None, None), slice(None, 2, None)))
+                         [slice(None, None, None), slice(None, 2, None)])
         self.assertIs(new_tensor.chunks[0].inputs[1].inputs[0], tensor.chunks[3].data)
         self.assertEqual(new_tensor.chunks[0].inputs[1].op.slices,
-                         (slice(None, None, None), slice(None, 2, None)))
+                         [slice(None, None, None), slice(None, 2, None)])
         self.assertIs(new_tensor.chunks[0].inputs[2].inputs[0], tensor.chunks[6].data)
         self.assertEqual(new_tensor.chunks[0].inputs[2].op.slices,
-                         (slice(None, 1, None), slice(None, 2, None)))
+                         [slice(None, 1, None), slice(None, 2, None)])
         self.assertIs(new_tensor.chunks[-1].inputs[0], tensor.chunks[-1].data)
         self.assertEqual(new_tensor.chunks[-1].op.slices,
-                         (slice(None, None, None), slice(1, None, None)))
+                         [slice(None, None, None), slice(1, None, None)])
 
     def testRechunk(self):
         tensor = ones((12, 9), chunk_size=4)
@@ -53,14 +53,14 @@ class Test(unittest.TestCase):
         self.assertEqual(new_tensor.chunks[0].inputs[0], get_tiled(tensor).chunks[0].data)
         self.assertEqual(len(new_tensor.chunks[1].inputs), 2)
         self.assertEqual(new_tensor.chunks[1].inputs[0].op.slices,
-                         (slice(None, 3, None), slice(3, None, None)))
+                         [slice(None, 3, None), slice(3, None, None)])
         self.assertEqual(new_tensor.chunks[1].inputs[1].op.slices,
-                         (slice(None, 3, None), slice(None, 2, None)))
+                         [slice(None, 3, None), slice(None, 2, None)])
         self.assertEqual(len(new_tensor.chunks[-1].inputs), 2)
         self.assertEqual(new_tensor.chunks[-1].inputs[0].op.slices,
-                         (slice(1, None, None), slice(2, None, None)))
+                         [slice(1, None, None), slice(2, None, None)])
         self.assertEqual(new_tensor.chunks[-1].inputs[1].op.slices,
-                         (slice(1, None, None), slice(None, None, None)))
+                         [slice(1, None, None), slice(None, None, None)])
 
     def testSparse(self):
         tensor = ones((7, 12), chunk_size=4).tosparse()


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR implements Serializable based on new serialization mechanism.

TODO:

- [x] Serializables based on serialization.
- [x] Adapt old serializables to new one according to environment variables.
- [x] Benchmark

I did some benchmark as below.

### Old serialization.

```python
import mars.tensor as mt
import mars.dataframe as md
from mars.utils import deserialize_graph
import json

df = md.DataFrame(mt.random.rand(10000, 1000), chunk_size=(10, 1000))
df2 = df.groupby(0).agg(['sum', 'mean', 'min', 'max'], method='shuffle')

graph = df2.build_graph(tiled=True, compose=False)

%%time

_ = type(graph).from_json(json.loads(json.dumps(graph.to_json())))

# CPU times: user 30.4 s, sys: 2.16 s, total: 32.5 s
# Wall time: 32.8 s

%%time

_ = deserialize_graph(graph.to_pb().SerializeToString())

# CPU times: user 30.2 s, sys: 1.99 s, total: 32.1 s
# Wall time: 32.3 s
```

### New serialization.

```python
import os
os.environ['enable_new_serialization'] = '1'

import mars.tensor as mt
import mars.dataframe as md

df = md.DataFrame(mt.random.rand(10000, 1000), chunk_size=(10, 1000))
df2 = df.groupby(0).agg(['sum', 'mean', 'min', 'max'], method='shuffle')

from typing import List, Union

from mars._core.graph import DAG, GraphContainsCycleError, TileableGraph, ChunkGraph, \
    TileableGraphBuilder, ChunkGraphBuilder
from mars.core import Tileable
from mars.serialization import serialize, deserialize
from mars.utils import enter_mode

@enter_mode(kernel=True)
def _build_graph(tileables: List[Tileable],
                 tiled: bool = False,
                 fuse_enabled: bool = True,
                 **chunk_graph_build_kwargs) -> Union[TileableGraph, ChunkGraph]:
    tileable_graph = TileableGraph(tileables)
    tileable_graph_builder = TileableGraphBuilder(tileable_graph)
    tileable_graph = next(tileable_graph_builder.build())
    if not tiled:
        return tileable_graph
    chunk_graph_builder = ChunkGraphBuilder(
        tileable_graph, fuse_enabled=fuse_enabled,
        **chunk_graph_build_kwargs)
    return next(chunk_graph_builder.build())

graph = _build_graph([df2], fuse_enabled=False, tiled=True)

%%time

_ = deserialize(*serialize(graph))

# CPU times: user 5.77 s, sys: 67.3 ms, total: 5.84 s
# Wall time: 5.87 s
```

**~5.5x faster than the old one.**

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA
