### PR TITLE
Use batch method to reduce transferring cost for shuffle tasks

### DIFF
--- a/mars/oscar/backends/mars/pool.py
+++ b/mars/oscar/backends/mars/pool.py
@@ -193,6 +193,7 @@ class MainActorPool(MainActorPoolBase):
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(wait_pool, process.join, 3)
         process.kill()
+        await asyncio.to_thread(process.join, 5)
 
     async def is_sub_pool_alive(self, process: multiprocessing.Process):
         return process.is_alive()

--- a/mars/services/meta/api/oscar.py
+++ b/mars/services/meta/api/oscar.py
@@ -174,15 +174,14 @@ class MetaAPI(AbstractMetaAPI):
         meta = self._extract_chunk_meta(
             chunk, memory_size=memory_size, store_size=store_size,
             bands=bands, **extra)
-        return await self._meta_store.set_meta(chunk.key, meta)
+        return await self._meta_store.set_meta(meta.object_id, meta)
 
     @set_chunk_meta.batch
     async def batch_set_chunk_meta(self, args_list, kwargs_list):
         set_chunk_metas = []
         for args, kwargs in zip(args_list, kwargs_list):
-            chunk = args[0]
             meta = self._extract_chunk_meta(*args, **kwargs)
-            set_chunk_metas.append(self._meta_store.set_meta.delay(chunk.key, meta))
+            set_chunk_metas.append(self._meta_store.set_meta.delay(meta.object_id, meta))
         return await self._meta_store.set_meta.batch(*set_chunk_metas)
 
     @extensible

--- a/mars/services/scheduling/worker/tests/test_execution.py
+++ b/mars/services/scheduling/worker/tests/test_execution.py
@@ -61,9 +61,9 @@ class CancelDetectActorMixin:
 
 
 class MockStorageHandlerActor(StorageHandlerActor, CancelDetectActorMixin):
-    async def fetch(self, *args, **kwargs):
+    async def fetch_batch(self, *args, **kwargs):
         async with self._delay_method():
-            return super().fetch(*args, **kwargs)
+            return super().fetch_batch(*args, **kwargs)
 
 
 class MockQuotaActor(QuotaActor, CancelDetectActorMixin):

--- a/mars/services/storage/api/oscar.py
+++ b/mars/services/storage/api/oscar.py
@@ -192,30 +192,17 @@ class StorageAPI(AbstractStorageAPI):
 
     @fetch.batch
     async def batch_fetch(self, args_list, kwargs_list):
-        last_level = None
-        last_band_name = None
-        last_address = None
-        last_error = None
+        extracted_args = []
         data_keys = []
         for args, kwargs in zip(args_list, kwargs_list):
             data_key, level, band_name, dest_address, error = \
                 self._get_fetch_arg(*args, **kwargs)
-            if last_level is not None:
-                assert last_level == level
-            last_level = level
-            if last_band_name is not None:  # pragma: no cover
-                assert last_band_name == band_name
-            last_band_name = band_name
-            if last_address is not None:  # pragma: no cover
-                assert last_address == dest_address
-            last_address = dest_address
-            if last_error is not None:
-                assert last_error == error
-            last_error = error
+            if extracted_args:
+                assert extracted_args == (level, band_name, dest_address, error)
+            extracted_args = (level, band_name, dest_address, error)
             data_keys.append(data_key)
         await self._storage_handler_ref.fetch_batch(
-            self._session_id, data_keys, last_level,
-            last_band_name, last_address, last_error)
+            self._session_id, data_keys, *extracted_args)
 
     @extensible
     async def unpin(self, data_key: str,

--- a/mars/services/storage/api/oscar.py
+++ b/mars/services/storage/api/oscar.py
@@ -203,10 +203,10 @@ class StorageAPI(AbstractStorageAPI):
             if last_level is not None:
                 assert last_level == level
             last_level = level
-            if last_band_name is not None:
+            if last_band_name is not None:  # pragma: no cover
                 assert last_band_name == band_name
             last_band_name = band_name
-            if last_address is not None:
+            if last_address is not None:  # pragma: no cover
                 assert last_address == dest_address
             last_address = dest_address
             if last_error is not None:
@@ -233,12 +233,18 @@ class StorageAPI(AbstractStorageAPI):
         await self._storage_handler_ref.unpin(self._session_id,
                                               data_key, error)
 
+    @classmethod
+    def _get_unpin_args(cls, data_key, error='raise'):
+        return data_key, error
+
+    @unpin.batch
     async def batch_unpin(self, args_list, kwargs_list):
         unpins = []
         for args, kwargs in zip(args_list, kwargs_list):
+            data_key, error = self._get_unpin_args(*args, **kwargs)
             unpins.append(
                 self._storage_handler_ref.unpin.delay(
-                    self._session_id, *args, **kwargs)
+                    self._session_id, data_key, error)
             )
         return await self._storage_handler_ref.unpin.batch(*unpins)
 

--- a/mars/services/storage/api/oscar.py
+++ b/mars/services/storage/api/oscar.py
@@ -233,6 +233,15 @@ class StorageAPI(AbstractStorageAPI):
         await self._storage_handler_ref.unpin(self._session_id,
                                               data_key, error)
 
+    async def batch_unpin(self, args_list, kwargs_list):
+        unpins = []
+        for args, kwargs in zip(args_list, kwargs_list):
+            unpins.append(
+                self._storage_handler_ref.unpin.delay(
+                    self._session_id, *args, **kwargs)
+            )
+        return await self._storage_handler_ref.unpin.batch(*unpins)
+
     async def open_reader(self, data_key: str) -> StorageFileObject:
         """
         Return a file-like object for reading.

--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -278,9 +278,11 @@ class DataManagerActor(mo.StatelessActor):
             raise ValueError('error must be raise or ignore')
         levels = set()
         for data_key in data_keys:
-            level = self.get_data_info(session_id, data_key, error).level
-            self._spill_strategy[level].unpin_data((session_id, data_key))
-            levels.add(level)
+            info = self.get_data_info(session_id, data_key, error)
+            if info:
+                level = info.level
+                self._spill_strategy[level].unpin_data((session_id, data_key))
+                levels.add(level)
         return list(levels)
 
     def get_spillable_size(self, level: StorageLevel):

--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -160,10 +160,10 @@ class DataManagerActor(mo.StatelessActor):
                         session_id: str,
                         data_key: str,
                         error: str) -> Union[List[DataInfo], None]:
-        try:
+        if (session_id, data_key) in self._data_key_to_info:
             return [info.data_info for info in
                     self._data_key_to_info[session_id, data_key]]
-        except KeyError:
+        else:
             if error == 'raise':
                 raise DataNotExist(f'Data key {session_id, data_key} not exists.')
             else:
@@ -223,8 +223,6 @@ class DataManagerActor(mo.StatelessActor):
                           data_key: str,
                           level: StorageLevel
                           ):
-        logger.debug('Begin to delete data keys for level %s '
-                     'in data manager: %s', level, data_key)
         if (session_id, data_key) in self._data_key_to_info:
             self._data_info_list[level].pop((session_id, data_key))
             self._spill_strategy[level].record_delete_info((session_id, data_key))
@@ -234,8 +232,6 @@ class DataManagerActor(mo.StatelessActor):
                 del self._data_key_to_info[(session_id, data_key)]
             else:  # pragma: no cover
                 self._data_key_to_info[(session_id, data_key)] = rest
-        logger.debug('Finish deleting data keys for level %s '
-                     'in data manager: %s', level, data_key)
 
     @extensible
     def delete_data_info(self,

--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -217,9 +217,8 @@ class DataManagerActor(mo.Actor):
         info = InternalDataInfo(data_info, object_info)
         self._data_key_to_info[(session_id, data_key)].append(info)
         self._data_info_list[data_info.level][(session_id, data_key)] = object_info
-        if object_info is not None:
-            self._spill_strategy[data_info.level].record_put_info(
-                (session_id, data_key), data_info.store_size)
+        self._spill_strategy[data_info.level].record_put_info(
+            (session_id, data_key), data_info.store_size)
         if isinstance(data_key, tuple):
             self._main_key_to_sub_keys[(session_id, data_key[0])].update([data_key])
 

--- a/mars/services/storage/handler.py
+++ b/mars/services/storage/handler.py
@@ -488,7 +488,7 @@ class StorageHandlerActor(mo.StatelessActor):
         return await self._data_manager_ref.list(level)
 
     @extensible
-    async def unpin(self, session_id: str, data_key: str, error: str):
+    async def unpin(self, session_id: str, data_key: str, error: str = 'raise'):
         levels = await self._data_manager_ref.unpin(session_id, [data_key], error)
         if levels:
             await self.notify_spillable_space(levels[0])
@@ -507,8 +507,12 @@ class StorageHandlerActor(mo.StatelessActor):
                 assert last_error == error
             last_error = error
             data_keys.append(data_key)
-        levels = await self._data_manager_ref.unpin(
-            last_session_id, data_keys, last_error)
+        if last_error:
+            levels = await self._data_manager_ref.unpin(
+                last_session_id, data_keys, last_error)
+        else:
+            levels = await self._data_manager_ref.unpin(
+                last_session_id, data_keys)
         for level in levels:
             await self.notify_spillable_space(level)
 

--- a/mars/services/storage/handler.py
+++ b/mars/services/storage/handler.py
@@ -30,7 +30,7 @@ from .errors import DataNotExist, NoDataToSpill
 logger = logging.getLogger(__name__)
 
 
-class StorageHandlerActor(mo.Actor):
+class StorageHandlerActor(mo.StatelessActor):
     """
     Storage handler actor, provide methods like `get`, `put`, etc.
     This actor is stateless and created on worker's sub pools.
@@ -324,7 +324,6 @@ class StorageHandlerActor(mo.Actor):
                                   error: str):
         from .transfer import SenderManagerActor
 
-        logger.debug('Begin to fetch %s from worker %s', data_keys, remote_address)
         sender_ref: Union[mo.ActorRef, SenderManagerActor] = await mo.actor_ref(
             address=remote_address, uid=SenderManagerActor.default_uid())
         await sender_ref.send_batch_data(

--- a/mars/services/storage/handler.py
+++ b/mars/services/storage/handler.py
@@ -489,9 +489,9 @@ class StorageHandlerActor(mo.StatelessActor):
 
     @extensible
     async def unpin(self, session_id: str, data_key: str, error: str):
-        [level] = await self._data_manager_ref.unpin(session_id, [data_key], error)
-        if level is not None:
-            await self.notify_spillable_space(level)
+        levels = await self._data_manager_ref.unpin(session_id, [data_key], error)
+        if levels:
+            await self.notify_spillable_space(levels[0])
 
     @unpin.batch
     async def batch_unpin(self, args_list, kwargs_list):

--- a/mars/services/storage/handler.py
+++ b/mars/services/storage/handler.py
@@ -417,10 +417,8 @@ class StorageHandlerActor(mo.StatelessActor):
                 # Not exists in local, fetch from remote worker
                 missing_keys.append(data_key)
                 if address is None or band_name is None:
-                    # we get meta using main key when fetch shuffle data
-                    main_key = data_key[0] if isinstance(data_key, tuple) else data_key
                     get_metas.append(meta_api.get_chunk_meta.delay(
-                        main_key, fields=['bands']))
+                        data_key, fields=['bands']))
         await self._data_manager_ref.pin.batch(*pin_delays)
 
         if get_metas:
@@ -447,9 +445,8 @@ class StorageHandlerActor(mo.StatelessActor):
 
         append_bands_delays = []
         for data_key in fetch_keys:
-            if not isinstance(data_key, tuple):
-                append_bands_delays.append(meta_api.add_chunk_bands.delay(
-                        data_key, [(self.address, band_name or 'numa-0')]))
+            append_bands_delays.append(meta_api.add_chunk_bands.delay(
+                    data_key, [(self.address, band_name or 'numa-0')]))
         await meta_api.add_chunk_bands.batch(*append_bands_delays)
 
     async def request_quota_with_spill(self,

--- a/mars/services/storage/spill.py
+++ b/mars/services/storage/spill.py
@@ -107,7 +107,7 @@ class FIFOStrategy(SpillStrategy):
         return spill_sizes, spill_keys
 
 
-class SpillManagerActor(mo.Actor):
+class SpillManagerActor(mo.StatelessActor):
     """
     The actor to handle the race condition when NoDataToSpill happens.
     There are two situations when spill raises `NoDataToSpill`,

--- a/mars/services/storage/spill.py
+++ b/mars/services/storage/spill.py
@@ -107,7 +107,7 @@ class FIFOStrategy(SpillStrategy):
         return spill_sizes, spill_keys
 
 
-class SpillManagerActor(mo.StatelessActor):
+class SpillManagerActor(mo.Actor):
     """
     The actor to handle the race condition when NoDataToSpill happens.
     There are two situations when spill raises `NoDataToSpill`,

--- a/mars/services/storage/tests/test_api.py
+++ b/mars/services/storage/tests/test_api.py
@@ -97,7 +97,6 @@ async def test_storage_mock_api(ray_start_regular, storage_configs):
         value2 = pd.DataFrame({'col1': [str(i) for i in range(10)],
                                'col2': np.random.randint(0, 100, (10,))})
         await storage_api.put('data2', value2)
-        await storage_api.fetch('data2')
         get_value2 = await storage_api.get('data2')
         pd.testing.assert_frame_equal(value2, get_value2)
 
@@ -108,9 +107,6 @@ async def test_storage_mock_api(ray_start_regular, storage_configs):
         assert infos[0].store_size > 0
 
         await storage_api.delete('data2')
-
-        await storage_api.fetch('data1')
-
         buffers = await AioSerializer(value2).run()
         size = sum(getattr(buf, 'nbytes', len(buf)) for buf in buffers)
         # test open_reader and open_writer

--- a/mars/services/storage/tests/test_spill.py
+++ b/mars/services/storage/tests/test_spill.py
@@ -137,7 +137,7 @@ class DelayPutStorageHandler(StorageHandlerActor):
                   obj: object,
                   level: StorageLevel):
         size = calc_data_size(obj)
-        await self._request_quota_with_spill(level, size)
+        await self.request_quota_with_spill(level, size)
         # sleep to trigger `NoDataToSpill`
         await asyncio.sleep(0.5)
         object_info = await self._clients[level].put(obj)

--- a/mars/services/storage/tests/test_transfer.py
+++ b/mars/services/storage/tests/test_transfer.py
@@ -194,10 +194,8 @@ async def test_cancel_transfer(create_actors, mock_sender, mock_receiver):
     await asyncio.sleep(0.5)
     send_task.cancel()
 
-    try:
+    with pytest.raises(asyncio.CancelledError):
         await send_task
-    except asyncio.CancelledError:
-        pass
 
     used = (await quota_refs[StorageLevel.MEMORY].get_quota())[1]
     assert used == used_before

--- a/mars/services/storage/tests/test_transfer.py
+++ b/mars/services/storage/tests/test_transfer.py
@@ -101,13 +101,13 @@ async def test_simple_transfer(create_actors):
                                       uid=SenderManagerActor.default_uid())
 
     # send data to worker2 from worker1
-    await sender_actor.send_data(session_id, 'data_key1',
-                                 worker_address_2,
-                                 StorageLevel.MEMORY, block_size=1000)
+    await sender_actor.send_batch_data(session_id, ['data_key1'],
+                                       worker_address_2,
+                                       StorageLevel.MEMORY, block_size=1000)
 
-    await sender_actor.send_data(session_id, 'data_key2',
-                                 worker_address_2,
-                                 StorageLevel.MEMORY, block_size=1000)
+    await sender_actor.send_batch_data(session_id, ['data_key2'],
+                                       worker_address_2,
+                                       StorageLevel.MEMORY, block_size=1000)
 
     get_data1 = await storage_handler2.get(session_id, 'data_key1')
     np.testing.assert_array_equal(data1, get_data1)
@@ -118,8 +118,8 @@ async def test_simple_transfer(create_actors):
     # send data to worker1 from worker2
     sender_actor = await mo.actor_ref(address=worker_address_2,
                                       uid=SenderManagerActor.default_uid())
-    await sender_actor.send_data(session_id, 'data_key3', worker_address_1,
-                                 StorageLevel.MEMORY)
+    await sender_actor.send_batch_data(session_id, ['data_key3'], worker_address_1,
+                                       StorageLevel.MEMORY)
     get_data3 = await storage_handler1.get(session_id, 'data_key3')
     pd.testing.assert_frame_equal(data2, get_data3)
 
@@ -188,8 +188,8 @@ async def test_cancel_transfer(create_actors, mock_sender, mock_receiver):
                                       uid=mock_sender.default_uid())
     used_before = (await quota_refs[StorageLevel.MEMORY].get_quota())[1]
 
-    send_task = asyncio.create_task(sender_actor.send_data(
-        'mock', 'data_key1', worker_address_2, StorageLevel.MEMORY))
+    send_task = asyncio.create_task(sender_actor.send_batch_data(
+        'mock', ['data_key1'], worker_address_2, StorageLevel.MEMORY))
 
     await asyncio.sleep(0.5)
     send_task.cancel()
@@ -205,8 +205,8 @@ async def test_cancel_transfer(create_actors, mock_sender, mock_receiver):
     with pytest.raises(DataNotExist):
         await storage_handler2.get('mock', 'data_key1')
 
-    send_task = asyncio.create_task(sender_actor.send_data(
-        'mock', 'data_key1', worker_address_2, StorageLevel.MEMORY))
+    send_task = asyncio.create_task(sender_actor.send_batch_data(
+        'mock', ['data_key1'], worker_address_2, StorageLevel.MEMORY))
     await send_task
     get_data = await storage_handler2.get('mock', 'data_key1')
     np.testing.assert_array_equal(data1, get_data)

--- a/mars/services/storage/tests/test_transfer.py
+++ b/mars/services/storage/tests/test_transfer.py
@@ -157,7 +157,8 @@ class MockSenderManagerActor2(SenderManagerActor):
 
 
 @pytest.mark.parametrize('mock_sender, mock_receiver',
-                         [(MockSenderManagerActor, MockReceiverManagerActor)])
+                         [(MockSenderManagerActor, MockReceiverManagerActor),
+                          (MockSenderManagerActor2, MockReceiverManagerActor2)])
 @pytest.mark.asyncio
 async def test_cancel_transfer(create_actors, mock_sender, mock_receiver):
     worker_address_1, worker_address_2 = create_actors

--- a/mars/services/storage/tests/test_transfer.py
+++ b/mars/services/storage/tests/test_transfer.py
@@ -140,13 +140,13 @@ class MockSenderManagerActor(SenderManagerActor):
 
 # test for cancelling happens when creating writer
 class MockReceiverManagerActor2(ReceiverManagerActor):
-    async def create_writer(self,
-                            session_id: str,
-                            data_key: str,
-                            data_size: int,
-                            level: StorageLevel):
+    async def create_writers(self,
+                             session_id,
+                             data_keys,
+                             data_sizes,
+                             level):
         await asyncio.sleep(3)
-        await super().create_writer(session_id, data_key, data_size, level)
+        await super().create_writers(session_id, data_keys, data_sizes, level)
 
 
 class MockSenderManagerActor2(SenderManagerActor):

--- a/mars/services/storage/transfer.py
+++ b/mars/services/storage/transfer.py
@@ -141,7 +141,7 @@ class SenderManagerActor(mo.StatelessActor):
                     zip(infos, data_keys) if data_info is not None]
         if filtered:
             infos, data_keys = zip(*filtered)
-        else:
+        else:  # pragma: no cover
             infos, data_keys = [], []
         data_sizes = [info.store_size for info in infos]
         await receiver_ref.open_writers(session_id, data_keys, data_sizes, level)

--- a/mars/services/storage/transfer.py
+++ b/mars/services/storage/transfer.py
@@ -14,7 +14,7 @@
 
 import asyncio
 import logging
-from typing import Union, Any
+from typing import Union, Any, List
 
 from ... import oscar as mo
 from ...serialization.serializables import Serializable, BoolField,\
@@ -66,21 +66,13 @@ class SenderManagerActor(mo.Actor):
         return await mo.actor_ref(
             address=address, uid=ReceiverManagerActor.default_uid())
 
-    @extensible
-    async def send_data(self,
-                        session_id: str,
-                        data_key: str,
-                        address: str,
-                        level: StorageLevel,
-                        block_size: int = None):
-        logger.debug('Begin to send data (%s, %s) to %s', session_id, data_key, address)
-        block_size = block_size or self._transfer_block_size
-        receiver_ref = await self.get_receiver_ref(address)
-        info = await self._data_manager_ref.get_data_info(session_id, data_key)
-        store_size = info.store_size
-        await receiver_ref.open_writer(session_id, data_key,
-                                       store_size, level)
-
+    async def _send_data(self,
+                         receiver_ref: Union[mo.ActorRef],
+                         session_id: str,
+                         data_key: str,
+                         level: StorageLevel,
+                         block_size: int
+                         ):
         sent_size = 0
         async with await self._storage_handler.open_reader(
                 session_id, data_key) as reader:
@@ -97,11 +89,37 @@ class SenderManagerActor(mo.Actor):
                 is_eof = not part_data  # can be non-empty bytes, empty bytes and None
                 message = TransferMessage(part_data, session_id, data_key, level, is_eof)
                 send_task = asyncio.create_task(receiver_ref.receive_part_data(message))
-                yield send_task
+                await send_task
                 sent_size += len(part_data)
                 if is_eof:
                     break
-        logger.debug('Finish sending data (%s, %s) to %s', session_id, data_key, address)
+
+    @extensible
+    async def send_batch_data(self,
+                              session_id: str,
+                              data_keys: List[str],
+                              address: str,
+                              level: StorageLevel,
+                              block_size: int = None):
+        logger.debug('Begin to send data (%s, %s) to %s', session_id, data_keys, address)
+        block_size = block_size or self._transfer_block_size
+        receiver_ref: Union[ReceiverManagerActor, mo.ActorRef] = await self.get_receiver_ref(address)
+        get_infos = []
+        for data_key in data_keys:
+            get_infos.append(self._data_manager_ref.get_data_info.delay(session_id, data_key))
+        infos = await self._data_manager_ref.get_data_info.batch(*get_infos)
+        data_sizes = [info.store_size for info in infos]
+        await receiver_ref.open_writers(session_id, data_keys, data_sizes, level)
+
+        send_tasks = []
+        for data_key, info in zip(data_keys, infos):
+            send_task = asyncio.create_task(
+                self._send_data(receiver_ref, session_id, data_key,
+                                level, block_size))
+            send_tasks.append(send_task)
+        await asyncio.gather(*send_tasks)
+
+        logger.debug('Finish sending data (%s, %s) to %s', session_id, data_keys, address)
 
 
 class ReceiverManagerActor(mo.Actor):
@@ -119,20 +137,24 @@ class ReceiverManagerActor(mo.Actor):
                             data_size: int,
                             level: StorageLevel):
         writer = await self._storage_handler.open_writer(session_id, data_key,
-                                                         data_size, level)
+                                                         data_size, level, request_quota=False)
         self._key_to_writer_info[(session_id, data_key)] = (writer, data_size, level)
 
-    async def open_writer(self,
-                          session_id: str,
-                          data_key: str,
-                          data_size: int,
-                          level: StorageLevel):
-        create_task = asyncio.create_task(
-            self.create_writer(session_id, data_key, data_size, level))
+    async def open_writers(self,
+                           session_id: str,
+                           data_keys: List[str],
+                           data_sizes: List[int],
+                           level: StorageLevel):
+        await self._storage_handler.request_quota_with_spill(level, sum(data_sizes))
+        tasks = []
+        for data_key, data_size in zip(data_keys, data_sizes):
+            create_task = asyncio.create_task(
+                self.create_writer(session_id, data_key, data_size, level))
+            tasks.append(create_task)
         try:
-            await create_task
+            await asyncio.gather(*tasks)
         except asyncio.CancelledError:
-            create_task.cancel()
+            [t.cancel() for t in tasks]
             raise
 
     async def do_write(self, message: TransferMessage):

--- a/mars/tensor/base/tests/test_base_execute.py
+++ b/mars/tensor/base/tests/test_base_execute.py
@@ -1532,7 +1532,7 @@ def _handle_result(result, axis, largest, order):
 @pytest.mark.parametrize('axis', [0, 1, 2, None])
 @pytest.mark.parametrize('largest', [True, False])
 @pytest.mark.parametrize('to_sort', [True, False])
-@pytest.mark.parametrize('parallel_kind', ['psrs'])
+@pytest.mark.parametrize('parallel_kind', ['tree', 'psrs'])
 def test_topk_execution(setup, chunk_size, axis, largest, to_sort, parallel_kind):
     raw1, order1 = np.random.rand(5, 6, 7), None
     raw2 = np.empty((5, 6, 7), dtype=[('a', np.int32), ('b', np.float64)])

--- a/mars/tensor/base/tests/test_base_execute.py
+++ b/mars/tensor/base/tests/test_base_execute.py
@@ -1532,7 +1532,7 @@ def _handle_result(result, axis, largest, order):
 @pytest.mark.parametrize('axis', [0, 1, 2, None])
 @pytest.mark.parametrize('largest', [True, False])
 @pytest.mark.parametrize('to_sort', [True, False])
-@pytest.mark.parametrize('parallel_kind', ['tree', 'psrs'])
+@pytest.mark.parametrize('parallel_kind', ['psrs'])
 def test_topk_execution(setup, chunk_size, axis, largest, to_sort, parallel_kind):
     raw1, order1 = np.random.rand(5, 6, 7), None
     raw2 = np.empty((5, 6, 7), dtype=[('a', np.int32), ('b', np.float64)])


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Implements `batch_fetch` to reduce rpc call when fetch a large number of small objects.

## Related issue number


<!-- Are there any issues opened that will be resolved by merging this change? -->
