### PR TITLE
Fix batch get / delete object id and stop launching plasma when working on vineyard

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -157,8 +157,11 @@ jobs:
             coverage combine build/ && coverage report
           fi
           if [ -n "$WITH_RAY" ]; then
-            pytest $PYTEST_CONFIG --cov-config .coveragerc-threaded -m ray
-            coverage report
+            pytest $PYTEST_CONFIG --cov-config .coveragerc-threaded -m ray --ignore-glob "mars/oscar/*"
+            mv .coverage build/.coverage.non-aio.file
+            retry pytest $PYTEST_CONFIG --cov-config .coveragerc-threaded -m ray mars/oscar
+            mv .coverage build/.coverage.aio.file
+            coverage combine build/ && coverage report
           fi
           coverage xml
 

--- a/mars/deploy/local/core.py
+++ b/mars/deploy/local/core.py
@@ -115,7 +115,8 @@ class LocalDistributedCluster(object):
         self._started = True
 
         # start plasma
-        self._worker_service.start_plasma()
+        if not options.vineyard.enabled:
+            self._worker_service.start_plasma()
 
         # start actor pool
         n_process = self._scheduler_n_process + self._worker_n_process

--- a/mars/tensor/datasource/from_vineyard.py
+++ b/mars/tensor/datasource/from_vineyard.py
@@ -103,10 +103,13 @@ class TensorFromVineyard(TensorNoInput):
         client = vineyard.connect(op.vineyard_socket)
 
         # setup resolver context
-        from vineyard.data.tensor import tensor_resolver
+        try:
+            from vineyard.data.tensor import numpy_ndarray_resolver
+        except ImportError:
+            from vineyard.data.tensor import tensor_resolver as numpy_ndarray_resolver
 
         # chunk has a tensor chunk
-        ctx[op.outputs[0].key] = client.get(vineyard.ObjectID(op.object_id), tensor_resolver)
+        ctx[op.outputs[0].key] = client.get(vineyard.ObjectID(op.object_id), numpy_ndarray_resolver)
 
 
 def from_vineyard(tensor, vineyard_socket=None):

--- a/mars/worker/service.py
+++ b/mars/worker/service.py
@@ -387,4 +387,5 @@ class WorkerService(object):
                 shutil.rmtree(custom_dir, ignore_errors=True)
                 options.custom_log_dir = None
         finally:
-            self._plasma_store.__exit__(None, None, None)
+            if not options.vineyard.enabled:
+                self._plasma_store.__exit__(None, None, None)

--- a/mars/worker/storage/objectholder.py
+++ b/mars/worker/storage/objectholder.py
@@ -299,7 +299,8 @@ class SharedHolderActor(ObjectHolderActor):
 
     def post_create(self):
         super().post_create()
-        self._size_limit = self._shared_store.get_actual_capacity(self._size_limit)
+        if not options.vineyard.enabled:
+            self._size_limit = self._shared_store.get_actual_capacity(self._size_limit)
         logger.info('Detected actual plasma store size: %s', readable_size(self._size_limit))
 
     def update_cache_status(self):
@@ -308,7 +309,8 @@ class SharedHolderActor(ObjectHolderActor):
                 dict(hold=self._total_hold, total=self._size_limit), _tell=True, _wait=False)
 
     def post_delete(self, session_id, data_keys):
-        self._shared_store.batch_delete(session_id, data_keys)
+        if self._shared_store:
+            self._shared_store.batch_delete(session_id, data_keys)
         self._storage_handler.unregister_data(session_id, data_keys)
 
     def put_objects_by_keys(self, session_id, data_keys, shapes=None, pin_token=None):

--- a/mars/worker/storage/vineyardhandler.py
+++ b/mars/worker/storage/vineyardhandler.py
@@ -210,15 +210,19 @@ class VineyardHandler(StorageHandler, ObjectStorageMixin):
         return obj_id
 
     def _batch_get_object_id(self, session_id, data_keys):
-        addr = self._cluster_info.get_scheduler((session_id, data_keys[0]))
-        obj_ids = self._actor_ctx.actor_ref(VineyardKeyMapActor.default_uid(), address=addr) \
-            .batch_get(session_id, data_keys)
+        obj_ids = []
+        for data_key in data_keys:
+            addr = self._cluster_info.get_scheduler((session_id, data_key))
+            obj_id = self._actor_ctx.actor_ref(VineyardKeyMapActor.default_uid(), address=addr) \
+                .get(session_id, data_key)
+            obj_ids.append(obj_id)
         return obj_ids
 
     def _batch_delete_from_key_mapper(self, session_id, data_keys):
-        addr = self._cluster_info.get_scheduler((session_id, data_keys[0]))
-        self._actor_ctx.actor_ref(VineyardKeyMapActor.default_uid(), address=addr) \
-            .batch_delete(session_id, data_keys)
+        for data_key in data_keys:
+            addr = self._cluster_info.get_scheduler((session_id, data_key))
+            self._actor_ctx.actor_ref(VineyardKeyMapActor.default_uid(), address=addr) \
+                .delete(session_id, data_key)
 
     @wrap_promised
     def create_bytes_reader(self, session_id, data_key, packed=False, packed_compression=None,

--- a/mars/worker/storage/vineyardhandler.py
+++ b/mars/worker/storage/vineyardhandler.py
@@ -285,7 +285,10 @@ class VineyardHandler(StorageHandler, ObjectStorageMixin):
 
     def delete(self, session_id, data_keys, _tell=False):
         data_ids = self._batch_get_object_id(session_id, data_keys)
-        logger.debug('delete chunks from vineyard: %s', data_ids)
+        logger.debug('delete chunks from vineyard: keys = %s, in vineyard is %s', data_keys, data_ids)
+        # when multiple workers connected to the same vineyard, they will think they both
+        # hold the chunk, but when it being deleted, it won't be there anymore.
+        data_ids = [data_id for data_id in data_ids if data_id]
         try:
             self._client.delete(data_ids, deep=True)
         except vineyard._C.ObjectNotExistsException:

--- a/mars/worker/utils.py
+++ b/mars/worker/utils.py
@@ -64,7 +64,10 @@ class WorkerActor(WorkerHasClusterInfoActor, PromiseActor):
             self.set_cluster_info_ref()
         except ActorNotExist:
             pass
-        self._init_shared_store()
+        if not options.vineyard.enabled:
+            self._init_shared_store()
+        else:
+            self._shared_store = None
         self._proc_id = self.ctx.distributor.distribute(self.uid)
 
     def pre_destroy(self):


### PR DESCRIPTION
## What do these changes do?

+ Fixes the bug in batch get/delete vineyard object ID
+ Don't launch plasma if vineyard is enabled.

## Related issue number

This pull request may could fixes recent random failures in CI.