### PR TITLE
Fix distributed `make_blobs` and column pruning in `read_sql`

### DIFF
--- a/mars/dataframe/datasource/core.py
+++ b/mars/dataframe/datasource/core.py
@@ -91,5 +91,5 @@ class ColumnPruneSupportedDataSourceMixin(DataFrameOperandMixin):
     def get_columns(self):  # pragma: no cover
         raise NotImplementedError
 
-    def set_pruned_columns(self, columns):  # pragma: no cover
+    def set_pruned_columns(self, columns, *, keep_order=None):  # pragma: no cover
         raise NotImplementedError

--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -167,8 +167,9 @@ class DataFrameReadCSV(HeadOptimizedDataSource, ColumnPruneSupportedDataSourceMi
     def get_columns(self):
         return self._usecols
 
-    def set_pruned_columns(self, columns):
+    def set_pruned_columns(self, columns, *, keep_order=None):
         self._usecols = columns
+        self._keep_usecols_order = keep_order
 
     @classmethod
     def _tile_compressed(cls, op):

--- a/mars/dataframe/datasource/read_parquet.py
+++ b/mars/dataframe/datasource/read_parquet.py
@@ -253,7 +253,7 @@ class DataFrameReadParquet(HeadOptimizedDataSource, ColumnPruneSupportedDataSour
     def get_columns(self):
         return self._columns
 
-    def set_pruned_columns(self, columns):
+    def set_pruned_columns(self, columns, *, keep_order=None):
         self._columns = columns
 
     @classmethod

--- a/mars/dataframe/datasource/read_sql.py
+++ b/mars/dataframe/datasource/read_sql.py
@@ -168,7 +168,7 @@ class DataFrameReadSQL(DataFrameOperand, ColumnPruneSupportedDataSourceMixin):
     def get_columns(self):
         return self._columns
 
-    def set_pruned_columns(self, columns):
+    def set_pruned_columns(self, columns, *, keep_order=None):
         self._columns = columns
 
     def _get_selectable(self, engine_or_conn, columns=None):
@@ -490,7 +490,11 @@ class DataFrameReadSQL(DataFrameOperand, ColumnPruneSupportedDataSourceMixin):
                     if isinstance(dtype, ArrowStringDtype):
                         df.iloc[:, i] = df.iloc[:, i].astype(dtype)
 
-            ctx[out.key] = df
+            if out.ndim == 2:
+                ctx[out.key] = df
+            else:
+                # this happens when column pruning results in one single series
+                ctx[out.key] = df.iloc[:, 0]
         finally:
             engine.dispose()
 

--- a/mars/learn/datasets/tests/integrated/__init__.py
+++ b/mars/learn/datasets/tests/integrated/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mars/learn/datasets/tests/integrated/test_distributed_samples_generator.py
+++ b/mars/learn/datasets/tests/integrated/test_distributed_samples_generator.py
@@ -1,0 +1,51 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+
+import numpy as np
+
+try:
+    import sklearn
+except ImportError:
+    sklearn = None
+
+from mars.core import ExecutableTuple
+from mars.learn.datasets import make_blobs
+from mars.session import new_session
+from mars.tests.integrated.base import IntegrationTestBase
+
+
+@unittest.skipIf(sklearn is None, 'sklearn not installed')
+@unittest.skipIf(sys.platform == 'win32', "plasma don't support windows")
+class Test(IntegrationTestBase):
+    def testDistributedMakeBlobs(self):
+        service_ep = 'http://127.0.0.1:' + self.web_port
+        timeout = 120 if 'CI' in os.environ else -1
+        with new_session(service_ep) as sess:
+            run_kwargs = {'timeout': timeout}
+
+            X, y = make_blobs(
+                n_samples=100000, n_features=3,
+                centers=[[3, 3, 3], [0, 0, 0],
+                         [1, 1, 1], [2, 2, 2]],
+                cluster_std=[0.2, 0.1, 0.2, 0.2],
+                random_state=9)
+
+            X_res, y_res = ExecutableTuple([X, y]).execute(session=sess, **run_kwargs) \
+                .fetch(session=sess)
+            self.assertIsInstance(X_res, np.ndarray)
+            self.assertIsInstance(y_res, np.ndarray)

--- a/mars/learn/decomposition/_pca.py
+++ b/mars/learn/decomposition/_pca.py
@@ -466,7 +466,7 @@ class PCA(_BasePCA):
         if n_components == 'mle':
             n_components = mr.spawn(_infer_dimension, args=(explained_variance_, n_samples))
             ExecutableTuple([n_components, U, V]).execute(session=session, **(run_kwargs or dict()))
-            n_components = n_components.fetch()
+            n_components = n_components.fetch(session=session)
         elif 0 < n_components < 1.0:
             # number of components for which the cumulated explained
             # variance percentage is superior to the desired threshold

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -250,8 +250,11 @@ class LearnShuffle(MapReduceOperand, LearnOperandMixin):
                     map_chunk = map_chunk_op.new_chunk([in_chunk], **params)
                     map_chunks.append(map_chunk)
 
-                proxy_chunk = LearnShuffleProxy(
-                    _tensor_keys=[inp.key], output_types=[output_type]).new_chunk(map_chunks)
+                map_chunk_kw = {}
+                if output_type == OutputType.tensor:
+                    map_chunk_kw = {'dtype': inp.dtype, 'shape': ()}
+                proxy_chunk = LearnShuffleProxy(_tileable_keys=[inp.key], output_types=[output_type]) \
+                    .new_chunk(map_chunks, **map_chunk_kw)
 
                 reduce_axes = tuple(ax for j, ax in enumerate(inp_axes) if reduce_sizes[j] > 1)
                 reduce_sizes_ = tuple(rs for rs in reduce_sizes if rs > 1)


### PR DESCRIPTION
## What do these changes do?

This PR fixes two issues.

1. Distributed `make_blobs` caused by missing `dtype` in learn shuffle.
2. `read_sql` followed by column selection when optimization is valid.

## Related issue number

Fixes #2091 
Fixes #2074
