### PR TITLE
Enable mars (oscar) runs on vineyard.

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8-kubernetes, 3.8-hadoop, 3.8-ray] # [3.8-vineyard]
+        python-version: [3.8-kubernetes, 3.8-hadoop, 3.8-ray, 3.8-vineyard]
         include:
           - { os: ubuntu-latest, python-version: 3.8-kubernetes, no-common-tests: 1,
               no-deploy: 1, with-kubernetes: "with Kubernetes" }

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -15,8 +15,8 @@ jobs:
               no-deploy: 1, with-kubernetes: "with Kubernetes" }
           - { os: ubuntu-latest, python-version: 3.8-hadoop, no-common-tests: 1,
               no-deploy: 1, with-hadoop: "with hadoop" }
-          #- { os: ubuntu-latest, python-version: 3.8-vineyard, no-common-tests: 1,
-          #    no-deploy: 1, with-vineyard: "with vineyard" }
+          - { os: ubuntu-latest, python-version: 3.8-vineyard, no-common-tests: 1,
+             no-deploy: 1, with-vineyard: "with vineyard" }
           - { os: ubuntu-latest, python-version: 3.8-ray, no-common-tests: 1,
               no-deploy: 1, with-ray: "with ray" }
 
@@ -66,8 +66,7 @@ jobs:
               conda install -n test --quiet --yes -c conda-forge python=$PYTHON skein conda-pack
             fi
             if [ -n "$WITH_VINEYARD" ]; then
-              pip install vineyard==0.2.4
-              sudo docker pull libvineyard/vineyardd:v0.2.4
+              pip install vineyard==0.2.4 -i https://pypi.org/simple
 
               mkdir -p /tmp/etcd-download-test
               export ETCD_VER=v3.4.13
@@ -83,23 +82,6 @@ jobs:
             fi
           fi
           conda list -n test
-
-      - name: Prepare vineyard runtime
-        if: ${{ matrix.with-vineyard }}
-        shell: bash
-        run: |
-          source ./ci/reload-env.sh
-
-          # launch vineyardd
-          sudo docker run --rm -d --name vineyard --shm-size=3072m -v /tmp/vineyard:/var/run libvineyard/vineyardd:v0.2.4
-
-          until [ -S /tmp/vineyard/vineyard.sock ]
-          do
-              sleep 1;
-              echo "Waiting for vineyardd ..."
-          done
-          echo "Vineyard service ready"
-          sudo chmod a+wrx /tmp/vineyard/vineyard.sock
 
       - name: Test with pytest
         env:
@@ -125,15 +107,11 @@ jobs:
             coverage report
           fi
           if [ -n "$WITH_VINEYARD" ]; then
-            export VINEYARD_IPC_SOCKET=/tmp/vineyard/vineyard.sock
-            mkdir -p build
-
             pytest $PYTEST_CONFIG mars/storage/tests/test_libs.py
             mv .coverage build/.coverage.test_lib.file
 
-            pytest $PYTEST_CONFIG mars/dataframe/datastore/tests/test_datastore_execute.py \
-                                                                    mars/tensor/datastore/tests/test_datastore_execute.py -k "vineyard"
-            mv .coverage build/.coverage.test_tensor.file
+            pytest $PYTEST_CONFIG mars/deploy/oscar/tests/test_local.py
+            mv .coverage build/.coverage.test_local.file
 
             coverage combine build/ && coverage report
           fi

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -66,8 +66,8 @@ jobs:
               conda install -n test --quiet --yes -c conda-forge python=$PYTHON skein conda-pack
             fi
             if [ -n "$WITH_VINEYARD" ]; then
-              pip install vineyard==0.1.10
-              sudo docker pull libvineyard/vineyardd:v0.1.10
+              pip install vineyard==0.2.4
+              sudo docker pull libvineyard/vineyardd:v0.2.4
 
               mkdir -p /tmp/etcd-download-test
               export ETCD_VER=v3.4.13
@@ -91,7 +91,7 @@ jobs:
           source ./ci/reload-env.sh
 
           # launch vineyardd
-          sudo docker run --rm -d --name vineyard --shm-size=3072m -v /tmp/vineyard:/var/run libvineyard/vineyardd:v0.1.10
+          sudo docker run --rm -d --name vineyard --shm-size=3072m -v /tmp/vineyard:/var/run libvineyard/vineyardd:v0.2.4
 
           until [ -S /tmp/vineyard/vineyard.sock ]
           do

--- a/mars/deploy/oscar/tests/local_test_with_vineyard_config.yml
+++ b/mars/deploy/oscar/tests/local_test_with_vineyard_config.yml
@@ -1,0 +1,6 @@
+inherits: '@mars/deploy/oscar/base_config.yml'
+session:
+  custom_log_dir: auto
+
+storage:
+  backends: [vineyard]

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -39,8 +39,7 @@ CONFIG_VINEYARD_TEST_FILE = os.path.join(
     os.path.dirname(__file__), 'local_test_with_vineyard_config.yml')
 
 
-# params = ['default']
-params = []
+params = ['default']
 if vineyard is not None:
     params.append('vineyard')
 

--- a/mars/storage/core.py
+++ b/mars/storage/core.py
@@ -106,6 +106,7 @@ class BufferWrappedFileObject(ABC):
         if self._closed:
             return
 
+        self._closed = True
         if self._mode == 'w':
             self._write_close()
         else:

--- a/mars/storage/vineyard.py
+++ b/mars/storage/vineyard.py
@@ -27,7 +27,7 @@ from .base import StorageBackend, StorageLevel, ObjectInfo, register_storage_bac
 from .core import BufferWrappedFileObject, StorageFileObject
 
 vineyard = lazy_import("vineyard")
-pyarrow =  lazy_import("pyarrow")
+pyarrow = lazy_import("pyarrow")
 
 if sys.platform.startswith('win'):
     vineyard = None
@@ -35,7 +35,7 @@ if sys.platform.startswith('win'):
 logger = logging.getLogger(__name__)
 
 
-## Setup support for mars datatypes on vineyard
+# Setup support for mars datatypes on vineyard
 
 def mars_sparse_matrix_builder(client, value, builder, **kw):
     meta = vineyard.ObjectMeta()

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,7 @@ extra =
     bokeh>=1.0.0
     jinja2>=2.0
 vineyard =
-    vineyard==0.1.10; sys.platform != "win32"
+    vineyard==0.2.4; sys.platform != "win32"
 
 [tool:pytest]
 markers =


### PR DESCRIPTION
## What do these changes do?

This pull request brings back the vineyard support, more specifically,

1. Overhual the vineyard storage implementation.
2. Support (put + open_reader) and (open_writer + get) operations on vineayrd storage.
3. A bugfix in `BufferWrappedFileObject.close()`
4. Split the "test_reader_and_writer" test case to verify the roundtrip property of storage backend.

The code has been tested with `test_lib.py` and `test_local.py` with vineyard storage backend, and all cases are green. Note this pull request also bumps up the dependency version of vineyard package to v0.2.4, which, will be uploaded to pypi and dockerhub later today.

## Related issue number

N/A.