### PR TITLE
Fix starting multiple workers in shared file system

### DIFF
--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -16,6 +16,7 @@ import asyncio
 import concurrent.futures as futures
 import contextlib
 import itertools
+import os
 import threading
 import multiprocessing
 from abc import ABC, ABCMeta, abstractmethod
@@ -31,6 +32,7 @@ from ..utils import create_actor_ref
 from .allocate_strategy import allocated_type, AddressSpecified
 from .communication import Channel, Server, \
     get_server_type, gen_local_address
+from .communication.errors import ChannelClosed
 from .config import ActorPoolConfig
 from .core import result_message_type, ActorCaller
 from .message import _MessageBase, new_message_id, DEFAULT_PROTOCOL, MessageType, \
@@ -300,7 +302,7 @@ class AbstractActorPool(ABC):
                 processor.result = await future
         try:
             await channel.send(processor.result)
-        except ConnectionResetError:
+        except (ChannelClosed, ConnectionResetError):
             if not self._stopped.is_set():
                 raise
 
@@ -666,7 +668,10 @@ class MainActorPoolBase(ActorPoolBase):
 
     @classmethod
     def process_index_gen(cls, address):
-        return cls._process_index_gen
+        # make sure different processes does not share process indexes
+        pid = os.getpid()
+        for idx in cls._process_index_gen:
+            yield pid << 16 + idx
 
     @property
     def _sub_processes(self):

--- a/mars/services/scheduling/supervisor/globalslot.py
+++ b/mars/services/scheduling/supervisor/globalslot.py
@@ -54,7 +54,7 @@ class GlobalSlotManagerActor(mo.Actor):
 
     async def apply_subtask_slots(self, band: Tuple, session_id: str,
                                   subtask_ids: List[str], subtask_slots: List[int]) -> List[str]:
-        if not self._band_total_slots:
+        if not self._band_total_slots or band not in self._band_total_slots:
             self._band_total_slots = await self._cluster_api.get_all_bands()
 
         idx = 0

--- a/mars/services/scheduling/supervisor/queueing.py
+++ b/mars/services/scheduling/supervisor/queueing.py
@@ -152,7 +152,7 @@ class SubtaskQueueingActor(mo.Actor):
                         if stid not in submitted_ids:
                             continue
                         item = submit_items[stid]
-                        logger.debug('Submit subtask %s to worker', item.subtask.subtask_id)
+                        logger.debug('Submit subtask %s to band %r', item.subtask.subtask_id, band)
                         submit_aio_tasks.append(asyncio.create_task(
                             manager_ref.submit_subtask_to_band.tell(item.subtask.subtask_id, band)))
                         self.remove_queued_subtasks([item.subtask.subtask_id])

--- a/mars/services/subtask/api.py
+++ b/mars/services/subtask/api.py
@@ -25,7 +25,7 @@ class SubtaskAPI:
     async def create(cls, address: str) -> "SubtaskAPI":
         return SubtaskAPI(address)
 
-    @alru_cache
+    @alru_cache(cache_exceptions=False)
     async def _get_runner_ref(self, band_name: str, slot_id: int):
         from .worker.runner import SubtaskRunnerActor
         return await mo.actor_ref(

--- a/mars/services/subtask/worker/runner.py
+++ b/mars/services/subtask/worker/runner.py
@@ -66,11 +66,11 @@ class SubtaskRunnerActor(mo.Actor):
 
     async def run_subtask(self, subtask: Subtask):
         if self._running_processor is not None:  # pragma: no cover
-            subtask_id = await self._running_processor.get_running_subtask_id()
+            running_subtask_id = await self._running_processor.get_running_subtask_id()
             # current subtask is still running
             raise SlotOccupiedAlready(
-                f'There is subtask(id: {subtask_id}) running, '
-                f'cannot run another subtask')
+                f'There is subtask(id: {running_subtask_id}) running in {self.uid} '
+                f'at {self.address}, cannot run subtask {subtask.subtask_id}')
 
         session_id = subtask.session_id
         if session_id not in self._session_id_to_processors:


### PR DESCRIPTION
## What do these changes do?

Fix starting multiple workers in shared file system by allocating different process indexes. Also fixes missing slots when running jobs immediately after worker start.

## Related issue number

Fixes #2180
Fixes #2188 