### PR TITLE
Fix groupby on indexes with duplicate items

### DIFF
--- a/mars/dataframe/base/drop_duplicates.py
+++ b/mars/dataframe/base/drop_duplicates.py
@@ -143,7 +143,7 @@ class DataFrameDropDuplicates(DuplicateOperand):
         hashed = hash_dataframe_on(dropped, subset, shuffle_size)
         for i, data in enumerate(hashed):
             reducer_idx = (i,) + out.index[1:]
-            ctx[out.key, reducer_idx] = dropped.loc[data]
+            ctx[out.key, reducer_idx] = dropped.iloc[data]
 
     @classmethod
     def _execute_shuffle_reduce(cls, ctx, op: "DataFrameDropDuplicates"):

--- a/mars/dataframe/base/duplicated.py
+++ b/mars/dataframe/base/duplicated.py
@@ -202,7 +202,7 @@ class DataFrameDuplicated(DuplicateOperand):
         hashed = hash_dataframe_on(result, subset, shuffle_size)
         for i, data in enumerate(hashed):
             reducer_idx = (i,) + out.index[1:]
-            ctx[out.key, reducer_idx] = result.loc[data]
+            ctx[out.key, reducer_idx] = result.iloc[data]
 
     @classmethod
     def _execute_shuffle_reduce(cls, ctx, op: "DataFrameDuplicated"):

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -299,7 +299,7 @@ class DataFrameGroupByOperand(MapReduceOperand, DataFrameOperandMixin):
             filters = hash_dataframe_on(df, on, op.shuffle_size, level=op.level)
 
         def _take_index(src, f):
-            result = src.loc[f]
+            result = src.iloc[f]
             if src.index.names:
                 result.index.names = src.index.names
             return result

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -55,28 +55,31 @@ def test_groupby(setup):
                  'b': rs.randint(0, 10, size=(data_size,)),
                  'c': rs.choice(list('abcd'), size=(data_size,))}
 
+    # test groupby with DataFrames and RangeIndex
     df1 = pd.DataFrame(data_dict)
     mdf = md.DataFrame(df1, chunk_size=13)
     grouped = mdf.groupby('b')
     assert_groupby_equal(grouped.execute().fetch(),
                          df1.groupby('b'))
 
-    df2 = pd.DataFrame(data_dict, index=['i' + str(i) for i in range(data_size)])
+    # test groupby with string index with duplications
+    df2 = pd.DataFrame(data_dict, index=['i' + str(i % 3) for i in range(data_size)])
     mdf = md.DataFrame(df2, chunk_size=13)
     grouped = mdf.groupby('b')
     assert_groupby_equal(grouped.execute().fetch(),
                          df2.groupby('b'))
 
-    # test groupby series
+    # test groupby with DataFrames by series
     grouped = mdf.groupby(mdf['b'])
     assert_groupby_equal(grouped.execute().fetch(),
                          df2.groupby(df2['b']))
 
-    # test groupby multiple series
+    # test groupby with DataFrames by multiple series
     grouped = mdf.groupby(by=[mdf['b'], mdf['c']])
     assert_groupby_equal(grouped.execute().fetch(),
                          df2.groupby(by=[df2['b'], df2['c']]))
 
+    # test groupby with DataFrames with MultiIndex
     df3 = pd.DataFrame(data_dict,
                        index=pd.MultiIndex.from_tuples(
                            [(i % 3, 'i' + str(i)) for i in range(data_size)]))
@@ -85,7 +88,7 @@ def test_groupby(setup):
     assert_groupby_equal(grouped.execute().fetch(),
                          df3.groupby(level=0))
 
-    # test groupby with integer columns
+    # test groupby with DataFrames by integer columns
     df4 = pd.DataFrame(list(data_dict.values())).T
     mdf = md.DataFrame(df4, chunk_size=13)
     grouped = mdf.groupby(0)

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -80,7 +80,7 @@ class DataFrameMergeAlign(MapReduceOperand, DataFrameOperandMixin):
         for index_idx, index_filter in enumerate(filters):
             reducer_index = (index_idx, chunk.index[1])
             if index_filter is not None and index_filter is not list():
-                ctx[chunk.key, reducer_index] = df.loc[index_filter]
+                ctx[chunk.key, reducer_index] = df.iloc[index_filter]
             else:
                 ctx[chunk.key, reducer_index] = None
 

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -64,8 +64,8 @@ def hash_dataframe_on(df, on, size, level=None):
         else:
             data = df[on]
         hashed_label = pd.util.hash_pandas_object(data, index=False, categorize=False)
-    idx_to_grouped = df.index.groupby(hashed_label % size)
-    return [idx_to_grouped.get(i, pd.Index([])).unique() for i in range(size)]
+    idx_to_grouped = pd.RangeIndex(0, len(hashed_label)).groupby(hashed_label % size)
+    return [idx_to_grouped.get(i, pd.Index([])) for i in range(size)]
 
 
 def hash_dtypes(dtypes, size):


### PR DESCRIPTION
## What do these changes do?

Fix groupby on indexes with duplicate items by filtering DataFrames with `iloc`.

## Related issue number

Fixes #2185