### PR TITLE
Add support for stateless actors

### DIFF
--- a/mars/oscar/__init__.py
+++ b/mars/oscar/__init__.py
@@ -18,7 +18,8 @@ del aio
 
 from . import debug
 from .api import actor_ref, create_actor, has_actor, destroy_actor, \
-    kill_actor, Actor, create_actor_pool, setup_cluster
+    kill_actor, Actor, StatelessActor, create_actor_pool, setup_cluster, \
+    wait_actor_pool_recovered
 from .backends import allocate_strategy
 from .backends.pool import MainActorPoolType
 from .core import ActorRef

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -163,3 +163,27 @@ class MarsActorContext(BaseActorContext):
             protocol=DEFAULT_PROTOCOL)
         result = await self._call(address, message)
         return self._process_result_message(result)
+
+    async def wait_actor_pool_recovered(self, address: str,
+                                        main_address: str = None):
+        # get main_pool_address
+        control_message = ControlMessage(
+            new_message_id(), main_address,
+            ControlMessageType.get_config,
+            'main_pool_address',
+            protocol=DEFAULT_PROTOCOL)
+        main_address = self._process_result_message(
+            await self._call(main_address, control_message))
+
+        # if address is main pool, it is never recovered
+        if address == main_address:
+            return
+
+        control_message = ControlMessage(
+            new_message_id(), address,
+            ControlMessageType.wait_pool_recovered,
+            None,
+            protocol=DEFAULT_PROTOCOL
+        )
+        self._process_result_message(
+            await self._call(main_address, control_message))

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -139,14 +139,14 @@ class CreateDestroyActor(mo.Actor):
         return message
 
 
-class ResourceLockActor(mo.Actor):
+class ResourceLockActor(mo.StatelessActor):
     def __init__(self, count=1):
         self._sem = asyncio.Semaphore(count)
         self._requests = deque()
 
     async def apply(self, val=None):
-        yield self._sem.acquire()
-        raise mo.Return(val + 1 if val is not None else None)
+        await self._sem.acquire()
+        return val + 1 if val is not None else None
 
     def release(self):
         self._sem.release()

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -25,6 +25,7 @@ import pytest
 import mars.oscar as mo
 from mars.oscar.backends.allocate_strategy import RandomSubPool
 from mars.oscar.debug import set_debug_options, DebugOptions
+from mars.tests.core import flaky
 from mars.utils import extensible
 
 logger = logging.getLogger(__name__)
@@ -242,6 +243,7 @@ async def actor_pool_context(request):
         set_debug_options(None)
 
 
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_simple_local_actor_pool(actor_pool_context):
     pool = actor_pool_context
@@ -260,6 +262,7 @@ async def test_simple_local_actor_pool(actor_pool_context):
     assert await ref.add(2) == 104
 
 
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_mars_post_create_pre_destroy(actor_pool_context):
     pool = actor_pool_context
@@ -274,6 +277,7 @@ async def test_mars_post_create_pre_destroy(actor_pool_context):
     assert records[1].startswith('destroy')
 
 
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_mars_create_actor(actor_pool_context):
     pool = actor_pool_context
@@ -288,6 +292,7 @@ async def test_mars_create_actor(actor_pool_context):
     assert r == 6
 
 
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_mars_create_actor_error(actor_pool_context):
     pool = actor_pool_context
@@ -303,6 +308,7 @@ async def test_mars_create_actor_error(actor_pool_context):
         await ref1.create(DummyActor, -2, address=pool.external_address)
 
 
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_mars_send(actor_pool_context):
     pool = actor_pool_context
@@ -316,6 +322,7 @@ async def test_mars_send(actor_pool_context):
     assert await ref4.send(ref3, 'add', 3) == 4
 
 
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_mars_send_error(actor_pool_context):
     pool = actor_pool_context
@@ -329,6 +336,7 @@ async def test_mars_send_error(actor_pool_context):
         await (await mo.actor_ref('fake_uid', address=pool.external_address)).add(1)
 
 
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_mars_tell(actor_pool_context):
     pool = actor_pool_context
@@ -349,6 +357,7 @@ async def test_mars_tell(actor_pool_context):
         await ref1.tell(await mo.actor_ref(set()), 'add', 3)
 
 
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_mars_batch_method(actor_pool_context):
     pool = actor_pool_context
@@ -369,6 +378,7 @@ async def test_mars_batch_method(actor_pool_context):
         await ref1.add_ret.batch(ref1.add_ret.delay(1), ref1.add.delay(2))
 
 
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_mars_destroy_has_actor(actor_pool_context):
     pool = actor_pool_context
@@ -409,6 +419,7 @@ async def test_mars_destroy_has_actor(actor_pool_context):
     assert not await mo.has_actor(ref1)
 
 
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_mars_resource_lock(actor_pool_context):
     pool = actor_pool_context
@@ -431,6 +442,7 @@ async def test_mars_resource_lock(actor_pool_context):
         assert event_pair[0][1] == event_pair[1][1]
 
 
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_promise_chain(actor_pool_context):
     pool = actor_pool_context

--- a/mars/oscar/backends/mars/tests/test_pool.py
+++ b/mars/oscar/backends/mars/tests/test_pool.py
@@ -89,7 +89,7 @@ def clear_routers():
     Router.set_instance(None)
 
 
-@flaky(platform='win', max_runs=10)
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 @mock.patch('mars.oscar.backends.mars.pool.SubActorPool.notify_main_pool_to_destroy')
 async def test_sub_actor_pool(notify_main_pool):
@@ -220,7 +220,7 @@ async def test_sub_actor_pool(notify_main_pool):
     assert pool.stopped
 
 
-@flaky(platform='win', max_runs=10)
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_main_actor_pool():
     config = ActorPoolConfig()
@@ -348,7 +348,7 @@ async def test_main_actor_pool():
     assert pool.stopped
 
 
-@flaky(platform='win', max_runs=10)
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_create_actor_pool():
     start_method = os.environ.get('POOL_START_METHOD', 'forkserver') \
@@ -418,7 +418,7 @@ async def test_create_actor_pool():
     assert len(global_router._mapping) == 0
 
 
-@flaky(platform='win', max_runs=10)
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_errors():
     with pytest.raises(ValueError):
@@ -437,7 +437,7 @@ async def test_errors():
                                     auto_recover='illegal')
 
 
-@flaky(platform='win', max_runs=10)
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_server_closed():
     start_method = os.environ.get('POOL_START_METHOD', 'forkserver') \
@@ -477,7 +477,7 @@ async def test_server_closed():
         await ctx.has_actor(actor_ref)
 
 
-@flaky(platform='win', max_runs=10)
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 @pytest.mark.skipif(sys.platform.startswith('win'), reason='skip under Windows')
 @pytest.mark.parametrize(
@@ -533,7 +533,7 @@ async def test_auto_recover(auto_recover):
                 await ctx.has_actor(actor_ref)
 
 
-@flaky(platform='win', max_runs=10)
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_two_pools():
     start_method = os.environ.get('POOL_START_METHOD', 'forkserver') \
@@ -588,7 +588,7 @@ async def test_two_pools():
         assert await actor_ref2.add_other(actor_ref4, 3) == 13
 
 
-@flaky(platform='win', max_runs=10)
+@flaky(platform='win', max_runs=3)
 @pytest.mark.asyncio
 async def test_parallel_allocate_idle_label():
     start_method = os.environ.get('POOL_START_METHOD', 'forkserver') \

--- a/mars/oscar/backends/mars/tests/test_pool.py
+++ b/mars/oscar/backends/mars/tests/test_pool.py
@@ -500,6 +500,10 @@ async def test_auto_recover(auto_recover):
     async with pool:
         ctx = get_context()
 
+        # wait for recover of main pool always returned immediately
+        await ctx.wait_actor_pool_recovered(
+            pool.external_address, pool.external_address)
+
         # create actor on main
         actor_ref = await ctx.create_actor(
             TestActor, address=pool.external_address,
@@ -518,7 +522,9 @@ async def test_auto_recover(auto_recover):
 
         if auto_recover:
             # process must have been killed
-            await recovered.wait()
+            await ctx.wait_actor_pool_recovered(
+                actor_ref.address, pool.external_address)
+            assert recovered.is_set()
 
             expect_has_actor = True if auto_recover in ['actor', True] else False
             assert await ctx.has_actor(actor_ref) is expect_has_actor

--- a/mars/oscar/backends/message.py
+++ b/mars/oscar/backends/message.py
@@ -52,6 +52,7 @@ class ControlMessageType(Enum):
     restart = 1
     sync_config = 2
     get_config = 3
+    wait_pool_recovered = 4
 
 
 @dataslots

--- a/mars/oscar/context.pyx
+++ b/mars/oscar/context.pyx
@@ -130,6 +130,19 @@ cdef class BaseActorContext:
         """
         raise NotImplementedError
 
+    async def wait_actor_pool_recovered(self, str address, str main_address = None):
+        """
+        Wait until an actor pool is recovered
+
+        Parameters
+        ----------
+        address
+            address of the actor pool
+        main_address
+            address of the main pool
+        """
+        raise NotImplementedError
+
 
 cdef class ClientActorContext(BaseActorContext):
     """
@@ -181,6 +194,11 @@ cdef class ClientActorContext(BaseActorContext):
     def send(self, ActorRef actor_ref, object message, bint wait_response=True):
         context = self._get_backend_context(actor_ref.address)
         return context.send(actor_ref, message, wait_response=wait_response)
+
+    def wait_actor_pool_recovered(self, str address, str main_address = None):
+        main_address = main_address or address
+        context = self._get_backend_context(address)
+        return context.wait_actor_pool_recovered(address, main_address)
 
 
 def register_backend_context(scheme, cls):

--- a/mars/oscar/core.pxd
+++ b/mars/oscar/core.pxd
@@ -22,7 +22,7 @@ cdef class ActorRef:
     cdef __tell__(self, object message, object delay=*)
 
 
-cdef class _Actor:
+cdef class _BaseActor:
     cdef object __weakref__
     cdef str _address
     cdef object _lock

--- a/mars/services/cluster/api/oscar.py
+++ b/mars/services/cluster/api/oscar.py
@@ -138,6 +138,12 @@ class ClusterAPI(AbstractClusterAPI):
         """
         await self._uploader_ref.mark_node_ready()
 
+    async def wait_node_ready(self):
+        """
+        Wait current node to be ready
+        """
+        await self._uploader_ref.wait_node_ready()
+
     async def wait_all_supervisors_ready(self):
         """
         Wait till all expected supervisors are ready

--- a/mars/services/cluster/tests/test_uploader.py
+++ b/mars/services/cluster/tests/test_uploader.py
@@ -45,7 +45,9 @@ async def test_uploader(actor_pool):
         NodeInfoUploaderActor, role=NodeRole.WORKER, interval=0.1,
         uid=NodeInfoUploaderActor.default_uid(), address=pool_addr
     )
+    wait_ready_task = asyncio.create_task(uploader_ref.wait_node_ready())
     await uploader_ref.mark_node_ready()
+    await asyncio.wait_for(wait_ready_task, timeout=0.1)
 
     # test empty result
     result = await collector_ref.get_nodes_info(role=NodeRole.WORKER)


### PR DESCRIPTION
## What do these changes do?

Add support for stateless actors. Also add method `wait_actor_pool_recovered` for oscar. Calling the method will wait till a sub pool is recovered.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
