### PR TITLE
Fix main pool that creating servers only when sub pools finished creation

### DIFF
--- a/mars/oscar/backends/mars/pool.py
+++ b/mars/oscar/backends/mars/pool.py
@@ -899,15 +899,13 @@ class MainActorPool(ActorPoolBase):
                 await asyncio.sleep(0)
                 tasks.append(create_task_pool)
 
-        # create main actor pool
-        create_task = asyncio.create_task(super().create(config))
-        tasks.append(create_task)
-
-        # wait for all pools
+        # wait for sub pools to start
         await asyncio.gather(*tasks)
-        pool: MainActorPool = await create_task
+
+        # create main actor pool
+        pool: MainActorPool = await super().create(config)
         addresses = actor_pool_config.get_external_addresses()[1:]
-        processes = [await t for t in tasks[:-1]]
+        processes = [await t for t in tasks]
         assert len(addresses) == len(processes)
         for addr, proc in zip(addresses, processes):
             pool.attach_sub_process(addr, proc)

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -20,6 +20,7 @@ import pandas as pd
 import pytest
 
 import mars.oscar as mo
+from mars.oscar.backends.mars.allocate_strategy import RandomSubPool
 from mars.utils import extensible
 
 
@@ -289,6 +290,11 @@ async def test_mars_send(actor_pool_context):
     ref1 = await mo.create_actor(DummyActor, 1, address=pool.external_address)
     ref2 = await mo.actor_ref(await ref1.create(DummyActor, 2, address=pool.external_address))
     assert await ref1.send(ref2, 'add', 3) == 5
+
+    ref3 = await mo.create_actor(DummyActor, 1, address=pool.external_address)
+    ref4 = await mo.create_actor(DummyActor, 2, address=pool.external_address,
+                                 allocate_strategy=RandomSubPool())
+    assert await ref4.send(ref3, 'add', 3) == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixes main pool that creating servers only when sub pools finished creation.

Before, because creating servers is quicker than forking sub processes, so the servers on main pool will be forked.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
