### PR TITLE
Pass logging config file name into sub pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
 
         if [ -z "$NO_COMMON_TESTS" ]; then
           if [[ ! "$PYTHON" =~ "3.6" ]] && [[ ! "$PYTHON" =~ "3.9" ]]; then
-            pip install h5py zarr matplotlib fastparquet
+            pip install h5py zarr matplotlib fastparquet\<0.7.0
             conda install -n test --quiet --yes -c conda-forge python=$PYTHON \
               "tiledb-py>=0.4.3,<0.6.0" "tiledb<2.0.0" || true
           fi

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -618,7 +618,12 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
                 else:
                     r.index = xdf.MultiIndex.from_tuples([group_key], names=input_objs[0].grouper.names)
             results.append(result)
-        concat_result = tuple(xdf.concat(parts) for parts in zip(*results))
+        if not results and op.stage == OperandStage.agg:
+            empty_df = pd.DataFrame([], columns=out.dtypes.index,
+                                    index=out.index_value.to_pandas()[:0])
+            concat_result = (empty_df.astype(out.dtypes),)
+        else:
+            concat_result = tuple(xdf.concat(parts) for parts in zip(*results))
         return concat_result
 
     @staticmethod

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -299,16 +299,16 @@ def test_dataframe_groupby_agg(setup):
         assert r.op.groupby_params['as_index'] is False
 
     # test as_index=False takes no effect
-    r = mdf.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count'], method='tree')
+    r = mdf.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count'])
     pd.testing.assert_frame_equal(r.execute().fetch(),
                                   raw.groupby(['c1', 'c2'], as_index=False).agg(['mean', 'count']))
     assert r.op.groupby_params['as_index'] is True
 
-    r = mdf.groupby('c2').agg(['cumsum', 'cumcount'], method='tree')
+    r = mdf.groupby('c2').agg(['cumsum', 'cumcount'])
     pd.testing.assert_frame_equal(r.execute().fetch().sort_index(),
                                   raw.groupby('c2').agg(['cumsum', 'cumcount']).sort_index())
 
-    r = mdf[['c1', 'c3']].groupby(mdf['c2']).agg(MockReduction2(), method='tree')
+    r = mdf[['c1', 'c3']].groupby(mdf['c2']).agg(MockReduction2())
     pd.testing.assert_frame_equal(r.execute().fetch(),
                                   raw[['c1', 'c3']].groupby(raw['c2']).agg(MockReduction2()))
 

--- a/mars/deploy/oscar/cmdline.py
+++ b/mars/deploy/oscar/cmdline.py
@@ -48,6 +48,8 @@ class OscarCommandRunner:
         self.config = {}
         self.pool = None
 
+        self.logging_conf_file = None
+
         self._running = False
 
     def config_args(self, parser):
@@ -78,6 +80,7 @@ class OscarCommandRunner:
         for path in conf_file_paths:
             conf_path = os.path.join(path, log_conf) if path else log_conf
             if os.path.exists(conf_path):
+                self.logging_conf_file = conf_path
                 logging.config.fileConfig(conf_path, disable_existing_loggers=False)
                 break
         else:

--- a/mars/deploy/oscar/cmdline.py
+++ b/mars/deploy/oscar/cmdline.py
@@ -48,7 +48,7 @@ class OscarCommandRunner:
         self.config = {}
         self.pool = None
 
-        self.logging_conf_file = None
+        self.logging_conf = {}
 
         self._running = False
 
@@ -80,7 +80,7 @@ class OscarCommandRunner:
         for path in conf_file_paths:
             conf_path = os.path.join(path, log_conf) if path else log_conf
             if os.path.exists(conf_path):
-                self.logging_conf_file = conf_path
+                self.logging_conf['file'] = conf_path
                 logging.config.fileConfig(conf_path, disable_existing_loggers=False)
                 break
         else:
@@ -88,6 +88,7 @@ class OscarCommandRunner:
             level = getattr(logging, log_level.upper()) if log_level else logging.INFO
             logging.getLogger('mars').setLevel(level)
             logging.basicConfig(format=self.args.log_format)
+            self.logging_conf.update({'level': log_level, 'format': self.args.log_format})
 
     @classmethod
     def _build_endpoint_file_path(cls, pid: int = None, asterisk: bool = False):

--- a/mars/deploy/oscar/supervisor.py
+++ b/mars/deploy/oscar/supervisor.py
@@ -51,6 +51,7 @@ class SupervisorCommandRunner(OscarCommandRunner):
         return await create_supervisor_actor_pool(
             self.args.endpoint, n_process=0, ports=self.ports,
             modules=self.args.load_modules,
+            logging_conf_file=self.logging_conf_file,
             subprocess_start_method='forkserver' if os.name == 'nt' else 'spawn'
         )
 

--- a/mars/deploy/oscar/supervisor.py
+++ b/mars/deploy/oscar/supervisor.py
@@ -51,7 +51,7 @@ class SupervisorCommandRunner(OscarCommandRunner):
         return await create_supervisor_actor_pool(
             self.args.endpoint, n_process=0, ports=self.ports,
             modules=self.args.load_modules,
-            logging_conf_file=self.logging_conf_file,
+            logging_conf=self.logging_conf,
             subprocess_start_method='forkserver' if os.name == 'nt' else 'spawn'
         )
 

--- a/mars/deploy/oscar/worker.py
+++ b/mars/deploy/oscar/worker.py
@@ -74,7 +74,7 @@ class WorkerCommandRunner(OscarCommandRunner):
         return await create_worker_actor_pool(
             self.args.endpoint, self.band_to_slot, ports=self.ports,
             n_io_process=self.n_io_process, modules=list(self.args.load_modules),
-            logging_conf_file=self.logging_conf_file,
+            logging_conf=self.logging_conf,
             subprocess_start_method='forkserver' if os.name != 'nt' else 'spawn'
         )
 

--- a/mars/deploy/oscar/worker.py
+++ b/mars/deploy/oscar/worker.py
@@ -74,6 +74,7 @@ class WorkerCommandRunner(OscarCommandRunner):
         return await create_worker_actor_pool(
             self.args.endpoint, self.band_to_slot, ports=self.ports,
             n_io_process=self.n_io_process, modules=list(self.args.load_modules),
+            logging_conf_file=self.logging_conf_file,
             subprocess_start_method='forkserver' if os.name != 'nt' else 'spawn'
         )
 

--- a/mars/oscar/backends/config.py
+++ b/mars/oscar/backends/config.py
@@ -40,6 +40,7 @@ class ActorPoolConfig:
                       modules: List[str] = None,
                       suspend_sigint: bool = False,
                       use_uvloop: bool = False,
+                      logging_conf_file: str = None,
                       kwargs: Dict = None):
         pools: Dict = self._conf['pools']
         if not isinstance(external_address, list):
@@ -52,6 +53,7 @@ class ActorPoolConfig:
             'modules': modules,
             'suspend_sigint': suspend_sigint,
             'use_uvloop': use_uvloop,
+            'logging_conf_file': logging_conf_file,
             'kwargs': kwargs or {},
         }
         for addr in external_address:

--- a/mars/oscar/backends/config.py
+++ b/mars/oscar/backends/config.py
@@ -40,7 +40,7 @@ class ActorPoolConfig:
                       modules: List[str] = None,
                       suspend_sigint: bool = False,
                       use_uvloop: bool = False,
-                      logging_conf_file: str = None,
+                      logging_conf: Dict = None,
                       kwargs: Dict = None):
         pools: Dict = self._conf['pools']
         if not isinstance(external_address, list):
@@ -53,7 +53,7 @@ class ActorPoolConfig:
             'modules': modules,
             'suspend_sigint': suspend_sigint,
             'use_uvloop': use_uvloop,
-            'logging_conf_file': logging_conf_file,
+            'logging_conf': logging_conf,
             'kwargs': kwargs or {},
         }
         for addr in external_address:

--- a/mars/oscar/backends/mars/pool.py
+++ b/mars/oscar/backends/mars/pool.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import concurrent.futures as futures
+import logging.config
 import multiprocessing
 import os
 import signal
@@ -44,6 +45,8 @@ elif sys.version_info[:2] == (3, 6):
 
     from multiprocessing.process import BaseProcess
     BaseProcess.kill = _mp_kill
+
+logger = logging.getLogger(__name__)
 
 
 @_register_message_handler
@@ -130,6 +133,11 @@ class MainActorPool(MainActorPoolBase):
         suspend_sigint = conf['suspend_sigint']
         if suspend_sigint:
             signal.signal(signal.SIGINT, lambda *_: None)
+
+        logging_conf_file = conf['logging_conf_file']
+        if logging_conf_file:
+            logging.config.fileConfig(logging_conf_file)
+
         use_uvloop = conf['use_uvloop']
         if use_uvloop:
             import uvloop

--- a/mars/oscar/backends/mars/pool.py
+++ b/mars/oscar/backends/mars/pool.py
@@ -134,9 +134,13 @@ class MainActorPool(MainActorPoolBase):
         if suspend_sigint:
             signal.signal(signal.SIGINT, lambda *_: None)
 
-        logging_conf_file = conf['logging_conf_file']
-        if logging_conf_file:
-            logging.config.fileConfig(logging_conf_file)
+        logging_conf = conf['logging_conf'] or {}
+        if logging_conf.get('file'):
+            logging.config.fileConfig(logging_conf['file'])
+        elif logging_conf.get('level'):
+            logging.basicConfig(
+                level=logging_conf['level'], format=logging_conf.get('format')
+            )
 
         use_uvloop = conf['use_uvloop']
         if use_uvloop:

--- a/mars/oscar/backends/mars/tests/test-logging.conf
+++ b/mars/oscar/backends/mars/tests/test-logging.conf
@@ -1,0 +1,26 @@
+[loggers]
+keys=root,test_mars_pool
+
+[handlers]
+keys=stream_handler
+
+[formatters]
+keys=formatter
+
+[logger_root]
+level=WARN
+handlers=stream_handler
+
+[logger_test_mars_pool]
+level=DEBUG
+handlers=stream_handler
+qualname=mars.oscar.backends.mars.tests
+propagate=0
+
+[handler_stream_handler]
+class=StreamHandler
+formatter=formatter
+args=(sys.stderr,)
+
+[formatter_formatter]
+format=%(asctime)s %(name)-12s %(process)d %(levelname)-8s %(message)s

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -1077,7 +1077,7 @@ async def create_actor_pool(address: str, *,
                             modules: List[str] = None,
                             suspend_sigint: bool = None,
                             use_uvloop: Union[str, bool] = 'auto',
-                            logging_conf_file: str = None,
+                            logging_conf: Union[Dict, None] = None,
                             on_process_down: Callable[[MainActorPoolType, str], None] = None,
                             on_process_recover: Callable[[MainActorPoolType, str], None] = None,
                             **kwargs) -> MainActorPoolType:
@@ -1114,7 +1114,7 @@ async def create_actor_pool(address: str, *,
         modules=modules,
         suspend_sigint=suspend_sigint,
         use_uvloop=use_uvloop,
-        logging_conf_file=logging_conf_file,
+        logging_conf=logging_conf,
         kwargs=kwargs)
     # add sub configs
     for i in range(n_process):
@@ -1128,7 +1128,7 @@ async def create_actor_pool(address: str, *,
             modules=modules,
             suspend_sigint=suspend_sigint,
             use_uvloop=use_uvloop,
-            logging_conf_file=logging_conf_file,
+            logging_conf=logging_conf,
             kwargs=kwargs)
 
     pool: MainActorPoolType = await pool_cls.create({

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -16,6 +16,7 @@ import asyncio
 import concurrent.futures as futures
 import contextlib
 import itertools
+import logging
 import os
 import threading
 import multiprocessing
@@ -41,6 +42,7 @@ from .message import _MessageBase, new_message_id, DEFAULT_PROTOCOL, MessageType
     CancelMessage, ControlMessage, ControlMessageType
 from .router import Router
 
+logger = logging.getLogger(__name__)
 ray = lazy_import("ray")
 
 
@@ -1075,6 +1077,7 @@ async def create_actor_pool(address: str, *,
                             modules: List[str] = None,
                             suspend_sigint: bool = None,
                             use_uvloop: Union[str, bool] = 'auto',
+                            logging_conf_file: str = None,
                             on_process_down: Callable[[MainActorPoolType, str], None] = None,
                             on_process_recover: Callable[[MainActorPoolType, str], None] = None,
                             **kwargs) -> MainActorPoolType:
@@ -1097,6 +1100,7 @@ async def create_actor_pool(address: str, *,
             use_uvloop = True
         except ImportError:
             use_uvloop = False
+
     external_addresses = pool_cls.get_external_addresses(address, n_process=n_process, ports=ports)
     actor_pool_config = ActorPoolConfig()
     # add main config
@@ -1110,6 +1114,7 @@ async def create_actor_pool(address: str, *,
         modules=modules,
         suspend_sigint=suspend_sigint,
         use_uvloop=use_uvloop,
+        logging_conf_file=logging_conf_file,
         kwargs=kwargs)
     # add sub configs
     for i in range(n_process):
@@ -1123,6 +1128,7 @@ async def create_actor_pool(address: str, *,
             modules=modules,
             suspend_sigint=suspend_sigint,
             use_uvloop=use_uvloop,
+            logging_conf_file=logging_conf_file,
             kwargs=kwargs)
 
     pool: MainActorPoolType = await pool_cls.create({

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -22,6 +22,7 @@ from typing import Dict
 import numpy as np
 import pandas as pd
 import pytest
+
 try:
     from flaky import flaky as _raw_flaky
 except ImportError:
@@ -33,6 +34,7 @@ except ImportError:
 _mock = mock
 
 from ..config import option_context
+from ..core.operand import OperandStage
 from ..utils import lazy_import
 
 
@@ -357,6 +359,10 @@ class ObjectCheckMixin:
         from mars.tensor.core import TENSOR_CHUNK_TYPE
         from mars.dataframe.core import DATAFRAME_CHUNK_TYPE, SERIES_CHUNK_TYPE, \
             GROUPBY_CHUNK_TYPE, INDEX_CHUNK_TYPE, CATEGORICAL_CHUNK_TYPE
+
+        op = getattr(expected, 'op', None)
+        if op and getattr(op, 'stage', None) == OperandStage.map:
+            return
 
         if isinstance(expected, (TENSOR_TYPE, TENSOR_CHUNK_TYPE)):
             self.assert_tensor_consistent(expected, real)


### PR DESCRIPTION
## What do these changes do?

Pass logging config file name into sub pools to let sub pools print logs as configured. Also fixes aggregation issue.

## Related issue number

Fixes #2212