### PR TITLE
Make sure slot usages updated when some task ends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,14 +37,15 @@ npm-debug.log*
 .grunt
 
 # Unit test / coverage reports
+.cache
 .coverage
 .coverage.*
-htmlcov
-.tox
-nosetests.xml
-.cache
-.pytest*
 .dist-coverage
+.hypothesis
+.pytest*
+.tox
+htmlcov
+nosetests.xml
 test.conf
 
 # IDEs

--- a/mars/services/scheduling/supervisor/globalslot.py
+++ b/mars/services/scheduling/supervisor/globalslot.py
@@ -72,8 +72,14 @@ class GlobalSlotManagerActor(mo.Actor):
 
     @extensible
     def update_subtask_slots(self, band: Tuple, session_id: str, subtask_id: str, slots: int):
-        slots_delta = slots - self._band_stid_slots[band][(session_id, subtask_id)]
-        self._band_stid_slots[band][(session_id, subtask_id)] = slots
+        session_subtask_id = (session_id, subtask_id)
+        subtask_slots = self._band_stid_slots[band]
+
+        if session_subtask_id not in subtask_slots:
+            return
+
+        slots_delta = slots - subtask_slots[session_subtask_id]
+        subtask_slots[session_subtask_id] = slots
         self._band_used_slots[band] += slots_delta
 
     @extensible

--- a/mars/tensor/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/tensor/arithmetic/tests/test_arithmetic_execution.py
@@ -343,7 +343,7 @@ def test_frexp_execution(setup):
 
     res = o.execute().fetch()
     expected = sum(np.frexp(data1))
-    np.testing.assert_array_almost_equal(res, expected)
+    np.testing.assert_array_almost_equal(res, expected, decimal=4)
 
     data1 = sps.random(5, 9, density=.1)
 

--- a/mars/tensor/random/tests/test_random_execute.py
+++ b/mars/tensor/random/tests/test_random_execute.py
@@ -210,25 +210,26 @@ def test_random_execute(setup, test_opts):
 
 
 def test_permutation_execute(setup):
-    x = tensor.random.permutation(10)
+    rs = tensor.random.RandomState(0)
+    x = rs.permutation(10)
     res = x.execute().fetch()
     assert not np.all(res[:-1] < res[1:])
     np.testing.assert_array_equal(np.sort(res), np.arange(10))
 
     arr = from_ndarray([1, 4, 9, 12, 15], chunk_size=2)
-    x = tensor.random.permutation(arr)
+    x = rs.permutation(arr)
     res = x.execute().fetch()
     assert not np.all(res[:-1] < res[1:])
     np.testing.assert_array_equal(np.sort(res), np.asarray([1, 4, 9, 12, 15]))
 
     arr = from_ndarray(np.arange(48).reshape(12, 4), chunk_size=2)
     # axis = 0
-    x = tensor.random.permutation(arr)
+    x = rs.permutation(arr)
     res = x.execute().fetch()
     assert not np.all(res[:-1] < res[1:])
     np.testing.assert_array_equal(np.sort(res, axis=0), np.arange(48).reshape(12, 4))
     # axis != 0
-    x2 = tensor.random.permutation(arr, axis=1)
+    x2 = rs.permutation(arr, axis=1)
     res = x2.execute().fetch()
     assert not np.all(res[:, :-1] < res[:, 1:])
     np.testing.assert_array_equal(np.sort(res, axis=1), np.arange(48).reshape(12, 4))


### PR DESCRIPTION
## What do these changes do?

Make sure slot usages are updated when some task ends. This may reduce the ratio when heavy-loaded jobs are loaded onto the same worker.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
