### PR TITLE
Restart idle slots when hard memory limit is encountered

### DIFF
--- a/mars/deploy/oscar/tests/modules/replace_op.py
+++ b/mars/deploy/oscar/tests/modules/replace_op.py
@@ -22,5 +22,4 @@ def _replace_op(ctx, op):
     return executor(ctx, op)
 
 
-print("replace TensorAdd to TensorSubtract for testing.")
 TensorAdd.register_executor(_replace_op)

--- a/mars/oscar/backends/mars/tests/test_pool.py
+++ b/mars/oscar/backends/mars/tests/test_pool.py
@@ -89,7 +89,7 @@ def clear_routers():
     Router.set_instance(None)
 
 
-@flaky(platform='win', max_runs=3)
+@flaky(platform='win', max_runs=10)
 @pytest.mark.asyncio
 @mock.patch('mars.oscar.backends.mars.pool.SubActorPool.notify_main_pool_to_destroy')
 async def test_sub_actor_pool(notify_main_pool):
@@ -220,7 +220,7 @@ async def test_sub_actor_pool(notify_main_pool):
     assert pool.stopped
 
 
-@flaky(platform='win', max_runs=3)
+@flaky(platform='win', max_runs=10)
 @pytest.mark.asyncio
 async def test_main_actor_pool():
     config = ActorPoolConfig()
@@ -348,7 +348,7 @@ async def test_main_actor_pool():
     assert pool.stopped
 
 
-@flaky(platform='win', max_runs=3)
+@flaky(platform='win', max_runs=10)
 @pytest.mark.asyncio
 async def test_create_actor_pool():
     start_method = os.environ.get('POOL_START_METHOD', 'forkserver') \
@@ -418,7 +418,7 @@ async def test_create_actor_pool():
     assert len(global_router._mapping) == 0
 
 
-@flaky(platform='win', max_runs=3)
+@flaky(platform='win', max_runs=10)
 @pytest.mark.asyncio
 async def test_errors():
     with pytest.raises(ValueError):
@@ -437,7 +437,7 @@ async def test_errors():
                                     auto_recover='illegal')
 
 
-@flaky(platform='win', max_runs=3)
+@flaky(platform='win', max_runs=10)
 @pytest.mark.asyncio
 async def test_server_closed():
     start_method = os.environ.get('POOL_START_METHOD', 'forkserver') \
@@ -477,7 +477,7 @@ async def test_server_closed():
         await ctx.has_actor(actor_ref)
 
 
-@flaky(platform='win', max_runs=3)
+@flaky(platform='win', max_runs=10)
 @pytest.mark.asyncio
 @pytest.mark.skipif(sys.platform.startswith('win'), reason='skip under Windows')
 @pytest.mark.parametrize(
@@ -527,7 +527,7 @@ async def test_auto_recover(auto_recover):
                 await ctx.has_actor(actor_ref)
 
 
-@flaky(platform='win', max_runs=3)
+@flaky(platform='win', max_runs=10)
 @pytest.mark.asyncio
 async def test_two_pools():
     start_method = os.environ.get('POOL_START_METHOD', 'forkserver') \
@@ -582,6 +582,7 @@ async def test_two_pools():
         assert await actor_ref2.add_other(actor_ref4, 3) == 13
 
 
+@flaky(platform='win', max_runs=10)
 @pytest.mark.asyncio
 async def test_parallel_allocate_idle_label():
     start_method = os.environ.get('POOL_START_METHOD', 'forkserver') \

--- a/mars/services/scheduling/worker/service.py
+++ b/mars/services/scheduling/worker/service.py
@@ -38,12 +38,15 @@ async def start(config: Dict, address: str):
     total_mem = mars_resource.virtual_memory().total
     mem_quota_size = calc_size_by_str(
         scheduling_config.get('mem_quota_size', '80%'), total_mem)
+    mem_hard_limit = calc_size_by_str(
+        scheduling_config.get('mem_hard_limit', '95%'), total_mem)
 
     await mo.create_actor(WorkerSlotManagerActor,
                           uid=WorkerSlotManagerActor.default_uid(),
                           address=address)
     await mo.create_actor(WorkerQuotaManagerActor,
-                          default_config=dict(quota_size=mem_quota_size),
+                          default_config=dict(quota_size=mem_quota_size,
+                                              hard_limit=mem_hard_limit),
                           uid=WorkerQuotaManagerActor.default_uid(),
                           address=address)
     await mo.create_actor(SubtaskExecutionActor,


### PR DESCRIPTION
## What do these changes do?

Restart idle slots when hard memory limit is encountered. This will relieve task stuck when too much memory used by small allocations caused by `PyAlloc`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
