### PR TITLE
Make import of LightGBM and XGBoost lazy

### DIFF
--- a/.github/workflows/install-hadoop.sh
+++ b/.github/workflows/install-hadoop.sh
@@ -3,7 +3,10 @@ set -e
 
 java -version
 
+# remove yarnpkg to make sure hadoop yarn is called correctly
 sudo apt-get remove -yq yarn || true
+sudo npm uninstall -g yarn || true
+
 sudo apt-get install -yq ssh rsync
 
 VERSION=2.10.1

--- a/mars/learn/contrib/lightgbm/__init__.py
+++ b/mars/learn/contrib/lightgbm/__init__.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .classifier import LGBMClassifier
-from .regressor import LGBMRegressor
-from .ranker import LGBMRanker
-
 from ._predict import predict, predict_proba
 
 
@@ -24,3 +20,12 @@ def register_op():
     from ._align import align_data_set
 
     del train, align_data_set
+
+
+from ..utils import config_mod_getattr as _config_mod_getattr
+
+_config_mod_getattr({
+    'LGBMClassifier': '.classifier.LGBMClassifier',
+    'LGBMRegressor': '.regressor.LGBMRegressor',
+    'LGBMRanker': '.ranker.LGBMRanker',
+}, globals())

--- a/mars/learn/contrib/lightgbm/_predict.py
+++ b/mars/learn/contrib/lightgbm/_predict.py
@@ -21,14 +21,7 @@ from .... import opcodes
 from ....dataframe.utils import parse_index
 from ....serialize import BoolField, BytesField, DictField, KeyField
 from ....tensor.core import TENSOR_TYPE, TensorOrder
-from ....utils import register_tokenizer
 from ...operands import LearnOperand, LearnOperandMixin, OutputType
-
-try:
-    from lightgbm import LGBMModel
-    register_tokenizer(LGBMModel, pickle.dumps)
-except ImportError:
-    pass
 
 
 class LGBMPredict(LearnOperand, LearnOperandMixin):
@@ -49,7 +42,7 @@ class LGBMPredict(LearnOperand, LearnOperandMixin):
         return self._data
 
     @property
-    def model(self) -> "LGBMModel":
+    def model(self):
         return self._model
 
     @property

--- a/mars/learn/contrib/lightgbm/classifier.py
+++ b/mars/learn/contrib/lightgbm/classifier.py
@@ -14,9 +14,14 @@
 
 from ...utils import check_consistent_length
 from ..utils import make_import_error_func
-from .core import lightgbm, LGBMScikitLearnBase, LGBMModelType
+from .core import LGBMScikitLearnBase, LGBMModelType
 from ._train import train
 from ._predict import predict_base
+
+try:
+    import lightgbm
+except ImportError:
+    lightgbm = None
 
 
 LGBMClassifier = make_import_error_func('lightgbm')

--- a/mars/learn/contrib/lightgbm/core.py
+++ b/mars/learn/contrib/lightgbm/core.py
@@ -22,11 +22,6 @@ import pandas as pd
 from ....tensor import tensor as mars_tensor
 from ....dataframe import DataFrame as MarsDataFrame, Series as MarsSeries
 
-try:
-    import lightgbm
-except ImportError:
-    lightgbm = None
-
 
 class LGBMModelType(enum.Enum):
     CLASSIFIER = 0
@@ -35,15 +30,16 @@ class LGBMModelType(enum.Enum):
 
 
 _model_type_to_model = dict()
-if lightgbm:
-    _model_type_to_model = {
-        LGBMModelType.CLASSIFIER: lightgbm.LGBMClassifier,
-        LGBMModelType.REGRESSOR: lightgbm.LGBMRegressor,
-        LGBMModelType.RANKER: lightgbm.LGBMRanker,
-    }
 
 
 def get_model_cls_from_type(model_type: LGBMModelType):
+    import lightgbm
+    if not _model_type_to_model:
+        _model_type_to_model.update({
+            LGBMModelType.CLASSIFIER: lightgbm.LGBMClassifier,
+            LGBMModelType.REGRESSOR: lightgbm.LGBMRegressor,
+            LGBMModelType.RANKER: lightgbm.LGBMRanker,
+        })
     return _model_type_to_model[model_type]
 
 

--- a/mars/learn/contrib/lightgbm/ranker.py
+++ b/mars/learn/contrib/lightgbm/ranker.py
@@ -14,9 +14,14 @@
 
 from ...utils import check_consistent_length
 from ..utils import make_import_error_func
-from .core import lightgbm, LGBMScikitLearnBase, LGBMModelType
+from .core import LGBMScikitLearnBase, LGBMModelType
 from ._train import train
 from ._predict import predict_base
+
+try:
+    import lightgbm
+except ImportError:
+    lightgbm = None
 
 
 LGBMRanker = make_import_error_func('lightgbm')

--- a/mars/learn/contrib/lightgbm/regressor.py
+++ b/mars/learn/contrib/lightgbm/regressor.py
@@ -14,9 +14,14 @@
 
 from ...utils import check_consistent_length
 from ..utils import make_import_error_func
-from .core import lightgbm, LGBMScikitLearnBase, LGBMModelType
+from .core import LGBMScikitLearnBase, LGBMModelType
 from ._train import train
 from ._predict import predict_base
+
+try:
+    import lightgbm
+except ImportError:
+    lightgbm = None
 
 
 LGBMRegressor = make_import_error_func('lightgbm')

--- a/mars/learn/contrib/utils.py
+++ b/mars/learn/contrib/utils.py
@@ -59,7 +59,7 @@ def config_mod_getattr(mod_dict, globals_):
             mod = importlib.import_module(mod_name, globals_['__name__'])
             cls = globals_[name] = getattr(mod, cls_name)
             return cls
-        else:
+        else:  # pragma: no cover
             raise ImportError(f'Cannot import {name}')
 
     if sys.version_info[:2] < (3, 7):
@@ -73,4 +73,5 @@ def config_mod_getattr(mod_dict, globals_):
     globals_.update({
         '__getattr__': __getattr__,
         '__dir__': __dir__,
+        '__warningregistry__': dict(),
     })

--- a/mars/learn/contrib/utils.py
+++ b/mars/learn/contrib/utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import numpy as np
 
 
@@ -47,3 +49,28 @@ def pick_workers(workers, size):
             np.random.permutation(workers)[:to_pick_size]
         rest = rest - to_pick_size
     return result
+
+
+def config_mod_getattr(mod_dict, globals_):
+    def __getattr__(name):
+        import importlib
+        if name in mod_dict:
+            mod_name, cls_name = mod_dict[name].rsplit('.', 1)
+            mod = importlib.import_module(mod_name, globals_['__name__'])
+            cls = globals_[name] = getattr(mod, cls_name)
+            return cls
+        else:
+            raise ImportError(f'Cannot import {name}')
+
+    if sys.version_info[:2] < (3, 7):
+        for _mod in mod_dict.keys():
+            __getattr__(_mod)
+
+    def __dir__():
+        return sorted([n for n in globals_ if not n.startswith('_')]
+                      + list(mod_dict))
+
+    globals_.update({
+        '__getattr__': __getattr__,
+        '__dir__': __dir__,
+    })

--- a/mars/learn/contrib/xgboost/__init__.py
+++ b/mars/learn/contrib/xgboost/__init__.py
@@ -15,10 +15,16 @@
 from .dmatrix import MarsDMatrix
 from .train import train
 from .predict import predict
-from .classifier import XGBClassifier
-from .regressor import XGBRegressor
 
 
 def register_op():
     from .start_tracker import StartTracker
     del StartTracker
+
+
+from ..utils import config_mod_getattr as _config_mod_getattr
+
+_config_mod_getattr({
+    'XGBClassifier': '.classifier.XGBClassifier',
+    'XGBRegressor': '.regressor.XGBRegressor',
+}, globals())

--- a/mars/learn/contrib/xgboost/predict.py
+++ b/mars/learn/contrib/xgboost/predict.py
@@ -23,16 +23,9 @@ from ....serialize import KeyField, BytesField, DictField
 from ....dataframe.core import SERIES_CHUNK_TYPE, DATAFRAME_CHUNK_TYPE
 from ....dataframe.utils import parse_index
 from ....tensor.core import TENSOR_TYPE, TensorOrder
-from ....utils import register_tokenizer, check_chunks_unknown_shape
+from ....utils import check_chunks_unknown_shape
 from ...operands import LearnOperand, LearnOperandMixin, OutputType
 from .dmatrix import ToDMatrix, check_data
-
-try:
-    from xgboost import Booster
-
-    register_tokenizer(Booster, pickle.dumps)
-except ImportError:
-    pass
 
 
 class XGBPredict(LearnOperand, LearnOperandMixin):


### PR DESCRIPTION
## What do these changes do?

Use module-level `__getattr__` to load lightgbm and xgboost lazily. This prevents loading CUDA modules before fork.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
