### PR TITLE
Support configuring overriding fields

### DIFF
--- a/mars/deploy/kubernetes/config.yml
+++ b/mars/deploy/kubernetes/config.yml
@@ -1,4 +1,4 @@
-inherits: ../oscar/base_config.yml
+"@inherits": ../oscar/base_config.yml
 cluster:
   backend: k8s
 storage:

--- a/mars/deploy/kubernetes/tests/test_kube_config.yml
+++ b/mars/deploy/kubernetes/tests/test_kube_config.yml
@@ -1,4 +1,4 @@
-inherits: '@mars/deploy/kubernetes/config.yml'
+"@inherits": '@mars/deploy/kubernetes/config.yml'
 storage:
   plasma:
     store_memory: 20M

--- a/mars/deploy/oscar/base_config.yml
+++ b/mars/deploy/oscar/base_config.yml
@@ -16,6 +16,9 @@ session:
 storage:
   default_config:
     transfer_block_size: 5 * 1024 ** 2
+  plasma:
+    store_memory: 20%
+  "@overriding_fields": ["backends"]
 meta:
   store: dict
 task:

--- a/mars/deploy/oscar/config.yml
+++ b/mars/deploy/oscar/config.yml
@@ -1,4 +1,4 @@
-inherits: base_config.yml
+"@inherits": base_config.yml
 storage:
   backends: [shared_memory]
   plasma:

--- a/mars/deploy/oscar/rayconfig.yml
+++ b/mars/deploy/oscar/rayconfig.yml
@@ -1,4 +1,4 @@
-inherits: base_config.yml
+"@inherits": base_config.yml
 cluster:
   ray:
     supervisor:

--- a/mars/deploy/oscar/tests/check_enabled_config.yml
+++ b/mars/deploy/oscar/tests/check_enabled_config.yml
@@ -1,4 +1,4 @@
-inherits: '@default'
+"@inherits": '@default'
 task:
   task_preprocessor_cls: mars.services.task.supervisor.tests.CheckedTaskPreprocessor
 subtask:

--- a/mars/deploy/oscar/tests/fault_injection_config.yml
+++ b/mars/deploy/oscar/tests/fault_injection_config.yml
@@ -1,3 +1,3 @@
-inherits: '@default'
+"@inherits": '@default'
 subtask:
   subtask_processor_cls: mars.services.subtask.worker.tests.FaultInjectionSubtaskProcessor

--- a/mars/deploy/oscar/tests/local_test_config.yml
+++ b/mars/deploy/oscar/tests/local_test_config.yml
@@ -1,3 +1,3 @@
-inherits: '@default'
+"@inherits": '@default'
 session:
   custom_log_dir: auto

--- a/mars/deploy/oscar/tests/local_test_with_vineyard_config.yml
+++ b/mars/deploy/oscar/tests/local_test_with_vineyard_config.yml
@@ -1,4 +1,4 @@
-inherits: '@mars/deploy/oscar/base_config.yml'
+"@inherits": '@mars/deploy/oscar/base_config.yml'
 session:
   custom_log_dir: auto
 

--- a/mars/deploy/tests/base_test_cfg.yml
+++ b/mars/deploy/tests/base_test_cfg.yml
@@ -1,5 +1,8 @@
-inherits: '@default'
+"@inherits": '@default'
 test_list:
+  - item1
+  - item2
+test_list2:
   - item1
   - item2
 test_dict:
@@ -7,3 +10,4 @@ test_dict:
   key2:
     key2_key1:
       val2
+"@overriding_fields": ["test_list2"]

--- a/mars/deploy/tests/inherit_test_cfg1.yml
+++ b/mars/deploy/tests/inherit_test_cfg1.yml
@@ -1,3 +1,5 @@
-inherits: '@mars/deploy/tests/base_test_cfg.yml'
+"@inherits": '@mars/deploy/tests/base_test_cfg.yml'
 test_list:
+  - item3
+test_list2:  # overriding
   - item3

--- a/mars/deploy/tests/inherit_test_cfg2.yml
+++ b/mars/deploy/tests/inherit_test_cfg2.yml
@@ -1,4 +1,4 @@
-inherits: inherit_test_cfg1.yml
+"@inherits": inherit_test_cfg1.yml
 test_dict:
   key2:
     key2_key1:

--- a/mars/deploy/tests/test_utils.py
+++ b/mars/deploy/tests/test_utils.py
@@ -31,7 +31,9 @@ def test_load_service_config(cwd):
 
         assert 'services' in cfg
         assert cfg['test_list'] == ['item1', 'item2', 'item3']
+        assert cfg['test_list2'] == ['item3']
         assert set(cfg['test_dict'].keys()) == {'key1', 'key2', 'key3'}
         assert set(cfg['test_dict']['key2'].values()) == {'val2_modified'}
+        assert all(not k.startswith('@') for k in cfg.keys())
     finally:
         os.chdir(old_cwd)

--- a/mars/deploy/utils.py
+++ b/mars/deploy/utils.py
@@ -62,7 +62,7 @@ def load_service_config_file(path: Union[str, TextIO]) -> Dict:
         cfg_stack.append(cfg)
         cfg_file_set.add(path)
 
-        inherit_path = cfg.pop('inherits', None)
+        inherit_path = cfg.pop('@inherits', None)
         if not inherit_path:
             path = None
         elif os.path.isfile(inherit_path):
@@ -76,17 +76,32 @@ def load_service_config_file(path: Union[str, TextIO]) -> Dict:
 
     def _override_cfg(src: Union[Dict, List], override: Union[Dict, List]):
         if isinstance(override, dict):
+            overriding_fields = set(src.get('@overriding_fields') or set())
             for key, val in override.items():
-                if key not in src or not isinstance(val, (list, dict)):
+                if key not in src or not isinstance(val, (list, dict)) \
+                        or key in overriding_fields:
                     src[key] = val
                 else:
                     _override_cfg(src[key], override[key])
         else:
             src.extend(override)
 
+    def _clear_meta_cfg(src: Dict):
+        meta_keys = []
+        for k, v in src.items():
+            if k.startswith('@'):
+                meta_keys.append(k)
+            elif isinstance(v, dict):
+                _clear_meta_cfg(v)
+
+        for k in meta_keys:
+            src.pop(k)
+
     cfg = cfg_stack[-1]
     for new_cfg in cfg_stack[-2::-1]:
         _override_cfg(cfg, new_cfg)
+
+    _clear_meta_cfg(cfg)
     return cfg
 
 

--- a/mars/deploy/yarn/config.yml
+++ b/mars/deploy/yarn/config.yml
@@ -1,3 +1,3 @@
-inherits: ../oscar/config.yml
+"@inherits": ../oscar/config.yml
 cluster:
   backend: yarn

--- a/mars/deploy/yarn/tests/test_yarn_config.yml
+++ b/mars/deploy/yarn/tests/test_yarn_config.yml
@@ -1,4 +1,4 @@
-inherits: '@mars/deploy/yarn/config.yml'
+"@inherits": '@mars/deploy/yarn/config.yml'
 storage:
   plasma:
     store_memory: 20M

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -339,7 +339,7 @@ def test_iter(setup):
 
 
 CONFIG = """
-inherits: '@default'
+"@inherits": '@default'
 session:
   custom_log_dir: '{custom_log_dir}'
 """


### PR DESCRIPTION
## What do these changes do?

Allow configuring overriding fields for config sections. Add `@` as prefix for meta configs also.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
