### PR TITLE
Fix `mt.unique` on empty arrays

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,13 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
         include:
-          - { os: ubuntu-16.04, python-version: 3.6, python-abis: "cp36-cp36m" }
-          - { os: ubuntu-16.04, python-version: 3.7, python-abis: "cp37-cp37m" }
-          - { os: ubuntu-16.04, python-version: 3.8, python-abis: "cp38-cp38" }
-          - { os: ubuntu-16.04, python-version: 3.9, python-abis: "cp39-cp39" }
+          - { os: ubuntu-latest, python-version: 3.6, python-abis: "cp36-cp36m" }
+          - { os: ubuntu-latest, python-version: 3.7, python-abis: "cp37-cp37m" }
+          - { os: ubuntu-latest, python-version: 3.8, python-abis: "cp38-cp38" }
+          - { os: ubuntu-latest, python-version: 3.9, python-abis: "cp39-cp39" }
           - { os: windows-latest, python-version: 3.9, build-static: 1 }
 
     steps:

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04]
+        os: [ubuntu-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, 3.8-cython]
         include:
-          - { os: ubuntu-16.04, python-version: 3.8-cython, no-common-tests: 1,
+          - { os: ubuntu-latest, python-version: 3.8-cython, no-common-tests: 1,
               no-deploy: 1, with-cython: 1, with-flake8: 1 }
 
     steps:

--- a/.github/workflows/install-minikube.sh
+++ b/.github/workflows/install-minikube.sh
@@ -23,8 +23,12 @@ curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/miniku
   chmod +x minikube && sudo mv minikube /usr/local/bin/
 
 sudo minikube start --vm-driver=none --kubernetes-version=$K8S_VERSION
-sudo chown -R $(id -u):$(id -g) $HOME/.minikube
-sudo chown -R $(id -u):$(id -g) $HOME/.kube
+export KUBECONFIG=$HOME/.kube/config
+sudo cp -R /root/.kube /root/.minikube $HOME/
+sudo chown -R $(id -u):$(id -g) $HOME/.kube $HOME/.minikube
+
+sed "s/root/home\/$USER/g" $KUBECONFIG > tmp
+mv tmp $KUBECONFIG
 
 minikube update-context
 

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -8,16 +8,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04]
+        os: [ubuntu-latest]
         python-version: [3.8-kubernetes, 3.8-hadoop, 3.8-vineyard, 3.8-ray]
         include:
-          - { os: ubuntu-16.04, python-version: 3.8-kubernetes, no-common-tests: 1,
+          - { os: ubuntu-latest, python-version: 3.8-kubernetes, no-common-tests: 1,
               no-deploy: 1, with-kubernetes: "with Kubernetes" }
-          - { os: ubuntu-16.04, python-version: 3.8-hadoop, no-common-tests: 1,
+          - { os: ubuntu-latest, python-version: 3.8-hadoop, no-common-tests: 1,
               no-deploy: 1, with-hadoop: "with hadoop" }
-          - { os: ubuntu-16.04, python-version: 3.8-vineyard, no-common-tests: 1,
+          - { os: ubuntu-latest, python-version: 3.8-vineyard, no-common-tests: 1,
               no-deploy: 1, with-vineyard: "with vineyard" }
-          - { os: ubuntu-16.04, python-version: 3.8-ray, no-common-tests: 1,
+          - { os: ubuntu-latest, python-version: 3.8-ray, no-common-tests: 1,
               no-deploy: 1, with-ray: "with ray" }
 
     steps:

--- a/mars/learn/neighbors/tests/test_faiss.py
+++ b/mars/learn/neighbors/tests/test_faiss.py
@@ -154,7 +154,8 @@ class Test(unittest.TestCase):
                 expected_distance, expected_indices = nn.kneighbors(y, 5)
 
                 np.testing.assert_array_equal(indices, expected_indices.fetch())
-                np.testing.assert_almost_equal(distance, expected_distance.fetch())
+                np.testing.assert_almost_equal(
+                    distance, expected_distance.fetch(), decimal=4)
 
                 # test other index
                 X2 = X.astype(np.float64)

--- a/mars/tensor/base/tests/test_base_execute.py
+++ b/mars/tensor/base/tests/test_base_execute.py
@@ -1024,6 +1024,17 @@ class Test(TestBase):
         res = np.sort(self.executor.execute_tensor(y, concat=True)[0])
         np.testing.assert_array_equal(res, np.unique(sparse_raw.data))
 
+        # test empty
+        x = tensor([])
+        y = unique(x)
+        res = self.executor.execute_tensor(y, concat=True)[0]
+        np.testing.assert_array_equal(res, np.unique([]))
+
+        x = tensor([[]])
+        y = unique(x)
+        res = self.executor.execute_tensor(y, concat=True)[0]
+        np.testing.assert_array_equal(res, np.unique([[]]))
+
     @require_cupy
     def testToGPUExecution(self):
         raw = np.random.rand(10, 10)

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -401,8 +401,8 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
                 kw = dict(return_index=op.return_index,
                           return_inverse=op.return_inverse,
                           return_counts=op.return_counts)
-                if ar.dtype != object:
-                    # axis cannot pass when dtype is object
+                if ar.dtype != object and sum(ar.shape) > 0:
+                    # axis cannot pass when dtype is object or array size is 0
                     kw['axis'] = op.axis
                 results = xp.unique(ar, **kw)
                 outs = op.outputs


### PR DESCRIPTION
## What do these changes do?

Fix `mt.unique` on empty arrays for numpy 1.18.x.

## Related issue number

Deal with #2059 on v0.6.