### PR TITLE
Fix unexpected NaNs in groupby-agg

### DIFF
--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -250,6 +250,10 @@ def test_dataframe_groupby_agg(setup):
         pd.testing.assert_frame_equal(r.execute().fetch().sort_index(),
                                       raw.groupby('c2').agg(agg).sort_index())
 
+        r = mdf.groupby('c2').agg({'c1': 'min', 'c3': 'min'}, method=method)
+        pd.testing.assert_frame_equal(r.execute().fetch().sort_index(),
+                                      raw.groupby('c2').agg({'c1': 'min', 'c3': 'min'}).sort_index())
+
         r = mdf.groupby('c2').agg({'c1': 'min'}, method=method)
         pd.testing.assert_frame_equal(r.execute().fetch().sort_index(),
                                       raw.groupby('c2').agg({'c1': 'min'}).sort_index())
@@ -275,12 +279,18 @@ def test_dataframe_groupby_agg(setup):
         pd.testing.assert_frame_equal(r.execute().fetch(),
                                       getattr(raw.groupby('c2'), agg_fun)())
 
+    # test as_index=False
     for method in ['tree', 'shuffle']:
-        # test as_index=False
         r = mdf.groupby('c2', as_index=False).agg('mean', method=method)
         pd.testing.assert_frame_equal(
             r.execute().fetch().sort_values('c2', ignore_index=True),
             raw.groupby('c2', as_index=False).agg('mean').sort_values('c2', ignore_index=True))
+        assert r.op.groupby_params['as_index'] is False
+
+        r = mdf.groupby(['c1', 'c2'], as_index=False).agg('mean', method=method)
+        pd.testing.assert_frame_equal(
+            r.execute().fetch().sort_values(['c1', 'c2'], ignore_index=True),
+            raw.groupby(['c1', 'c2'], as_index=False).agg('mean').sort_values(['c1', 'c2'], ignore_index=True))
         assert r.op.groupby_params['as_index'] is False
 
     # test as_index=False takes no effect

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -480,7 +480,24 @@ def test_compile_function():
     # check post_funcs
     assert len(result.post_funcs) == 2
     assert set(''.join(sorted(result.post_funcs[i].columns)) for i in range(2)) == {'ab', 'bc'}
-    
+
+    # test agg for multiple columns
+    compiler = ReductionCompiler(store_source=True)
+    compiler.add_function(lambda x: x.sum(), ndim=2, cols=['a'])
+    compiler.add_function(lambda x: x.sum(), ndim=2, cols=['b'])
+    compiler.add_function(lambda x: x.min(), ndim=2, cols=['c'])
+    result = compiler.compile()
+    # check pre_funcs
+    assert len(result.pre_funcs) == 1
+    assert set(result.pre_funcs[0].columns) == set('abc')
+    # check agg_funcs
+    assert len(result.agg_funcs) == 2
+    assert result.agg_funcs[0].map_func_name == 'sum'
+    assert result.agg_funcs[0].agg_func_name == 'sum'
+    # check post_funcs
+    assert len(result.post_funcs) == 2
+    assert set(result.post_funcs[0].columns) == set('ab')
+
     
 def test_custom_aggregation():
     class MockReduction1(CustomReduction):

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,16 +67,14 @@ dev =
     jinja2>=2.0
     mock>=4.0.0; python_version<"3.8"
 distributed =
-    pyarrow>=0.11.0,!=0.16.*
-    cython>=0.29
-    pytest>=3.5.0
-    pytest-cov>=2.5.0
-    pytest-timeout>=1.2.0
-    pytest-forked>=1.0
-    pytest-asyncio>=0.14.0
-    sqlalchemy>=1.2.0
     scipy>=1.0.0
-    mock>=4.0.0; python_version<"3.8"
+    scikit-learn>=0.20
+    numexpr>=2.6.4
+    pyarrow>=0.11.0,!=0.16.*
+    lz4>=1.0.0
+    bokeh>=1.0.0
+    sqlalchemy>=1.2.0
+    jinja2>=2.0
 extra =
     scipy>=1.0.0
     scikit-learn>=0.20
@@ -84,6 +82,7 @@ extra =
     pyarrow>=0.11.0,!=0.16.*
     lz4>=1.0.0
     bokeh>=1.0.0
+    sqlalchemy>=1.2.0
     jinja2>=2.0
 vineyard =
     vineyard==0.2.4; sys.platform != "win32"


### PR DESCRIPTION
## What do these changes do?

Fix unexpected NaNs in groupby-agg discovered in two scenarios:

1. multiple group keys with `as_index == False`
2. aggregation with same function on different rows

## Related issue number

Fixes #2175 
Fixes #2176