### PR TITLE
Fix result error when yield after exceptions

### DIFF
--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -209,7 +209,14 @@ class PromiseTestActor(mo.Actor):
         raise KeyError
 
     async def test_cancel(self, delay):
+        async def intermediate_error():
+            raise ValueError
+
         async def task_fun():
+            try:
+                yield intermediate_error()
+            except ValueError:
+                pass
             try:
                 yield asyncio.sleep(delay)
             except asyncio.CancelledError:

--- a/mars/serialization/core.py
+++ b/mars/serialization/core.py
@@ -311,6 +311,11 @@ class Placeholder:
 
 
 def serialize(obj, context: Dict = None):
+    # todo remove this when gevent dependency removed
+    # workaround for traceback pickling error
+    from ..lib.tblib import pickling_support
+    pickling_support.install()
+
     def _wrap_headers(_obj, _serializer_name, _header, _buffers):
         if _header.get('serializer') == 'ref':
             return _header, _buffers


### PR DESCRIPTION
## What do these changes do?

Fix result error when yield after exceptions.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
