### PR TITLE
Fix compatibility issue for pandas 1.3

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -48,9 +48,6 @@ jobs:
           pip install numpy\<1.20.0
         fi
 
-        # todo remove this when #2191 is fixed.
-        pip install pandas\<1.3.0
-
         source ./ci/rewrite-cov-config.sh
 
         pip install numpy scipy cython

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,9 +62,6 @@ jobs:
           pip install numpy\<1.20.0
         fi
 
-        # todo remove this when compatibility issue for pandas 1.3 is resolved.
-        pip install pandas\<1.3.0
-
         source ./ci/rewrite-cov-config.sh
 
         if [[ "$(mars.test.module)" == "learn" ]]; then

--- a/mars/dataframe/base/shift.py
+++ b/mars/dataframe/base/shift.py
@@ -22,6 +22,8 @@ from ...utils import has_unknown_shape
 from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index, build_df, build_series, validate_axis
 
+_need_consolidate = pd.__version__ in ('1.1.0', '1.3.0')
+
 
 class DataFrameShift(DataFrameOperand, DataFrameOperandMixin):
     _op_type_ = OperandDef.SHIFT
@@ -312,7 +314,7 @@ class DataFrameShift(DataFrameOperand, DataFrameOperandMixin):
         obj = ctx[op.input.key]
         out = op.outputs[0]
 
-        if pd.__version__ == '1.1.0' and \
+        if _need_consolidate and \
                 isinstance(obj, (pd.Series, pd.DataFrame)) and len(obj._data.blocks) > 1:
             # if #internal blocks > 1, shift will create wrong result in pandas 1.1.0
             # see https://github.com/pandas-dev/pandas/issues/35488

--- a/mars/dataframe/base/shift.py
+++ b/mars/dataframe/base/shift.py
@@ -318,6 +318,8 @@ class DataFrameShift(DataFrameOperand, DataFrameOperandMixin):
                 isinstance(obj, (pd.Series, pd.DataFrame)) and len(obj._data.blocks) > 1:
             # if #internal blocks > 1, shift will create wrong result in pandas 1.1.0
             # see https://github.com/pandas-dev/pandas/issues/35488
+            # if shifting merged dataframe slices, shift will raise TypeError in pandas 1.3.0
+            # see https://github.com/pandas-dev/pandas/issues/42401
             # thus we force to do consolidate
             obj._data._consolidate_inplace()
 

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -65,19 +65,17 @@ def _patch_groupby_kurt():
     try:
         from pandas.core.groupby import DataFrameGroupBy, SeriesGroupBy
         if not hasattr(DataFrameGroupBy, 'kurt'):  # pragma: no branch
-            def _kurt_fun(a, *args, **kwargs):
+            def _kurt_by_frame(a, *args, **kwargs):
                 return a.to_frame().kurt(*args, **kwargs).iloc[0]
 
-            def _series_group_kurt(x, *args, **kwargs):
+            def _group_kurt(x, *args, **kwargs):
                 if kwargs.get('numeric_only') is not None:
-                    return x.agg(functools.partial(_kurt_fun, *args, **kwargs))
+                    return x.agg(functools.partial(_kurt_by_frame, *args, **kwargs))
                 else:
                     return x.agg(functools.partial(pd.Series.kurt, *args, **kwargs))
 
-            DataFrameGroupBy.kurt = _series_group_kurt
-            SeriesGroupBy.kurt = _series_group_kurt
-            DataFrameGroupBy.kurtosis = _series_group_kurt
-            SeriesGroupBy.kurtosis = _series_group_kurt
+            DataFrameGroupBy.kurt = DataFrameGroupBy.kurtosis = _group_kurt
+            SeriesGroupBy.kurt = SeriesGroupBy.kurtosis = _group_kurt
     except (AttributeError, ImportError):  # pragma: no cover
         pass
 

--- a/mars/dataframe/indexing/loc.py
+++ b/mars/dataframe/indexing/loc.py
@@ -311,7 +311,7 @@ class DataFrameLocGetItem(DataFrameOperand, DataFrameOperandMixin):
             if isinstance(inp, DATAFRAME_TYPE):
                 if sizes[0] is None:
                     # label on axis 0
-                    dtype = find_common_type(dtypes)
+                    dtype = find_common_type(list(dtypes))
                     return self.new_series(inputs, shape=shape, dtype=dtype,
                                            index_value=columns_value, name=self._indexes[0])
                 else:

--- a/mars/dataframe/reduction/tests/test_reduction_execute.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execute.py
@@ -27,11 +27,13 @@ from mars.config import option_context
 from mars.core.session import get_default_session, SyncSession
 from mars.dataframe import CustomReduction, NamedAgg
 from mars.dataframe.base import to_gpu
+from mars.lib.version import parse as parse_version
 from mars.tests import setup
 from mars.tests.core import require_cudf, require_cupy
 from mars.utils import lazy_import
 
 cp = lazy_import('cupy', rename='cp', globals=globals())
+_agg_size_as_series = parse_version(pd.__version__) >= parse_version('1.3.0')
 
 
 setup = setup
@@ -765,7 +767,10 @@ def test_dataframe_aggregate(setup, check_ref_counts):
                                   data.agg(all_aggs))
 
     result = df.agg('size')
-    assert result.execute().fetch() == data.agg('size')
+    if _agg_size_as_series:
+        pd.testing.assert_series_equal(result.execute().fetch(), data.agg('size'))
+    else:
+        assert result.execute().fetch() == data.agg('size')
 
     for func in (a for a in all_aggs if a != 'size'):
         result = df.agg(func)
@@ -784,7 +789,10 @@ def test_dataframe_aggregate(setup, check_ref_counts):
                                   data.agg(['cumsum', 'cummax']))
 
     result = df.agg('size')
-    assert result.execute().fetch() == data.agg('size')
+    if _agg_size_as_series:
+        pd.testing.assert_series_equal(result.execute().fetch(), data.agg('size'))
+    else:
+        assert result.execute().fetch() == data.agg('size')
 
     for func in (a for a in all_aggs if a != 'size'):
         result = df.agg(func)

--- a/mars/dataframe/statistics/quantile.py
+++ b/mars/dataframe/statistics/quantile.py
@@ -113,7 +113,7 @@ class DataFrameQuantile(DataFrameOperand, DataFrameOperandMixin):
             index_value = a.index_value
             shape = (len(a),)
             # calc dtype
-            dt = tensor_quantile(empty(a.shape[1], dtype=find_common_type(dtypes)),
+            dt = tensor_quantile(empty(a.shape[1], dtype=find_common_type(list(dtypes))),
                                  self._q, interpolation=self._interpolation,
                                  handle_non_numeric=not self._numeric_only).dtype
             return self.new_series(inputs, shape=shape, dtype=dt,

--- a/mars/dataframe/tests/test_arrays.py
+++ b/mars/dataframe/tests/test_arrays.py
@@ -22,6 +22,7 @@ except ImportError:
 
 from mars.config import option_context
 from mars.core import enter_mode
+from mars.dataframe.arrays import _use_bool_any_all
 from mars.dataframe import ArrowStringDtype, ArrowStringArray, ArrowListDtype, ArrowListArray
 from mars.dataframe.utils import arrow_table_to_pandas_dataframe
 
@@ -359,8 +360,12 @@ def test_arrow_list_functions():
             assert list(arrow_array.shift(2, fill_value=['aa'])) == [['aa']] * 2 + lst[:-2].tolist()
 
             # test all any
-            assert arrow_array.all() == pd.array(lst).all()
-            assert arrow_array.any() == pd.array(lst).any()
+            if _use_bool_any_all:
+                assert arrow_array.all() == pd.array(lst).all()
+                assert arrow_array.any() == pd.array(lst).any()
+            else:
+                assert arrow_array.all() == lst.all()
+                assert arrow_array.any() == lst.any()
 
             # test repr
             assert 'ArrowListArray' in repr(arrow_array)

--- a/mars/dataframe/tests/test_arrays.py
+++ b/mars/dataframe/tests/test_arrays.py
@@ -249,14 +249,10 @@ def test_arrow_string_array_functions():
 
             # test take
             assert list(arrow_array.take([1, 2, -1])) == list(string_array.take([1, 2, -1]))
-            assert list(arrow_array.take([1, 2, -1],
-                                                       allow_fill=True).fillna('aa')) == list(string_array.take([1, 2, -1],
-                                                        allow_fill=True).fillna('aa'))
-            assert list(arrow_array.take([1, 2, -1],
-                                                       allow_fill=True,
-                                                       fill_value='aa')) == list(string_array.take([1, 2, -1],
-                                                        allow_fill=True,
-                                                        fill_value='aa'))
+            assert list(arrow_array.take([1, 2, -1], allow_fill=True).fillna('aa')) \
+                   == list(string_array.take([1, 2, -1], allow_fill=True).fillna('aa'))
+            assert list(arrow_array.take([1, 2, -1], allow_fill=True, fill_value='aa')) \
+                   == list(string_array.take([1, 2, -1], allow_fill=True, fill_value='aa'))
 
             # test shift
             assert list(arrow_array.shift(2, fill_value='aa')) == list(string_array.shift(2, fill_value='aa'))
@@ -363,8 +359,8 @@ def test_arrow_list_functions():
             assert list(arrow_array.shift(2, fill_value=['aa'])) == [['aa']] * 2 + lst[:-2].tolist()
 
             # test all any
-            assert arrow_array.all() == lst.all()
-            assert arrow_array.any() == lst.any()
+            assert arrow_array.all() == pd.array(lst).all()
+            assert arrow_array.any() == pd.array(lst).any()
 
             # test repr
             assert 'ArrowListArray' in repr(arrow_array)

--- a/mars/dataframe/window/ewm/core.py
+++ b/mars/dataframe/window/ewm/core.py
@@ -65,7 +65,8 @@ class EWM(Window):
         return df.ewm(**self.params)
 
     def _repr(self, params):
-        params['com'] = 1.0 / params.pop('alpha') - 1
+        com = 1.0 / params.pop('alpha') - 1
+        params['com'] = int(com) if com == math.floor(com) else com
         try:
             params.move_to_end('com', last=False)
         except AttributeError:  # pragma: no cover

--- a/mars/dataframe/window/expanding/core.py
+++ b/mars/dataframe/window/expanding/core.py
@@ -14,7 +14,8 @@
 
 from collections import OrderedDict
 
-from ....serialization.serializables import Int64Field, BoolField, Int32Field
+from ....serialization.serializables import BoolField, Int32Field, \
+    Int64Field, StringField
 from ...utils import validate_axis
 from ..core import Window
 
@@ -23,9 +24,11 @@ class Expanding(Window):
     _min_periods = Int64Field('min_periods')
     _axis = Int32Field('axis')
     _center = BoolField('center')
+    _method = StringField('method')
 
-    def __init__(self, min_periods=None, axis=None, center=None, **kw):
-        super().__init__(_min_periods=min_periods, _axis=axis, _center=center, **kw)
+    def __init__(self, min_periods=None, axis=None, center=None, method=None, **kw):
+        super().__init__(_min_periods=min_periods, _axis=axis, _center=center,
+                         _method=method, **kw)
 
     @property
     def min_periods(self):
@@ -39,13 +42,17 @@ class Expanding(Window):
     def center(self):
         return self._center
 
+    @property
+    def method(self):
+        return self._method or 'single'
+
     def __call__(self, df):
         return df.expanding(**self.params)
 
     @property
     def params(self):
         p = OrderedDict()
-        for k in ['min_periods', 'center', 'axis']:
+        for k in ['min_periods', 'center', 'axis', 'method']:
             p[k] = getattr(self, k)
         return p
 

--- a/mars/dataframe/window/rolling/core.py
+++ b/mars/dataframe/window/rolling/core.py
@@ -28,11 +28,13 @@ class Rolling(Window):
     _on = StringField('on')
     _axis = Int32Field('axis')
     _closed = StringField('closed')
+    _method = StringField('method')
 
     def __init__(self, window=None, min_periods=None, center=None, win_type=None, on=None,
-                 axis=None, closed=None, **kw):
+                 axis=None, closed=None, method=None, **kw):
         super().__init__(_window=window, _min_periods=min_periods, _center=center,
-                         _win_type=win_type, _on=on, _axis=axis, _closed=closed, **kw)
+                         _win_type=win_type, _on=on, _axis=axis, _closed=closed,
+                         _method=method, **kw)
 
     @property
     def window(self):
@@ -63,10 +65,14 @@ class Rolling(Window):
         return self._closed
 
     @property
+    def method(self):
+        return self._method or 'single'
+
+    @property
     def params(self):
         p = OrderedDict()
-        for attr in ['window', 'min_periods', 'center',
-                     'win_type', 'axis', 'on', 'closed']:
+        for attr in ['window', 'min_periods', 'center', 'win_type',
+                     'axis', 'on', 'closed', 'method']:
             p[attr] = getattr(self, attr)
         return p
 

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ class BuildWeb(Command):
         web_src_path = os.path.join(repo_root, *cls._web_src_path.split('/'))
         web_dest_path = os.path.join(repo_root, *cls._web_dest_path.split('/'))
 
-        if not os.path.exists(web_dest_path):
+        if os.path.exists(web_dest_path):
             if npm_path is None:
                 warnings.warn('Cannot find NPM, may affect displaying Mars Web')
             return


### PR DESCRIPTION
## What do these changes do?

Fix compatibility issue for pandas 1.3, including

1. initialize binary class for `PandasArray`
2. copy non-contiguous data before astype (see pandas-dev/pandas#42396)
3. consolidate data before shift to workaround (see pandas-dev/pandas#42401)
4. change input type of find_common_type into lists
5. window function reprs
6. keep original order when calculating `value_counts`.

## Related issue number

Fixes #2191 