### PR TITLE
Fix `NoDataToSpill` when multiple storage quota requests happen simultaneously

### DIFF
--- a/mars/services/scheduling/worker/tests/test_execution.py
+++ b/mars/services/scheduling/worker/tests/test_execution.py
@@ -33,7 +33,7 @@ from mars.services.lifecycle import MockLifecycleAPI
 from mars.services.meta import MockMetaAPI
 from mars.services.session import MockSessionAPI
 from mars.services.storage import MockStorageAPI
-from mars.services.storage.core import StorageHandlerActor
+from mars.services.storage.handler import StorageHandlerActor
 from mars.services.subtask import MockSubtaskAPI, Subtask
 from mars.services.task.supervisor.manager import TaskManagerActor
 from mars.tensor.fetch import TensorFetch

--- a/mars/services/storage/api/oscar.py
+++ b/mars/services/storage/api/oscar.py
@@ -19,8 +19,9 @@ from .... import oscar as mo
 from ....lib.aio import alru_cache
 from ....storage.base import StorageLevel, StorageFileObject
 from ....utils import extensible
-from ..core import StorageHandlerActor, StorageManagerActor, DataManagerActor, \
+from ..core import StorageManagerActor, DataManagerActor, \
     DataInfo, WrappedStorageFileObject
+from ..handler import StorageHandlerActor
 from .core import AbstractStorageAPI
 
 APIType = TypeVar('APIType', bound='StorageAPI')

--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from ... import oscar as mo
 from ...lib.aio import AioFileObject
@@ -25,15 +24,13 @@ from ...oscar.backends.allocate_strategy import IdleLabel, NoIdleSlot
 from ...storage import StorageLevel, get_storage_backend
 from ...storage.base import ObjectInfo, StorageBackend
 from ...storage.core import StorageFileObject
-from ...utils import calc_data_size, dataslots, extensible
-from ..cluster import ClusterAPI
-from ..meta import MetaAPI
-from .errors import DataNotExist
+from ...utils import dataslots, extensible
+from .errors import DataNotExist, StorageFull
 
 logger = logging.getLogger(__name__)
 
 
-def _build_data_info(storage_info: ObjectInfo, level, size):
+def build_data_info(storage_info: ObjectInfo, level, size):
     # todo handle multiple
     band = 'numa-0' if storage_info.device is None \
         else f'gpu-{storage_info.device}'
@@ -80,7 +77,7 @@ class WrappedStorageFileObject(AioFileObject):
             self._object_id = self._file.object_id
         if 'w' in self._file.mode:
             object_info = await self._storage_handler.object_info(self._object_id)
-            data_info = _build_data_info(object_info, self._level, self._size)
+            data_info = build_data_info(object_info, self._level, self._size)
             await self._data_manager.put_data_info(
                 self._session_id, self._data_key, data_info, object_info)
 
@@ -107,8 +104,8 @@ class StorageQuotaActor(mo.Actor):
 
     def request_quota(self, size: int) -> bool:
         if self._total_size is not None and size > self._total_size:  # pragma: no cover
-            raise RuntimeError(f'Request size {size} is larger '
-                               f'than total size {self._total_size}')
+            raise StorageFull(f'Request size {size} is larger '
+                              f'than total size {self._total_size}')
         if self._total_size is None:
             self._used_size += size
             return True
@@ -150,8 +147,6 @@ class InternalDataInfo:
 
 class DataManagerActor(mo.Actor):
     _data_key_to_info: Dict[tuple, List[InternalDataInfo]]
-    _spill_semaphore: Dict[StorageLevel, asyncio.Semaphore]
-    _spill_events: Dict[StorageLevel, Union[None, asyncio.Event]]
 
     def __init__(self):
         from .spill import FIFOStrategy
@@ -161,16 +156,12 @@ class DataManagerActor(mo.Actor):
         self._data_key_to_info = defaultdict(list)
         self._data_info_list = dict()
         self._spill_strategy = dict()
-        self._spill_semaphore = dict()
-        self._spill_events = dict()
         # data key may be a tuple in some cases,
         # we record main key to manage their lifecycle
         self._main_key_to_sub_keys = defaultdict(set)
         for level in StorageLevel.__members__.values():
             self._data_info_list[level] = dict()
             self._spill_strategy[level] = FIFOStrategy(level)
-            self._spill_semaphore[level] = asyncio.Semaphore()
-            self._spill_events[level] = None
 
     def _get_data_infos(self,
                         session_id: str,
@@ -235,17 +226,6 @@ class DataManagerActor(mo.Actor):
                 (session_id, data_key), data_info.store_size)
         if isinstance(data_key, tuple):
             self._main_key_to_sub_keys[(session_id, data_key[0])].update([data_key])
-        level = data_info.level
-        # when put finishes, check if spillable size is enough for spilling task
-        if self._spill_events[level] is not None:
-            event = self._spill_events[level]
-            delta_size = 0
-            if object_info.size is not None and data_info.memory_size != object_info.size:
-                delta_size = object_info.size - data_info.memory_size
-            request_size = event.request_size + delta_size
-            if request_size < self._spill_strategy[level].spillable_size:
-                event.request_size = request_size
-                event.set()
 
     @extensible
     def put_data_info(self,
@@ -300,389 +280,35 @@ class DataManagerActor(mo.Actor):
         try:
             level = self.get_data_info(session_id, data_key).level
             self._spill_strategy[level].unpin_data((session_id, data_key))
+            return level
         except DataNotExist:
             if error == 'raise':
                 raise
             else:
                 return
 
-    async def get_spill_keys(self, level: StorageLevel, size: int, object_size: int):
-        from .spill import NoDataToSpill
+    def get_spillable_size(self, level: StorageLevel):
+        return self._spill_strategy[level].spillable_size
 
-        yield self._spill_semaphore[level].acquire()
-        try:
-            if level.spill_level() not in self._spill_strategy:  # pragma: no cover
-                raise RuntimeError(f'Spill level of {level} is not configured')
-            try:
-                raise mo.Return(self._spill_strategy[level].get_spill_keys(size))
-            except NoDataToSpill:
-                # when NoDataToSpill happens, there are two situations,
-                # one is that space is allocated while objects are not put into storage,
-                # another is some objects are pinned that can not be spilled,
-                # so we create an asyncio event, when quota changes, we will
-                # check spillable size, if size is enough for spilling, call event.set()
-                # to wake up spilling task.
-                logger.warning('No data to spill %s bytes, waiting event', size)
-                self._spill_events[level] = event = asyncio.Event()
-                event.request_size = size
-                event.object_size = object_size
-                yield event.wait()
-                logger.warning('Event is set, continue to spill %s bytes', event.request_size)
-                spill_keys = self._spill_strategy[level].get_spill_keys(event.request_size)
-                self._spill_events[level] = None
-                raise mo.Return(spill_keys)
-        finally:
-            self._spill_semaphore[level].release()
-
-
-class StorageHandlerActor(mo.Actor):
-    _quota_refs: Dict[StorageLevel,  Union["StorageQuotaActor", mo.ActorRef]]
-    _data_manager_ref: Union["DataManagerActor", mo.ActorRef]
-
-    def __init__(self,
-                 storage_init_params: Dict,
-                 data_manager_ref: Union["DataManagerActor", mo.ActorRef],
-                 quota_refs: Dict[StorageLevel,
-                                  Union["StorageQuotaActor", mo.ActorRef]]):
-        self._storage_init_params = storage_init_params
-        self._data_manager_ref = data_manager_ref
-        self._quota_refs = quota_refs
-        self._supervisor_address = None
-
-    async def __post_create__(self):
-        self._clients = clients = dict()
-        for backend, init_params in self._storage_init_params.items():
-            logger.debug('Start storage %s with params %s', backend, init_params)
-            storage_cls = get_storage_backend(backend)
-            client = storage_cls(**init_params)
-            for level in StorageLevel.__members__.values():
-                if client.level & level:
-                    clients[level] = client
-
-    async def _get_data(self, data_info, conditions):
-        if conditions is None:
-            res = yield self._clients[data_info.level].get(
-                data_info.object_id)
-        else:
-            try:
-                res = yield self._clients[data_info.level].get(
-                    data_info.object_id, conditions=conditions)
-            except NotImplementedError:
-                data = yield await self._clients[data_info.level].get(
-                    data_info.object_id)
-                try:
-                    sliced_value = data.iloc[tuple(conditions)]
-                except AttributeError:
-                    sliced_value = data[tuple(conditions)]
-                res = sliced_value
-        raise mo.Return(res)
-
-    @extensible
-    async def get(self,
-                  session_id: str,
-                  data_key: str,
-                  conditions: List = None,
-                  error: str = 'raise'):
-        try:
-            data_info = await self._data_manager_ref.get_data_info(
-                session_id, data_key)
-            data = yield self._get_data(data_info, conditions)
-            raise mo.Return(data)
-        except DataNotExist:
-            if error == 'raise':
-                raise
-
-    def _get_data_info(self,
-                       session_id: str,
-                       data_key: str,
-                       conditions: List = None,
-                       error: str = 'raise'):
-        info = self._data_manager_ref.get_data_info.delay(
-            session_id, data_key, error)
-        return info, conditions
-
-    @get.batch
-    async def batch_get(self, args_list, kwargs_list):
-        infos = []
-        conditions_list = []
-        for args, kwargs in zip(args_list, kwargs_list):
-            info, conditions = self._get_data_info(*args, **kwargs)
-            infos.append(info)
-            conditions_list.append(conditions)
-        data_infos = await self._data_manager_ref.get_data_info.batch(*infos)
-        results = []
-        for data_info, conditions in zip(data_infos, conditions_list):
-            if data_info is None:
-                results.append(None)
-            else:
-                result = yield self._get_data(data_info, conditions)
-                results.append(result)
-        raise mo.Return(results)
-
-    @extensible
-    async def put(self,
-                  session_id: str,
-                  data_key: str,
-                  obj: object,
-                  level: StorageLevel) -> DataInfo:
-        size = calc_data_size(obj)
-        await self._request_quota_with_spill(level, size)
-        object_info = await self._clients[level].put(obj)
-        data_info = _build_data_info(object_info, level, size)
-        await self._data_manager_ref.put_data_info(
-            session_id, data_key, data_info, object_info)
-        if object_info.size is not None and data_info.memory_size != object_info.size:
-            await self._quota_refs[level].update_quota(
-                object_info.size - data_info.memory_size)
-        return data_info
-
-    @classmethod
-    def _get_put_arg(cls,
-                     session_id: str,
-                     data_key: str,
-                     obj: object,
-                     level: StorageLevel):
-        return session_id, data_key, obj, level, calc_data_size(obj)
-
-    @put.batch
-    async def batch_put(self, args_list, kwargs_list):
-        objs = []
-        data_keys = []
-        session_id = None
-        level = last_level = None
-        sizes = []
-        for args, kwargs in zip(args_list, kwargs_list):
-            session_id, data_key, obj, level, size = \
-                self._get_put_arg(*args, **kwargs)
-            if last_level is not None:
-                assert last_level == level
-            last_level = level
-            objs.append(obj)
-            data_keys.append(data_key)
-            sizes.append(size)
-
-        await self._request_quota_with_spill(level, sum(sizes))
-
-        data_infos = []
-        put_infos = []
-        for size, data_key, obj in zip(sizes, data_keys, objs):
-            object_info = await self._clients[level].put(obj)
-            data_info = _build_data_info(object_info, level, size)
-            data_infos.append(data_info)
-            if object_info.size is not None and \
-                    data_info.memory_size != object_info.size:
-                # we request memory size before putting, when put finishes,
-                # update quota to the true store size
-                await self._quota_refs[level].update_quota(
-                    object_info.size - data_info.memory_size)
-            put_infos.append(
-                self._data_manager_ref.put_data_info.delay(
-                    session_id, data_key, data_info, object_info))
-            logger.debug('Finish putting data key %s, size is %s, '
-                         'object_id is %s', data_key, size, data_info.object_id)
-        await self._data_manager_ref.put_data_info.batch(*put_infos)
-        return data_infos
-
-    def _get_data_infos_arg(self,
-                            session_id: str,
-                            data_key: str,
-                            error: str = 'raise'):
-        infos = self._data_manager_ref.get_data_infos.delay(
-            session_id, data_key, error)
-        return infos, session_id, data_key
-
-    async def delete_object(self,
-                            session_id: str,
-                            data_key: Any,
-                            data_size: Union[int, float],
-                            object_id: Any,
-                            level: StorageLevel):
-        await self._data_manager_ref.delete_data_info(
-            session_id, data_key, level)
-        await self._clients[level].delete(object_id)
-        await self._quota_refs[level].release_quota(data_size)
-
-    @extensible
-    async def delete(self,
-                     session_id: str,
-                     data_key: str,
-                     error: str = 'raise'):
-        if error not in ('raise', 'ignore'):  # pragma: no cover
-            raise ValueError('error must be raise or ignore')
-
-        infos = await self._data_manager_ref.get_data_infos(
-            session_id, data_key, error)
-        if not infos:
-            return
-
-        for info in infos:
-            level = info.level
-            await self._data_manager_ref.delete_data_info(
-                session_id, data_key, level)
-            yield self._clients[level].delete(info.object_id)
-            await self._quota_refs[level].release_quota(info.store_size)
-
-    @delete.batch
-    async def batch_delete(self, args_list, kwargs_list):
-        get_infos = []
-        session_id = None
-        data_keys = []
-        for args, kwargs in zip(args_list, kwargs_list):
-            infos, session_id, data_key = self._get_data_infos_arg(*args, **kwargs)
-            get_infos.append(infos)
-            data_keys.append(data_key)
-        infos_list = await self._data_manager_ref.get_data_infos.batch(*get_infos)
-
-        delete_infos = []
-        to_removes = []
-        level_sizes = defaultdict(lambda: 0)
-        for infos, data_key in zip(infos_list, data_keys):
-            if not infos:
-                # data not exist and error == 'ignore'
-                continue
-            for info in infos:
-                level = info.level
-                delete_infos.append(
-                    self._data_manager_ref.delete_data_info.delay(
-                        session_id, data_key, level))
-                to_removes.append((level, info.object_id))
-                level_sizes[level] += info.store_size
-
-        if not delete_infos:
-            # no data to remove
-            return
-
-        await self._data_manager_ref.delete_data_info.batch(*delete_infos)
-        logger.debug('Begin to delete batch data %s', to_removes)
-        for level, object_id in to_removes:
-            yield self._clients[level].delete(object_id)
-        logger.debug('Finish deleting batch data %s', to_removes)
-        for level, size in level_sizes.items():
-            await self._quota_refs[level].release_quota(size)
-
-    async def open_reader(self,
-                          session_id: str,
-                          data_key: str) -> StorageFileObject:
-        data_info = await self._data_manager_ref.get_data_info(
-            session_id, data_key)
-        reader = await self._clients[data_info.level].open_reader(
-            data_info.object_id)
-        return reader
-
-    async def open_writer(self,
-                          session_id: str,
-                          data_key: str,
-                          size: int,
-                          level: StorageLevel) -> WrappedStorageFileObject:
-        await self._request_quota_with_spill(level, size)
-        writer = await self._clients[level].open_writer(size)
-        return WrappedStorageFileObject(writer, level, size, session_id, data_key,
-                                        self._data_manager_ref, self._clients[level])
-
-    async def _get_meta_api(self, session_id: str):
-        if self._supervisor_address is None:
-            cluster_api = await ClusterAPI.create(self.address)
-            self._supervisor_address = (await cluster_api.get_supervisors())[0]
-        return await MetaAPI.create(session_id=session_id,
-                                    address=self._supervisor_address)
-
-    async def _fetch_remote(self,
-                            session_id: str,
-                            data_key: Union[str, tuple],
-                            level: StorageLevel,
-                            remote_address: str):
-        remote_manager_ref = await mo.actor_ref(uid=DataManagerActor.default_uid(),
-                                                address=remote_address)
-        data_info = await remote_manager_ref.get_data_info(session_id, data_key)
-        await self._data_manager_ref.put_data_info(
-            session_id, data_key, data_info, None)
-        try:
-            await self._clients[level].fetch(data_info.object_id)
-        except asyncio.CancelledError:  # pragma: no cover
-            await self._data_manager_ref.delete_data_info(
-                session_id, data_key, data_info.level)
-            raise
-
-    async def _fetch_via_transfer(self,
-                                  session_id: str,
-                                  data_key: Union[str, tuple],
-                                  level: StorageLevel,
-                                  remote_address: str):
-        from .transfer import SenderManagerActor
-
-        sender_ref = await mo.actor_ref(
-            address=remote_address, uid=SenderManagerActor.default_uid())
-        await sender_ref.send_data(
-            session_id, data_key, self._data_manager_ref.address, level)
-
-    async def fetch(self,
-                    session_id: str,
-                    data_key: str,
-                    level: StorageLevel,
-                    address: str,
-                    band_name: str,
-                    error: str):
-
-        if error not in ('raise', 'ignore'):  # pragma: no cover
-            raise ValueError('error must be raise or ignore')
-
-        try:
-            await self._data_manager_ref.get_data_info(session_id, data_key)
-            await self._data_manager_ref.pin(session_id, data_key)
-        except DataNotExist:
-            # Not exists in local, fetch from remote worker
-            try:
-                meta_api = await self._get_meta_api(session_id)
-                if address is None:
-                    # we get meta using main key when fetch shuffle data
-                    main_key = data_key[0] if isinstance(data_key, tuple) else data_key
-                    address = (await meta_api.get_chunk_meta(
-                        main_key, fields=['bands']))['bands'][0][0]
-                logger.debug('Begin to fetch data %s from %s', data_key, address)
-                if StorageLevel.REMOTE in self._quota_refs:
-                    yield self._fetch_remote(session_id, data_key, level, address)
-                else:
-                    await self._fetch_via_transfer(session_id, data_key, level, address)
-                logger.debug('finish fetching data %s from %s', data_key, address)
-                if not isinstance(data_key, tuple):
-                    # no need to update meta for shuffle data
-                    await meta_api.add_chunk_bands(
-                        data_key, [(address, band_name or 'numa-0')])
-            except DataNotExist:
-                if error == 'raise':  # pragma: no cover
-                    raise
-
-    async def _request_quota_with_spill(self,
-                                        level: StorageLevel,
-                                        size: int):
-        if await self._quota_refs[level].request_quota(size):
-            return
-        else:
-            total, used = await self._quota_refs[level].get_quota()
-            await self.spill(level, int(size + used - total), size)
-            await self._quota_refs[level].request_quota(size)
-            logger.debug('Spill is triggered, request %s bytes of %s finished', size, level)
-
-    async def spill(self, level: StorageLevel, size: int, object_size: int):
-        from .spill import spill
-
-        await spill(size, object_size, level, self._data_manager_ref, self)
-
-    async def list(self, level: StorageLevel) -> List:
-        return await self._data_manager_ref.list(level)
-
-    async def unpin(self, session_id, data_key, error):
-        await self._data_manager_ref.unpin(session_id, data_key, error)
+    async def get_spill_keys(self, level: StorageLevel, size: int):
+        if level.spill_level() not in self._spill_strategy:  # pragma: no cover
+            raise RuntimeError(f'Spill level of {level} is not configured')
+        return self._spill_strategy[level].get_spill_keys(size)
 
 
 class StorageManagerActor(mo.Actor):
+    """
+    Storage manager actor, created only on main process, mainly to setup storage backends
+    and create all the necessary actors for storage service.
+    """
     _data_manager: Union[mo.ActorRef, DataManagerActor]
-    _storage_handler: Union[mo.ActorRef, StorageHandlerActor]
 
     def __init__(self,
                  storage_configs: Dict,
                  transfer_block_size: int = None,
                  **kwargs):
+        from .handler import StorageHandlerActor
+
         self._handler_cls = kwargs.pop('storage_handler_cls', StorageHandlerActor)
         self._storage_configs = storage_configs
         # params to init and teardown
@@ -695,6 +321,8 @@ class StorageManagerActor(mo.Actor):
         self._transfer_block_size = transfer_block_size
 
     async def __post_create__(self):
+        from .handler import StorageHandlerActor
+        from .spill import SpillManagerActor
         from .transfer import SenderManagerActor, ReceiverManagerActor
 
         # stores the mapping from data key to storage info
@@ -705,6 +333,7 @@ class StorageManagerActor(mo.Actor):
 
         # setup storage backend
         quotas = dict()
+        spill_managers = dict()
         for backend, setup_params in self._storage_configs.items():
             client = await self._setup_storage(backend, setup_params)
             for level in StorageLevel.__members__.values():
@@ -717,7 +346,10 @@ class StorageManagerActor(mo.Actor):
                         uid=StorageQuotaActor.gen_uid(level),
                         address=self.address,
                     )
-        self._quotas: Dict[StorageLevel, Union[mo.ActorRef, StorageQuotaActor]] = quotas
+                    spill_managers[level] = await mo.create_actor(
+                        SpillManagerActor, level,
+                        uid=SpillManagerActor.gen_uid(level),
+                        address=self.address)
 
         # create handler actors for every process
         strategy = IdleLabel(None, 'StorageHandler')
@@ -726,6 +358,7 @@ class StorageManagerActor(mo.Actor):
                 await mo.create_actor(self._handler_cls,
                                       self._init_params,
                                       self._data_manager,
+                                      spill_managers,
                                       quotas,
                                       uid=StorageHandlerActor.default_uid(),
                                       address=self.address,
@@ -749,9 +382,6 @@ class StorageManagerActor(mo.Actor):
                                       allocate_strategy=receiver_strategy)
             except NoIdleSlot:
                 break
-
-        self._storage_handler = await mo.actor_ref(address=self.address,
-                                                   uid=StorageHandlerActor.default_uid())
 
     async def __pre_destroy__(self):
         for backend, teardown_params in self._teardown_params.items():

--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -288,7 +288,7 @@ class DataManagerActor(mo.Actor):
                 return
 
     def get_spillable_size(self, level: StorageLevel):
-        return self._spill_strategy[level].spillable_size
+        return self._spill_strategy[level].get_spillable_size()
 
     async def get_spill_keys(self, level: StorageLevel, size: int):
         if level.spill_level() not in self._spill_strategy:  # pragma: no cover

--- a/mars/services/storage/errors.py
+++ b/mars/services/storage/errors.py
@@ -20,3 +20,7 @@ DataNotExist = DataNotExist
 
 class NoDataToSpill(Exception):
     pass
+
+
+class StorageFull(Exception):
+    pass

--- a/mars/services/storage/handler.py
+++ b/mars/services/storage/handler.py
@@ -1,0 +1,393 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+from collections import defaultdict
+from typing import Any, Dict, List, Union
+
+from ... import oscar as mo
+from ...storage import StorageLevel, get_storage_backend
+from ...storage.core import StorageFileObject
+from ...utils import calc_data_size, extensible
+from ..cluster import ClusterAPI
+from ..meta import MetaAPI
+from .core import StorageQuotaActor, DataManagerActor, DataInfo, \
+    build_data_info, WrappedStorageFileObject
+from .errors import DataNotExist, NoDataToSpill
+
+logger = logging.getLogger(__name__)
+
+
+class StorageHandlerActor(mo.Actor):
+    """
+    Storage handler actor, provide methods like `get`, `put`, etc.
+    This actor is stateless and created on worker's subpools.
+    """
+    def __init__(self,
+                 storage_init_params: Dict,
+                 data_manager_ref: Union[DataManagerActor, mo.ActorRef],
+                 spill_manager_refs,
+                 quota_refs: Dict[StorageLevel,
+                                  Union[StorageQuotaActor, mo.ActorRef]]):
+        from .spill import SpillManagerActor
+
+        self._storage_init_params = storage_init_params
+        self._data_manager_ref = data_manager_ref
+        self._spill_manager_refs: \
+            Dict[StorageLevel, Union[SpillManagerActor, mo.ActorRef]] = spill_manager_refs
+        self._quota_refs = quota_refs
+        self._supervisor_address = None
+
+    async def __post_create__(self):
+        self._clients = clients = dict()
+        for backend, init_params in self._storage_init_params.items():
+            logger.debug('Start storage %s with params %s', backend, init_params)
+            storage_cls = get_storage_backend(backend)
+            client = storage_cls(**init_params)
+            for level in StorageLevel.__members__.values():
+                if client.level & level:
+                    clients[level] = client
+
+    async def _get_data(self, data_info, conditions):
+        if conditions is None:
+            res = yield self._clients[data_info.level].get(
+                data_info.object_id)
+        else:
+            try:
+                res = yield self._clients[data_info.level].get(
+                    data_info.object_id, conditions=conditions)
+            except NotImplementedError:
+                data = yield await self._clients[data_info.level].get(
+                    data_info.object_id)
+                try:
+                    sliced_value = data.iloc[tuple(conditions)]
+                except AttributeError:
+                    sliced_value = data[tuple(conditions)]
+                res = sliced_value
+        raise mo.Return(res)
+
+    @extensible
+    async def get(self,
+                  session_id: str,
+                  data_key: str,
+                  conditions: List = None,
+                  error: str = 'raise'):
+        try:
+            data_info = await self._data_manager_ref.get_data_info(
+                session_id, data_key)
+            data = yield self._get_data(data_info, conditions)
+            raise mo.Return(data)
+        except DataNotExist:
+            if error == 'raise':
+                raise
+
+    def _get_data_info(self,
+                       session_id: str,
+                       data_key: str,
+                       conditions: List = None,
+                       error: str = 'raise'):
+        info = self._data_manager_ref.get_data_info.delay(
+            session_id, data_key, error)
+        return info, conditions
+
+    @get.batch
+    async def batch_get(self, args_list, kwargs_list):
+        infos = []
+        conditions_list = []
+        for args, kwargs in zip(args_list, kwargs_list):
+            info, conditions = self._get_data_info(*args, **kwargs)
+            infos.append(info)
+            conditions_list.append(conditions)
+        data_infos = await self._data_manager_ref.get_data_info.batch(*infos)
+        results = []
+        for data_info, conditions in zip(data_infos, conditions_list):
+            if data_info is None:
+                results.append(None)
+            else:
+                result = yield self._get_data(data_info, conditions)
+                results.append(result)
+        raise mo.Return(results)
+
+    @extensible
+    async def put(self,
+                  session_id: str,
+                  data_key: str,
+                  obj: object,
+                  level: StorageLevel) -> DataInfo:
+        size = calc_data_size(obj)
+        await self._request_quota_with_spill(level, size)
+        object_info = await self._clients[level].put(obj)
+        data_info = build_data_info(object_info, level, size)
+        await self._data_manager_ref.put_data_info(
+            session_id, data_key, data_info, object_info)
+        if object_info.size is not None and data_info.memory_size != object_info.size:
+            await self._quota_refs[level].update_quota(
+                object_info.size - data_info.memory_size)
+        await self.notify_spill_event(level)
+        return data_info
+
+    @classmethod
+    def _get_put_arg(cls,
+                     session_id: str,
+                     data_key: str,
+                     obj: object,
+                     level: StorageLevel):
+        return session_id, data_key, obj, level, calc_data_size(obj)
+
+    @put.batch
+    async def batch_put(self, args_list, kwargs_list):
+        objs = []
+        data_keys = []
+        session_id = None
+        level = last_level = None
+        sizes = []
+        for args, kwargs in zip(args_list, kwargs_list):
+            session_id, data_key, obj, level, size = \
+                self._get_put_arg(*args, **kwargs)
+            if last_level is not None:
+                assert last_level == level
+            last_level = level
+            objs.append(obj)
+            data_keys.append(data_key)
+            sizes.append(size)
+
+        await self._request_quota_with_spill(level, sum(sizes))
+
+        data_infos = []
+        put_infos = []
+        quota_delta = 0
+        for size, data_key, obj in zip(sizes, data_keys, objs):
+            object_info = await self._clients[level].put(obj)
+            data_info = build_data_info(object_info, level, size)
+            data_infos.append(data_info)
+            if object_info.size is not None and \
+                    data_info.memory_size != object_info.size:
+                # we request memory size before putting, when put finishes,
+                # update quota to the true store size
+                quota_delta += object_info.size - data_info.memory_size
+            put_infos.append(
+                self._data_manager_ref.put_data_info.delay(
+                    session_id, data_key, data_info, object_info))
+            logger.debug('Finish putting data key %s, size is %s, '
+                         'object_id is %s', data_key, size, data_info.object_id)
+        await self._quota_refs[level].update_quota(quota_delta)
+        await self._data_manager_ref.put_data_info.batch(*put_infos)
+        await self.notify_spill_event(level)
+        return data_infos
+
+    def _get_data_infos_arg(self,
+                            session_id: str,
+                            data_key: str,
+                            error: str = 'raise'):
+        infos = self._data_manager_ref.get_data_infos.delay(
+            session_id, data_key, error)
+        return infos, session_id, data_key
+
+    async def delete_object(self,
+                            session_id: str,
+                            data_key: Any,
+                            data_size: Union[int, float],
+                            object_id: Any,
+                            level: StorageLevel):
+        await self._data_manager_ref.delete_data_info(
+            session_id, data_key, level)
+        await self._clients[level].delete(object_id)
+        await self._quota_refs[level].release_quota(data_size)
+
+    @extensible
+    async def delete(self,
+                     session_id: str,
+                     data_key: str,
+                     error: str = 'raise'):
+        if error not in ('raise', 'ignore'):  # pragma: no cover
+            raise ValueError('error must be raise or ignore')
+
+        infos = await self._data_manager_ref.get_data_infos(
+            session_id, data_key, error)
+        if not infos:
+            return
+
+        for info in infos:
+            level = info.level
+            await self._data_manager_ref.delete_data_info(
+                session_id, data_key, level)
+            yield self._clients[level].delete(info.object_id)
+            await self._quota_refs[level].release_quota(info.store_size)
+
+    @delete.batch
+    async def batch_delete(self, args_list, kwargs_list):
+        get_infos = []
+        session_id = None
+        data_keys = []
+        for args, kwargs in zip(args_list, kwargs_list):
+            infos, session_id, data_key = self._get_data_infos_arg(*args, **kwargs)
+            get_infos.append(infos)
+            data_keys.append(data_key)
+        infos_list = await self._data_manager_ref.get_data_infos.batch(*get_infos)
+
+        delete_infos = []
+        to_removes = []
+        level_sizes = defaultdict(lambda: 0)
+        for infos, data_key in zip(infos_list, data_keys):
+            if not infos:
+                # data not exist and error == 'ignore'
+                continue
+            for info in infos:
+                level = info.level
+                delete_infos.append(
+                    self._data_manager_ref.delete_data_info.delay(
+                        session_id, data_key, level))
+                to_removes.append((level, info.object_id))
+                level_sizes[level] += info.store_size
+
+        if not delete_infos:
+            # no data to remove
+            return
+
+        await self._data_manager_ref.delete_data_info.batch(*delete_infos)
+        logger.debug('Begin to delete batch data %s', to_removes)
+        for level, object_id in to_removes:
+            yield self._clients[level].delete(object_id)
+        logger.debug('Finish deleting batch data %s', to_removes)
+        for level, size in level_sizes.items():
+            await self._quota_refs[level].release_quota(size)
+
+    async def open_reader(self,
+                          session_id: str,
+                          data_key: str) -> StorageFileObject:
+        data_info = await self._data_manager_ref.get_data_info(
+            session_id, data_key)
+        reader = await self._clients[data_info.level].open_reader(
+            data_info.object_id)
+        return reader
+
+    async def open_writer(self,
+                          session_id: str,
+                          data_key: str,
+                          size: int,
+                          level: StorageLevel) -> WrappedStorageFileObject:
+        await self._request_quota_with_spill(level, size)
+        writer = await self._clients[level].open_writer(size)
+        return WrappedStorageFileObject(writer, level, size, session_id, data_key,
+                                        self._data_manager_ref, self._clients[level])
+
+    async def _get_meta_api(self, session_id: str):
+        if self._supervisor_address is None:
+            cluster_api = await ClusterAPI.create(self.address)
+            self._supervisor_address = (await cluster_api.get_supervisors())[0]
+        return await MetaAPI.create(session_id=session_id,
+                                    address=self._supervisor_address)
+
+    async def _fetch_remote(self,
+                            session_id: str,
+                            data_key: Union[str, tuple],
+                            level: StorageLevel,
+                            remote_address: str):
+        remote_manager_ref = await mo.actor_ref(uid=DataManagerActor.default_uid(),
+                                                address=remote_address)
+        data_info = await remote_manager_ref.get_data_info(session_id, data_key)
+        await self._data_manager_ref.put_data_info(
+            session_id, data_key, data_info, None)
+        try:
+            await self._clients[level].fetch(data_info.object_id)
+        except asyncio.CancelledError:  # pragma: no cover
+            await self._data_manager_ref.delete_data_info(
+                session_id, data_key, data_info.level)
+            raise
+
+    async def _fetch_via_transfer(self,
+                                  session_id: str,
+                                  data_key: Union[str, tuple],
+                                  level: StorageLevel,
+                                  remote_address: str):
+        from .transfer import SenderManagerActor
+
+        sender_ref = await mo.actor_ref(
+            address=remote_address, uid=SenderManagerActor.default_uid())
+        await sender_ref.send_data(
+            session_id, data_key, self._data_manager_ref.address, level)
+
+    async def fetch(self,
+                    session_id: str,
+                    data_key: str,
+                    level: StorageLevel,
+                    address: str,
+                    band_name: str,
+                    error: str):
+
+        if error not in ('raise', 'ignore'):  # pragma: no cover
+            raise ValueError('error must be raise or ignore')
+
+        try:
+            await self._data_manager_ref.get_data_info(session_id, data_key)
+            await self._data_manager_ref.pin(session_id, data_key)
+        except DataNotExist:
+            # Not exists in local, fetch from remote worker
+            try:
+                meta_api = await self._get_meta_api(session_id)
+                if address is None:
+                    # we get meta using main key when fetch shuffle data
+                    main_key = data_key[0] if isinstance(data_key, tuple) else data_key
+                    address = (await meta_api.get_chunk_meta(
+                        main_key, fields=['bands']))['bands'][0][0]
+                logger.debug('Begin to fetch data %s from %s', data_key, address)
+                if StorageLevel.REMOTE in self._quota_refs:
+                    yield self._fetch_remote(session_id, data_key, level, address)
+                else:
+                    await self._fetch_via_transfer(session_id, data_key, level, address)
+                logger.debug('finish fetching data %s from %s', data_key, address)
+                if not isinstance(data_key, tuple):
+                    # no need to update meta for shuffle data
+                    await meta_api.add_chunk_bands(
+                        data_key, [(address, band_name or 'numa-0')])
+            except DataNotExist:
+                if error == 'raise':  # pragma: no cover
+                    raise
+
+    async def _request_quota_with_spill(self,
+                                        level: StorageLevel,
+                                        size: int):
+        if await self._quota_refs[level].request_quota(size):
+            return
+        else:
+            await self._quota_refs[level].get_quota()
+            await self.spill(level, size)
+            await self._quota_refs[level].request_quota(size)
+            logger.debug('Spill is triggered, request %s bytes of %s finished', size, level)
+
+    async def notify_spill_event(self, level):
+        total, used = await self._quota_refs[level].get_quota()
+        if total is not None:
+            spillable_size = await self._data_manager_ref.get_spillable_size(level)
+            await self._spill_manager_refs[level].notify_spill_event(
+                spillable_size, total - used)
+            print('notify_spill_event')
+
+    async def spill(self, level: StorageLevel, size: int):
+        from .spill import spill
+
+        try:
+            await spill(size, level, self._data_manager_ref, self)
+        except NoDataToSpill:
+            await self._spill_manager_refs[level].create_spill_event(size)
+            size = await self._spill_manager_refs[level].wait_spill_event()
+            await spill(size, level, self._data_manager_ref, self)
+
+    async def list(self, level: StorageLevel) -> List:
+        return await self._data_manager_ref.list(level)
+
+    async def unpin(self, session_id, data_key, error):
+        level = await self._data_manager_ref.unpin(session_id, data_key, error)
+        await self.notify_spill_event(level)

--- a/mars/services/storage/spill.py
+++ b/mars/services/storage/spill.py
@@ -72,6 +72,15 @@ class FIFOStrategy(SpillStrategy):
         if self._pinned_keys[key] <= 0:
             del self._pinned_keys[key]
 
+    @property
+    def spillable_size(self):
+        total_size = 0
+        for data_key, data_size in self._data_sizes.items():
+            if data_key not in self._pinned_keys and \
+                    data_key not in self._spilling_keys:
+                total_size += data_size
+        return total_size
+
     def get_spill_keys(self, size: int) -> Tuple[List, List]:
         spill_sizes = []
         spill_keys = []

--- a/mars/services/storage/tests/test_spill.py
+++ b/mars/services/storage/tests/test_spill.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import asyncio
 import os
 import sys

--- a/mars/services/storage/tests/test_spill.py
+++ b/mars/services/storage/tests/test_spill.py
@@ -73,13 +73,13 @@ async def create_actors(actor_pool):
         address=actor_pool.external_address)
 
     sub_processes = list(actor_pool.sub_processes)
-    yield actor_pool.external_address, *sub_processes
+    yield actor_pool.external_address, sub_processes[0], sub_processes[1]
     await mo.destroy_actor(manager_ref)
 
 
 @pytest.mark.asyncio
 async def test_spill(create_actors):
-    worker_address, *_ = create_actors
+    worker_address, _, _ = create_actors
     storage_handler = await mo.actor_ref(uid=StorageHandlerActor.default_uid(),
                                          address=worker_address)
 
@@ -109,8 +109,8 @@ async def test_spill(create_actors):
 
     memory_object_list = await storage_handler.list(StorageLevel.MEMORY)
     disk_object_list = await storage_handler.list(StorageLevel.DISK)
-    assert len(memory_object_list) == 2
-    assert len(disk_object_list) == 8
+    assert len(memory_object_list) == 3
+    assert len(disk_object_list) == 7
 
     for key, data in zip(key_list, data_list):
         get_data = await storage_handler.get(session_id, key)

--- a/mars/services/storage/tests/test_spill.py
+++ b/mars/services/storage/tests/test_spill.py
@@ -115,8 +115,8 @@ async def test_spill(create_actors):
 
     memory_object_list = await storage_handler.list(StorageLevel.MEMORY)
     disk_object_list = await storage_handler.list(StorageLevel.DISK)
-    assert len(memory_object_list) == 2
-    assert len(disk_object_list) == 8
+    assert len(memory_object_list) == 3
+    assert len(disk_object_list) == 7
 
     for key, data in zip(key_list, data_list):
         get_data = await storage_handler.get(session_id, key)

--- a/mars/services/storage/tests/test_spill.py
+++ b/mars/services/storage/tests/test_spill.py
@@ -143,7 +143,7 @@ class DelayPutStorageHandler(StorageHandlerActor):
         if object_info.size is not None and data_info.memory_size != object_info.size:
             await self._quota_refs[level].update_quota(
                 object_info.size - data_info.memory_size)
-        await self.notify_spill_event(level)
+        await self.notify_spillable_space(level)
         return data_info
 
 

--- a/mars/services/storage/tests/test_transfer.py
+++ b/mars/services/storage/tests/test_transfer.py
@@ -24,8 +24,8 @@ import pytest
 import mars.oscar as mo
 from mars.oscar.backends.allocate_strategy import IdleLabel
 from mars.services.storage.errors import DataNotExist
-from mars.services.storage.core import StorageManagerActor, StorageHandlerActor, \
-    StorageQuotaActor
+from mars.services.storage.core import StorageManagerActor, StorageQuotaActor
+from mars.services.storage.handler import StorageHandlerActor
 from mars.services.storage.transfer import ReceiverManagerActor, SenderManagerActor
 from mars.storage import StorageLevel
 

--- a/mars/services/storage/transfer.py
+++ b/mars/services/storage/transfer.py
@@ -21,7 +21,8 @@ from ...serialization.serializables import Serializable, BoolField,\
     StringField, ReferenceField, AnyField
 from ...storage import StorageLevel
 from ...utils import extensible
-from .core import StorageHandlerActor, DataManagerActor
+from .core import DataManagerActor
+from .handler import StorageHandlerActor
 
 DEFAULT_TRANSFER_BLOCK_SIZE = 5 * 1024 ** 2
 

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -342,6 +342,7 @@ class SubtaskProcessor:
     async def run(self):
         self.result.status = SubtaskStatus.running
         input_keys = None
+        unpinned = False
         try:
             chunk_graph = optimize(self._chunk_graph, self._engines)
             self._gen_chunk_key_to_data_keys()
@@ -355,6 +356,7 @@ class SubtaskProcessor:
                 await self._execute_graph(chunk_graph)
             finally:
                 # unpin inputs data
+                unpinned = True
                 await self._unpin_data(input_keys)
             # store results data
             stored_keys, store_sizes, memory_sizes = await self._store_data(chunk_graph)
@@ -371,7 +373,7 @@ class SubtaskProcessor:
             await self.done()
             raise
         finally:
-            if input_keys is not None:
+            if input_keys is not None and not unpinned:
                 await self._unpin_data(input_keys)
 
         await self.done()

--- a/mars/storage/core.py
+++ b/mars/storage/core.py
@@ -16,7 +16,7 @@
 
 import asyncio
 from abc import ABC, abstractmethod
-from concurrent.futures import Executor
+from concurrent.futures import Executor, ThreadPoolExecutor
 from typing import Any, Optional, Union
 
 from ..lib.aio import AioFileObject
@@ -29,6 +29,8 @@ class StorageFileObject(AioFileObject):
                  loop: asyncio.BaseEventLoop = None,
                  executor: Executor = None):
         self._object_id = object_id
+        if executor is None:
+            executor = ThreadPoolExecutor()
         super().__init__(file, loop=loop, executor=executor)
 
     @property


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

We catch `NoDataToSpill` and create an asyncio event, when put or unpin finishes, we will check spillable size, if size is enough for spilling, call event.set() to wake up spilling task.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
