### PR TITLE
Support `fetch_log` for web session

### DIFF
--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -672,16 +672,16 @@ def test_groupby_sample(setup):
     sample_count = 10
     src_data_list = []
     for b in range(5):
-        data_count = int(np.random.randint(20, 100))
+        data_count = int(rs.randint(20, 100))
         src_data_list.append(pd.DataFrame({
-            'a': np.random.randint(0, 100, size=data_count),
+            'a': rs.randint(0, 100, size=data_count),
             'b': np.array([b] * data_count),
-            'c': np.random.randint(0, 100, size=data_count),
-            'd': np.random.randint(0, 100, size=data_count),
+            'c': rs.randint(0, 100, size=data_count),
+            'd': rs.randint(0, 100, size=data_count),
         }))
     df1 = pd.concat(src_data_list)
     shuffle_idx = np.arange(len(df1))
-    np.random.shuffle(shuffle_idx)
+    rs.shuffle(shuffle_idx)
     df1 = df1.iloc[shuffle_idx].reset_index(drop=True)
 
     # test single chunk

--- a/mars/deploy/oscar/tests/local_test_with_ray_config.yml
+++ b/mars/deploy/oscar/tests/local_test_with_ray_config.yml
@@ -1,0 +1,3 @@
+"@inherits": '@mars/deploy/oscar/rayconfig.yml'
+session:
+  custom_log_dir: auto

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -201,6 +201,12 @@ async def _run_web_session_test(web_address):
     assert info.exception() is None
     assert info.progress() == 1
     assert 'output from function' in str(r.fetch_log(session=session))
+    assert 'output from function' in str(r.fetch_log(session=session,
+                                                     offsets='0k',
+                                                     sizes=[1000]))
+    assert 'output from function' in str(r.fetch_log(session=session,
+                                                     offsets={r.op.key: '0k'},
+                                                     sizes=[1000]))
 
     AsyncSession.reset_default()
     await session.destroy()

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -173,6 +173,10 @@ async def test_sync_execute_in_async(create_cluster):
     np.testing.assert_array_equal(res, np.ones((10, 10)) + 1)
 
 
+def _my_func():
+    print('output from function')
+
+
 async def _run_web_session_test(web_address):
     session_id = str(uuid.uuid4())
     session = await AsyncSession.init(web_address, session_id)
@@ -190,10 +194,7 @@ async def _run_web_session_test(web_address):
     np.testing.assert_equal(raw + 1, await session.fetch(b))
     del a, b
 
-    def f():
-        print('output from function')
-
-    r = mr.spawn(f)
+    r = mr.spawn(_my_func)
     info = await session.execute(r)
     await info
     assert info.result() is None

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -177,6 +177,7 @@ async def _run_web_session_test(web_address):
     session_id = str(uuid.uuid4())
     session = await AsyncSession.init(web_address, session_id)
     session.as_default()
+
     raw = np.random.RandomState(0).rand(10, 10)
     a = mt.tensor(raw, chunk_size=5)
     b = a + 1
@@ -188,6 +189,17 @@ async def _run_web_session_test(web_address):
     assert info.progress() == 1
     np.testing.assert_equal(raw + 1, await session.fetch(b))
     del a, b
+
+    def f():
+        print('output from function')
+
+    r = mr.spawn(f)
+    info = await session.execute(r)
+    await info
+    assert info.result() is None
+    assert info.exception() is None
+    assert info.progress() == 1
+    assert 'output from function' in str(r.fetch_log(session=session))
 
     AsyncSession.reset_default()
     await session.destroy()

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -30,6 +30,8 @@ from .modules.utils import ( # noqa: F401; pylint: disable=unused-variable
 
 ray = lazy_import('ray')
 
+CONFIG_FILE = os.path.join(
+    os.path.dirname(__file__), 'local_test_with_ray_config.yml')
 CONFIG_THIRD_PARTY_MODULES_TEST_FILE = os.path.join(
     os.path.dirname(__file__), 'ray_test_with_third_parity_modules_config.yml')
 
@@ -37,7 +39,7 @@ CONFIG_THIRD_PARTY_MODULES_TEST_FILE = os.path.join(
 @pytest.fixture
 async def create_cluster(request):
     param = getattr(request, "param", {})
-    ray_config = _load_config()
+    ray_config = _load_config(CONFIG_FILE)
     ray_config.update(param.get('config', {}))
     client = await new_cluster('test_cluster',
                                worker_num=2,

--- a/mars/services/session/api/core.py
+++ b/mars/services/session/api/core.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import List, Union
+from typing import Dict, List, Union
 
 from ..core import SessionInfo
 
@@ -71,4 +71,30 @@ class AbstractSessionAPI(ABC):
         -------
         last_idle_time: str
             The last idle time if the session(s) is idle else None.
+        """
+
+    @abstractmethod
+    async def fetch_tileable_op_logs(self,
+                                     session_id: str,
+                                     tileable_op_key: str,
+                                     chunk_op_key_to_offsets: Dict[str, List[int]],
+                                     chunk_op_key_to_sizes: Dict[str, List[int]]) -> Dict:
+        """
+        Fetch tileable op's logs
+
+        Parameters
+        ----------
+        session_id : str
+            Session ID.
+        tileable_op_key : str
+            Tileable op key.
+        chunk_op_key_to_offsets : str or int or list of int
+            Fetch offsets.
+        chunk_op_key_to_sizes : str or int or list of int
+            Fetch sizes.
+
+        Returns
+        -------
+        logs : dict
+            chunk op key to result.
         """

--- a/mars/services/session/api/web.py
+++ b/mars/services/session/api/web.py
@@ -41,7 +41,7 @@ def _decode_size(encoded: str) -> Union[int, str, Dict[str, Union[int, List[int]
         ret = dict()
         for kv in encoded.split(','):
             k, v = kv.split('=', 1)
-            ret[k] = int(v)
+            ret[k] = int(parse_readable_size(v)[0])
         return ret
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

For oscar, `fetch_log` support is absent for web session, this PR added it.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
