### PR TITLE
Fix coverage result on SubActorPool

### DIFF
--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -106,7 +106,7 @@ class MarsActorContext(BaseActorContext):
         result = await self._wait(future, actor_ref.address, message)
         return self._process_result_message(result)
 
-    async def kill_actor(self, actor_ref: ActorRef):
+    async def kill_actor(self, actor_ref: ActorRef, force: bool = True):
         # get main_pool_address
         control_message = ControlMessage(
             new_message_id(), actor_ref.address,
@@ -121,8 +121,8 @@ class MarsActorContext(BaseActorContext):
         stop_message = ControlMessage(
             new_message_id(), real_actor_ref.address,
             ControlMessageType.stop,
-            # wait for 3 sec at most
-            3., protocol=DEFAULT_PROTOCOL)
+            # default timeout (3 secs) and force
+            (3., force), protocol=DEFAULT_PROTOCOL)
         # stop server
         result = await self._call(main_address, stop_message)
         return self._process_result_message(result)

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -189,6 +189,15 @@ class PromiseTestActor(mo.Actor):
             self._apply_step(idx, delay) for idx in range(4)
         ) + (asyncio.sleep(delay), 'PlainString')
 
+    async def async_raiser_func(self):
+        print('enter async_raiser_func')
+        yield asyncio.sleep(0.1)
+        raise ValueError
+
+    async def test_yield_exceptions(self):
+        task = asyncio.create_task(self.ref().async_raiser_func())
+        return task
+
     async def test_exceptions(self):
         async def async_raiser():
             yield asyncio.sleep(0.1)
@@ -457,6 +466,8 @@ async def test_promise_chain(actor_pool_context):
 
     with pytest.raises(ValueError):
         await promise_test_ref.test_exceptions()
+    with pytest.raises(ValueError):
+        await promise_test_ref.test_yield_exceptions()
 
     with pytest.raises(asyncio.CancelledError):
         task = asyncio.create_task(promise_test_ref.test_cancel(5))

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -190,7 +190,6 @@ class PromiseTestActor(mo.Actor):
         ) + (asyncio.sleep(delay), 'PlainString')
 
     async def async_raiser_func(self):
-        print('enter async_raiser_func')
         yield asyncio.sleep(0.1)
         raise ValueError
 

--- a/mars/oscar/backends/ray/pool.py
+++ b/mars/oscar/backends/ray/pool.py
@@ -68,7 +68,7 @@ class RayMainActorPool(MainActorPoolBase):
         await actor_handle.start.remote(actor_pool_config, process_index)
         return actor_handle
 
-    def kill_sub_pool(self, process: 'ray.actor.ActorHandle'):
+    async def kill_sub_pool(self, process: 'ray.actor.ActorHandle', force: bool = False):
         ray.kill(process)
 
     async def is_sub_pool_alive(self, process: 'ray.actor.ActorHandle'):

--- a/mars/services/task/supervisor/tests/test_task_manager.py
+++ b/mars/services/task/supervisor/tests/test_task_manager.py
@@ -124,4 +124,4 @@ async def test_cancel_task(actor_pool):
         result = await manager.get_task_result(task_id)
         assert result.status == TaskStatus.terminated
 
-    assert timer.duration < 10
+    assert timer.duration < 15


### PR DESCRIPTION
## What do these changes do?

Shutdown subprocesses gracefully to let coverage data being recorded.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
