### PR TITLE
Move `fetch` method from `StorageManagerActor` to `StorageHandlerActor`

### DIFF
--- a/mars/_version.py
+++ b/mars/_version.py
@@ -16,7 +16,7 @@ import subprocess
 import os
 from typing import NamedTuple, Optional
 
-version_info = (0, 7, 0, 'rc1')
+version_info = (0, 7, 0, 'rc2')
 _num_index = max(idx if isinstance(v, int) else 0
                  for idx, v in enumerate(version_info))
 __version__ = '.'.join(map(str, version_info[:_num_index + 1])) + \

--- a/mars/deploy/oscar/tests/test_cmdline.py
+++ b/mars/deploy/oscar/tests/test_cmdline.py
@@ -193,6 +193,7 @@ def test_parse_args():
         'MARS_TASK_DETAIL': task_detail,
         'MARS_CACHE_MEM_SIZE': '20M',
         'MARS_PLASMA_DIRS': '/dev/shm',
+        'MARS_SPILL_DIRS': '/tmp'
     }
     args = app.parse_args(parser, ['-p', '10324'], env)
     assert args.host == 'worker1'
@@ -202,4 +203,8 @@ def test_parse_args():
     assert app.config['storage']['plasma'] == {
         'store_memory': '20M',
         'plasma_directory': '/dev/shm',
+    }
+    assert app.config['storage']['filesystem'] == {
+            'root_dirs': '/tmp',
+            'level': 'DISK',
     }

--- a/mars/deploy/oscar/worker.py
+++ b/mars/deploy/oscar/worker.py
@@ -56,11 +56,17 @@ class WorkerCommandRunner(OscarCommandRunner):
             band_to_slot[f'gpu-{i}'] = 1
 
         storage_config = self.config['storage'] = self.config.get('storage', {})
+        backends = storage_config['backends'] = storage_config.get('backends', [])
         plasma_config = storage_config['plasma'] = storage_config.get('plasma', {})
+        filesystem_config = storage_config['filesystem'] = storage_config.get('filesystem', {})
         if 'MARS_CACHE_MEM_SIZE' in environ:
             plasma_config['store_memory'] = environ['MARS_CACHE_MEM_SIZE']
         if 'MARS_PLASMA_DIRS' in environ:
             plasma_config['plasma_directory'] = environ['MARS_PLASMA_DIRS']
+        if 'MARS_SPILL_DIRS' in environ:
+            backends.append('filesystem')
+            filesystem_config['root_dirs'] = environ['MARS_SPILL_DIRS']
+            filesystem_config['level'] = 'DISK'
 
         return args
 

--- a/mars/oscar/backends/test/backend.py
+++ b/mars/oscar/backends/test/backend.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from ...backend import register_backend
-from ..mars.backend import MarsActorBackend
+from ..mars.backend import MarsActorBackend, build_pool_kwargs
 from .pool import TestMainActorPool
 
 
@@ -30,6 +30,7 @@ class TestActorBackend(MarsActorBackend):
             **kwargs):
         from ..pool import create_actor_pool
 
+        n_process, kwargs = build_pool_kwargs(n_process, kwargs)
         return await create_actor_pool(
             address, pool_cls=TestMainActorPool,
             n_process=n_process, **kwargs)

--- a/mars/services/scheduling/worker/tests/test_execution.py
+++ b/mars/services/scheduling/worker/tests/test_execution.py
@@ -33,7 +33,7 @@ from mars.services.lifecycle import MockLifecycleAPI
 from mars.services.meta import MockMetaAPI
 from mars.services.session import MockSessionAPI
 from mars.services.storage import MockStorageAPI
-from mars.services.storage.worker.service import StorageManagerActor
+from mars.services.storage.core import StorageHandlerActor
 from mars.services.subtask import MockSubtaskAPI, Subtask
 from mars.services.task.supervisor.manager import TaskManagerActor
 from mars.tensor.fetch import TensorFetch
@@ -60,7 +60,7 @@ class CancelDetectActorMixin:
         return getattr(self, '_is_cancelled', False)
 
 
-class MockStorageManagerActor(StorageManagerActor, CancelDetectActorMixin):
+class MockStorageHandlerActor(StorageHandlerActor, CancelDetectActorMixin):
     async def fetch(self, *args, **kwargs):
         async with self._delay_method():
             return super().fetch(*args, **kwargs)
@@ -112,7 +112,7 @@ async def actor_pool(request):
         await MockLifecycleAPI.create(session_id, pool.external_address)
         await MockSubtaskAPI.create(pool.external_address)
         storage_api = await MockStorageAPI.create(session_id, pool.external_address,
-                                                  storage_manger_cls=MockStorageManagerActor)
+                                                  storage_handler_cls=MockStorageHandlerActor)
 
         # create assigner actor
         execution_ref = await mo.create_actor(SubtaskExecutionActor,
@@ -201,7 +201,7 @@ async def test_execute_with_cancel(actor_pool, cancel_phase):
     ref_to_delay = None
     if cancel_phase == 'prepare':
         ref_to_delay = await mo.actor_ref(
-            StorageManagerActor.default_uid(), address=pool.external_address)
+            StorageHandlerActor.default_uid(), address=pool.external_address)
     elif cancel_phase == 'quota':
         ref_to_delay = await mo.actor_ref(
             QuotaActor.gen_uid('numa-0'), address=pool.external_address)

--- a/mars/services/storage/api/oscar.py
+++ b/mars/services/storage/api/oscar.py
@@ -272,9 +272,10 @@ class MockStorageAPI(StorageAPI):
                 "plasma": plasma_setup_params,
             }
 
-        storage_manger_cls = kwargs.pop('storage_manger_cls', StorageManagerActor)
-        await mo.create_actor(storage_manger_cls,
+        storage_handler_cls = kwargs.pop('storage_handler_cls', StorageHandlerActor)
+        await mo.create_actor(StorageManagerActor,
                               storage_configs,
+                              storage_handler_cls=storage_handler_cls,
                               uid=StorageManagerActor.default_uid(),
                               address=address)
         return await super().create(address=address, session_id=session_id)

--- a/mars/services/storage/api/oscar.py
+++ b/mars/services/storage/api/oscar.py
@@ -28,7 +28,6 @@ APIType = TypeVar('APIType', bound='StorageAPI')
 
 class StorageAPI(AbstractStorageAPI):
     _storage_handler_ref: Union[StorageHandlerActor, mo.ActorRef]
-    _storage_manager_ref: Union[StorageManagerActor, mo.ActorRef]
     _data_manager_ref: Union[DataManagerActor, mo.ActorRef]
 
     def __init__(self,
@@ -40,8 +39,6 @@ class StorageAPI(AbstractStorageAPI):
     async def _init(self):
         self._storage_handler_ref = await mo.actor_ref(
             self._address, StorageHandlerActor.default_uid())
-        self._storage_manager_ref = await mo.actor_ref(
-            self._address, StorageManagerActor.default_uid())
         self._data_manager_ref = await mo.actor_ref(
             self._address, DataManagerActor.default_uid())
 
@@ -177,7 +174,7 @@ class StorageAPI(AbstractStorageAPI):
         error: str
             raise or ignore
         """
-        await self._storage_manager_ref.fetch(
+        await self._storage_handler_ref.fetch(
             self._session_id, data_key, level,
             band_name, dest_address, error)
 
@@ -194,7 +191,7 @@ class StorageAPI(AbstractStorageAPI):
         error: str
             raise or ignore
         """
-        await self._storage_manager_ref.unpin(self._session_id,
+        await self._storage_handler_ref.unpin(self._session_id,
                                               data_key, error)
 
     async def open_reader(self, data_key: str) -> StorageFileObject:
@@ -250,7 +247,7 @@ class StorageAPI(AbstractStorageAPI):
         -------
             list of data keys
         """
-        return await self._storage_manager_ref.list(level=level)
+        return await self._storage_handler_ref.list(level=level)
 
 
 class MockStorageAPI(StorageAPI):

--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -566,7 +566,7 @@ class StorageHandlerActor(mo.Actor):
                             remote_address: str):
         remote_manager_ref = await mo.actor_ref(uid=DataManagerActor.default_uid(),
                                                 address=remote_address)
-        data_info = yield remote_manager_ref.get_data_info(session_id, data_key)
+        data_info = await remote_manager_ref.get_data_info(session_id, data_key)
         await self._data_manager_ref.put_data_info(
             session_id, data_key, data_info, None)
         try:
@@ -613,7 +613,7 @@ class StorageHandlerActor(mo.Actor):
                         main_key, fields=['bands']))['bands'][0][0]
                 logger.debug('Begin to fetch data %s from %s', data_key, address)
                 if StorageLevel.REMOTE in self._quota_refs:
-                    await self._fetch_remote(session_id, data_key, level, address)
+                    yield self._fetch_remote(session_id, data_key, level, address)
                 else:
                     await self._fetch_via_transfer(session_id, data_key, level, address)
                 logger.debug('finish fetching data %s from %s', data_key, address)

--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -306,7 +306,7 @@ class DataManagerActor(mo.Actor):
                 return
 
     def get_spill_keys(self, level: StorageLevel, size):
-        if level.spill_level() not in self._spill_strategy:
+        if level.spill_level() not in self._spill_strategy:  # pragma: no cover
             raise RuntimeError(f'Spill level of {level} is not configured')
         return self._spill_strategy[level].get_spill_keys(size)
 
@@ -610,7 +610,7 @@ class StorageHandlerActor(mo.Actor):
             except (KeyError, mo.ActorNotExist):
                 # for local cluster, will raise ActorNotExist
                 # for multiply workers, will raise KeyError
-                if error == 'raise':
+                if error == 'raise':  # pragma: no cover
                     raise DataNotExist(f'Data {session_id, data_key} not exists')
 
     async def _request_quota_with_spill(self,
@@ -632,9 +632,6 @@ class StorageHandlerActor(mo.Actor):
 
     async def list(self, level: StorageLevel) -> List:
         return await self._data_manager_ref.list(level)
-
-    async def pin(self, session_id, data_key):
-        await self._data_manager_ref.pin(session_id, data_key)
 
     async def unpin(self, session_id, data_key, error):
         await self._data_manager_ref.unpin(session_id, data_key, error)

--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -336,7 +336,6 @@ class StorageHandlerActor(mo.Actor):
                     clients[level] = client
 
     async def _get_data(self, data_info, conditions):
-        logger.debug(f'Begin to get data {data_info} with conditions {conditions}')
         if conditions is None:
             res = yield self._clients[data_info.level].get(
                 data_info.object_id)
@@ -352,7 +351,6 @@ class StorageHandlerActor(mo.Actor):
                 except AttributeError:
                     sliced_value = data[tuple(conditions)]
                 res = sliced_value
-        logger.debug(f'Finish getting data {data_info} with conditions {conditions}')
         raise mo.Return(res)
 
     @extensible
@@ -377,8 +375,6 @@ class StorageHandlerActor(mo.Actor):
                        error: str = 'raise'):
         info = self._data_manager_ref.get_data_info.delay(
             session_id, data_key, error)
-        logger.debug(f'Get info of data {session_id}-{data_key}: '
-                     f'{info}')
         return info, conditions
 
     @get.batch
@@ -446,7 +442,6 @@ class StorageHandlerActor(mo.Actor):
         data_infos = []
         put_infos = []
         for size, data_key, obj in zip(sizes, data_keys, objs):
-            logger.debug(f'Begin to put data key {data_key}')
             object_info = await self._clients[level].put(obj)
             data_info = _build_data_info(object_info, level, size)
             data_infos.append(data_info)
@@ -617,7 +612,6 @@ class StorageHandlerActor(mo.Actor):
                                         level: StorageLevel,
                                         size: int):
         if await self._quota_refs[level].request_quota(size):
-            logger.debug(f'Request {size} bytes of {level} finished')
             return
         else:
             await self.spill(level, size)

--- a/mars/services/storage/spill.py
+++ b/mars/services/storage/spill.py
@@ -87,8 +87,10 @@ class FIFOStrategy(SpillStrategy):
             if spill_size > size:
                 break
         if spill_size < size:  # pragma: no cover
+            pinned_sizes = dict((k, self._data_sizes[k]) for k in self._pinned_keys)
+            spilling_keys = dict((k, self._data_sizes[k]) for k in self._spilling_keys)
             raise NoDataToSpill(f'No data can be spilled for level: {self._level},'
-                                f'pinned keys: {self._pinned_keys}')
+                                f'pinned keys: {pinned_sizes}, spilling keys: {spilling_keys}')
         self._spilling_keys.update(set(spill_keys))
         return spill_sizes, spill_keys
 

--- a/mars/services/storage/spill.py
+++ b/mars/services/storage/spill.py
@@ -102,15 +102,15 @@ async def spill(request_size: int,
                 quota: Union[mo.ActorRef, StorageQuotaActor],
                 block_size=None,
                 multiplier=1.2):
-    logger.debug(f'{level} is full, need to spill {request_size} bytes, '
-                 f'multiplier is {multiplier}')
+    logger.debug('%s is full, need to spill %s bytes, '
+                 'multiplier is %s', level, request_size, multiplier)
     request_size *= multiplier
     block_size = block_size or DEFAULT_SPILL_BLOCK_SIZE
     spill_level = level.spill_level()
     spill_sizes, spill_keys = await data_manager.get_spill_keys(
         level, request_size)
-    logger.debug(f'Decide to spill {sum(spill_sizes)} bytes, '
-                 f'data keys are {spill_keys}')
+    logger.debug('Decide to spill %s bytes, '
+                 'data keys are %s', sum(spill_sizes), spill_keys)
 
     await quota.request_quota(sum(spill_sizes))
     for (session_id, key), size in zip(spill_keys, spill_sizes):
@@ -129,4 +129,4 @@ async def spill(request_size: int,
             session_id, key, reader.object_id, level)
 
     await quota.release_quota(sum(spill_sizes))
-    logger.debug(f'Spill finishes, release {sum(spill_sizes)} bytes of {level}')
+    logger.debug('Spill finishes, release %s bytes of %s', sum(spill_sizes), level)

--- a/mars/services/storage/transfer.py
+++ b/mars/services/storage/transfer.py
@@ -117,8 +117,6 @@ class ReceiverManagerActor(mo.Actor):
                             data_key: str,
                             data_size: int,
                             level: StorageLevel):
-        if (session_id, data_key) in self._key_to_writer_info:
-            return
         writer = await self._storage_handler.open_writer(session_id, data_key,
                                                          data_size, level)
         self._key_to_writer_info[(session_id, data_key)] = (writer, data_size, level)

--- a/mars/services/storage/transfer.py
+++ b/mars/services/storage/transfer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import logging
 from typing import Union, Any
 
 from ... import oscar as mo
@@ -23,6 +24,9 @@ from ...utils import extensible
 from .core import StorageHandlerActor, DataManagerActor
 
 DEFAULT_TRANSFER_BLOCK_SIZE = 5 * 1024 ** 2
+
+
+logger = logging.getLogger(__name__)
 
 
 class TransferMessage(Serializable):
@@ -68,6 +72,7 @@ class SenderManagerActor(mo.Actor):
                         address: str,
                         level: StorageLevel,
                         block_size: int = None):
+        logger.debug(f'Begin to send data {session_id, data_key} to {address}')
         block_size = block_size or self._transfer_block_size
         receiver_ref = await self.get_receiver_ref(address)
         info = await self._data_manager_ref.get_data_info(session_id, data_key)
@@ -95,6 +100,7 @@ class SenderManagerActor(mo.Actor):
                 sent_size += len(part_data)
                 if is_eof:
                     break
+        logger.debug(f'Finish sending data {session_id, data_key} to {address}')
 
 
 class ReceiverManagerActor(mo.Actor):
@@ -111,6 +117,8 @@ class ReceiverManagerActor(mo.Actor):
                             data_key: str,
                             data_size: int,
                             level: StorageLevel):
+        if (session_id, data_key) in self._key_to_writer_info:
+            return
         writer = await self._storage_handler.open_writer(session_id, data_key,
                                                          data_size, level)
         self._key_to_writer_info[(session_id, data_key)] = (writer, data_size, level)

--- a/mars/services/storage/transfer.py
+++ b/mars/services/storage/transfer.py
@@ -72,7 +72,7 @@ class SenderManagerActor(mo.Actor):
                         address: str,
                         level: StorageLevel,
                         block_size: int = None):
-        logger.debug(f'Begin to send data {session_id, data_key} to {address}')
+        logger.debug('Begin to send data (%s, %s) to %s', session_id, data_key, address)
         block_size = block_size or self._transfer_block_size
         receiver_ref = await self.get_receiver_ref(address)
         info = await self._data_manager_ref.get_data_info(session_id, data_key)
@@ -100,7 +100,7 @@ class SenderManagerActor(mo.Actor):
                 sent_size += len(part_data)
                 if is_eof:
                     break
-        logger.debug(f'Finish sending data {session_id, data_key} to {address}')
+        logger.debug('Finish sending data (%s, %s) to %s', session_id, data_key, address)
 
 
 class ReceiverManagerActor(mo.Actor):

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -124,13 +124,13 @@ class SubtaskProcessor:
                     gets.append(self._storage_api.get.delay(key, error='ignore'))
                     fetches.append(self._storage_api.fetch.delay(key, error='ignore'))
         if keys:
-            logger.debug(f'Start getting input data keys: {keys}, '
-                         f'subtask id: {self.subtask.subtask_id}')
+            logger.debug('Start getting input data keys: %s, '
+                         'subtask id: %s', keys, self.subtask.subtask_id)
             await self._storage_api.fetch.batch(*fetches)
             inputs = await self._storage_api.get.batch(*gets)
             self._datastore.update({key: get for key, get in zip(keys, inputs) if get is not None})
-            logger.debug(f'Finish getting input data keys: {keys}, '
-                         f'subtask id: {self.subtask.subtask_id}')
+            logger.debug('Finish getting input data keys: %s, '
+                         'subtask id: %s', keys, self.subtask.subtask_id)
         return keys
 
     @staticmethod
@@ -186,22 +186,26 @@ class SubtaskProcessor:
             if chunk.key not in self._datastore:
                 # since `op.execute` may be a time-consuming operation,
                 # we make it run in a thread pool to not block current thread.
-                logger.debug(f'Start executing operand: {chunk.op},'
-                             f'chunk: {chunk}, subtask id: {self.subtask.subtask_id}')
+                logger.debug('Start executing operand: %s,'
+                             'chunk: %s, subtask id: %s', chunk.op, chunk,
+                             self.subtask.subtask_id)
                 future = await self._async_execute_operand(loop, executor,
                                                            self._datastore, chunk.op)
                 try:
                     await future
-                    logger.debug(f'Finish executing operand: {chunk.op},'
-                                 f'chunk: {chunk}, subtask id: {self.subtask.subtask_id}')
+                    logger.debug('Finish executing operand: %s,'
+                                 'chunk: %s, subtask id: %s', chunk.op, chunk,
+                                 self.subtask.subtask_id)
                 except asyncio.CancelledError:
-                    logger.debug(f'Receive cancel instruction for operand: {chunk.op},'
-                                 f'chunk: {chunk}, subtask id: {self.subtask.subtask_id}')
+                    logger.debug('Receive cancel instruction for operand: %s,'
+                                 'chunk: %s, subtask id: %s', chunk.op, chunk,
+                                 self.subtask.subtask_id)
                     # wait for this computation to finish
                     await loop.run_in_executor(None, executor.shutdown)
-                    # if cancelled, stop next computation,
-                    logger.debug(f'Cancelled operand: {chunk.op}, chunk: {chunk}, '
-                                 f'subtask id: {self.subtask.subtask_id}')
+                    # if cancelled, stop next computation
+                    logger.debug('Cancelled operand: %s, chunk: %s, '
+                                 'subtask id: %s', chunk.op, chunk,
+                                 self.subtask.subtask_id)
                     self.result.status = SubtaskStatus.cancelled
                     raise
 
@@ -255,8 +259,8 @@ class SubtaskProcessor:
                     result_data = self._datastore[key]
                     put = self._storage_api.put.delay(key, result_data)
                     data_key_to_puts[data_key].append(put)
-        logger.debug(f'Start putting data keys: {stored_keys}, '
-                     f'subtask id: {self.subtask.subtask_id}')
+        logger.debug('Start putting data keys: %s, '
+                     'subtask id: %s', stored_keys, self.subtask.subtask_id)
         puts = list(chain(*data_key_to_puts.values()))
         data_key_to_store_size = defaultdict(lambda: 0)
         data_key_to_memory_size = defaultdict(lambda: 0)
@@ -270,15 +274,15 @@ class SubtaskProcessor:
                         store_info = next(store_infos_iter)
                         data_key_to_store_size[data_key] += store_info.store_size
                         data_key_to_memory_size[data_key] += store_info.memory_size
-                logger.debug(f'Finish putting data keys: {stored_keys}, '
-                             f'subtask id: {self.subtask.subtask_id}')
+                logger.debug('Finish putting data keys: %s, '
+                             'subtask id: %s', stored_keys, self.subtask.subtask_id)
             except asyncio.CancelledError:
-                logger.debug(f'Cancelling put data keys: {stored_keys}, '
-                             f'subtask id: {self.subtask.subtask_id}')
+                logger.debug('Cancelling put data keys: %s, '
+                             'subtask id: %s', stored_keys, self.subtask.subtask_id)
                 put_infos.cancel()
 
-                logger.debug(f'Cancelled put data keys: {stored_keys}, '
-                             f'subtask id: {self.subtask.subtask_id}')
+                logger.debug('Cancelled put data keys: %s, '
+                             'subtask id: %s', stored_keys, self.subtask.subtask_id)
                 self.result.status = SubtaskStatus.cancelled
                 raise
 
@@ -302,18 +306,18 @@ class SubtaskProcessor:
                 self._meta_api.set_chunk_meta.delay(
                     result_chunk, memory_size=memory_size,
                     store_size=store_size, bands=[self._band]))
-        logger.debug(f'Start storing chunk metas for data keys: {stored_keys}, '
-                     f'subtask id: {self.subtask.subtask_id}')
+        logger.debug('Start storing chunk metas for data keys: %s, '
+                     'subtask id: %s', stored_keys, self.subtask.subtask_id)
         if set_chunk_metas:
             set_chunks_meta = asyncio.create_task(
                 self._meta_api.set_chunk_meta.batch(*set_chunk_metas))
             try:
                 await set_chunks_meta
-                logger.debug(f'Finish store chunk metas for data keys: {stored_keys}, '
-                             f'subtask id: {self.subtask.subtask_id}')
+                logger.debug('Finish store chunk metas for data keys: %s, '
+                             'subtask id: %s', stored_keys, self.subtask.subtask_id)
             except asyncio.CancelledError:
-                logger.debug(f'Cancelling store chunk metas for data keys: {stored_keys}, '
-                             f'subtask id: {self.subtask.subtask_id}')
+                logger.debug('Cancelling store chunk metas for data keys: %s, '
+                             'subtask id: %s', stored_keys, self.subtask.subtask_id)
                 set_chunks_meta.cancel()
 
                 # remote stored data
@@ -323,8 +327,8 @@ class SubtaskProcessor:
                 await self._storage_api.delete.batch(*deletes)
 
                 self.result.status = SubtaskStatus.cancelled
-                logger.debug(f'Cancelled store chunk metas for data keys: {stored_keys}, '
-                             f'subtask id: {self.subtask.subtask_id}')
+                logger.debug('Cancelled store chunk metas for data keys: %s, '
+                             'subtask id: %s', stored_keys, self.subtask.subtask_id)
                 raise
         # set result data size
         self.result.data_size = sum(memory_sizes)
@@ -446,7 +450,7 @@ class SubtaskProcessorActor(mo.Actor):
         set_context(context)
 
     async def run(self, subtask: Subtask):
-        logger.debug(f'Start to run subtask: {subtask.subtask_id}')
+        logger.debug('Start to run subtask: %s', subtask.subtask_id)
 
         assert subtask.session_id == self._session_id
 
@@ -470,8 +474,7 @@ class SubtaskProcessorActor(mo.Actor):
         return self._last_processor.result
 
     async def cancel(self):
-        logger.debug(f'Cancelling subtask: '
-                     f'{self._processor.subtask_id}')
+        logger.debug('Cancelling subtask: %s', self._processor.subtask_id)
 
         aio_task = self._running_aio_task
         aio_task.cancel()

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -124,13 +124,13 @@ class SubtaskProcessor:
                     gets.append(self._storage_api.get.delay(key, error='ignore'))
                     fetches.append(self._storage_api.fetch.delay(key, error='ignore'))
         if keys:
-            logger.info(f'Start getting input data keys: {keys}, '
-                        f'subtask id: {self.subtask.subtask_id}')
+            logger.debug(f'Start getting input data keys: {keys}, '
+                         f'subtask id: {self.subtask.subtask_id}')
             await self._storage_api.fetch.batch(*fetches)
             inputs = await self._storage_api.get.batch(*gets)
             self._datastore.update({key: get for key, get in zip(keys, inputs) if get is not None})
-            logger.info(f'Finish getting input data keys: {keys}, '
-                        f'subtask id: {self.subtask.subtask_id}')
+            logger.debug(f'Finish getting input data keys: {keys}, '
+                         f'subtask id: {self.subtask.subtask_id}')
         return keys
 
     @staticmethod
@@ -186,22 +186,22 @@ class SubtaskProcessor:
             if chunk.key not in self._datastore:
                 # since `op.execute` may be a time-consuming operation,
                 # we make it run in a thread pool to not block current thread.
-                logger.info(f'Start executing operand: {chunk.op},'
-                            f'chunk: {chunk}, subtask id: {self.subtask.subtask_id}')
+                logger.debug(f'Start executing operand: {chunk.op},'
+                             f'chunk: {chunk}, subtask id: {self.subtask.subtask_id}')
                 future = await self._async_execute_operand(loop, executor,
                                                            self._datastore, chunk.op)
                 try:
                     await future
-                    logger.info(f'Finish executing operand: {chunk.op},'
-                                f'chunk: {chunk}, subtask id: {self.subtask.subtask_id}')
+                    logger.debug(f'Finish executing operand: {chunk.op},'
+                                 f'chunk: {chunk}, subtask id: {self.subtask.subtask_id}')
                 except asyncio.CancelledError:
-                    logger.info(f'Receive cancel instruction for operand: {chunk.op},'
-                                f'chunk: {chunk}, subtask id: {self.subtask.subtask_id}')
+                    logger.debug(f'Receive cancel instruction for operand: {chunk.op},'
+                                 f'chunk: {chunk}, subtask id: {self.subtask.subtask_id}')
                     # wait for this computation to finish
                     await loop.run_in_executor(None, executor.shutdown)
                     # if cancelled, stop next computation,
-                    logger.info(f'Cancelled operand: {chunk.op}, chunk: {chunk}, '
-                                f'subtask id: {self.subtask.subtask_id}')
+                    logger.debug(f'Cancelled operand: {chunk.op}, chunk: {chunk}, '
+                                 f'subtask id: {self.subtask.subtask_id}')
                     self.result.status = SubtaskStatus.cancelled
                     raise
 
@@ -255,8 +255,8 @@ class SubtaskProcessor:
                     result_data = self._datastore[key]
                     put = self._storage_api.put.delay(key, result_data)
                     data_key_to_puts[data_key].append(put)
-        logger.info(f'Start putting data keys: {stored_keys}, '
-                    f'subtask id: {self.subtask.subtask_id}')
+        logger.debug(f'Start putting data keys: {stored_keys}, '
+                     f'subtask id: {self.subtask.subtask_id}')
         puts = list(chain(*data_key_to_puts.values()))
         data_key_to_store_size = defaultdict(lambda: 0)
         data_key_to_memory_size = defaultdict(lambda: 0)
@@ -270,15 +270,15 @@ class SubtaskProcessor:
                         store_info = next(store_infos_iter)
                         data_key_to_store_size[data_key] += store_info.store_size
                         data_key_to_memory_size[data_key] += store_info.memory_size
-                logger.info(f'Finish putting data keys: {stored_keys}, '
-                            f'subtask id: {self.subtask.subtask_id}')
+                logger.debug(f'Finish putting data keys: {stored_keys}, '
+                             f'subtask id: {self.subtask.subtask_id}')
             except asyncio.CancelledError:
-                logger.info(f'Cancelling put data keys: {stored_keys}, '
-                            f'subtask id: {self.subtask.subtask_id}')
+                logger.debug(f'Cancelling put data keys: {stored_keys}, '
+                             f'subtask id: {self.subtask.subtask_id}')
                 put_infos.cancel()
 
-                logger.info(f'Cancelled put data keys: {stored_keys}, '
-                            f'subtask id: {self.subtask.subtask_id}')
+                logger.debug(f'Cancelled put data keys: {stored_keys}, '
+                             f'subtask id: {self.subtask.subtask_id}')
                 self.result.status = SubtaskStatus.cancelled
                 raise
 
@@ -302,18 +302,18 @@ class SubtaskProcessor:
                 self._meta_api.set_chunk_meta.delay(
                     result_chunk, memory_size=memory_size,
                     store_size=store_size, bands=[self._band]))
-        logger.info(f'Start storing chunk metas for data keys: {stored_keys}, '
-                    f'subtask id: {self.subtask.subtask_id}')
+        logger.debug(f'Start storing chunk metas for data keys: {stored_keys}, '
+                     f'subtask id: {self.subtask.subtask_id}')
         if set_chunk_metas:
             set_chunks_meta = asyncio.create_task(
                 self._meta_api.set_chunk_meta.batch(*set_chunk_metas))
             try:
                 await set_chunks_meta
-                logger.info(f'Finish store chunk metas for data keys: {stored_keys}, '
-                            f'subtask id: {self.subtask.subtask_id}')
+                logger.debug(f'Finish store chunk metas for data keys: {stored_keys}, '
+                             f'subtask id: {self.subtask.subtask_id}')
             except asyncio.CancelledError:
-                logger.info(f'Cancelling store chunk metas for data keys: {stored_keys}, '
-                            f'subtask id: {self.subtask.subtask_id}')
+                logger.debug(f'Cancelling store chunk metas for data keys: {stored_keys}, '
+                             f'subtask id: {self.subtask.subtask_id}')
                 set_chunks_meta.cancel()
 
                 # remote stored data
@@ -323,8 +323,8 @@ class SubtaskProcessor:
                 await self._storage_api.delete.batch(*deletes)
 
                 self.result.status = SubtaskStatus.cancelled
-                logger.info(f'Cancelled store chunk metas for data keys: {stored_keys}, '
-                            f'subtask id: {self.subtask.subtask_id}')
+                logger.debug(f'Cancelled store chunk metas for data keys: {stored_keys}, '
+                             f'subtask id: {self.subtask.subtask_id}')
                 raise
         # set result data size
         self.result.data_size = sum(memory_sizes)
@@ -446,7 +446,7 @@ class SubtaskProcessorActor(mo.Actor):
         set_context(context)
 
     async def run(self, subtask: Subtask):
-        logger.info(f'Start to run subtask: {subtask.subtask_id}')
+        logger.debug(f'Start to run subtask: {subtask.subtask_id}')
 
         assert subtask.session_id == self._session_id
 
@@ -470,8 +470,8 @@ class SubtaskProcessorActor(mo.Actor):
         return self._last_processor.result
 
     async def cancel(self):
-        logger.info(f'Cancelling subtask: '
-                    f'{self._processor.subtask_id}')
+        logger.debug(f'Cancelling subtask: '
+                     f'{self._processor.subtask_id}')
 
         aio_task = self._running_aio_task
         aio_task.cancel()

--- a/mars/services/task/api/web.py
+++ b/mars/services/task/api/web.py
@@ -95,9 +95,7 @@ class TaskWebAPIHandler(MarsServiceWebAPIHandler):
     async def get_fetch_tileables(self, session_id: str, task_id: str):
         oscar_api = await self._get_oscar_task_api(session_id)
         res = await oscar_api.get_fetch_tileables(task_id)
-        r = serialize_serializable(res)
-        print(f'serialize length: {len(r)}')
-        self.write(r)
+        self.write(serialize_serializable(res))
 
     @web_api('(?P<task_id>[^/]+)', method='get')
     async def get_task_result(self, session_id: str, task_id: str):

--- a/mars/services/task/api/web.py
+++ b/mars/services/task/api/web.py
@@ -95,7 +95,9 @@ class TaskWebAPIHandler(MarsServiceWebAPIHandler):
     async def get_fetch_tileables(self, session_id: str, task_id: str):
         oscar_api = await self._get_oscar_task_api(session_id)
         res = await oscar_api.get_fetch_tileables(task_id)
-        self.write(serialize_serializable(res))
+        r = serialize_serializable(res)
+        print(f'serialize length: {len(r)}')
+        self.write(r)
 
     @web_api('(?P<task_id>[^/]+)', method='get')
     async def get_task_result(self, session_id: str, task_id: str):

--- a/mars/storage/filesystem.py
+++ b/mars/storage/filesystem.py
@@ -51,7 +51,7 @@ class FileSystemStorage(StorageBackend):
             raise TypeError(f'FileSystemStorage got unexpected config: {",".join(kwargs)}')
 
         if isinstance(root_dirs, str):
-            root_dirs = root_dirs.split(',')
+            root_dirs = root_dirs.split(':')
         if isinstance(level, str):
             level = StorageLevel.from_str(level)
 

--- a/mars/storage/plasma.py
+++ b/mars/storage/plasma.py
@@ -162,7 +162,7 @@ class PlasmaStorage(StorageBackend):
         if kwargs:
             raise TypeError(f'PlasmaStorage got unexpected config: {",".join(kwargs)}')
 
-        store_memory = calc_size_by_str(store_memory, virtual_memory().total)
+        store_memory = int(calc_size_by_str(store_memory, virtual_memory().total) * 0.95)
         plasma_store = plasma.start_plasma_store(
             store_memory, plasma_directory=plasma_directory)
         plasma_socket = (await loop.run_in_executor(

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ class BuildWeb(Command):
         web_src_path = os.path.join(repo_root, *cls._web_src_path.split('/'))
         web_dest_path = os.path.join(repo_root, *cls._web_dest_path.split('/'))
 
-        if not os.path.exists(web_dest_path):
+        if os.path.exists(web_dest_path):
             if npm_path is None:
                 warnings.warn('Cannot find NPM, may affect displaying Mars Web')
             return


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Make all storage API like `put`, `get`, `fetch` methods call `StorageHandlerActor` directly.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
 