### PR TITLE
Support data dependency for `run_script`

### DIFF
--- a/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
@@ -26,12 +26,8 @@ from mars.dataframe import to_datetime
 from mars.dataframe.datasource.dataframe import from_pandas
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
 from mars.dataframe.arithmetic.tests.test_arithmetic import comp_func
-from mars.tests import setup
 from mars.tensor.datasource import array as from_array
 from mars.utils import dataslots
-
-
-setup = setup
 
 
 @dataslots

--- a/mars/dataframe/arithmetic/tests/test_comparison.py
+++ b/mars/dataframe/arithmetic/tests/test_comparison.py
@@ -21,10 +21,6 @@ import pytest
 
 from mars.core import enter_mode
 from mars.dataframe.initializer import DataFrame
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_comp(setup):

--- a/mars/dataframe/arithmetic/tests/test_dot.py
+++ b/mars/dataframe/arithmetic/tests/test_dot.py
@@ -17,10 +17,6 @@ import pandas as pd
 import pytest
 
 from mars.dataframe import DataFrame, Series
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_dot_execution(setup):

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -31,14 +31,10 @@ from mars.dataframe.datasource.dataframe import from_pandas as from_pandas_df
 from mars.dataframe.datasource.series import from_pandas as from_pandas_series
 from mars.dataframe.datasource.index import from_pandas as from_pandas_index
 from mars.tensor import tensor
-from mars.tests import setup
 from mars.tests.core import require_cudf
 from mars.utils import lazy_import
 
 cudf = lazy_import('cudf', globals=globals())
-
-
-setup = setup
 
 
 @require_cudf

--- a/mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -39,12 +39,8 @@ from mars.dataframe.datasource.series import from_pandas as from_pandas_series
 from mars.dataframe.datasource.index import from_pandas as from_pandas_index, from_tileable
 from mars.dataframe.datasource.from_tensor import dataframe_from_tensor, dataframe_from_1d_tileables
 from mars.dataframe.datasource.from_records import from_records
-from mars.tests import setup
 from mars.tests.core import require_cudf
 from mars.utils import arrow_array_to_objects
-
-
-setup = setup
 
 
 def test_from_pandas_dataframe_execution(setup):

--- a/mars/dataframe/datasource/tests/test_datasource_hdfs.py
+++ b/mars/dataframe/datasource/tests/test_datasource_hdfs.py
@@ -20,12 +20,10 @@ import numpy as np
 import pytest
 
 import mars.dataframe as md
-from mars.tests import setup
 from mars.tests.core import require_hadoop
 
 
 TEST_DIR = '/tmp/test'
-setup = setup
 
 
 @require_hadoop

--- a/mars/dataframe/datastore/tests/test_datastore_execute.py
+++ b/mars/dataframe/datastore/tests/test_datastore_execute.py
@@ -37,12 +37,6 @@ except ImportError:
 
 import mars.dataframe as md
 from mars.dataframe import DataFrame
-from mars.tests import setup
-
-_exec_timeout = 120 if 'CI' in os.environ else -1
-
-
-setup = setup
 
 
 def test_to_csv_execution(setup):

--- a/mars/dataframe/datastore/tests/test_datastore_hdfs.py
+++ b/mars/dataframe/datastore/tests/test_datastore_hdfs.py
@@ -17,12 +17,10 @@ import numpy as np
 import pytest
 
 import mars.dataframe as md
-from mars.tests import setup
 from mars.tests.core import require_hadoop
 
 
 TEST_DIR = '/tmp/test'
-setup = setup
 
 
 @require_hadoop

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -26,12 +26,8 @@ except ImportError:  # pragma: no cover
 import mars.dataframe as md
 from mars.core.operand import OperandStage
 from mars.dataframe.groupby.aggregation import DataFrameGroupByAgg
-from mars.tests import setup
 from mars.tests.core import assert_groupby_equal, require_cudf
 from mars.utils import arrow_array_to_objects
-
-
-setup = setup
 
 
 class MockReduction1(md.CustomReduction):

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -32,10 +32,6 @@ import mars.tensor as mt
 from mars.dataframe.datasource.read_csv import DataFrameReadCSV
 from mars.dataframe.datasource.read_sql import DataFrameReadSQL
 from mars.dataframe.datasource.read_parquet import DataFrameReadParquet
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.mark.parametrize('chunk_size', [2, (2, 3)])

--- a/mars/dataframe/merge/tests/test_merge_execution.py
+++ b/mars/dataframe/merge/tests/test_merge_execution.py
@@ -19,10 +19,6 @@ from mars.dataframe.datasource.dataframe import from_pandas
 from mars.dataframe.datasource.series import from_pandas as series_from_pandas
 from mars.dataframe.merge import concat
 from mars.dataframe.utils import sort_dataframe_inplace
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_merge(setup):

--- a/mars/dataframe/missing/tests/test_missing_execute.py
+++ b/mars/dataframe/missing/tests/test_missing_execute.py
@@ -24,10 +24,6 @@ except ImportError:  # pragma: no cover
     pa = None
 
 import mars.dataframe as md
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_check_na_execution(setup):

--- a/mars/dataframe/plotting/tests/test_plot.py
+++ b/mars/dataframe/plotting/tests/test_plot.py
@@ -25,10 +25,6 @@ except ImportError:  # pragma: no cover
 
 from mars import tensor as mt
 from mars import dataframe as md
-from mars.tests import setup
-
-
-setup = setup
 
 
 def close(fignum=None):  # pragma: no cover

--- a/mars/dataframe/reduction/tests/test_reduction_execute.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execute.py
@@ -28,15 +28,11 @@ from mars.dataframe import CustomReduction, NamedAgg
 from mars.dataframe.base import to_gpu
 from mars.deploy.oscar.session import get_default_session
 from mars.lib.version import parse as parse_version
-from mars.tests import setup
 from mars.tests.core import require_cudf, require_cupy
 from mars.utils import lazy_import
 
 cp = lazy_import('cupy', rename='cp', globals=globals())
 _agg_size_as_series = parse_version(pd.__version__) >= parse_version('1.3.0')
-
-
-setup = setup
 
 
 @pytest.fixture

--- a/mars/dataframe/sort/tests/test_sort_execute.py
+++ b/mars/dataframe/sort/tests/test_sort_execute.py
@@ -20,11 +20,7 @@ import pandas as pd
 import pytest
 
 from mars.dataframe import DataFrame, Series, ArrowStringDtype
-from mars.tests import setup
 from mars.tests.core import require_cudf
-
-
-setup = setup
 
 
 @pytest.mark.parametrize(

--- a/mars/dataframe/statistics/tests/test_statistics_execute.py
+++ b/mars/dataframe/statistics/tests/test_statistics_execute.py
@@ -18,10 +18,6 @@ import pytest
 
 from mars.dataframe import Series, DataFrame
 from mars.tensor import tensor
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_series_quantile_execution(setup):

--- a/mars/dataframe/tests/test_core.py
+++ b/mars/dataframe/tests/test_core.py
@@ -20,9 +20,6 @@ from mars.core import tile
 from mars.dataframe import cut
 from mars.dataframe.initializer import DataFrame, Series, Index
 from mars.lib.groupby_wrapper import wrapped_groupby
-from mars.tests import setup
-
-setup = setup
 
 
 def test_dataframe_params():

--- a/mars/dataframe/tests/test_initializer.py
+++ b/mars/dataframe/tests/test_initializer.py
@@ -17,10 +17,6 @@ import pandas as pd
 
 import mars.dataframe as md
 import mars.tensor as mt
-from mars.tests import setup
-
-
-setup = setup
 
     
 def test_dataframe_initializer(setup):

--- a/mars/dataframe/tests/test_utils.py
+++ b/mars/dataframe/tests/test_utils.py
@@ -29,11 +29,7 @@ from mars.dataframe.utils import decide_dataframe_chunk_sizes, \
     build_split_idx_to_origin_idx, parse_index, filter_index_value, \
     infer_dtypes, infer_index_value, validate_axis, fetch_corner_data, \
     make_dtypes, build_concatenated_rows_frame, merge_index_value
-from mars.tests import setup
 from mars.utils import Timer
-
-
-setup = setup
 
     
 def test_decide_dataframe_chunks():

--- a/mars/dataframe/tseries/tests/test_tseries_execution.py
+++ b/mars/dataframe/tseries/tests/test_tseries_execution.py
@@ -16,9 +16,6 @@ import pandas as pd
 
 from mars.dataframe import to_datetime, Series, DataFrame, Index
 from mars.tensor import tensor
-from mars.tests import setup
-
-setup = setup
 
 
 def test_to_datetime_execution(setup):

--- a/mars/dataframe/window/ewm/tests/test_ewm_execute.py
+++ b/mars/dataframe/window/ewm/tests/test_ewm_execute.py
@@ -18,10 +18,6 @@ import numpy as np
 import pandas as pd
 
 from mars import dataframe as md
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_dataframe_ewm_agg(setup):

--- a/mars/dataframe/window/expanding/tests/test_expanding_execute.py
+++ b/mars/dataframe/window/expanding/tests/test_expanding_execute.py
@@ -18,10 +18,6 @@ import numpy as np
 import pandas as pd
 
 from mars import dataframe as md
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_dataframe_expanding_agg(setup):

--- a/mars/dataframe/window/rolling/tests/test_rolling_execute.py
+++ b/mars/dataframe/window/rolling/tests/test_rolling_execute.py
@@ -16,10 +16,6 @@ import numpy as np
 import pandas as pd
 
 from mars import dataframe as md
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_rolling_agg_execution(setup):

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -1278,14 +1278,15 @@ class SyncSession(AbstractSyncSession):
         asyncio.run_coroutine_threadsafe(coro, self._loop).result()
         self.reset_default()
 
-    def stop_server(self):
+    def stop_server(self, isolation=True):
         try:
             coro = self._isolated_session.stop_server()
             future = asyncio.run_coroutine_threadsafe(coro, self._loop)
             future.result(timeout=5)
         finally:
             self.reset_default()
-            stop_isolation()
+            if isolation:
+                stop_isolation()
 
     def close(self):
         self.destroy()

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -21,7 +21,6 @@ from mars.deploy.oscar.ray import new_cluster, _load_config
 from mars.deploy.oscar.session import get_default_session, new_session
 from mars.deploy.oscar.tests import test_local
 from mars.serialization.ray import register_ray_serializers
-from mars.tests.conftest import *  # noqa
 from mars.tests.core import require_ray
 from mars.utils import lazy_import
 from .modules.utils import ( # noqa: F401; pylint: disable=unused-variable

--- a/mars/learn/cluster/tests/test_k_means.py
+++ b/mars/learn/cluster/tests/test_k_means.py
@@ -30,9 +30,6 @@ from mars.core import TileableGraphBuilder, TileableGraph, ChunkGraphBuilder
 from mars.config import options
 from mars.learn.cluster import KMeans, k_means
 from mars.learn.cluster._kmeans import _init_centroids
-from mars.tests import setup
-
-setup = setup
 
 
 @pytest.mark.skipif(KMeans is None, reason='scikit-learn not installed')

--- a/mars/learn/contrib/joblib/tests/test_backend.py
+++ b/mars/learn/contrib/joblib/tests/test_backend.py
@@ -24,10 +24,8 @@ except ImportError:
     joblib = sklearn = None
 
 from mars.learn.contrib.joblib import register_mars_backend
-from mars.tests import setup
 
 register_mars_backend()
-setup = setup
 
 
 @pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')

--- a/mars/learn/contrib/lightgbm/tests/test_classifier.py
+++ b/mars/learn/contrib/lightgbm/tests/test_classifier.py
@@ -21,7 +21,6 @@ import pytest
 
 import mars.tensor as mt
 import mars.dataframe as md
-from mars.tests import setup
 
 try:
     import lightgbm
@@ -29,8 +28,6 @@ try:
 except ImportError:
     lightgbm = LGBMClassifier = None
 
-
-setup = setup
 
 n_rows = 1000
 n_columns = 10

--- a/mars/learn/contrib/lightgbm/tests/test_ranker.py
+++ b/mars/learn/contrib/lightgbm/tests/test_ranker.py
@@ -15,7 +15,6 @@
 import pytest
 
 import mars.tensor as mt
-from mars.tests import setup
 
 try:
     import lightgbm
@@ -23,7 +22,6 @@ try:
 except ImportError:
     lightgbm = LGBMRanker = None
 
-setup = setup
 
 n_rows = 1000
 n_columns = 10

--- a/mars/learn/contrib/lightgbm/tests/test_regressor.py
+++ b/mars/learn/contrib/lightgbm/tests/test_regressor.py
@@ -16,7 +16,6 @@ import pandas as pd
 import pytest
 
 import mars.tensor as mt
-from mars.tests import setup
 
 try:
     import lightgbm
@@ -24,8 +23,6 @@ try:
 except ImportError:
     lightgbm = LGBMRegressor = None
 
-
-setup = setup
 
 n_rows = 1000
 n_columns = 10

--- a/mars/learn/contrib/pytorch/tests/test_run_script.py
+++ b/mars/learn/contrib/pytorch/tests/test_run_script.py
@@ -17,19 +17,19 @@ import os
 import pytest
 
 from mars.learn.contrib.pytorch import run_pytorch_script
-from mars.tests import setup
+from mars.tests import setup_cluster
 from mars.utils import lazy_import
 
-setup = setup
+setup_cluster = setup_cluster
 
 torch_installed = lazy_import('torch', globals=globals()) is not None
 
 
 @pytest.mark.skipif(not torch_installed, reason='pytorch not installed')
-def test_distributed_run_py_torch_script(setup):
-    sess = setup
+def test_distributed_run_py_torch_script(setup_cluster):
+    sess = setup_cluster
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                         'pytorch_sample.py')
     assert run_pytorch_script(
-        path, n_workers=1, command_argv=['multiple'],
-        port=9945, session=sess)['status'] == 'ok'
+        path, n_workers=2, command_argv=['multiple'],
+        port=9945, session=sess).fetch()['status'] == 'ok'

--- a/mars/learn/contrib/pytorch/tests/test_run_script.py
+++ b/mars/learn/contrib/pytorch/tests/test_run_script.py
@@ -17,10 +17,8 @@ import os
 import pytest
 
 from mars.learn.contrib.pytorch import run_pytorch_script
-from mars.tests import setup_cluster
 from mars.utils import lazy_import
 
-setup_cluster = setup_cluster
 
 torch_installed = lazy_import('torch', globals=globals()) is not None
 

--- a/mars/learn/contrib/statsmodels/tests/test_statsmodels.py
+++ b/mars/learn/contrib/statsmodels/tests/test_statsmodels.py
@@ -15,7 +15,6 @@
 import pytest
 
 import mars.tensor as mt
-from mars.tests import setup
 
 try:
     import statsmodels
@@ -23,7 +22,6 @@ try:
 except ImportError:  # pragma: no cover
     statsmodels = MarsDistributedModel = MarsResults = None
 
-setup = setup
 
 n_rows = 1000
 n_columns = 10

--- a/mars/learn/contrib/tensorflow/tests/test_run_script.py
+++ b/mars/learn/contrib/tensorflow/tests/test_run_script.py
@@ -17,14 +17,11 @@ import os
 import pytest
 
 from mars.learn.contrib.tensorflow import run_tensorflow_script
-from mars.tests import setup_cluster
 
 try:
     import tensorflow
 except ImportError:
     tensorflow = None
-
-setup_cluster = setup_cluster
 
 
 @pytest.mark.skipif(tensorflow is None, reason='tensorflow not installed')

--- a/mars/learn/contrib/tensorflow/tests/test_run_script.py
+++ b/mars/learn/contrib/tensorflow/tests/test_run_script.py
@@ -17,22 +17,22 @@ import os
 import pytest
 
 from mars.learn.contrib.tensorflow import run_tensorflow_script
-from mars.tests import setup
+from mars.tests import setup_cluster
 
 try:
     import tensorflow
 except ImportError:
     tensorflow = None
 
-setup = setup
+setup_cluster = setup_cluster
 
 
 @pytest.mark.skipif(tensorflow is None, reason='tensorflow not installed')
-def test_local_run_tensor_flow_script(setup):
+def test_local_run_tensor_flow_script(setup_cluster):
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'tf_distributed_sample.py')
     assert run_tensorflow_script(
-        path, n_workers=1, command_argv=['multiple'],
-        port=2222)['status'] == 'ok'
+        path, n_workers=2, command_argv=['multiple'],
+        port=2222).fetch()['status'] == 'ok'
 
     with pytest.raises(ValueError):
         run_tensorflow_script(path, n_workers=0)

--- a/mars/learn/contrib/tsfresh/tests/test_tsfresh.py
+++ b/mars/learn/contrib/tsfresh/tests/test_tsfresh.py
@@ -16,7 +16,6 @@ import pytest
 
 from mars.deploy.oscar.session import new_session, get_default_session
 from mars.learn.contrib.tsfresh import MarsDistributor
-from mars.tests import setup
 
 try:
     import tsfresh
@@ -26,8 +25,6 @@ try:
     from tsfresh.utilities.dataframe_functions import impute
 except ImportError:
     tsfresh = None
-
-setup = setup
 
 
 @pytest.mark.skipif(tsfresh is None, reason='tsfresh not installed')

--- a/mars/learn/contrib/xgboost/tests/test_classifier.py
+++ b/mars/learn/contrib/xgboost/tests/test_classifier.py
@@ -22,14 +22,12 @@ import pytest
 import mars.tensor as mt
 import mars.dataframe as md
 from mars.learn.contrib.xgboost import XGBClassifier
-from mars.tests import setup
 
 try:
     import xgboost
 except ImportError:
     xgboost = None
 
-setup = setup
 n_rows = 1000
 n_columns = 10
 chunk_size = 200

--- a/mars/learn/contrib/xgboost/tests/test_predict.py
+++ b/mars/learn/contrib/xgboost/tests/test_predict.py
@@ -19,15 +19,12 @@ import pytest
 import mars.tensor as mt
 import mars.dataframe as md
 from mars.learn.contrib.xgboost import MarsDMatrix, train, predict
-from mars.tests import setup
 
 try:
     import xgboost
     from xgboost import Booster
 except ImportError:
     xgboost = None
-
-setup = setup
 
 n_rows = 1000
 n_columns = 10

--- a/mars/learn/contrib/xgboost/tests/test_regressor.py
+++ b/mars/learn/contrib/xgboost/tests/test_regressor.py
@@ -16,14 +16,12 @@ import pytest
 
 import mars.tensor as mt
 from mars.learn.contrib.xgboost import XGBRegressor
-from mars.tests import setup
 
 try:
     import xgboost
 except ImportError:
     xgboost = None
 
-setup = setup
 n_rows = 1000
 n_columns = 10
 chunk_size = 200

--- a/mars/learn/contrib/xgboost/tests/test_train.py
+++ b/mars/learn/contrib/xgboost/tests/test_train.py
@@ -18,15 +18,12 @@ import pytest
 import mars.tensor as mt
 import mars.dataframe as md
 from mars.learn.contrib.xgboost import train, MarsDMatrix
-from mars.tests import setup
 
 try:
     import xgboost
     from xgboost import Booster
 except ImportError:
     xgboost = None
-
-setup = setup
 
 n_rows = 1000
 n_columns = 10

--- a/mars/learn/datasets/tests/test_samples_generator.py
+++ b/mars/learn/datasets/tests/test_samples_generator.py
@@ -29,10 +29,6 @@ from mars import tensor as mt
 from mars.learn.datasets.samples_generator import make_low_rank_matrix, \
     make_classification, make_blobs
 from mars.tensor.linalg import svd
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.mark.skipif(sklearn is None, reason='sklearn not installed')

--- a/mars/learn/decomposition/tests/test_pca.py
+++ b/mars/learn/decomposition/tests/test_pca.py
@@ -26,12 +26,8 @@ except ImportError:
     sklearn = None
 
 import mars.tensor as mt
-from mars.tests import setup
 if sklearn:
     from mars.learn.decomposition._pca import PCA, _assess_dimension, _infer_dimension
-
-
-setup = setup
 
 
 iris = mt.tensor(datasets.load_iris().data)

--- a/mars/learn/decomposition/tests/test_truncated_svd.py
+++ b/mars/learn/decomposition/tests/test_truncated_svd.py
@@ -23,11 +23,9 @@ except ImportError:
     sklearn = None
 
 import mars.tensor as mt
-from mars.tests import setup
 if sklearn:
     from mars.learn.decomposition import TruncatedSVD
 
-setup = setup
 
 # Make an X that looks somewhat like a small tf-idf matrix.
 # XXX newer versions of SciPy >0.16 have scipy.sparse.rand for this.

--- a/mars/learn/metrics/pairwise/tests/test_cosine_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_cosine_distances.py
@@ -24,10 +24,7 @@ except ImportError:
 
 from mars import tensor as mt
 from mars.learn.metrics.pairwise import cosine_distances
-from mars.tests import setup
 
-
-setup = setup
 
 raw_dense_x = np.random.rand(25, 10)
 raw_dense_y = np.random.rand(17, 10)

--- a/mars/learn/metrics/pairwise/tests/test_euclidean_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_euclidean_distances.py
@@ -27,10 +27,6 @@ from mars.config import option_context
 from mars.lib.sparse import SparseNDArray
 from mars.learn.metrics import euclidean_distances
 from mars.learn.utils import check_array
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')

--- a/mars/learn/metrics/pairwise/tests/test_haversine_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_haversine_distances.py
@@ -23,10 +23,6 @@ except ImportError:  # pragma: no cover
 
 from mars import tensor as mt
 from mars.learn.metrics.pairwise import haversine_distances
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')

--- a/mars/learn/metrics/pairwise/tests/test_manhattan_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_manhattan_distances.py
@@ -24,10 +24,6 @@ except ImportError:  # pragma: no cover
 
 from mars import tensor as mt
 from mars.learn.metrics.pairwise import manhattan_distances
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')

--- a/mars/learn/metrics/pairwise/tests/test_pariwise_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_pariwise_distances.py
@@ -27,10 +27,6 @@ except ImportError:
 from mars import tensor as mt
 from mars.learn.metrics import pairwise_distances, pairwise_distances_topk
 from mars.session import execute, fetch
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')

--- a/mars/learn/metrics/pairwise/tests/test_rbf_kernel.py
+++ b/mars/learn/metrics/pairwise/tests/test_rbf_kernel.py
@@ -22,10 +22,6 @@ except ImportError:  # pragma: no cover
     sklearn = None
 
 from mars.learn.metrics.pairwise import rbf_kernel
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')

--- a/mars/learn/metrics/tests/test_classification.py
+++ b/mars/learn/metrics/tests/test_classification.py
@@ -24,10 +24,7 @@ import mars.tensor as mt
 from mars.learn.metrics import accuracy_score
 from mars.learn.metrics._classification import _check_targets
 from mars.lib.sparse import SparseNDArray
-from mars.tests import setup
 
-
-setup = setup
 
 IND = 'multilabel-indicator'
 MC = 'multiclass'

--- a/mars/learn/metrics/tests/test_ranking.py
+++ b/mars/learn/metrics/tests/test_ranking.py
@@ -32,10 +32,6 @@ import pytest
 from mars import dataframe as md
 from mars import tensor as mt
 from mars.learn.metrics import roc_curve, auc, accuracy_score
-from mars.tests import setup
-
-
-setup = setup
 
     
 def test_roc_curve(setup):

--- a/mars/learn/model_selection/tests/test_split.py
+++ b/mars/learn/model_selection/tests/test_split.py
@@ -27,10 +27,6 @@ from mars import tensor as mt
 from mars.dataframe.core import DATAFRAME_TYPE
 from mars.learn.model_selection import train_test_split
 from mars.lib.sparse import SparseNDArray
-from mars.tests import setup
-
-
-setup = setup
     
     
 def test_train_test_split_errors(setup):

--- a/mars/learn/neighbors/tests/test_faiss.py
+++ b/mars/learn/neighbors/tests/test_faiss.py
@@ -25,10 +25,6 @@ from mars.learn.neighbors._faiss import build_faiss_index, _load_index, \
     faiss_query, _gen_index_string_and_sample_count
 from mars.learn.neighbors import NearestNeighbors
 from mars.session import execute, fetch
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.mark.skipif(faiss is None, reason='faiss not installed')

--- a/mars/learn/neighbors/tests/test_nearest_neighbors.py
+++ b/mars/learn/neighbors/tests/test_nearest_neighbors.py
@@ -32,14 +32,10 @@ from mars.core import tile
 from mars.learn.neighbors import NearestNeighbors
 from mars.learn.proxima.core import proxima
 from mars.lib.sparse import SparseNDArray
-from mars.tests import setup
 from mars.tests.core import require_cupy
 from mars.utils import lazy_import
 
 cupy = lazy_import('cupy', globals=globals())
-
-
-setup = setup
 
     
 def test_nearest_neighbors(setup):

--- a/mars/learn/preprocessing/tests/test_data.py
+++ b/mars/learn/preprocessing/tests/test_data.py
@@ -23,12 +23,8 @@ except ImportError:
     sklearn = None
 
 from mars import tensor as mt
-from mars.tests import setup
 if sklearn:
     from mars.learn.preprocessing import MinMaxScaler, minmax_scale
-
-
-setup = setup
 
 
 def assert_correct_incr(i, batch_start, batch_stop, n, chunk_size,

--- a/mars/learn/preprocessing/tests/test_normalize.py
+++ b/mars/learn/preprocessing/tests/test_normalize.py
@@ -24,10 +24,6 @@ except ImportError:
 
 from mars import tensor as mt
 from mars.learn.preprocessing import normalize
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')

--- a/mars/learn/proxima/simple_index/tests/test_simple_index.py
+++ b/mars/learn/proxima/simple_index/tests/test_simple_index.py
@@ -23,10 +23,6 @@ import mars.dataframe as md
 import mars.tensor as mt
 from mars.learn.proxima.core import proxima
 from mars.learn.proxima.simple_index import build_index, search_index, recall
-from mars.tests import setup
-
-
-setup = setup
 
 
 def proxima_build_and_query(doc, query, topk, measure_name=None, dimension=None,

--- a/mars/learn/semi_supervised/tests/test_label_propagation.py
+++ b/mars/learn/semi_supervised/tests/test_label_propagation.py
@@ -28,10 +28,6 @@ from mars import tensor as mt
 from mars.learn.metrics.pairwise import rbf_kernel
 from mars.learn.neighbors import NearestNeighbors
 from mars.learn.semi_supervised import LabelPropagation
-from mars.tests import setup
-
-
-setup = setup
 
 
 estimators = [

--- a/mars/learn/utils/tests/test_checks.py
+++ b/mars/learn/utils/tests/test_checks.py
@@ -20,11 +20,7 @@ import scipy.sparse as sps
 from mars import tensor as mt
 from mars import dataframe as md
 from mars.config import option_context
-from mars.tests import setup
 from mars.learn.utils.checks import check_non_negative_then_return_value, assert_all_finite
-
-
-setup = setup
     
     
 def test_check_non_negative_then_return_value_execution(setup):

--- a/mars/learn/utils/tests/test_multiclass.py
+++ b/mars/learn/utils/tests/test_multiclass.py
@@ -25,10 +25,6 @@ except ImportError:  # pragma: no cover
 
 import mars.tensor as mt
 from mars.learn.utils.multiclass import is_multilabel, type_of_target
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_is_multilabel(setup):

--- a/mars/learn/utils/tests/test_shuffle.py
+++ b/mars/learn/utils/tests/test_shuffle.py
@@ -21,10 +21,6 @@ import mars.dataframe as md
 from mars.core import tile
 from mars.learn.utils import shuffle
 from mars.learn.utils.shuffle import LearnShuffle
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_shuffle_expr():

--- a/mars/learn/utils/tests/test_validation.py
+++ b/mars/learn/utils/tests/test_validation.py
@@ -28,12 +28,8 @@ except ImportError:
 import mars.tensor as mt
 import mars.dataframe as md
 from mars.tensor.core import Tensor
-from mars.tests import setup
 if sklearn:
     from mars.learn.utils.validation import check_array, check_consistent_length
-
-
-setup = setup
 
 
 @pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')

--- a/mars/optimization/logical/tileable/tests/test_head.py
+++ b/mars/optimization/logical/tileable/tests/test_head.py
@@ -23,10 +23,6 @@ import mars.dataframe as md
 from mars.core import TileableGraph, TileableGraphBuilder, enter_mode
 from mars.dataframe.indexing.iloc import DataFrameIlocGetItem, SeriesIlocGetItem
 from mars.optimization.logical.tileable import optimize
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.fixture(scope='module')

--- a/mars/oscar/backends/ray/tests/test_communication.py
+++ b/mars/oscar/backends/ray/tests/test_communication.py
@@ -19,12 +19,11 @@ import sys
 
 import pytest
 
+from .....tests.core import require_ray
 from .....utils import lazy_import
 from ....errors import ServerClosed
 from ...communication.base import ChannelType
 from ..communication import ChannelID, Channel, RayServer, RayClient
-from mars.tests.conftest import *  # noqa
-from mars.tests.core import require_ray
 
 ray = lazy_import('ray')
 _is_windows: bool = sys.platform.startswith('win')

--- a/mars/oscar/backends/ray/tests/test_ray_actor_context.py
+++ b/mars/oscar/backends/ray/tests/test_ray_actor_context.py
@@ -17,13 +17,12 @@ import inspect
 import pytest
 
 from .....utils import lazy_import
+from .....tests.core import require_ray
 from ...mars.tests import test_mars_actor_context
 from ...router import Router
 from ..communication import RayServer
 from ..pool import RayMainPool
 from ..utils import process_placement_to_address
-from mars.tests.conftest import *  # noqa
-from mars.tests.core import require_ray
 
 ray = lazy_import('ray')
 

--- a/mars/oscar/backends/ray/tests/test_ray_actor_driver.py
+++ b/mars/oscar/backends/ray/tests/test_ray_actor_driver.py
@@ -29,7 +29,6 @@ from ..utils import (
     process_address_to_placement,
 )
 import mars.oscar as mo
-from mars.tests.conftest import *  # noqa
 from mars.tests.core import require_ray
 
 ray = lazy_import('ray')

--- a/mars/oscar/backends/ray/tests/test_ray_pool.py
+++ b/mars/oscar/backends/ray/tests/test_ray_pool.py
@@ -15,7 +15,6 @@
 import pytest
 
 from mars.tests.core import require_ray
-from mars.tests.conftest import *  # noqa
 from .....utils import lazy_import
 from ..pool import RayMainPool, RayMainActorPool, create_actor_pool
 from ..utils import process_placement_to_address

--- a/mars/remote/core.py
+++ b/mars/remote/core.py
@@ -115,10 +115,14 @@ class RemoteFunction(RemoteOperandMixin, ObjectOperand):
 
         chunk_inputs = []
         pure_depends = []
+        executed = False
         for inp in op.inputs:
             if cls._no_prepare(inp):  # pragma: no cover
-                # trigger execution
-                yield
+                if not executed:
+                    # trigger execution
+                    yield
+                else:
+                    executed = True
                 # if input is tensor, DataFrame etc,
                 # do not prepare data, because the data may be to huge,
                 # and users can choose to fetch slice of the data themselves

--- a/mars/remote/run_script.py
+++ b/mars/remote/run_script.py
@@ -14,32 +14,33 @@
 
 import os
 import sys
-import tempfile
-import subprocess
+from typing import Any, BinaryIO, Dict, List, TextIO, Union
 
 import numpy as np
 
-
 from .. import opcodes
-from ..core import OutputType
+from ..core import OutputType, TILEABLE_TYPE
+from ..core.context import Context
 from ..core.operand import MergeDictOperand
-from ..serialization.serializables import BytesField, ListField, Int32Field, StringField, BoolField
-from ..utils import to_binary
+from ..serialization.serializables import BytesField, ListField, \
+    Int32Field, DictField, BoolField
+from ..typing import TileableType, SessionType
+from ..utils import to_binary, build_fetch_tileable
 
 
 class RunScript(MergeDictOperand):
     _op_type_ = opcodes.RUN_SCRIPT
 
-    _code = BytesField('code')
-    _mode = StringField('mode')
-    _retry_when_fail = BoolField('retry_when_fail')
-    _command_args = ListField('command_args')
-    _world_size = Int32Field('world_size')
-    _rank = Int32Field('rank')
+    _code: bytes = BytesField('code')
+    _data: Dict[str, TileableType] = DictField('data')
+    _retry_when_fail: bool = BoolField('retry_when_fail')
+    _command_args: List[str] = ListField('command_args')
+    _world_size: int = Int32Field('world_size')
+    _rank: int = Int32Field('rank')
 
-    def __init__(self, code=None, mode=None, world_size=None, rank=None, retry_when_fail=None,
-                 command_args=None, **kw):
-        super().__init__(_code=code, _mode=mode, _world_size=world_size, _rank=rank,
+    def __init__(self, code=None, data=None, world_size=None, rank=None,
+                 retry_when_fail=None, command_args=None, **kw):
+        super().__init__(_code=code, _data=data, _world_size=world_size, _rank=rank,
                          _retry_when_fail=retry_when_fail, _command_args=command_args,
                          **kw)
         if self.output_types is None:
@@ -50,8 +51,8 @@ class RunScript(MergeDictOperand):
         return self._code
 
     @property
-    def mode(self):
-        return self._mode
+    def data(self):
+        return self._data
 
     @property
     def world_size(self):
@@ -69,14 +70,32 @@ class RunScript(MergeDictOperand):
     def retryable(self):
         return self._retry_when_fail
 
-    def __call__(self):
-        return self.new_tileable(None)
+    def __call__(self, inputs):
+        return self.new_tileable(inputs)
 
     @classmethod
-    def tile(cls, op):
+    def tile(cls, op: "RunScript"):
+        if len(op.inputs) > 0:
+            # trigger inputs to execute
+            yield
+
+        new_data = None
+        input_chunks = []
+        inputs_iter = iter(op.inputs)
+        if op.data:
+            new_data = dict()
+            for k, v in op.data.items():
+                if isinstance(v, TILEABLE_TYPE):
+                    v = next(inputs_iter)
+                    new_data[k] = build_fetch_tileable(v)
+                    input_chunks.extend(v.chunks)
+                else:
+                    new_data[k] = v
+
         out_chunks = []
         for i in range(op.world_size):
             chunk_op = op.copy().reset_key()
+            chunk_op._data = new_data
             chunk_op._rank = i
             out_chunks.append(chunk_op.new_chunk(None, index=(i,)))
 
@@ -85,49 +104,20 @@ class RunScript(MergeDictOperand):
                                     nsplits=(tuple(np.nan for _ in range(len(out_chunks))),))
 
     @classmethod
-    def _execute_with_subprocess(cls, op, envs=None):
-        # write source code into a temp file
-        fd, filename = tempfile.mkstemp('.py')
-        with os.fdopen(fd, 'wb') as f:
-            f.write(op.code)
-
-        new_envs = os.environ.copy()
-        new_envs.update(envs or dict())
-        try:
-            # exec code in a new process
-            process = subprocess.Popen([sys.executable, filename] + op.command_args,
-                                       env=new_envs)
-            process.wait()
-            if process.returncode != 0:  # pragma: no cover
-                raise RuntimeError('Run script failed')
-
-        finally:
-            os.remove(filename)
-
-    @classmethod
-    def _execute_with_exec(cls, op, local=None):
-        local = local or dict()
-
-        try:
-            exec(op.code, local)
-        finally:
-            sys.stdout.flush()
-
-    @classmethod
     def _build_envs(cls, ctx, op):
         # set mars envs
         envs = dict()
-        envs['MARS_SESSION_ID'] = str(ctx.session_id)
         envs['RANK'] = str(op.rank)
         envs['WORLD_SIZE'] = str(op.world_size)
-        envs['MARS_SUPERVISOR_ADDRESS'] = ctx.supervisor_address
         return envs
 
     @classmethod
-    def _build_locals(cls, ctx, op):
+    def _build_locals(cls, ctx: Union[Context, dict], op: "RunScript"):
         sess = ctx.get_current_session().as_default()
-
-        return dict(session=sess)
+        local = {'session': sess}
+        if op.data is not None:
+            local.update(op.data)
+        return local
 
     @classmethod
     def execute(cls, ctx, op):
@@ -136,15 +126,14 @@ class RunScript(MergeDictOperand):
 
         old_env = os.environ.copy()
         envs = cls._build_envs(ctx, op)
+        old_argv = sys.argv.copy()
 
         try:
-            if op.mode == 'spawn':
-                cls._execute_with_subprocess(op, envs)
-            elif op.mode == 'exec':
-                os.environ.update(envs)
-                cls._execute_with_exec(op, cls._build_locals(ctx, op))
-            else:  # pragma: no cover
-                raise TypeError(f'Unsupported mode {op.mode}')
+            os.environ.update(envs)
+            sys.argv = ['script']
+            sys.argv.extend(op.command_args)
+
+            exec(op.code, cls._build_locals(ctx, op))
 
             if op.rank == 0:
                 ctx[op.outputs[0].key] = {'status': 'ok'}
@@ -152,10 +141,31 @@ class RunScript(MergeDictOperand):
                 ctx[op.outputs[0].key] = {}
         finally:
             os.environ = old_env
+            sys.argv = old_argv
+            sys.stdout.flush()
 
 
-def run_script(script, n_workers=1, mode='spawn', command_argv=None,
-               session=None, retry_when_fail=False, run_kwargs=None):
+def _extract_inputs(data: Dict[str, TileableType] = None) -> List[TileableType]:
+    if data is not None and not isinstance(data, dict):
+        raise TypeError('`data` must be a dict whose key is '
+                        'variable name and value is data')
+
+    inputs = []
+    if data is not None:
+        for v in data.values():
+            if isinstance(v, TILEABLE_TYPE):
+                inputs.append(v)
+
+    return inputs
+
+
+def run_script(script: Union[bytes, str, BinaryIO, TextIO],
+               data: Dict[str, TileableType] = None,
+               n_workers: int = 1,
+               command_argv: List[str] = None,
+               session: SessionType = None,
+               retry_when_fail: bool = False,
+               run_kwargs: Dict[str, Any] = None):
     """
     Run script in Mars cluster.
 
@@ -163,11 +173,10 @@ def run_script(script, n_workers=1, mode='spawn', command_argv=None,
     ----------
     script: str or file-like object
         Script to run.
+    data: dict
+        Variable name to data.
     n_workers: int
         number of workers to run the script
-    mode: str, 'spawn' as default
-        'spawn' mode use subprocess to run script,
-        'exec' mode use exec to run in current process.
     command_argv: list
         extra command args for script
     session: Mars session
@@ -189,9 +198,8 @@ def run_script(script, n_workers=1, mode='spawn', command_argv=None,
     else:
         with open(os.path.abspath(script), 'rb') as f:
             code = f.read()
-    if mode not in ['exec', 'spawn']:  # pragma: no cover
-        raise TypeError(f'Unsupported mode {mode}')
 
-    op = RunScript(code=to_binary(code), mode=mode, world_size=n_workers,
+    inputs = _extract_inputs(data)
+    op = RunScript(data=data, code=to_binary(code), world_size=n_workers,
                    retry_when_fail=retry_when_fail, command_args=command_argv)
-    return op().execute(session=session, **(run_kwargs or {})).fetch(session=session)
+    return op(inputs).execute(session=session, **(run_kwargs or {}))

--- a/mars/remote/tests/test_remote_function.py
+++ b/mars/remote/tests/test_remote_function.py
@@ -25,10 +25,6 @@ from mars.deploy.oscar.session import get_default_session
 from mars.learn.utils import shuffle
 from mars.lib.mmh3 import hash as mmh3_hash
 from mars.remote import spawn, ExecutableTuple
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_params():

--- a/mars/remote/tests/test_run_script.py
+++ b/mars/remote/tests/test_run_script.py
@@ -15,8 +15,12 @@
 import os
 from io import BytesIO
 
+import pytest
+
+import mars.tensor as mt
+import mars.dataframe as md
 from mars.remote import run_script
-from mars.tests import setup
+from mars.tests import setup_cluster
 
 
 script1 = b"""
@@ -28,26 +32,50 @@ script2 = b"""
 assert session is not None
 """
 
+script3 = b"""
+from mars.core.operand import Fetch
+from mars.deploy.oscar.session import AbstractSession
 
-setup = setup
+assert AbstractSession.default is not None
+assert isinstance(tensor.op, Fetch)
+assert len(tensor.chunks) > 0
+assert isinstance(tensor.chunks[0].op, Fetch)
+tensor.fetch().sum() == df.fetch()['s'].sum()
+"""
 
 
-def test_local_run_script(setup):
+setup_cluster = setup_cluster
+
+
+def test_local_run_script(setup_cluster):
     s = BytesIO(script1)
     assert run_script(
         s, n_workers=2
-    )['status'] == 'ok'
+    ).fetch()['status'] == 'ok'
 
 
-def test_local_run_script_with_exec(setup):
+def test_local_run_script_with_exec(setup_cluster):
     s = BytesIO(script2)
     assert run_script(
-        s, n_workers=2, mode='exec'
-    )['status'] == 'ok'
+        s, n_workers=2,
+    ).fetch()['status'] == 'ok'
 
 
-def test_run_with_file(setup):
+def test_local_run_script_with_data(setup_cluster):
+    s = BytesIO(script3)
+    data = {
+        'tensor': mt.arange(10),
+        'df': md.DataFrame({'s': mt.arange(9, 0, -1)})
+    }
+    assert run_script(
+        s, data=data, n_workers=1,
+    ).fetch()['status'] == 'ok'
+
+    pytest.raises(TypeError, run_script, s, data=[])
+
+
+def test_run_with_file(setup_cluster):
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'sample_script.py')
     assert run_script(
         path, n_workers=2
-    )['status'] == 'ok'
+    ).fetch()['status'] == 'ok'

--- a/mars/remote/tests/test_run_script.py
+++ b/mars/remote/tests/test_run_script.py
@@ -20,7 +20,6 @@ import pytest
 import mars.tensor as mt
 import mars.dataframe as md
 from mars.remote import run_script
-from mars.tests import setup_cluster
 
 
 script1 = b"""
@@ -42,9 +41,6 @@ assert len(tensor.chunks) > 0
 assert isinstance(tensor.chunks[0].op, Fetch)
 tensor.fetch().sum() == df.fetch()['s'].sum()
 """
-
-
-setup_cluster = setup_cluster
 
 
 def test_local_run_script(setup_cluster):

--- a/mars/services/storage/tests/test_api.py
+++ b/mars/services/storage/tests/test_api.py
@@ -29,7 +29,6 @@ from mars.services.storage.api import MockStorageAPI, WebStorageAPI
 from mars.services.web import WebActor
 from mars.storage import StorageLevel
 from mars.tests.core import require_ray
-from mars.tests.conftest import *  # noqa
 from mars.utils import get_next_port
 
 try:

--- a/mars/services/task/supervisor/tests/test_task_manager_on_ray.py
+++ b/mars/services/task/supervisor/tests/test_task_manager_on_ray.py
@@ -16,7 +16,6 @@ import pytest
 
 import mars.oscar as mo
 from mars.tests.core import require_ray
-from mars.tests.conftest import *  # noqa
 from mars.utils import lazy_import
 from mars.oscar.backends.ray.utils import placement_group_info_to_addresses
 from mars.services.task.supervisor.manager import TaskConfigurationActor

--- a/mars/storage/tests/test_libs.py
+++ b/mars/storage/tests/test_libs.py
@@ -35,7 +35,6 @@ from mars.storage.shared_memory import SharedMemoryStorage
 from mars.storage.vineyard import VineyardStorage
 from mars.storage.ray import RayStorage
 from mars.tests.core import require_ray, require_cudf, require_cupy
-from mars.tests.conftest import *  # noqa
 
 try:
     import vineyard

--- a/mars/tensor/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/tensor/arithmetic/tests/test_arithmetic_execution.py
@@ -27,11 +27,7 @@ from mars.tensor.datasource import ones, tensor, zeros
 from mars.tensor.arithmetic import add, cos, truediv, frexp, \
     modf, clip, isclose, arctan2, tree_add, tree_multiply
 from mars.tests.core import require_cupy
-from mars.tests import setup
 from mars.utils import ignore_warning
-
-
-setup = setup
 
 
 def _nan_equal(a, b):

--- a/mars/tensor/base/tests/test_base_execute.py
+++ b/mars/tensor/base/tests/test_base_execute.py
@@ -28,11 +28,7 @@ from mars.tensor.base import copyto, transpose, moveaxis, broadcast_to, broadcas
     isin, searchsorted, unique, sort, argsort, partition, argpartition, topk, argtopk, \
     trapz, shape, to_gpu, to_cpu, swapaxes
 from mars.tensor.datasource import tensor, ones, zeros, arange
-from mars.tests import setup
 from mars.tests.core import require_cupy
-
-
-setup = setup
 
 
 def test_rechunk_execution(setup):

--- a/mars/tensor/datasource/tests/test_datasource_execute.py
+++ b/mars/tensor/datasource/tests/test_datasource_execute.py
@@ -46,10 +46,6 @@ from mars.tensor.datasource import tensor, ones_like, zeros, zeros_like, full, f
     arange, empty, empty_like, diag, diagflat, eye, linspace, meshgrid, indices, \
     triu, tril, from_dataframe, fromtiledb, fromhdf5, fromzarr
 from mars.tensor.lib import nd_grid
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_create_sparse_execution(setup):

--- a/mars/tensor/datastore/tests/test_datastore_execute.py
+++ b/mars/tensor/datastore/tests/test_datastore_execute.py
@@ -39,12 +39,8 @@ except ImportError:
     vineyard = None
 
 from mars.tensor import tensor, arange, totiledb, tohdf5, tozarr
-from mars.tests import setup
 
 _exec_timeout = 120 if 'CI' in os.environ else -1
-
-
-setup = setup
 
 
 @pytest.mark.skipif(tiledb is None, reason='tiledb not installed')

--- a/mars/tensor/einsum/tests/test_einsum_execute.py
+++ b/mars/tensor/einsum/tests/test_einsum_execute.py
@@ -18,10 +18,6 @@ import numpy as np
 
 from mars.tensor.datasource import tensor
 from mars.tensor import einsum
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_einsum_execution(setup):

--- a/mars/tensor/fft/tests/test_fft_execute.py
+++ b/mars/tensor/fft/tests/test_fft_execute.py
@@ -20,10 +20,6 @@ from mars.lib.mkl_interface import mkl_free_buffers
 from mars.tensor.datasource import tensor
 from mars.tensor.fft import fft, ifft, fft2, ifft2, fftn, ifftn, rfft, irfft, rfft2, irfft2, \
     rfftn, hfft, ihfft, fftfreq, rfftfreq, fftshift, ifftshift, irfftn
-from mars.tests import setup
-
-
-setup = setup
 
     
 def test_fft_execution(setup):

--- a/mars/tensor/fuse/tests/test_numexpr_execute.py
+++ b/mars/tensor/fuse/tests/test_numexpr_execute.py
@@ -18,11 +18,7 @@
 import numpy as np
 
 from mars.tensor.datasource import tensor
-from mars.tests import setup
 from mars.utils import ignore_warning
-
-
-setup = setup
 
 
 def test_base_execution(setup):

--- a/mars/tensor/images/tests/test_images_execute.py
+++ b/mars/tensor/images/tests/test_images_execute.py
@@ -22,11 +22,7 @@ try:
 except ImportError:
     Image = None
 
-from mars.tests import setup
 from mars.tensor.images import imread
-
-
-setup = setup
 
 
 @pytest.mark.skipif(not Image, reason='Pillow not installed')

--- a/mars/tensor/indexing/tests/test_indexing_execute.py
+++ b/mars/tensor/indexing/tests/test_indexing_execute.py
@@ -23,10 +23,6 @@ from mars.tensor.datasource import tensor, arange, zeros
 from mars.tensor.indexing import take, compress, extract, choose, \
     unravel_index, nonzero, flatnonzero, fill_diagonal
 from mars.tensor import mod, stack, hstack
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_bool_indexing_execution(setup):

--- a/mars/tensor/lib/tests/test_index_tricks.py
+++ b/mars/tensor/lib/tests/test_index_tricks.py
@@ -20,10 +20,6 @@ import pytest
 from mars import tensor as mt
 from mars.core import tile
 from mars.tensor.lib import nd_grid
-from mars.tests import setup
-
-
-setup = setup
 
     
 def test_index_tricks():

--- a/mars/tensor/linalg/tests/test_linalg_execute.py
+++ b/mars/tensor/linalg/tests/test_linalg_execute.py
@@ -23,11 +23,7 @@ from mars.tensor.datasource import tensor, diag, ones, arange
 from mars.tensor.linalg import qr, svd, cholesky, norm, lu, \
     solve_triangular, solve, inv, tensordot, dot, inner, vdot, matmul, randomized_svd
 from mars.tensor.random import uniform
-from mars.tests import setup
 from mars.utils import ignore_warning
-
-
-setup = setup
 
 
 def test_qr_execution(setup):

--- a/mars/tensor/merge/tests/test_merge_execute.py
+++ b/mars/tensor/merge/tests/test_merge_execute.py
@@ -20,10 +20,6 @@ import pytest
 
 from mars.tensor.datasource import tensor, empty, eye, ones, zeros
 from mars.tensor import concatenate, stack, hstack, vstack, dstack, column_stack, union1d, array, block
-from mars.tests import setup
-
-
-setup = setup
     
     
 def test_concatenate_execution(setup):

--- a/mars/tensor/random/tests/test_random_execute.py
+++ b/mars/tensor/random/tests/test_random_execute.py
@@ -23,10 +23,6 @@ from mars import tensor
 from mars.core import tile
 from mars.lib.sparse.core import issparse
 from mars.tensor.datasource import tensor as from_ndarray
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_rand_execution(setup):

--- a/mars/tensor/reduction/tests/test_reduction_execute.py
+++ b/mars/tensor/reduction/tests/test_reduction_execute.py
@@ -22,10 +22,6 @@ from mars.tensor.datasource import ones, tensor
 from mars.tensor.reduction import mean, nansum, nanmax, nanmin, nanmean, nanprod, nanargmax, \
     nanargmin, nanvar, nanstd, count_nonzero, allclose, array_equal, var, std, nancumsum, nancumprod
 from mars.utils import ignore_warning
-from mars.tests import setup
-
-
-setup = setup
     
     
 def test_sum_prod_execution(setup):

--- a/mars/tensor/reshape/tests/test_reshape_execute.py
+++ b/mars/tensor/reshape/tests/test_reshape_execute.py
@@ -15,10 +15,6 @@
 import numpy as np
 
 from mars.tensor.datasource import ones, tensor
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_reshape_execution(setup):

--- a/mars/tensor/spatial/distance/tests/test_distance_execute.py
+++ b/mars/tensor/spatial/distance/tests/test_distance_execute.py
@@ -18,10 +18,6 @@ import pytest
 from mars.core import tile
 from mars.tensor.datasource import tensor
 from mars.tensor.spatial import distance
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.mark.skipif(distance.pdist is None, reason='scipy not installed')

--- a/mars/tensor/special/tests/test_special_execute.py
+++ b/mars/tensor/special/tests/test_special_execute.py
@@ -24,10 +24,6 @@ except ImportError:
     scipy = None
 
 from mars.tensor import tensor
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.mark.skipif(scipy is None, reason='scipy not installed')

--- a/mars/tensor/statistics/tests/test_statistics_execute.py
+++ b/mars/tensor/statistics/tests/test_statistics_execute.py
@@ -24,10 +24,6 @@ from mars.tensor.statistics.quantile import INTERPOLATION_TYPES
 from mars.tensor.base import sort
 from mars.tensor.merge import stack
 from mars.tensor.reduction import all as tall
-from mars.tests import setup
-
-
-setup = setup
     
     
 def test_average_execution(setup):

--- a/mars/tensor/stats/tests/test_stats_execute.py
+++ b/mars/tensor/stats/tests/test_stats_execute.py
@@ -38,10 +38,6 @@ except ImportError:
 
 from mars.lib.version import parse as parse_version
 from mars.tensor import tensor
-from mars.tests import setup
-
-
-setup = setup
 
 
 @pytest.mark.skipif(scipy is None, reason='scipy not installed')

--- a/mars/tensor/tests/test_core_execute.py
+++ b/mars/tensor/tests/test_core_execute.py
@@ -18,10 +18,6 @@ import numpy as np
 
 from mars.tensor import ones, add, swapaxes, moveaxis, atleast_1d, atleast_2d, \
     atleast_3d, squeeze, tensor
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_array_function(setup):

--- a/mars/tensor/tests/test_utils.py
+++ b/mars/tensor/tests/test_utils.py
@@ -18,10 +18,6 @@ import pytest
 from mars import tensor as mt
 from mars.lib.mmh3 import hash_from_buffer as mmh3_hash_from_buffer
 from mars.tensor.utils import hash_on_axis, normalize_axis_tuple, fetch_corner_data
-from mars.tests import setup
-
-
-setup = setup
 
 
 def test_hash_on_axis():

--- a/mars/tests/__init__.py
+++ b/mars/tests/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .core import flaky, setup, setup_cluster
+from .core import flaky

--- a/mars/tests/__init__.py
+++ b/mars/tests/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .core import flaky, setup
+from .core import flaky, setup, setup_cluster

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -33,7 +33,6 @@ except ImportError:
     from unittest import mock
 _mock = mock
 
-from ..config import option_context
 from ..core.operand import OperandStage
 from ..utils import lazy_import
 
@@ -43,34 +42,6 @@ cudf = lazy_import('cudf', globals=globals())
 ray = lazy_import('ray', globals=globals())
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope='module')
-def setup():
-    from ..deploy.oscar.tests.session import new_test_session
-
-    sess = new_test_session(address='test://127.0.0.1',
-                            init_local=True,
-                            default=True, timeout=300)
-    with option_context({'show_progress': False}):
-        try:
-            yield sess
-        finally:
-            sess.stop_server()
-
-
-@pytest.fixture(scope='module')
-def setup_cluster():
-    from ..deploy.oscar.tests.session import new_test_session
-
-    sess = new_test_session(address='127.0.0.1',
-                            init_local=True, n_worker=2,
-                            default=True, timeout=300)
-    with option_context({'show_progress': False}):
-        try:
-            yield sess
-        finally:
-            sess.stop_server()
 
 
 def flaky(o=None, *args, **kwargs):

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -59,6 +59,20 @@ def setup():
             sess.stop_server()
 
 
+@pytest.fixture(scope='module')
+def setup_cluster():
+    from ..deploy.oscar.tests.session import new_test_session
+
+    sess = new_test_session(address='127.0.0.1',
+                            init_local=True, n_worker=2,
+                            default=True, timeout=300)
+    with option_context({'show_progress': False}):
+        try:
+            yield sess
+        finally:
+            sess.stop_server()
+
+
 def flaky(o=None, *args, **kwargs):
     platform = kwargs.pop('platform', '')
     if _raw_flaky is None or not sys.platform.startswith(platform):

--- a/mars/tests/test_eager_mode.py
+++ b/mars/tests/test_eager_mode.py
@@ -22,9 +22,6 @@ import mars.tensor as mt
 import mars.dataframe as md
 from mars.config import option_context
 from mars.dataframe.datasource.dataframe import from_pandas
-from mars.tests import setup
-
-setup = setup
     
     
 def test_base_execute(setup):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR supports data dependency for `run_script`. `data` argument can be specified, and it should be a dict whose key is the variable name and value is tileable object.

Other two modifications:

1. `spawn` mode is removed for `run_script`.
2. `setup_cluster` is added to start a local cluster for test.

e.g.

Driver.

```python
import mars.dataframe as md
import mars.remote as mr

s = md.Series([1, 2, 3])

mr.run_script('my_script.py', data={'my_series': s})
```

`my_script.py`:

```python
s = my_series  # `my_series` can be used directly.
print(s.fetch().sum())  # should be 6
```

This is related to #2246 .

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
