### PR TITLE
Ensure range index incremental for data source op like `md.read_csv`

### DIFF
--- a/mars/core/context.py
+++ b/mars/core/context.py
@@ -16,7 +16,7 @@ import os
 from abc import ABC, abstractmethod
 from typing import List, Dict
 
-from ..typing import SessionType
+from ..typing import BandType, SessionType
 
 
 class Context(ABC):
@@ -30,7 +30,8 @@ class Context(ABC):
     def __init__(self,
                  session_id: str = None,
                  supervisor_address: str = None,
-                 current_address: str = None):
+                 current_address: str = None,
+                 band: BandType = None):
         if session_id is None:
             # try to get session id from environment
             session_id = os.environ.get('MARS_SESSION_ID')
@@ -47,6 +48,7 @@ class Context(ABC):
         self.session_id = session_id
         self.supervisor_address = supervisor_address
         self.current_address = current_address
+        self.band = band
 
     @abstractmethod
     def get_current_session(self) -> SessionType:

--- a/mars/core/entity/executable.py
+++ b/mars/core/entity/executable.py
@@ -54,8 +54,8 @@ class _TileableSession:
             if not decref_in_isolation:
                 # if decref in isolation, means that this tileable
                 # is not required for main thread, thus we do not need
-                # to wait for decref, otherwise, wait it
-                fut.result()
+                # to wait for decref, otherwise, wait a bit
+                fut.result(.5)
 
         self.tileable = ref(tileable, cb)
 

--- a/mars/core/entity/tileables.py
+++ b/mars/core/entity/tileables.py
@@ -64,16 +64,22 @@ class OperandTilesHandler:
     def tile(cls, tileables: List[TileableType]) \
             -> Generator[List[ChunkType], List[ChunkType], List[TileableType]]:
         op = tileables[0].op
-        tile_handler = cls.get_handler(op)
-        if inspect.isgeneratorfunction(tile_handler):
-            # op.tile can be a generator function,
-            # each time an operand yield some chunks,
-            # they will be put into ChunkGraph and executed first.
-            # After execution, resume from the yield place.
-            tiled_result = yield from tile_handler(op)
-        else:
-            # without iterative tiling
-            tiled_result = tile_handler(op)
+        # pre tile
+        op.pre_tile(op)
+        tiled_result = None
+        try:
+            tile_handler = cls.get_handler(op)
+            if inspect.isgeneratorfunction(tile_handler):
+                # op.tile can be a generator function,
+                # each time an operand yield some chunks,
+                # they will be put into ChunkGraph and executed first.
+                # After execution, resume from the yield place.
+                tiled_result = yield from tile_handler(op)
+            else:
+                # without iterative tiling
+                tiled_result = tile_handler(op)
+        finally:
+            op.post_tile(op, tiled_result)
 
         if not isinstance(tiled_result, list):
             tiled_result = [tiled_result]

--- a/mars/core/operand/base.py
+++ b/mars/core/operand/base.py
@@ -63,11 +63,12 @@ class SchedulingHint(Serializable):
     reassign_worker = BoolField('reassign_worker', default=False)
     # True means control dependency, False means data dependency
     _pure_depends = ListField('pure_depends', FieldTypes.bool)
-    # chunk index as priority, useful for those op like read_csv,
-    # the first chunk need to be executed not later than the later ones,
+    # useful when setting chunk index as priority,
+    # useful for those op like read_csv, the first chunk
+    # need to be executed not later than the later ones,
     # because the range index of later chunk should be accumulated from
     # indexes of previous ones
-    index_as_priority = BoolField('index_as_priority', default=False)
+    priority = Int32Field('priority', default=0)
 
     @classproperty
     def all_hint_names(cls):

--- a/mars/core/operand/base.py
+++ b/mars/core/operand/base.py
@@ -63,8 +63,11 @@ class SchedulingHint(Serializable):
     reassign_worker = BoolField('reassign_worker', default=False)
     # True means control dependency, False means data dependency
     _pure_depends = ListField('pure_depends', FieldTypes.bool)
-    # priority as the chunk index
-    priority_as_index = BoolField('priority_as_index', default=False)
+    # chunk index as priority, useful for those op like read_csv,
+    # the first chunk need to be executed not later than the later ones,
+    # because the range index of later chunk should be accumulated from
+    # indexes of previous ones
+    index_as_priority = BoolField('index_as_priority', default=False)
 
     @classproperty
     def all_hint_names(cls):

--- a/mars/core/operand/base.py
+++ b/mars/core/operand/base.py
@@ -16,15 +16,16 @@ import weakref
 from copy import deepcopy
 from enum import Enum
 from functools import partial
-from typing import List, Tuple, Dict, Type, Union
+from typing import Any, List, Tuple, Dict, Type, Union
 
 from ...serialization.serializables import SerializableMeta, FieldTypes, \
     BoolField, Int32Field, Float32Field, StringField, \
     ListField, DictField, ReferenceField
 from ...serialization.core import Placeholder
+from ...serialization.serializables import Serializable
 from ...serialization.serializables.core import SerializableSerializer
 from ...typing import OperandType
-from ...utils import AttributeDict
+from ...utils import AttributeDict, classproperty
 from ..base import Base
 from ..entity.core import Entity, EntityData
 from ..entity.chunks import Chunk
@@ -53,6 +54,43 @@ class OperandStage(Enum):
     agg = 3
 
 
+class SchedulingHint(Serializable):
+    # worker to execute, only work for chunk op,
+    # if specified, the op should be executed on the specified worker
+    # only work for those operand that has no input
+    expect_worker = StringField('expect_worker', default=None)
+    # will this operand be assigned a worker or not
+    reassign_worker = BoolField('reassign_worker', default=False)
+    # True means control dependency, False means data dependency
+    _pure_depends = ListField('pure_depends', FieldTypes.bool)
+    # priority as the chunk index
+    priority_as_index = BoolField('priority_as_index', default=False)
+
+    @classproperty
+    def all_hint_names(cls):
+        return list(cls._FIELDS)
+
+
+def _install_scheduling_hint_properties(cls: Type["Operand"]):
+    def get_hint(name):
+        def _get_val(operand: "Operand"):
+            if operand.scheduling_hint:
+                return getattr(operand.scheduling_hint, name)
+
+        def _set_val(operand: "Operand", val: Any):
+            if not operand.scheduling_hint:
+                operand.scheduling_hint = SchedulingHint(**{hint_name: val})
+            else:
+                setattr(operand.scheduling_hint, hint_name, val)
+
+        return property(_get_val, _set_val)
+
+    for hint_name in SchedulingHint.all_hint_names:
+        setattr(cls, hint_name, get_hint(hint_name))
+    return cls
+
+
+@_install_scheduling_hint_properties
 class Operand(Base, metaclass=OperandMetaclass):
     """
     Operand base class. All operands should have a type, which can be Add, Subtract etc.
@@ -70,28 +108,36 @@ class Operand(Base, metaclass=OperandMetaclass):
     sparse = BoolField('sparse', default=False)
     gpu = BoolField('gpu', default=None)
     device = Int32Field('device', default=None)
-    # worker to execute, only work for chunk op,
-    # if specified, the op should be executed on the specified worker
-    # only work for those operand that has no input
-    expect_worker = StringField('expect_worker', default=None)
     # will this operand create a view of input data or not
     create_view = BoolField('create_view', default=False)
-    # will this operand be assigned a worker or not
-    reassign_worker = BoolField('reassign_worker', default=False)
     stage = ReferenceField('stage', OperandStage, default=None)
     memory_scale = Float32Field('memory_scale', default=None)
     tileable_op_key = StringField('tileable_op_key', default=None)
     extra_params = DictField('extra_params', key_type=FieldTypes.string)
+    # scheduling hint
+    scheduling_hint = ReferenceField('scheduling_hint', default=None)
 
     _inputs = ListField('inputs', FieldTypes.reference(EntityData))
-    _pure_depends = ListField('pure_depends', FieldTypes.bool)
     _outputs = ListField('outputs')
     _output_types = ListField('output_type', FieldTypes.reference(OutputType))
 
     def __init__(self: OperandType, *args, **kwargs):
         extras = AttributeDict((k, kwargs.pop(k)) for k in set(kwargs) - set(self._FIELDS))
         kwargs['extra_params'] = kwargs.pop('extra_params', extras)
+        self._extract_scheduling_hint(kwargs)
         super().__init__(*args, **kwargs)
+
+    @classmethod
+    def _extract_scheduling_hint(cls, kwargs: Dict[str, Any]):
+        if 'scheduling_hint' in kwargs:
+            return
+
+        scheduling_hint_kwargs = dict()
+        for hint_name in SchedulingHint.all_hint_names:
+            if hint_name in kwargs:
+                scheduling_hint_kwargs[hint_name] = kwargs.pop(hint_name)
+        if scheduling_hint_kwargs:
+            kwargs['scheduling_hint'] = SchedulingHint(**scheduling_hint_kwargs)
 
     def __repr__(self):
         if self.stage is None:

--- a/mars/core/operand/base.py
+++ b/mars/core/operand/base.py
@@ -62,7 +62,7 @@ class SchedulingHint(Serializable):
     # will this operand be assigned a worker or not
     reassign_worker = BoolField('reassign_worker', default=False)
     # True means control dependency, False means data dependency
-    _pure_depends = ListField('pure_depends', FieldTypes.bool)
+    _pure_depends = ListField('pure_depends', FieldTypes.bool, default=None)
     # useful when setting chunk index as priority,
     # useful for those op like read_csv, the first chunk
     # need to be executed not later than the later ones,
@@ -74,6 +74,15 @@ class SchedulingHint(Serializable):
     def all_hint_names(cls):
         return list(cls._FIELDS)
 
+    def can_be_fused(self) -> bool:
+        if self.reassign_worker:
+            return False
+        if self._pure_depends and \
+                any(depend for depend in self._pure_depends):
+            # control dependency exists
+            return False
+        return True
+
 
 def _install_scheduling_hint_properties(cls: Type["Operand"]):
     def get_hint(name):
@@ -83,9 +92,9 @@ def _install_scheduling_hint_properties(cls: Type["Operand"]):
 
         def _set_val(operand: "Operand", val: Any):
             if not operand.scheduling_hint:
-                operand.scheduling_hint = SchedulingHint(**{hint_name: val})
+                operand.scheduling_hint = SchedulingHint(**{name: val})
             else:
-                setattr(operand.scheduling_hint, hint_name, val)
+                setattr(operand.scheduling_hint, name, val)
 
         return property(_get_val, _set_val)
 
@@ -126,7 +135,8 @@ class Operand(Base, metaclass=OperandMetaclass):
     _output_types = ListField('output_type', FieldTypes.reference(OutputType))
 
     def __init__(self: OperandType, *args, **kwargs):
-        extras = AttributeDict((k, kwargs.pop(k)) for k in set(kwargs) - set(self._FIELDS))
+        extra_names = set(kwargs) - set(self._FIELDS) - set(SchedulingHint.all_hint_names)
+        extras = AttributeDict((k, kwargs.pop(k)) for k in extra_names)
         kwargs['extra_params'] = kwargs.pop('extra_params', extras)
         self._extract_scheduling_hint(kwargs)
         super().__init__(*args, **kwargs)

--- a/mars/core/operand/core.py
+++ b/mars/core/operand/core.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import sys
-from typing import List, Dict, Type, Callable, Any
+from typing import Any, Callable, Dict, List, Type, Union
 
 import numpy as np
 try:
@@ -23,6 +23,7 @@ except ImportError:  # pragma: no cover
 
 from ...typing import TileableType, ChunkType, OperandType
 from ...utils import calc_data_size
+from ..context import Context
 from ..mode import is_eager_mode
 from ..entity import OutputType, ExecutableTuple, \
     get_chunk_types, get_tileable_types, \
@@ -221,11 +222,11 @@ class TileableOperandMixin:
         """
 
     @classmethod
-    def tile(cls, op):
+    def tile(cls, op: OperandType):
         raise NotImplementedError
 
     @classmethod
-    def post_tile(cls, op: OperandType, result: TileableType):
+    def post_tile(cls, op: OperandType, results: List[TileableType]):
         """
         Operation after tile.
 
@@ -233,12 +234,12 @@ class TileableOperandMixin:
         ----------
         op : OperandType
           Operand to tile.
-        result: TileableType
-          Tiled result
+        results: list
+          List of tiled results.
         """
 
     @classmethod
-    def pre_execute(cls, ctx: Dict, op: OperandType):
+    def pre_execute(cls, ctx: Union[dict, Context], op: OperandType):
         """
         Operation before execute.
 
@@ -251,11 +252,11 @@ class TileableOperandMixin:
         """
 
     @classmethod
-    def execute(cls, ctx: dict, op: OperandType):
+    def execute(cls, ctx: Union[dict, Context], op: OperandType):
         raise NotImplementedError
 
     @classmethod
-    def post_execute(cls, ctx: dict, op: OperandType):
+    def post_execute(cls, ctx: Union[dict, Context], op: OperandType):
         """
         Operand before execute.
 

--- a/mars/dataframe/datasource/core.py
+++ b/mars/dataframe/datasource/core.py
@@ -137,7 +137,8 @@ class IncrementalIndexDataSourceMixin(DataFrameOperandMixin):
         out = op.outputs[0]
         result = ctx[out.key]
         if op.incremental_index and \
-                isinstance(out.index_value.value, IndexValue.RangeIndex):
+                isinstance(out.index_value.value, IndexValue.RangeIndex) and \
+                getattr(op, 'incremental_index_recorder_name', None):
             recorder_name = op.incremental_index_recorder_name
             recorder = ctx.get_remote_object(recorder_name)
             index = out.index[0]

--- a/mars/dataframe/datasource/core.py
+++ b/mars/dataframe/datasource/core.py
@@ -126,11 +126,12 @@ class IncrementalIndexDataSourceMixin(DataFrameOperandMixin):
                 chunk.op.priority = -chunk.index[0]
             n_chunk = len(result.chunks)
             ctx = get_context()
-            name = str(uuid.uuid4())
-            ctx.create_remote_object(
-                name, _IncrementalIndexRecorder, n_chunk)
-            for chunk in result.chunks:
-                chunk.op.incremental_index_recorder_name = name
+            if ctx:
+                name = str(uuid.uuid4())
+                ctx.create_remote_object(
+                    name, _IncrementalIndexRecorder, n_chunk)
+                for chunk in result.chunks:
+                    chunk.op.incremental_index_recorder_name = name
 
     @classmethod
     def post_execute(cls, ctx: Union[dict, Context], op: OperandType):

--- a/mars/dataframe/datasource/read_csv.py
+++ b/mars/dataframe/datasource/read_csv.py
@@ -35,7 +35,8 @@ from ..arrays import ArrowStringDtype
 from ..core import IndexValue
 from ..utils import parse_index, build_empty_df, standardize_range_index, \
     to_arrow_dtypes, contain_arrow_dtype
-from .core import HeadOptimizedDataSource, ColumnPruneSupportedDataSourceMixin
+from .core import IncrementalIndexDatasource, ColumnPruneSupportedDataSourceMixin, \
+    IncrementalIndexDataSourceMixin
 
 
 cudf = lazy_import('cudf', globals=globals())
@@ -82,7 +83,9 @@ def _find_chunk_start_end(f, offset, size):
     return start, end
 
 
-class DataFrameReadCSV(HeadOptimizedDataSource, ColumnPruneSupportedDataSourceMixin):
+class DataFrameReadCSV(IncrementalIndexDatasource,
+                       ColumnPruneSupportedDataSourceMixin,
+                       IncrementalIndexDataSourceMixin):
     _op_type_ = OperandDef.READ_CSV
 
     _path = AnyField('path')

--- a/mars/dataframe/datasource/read_parquet.py
+++ b/mars/dataframe/datasource/read_parquet.py
@@ -429,7 +429,7 @@ class DataFrameReadParquet(IncrementalIndexDatasource,
 
 def read_parquet(path, engine: str = "auto", columns=None,
                  groups_as_chunks=False, use_arrow_dtype=None,
-                 incremental_index=True, storage_options=None,
+                 incremental_index=False, storage_options=None,
                  memory_scale=None, **kwargs):
     """
     Load a parquet object from the file path, returning a DataFrame.
@@ -456,7 +456,7 @@ def read_parquet(path, engine: str = "auto", columns=None,
         if True, each row group correspond to a chunk.
         if False, each file correspond to a chunk.
         Only available for 'pyarrow' engine.
-    incremental_index: bool, default True
+    incremental_index: bool, default False
         If index_col not specified, ensure range index incremental,
         gain a slightly better performance if setting False.
     use_arrow_dtype: bool, default None

--- a/mars/dataframe/datasource/read_parquet.py
+++ b/mars/dataframe/datasource/read_parquet.py
@@ -40,9 +40,9 @@ from ...serialization.serializables import AnyField, BoolField, DictField, ListF
 from ...utils import is_object_dtype
 from ..arrays import ArrowStringDtype
 from ..operands import OutputType
-from ..utils import parse_index, to_arrow_dtypes, contain_arrow_dtype, \
-    standardize_range_index
-from .core import HeadOptimizedDataSource, ColumnPruneSupportedDataSourceMixin
+from ..utils import parse_index, to_arrow_dtypes, contain_arrow_dtype
+from .core import IncrementalIndexDatasource, ColumnPruneSupportedDataSourceMixin, \
+    IncrementalIndexDataSourceMixin
 
 
 PARQUET_MEMORY_SCALE = 15
@@ -151,7 +151,9 @@ class FastpaquetEngine(ParquetEngine):
         return df
 
 
-class DataFrameReadParquet(HeadOptimizedDataSource, ColumnPruneSupportedDataSourceMixin):
+class DataFrameReadParquet(IncrementalIndexDatasource,
+                           ColumnPruneSupportedDataSourceMixin,
+                           IncrementalIndexDataSourceMixin):
     _op_type_ = OperandDef.READ_PARQUET
 
     _path = AnyField('path')
@@ -353,9 +355,6 @@ class DataFrameReadParquet(HeadOptimizedDataSource, ColumnPruneSupportedDataSour
                 out_chunks.append(new_chunk)
                 chunk_index += 1
 
-        if op.incremental_index:
-            out_chunks = standardize_range_index(out_chunks)
-
         new_op = op.copy()
         nsplits = ((np.nan,) * len(out_chunks), (out_df.shape[1],))
         return new_op.new_dataframes(None, out_df.shape, dtypes=dtypes,
@@ -430,7 +429,7 @@ class DataFrameReadParquet(HeadOptimizedDataSource, ColumnPruneSupportedDataSour
 
 def read_parquet(path, engine: str = "auto", columns=None,
                  groups_as_chunks=False, use_arrow_dtype=None,
-                 incremental_index=False, storage_options=None,
+                 incremental_index=True, storage_options=None,
                  memory_scale=None, **kwargs):
     """
     Load a parquet object from the file path, returning a DataFrame.
@@ -457,8 +456,9 @@ def read_parquet(path, engine: str = "auto", columns=None,
         if True, each row group correspond to a chunk.
         if False, each file correspond to a chunk.
         Only available for 'pyarrow' engine.
-    incremental_index: bool, default False
-        Create a new RangeIndex if csv doesn't contain index columns.
+    incremental_index: bool, default True
+        If index_col not specified, ensure range index incremental,
+        gain a slightly better performance if setting False.
     use_arrow_dtype: bool, default None
         If True, use arrow dtype to store columns.
     storage_options: dict, optional

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -865,7 +865,8 @@ def test_read_parquet_arrow(setup):
         test_df.to_parquet(file_path, row_group_size=5)
 
         df = md.read_parquet(file_path, groups_as_chunks=True,
-                             use_arrow_dtype=True)
+                             use_arrow_dtype=True,
+                             incremental_index=True)
         result = df.execute().fetch()
         assert isinstance(df.dtypes.iloc[1], md.ArrowStringDtype)
         assert isinstance(result.dtypes.iloc[1], md.ArrowStringDtype)

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -370,18 +370,17 @@ def test_read_csv_execution(setup):
                           columns=['a', 'b', 'c'])
         df.to_csv(file_path, index=False)
 
-        mdf = md.read_csv(file_path,
-                                                          usecols=['c', 'b']).execute().fetch()
+        mdf = md.read_csv(file_path, usecols=['c', 'b']).execute().fetch()
         pd.testing.assert_frame_equal(
             pd.read_csv(file_path, usecols=['c', 'b']), mdf)
 
         mdf = md.read_csv(file_path, names=['a', 'b', 'c'],
-                                                          usecols=['c', 'b']).execute().fetch()
+                          usecols=['c', 'b']).execute().fetch()
         pd.testing.assert_frame_equal(
             pd.read_csv(file_path, names=['a', 'b', 'c'], usecols=['c', 'b']), mdf)
 
         mdf = md.read_csv(file_path, names=['a', 'b', 'c'],
-                                                          usecols=['a', 'c']).execute().fetch()
+                          usecols=['a', 'c']).execute().fetch()
         pd.testing.assert_frame_equal(
             pd.read_csv(file_path, names=['a', 'b', 'c'], usecols=['a', 'c']), mdf)
 
@@ -477,7 +476,7 @@ def test_read_csv_execution(setup):
                                                            chunk_bytes='1k').execute().fetch()
         pd.testing.assert_frame_equal(pdf, mdf2)
 
-    # test multiply files
+    # test multiple files
     with tempfile.TemporaryDirectory() as tempdir:
         df = pd.DataFrame(np.random.rand(300, 3), columns=['a', 'b', 'c'])
 
@@ -603,11 +602,21 @@ def test_read_csv_without_index(setup):
         df.to_csv(file_path, index=False)
 
         pdf = pd.read_csv(file_path)
-        mdf = md.read_csv(file_path, incremental_index=True).execute().fetch()
+        mdf = md.read_csv(file_path).execute().fetch()
         pd.testing.assert_frame_equal(pdf, mdf)
 
-        mdf2 = md.read_csv(file_path, incremental_index=True, chunk_bytes=10).execute().fetch()
+        mdf2 = md.read_csv(file_path, chunk_bytes=10).execute().fetch()
         pd.testing.assert_frame_equal(pdf, mdf2)
+
+        file_path2 = os.path.join(tempdir, 'test.csv')
+        df = pd.DataFrame(np.random.RandomState(0).rand(100, 10),
+                          columns=[f'col{i}' for i in range(10)])
+        df.to_csv(file_path2, index=False)
+
+        mdf3 = md.read_csv(file_path2, chunk_bytes=os.stat(file_path2).st_size / 5)
+        result = mdf3.execute().fetch()
+        expected = pd.read_csv(file_path2)
+        pd.testing.assert_frame_equal(result, expected)
 
 
 def test_read_sql_execution(setup):

--- a/mars/learn/utils/collect_ports.py
+++ b/mars/learn/utils/collect_ports.py
@@ -89,6 +89,7 @@ class CollectPorts(LearnOperand, LearnOperandMixin):
 
     @classmethod
     def execute(cls, ctx, op):
+        assert ctx.band[0] == op.expect_worker
         socket_type = op.socket_type or socket.SOCK_STREAM
         port_num = get_next_port(socket_type, occupy=False)
         ctx[op.outputs[0].key] = np.array([port_num], dtype=int)

--- a/mars/learn/utils/tests/test_collect_ports.py
+++ b/mars/learn/utils/tests/test_collect_ports.py
@@ -1,0 +1,26 @@
+# Copyright 1999-2020 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mars.deploy.oscar.tests.session import new_test_session
+from mars.learn.utils.collect_ports import collect_ports
+
+
+def test_collect_ports():
+    session = new_test_session(address='test://127.0.0.1',
+                               init_local=True,
+                               n_worker=2)
+    workers = [pool.external_address for pool
+               in session._session.client._cluster._worker_pools]
+    # make sure assert works inside execution of collect ports
+    collect_ports(workers * 2).execute(session=session)

--- a/mars/services/context.py
+++ b/mars/services/context.py
@@ -20,7 +20,7 @@ from typing import List, Dict
 from .. import oscar as mo
 from ..lib.aio import new_isolation
 from ..core.context import Context
-from ..typing import SessionType
+from ..typing import BandType, SessionType
 from ..utils import implements
 from .cluster import ClusterAPI, NodeRole
 from .session import SessionAPI
@@ -39,10 +39,12 @@ class ThreadedServiceContext(Context):
                  session_id: str,
                  supervisor_address: str,
                  current_address: str,
-                 loop: asyncio.AbstractEventLoop):
+                 loop: asyncio.AbstractEventLoop,
+                 band: BandType = None):
         super().__init__(session_id=session_id,
                          supervisor_address=supervisor_address,
-                         current_address=current_address)
+                         current_address=current_address,
+                         band=band)
         self._loop = loop
         # new isolation with current loop,
         # so that session created in tile and execute

--- a/mars/services/core.py
+++ b/mars/services/core.py
@@ -15,9 +15,12 @@
 import asyncio
 import enum
 import importlib
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Union
 
-BandType = Tuple[str, str]
+from ..typing import BandType
+
+
+BandType = BandType
 
 
 class NodeRole(enum.Enum):

--- a/mars/services/scheduling/api.py
+++ b/mars/services/scheduling/api.py
@@ -109,7 +109,7 @@ class SchedulingAPI(ABC):
             list of priorities of subtasks
         """
         if priorities is None:
-            priorities = [subtask.priority for subtask in subtasks]
+            priorities = [subtask.priority or tuple() for subtask in subtasks]
         await self._manager_ref.add_subtasks(subtasks, priorities)
 
     @extensible

--- a/mars/services/scheduling/api.py
+++ b/mars/services/scheduling/api.py
@@ -109,7 +109,7 @@ class SchedulingAPI(ABC):
             list of priorities of subtasks
         """
         if priorities is None:
-            priorities = [(subtask.priority,) for subtask in subtasks]
+            priorities = [subtask.priority for subtask in subtasks]
         await self._manager_ref.add_subtasks(subtasks, priorities)
 
     @extensible

--- a/mars/services/scheduling/tests/test_service.py
+++ b/mars/services/scheduling/tests/test_service.py
@@ -185,7 +185,7 @@ async def test_schedule_queue(actor_pools):
         subtask = _gen_subtask(a, session_id)
         subtask.subtask_id = f'test_schedule_queue_subtask_{task_id}'
         subtask.expect_bands = [(worker_pool.external_address, 'numa-0')]
-        subtask.priority = 4 - task_id
+        subtask.priority = (4 - task_id,)
         wait_tasks.append(asyncio.create_task(_waiter_fun(subtask.subtask_id)))
         subtasks.append(subtask)
 
@@ -239,7 +239,7 @@ async def test_schedule_cancel(actor_pools):
         subtask = _gen_subtask(a, session_id)
         subtask.subtask_id = f'test_schedule_queue_subtask_{task_id}'
         subtask.expect_bands = [(worker_pool.external_address, 'numa-0')]
-        subtask.priority = 4 - task_id
+        subtask.priority = (4 - task_id,)
         wait_tasks.append(asyncio.create_task(_waiter_fun(subtask.subtask_id)))
         subtasks.append(subtask)
 

--- a/mars/services/session/supervisor/core.py
+++ b/mars/services/session/supervisor/core.py
@@ -204,6 +204,10 @@ class RemoteObjectActor(mo.Actor):
         @functools.wraps(func)
         async def wrap(*args, **kwargs):
             # return coroutine to not block current actor
-            return asyncio.to_thread(func, *args, **kwargs)
+            if asyncio.iscoroutinefunction(func):
+                return func(*args, **kwargs)
+            else:
+                # for sync call, running in thread
+                return asyncio.to_thread(func, *args, **kwargs)
 
         return wrap

--- a/mars/services/subtask/core.py
+++ b/mars/services/subtask/core.py
@@ -44,7 +44,7 @@ class Subtask(Serializable):
     chunk_graph: ChunkGraph = ReferenceField('chunk_graph', ChunkGraph)
     expect_bands: List[BandType] = ListField('expect_bands', FieldTypes.tuple)
     virtual: bool = BoolField('virtual')
-    priority: Tuple[int] = TupleField('priority', FieldTypes.int32)
+    priority: Tuple[int, int] = TupleField('priority', FieldTypes.int32)
     rerun_time: int = Int32Field('rerun_time')
     extra_config: dict = DictField('extra_config')
 
@@ -55,7 +55,7 @@ class Subtask(Serializable):
                  chunk_graph: ChunkGraph = None,
                  subtask_name: str = None,
                  expect_bands: List[BandType] = None,
-                 priority: Tuple[int] = None,
+                 priority: Tuple[int, int] = None,
                  virtual: bool = False,
                  rerun_time: int = 0,
                  extra_config: dict = None):

--- a/mars/services/subtask/core.py
+++ b/mars/services/subtask/core.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import Iterable, List
+from typing import Iterable, List, Tuple
 
 from ...core import ChunkGraph, DAG
 from ...serialization.serializables import Serializable, StringField, \
     ReferenceField, Int32Field, Int64Field, Float64Field, \
-    BoolField, AnyField, DictField, ListField, FieldTypes
+    BoolField, AnyField, DictField, ListField, TupleField, FieldTypes
 from ..core import BandType
 
 
@@ -44,7 +44,7 @@ class Subtask(Serializable):
     chunk_graph: ChunkGraph = ReferenceField('chunk_graph', ChunkGraph)
     expect_bands: List[BandType] = ListField('expect_bands', FieldTypes.tuple)
     virtual: bool = BoolField('virtual')
-    priority: int = Int32Field('priority')
+    priority: Tuple[int] = TupleField('priority', FieldTypes.int32)
     rerun_time: int = Int32Field('rerun_time')
     extra_config: dict = DictField('extra_config')
 
@@ -55,7 +55,7 @@ class Subtask(Serializable):
                  chunk_graph: ChunkGraph = None,
                  subtask_name: str = None,
                  expect_bands: List[BandType] = None,
-                 priority: int = None,
+                 priority: Tuple[int] = None,
                  virtual: bool = False,
                  rerun_time: int = 0,
                  extra_config: dict = None):

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -448,7 +448,7 @@ class SubtaskProcessorActor(mo.Actor):
         loop = asyncio.get_running_loop()
         context = ThreadedServiceContext(
             session_id, self._supervisor_address,
-            self.address, loop)
+            self.address, loop, band=self._band)
         await context.init()
         set_context(context)
 

--- a/mars/services/task/analyzer/analyzer.py
+++ b/mars/services/task/analyzer/analyzer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from collections import deque
-from typing import Dict, List, Tuple, Type
+from typing import Dict, List, Tuple, Type, Union
 
 from ....core import ChunkGraph, ChunkType, enter_mode
 from ....core.operand import Fetch, Fuse, VirtualOperand
@@ -77,8 +77,14 @@ class GraphAnalyzer:
         assert len(to_fuse_nodes_list) == len(fused_nodes)
         fuse_to_fused = dict()
         for to_fuse_nodes, fused_node in zip(to_fuse_nodes_list, fused_nodes):
+            priority = None
             for to_fuse_node in to_fuse_nodes:
+                if to_fuse_node.op.priority:
+                    assert priority is None or priority == to_fuse_node.op.priority
+                    priority = to_fuse_node.op.priority
                 fuse_to_fused[to_fuse_node] = fused_node
+            if priority:
+                fused_node.op.priority = priority
         # modify chunk_to_bands if some chunk fused
         new_chunk_to_bands = dict()
         for chunk, band in chunk_to_bands.items():
@@ -193,7 +199,7 @@ class GraphAnalyzer:
                         for inp_chunk in inp_chunks) + 1
         else:
             depth = 0
-        priority = (depth, chunk.op.priority)
+        priority = (depth, chunk.op.priority or 0)
         for out in chunk.op.outputs:
             chunk_to_priorities[out] = priority
 
@@ -216,6 +222,14 @@ class GraphAnalyzer:
             extra_config=self._extra_config)
         return subtask
 
+    @staticmethod
+    def _to_band(band_or_worker: Union[BandType, str]) -> BandType:
+        if isinstance(band_or_worker, tuple) and len(band_or_worker) == 2:
+            # band already
+            return band_or_worker
+        else:
+            return band_or_worker, 'numa-0'
+
     @enter_mode(build=True)
     def gen_subtask_graph(self) -> SubtaskGraph:
         """
@@ -227,17 +241,24 @@ class GraphAnalyzer:
             Subtask graph.
         """
         fetch_removed_chunk_graph = self._chunk_graph.copy()
+        reassign_worker_ops = []
         for chunk in self._chunk_graph:
             if isinstance(chunk.op, Fetch):
                 fetch_removed_chunk_graph.remove_node(chunk)
+            elif chunk.op.reassign_worker:
+                reassign_worker_ops.append(chunk.op)
 
         start_ops = list(self._iter_start_ops(fetch_removed_chunk_graph)) \
             if len(fetch_removed_chunk_graph) > 0 else []
 
         # assign start chunks
+        to_assign_ops = start_ops + reassign_worker_ops
         assigner = self._graph_assigner_cls(
-            fetch_removed_chunk_graph, start_ops, self._band_slots)
-        chunk_to_bands = assigner.assign()
+            fetch_removed_chunk_graph, to_assign_ops, self._band_slots)
+        # assign expect workers
+        cur_assigns = {op.key: self._to_band(op.expect_worker)
+                       for op in start_ops if op.expect_worker is not None}
+        chunk_to_bands = assigner.assign(cur_assigns=cur_assigns)
 
         # fuse node
         if self._fuse_enabled:

--- a/mars/services/task/analyzer/analyzer.py
+++ b/mars/services/task/analyzer/analyzer.py
@@ -193,12 +193,7 @@ class GraphAnalyzer:
                         for inp_chunk in inp_chunks) + 1
         else:
             depth = 0
-        if chunk.op.index_as_priority:
-            # chunk index smaller means higher priority
-            order = -chunk.index[0]
-        else:
-            order = 0
-        priority = (depth, order)
+        priority = (depth, chunk.op.priority)
         for out in chunk.op.outputs:
             chunk_to_priorities[out] = priority
 

--- a/mars/services/task/analyzer/assigner.py
+++ b/mars/services/task/analyzer/assigner.py
@@ -39,9 +39,12 @@ class AbstractGraphAssigner(ABC):
         self._band_slots = band_slots
 
     @abstractmethod
-    def assign(self) -> Dict[ChunkData, BandType]:
+    def assign(self, cur_assigns: Dict[str, str] = None) -> Dict[ChunkData, BandType]:
         """
         Assign start nodes to bands.
+
+        cur_assigns : dict
+            op already assigned.
 
         Returns
         -------
@@ -140,10 +143,12 @@ class GraphAssigner(AbstractGraphAssigner):
         initial_sizes[band] -= assigned
 
     @implements(AbstractGraphAssigner.assign)
-    def assign(self) -> Dict[ChunkData, BandType]:
+    def assign(self, cur_assigns: Dict[str, str] = None) -> Dict[ChunkData, BandType]:
         graph = self._chunk_graph
         assign_result = dict()
-        cur_assigns = dict()
+        cur_assigns = cur_assigns or dict()
+        # assigned by expect worker
+        initial_assigned_op_keys = set(cur_assigns)
 
         op_key_to_chunks = defaultdict(list)
         for chunk in graph:
@@ -151,8 +156,11 @@ class GraphAssigner(AbstractGraphAssigner):
 
         op_keys = set(self._op_keys)
         chunk_to_assign = [op_key_to_chunks[op_key][0]
-                           for op_key in op_keys]
+                           for op_key in op_keys
+                           if op_key not in cur_assigns]
         assigned_counts = defaultdict(lambda: 0)
+        for band in cur_assigns.values():
+            assigned_counts[band] += 1
 
         # calculate the number of chunks to be assigned to each band
         # given number of bands and existing assignments
@@ -173,7 +181,8 @@ class GraphAssigner(AbstractGraphAssigner):
             self._assign_by_dfs(cur, band, band_quotas, spread_ranges,
                                 op_keys, cur_assigns)
 
-        key_to_assign = {n.op.key for n in chunk_to_assign}
+        key_to_assign = \
+            {n.op.key for n in chunk_to_assign} | initial_assigned_op_keys
         for op_key, band in cur_assigns.items():
             if op_key in key_to_assign:
                 for chunk in op_key_to_chunks[op_key]:

--- a/mars/services/task/analyzer/fusion.py
+++ b/mars/services/task/analyzer/fusion.py
@@ -78,8 +78,9 @@ class Fusion:
             if isinstance(v.op, (VirtualOperand, Fetch)):  # pragma: no cover
                 # cannot fuse virtual operand or fetch
                 continue
-            if v.op.expect_worker is not None:  # pragma: no cover
-                # don't fuse operand that has explicit worker assignment
+            if v.op.scheduling_hint is not None and \
+                    not v.op.scheduling_hint.can_be_fused():  # pragma: no cover
+                # don't fuse operand that cannot be fused
                 continue
             selected = [v]
             # add successors

--- a/mars/services/task/supervisor/stage.py
+++ b/mars/services/task/supervisor/stage.py
@@ -75,7 +75,7 @@ class TaskStageProcessor:
             return
         self._submitted_subtask_ids.update(subtask.subtask_id for subtask in subtasks)
         return await self._scheduling_api.add_subtasks(
-            subtasks, [(subtask.priority,) for subtask in subtasks])
+            subtasks, [subtask.priority for subtask in subtasks])
 
     async def _update_chunks_meta(self, chunk_graph: ChunkGraph):
         get_meta = []

--- a/mars/tensor/datastore/to_hdf5.py
+++ b/mars/tensor/datastore/to_hdf5.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...core.context import get_context
+from ...oscar import ActorNotExist
 from ...serialization.serializables import FieldTypes, KeyField, \
     StringField, DictField, TupleField
 from ...lib.filesystem import open_file
@@ -183,7 +184,11 @@ class TensorHDF5DataStore(TensorDataStore):
                     container.mark_done(op.key)
         finally:
             if container:
-                container.release()
+                try:
+                    container.release()
+                except ActorNotExist:
+                    # destroyed by other execution, just ignore
+                    return
                 if container.is_done():
                     ctx.destroy_remote_object(container_name)
 

--- a/mars/typing.py
+++ b/mars/typing.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TypeVar
+from typing import Tuple, TypeVar
 
 OperandType = TypeVar('OperandType')
 TileableType = TypeVar('TileableType')
@@ -22,3 +22,5 @@ SessionType = TypeVar('SessionType')
 
 ClusterType = TypeVar('ClusterType')
 ClientType = TypeVar('ClientType')
+
+BandType = Tuple[str, str]


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Before, for op like `md.read_csv`, index is not guaranteed to be incremental, instead, each chunk's index is from 0 to length. User can add an argument `incremental_index=True` to the function to ensure it, however, this will decrease performance badly, because in that case, each chunk needs to wait for the finish of previous ones.

Now with implementation of this branch, incremental index will be guaranteed by default, and without much decreasing performance.

**This branch:**

```
In [1]: import mars

In [2]: mars.new_session(default=True)
WARNING:bokeh.server.util:Host wildcard '*' will allow connections originating from multiple (or possibly all) hostnames or IPs. Use non-wildcard values to restrict access explicitly
Out[2]: <mars.deploy.oscar.session.SyncSession at 0x7fefb91746d0>

In [3]: import mars.dataframe as md

In [5]: df = md.read_csv('Downloads/ratings.csv')

In [6]: %time df.execute()
100%|███████████████████████████████████████| 100.0/100 [00:01<00:00, 81.96it/s]
CPU times: user 309 ms, sys: 57 ms, total: 366 ms
Wall time: 1.24 s
Out[6]: 
          userId  movieId  rating   timestamp
0              1      110     1.0  1425941529
1              1      147     4.5  1425942435
2              1      858     5.0  1425941523
3              1     1221     5.0  1425941546
4              1     1246     5.0  1425941556
...          ...      ...     ...         ...
26024284  270896    58559     5.0  1257031564
26024285  270896    60069     5.0  1257032032
26024286  270896    63082     4.5  1257031764
26024287  270896    64957     4.5  1257033990
26024288  270896    71878     2.0  1257031858

[26024289 rows x 4 columns]
```

We can tell the index is right.

**Master branch:**

```
In [1]: import mars

In [2]: mars.new_session(default=True)
WARNING:bokeh.server.util:Host wildcard '*' will allow connections originating from multiple (or possibly all) hostnames or IPs. Use non-wildcard values to restrict access explicitly
Out[2]: <mars.deploy.oscar.session.SyncSession at 0x7fe6f8022520>

In [4]: import mars.dataframe as md

In [5]: df = md.read_csv('Downloads/ratings.csv')

In [6]: %time df.execute()
100%|███████████████████████████████████████| 100.0/100 [00:01<00:00, 85.20it/s]
CPU times: user 257 ms, sys: 41.6 ms, total: 298 ms
Wall time: 1.18 s
Out[6]: 
         userId  movieId  rating   timestamp
0             1      110     1.0  1425941529
1             1      147     4.5  1425942435
2             1      858     5.0  1425941523
3             1     1221     5.0  1425941546
4             1     1246     5.0  1425941556
...         ...      ...     ...         ...
1389025  270896    58559     5.0  1257031564
1389026  270896    60069     5.0  1257032032
1389027  270896    63082     4.5  1257031764
1389028  270896    64957     4.5  1257033990
1389029  270896    71878     2.0  1257031858

[26024289 rows x 4 columns]
```

Index is not incremental.

Tasks

- [x] `md.read_csv`
- [x] `md.read_sql`
- [x] `md.read_parquet`
- [x] Ensure works well when fused.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#
