### PR TITLE
Record mapper meta for shuffle task

### DIFF
--- a/mars/services/meta/api/oscar.py
+++ b/mars/services/meta/api/oscar.py
@@ -150,6 +150,7 @@ class MetaAPI(AbstractMetaAPI):
             # fuse op
             chunk = chunk.chunk
         params = chunk.params.copy()
+        chunk_key = extra.pop('chunk_key', chunk.key)
         if isinstance(chunk, (DATAFRAME_CHUNK_TYPE, DATAFRAME_GROUPBY_CHUNK_TYPE,
                               SERIES_GROUPBY_CHUNK_TYPE)):
             # dataframe chunk needs some special process for now
@@ -157,7 +158,7 @@ class MetaAPI(AbstractMetaAPI):
             params.pop('dtypes', None)
             params.pop('key_dtypes', None)
         params.update(extra)
-        return get_meta_type(type(chunk))(object_id=chunk.key,
+        return get_meta_type(type(chunk))(object_id=chunk_key,
                                           **params,
                                           bands=bands,
                                           memory_size=memory_size,

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -16,7 +16,6 @@ import asyncio
 import logging
 import sys
 from collections import defaultdict
-from itertools import chain
 from typing import Any, Dict, List, Optional, Type
 
 from .... import oscar as mo
@@ -237,7 +236,7 @@ class SubtaskProcessor:
                          if not isinstance(c.op, VirtualOperand)]
 
         # store data into storage
-        data_key_to_puts = defaultdict(list)
+        puts = []
         stored_keys = []
         for result_chunk in result_chunks:
             data_key = result_chunk.key
@@ -250,7 +249,7 @@ class SubtaskProcessor:
                     result_chunk.params = result_chunk.get_params_from_data(result_data)
 
                 put = self._storage_api.put.delay(data_key, result_data)
-                data_key_to_puts[data_key].append(put)
+                puts.append(put)
             else:
                 assert isinstance(result_chunk.op, MapReduceOperand)
                 keys = [store_key for store_key in self._datastore
@@ -259,22 +258,18 @@ class SubtaskProcessor:
                     stored_keys.append(key)
                     result_data = self._datastore[key]
                     put = self._storage_api.put.delay(key, result_data)
-                    data_key_to_puts[data_key].append(put)
+                    puts.append(put)
         logger.debug('Start putting data keys: %s, '
                      'subtask id: %s', stored_keys, self.subtask.subtask_id)
-        puts = list(chain(*data_key_to_puts.values()))
-        data_key_to_store_size = defaultdict(lambda: 0)
-        data_key_to_memory_size = defaultdict(lambda: 0)
+        data_key_to_store_size = dict()
+        data_key_to_memory_size = dict()
         if puts:
             put_infos = asyncio.create_task(self._storage_api.put.batch(*puts))
             try:
                 store_infos = await put_infos
-                store_infos_iter = iter(store_infos)
-                for data_key, puts in data_key_to_puts.items():
-                    for _ in puts:
-                        store_info = next(store_infos_iter)
-                        data_key_to_store_size[data_key] += store_info.store_size
-                        data_key_to_memory_size[data_key] += store_info.memory_size
+                for store_key, store_info in zip(stored_keys, store_infos):
+                    data_key_to_store_size[store_key] = store_info.store_size
+                    data_key_to_memory_size[store_key] = store_info.memory_size
                 logger.debug('Finish putting data keys: %s, '
                              'subtask id: %s', stored_keys, self.subtask.subtask_id)
             except asyncio.CancelledError:
@@ -296,17 +291,30 @@ class SubtaskProcessor:
                           stored_keys: List,
                           data_key_to_store_size: Dict,
                           data_key_to_memory_size: Dict):
+        key_to_result_chunk = {c.key: c for c in chunk_graph.result_chunks}
         # store meta
         set_chunk_metas = []
-        memory_sizes = []
-        for result_chunk in chunk_graph.result_chunks:
-            store_size = data_key_to_store_size[result_chunk.key]
-            memory_size = data_key_to_memory_size[result_chunk.key]
-            memory_sizes.append(memory_size)
+        result_data_size = 0
+        for chunk_key in stored_keys:
+            if isinstance(chunk_key, tuple):
+                result_chunk = key_to_result_chunk[chunk_key[0]]
+            else:
+                result_chunk = key_to_result_chunk[chunk_key]
+            store_size = data_key_to_store_size[chunk_key]
+            memory_size = data_key_to_memory_size[chunk_key]
+            result_data_size += memory_size
             set_chunk_metas.append(
                 self._meta_api.set_chunk_meta.delay(
                     result_chunk, memory_size=memory_size,
-                    store_size=store_size, bands=[self._band]))
+                    store_size=store_size, bands=[self._band],
+                    chunk_key=chunk_key))
+        for chunk in chunk_graph.result_chunks:
+            if chunk.key not in data_key_to_store_size:
+                # mapper, set meta, so that storage can make sure
+                # this operand is executed, some sub key is absent
+                # due to it's empty actually
+                set_chunk_metas.append(self._meta_api.set_chunk_meta.delay(
+                    chunk, memory_size=0, store_size=0, bands=[self._band]))
         logger.debug('Start storing chunk metas for data keys: %s, '
                      'subtask id: %s', stored_keys, self.subtask.subtask_id)
         if set_chunk_metas:
@@ -332,7 +340,7 @@ class SubtaskProcessor:
                              'subtask id: %s', stored_keys, self.subtask.subtask_id)
                 raise
         # set result data size
-        self.result.data_size = sum(memory_sizes)
+        self.result.data_size = result_data_size
 
     async def done(self):
         if self.result.status == SubtaskStatus.running:

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -481,7 +481,8 @@ class TaskProcessorActor(mo.Actor):
                 # for reducer chunk, decref mapper chunks
                 if isinstance(result_chunk.op, ShuffleProxy):
                     for chunk in subtask.chunk_graph:
-                        if isinstance(chunk.op, MapReduceOperand):
+                        if isinstance(chunk.op, MapReduceOperand) and \
+                                chunk.op.stage == OperandStage.reduce:
                             data_keys = chunk.op.get_dependent_data_keys()
                             decref_chunk_keys.extend(data_keys)
                             # decref main key as well

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -23,7 +23,7 @@ from typing import Callable, Coroutine, Dict, Iterator, \
 from .... import oscar as mo
 from ....config import Config
 from ....core import ChunkGraph, TileableGraph
-from ....core.operand import Fetch, MapReduceOperand, ShuffleProxy
+from ....core.operand import Fetch, MapReduceOperand, ShuffleProxy, OperandStage
 from ....optimization.logical import OptimizationRecords
 from ....typing import TileableType, BandType
 from ....utils import build_fetch, extensible
@@ -155,12 +155,16 @@ class TaskProcessor:
             n = subtask_graph.count_successors(subtask)
             for c in subtask.chunk_graph.results:
                 incref_chunk_keys.extend([c.key] * n)
-                # for shuffle reducer, incref its mapper chunk
-                for pre_graph in subtask_graph.predecessors(subtask):
-                    for chk in pre_graph.chunk_graph.results:
-                        if isinstance(chk.op, ShuffleProxy):
-                            incref_chunk_keys.extend(
-                                [map_chunk.key for map_chunk in chk.inputs])
+            # process reducer, since mapper will generate sub keys
+            # we incref (main_key, sub_key) for reducer
+            for chunk in subtask.chunk_graph:
+                if isinstance(chunk.op, MapReduceOperand) and \
+                        chunk.op.stage == OperandStage.reduce:
+                    # reducer
+                    data_keys = chunk.op.get_dependent_data_keys()
+                    incref_chunk_keys.extend(data_keys)
+                    # main key incref as well, to ensure existence of mata
+                    incref_chunk_keys.extend([key[0] for key in data_keys])
         result_chunks = stage_processor.chunk_graph.result_chunks
         incref_chunk_keys.extend([c.key for c in result_chunks])
         await self._lifecycle_api.incref_chunks(incref_chunk_keys)
@@ -168,7 +172,7 @@ class TaskProcessor:
     @classmethod
     def _get_decref_stage_chunk_keys(cls,
                                      stage_processor: "TaskStageProcessor") -> List[str]:
-        decref_chunks = []
+        decref_chunk_keys = []
         error_or_cancelled = stage_processor.error_or_cancelled()
         if stage_processor.subtask_graph:
             subtask_graph = stage_processor.subtask_graph
@@ -179,10 +183,21 @@ class TaskProcessor:
                         continue
                     # if subtask not executed, rollback incref of predecessors
                     for inp_subtask in subtask_graph.predecessors(subtask):
-                        decref_chunks.extend(inp_subtask.chunk_graph.results)
+                        for result_chunk in inp_subtask.chunk_graph.results:
+                            # for reducer chunk, decref mapper chunks
+                            if isinstance(result_chunk.op, ShuffleProxy):
+                                for chunk in subtask.chunk_graph:
+                                    if isinstance(chunk.op, MapReduceOperand):
+                                        data_keys = chunk.op.get_dependent_data_keys()
+                                        decref_chunk_keys.extend(data_keys)
+                                        decref_chunk_keys.extend(
+                                            [key[0] for key in data_keys])
+                        decref_chunk_keys.extend(
+                            [c.key for c in inp_subtask.chunk_graph.results])
             # decref result of chunk graphs
-            decref_chunks.extend(stage_processor.chunk_graph.results)
-        return [c.key for c in decref_chunks]
+            decref_chunk_keys.extend(
+                [c.key for c in stage_processor.chunk_graph.results])
+        return decref_chunk_keys
 
     @extensible
     @_record_error
@@ -460,16 +475,19 @@ class TaskProcessorActor(mo.Actor):
     async def _decref_input_subtasks(self,
                                      subtask: Subtask,
                                      subtask_graph: SubtaskGraph):
-        decref_chunks = []
+        decref_chunk_keys = []
         for in_subtask in subtask_graph.iter_predecessors(subtask):
             for result_chunk in in_subtask.chunk_graph.results:
                 # for reducer chunk, decref mapper chunks
                 if isinstance(result_chunk.op, ShuffleProxy):
-                    outputs_num = len([r for r in subtask.chunk_graph.results
-                                       if isinstance(r.op, MapReduceOperand)])
-                    decref_chunks.extend(result_chunk.inputs * outputs_num)
-                decref_chunks.append(result_chunk)
-        await self._lifecycle_api.decref_chunks([c.key for c in decref_chunks])
+                    for chunk in subtask.chunk_graph:
+                        if isinstance(chunk.op, MapReduceOperand):
+                            data_keys = chunk.op.get_dependent_data_keys()
+                            decref_chunk_keys.extend(data_keys)
+                            # decref main key as well
+                            decref_chunk_keys.extend([key[0] for key in data_keys])
+                decref_chunk_keys.append(result_chunk.key)
+        await self._lifecycle_api.decref_chunks(decref_chunk_keys)
 
     async def set_subtask_result(self, subtask_result: SubtaskResult):
         stage_processor = self._cur_processor.cur_stage_processor


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Subtask that contains mapper operand will generate multiple data whose key is consist of main and sub keys, before, only main key is recorded in meta, this will cause potential data leak, what's more, when auto scaling triggered, the data will be not aware of, so data may be lost. This PR tries to record their meta.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
