### PR TITLE
Allow serializer to serialize recursive objects

### DIFF
--- a/mars/oscar/backends/mars/core.py
+++ b/mars/oscar/backends/mars/core.py
@@ -18,7 +18,7 @@ from typing import Dict, Union
 from ...errors import ServerClosed
 from .communication import Client
 from .message import _MessageBase, ResultMessage, ErrorMessage, \
-    DesrializeMessageFailed
+    DeserializeMessageFailed
 from .router import Router
 
 
@@ -58,7 +58,7 @@ class ActorCaller:
                     raise ServerClosed(f'Remote server {client.dest_address} closed')
                 future = self._client_to_message_futures[client].pop(message.message_id)
                 future.set_result(message)
-            except DesrializeMessageFailed as e:  # pragma: no cover
+            except DeserializeMessageFailed as e:  # pragma: no cover
                 message_id = e.message_id
                 future = self._client_to_message_futures[client].pop(message_id)
                 future.set_exception(e)

--- a/mars/oscar/backends/mars/message.py
+++ b/mars/oscar/backends/mars/message.py
@@ -288,7 +288,7 @@ class CancelMessage(_MessageBase):
         return MessageType.cancel
 
 
-class DesrializeMessageFailed(Exception):
+class DeserializeMessageFailed(Exception):
     def __init__(self, message_id):
         self.message_id = message_id
 
@@ -299,20 +299,20 @@ class DesrializeMessageFailed(Exception):
 class MessageSerializer(Serializer):
     serializer_name = 'actor_message'
 
-    def serialize(self, obj: _MessageBase):
+    def serialize(self, obj: _MessageBase, context: Dict):
         assert obj.protocol == 0, 'only support protocol 0 for now'
         # use pickle for protocol 0
         return {'protocol': 0, 'message_id': obj.message_id}, \
-               pickle_buffers(obj)
+            pickle_buffers(obj)
 
-    def deserialize(self, header: Dict, buffers: List):
+    def deserialize(self, header: Dict, buffers: List, context: Dict):
         protocol = header['protocol']
         assert protocol == 0, 'only support protocol 0 for now'
         message_id = header['message_id']
         try:
             return unpickle_buffers(buffers)
         except pickle.UnpicklingError as e:  # pragma: no cover
-            raise DesrializeMessageFailed(message_id) from e
+            raise DeserializeMessageFailed(message_id) from e
 
 
 # register message serializer

--- a/mars/serialization/arrow.py
+++ b/mars/serialization/arrow.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import typing
+from typing import Union, List, Dict
 
 from .core import Serializer
 
@@ -25,7 +25,7 @@ except ImportError:  # pragma: no cover
 class ArrowBatchSerializer(Serializer):
     serializer_name = 'arrow'
 
-    def serialize(self, obj: typing.Union[pa.Table, pa.RecordBatch]):
+    def serialize(self, obj: Union[pa.Table, pa.RecordBatch], context: Dict):
         header = {}
 
         sink = pa.BufferOutputStream()
@@ -42,7 +42,7 @@ class ArrowBatchSerializer(Serializer):
         buffers = [buf]
         return header, buffers
 
-    def deserialize(self, header, buffers):
+    def deserialize(self, header: Dict, buffers: List, context: Dict):
         reader = pa.RecordBatchStreamReader(pa.BufferReader(buffers[0]))
         if header['type'] == 'Table':
             return reader.read_all()

--- a/mars/serialization/core.py
+++ b/mars/serialization/core.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List
 
 from ..utils import TypeDispatcher
 
+import cloudpickle
 if sys.version_info[:2] < (3, 8):
     try:
         import pickle5 as pickle  # nosec  # pylint: disable=import_pickle
@@ -60,18 +61,18 @@ def pickle_buffers(obj):
                 x = x.cast(x.format)
             buffers.append(memoryview(x))
 
-        buffers[0] = pickle.dumps(
+        buffers[0] = cloudpickle.dumps(
             obj,
             buffer_callback=buffer_cb,
             protocol=BUFFER_PICKLE_PROTOCOL,
         )
     else:  # pragma: no cover
-        buffers[0] = pickle.dumps(obj)
+        buffers[0] = cloudpickle.dumps(obj)
     return buffers
 
 
 def unpickle_buffers(buffers):
-    return pickle.loads(buffers[0], buffers=buffers[1:])
+    return cloudpickle.loads(buffers[0], buffers=buffers[1:])
 
 
 class ScalarSerializer(Serializer):
@@ -247,6 +248,11 @@ class Placeholder:
 
     def __hash__(self):
         return hash(self.id)
+
+    def __eq__(self, other):  # pragma: no cover
+        if not isinstance(other, Placeholder):
+            return False
+        return self.id == other.id
 
 
 def serialize(obj, context: Dict = None):

--- a/mars/serialization/cuda.py
+++ b/mars/serialization/cuda.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Dict
+from typing import Any, List, Dict
 
 from ..utils import lazy_import
 from .core import Serializer
@@ -24,7 +24,7 @@ cudf = lazy_import('cudf', globals=globals())
 class CupySerializer(Serializer):
     serializer_name = 'cupy'
 
-    def serialize(self, obj):
+    def serialize(self, obj: Any, context: Dict):
         if not (obj.flags["C_CONTIGUOUS"] or obj.flags["F_CONTIGUOUS"]):
             obj = cupy.array(obj, copy=True)
 
@@ -36,7 +36,7 @@ class CupySerializer(Serializer):
         )
         return header, [buffer]
 
-    def deserialize(self, header: Dict, buffers: List):
+    def deserialize(self, header: Dict, buffers: List, context: Dict):
         return cupy.ndarray(
             shape=header["shape"],
             dtype=header["typestr"],
@@ -48,10 +48,10 @@ class CupySerializer(Serializer):
 class CudfSerializer(Serializer):
     serializer_name = 'cudf'
 
-    def serialize(self, obj):
+    def serialize(self, obj: Any, context: Dict):
         return obj.device_serialize()
 
-    def deserialize(self, header: Dict, buffers: List):
+    def deserialize(self, header: Dict, buffers: List, context: Dict):
         from cudf.core.abc import Serializable
         return Serializable.device_deserialize(header, buffers)
 

--- a/mars/serialization/mars_objects.py
+++ b/mars/serialization/mars_objects.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List
+from typing import Any, Dict, List
 
 try:
     import scipy.sparse as sps
@@ -26,14 +26,14 @@ from .core import Serializer, serialize, deserialize
 class SparseNDArraySerializer(Serializer):
     serializer_name = 'mars.SparseNDArray'
 
-    def serialize(self, obj):
+    def serialize(self, obj: Any, context: Dict):
         raw_header, raw_buffers = serialize(obj.raw)
         header = {
             'raw_header': raw_header, 'shape': list(obj.shape),
         }
         return header, raw_buffers
 
-    def deserialize(self, header: Dict, buffers: List):
+    def deserialize(self, header: Dict, buffers: List, context: Dict):
         raw_csr = deserialize(header['raw_header'], buffers)
         return SparseNDArray(raw_csr, shape=tuple(header['shape']))
 

--- a/mars/serialization/numpy.py
+++ b/mars/serialization/numpy.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Dict, List
+
 import numpy as np
 
 from .core import Serializer, pickle_buffers, unpickle_buffers
@@ -20,7 +22,7 @@ from .core import Serializer, pickle_buffers, unpickle_buffers
 class NDArraySerializer(Serializer):
     serializer_name = 'np_ndarray'
 
-    def serialize(self, obj: np.ndarray):
+    def serialize(self, obj: np.ndarray, context: Dict):
         header = {}
         if obj.dtype.hasobject:
             header['pickle'] = True
@@ -41,7 +43,7 @@ class NDArraySerializer(Serializer):
         ))
         return header, [memoryview(obj.ravel(order=order).view('uint8').data)]
 
-    def deserialize(self, header, buffers):
+    def deserialize(self, header: Dict, buffers: List, context: Dict):
         if header['pickle']:
             return unpickle_buffers(buffers)
 

--- a/mars/serialization/scipy.py
+++ b/mars/serialization/scipy.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import numpy as np
 try:
@@ -26,7 +26,7 @@ from .core import Serializer, serialize, deserialize
 class CsrMatrixSerializer(Serializer):
     serializer_name = 'sps.csr_matrix'
 
-    def serialize(self, obj):
+    def serialize(self, obj: Any, context: Dict):
         data_header, data_buffers = serialize(obj.data)
         idx_header, idx_buffers = serialize(obj.indices)
         indptr_header, indptr_buffers = serialize(obj.indptr)
@@ -38,7 +38,7 @@ class CsrMatrixSerializer(Serializer):
         }
         return header, data_buffers + idx_buffers + indptr_buffers
 
-    def deserialize(self, header: Dict, buffers: List):
+    def deserialize(self, header: Dict, buffers: List, context: Dict):
         data_buf_num = header['data_buf_num']
         idx_buf_num = header['idx_buf_num']
         data_buffers = buffers[:data_buf_num]

--- a/mars/serialization/tests/test_serial.py
+++ b/mars/serialization/tests/test_serial.py
@@ -55,6 +55,37 @@ def test_core(val):
     assert val == deserialized
 
 
+def test_nested_list():
+    val = ['a' * 100] * 100
+    val[0] = val
+    deserialized = deserialize(*serialize(val))
+    assert deserialized[0] is deserialized
+    assert val[1:] == deserialized[1:]
+
+
+class KeyedDict(dict):
+    def _skeys(self):
+        return set(k for k in self.keys() if isinstance(k, str))
+
+    def __hash__(self):
+        return hash(frozenset(self._skeys()))
+
+    def __eq__(self, other: 'KeyedDict'):
+        return self._skeys() == other._skeys()
+
+
+def test_nested_dict():
+    val = {i: 'b' * 100 for i in range(10)}
+    val[0] = val
+    deserialized = deserialize(*serialize(val))
+    assert deserialized[0] is deserialized
+
+    val = KeyedDict(abcd='efgh')
+    val[val] = val
+    deserialized = deserialize(*serialize(val))
+    assert deserialized[val] is deserialized
+
+
 @pytest.mark.parametrize(
     'val', [
         np.array(np.random.rand(100, 100)),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ numpy>=1.14.0
 pandas>=1.0.0,<1.2.0; python_version<'3.7'
 pandas>=1.0.0; python_version>='3.7'
 requests>=2.4.0
-cloudpickle>=1.0.0
+cloudpickle>=1.5.0
 pyarrow>=0.11.0,!=0.16.*
 cython>=0.29
 pytest>=3.5.0

--- a/requirements-wheel.txt
+++ b/requirements-wheel.txt
@@ -7,4 +7,4 @@ scipy==1.5.4; python_version>='3.9'
 cython==0.29.21
 protobuf==3.6.1
 requests>=2.4.0
-cloudpickle>=1.0.0
+cloudpickle>=1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy>=1.14.0
 pandas>=1.0.0,<1.2.0; python_version<'3.7'
 pandas>=1.0.0; python_version>='3.7'
 requests>=2.4.0
-cloudpickle>=1.0.0
+cloudpickle>=1.5.0
 pickle5; python_version<'3.8'
 async_generator; python_version<'3.7'


### PR DESCRIPTION
## What do these changes do?

Allow serializer ro serialize recursive objects. Duplicated objects will be serialized only once.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
