### PR TITLE
Use Kubernetes Service to discover Mars Supervisors

### DIFF
--- a/conda-spec.txt
+++ b/conda-spec.txt
@@ -16,4 +16,3 @@ numexpr
 scikit-learn
 psutil
 bokeh
-jinja2

--- a/mars/deploy/kubernetes/core.py
+++ b/mars/deploy/kubernetes/core.py
@@ -136,15 +136,14 @@ class K8SClusterBackend(AbstractClusterBackend):
             name=self._service_name,
             namespace=self._k8s_namespace,
         )).to_dict()
-        supervisors = self._format_endpoint_query_result(result, filter_ready=filter_ready)
-        return supervisors
+        return self._format_endpoint_query_result(result, filter_ready=filter_ready)
 
     async def _get_supervisors_by_cluster_web_api(self, filter_ready: bool = True):
         api = self._get_web_cluster_api()
         try:
             supervisors = await api.get_supervisors(filter_ready=filter_ready)
             return supervisors
-        except (OSError, asyncio.TimeoutError):
+        except (OSError, asyncio.TimeoutError):  # pragma: no cover
             return []
 
     async def get_supervisors(self, filter_ready: bool = True) -> List[str]:

--- a/mars/deploy/kubernetes/core.py
+++ b/mars/deploy/kubernetes/core.py
@@ -16,13 +16,14 @@
 import asyncio
 import logging
 import os
-from typing import AsyncGenerator, List, Optional, TypeVar
+from typing import AsyncGenerator, Dict, List, Optional, TypeVar
 
+from ...services.cluster import WebClusterAPI
 from ...services.cluster.backends import register_cluster_backend, \
     AbstractClusterBackend
 from ...services.cluster.core import NodeRole
-from ..utils import wait_all_supervisors_ready
-from .config import MarsReplicationConfig, MarsSupervisorsConfig
+from ..utils import wait_all_supervisors_ready, next_in_thread
+from .config import MarsReplicationConfig
 
 logger = logging.getLogger(__name__)
 RetType = TypeVar('RetType')
@@ -32,9 +33,12 @@ RetType = TypeVar('RetType')
 class K8SClusterBackend(AbstractClusterBackend):
     name = "k8s"
 
-    def __init__(self, k8s_config=None, k8s_namespace=None):
+    def __init__(self, node_role=None, pool_address=None,
+                 k8s_config=None, k8s_namespace=None):
         from kubernetes import client
 
+        self._node_role = node_role
+        self._pool_address = pool_address
         self._k8s_config = k8s_config
 
         verify_ssl = bool(int(os.environ.get('KUBE_VERIFY_SSL', '1').strip('"')))
@@ -44,10 +48,11 @@ class K8SClusterBackend(AbstractClusterBackend):
             client.Configuration.set_default(c)
 
         self._k8s_namespace = k8s_namespace or os.environ.get('MARS_K8S_POD_NAMESPACE') or 'default'
+        self._service_name = os.environ.get('MARS_K8S_SERVICE_NAME')
         self._full_label_selector = None
         self._client = client.CoreV1Api(client.ApiClient(self._k8s_config))
 
-        self._service_pod_to_ep = dict()
+        self._pod_to_ep = dict()
 
     @classmethod
     async def create(cls, node_role: NodeRole, lookup_address: Optional[str],
@@ -66,109 +71,99 @@ class K8SClusterBackend(AbstractClusterBackend):
                 k8s_config.host = address_parts[0]
             else:
                 config.load_kube_config(address_parts[0], client_configuration=k8s_config)
-        return cls(k8s_config, k8s_namespace)
+        return cls(node_role, pool_address, k8s_config, k8s_namespace)
 
     def __reduce__(self):
-        return type(self), (self._k8s_config, self._k8s_namespace)
-
-    async def _get_label_selector(self, service_type):
-        if self._full_label_selector is not None:
-            return self._full_label_selector
-
-        selectors = [f'mars/service-type={service_type}']
-        if 'MARS_K8S_GROUP_LABELS' in os.environ:
-            group_labels = os.environ['MARS_K8S_GROUP_LABELS'].split(',')
-            cur_pod_info = (await asyncio.to_thread(self._client.read_namespaced_pod,
-                                                    os.environ['MARS_K8S_POD_NAME'],
-                                                    namespace=self._k8s_namespace)).to_dict()
-            for label in group_labels:
-                label_val = cur_pod_info['metadata']['labels'][label]
-                selectors.append(f'{label}={label_val}')
-        self._full_label_selector = ','.join(selectors)
-        logger.debug('Using pod selector %s', self._full_label_selector)
-        return self._full_label_selector
-
-    async def _extract_pod_name_ep(self, pod_data):
-        pod_ip = pod_data["status"].get("podIP") or pod_data["status"].get("pod_ip")
-        ports_def = pod_data['spec']['containers'][0]['ports'][0]
-        svc_port = ports_def.get('containerPort') or ports_def.get('container_port')
-        return pod_data['metadata']['name'], f'{pod_ip}:{svc_port}'
+        return type(self), (self._node_role, self._pool_address,
+                            self._k8s_config, self._k8s_namespace)
 
     @staticmethod
-    def _extract_pod_ready(obj_data):
-        return obj_data['status']['phase'] == 'Running'
+    def _format_endpoint_query_result(result: Dict, filter_ready: bool = True):
+        port = os.environ['MARS_K8S_SERVICE_PORT']
+        endpoints = [
+            f"{addr['ip']}:{port}"
+            for addr in result['subsets'][0]['addresses'] or []
+        ]
+        if not filter_ready:
+            endpoints = [
+                f"{addr['ip']}:{port}"
+                for addr in result['subsets'][0]['not_ready_addresses'] or []
+            ]
+        return endpoints
 
-    async def _get_pod_to_ep(self, service_type: str, filter_ready: bool = False):
-        query = (await asyncio.to_thread(
-            self._client.list_namespaced_pod,
-            namespace=self._k8s_namespace,
-            label_selector=await self._get_label_selector(service_type),
-            resource_version='0'
-        )).to_dict()
+    def _get_web_cluster_api(self):
+        supervisor_web_port = os.environ['MARS_K8S_SUPERVISOR_WEB_PORT']
+        web_url = f'http://{self._service_name}.{self._k8s_namespace}:{supervisor_web_port}'
+        api = WebClusterAPI(web_url)
+        return api
 
-        result = dict()
-        for el in query['items']:
-            name, pod_ep = await self._extract_pod_name_ep(el)
-            if filter_ready and pod_ep is not None and not self._extract_pod_ready(el):
-                pod_ep = None
-            result[name] = pod_ep
-        return result
-
-    async def _get_endpoints_by_service_type(self, service_type: str, update: bool = False,
-                                             filter_ready: bool = True):
-        if not self._service_pod_to_ep.get(service_type) or update:
-            self._service_pod_to_ep[service_type] = \
-                await self._get_pod_to_ep(service_type, filter_ready=filter_ready)
-        return sorted(a for a in self._service_pod_to_ep[service_type].values() if a is not None)
-
-    async def _watch_service(self, service_type, linger=10):
+    async def _watch_supervisors_by_service_api(self) -> AsyncGenerator[List[str], None]:
         from urllib3.exceptions import ReadTimeoutError
-        from kubernetes import watch
+        from kubernetes.watch import Watch as K8SWatch
 
-        cur_pods = set(await self._get_endpoints_by_service_type(service_type, update=True))
-        w = watch.Watch()
+        w = K8SWatch()
 
-        pod_to_ep = self._service_pod_to_ep[service_type]
         while True:
-            # when some pods are not ready, we refresh faster
-            linger_seconds = linger() if callable(linger) else linger
             streamer = w.stream(
-                self._client.list_namespaced_pod,
+                self._client.list_namespaced_endpoints,
                 namespace=self._k8s_namespace,
-                label_selector=await self._get_label_selector(service_type),
-                timeout_seconds=linger_seconds,
-                resource_version='0'
+                label_selector=f'mars/service-name={self._service_name}',
+                timeout_seconds=60,
             )
             while True:
                 try:
-                    event = await asyncio.to_thread(next, streamer, StopIteration)
-                    if event is StopIteration:
-                        # todo change this into a continuous watch
-                        #  when watching in a master node is implemented
-                        return
-                except (ReadTimeoutError, StopIteration):
-                    new_pods = set(await self._get_endpoints_by_service_type(service_type, update=True))
-                    if new_pods != cur_pods:
-                        cur_pods = new_pods
-                        yield await self._get_endpoints_by_service_type(service_type, update=False)
+                    event = await next_in_thread(streamer)
+                    obj_dict = event['object'].to_dict()
+                    yield self._format_endpoint_query_result(obj_dict)
+                except (ReadTimeoutError, StopAsyncIteration):
                     break
                 except:  # noqa: E722  # pragma: no cover  # pylint: disable=bare-except
                     logger.exception('Unexpected error when watching on kubernetes')
                     break
 
-                obj_dict = event['object'].to_dict()
-                pod_name, endpoint = await self._extract_pod_name_ep(obj_dict)
-                pod_to_ep[pod_name] = endpoint \
-                    if endpoint and self._extract_pod_ready(obj_dict) else None
-                yield await self._get_endpoints_by_service_type(service_type, update=False)
+    async def _watch_supervisors_by_cluster_web_api(self):
+        while True:
+            try:
+                api = self._get_web_cluster_api()
+                async for supervisors in api.watch_supervisors():
+                    yield supervisors
+            except (OSError, asyncio.TimeoutError):
+                pass
 
-    def watch_supervisors(self) -> AsyncGenerator[List[str], None]:
-        return self._watch_service(MarsSupervisorsConfig.rc_name)
+    async def _get_supervisors_by_service_api(self, filter_ready: bool = True) -> List[str]:
+        result = (await asyncio.to_thread(
+            self._client.read_namespaced_endpoints,
+            name=self._service_name,
+            namespace=self._k8s_namespace,
+        )).to_dict()
+        supervisors = self._format_endpoint_query_result(result, filter_ready=filter_ready)
+        return supervisors
+
+    async def _get_supervisors_by_cluster_web_api(self, filter_ready: bool = True):
+        api = self._get_web_cluster_api()
+        try:
+            supervisors = await api.get_supervisors(filter_ready=filter_ready)
+            return supervisors
+        except (OSError, asyncio.TimeoutError):
+            return []
 
     async def get_supervisors(self, filter_ready: bool = True) -> List[str]:
-        return await self._get_endpoints_by_service_type(
-            MarsSupervisorsConfig.rc_name, update=not filter_ready,
-            filter_ready=filter_ready)
+        if self._node_role == NodeRole.SUPERVISOR:
+            return await self._get_supervisors_by_service_api(filter_ready)
+        else:
+            return await self._get_supervisors_by_cluster_web_api(filter_ready)
+
+    async def watch_supervisors(self) -> AsyncGenerator[List[str], None]:
+        if self._node_role == NodeRole.SUPERVISOR:
+            watch_fun = self._watch_supervisors_by_service_api
+        else:
+            watch_fun = self._watch_supervisors_by_cluster_web_api
+
+        try:
+            async for supervisors in watch_fun():
+                yield supervisors
+        except asyncio.CancelledError:
+            pass
 
 
 class K8SServiceMixin:

--- a/mars/deploy/kubernetes/docker/Dockerfile.base
+++ b/mars/deploy/kubernetes/docker/Dockerfile.base
@@ -1,4 +1,4 @@
-ARG BASE_CONTAINER=continuumio/miniconda3:4.6.14
+ARG BASE_CONTAINER=continuumio/miniconda3:4.9.2
 FROM ${BASE_CONTAINER}
 
 COPY retry.sh /srv/retry.sh
@@ -7,9 +7,6 @@ RUN /srv/retry.sh 3 /opt/conda/bin/conda install \
     bokeh \
     cloudpickle \
     cython \
-    gevent \
-    jinja2 \
-    lz4 \
     mkl \
     numba \
     numexpr \
@@ -19,6 +16,7 @@ RUN /srv/retry.sh 3 /opt/conda/bin/conda install \
     scikit-learn \
     scipy \
     tornado \
+    aiohttp \
   && /srv/retry.sh 3 /opt/conda/bin/conda install -c conda-forge \
     libiconv \
     pyarrow\>=1.0 \

--- a/mars/deploy/kubernetes/docker/Dockerfile.base
+++ b/mars/deploy/kubernetes/docker/Dockerfile.base
@@ -17,9 +17,11 @@ RUN /srv/retry.sh 3 /opt/conda/bin/conda install \
     scipy \
     tornado \
     aiohttp \
+    lz4 \
   && /srv/retry.sh 3 /opt/conda/bin/conda install -c conda-forge \
     libiconv \
     pyarrow\>=1.0 \
     tiledb-py \
     python-kubernetes \
+    uvloop \
   && /opt/conda/bin/conda clean --all -f -y

--- a/mars/deploy/kubernetes/tests/test_kubernetes.py
+++ b/mars/deploy/kubernetes/tests/test_kubernetes.py
@@ -158,6 +158,10 @@ def test_run_in_kubernetes():
 @pytest.mark.skipif(not kube_available, reason='Cannot run without kubernetes')
 @mock.patch('kubernetes.client.CoreV1Api.create_namespaced_replication_controller',
             new=lambda *_, **__: None)
+@mock.patch('kubernetes.client.AppsV1Api.create_namespaced_deployment',
+            new=lambda *_, **__: None)
+@mock.patch('kubernetes.client.AppsV1Api.create_namespaced_replica_set',
+            new=lambda *_, **__: None)
 def test_create_timeout():
     api_client = k8s_config.new_client_from_config()
 

--- a/mars/deploy/kubernetes/tests/test_kubernetes.py
+++ b/mars/deploy/kubernetes/tests/test_kubernetes.py
@@ -160,8 +160,6 @@ def test_run_in_kubernetes():
             new=lambda *_, **__: None)
 @mock.patch('kubernetes.client.AppsV1Api.create_namespaced_deployment',
             new=lambda *_, **__: None)
-@mock.patch('kubernetes.client.AppsV1Api.create_namespaced_replica_set',
-            new=lambda *_, **__: None)
 def test_create_timeout():
     api_client = k8s_config.new_client_from_config()
 

--- a/mars/deploy/tests/test_utils.py
+++ b/mars/deploy/tests/test_utils.py
@@ -16,7 +16,8 @@ import os
 
 import pytest
 
-from mars.deploy.utils import load_service_config_file, get_third_party_modules_from_config
+from mars.deploy.utils import load_service_config_file, \
+    get_third_party_modules_from_config, next_in_thread
 from mars.services import NodeRole
 
 _cwd = os.path.abspath(os.getcwd())
@@ -84,3 +85,17 @@ def test_get_third_party_modules_from_config():
     config = {'third_party_modules': {'supervisor': 'a.module'}}
     with pytest.raises(TypeError, match='str'):
         get_third_party_modules_from_config(config, NodeRole.SUPERVISOR)
+
+
+@pytest.mark.asyncio
+async def test_next_in_thread():
+    def gen_fun():
+        yield 1
+        yield 2
+
+    gen = gen_fun()
+
+    assert await next_in_thread(gen) == 1
+    assert await next_in_thread(gen) == 2
+    with pytest.raises(StopAsyncIteration):
+        await next_in_thread(gen)

--- a/mars/deploy/utils.py
+++ b/mars/deploy/utils.py
@@ -147,3 +147,10 @@ def get_third_party_modules_from_config(config: Dict, role: NodeRole):
     for mods in tuple(modules or ()) + (os.environ.get('MARS_LOAD_MODULES'),):
         all_modules.extend(mods.split(',') if mods else [])
     return all_modules
+
+
+async def next_in_thread(gen):
+    res = await asyncio.to_thread(next, gen, StopIteration)
+    if res is StopIteration:
+        raise StopAsyncIteration
+    return res

--- a/mars/services/cluster/api/core.py
+++ b/mars/services/cluster/api/core.py
@@ -31,7 +31,7 @@ class AbstractClusterAPI:
             return {NodeStatus.READY}
 
     @abstractmethod
-    async def get_supervisors(self) -> List[str]:
+    async def get_supervisors(self, filter_ready: bool = True) -> List[str]:
         """
         Get supervisor addresses
 

--- a/mars/services/cluster/api/oscar.py
+++ b/mars/services/cluster/api/oscar.py
@@ -214,13 +214,13 @@ class ClusterAPI(AbstractClusterAPI):
 class MockClusterAPI(ClusterAPI):
     @classmethod
     async def create(cls: Type[APIType], address: str, **kw) -> APIType:
-        from ..locator import SupervisorLocatorActor
+        from ..supervisor.locator import SupervisorPeerLocatorActor
         from ..uploader import NodeInfoUploaderActor
         from ..supervisor.node_info import NodeInfoCollectorActor
 
         dones, _ = await asyncio.wait([
-            mo.create_actor(SupervisorLocatorActor, 'fixed', address,
-                            uid=SupervisorLocatorActor.default_uid(),
+            mo.create_actor(SupervisorPeerLocatorActor, 'fixed', address,
+                            uid=SupervisorPeerLocatorActor.default_uid(),
                             address=address),
             mo.create_actor(NodeInfoCollectorActor,
                             uid=NodeInfoCollectorActor.default_uid(),

--- a/mars/services/cluster/api/web.py
+++ b/mars/services/cluster/api/web.py
@@ -164,8 +164,10 @@ class WebClusterAPI(AbstractClusterAPI, MarsWebAPIClientMixin):
         else:
             return self._convert_node_dict(result['nodes'])
 
-    async def get_supervisors(self) -> List[str]:
-        res = await self._get_nodes_info(role=NodeRole.SUPERVISOR)
+    async def get_supervisors(self, filter_ready: bool = True) -> List[str]:
+        statuses = {NodeStatus.READY} if filter_ready \
+            else {NodeStatus.STARTING, NodeStatus.READY}
+        res = await self._get_nodes_info(role=NodeRole.SUPERVISOR, statuses=statuses)
         return list(res.keys())
 
     @watch_method

--- a/mars/services/cluster/backends/base.py
+++ b/mars/services/cluster/backends/base.py
@@ -15,18 +15,21 @@
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, Dict, List, Optional, Type
 
+from ..core import NodeRole
+
 
 class AbstractClusterBackend(ABC):
     name = None
 
     @classmethod
     @abstractmethod
-    async def create(cls, lookup_address: Optional[str],
+    async def create(cls, node_role: NodeRole, lookup_address: Optional[str],
                      pool_address: str) -> "AbstractClusterBackend":
         """
 
         Parameters
         ----------
+        node_role
         lookup_address
         pool_address
 
@@ -47,25 +50,19 @@ class AbstractClusterBackend(ABC):
         """
 
     @abstractmethod
-    async def get_supervisors(self) -> List[str]:
+    async def get_supervisors(self, filter_ready: bool = True) -> List[str]:
         """
         Get list of supervisors
+
+        Parameters
+        ----------
+        filter_ready : bool
+            True if return ready nodes only, or return starting and ready nodes
 
         Returns
         -------
         out : List[str]
             List of supervisors
-        """
-
-    @abstractmethod
-    async def get_expected_supervisors(self) -> List[str]:
-        """
-        Get list of all supervisors expected to create
-
-        Returns
-        -------
-        out : List[str]
-            List of expected supervisors
         """
 
 

--- a/mars/services/cluster/backends/fixed.py
+++ b/mars/services/cluster/backends/fixed.py
@@ -14,6 +14,7 @@
 
 from typing import AsyncGenerator, List, Optional
 
+from ..core import NodeRole
 from .base import AbstractClusterBackend, register_cluster_backend
 
 
@@ -25,15 +26,12 @@ class FixedClusterBackend(AbstractClusterBackend):
         self._supervisors = [n.strip() for n in lookup_address.split(',')]
 
     @classmethod
-    async def create(cls, lookup_address: Optional[str],
+    async def create(cls, node_role: NodeRole, lookup_address: Optional[str],
                      pool_address: str):
         return cls(lookup_address)
 
     async def watch_supervisors(self) -> AsyncGenerator[List[str], None]:
         yield self._supervisors
 
-    async def get_supervisors(self) -> List[str]:
-        return self._supervisors
-
-    async def get_expected_supervisors(self) -> List[str]:
+    async def get_supervisors(self, filter_ready: bool = True) -> List[str]:
         return self._supervisors

--- a/mars/services/cluster/locator.py
+++ b/mars/services/cluster/locator.py
@@ -20,13 +20,14 @@ from ... import oscar as mo
 from ...lib.uhashring import HashRing
 from ...utils import extensible
 from .backends import AbstractClusterBackend, get_cluster_backend
-from .core import WatchNotifier
+from .core import NodeRole, WatchNotifier
 
 logger = logging.getLogger(__name__)
 
 
 class SupervisorLocatorActor(mo.Actor):
     _backend: Optional[AbstractClusterBackend]
+    _node_role: NodeRole
 
     def __init__(self, backend_name: str, lookup_address: str):
         self._backend_name = backend_name
@@ -41,21 +42,37 @@ class SupervisorLocatorActor(mo.Actor):
     async def __post_create__(self):
         backend_cls = get_cluster_backend(self._backend_name)
         self._backend = await backend_cls.create(
-            self._lookup_address, self.address)
-        await self._set_supervisors(await self._backend.get_supervisors())
+            self._node_role, self._lookup_address, self.address)
+        await self._set_supervisors(await self._get_supervisors_from_backend())
 
-        self._watch_task = asyncio.create_task(self._watch_backend())
+        self._watch_task = asyncio.create_task(self._watch_supervisor_changes())
 
     async def __pre_destroy__(self):
         self._watch_task.cancel()
-
-    def get_supervisors(self):
-        return self._supervisors
 
     async def _set_supervisors(self, supervisors: List[str]):
         self._supervisors = supervisors
         self._hash_ring = HashRing(nodes=supervisors, hash_fn='ketama')
         await self._watch_notifier.notify()
+
+    async def _get_supervisors_from_backend(self, filter_ready: bool = True):
+        raise NotImplementedError
+
+    def _watch_supervisors_from_backend(self):
+        raise NotImplementedError
+
+    async def _watch_supervisor_changes(self):
+        last_supervisors = set()
+        try:
+            async for sv_list in self._watch_supervisors_from_backend():
+                if set(sv_list) != last_supervisors:
+                    await self._set_supervisors(sv_list)
+                    last_supervisors = set(sv_list)
+        except asyncio.CancelledError:
+            return
+
+    def get_supervisors(self):
+        return self._supervisors
 
     @extensible
     def get_supervisor(self, key: str, size=1):
@@ -67,13 +84,6 @@ class SupervisorLocatorActor(mo.Actor):
             return tuple(it['nodename']
                          for it in self._hash_ring.range(key, size=size))
 
-    async def _watch_backend(self):
-        last_supervisors = set()
-        async for sv_list in self._backend.watch_supervisors():
-            if set(sv_list) != last_supervisors:
-                await self._set_supervisors(sv_list)
-                last_supervisors = set(sv_list)
-
     async def watch_supervisors(self, version: Optional[int] = None):
         version = yield self._watch_notifier.watch(version)
         raise mo.Return((version, self._supervisors))
@@ -84,13 +94,9 @@ class SupervisorLocatorActor(mo.Actor):
         raise mo.Return((version, [self.get_supervisor(k) for k in keys]))
 
     async def wait_all_supervisors_ready(self):
-        expected_supervisors = await self._backend.get_expected_supervisors()
-        if set(self._supervisors or []) == set(expected_supervisors):
-            return
-
         version = None
         while True:
             version = yield self._watch_notifier.watch(version)
-            expected_supervisors = await self._backend.get_expected_supervisors()
+            expected_supervisors = await self._get_supervisors_from_backend(filter_ready=False)
             if set(self._supervisors) == set(expected_supervisors):
                 break

--- a/mars/services/cluster/locator.py
+++ b/mars/services/cluster/locator.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 class SupervisorLocatorActor(mo.Actor):
     _backend: Optional[AbstractClusterBackend]
-    _node_role: NodeRole
+    _node_role: NodeRole = None
 
     def __init__(self, backend_name: str, lookup_address: str):
         self._backend_name = backend_name

--- a/mars/services/cluster/supervisor/locator.py
+++ b/mars/services/cluster/supervisor/locator.py
@@ -1,0 +1,49 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .... import oscar as mo
+from ....lib.aio import alru_cache
+from ..core import NodeRole
+from ..locator import SupervisorLocatorActor
+
+
+class SupervisorPeerLocatorActor(SupervisorLocatorActor):
+    _node_role = NodeRole.SUPERVISOR
+
+    @classmethod
+    def default_uid(cls):
+        return SupervisorLocatorActor.__name__
+
+    async def __post_create__(self):
+        await super().__post_create__()
+
+        supervisors = await self._backend.get_supervisors(filter_ready=False)
+        try:
+            node_info_ref = await self._get_node_info_ref()
+            await node_info_ref.put_starting_nodes(supervisors, NodeRole.SUPERVISOR)
+        except mo.ActorNotExist:  # pragma: no cover
+            pass
+
+    @alru_cache(cache_exceptions=False)
+    async def _get_node_info_ref(self):
+        from .node_info import NodeInfoCollectorActor
+        return await mo.actor_ref(uid=NodeInfoCollectorActor.default_uid(),
+                                  address=self.address)
+
+    async def _get_supervisors_from_backend(self, filter_ready: bool = True):
+        return await self._backend.get_supervisors(filter_ready=filter_ready)
+
+    async def _watch_supervisors_from_backend(self):
+        async for supervisors in self._backend.watch_supervisors():
+            yield supervisors

--- a/mars/services/cluster/supervisor/node_info.py
+++ b/mars/services/cluster/supervisor/node_info.py
@@ -150,7 +150,7 @@ class NodeInfoCollectorActor(mo.Actor):
         version = yield self._role_to_notifier[role].watch(version=version)
         raise mo.Return((version, self.get_all_bands(role=role, statuses=statuses)))
 
-    def put_starting_nodes(self, nodes: List[str], role: NodeRole):
+    async def put_starting_nodes(self, nodes: List[str], role: NodeRole):
         for node_ep in nodes:
             if node_ep in self._node_infos \
                     and self._node_infos[node_ep].status not in {NodeStatus.STARTING, NodeStatus.STOPPED}:
@@ -164,4 +164,4 @@ class NodeInfoCollectorActor(mo.Actor):
             if info.status == NodeStatus.STARTING and node not in nodes_set:
                 info.status = NodeStatus.STOPPED
 
-        self._role_to_notifier[role].notify()
+        await self._role_to_notifier[role].notify()

--- a/mars/services/cluster/supervisor/service.py
+++ b/mars/services/cluster/supervisor/service.py
@@ -14,8 +14,8 @@
 
 from .... import oscar as mo
 from ...core import NodeRole
-from ..locator import SupervisorLocatorActor
 from ..uploader import NodeInfoUploaderActor
+from .locator import SupervisorPeerLocatorActor
 from .node_info import NodeInfoCollectorActor
 
 
@@ -43,16 +43,16 @@ async def start(config: dict, address: str):
     lookup_address = svc_config.get('lookup_address',
                                     address if backend == 'fixed' else None)
     await mo.create_actor(
-        SupervisorLocatorActor,
-        backend_name=backend,
-        lookup_address=lookup_address,
-        uid=SupervisorLocatorActor.default_uid(),
-        address=address)
-    await mo.create_actor(
         NodeInfoCollectorActor,
         timeout=svc_config.get('node_timeout'),
         check_interval=svc_config.get('node_check_interval'),
         uid=NodeInfoCollectorActor.default_uid(),
+        address=address)
+    await mo.create_actor(
+        SupervisorPeerLocatorActor,
+        backend_name=backend,
+        lookup_address=lookup_address,
+        uid=SupervisorPeerLocatorActor.default_uid(),
         address=address)
     await mo.create_actor(
         NodeInfoUploaderActor,
@@ -64,10 +64,10 @@ async def start(config: dict, address: str):
 
 async def stop(config: dict, address: str):
     await mo.destroy_actor(mo.create_actor_ref(
-        uid=SupervisorLocatorActor.default_uid(),
+        uid=NodeInfoCollectorActor.default_uid(),
         address=address))
     await mo.destroy_actor(mo.create_actor_ref(
-        uid=NodeInfoCollectorActor.default_uid(),
+        uid=SupervisorPeerLocatorActor.default_uid(),
         address=address))
     await mo.destroy_actor(mo.create_actor_ref(
         uid=NodeInfoUploaderActor.default_uid(),

--- a/mars/services/cluster/tests/backend.py
+++ b/mars/services/cluster/tests/backend.py
@@ -1,0 +1,56 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+import os
+from typing import Optional, List, AsyncGenerator
+
+from mars.services import NodeRole
+from mars.services.cluster.backends import \
+    AbstractClusterBackend, register_cluster_backend
+
+logger = logging.getLogger(__name__)
+
+
+@register_cluster_backend
+class TestClusterBackend(AbstractClusterBackend):
+    name = 'test'
+
+    def __init__(self, file_path: str):
+        self._file_path = file_path
+        self._modify_date = os.path.getmtime(file_path)
+
+    @classmethod
+    async def create(cls, node_role: NodeRole, lookup_address: Optional[str],
+                     pool_address: str) -> "AbstractClusterBackend":
+        return TestClusterBackend(lookup_address)
+
+    async def get_supervisors(self, filter_ready: bool = True) -> List[str]:
+        with open(self._file_path, 'r') as inp_file:
+            result = []
+            for line in inp_file.read().strip().splitlines(False):
+                line_parts = line.rsplit(',', 1)
+                if len(line_parts) == 1 \
+                        or (filter_ready and int(line_parts[1])):
+                    result.append(line_parts[0])
+            return result
+
+    async def watch_supervisors(self) -> AsyncGenerator[List[str], None]:
+        while True:
+            mtime = os.path.getmtime(self._file_path)
+            if mtime != self._modify_date:
+                self._modify_date = mtime
+                yield await self.get_supervisors()
+            await asyncio.sleep(0.1)

--- a/mars/services/cluster/tests/test_api.py
+++ b/mars/services/cluster/tests/test_api.py
@@ -95,7 +95,7 @@ async def test_web_api(actor_pool):
     await start_web(web_config, pool_addr)
 
     web_api = WebClusterAPI(f'http://127.0.0.1:{web_config["web"]["port"]}')
-    assert await web_api.get_supervisors() == []
+    assert await web_api.get_supervisors() == [pool_addr]
 
     assert len(await web_api.get_all_bands(statuses={NodeStatus.READY})) > 0
     assert len(await web_api.get_nodes_info(

--- a/mars/services/cluster/tests/test_locator.py
+++ b/mars/services/cluster/tests/test_locator.py
@@ -13,37 +13,58 @@
 # limitations under the License.
 
 import asyncio
-import time
+import os
+import tempfile
+from typing import List
 
 import pytest
 
 import mars.oscar as mo
+from mars.services.cluster.core import NodeRole, NodeStatus
+from mars.services.cluster.supervisor.node_info \
+    import NodeInfoCollectorActor
 from mars.services.cluster.supervisor.locator import \
     SupervisorPeerLocatorActor
-from mars.tests.core import mock
+from mars.services.cluster.worker.locator import \
+    WorkerSupervisorLocatorActor
+from mars.services.cluster.tests import backend
 from mars.utils import Timer
+
+del backend
+
+
+class MockNodeInfoCollectorActor(mo.Actor):
+    def __init__(self):
+        self._node_infos = dict()
+        self._version = 0
+
+    def set_all_node_infos(self, node_infos):
+        self._node_infos = node_infos
+
+    def get_nodes_info(self, *args, **kwargs):
+        return self._node_infos
+
+    async def watch_nodes(self, *args, version=None, **kwargs):
+        await asyncio.sleep(0.5)
+        self._version += 1
+        return self._version, self._node_infos
+
+    def put_starting_nodes(self, nodes: List[str], role: NodeRole):
+        for node in nodes:
+            self._node_infos[node] = NodeStatus.STARTING
 
 
 @pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool('127.0.0.1', n_process=0)
     await pool.start()
+
+    await mo.create_actor(MockNodeInfoCollectorActor,
+                          uid=NodeInfoCollectorActor.default_uid(),
+                          address=pool.external_address)
+
     yield pool
     await pool.stop()
-
-
-async def _changing_watch_supervisors(self):
-    idx = 0
-    t = time.time()
-    while time.time() - t < 1:
-        try:
-            await asyncio.sleep(0.1)
-            # make sure supervisors are different every time
-            idx = (idx + 2) % len(self._supervisors)
-            yield self._supervisors[idx:idx + 2]
-        except asyncio.CancelledError:
-            break
-    yield self._supervisors
 
 
 @pytest.mark.asyncio
@@ -67,25 +88,104 @@ async def test_fixed_locator(actor_pool):
     await mo.destroy_actor(locator_ref)
 
 
+@pytest.fixture
+def temp_address_file():
+    with tempfile.TemporaryDirectory(prefix='mars-test') as dir_name:
+        yield os.path.join(dir_name, 'addresses')
+
+
 @pytest.mark.asyncio
-@mock.patch('mars.services.cluster.backends.FixedClusterBackend.watch_supervisors',
-            new=_changing_watch_supervisors)
-async def test_changing_locator(actor_pool):
+async def test_supervisor_peer_locator(actor_pool, temp_address_file):
     addresses = ['1.2.3.4:1234', '1.2.3.4:1235',
                  '1.2.3.4:1236', '1.2.3.4:1237']
+    with open(temp_address_file, 'w') as file_obj:
+        file_obj.write('\n'.join(addresses))
+
     locator_ref = await mo.create_actor(
-        SupervisorPeerLocatorActor, 'fixed', ','.join(addresses),
+        SupervisorPeerLocatorActor, 'test', temp_address_file,
+        uid=SupervisorPeerLocatorActor.default_uid(),
         address=actor_pool.external_address)
 
+    # test starting nodes filled
+    info_ref = await mo.actor_ref(uid=NodeInfoCollectorActor.default_uid(),
+                                  address=actor_pool.external_address)
+    assert set(await info_ref.get_nodes_info()) == set(addresses)
+
+    # test watch nodes changes
     version, result = await locator_ref.watch_supervisors_by_keys(['mock_name'])
     assert result[0] in addresses
-    version, result = await locator_ref.watch_supervisors_by_keys(['mock_name'], version=version)
-    assert result[0] in addresses
 
-    assert all(addr in addresses for addr in (await locator_ref.watch_supervisors(version=version))[-1])
+    with open(temp_address_file, 'w') as file_obj:
+        file_obj.write('\n'.join(addresses[2:]))
+
+    version, result = await locator_ref.watch_supervisors_by_keys(
+        ['mock_name'], version=version)
+    assert result[0] in addresses[2:]
+
+    # test wait all supervisors ready
+    with open(temp_address_file, 'w') as file_obj:
+        file_obj.write('\n'.join(
+            f'{a},{idx % 2}' for idx, a in enumerate(addresses)))
+
+    async def delay_read_fun():
+        await asyncio.sleep(0.2)
+        with open(temp_address_file, 'w') as file_obj:
+            file_obj.write('\n'.join(
+                f'{a},{(idx + 1) % 2}' for idx, a in enumerate(addresses)))
+        await asyncio.sleep(0.3)
+        with open(temp_address_file, 'w') as file_obj:
+            file_obj.write('\n'.join(addresses))
+
+    asyncio.create_task(delay_read_fun())
 
     with Timer() as timer:
         await locator_ref.wait_all_supervisors_ready()
-    assert timer.duration > 0.1
+    assert timer.duration > 0.4
 
     await mo.destroy_actor(locator_ref)
+
+
+@pytest.mark.asyncio
+async def test_worker_supervisor_locator(actor_pool, temp_address_file):
+    addresses = [actor_pool.external_address]
+    with open(temp_address_file, 'w') as file_obj:
+        file_obj.write('\n'.join(addresses))
+
+    locator_ref = await mo.create_actor(
+        WorkerSupervisorLocatorActor, 'test', temp_address_file,
+        uid=WorkerSupervisorLocatorActor.default_uid(),
+        address=actor_pool.external_address)
+
+    info_ref = await mo.actor_ref(uid=NodeInfoCollectorActor.default_uid(),
+                                  address=actor_pool.external_address)
+    await info_ref.set_all_node_infos({actor_pool.external_address: NodeStatus.READY})
+
+    # test watch nodes changes
+    supervisors = await locator_ref.get_supervisors(filter_ready=False)
+    assert supervisors == addresses
+    version, result = await locator_ref.watch_supervisors_by_keys(['mock_name'])
+    assert result[0] in addresses
+
+    # test watch without NodeInfoCollectorActor
+    await info_ref.destroy()
+
+    addresses = ['localhost:1234', 'localhost:1235']
+    with open(temp_address_file, 'w') as file_obj:
+        file_obj.write('\n'.join(addresses))
+    version, result = await locator_ref.watch_supervisors_by_keys(
+        ['mock_name'], version=version)
+    assert result[0] in addresses
+
+    # test watch when NodeInfoCollectorActor is created again
+    info_ref = await mo.create_actor(MockNodeInfoCollectorActor,
+                                     uid=NodeInfoCollectorActor.default_uid(),
+                                     address=actor_pool.external_address)
+    await info_ref.set_all_node_infos({actor_pool.external_address: NodeStatus.READY})
+
+    addresses = [actor_pool.external_address]
+    with open(temp_address_file, 'w') as file_obj:
+        file_obj.write('\n'.join(addresses))
+
+    version, result = await locator_ref.watch_supervisors_by_keys(
+        ['mock_name'], version=version)
+    assert result[0] in addresses

--- a/mars/services/cluster/tests/test_locator.py
+++ b/mars/services/cluster/tests/test_locator.py
@@ -18,7 +18,8 @@ import time
 import pytest
 
 import mars.oscar as mo
-from mars.services.cluster.locator import SupervisorLocatorActor
+from mars.services.cluster.supervisor.locator import \
+    SupervisorPeerLocatorActor
 from mars.tests.core import mock
 from mars.utils import Timer
 
@@ -50,7 +51,7 @@ async def test_fixed_locator(actor_pool):
     addresses = ['1.2.3.4:1234', '1.2.3.4:1235',
                  '1.2.3.4:1236', '1.2.3.4:1237']
     locator_ref = await mo.create_actor(
-        SupervisorLocatorActor, 'fixed', ','.join(addresses),
+        SupervisorPeerLocatorActor, 'fixed', ','.join(addresses),
         address=actor_pool.external_address)
 
     assert await locator_ref.get_supervisor('mock_name') in addresses
@@ -73,7 +74,7 @@ async def test_changing_locator(actor_pool):
     addresses = ['1.2.3.4:1234', '1.2.3.4:1235',
                  '1.2.3.4:1236', '1.2.3.4:1237']
     locator_ref = await mo.create_actor(
-        SupervisorLocatorActor, 'fixed', ','.join(addresses),
+        SupervisorPeerLocatorActor, 'fixed', ','.join(addresses),
         address=actor_pool.external_address)
 
     version, result = await locator_ref.watch_supervisors_by_keys(['mock_name'])

--- a/mars/services/cluster/tests/test_uploader.py
+++ b/mars/services/cluster/tests/test_uploader.py
@@ -18,7 +18,8 @@ import pytest
 
 import mars.oscar as mo
 from mars.services import NodeRole
-from mars.services.cluster.locator import SupervisorLocatorActor
+from mars.services.cluster.supervisor.locator import \
+    SupervisorPeerLocatorActor
 from mars.services.cluster.supervisor.node_info import NodeInfoCollectorActor
 from mars.services.cluster.uploader import NodeInfoUploaderActor
 
@@ -35,8 +36,8 @@ async def actor_pool():
 async def test_uploader(actor_pool):
     pool_addr = actor_pool.external_address
     await mo.create_actor(
-        SupervisorLocatorActor, 'fixed', pool_addr,
-        uid=SupervisorLocatorActor.default_uid(), address=pool_addr)
+        SupervisorPeerLocatorActor, 'fixed', pool_addr,
+        uid=SupervisorPeerLocatorActor.default_uid(), address=pool_addr)
     node_info_ref = await mo.create_actor(
         NodeInfoCollectorActor, timeout=0.5, check_interval=0.1,
         uid=NodeInfoCollectorActor.default_uid(), address=pool_addr

--- a/mars/services/cluster/worker/locator.py
+++ b/mars/services/cluster/worker/locator.py
@@ -1,0 +1,77 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import List
+
+from .... import oscar as mo
+from ..core import NodeRole, NodeStatus
+from ..locator import SupervisorLocatorActor
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerSupervisorLocatorActor(SupervisorLocatorActor):
+    _node_role = NodeRole.WORKER
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._node_info_ref = None
+
+    @classmethod
+    def default_uid(cls):
+        return SupervisorLocatorActor.__name__
+
+    async def _set_supervisors(self, supervisors: List[str]):
+        await super()._set_supervisors(supervisors)
+        if self._node_info_ref is None:
+            from ..supervisor.node_info import NodeInfoCollectorActor
+            supervisor_addr = self.get_supervisor(
+                NodeInfoCollectorActor.default_uid())
+            self._node_info_ref = await mo.actor_ref(
+                uid=NodeInfoCollectorActor.default_uid(), address=supervisor_addr
+            )
+
+    async def _get_supervisors_from_backend(self, filter_ready: bool = True):
+        try:
+            assert self._node_info_ref is not None
+            statuses = {NodeStatus.READY} if filter_ready \
+                else {NodeStatus.READY, NodeStatus.STARTING}
+            infos = await self._node_info_ref.get_nodes_info(
+                role=NodeRole.SUPERVISOR, statuses=statuses)
+            return list(infos)
+        except (AssertionError, ConnectionError, mo.ServerClosed):
+            self._node_info_ref = None
+            return await self._backend.get_supervisors(filter_ready=filter_ready)
+
+    async def _watch_supervisor_from_node_info(self):
+        assert self._node_info_ref is not None
+        version = None
+        while True:
+            version, infos = await self._node_info_ref.watch_nodes(
+                role=NodeRole.SUPERVISOR, version=version)
+            yield list(infos)
+
+    async def _watch_supervisors_from_backend(self):
+        while True:
+            try:
+                async for supervisors in self._watch_supervisor_from_node_info():
+                    yield supervisors
+            except (AssertionError, ConnectionError, mo.ServerClosed):
+                self._node_info_ref = None
+
+            async for supervisors in self._backend.watch_supervisors():
+                yield supervisors
+                if self._node_info_ref is not None:
+                    break

--- a/mars/services/cluster/worker/locator.py
+++ b/mars/services/cluster/worker/locator.py
@@ -35,7 +35,7 @@ class WorkerSupervisorLocatorActor(SupervisorLocatorActor):
 
     async def _set_supervisors(self, supervisors: List[str]):
         await super()._set_supervisors(supervisors)
-        if self._node_info_ref is None:
+        if supervisors and self._node_info_ref is None:
             from ..supervisor.node_info import NodeInfoCollectorActor
             supervisor_addr = self.get_supervisor(
                 NodeInfoCollectorActor.default_uid())

--- a/mars/services/cluster/worker/service.py
+++ b/mars/services/cluster/worker/service.py
@@ -14,8 +14,8 @@
 
 from .... import oscar as mo
 from ...core import NodeRole
-from ..locator import SupervisorLocatorActor
 from ..uploader import NodeInfoUploaderActor
+from .locator import WorkerSupervisorLocatorActor
 
 
 async def start(config: dict, address: str):
@@ -46,10 +46,10 @@ async def start(config: dict, address: str):
     lookup_address = svc_config.get('lookup_address',
                                     address if backend == 'fixed' else None)
     await mo.create_actor(
-        SupervisorLocatorActor,
+        WorkerSupervisorLocatorActor,
         backend_name=backend,
         lookup_address=lookup_address,
-        uid=SupervisorLocatorActor.default_uid(),
+        uid=WorkerSupervisorLocatorActor.default_uid(),
         address=address)
     await mo.create_actor(
         NodeInfoUploaderActor,
@@ -65,5 +65,5 @@ async def stop(config: dict, address: str):
         uid=NodeInfoUploaderActor.default_uid(), address=address
     ))
     await mo.destroy_actor(mo.create_actor_ref(
-        uid=SupervisorLocatorActor.default_uid(), address=address
+        uid=WorkerSupervisorLocatorActor.default_uid(), address=address
     ))

--- a/mars/services/session/supervisor/core.py
+++ b/mars/services/session/supervisor/core.py
@@ -42,7 +42,7 @@ class SessionManagerActor(mo.Actor):
         if session_id in self._session_refs:
             raise mo.Return(self._session_refs[session_id])
 
-        address = (await self._cluster_api.get_supervisors_by_keys([session_id]))[0]
+        [address] = await self._cluster_api.get_supervisors_by_keys([session_id])
         session_actor_ref = await mo.create_actor(
             SessionActor, session_id, self._service_config,
             address=address,

--- a/mars/services/storage/handler.py
+++ b/mars/services/storage/handler.py
@@ -286,7 +286,8 @@ class StorageHandlerActor(mo.Actor):
     async def _get_meta_api(self, session_id: str):
         if self._supervisor_address is None:
             cluster_api = await ClusterAPI.create(self.address)
-            self._supervisor_address = (await cluster_api.get_supervisors())[0]
+            [self._supervisor_address] = await cluster_api.get_supervisors_by_keys([session_id])
+
         return await MetaAPI.create(session_id=session_id,
                                     address=self._supervisor_address)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,6 @@ dev =
     scikit-learn>=0.20
     numexpr>=2.6.4
     bokeh>=1.0.0
-    jinja2>=2.0
     mock>=4.0.0; python_version<"3.8"
     tornado>=6.0
 distributed =
@@ -75,7 +74,6 @@ distributed =
     lz4>=1.0.0
     bokeh>=1.0.0
     sqlalchemy>=1.2.0
-    jinja2>=2.0
     tornado>=6.0
     uvloop>=0.14.0; sys.platform!="win32" and python_version>="3.7"
 extra =


### PR DESCRIPTION
## What do these changes do?

Restrict use of Kubernetes API to supervisors and make use of Kubernetes Service objects. For supervisors, `Endpoints` will be watched and queried. For workers, DNS address of supervisor service will be used.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
