### PR TITLE
Merge default & distributed requirements

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,7 +53,7 @@ jobs:
           fi
 
           pip install numpy scipy cython
-          pip install -e ".[dev,distributed]"
+          pip install -e ".[dev,extra]"
           conda list -n test
 
       - name: Deploy packages

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -52,7 +52,7 @@ jobs:
 
         pip install git+https://github.com/mars-project/pytest-asyncio.git
         pip install numpy scipy cython
-        pip install -e ".[dev,distributed]"
+        pip install -e ".[dev,extra]"
         pip install virtualenv flaky flake8
 
         if [ -z "$NO_COMMON_TESTS" ]; then
@@ -74,13 +74,6 @@ jobs:
           if [[ ! "$PYTHON" =~ "3.6" ]] && [[ ! "$PYTHON" =~ "3.9" ]]; then
             pip install torch torchvision
             pip install statsmodels tsfresh
-          fi
-          virtualenv testenv && source testenv/bin/activate
-          pip install -e . && pip install pytest pytest-timeout
-          if [ -z "$DEFAULT_VENV" ]; then
-            deactivate
-          else
-            source $DEFAULT_VENV/bin/activate
           fi
         fi
         retry ./.github/workflows/download-etcd.sh

--- a/.github/workflows/os-compat-ci.yml
+++ b/.github/workflows/os-compat-ci.yml
@@ -39,22 +39,8 @@ jobs:
 
         pip install git+https://github.com/mars-project/pytest-asyncio.git
         pip install numpy scipy cython
-        pip install -e ".[dev,distributed]"
-
-        if [[ $UNAME == "windows" ]]; then
-          pip install virtualenv flaky flake8
-        else
-          pip install virtualenv flaky flake8
-          if [ -z "$NO_COMMON_TESTS" ]; then
-            virtualenv testenv && source testenv/bin/activate
-            pip install -e . && pip install pytest pytest-timeout
-            if [ -z "$DEFAULT_VENV" ]; then
-              deactivate
-            else
-              source $DEFAULT_VENV/bin/activate
-            fi
-          fi
-        fi
+        pip install -e ".[dev,extra]"
+        pip install virtualenv flaky flake8
         conda list -n test
 
     - name: Test with pytest

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -56,7 +56,7 @@ jobs:
             pip install pandas\<1.3
           fi
 
-          pip install -e ".[dev,distributed]"
+          pip install -e ".[dev,extra]"
 
           if [[ $UNAME == "windows" ]]; then
             pip install virtualenv flaky flake8

--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -25,13 +25,4 @@ if [ -z "$NO_COMMON_TESTS" ]; then
     --ignore mars/learn --ignore mars/remote mars
   mv .coverage build/.coverage.main.file
   coverage combine build/ && coverage report
-
-  export DEFAULT_VENV=$VIRTUAL_ENV
-  source testenv/bin/activate
-  pytest --timeout=1500 mars/tests/test_session.py mars/lib/filesystem/tests/test_filesystem.py
-  if [ -z "$DEFAULT_VENV" ]; then
-    deactivate
-  else
-    source $DEFAULT_VENV/bin/activate
-  fi
 fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ jobs:
         else
           pip install numpy scipy cython
         fi
-        pip install -e ".[dev,distributed]"
+        pip install -e ".[dev,extra]"
         pip install virtualenv flaky flake8
 
         if [ -z "$NO_COMMON_TESTS" ]; then

--- a/mars/deploy/kubedl/client.py
+++ b/mars/deploy/kubedl/client.py
@@ -54,7 +54,7 @@ class KubeDLClusterClient:
 
     def start(self):
         self._endpoint = self._cluster.start()
-        self._session = new_session(self._endpoint, verify_ssl=self._cluster.verify_ssl).as_default()
+        self._session = new_session(self._endpoint, verify_ssl=self._cluster.verify_ssl)
 
     def stop(self, wait=False, timeout=0):
         self._cluster.stop(wait=wait, timeout=timeout)

--- a/mars/deploy/kubernetes/client.py
+++ b/mars/deploy/kubernetes/client.py
@@ -57,7 +57,7 @@ class KubernetesClusterClient:
     def start(self):
         try:
             self._endpoint = self._cluster.start()
-            self._session = new_session(self._endpoint, default=True)
+            self._session = new_session(self._endpoint)
         except:  # noqa: E722  # nosec  # pylint: disable=bare-except
             self.stop()
             raise

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -107,8 +107,9 @@ class ExecutionInfo:
         return self._future_local.aio_future.__await__()
 
 
-warning_msg = """No session found, local session \
-will be created in the background, \
+warning_msg = """
+No session found, local session \
+will be created in background, \
 it may take a while before execution. \
 If you want to new a local session by yourself, \
 run code below:
@@ -116,7 +117,7 @@ run code below:
 ```
 import mars
 
-mars.new_session(default=True)
+mars.new_session()
 ```
 """
 
@@ -1354,6 +1355,8 @@ def execute(tileable: TileableType,
             new_session_kwargs: dict = None,
             show_progress: Union[bool, str] = None,
             progress_update_interval=1, **kwargs):
+    if isinstance(tileable, (tuple, list)) and len(tileables) == 0:
+        tileable, tileables = tileable[0], tileable[1:]
     if session is None:
         session = get_default_or_create(
             **(new_session_kwargs or dict()))
@@ -1393,6 +1396,8 @@ def fetch(tileable: TileableType,
 def fetch_log(*tileables: TileableType,
               session: SyncSession = None,
               **kwargs):
+    if len(tileables) == 1 and isinstance(tileables[0], (list, tuple)):
+        tileables = tileables[0]
     if session is None:
         session = get_default_session()
         if session is None:  # pragma: no cover
@@ -1442,7 +1447,7 @@ async def _new_session(address: str,
 def new_session(address: str = None,
                 session_id: str = None,
                 backend: str = 'oscar',
-                default: bool = False,
+                default: bool = True,
                 **kwargs) -> AbstractSession:
     ensure_isolation_created(kwargs)
 
@@ -1481,7 +1486,7 @@ def get_default_or_create(**kwargs):
             # no session attached, try to create one
             warnings.warn(warning_msg)
             session = new_session(
-                '127.0.0.1', default=True, init_local=True, **kwargs)
+                '127.0.0.1', init_local=True, **kwargs)
             session.as_default()
     if isinstance(session, _IsolatedSession):
         session = SyncSession.from_isolated_session(session)

--- a/mars/deploy/oscar/tests/test_cmdline.py
+++ b/mars/deploy/oscar/tests/test_cmdline.py
@@ -150,7 +150,7 @@ def test_cmdline_run(supervisor_args, worker_args, use_web_addr):
             _reload_args(worker_args), env=os.environ.copy()) for _ in range(2)]
         _wait_worker_ready(oscar_ep, w_procs)
 
-        new_session(api_ep, default=True)
+        new_session(api_ep)
         data = np.random.rand(10, 10)
         res = mt.tensor(data, chunk_size=5).sum().execute().fetch()
         np.testing.assert_almost_equal(res, data.sum())

--- a/mars/deploy/oscar/tests/test_cmdline.py
+++ b/mars/deploy/oscar/tests/test_cmdline.py
@@ -18,6 +18,7 @@ import os
 import subprocess
 import sys
 import time
+from concurrent import futures
 from typing import List
 
 import numpy as np
@@ -36,6 +37,8 @@ from mars.utils import get_next_port, kill_process_tree
 
 class _ProcessExitedException(Exception):
     pass
+
+_TimeoutErrors = (asyncio.TimeoutError, futures.TimeoutError, TimeoutError)
 
 
 def _wait_supervisor_ready(supervisor_proc: subprocess.Popen, timeout=120):
@@ -79,7 +82,7 @@ def _wait_worker_ready(supervisor_addr, worker_procs: List[subprocess.Popen],
                 await asyncio.sleep(0.1)
 
     isolation = get_isolation()
-    asyncio.run_coroutine_threadsafe(wait_for_workers(), isolation.loop).result()
+    asyncio.run_coroutine_threadsafe(wait_for_workers(), isolation.loop).result(120)
 
 
 _test_port_cache = dict()
@@ -124,15 +127,21 @@ def _reload_args(args):
     return [arg if not callable(arg) else arg() for arg in args]
 
 
+_rerun_errors = (_ProcessExitedException,) + _TimeoutErrors
+
+
 @pytest.mark.parametrize('supervisor_args,worker_args,use_web_addr',
                          list(start_params.values()), ids=list(start_params.keys()))
-@flaky(rerun_filter=lambda *args: issubclass(args[0][0], _ProcessExitedException))
+@flaky(rerun_filter=lambda *args: issubclass(args[0][0], _rerun_errors))
 def test_cmdline_run(supervisor_args, worker_args, use_web_addr):
     new_isolation()
     sv_proc = w_procs = None
     try:
+        env = os.environ.copy()
+        env['MARS_CPU_TOTAL'] = '2'
+
         sv_args = _reload_args(supervisor_args)
-        sv_proc = subprocess.Popen(sv_args, env=os.environ.copy())
+        sv_proc = subprocess.Popen(sv_args, env=env)
 
         oscar_port = _get_labelled_port('supervisor', create=False)
         if not oscar_port:
@@ -147,7 +156,7 @@ def test_cmdline_run(supervisor_args, worker_args, use_web_addr):
             api_ep = oscar_ep
 
         w_procs = [subprocess.Popen(
-            _reload_args(worker_args), env=os.environ.copy()) for _ in range(2)]
+            _reload_args(worker_args), env=env) for _ in range(2)]
         _wait_worker_ready(oscar_ep, w_procs)
 
         new_session(api_ep)

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -228,8 +228,7 @@ async def test_web_session(create_cluster):
 
 
 def test_sync_execute():
-    session = new_session(n_cpu=2, default=True,
-                          web=False, use_uvloop=False)
+    session = new_session(n_cpu=2, web=False, use_uvloop=False)
 
     # web not started
     assert session._session.client.web_address is None
@@ -293,7 +292,7 @@ def test_no_default_session():
 
 @pytest.fixture
 def setup_session():
-    session = new_session(n_cpu=2, default=True, use_uvloop=False)
+    session = new_session(n_cpu=2, use_uvloop=False)
     assert session.get_web_endpoint() is not None
 
     with session:
@@ -420,22 +419,18 @@ def test_load_third_party_modules(cleanup_third_party_modules_output):  # noqa: 
 
     config['third_party_modules'] = set()
     with pytest.raises(TypeError, match='set'):
-        new_session(n_cpu=2, default=True,
-                    web=False, config=config)
+        new_session(n_cpu=2, web=False, config=config)
 
     config['third_party_modules'] = {'supervisor': ['not_exists_for_supervisor']}
     with pytest.raises(ModuleNotFoundError, match='not_exists_for_supervisor'):
-        new_session(n_cpu=2, default=True,
-                    web=False, config=config)
+        new_session(n_cpu=2, web=False, config=config)
 
     config['third_party_modules'] = {'worker': ['not_exists_for_worker']}
     with pytest.raises(ModuleNotFoundError, match='not_exists_for_worker'):
-        new_session(n_cpu=2, default=True,
-                    web=False, config=config)
+        new_session(n_cpu=2, web=False, config=config)
 
     config['third_party_modules'] = ['mars.deploy.oscar.tests.modules.replace_op']
-    session = new_session(n_cpu=2, default=True,
-                          web=False, config=config)
+    session = new_session(n_cpu=2, web=False, config=config)
     # web not started
     assert session._session.client.web_address is None
 
@@ -451,8 +446,8 @@ def test_load_third_party_modules(cleanup_third_party_modules_output):  # noqa: 
     session.stop_server()
     assert get_default_session() is None
 
-    session = new_session(n_cpu=2, default=True,
-                          web=False, config=CONFIG_THIRD_PARTY_MODULES_TEST_FILE)
+    session = new_session(n_cpu=2, web=False,
+                          config=CONFIG_THIRD_PARTY_MODULES_TEST_FILE)
     # web not started
     assert session._session.client.web_address is None
 

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -72,7 +72,7 @@ async def test_execute_describe(ray_large_cluster, create_cluster):
 @pytest.mark.asyncio
 def test_sync_execute(ray_large_cluster, create_cluster):
     assert create_cluster.session
-    session = new_session(address=create_cluster.address, backend='oscar', default=True)
+    session = new_session(address=create_cluster.address, backend='oscar')
     with session:
         raw = np.random.RandomState(0).rand(10, 5)
         a = mt.tensor(raw, chunk_size=5).sum(axis=1)
@@ -99,7 +99,7 @@ def _run_web_session(web_address):
 
 def _sync_web_session_test(web_address):
     register_ray_serializers()
-    new_session(web_address, backend='oscar', default=True)
+    new_session(web_address, backend='oscar')
     raw = np.random.RandomState(0).rand(10, 5)
     a = mt.tensor(raw, chunk_size=5).sum(axis=1)
     b = a.execute(show_progress=False)
@@ -182,7 +182,7 @@ async def test_load_third_party_modules(ray_large_cluster):
 @pytest.mark.asyncio
 def test_load_third_party_modules2(ray_large_cluster, create_cluster):
     assert create_cluster.session
-    session = new_session(address=create_cluster.address, backend='oscar', default=True)
+    session = new_session(address=create_cluster.address, backend='oscar')
     with session:
         raw = np.random.RandomState(0).rand(10, 10)
         a = mt.tensor(raw, chunk_size=5)

--- a/mars/deploy/yarn/client.py
+++ b/mars/deploy/yarn/client.py
@@ -32,7 +32,7 @@ class YarnClusterClient:
         self._is_client_managed = is_client_managed
         self._application_id = application_id
         self._endpoint = endpoint
-        self._session = new_session(endpoint).as_default()
+        self._session = new_session(endpoint)
 
     @property
     def session(self):

--- a/mars/learn/contrib/joblib/backend.py
+++ b/mars/learn/contrib/joblib/backend.py
@@ -36,7 +36,7 @@ class MarsDistributedBackend(AutoBatchingMixin, ParallelBackendBase):
 
         if session is None:
             if service is not None:
-                self.session = new_session(service, backend=backend)
+                self.session = new_session(service, backend=backend, default=False)
             else:
                 self.session = get_default_session()
         else:

--- a/mars/learn/contrib/joblib/tests/test_backend.py
+++ b/mars/learn/contrib/joblib/tests/test_backend.py
@@ -13,22 +13,16 @@
 # limitations under the License.
 
 import numpy as np
-import pytest
-try:
-    import joblib
-    import sklearn
-    from sklearn.datasets import load_digits
-    from sklearn.model_selection import RandomizedSearchCV
-    from sklearn.svm import SVC
-except ImportError:
-    joblib = sklearn = None
+import joblib
+from sklearn.datasets import load_digits
+from sklearn.model_selection import RandomizedSearchCV
+from sklearn.svm import SVC
 
 from mars.learn.contrib.joblib import register_mars_backend
 
 register_mars_backend()
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_sk_learn_svc_train(setup):
     digits = load_digits()
     param_space = {

--- a/mars/learn/contrib/tsfresh/tests/test_tsfresh.py
+++ b/mars/learn/contrib/tsfresh/tests/test_tsfresh.py
@@ -32,7 +32,7 @@ def test_distributed_ts_fresh(setup):
     robot_execution_failures.download_robot_execution_failures()
     df, y = robot_execution_failures.load_robot_execution_failures()
     default_session = get_default_session()
-    sync_session = new_session(default_session.address)
+    sync_session = new_session(default_session.address, default=False)
     dist = MarsDistributor(session=sync_session)
 
     df = df.iloc[:200].copy()

--- a/mars/learn/datasets/tests/test_samples_generator.py
+++ b/mars/learn/datasets/tests/test_samples_generator.py
@@ -16,14 +16,8 @@ from functools import partial
 from collections import defaultdict
 
 import numpy as np
-import pytest
-
-try:
-    import sklearn
-    from sklearn.utils._testing import assert_array_almost_equal, assert_raises, \
-        assert_almost_equal, assert_raise_message
-except ImportError:  # pragma: no cover
-    sklearn = None
+from sklearn.utils._testing import assert_array_almost_equal, assert_raises, \
+    assert_almost_equal, assert_raise_message
 
 from mars import tensor as mt
 from mars.learn.datasets.samples_generator import make_low_rank_matrix, \
@@ -31,7 +25,6 @@ from mars.learn.datasets.samples_generator import make_low_rank_matrix, \
 from mars.tensor.linalg import svd
 
 
-@pytest.mark.skipif(sklearn is None, reason='sklearn not installed')
 def test_make_classification(setup):
     weights = [0.1, 0.25]
     X, y = make_classification(n_samples=100, n_features=20, n_informative=5,
@@ -61,7 +54,6 @@ def test_make_classification(setup):
         -1, X.shape[1]).shape[0] == 2000
 
 
-@pytest.mark.skipif(sklearn is None, reason='sklearn not installed')
 def test_make_classification_informative_features(setup):
     """Test the construction of informative features in make_classification
 
@@ -142,7 +134,6 @@ def test_make_classification_informative_features(setup):
                   n_clusters_per_class=2)
 
 
-@pytest.mark.skipif(sklearn is None, reason='sklearn not installed')
 def test_make_blobs(setup):
     cluster_stds = np.array([0.05, 0.2, 0.4])
     cluster_centers = np.array([[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
@@ -165,7 +156,6 @@ def test_make_blobs_n_samples_list(setup):
     assert all(np.bincount(y, minlength=len(n_samples)) == n_samples) is True
 
 
-@pytest.mark.skipif(sklearn is None, reason='sklearn not installed')
 def test_make_blobs_n_samples_list_with_centers(setup):
     n_samples = [20, 20, 20]
     centers = np.array([[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
@@ -190,7 +180,6 @@ def test_make_blobs_n_samples_centers_none(setup):
         assert all(np.bincount(y, minlength=len(n_samples)) == n_samples) is True
 
 
-@pytest.mark.skipif(sklearn is None, reason='sklearn not installed')
 def test_make_blobs_error(setup):
     n_samples = [20, 20, 20]
     centers = np.array([[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]])

--- a/mars/learn/decomposition/tests/test_pca.py
+++ b/mars/learn/decomposition/tests/test_pca.py
@@ -16,18 +16,13 @@ from itertools import product
 
 import numpy as np
 import pytest
-try:
-    import scipy as sp
-    import sklearn
-    from sklearn import datasets
-    from sklearn.utils._testing import assert_array_almost_equal, \
-        assert_almost_equal, assert_raises_regex, assert_raise_message, assert_raises
-except ImportError:
-    sklearn = None
+import scipy as sp
+from sklearn import datasets
+from sklearn.utils._testing import assert_array_almost_equal, \
+    assert_almost_equal, assert_raises_regex, assert_raise_message, assert_raises
 
 import mars.tensor as mt
-if sklearn:
-    from mars.learn.decomposition._pca import PCA, _assess_dimension, _infer_dimension
+from mars.learn.decomposition._pca import PCA, _assess_dimension, _infer_dimension
 
 
 iris = mt.tensor(datasets.load_iris().data)
@@ -35,7 +30,6 @@ iris = mt.tensor(datasets.load_iris().data)
 solver_list = ['full', 'randomized', 'auto']
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca(setup):
     X = iris
 
@@ -64,7 +58,6 @@ def test_pca(setup):
     np.testing.assert_allclose(pca.explained_variance_ratio_.sum().to_numpy(), 1.0, 3)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_randomized_solver(setup):
     # PCA on dense arrays
     X = iris
@@ -102,7 +95,6 @@ def test_pca_randomized_solver(setup):
                          svd_solver='randomized', random_state=0).svd_solver
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_whitening(setup):
     # Check that PCA output has unit-variance
     rng = np.random.RandomState(0)
@@ -151,7 +143,6 @@ def test_whitening(setup):
         # we always center, so no test for non-centering.
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_explained_variance(setup):
     # Check that PCA output has unit-variance
     rng = np.random.RandomState(0)
@@ -196,7 +187,6 @@ def test_explained_variance(setup):
                               rpca.explained_variance_ratio_.to_numpy(), 5)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_singular_values(setup):
     # Check that the PCA output has the correct singular values
 
@@ -249,7 +239,6 @@ def test_singular_values(setup):
     assert_array_almost_equal(rpca.singular_values_.fetch(), [3.142, 2.718, 1.0], 14)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_check_projection(setup):
     # Test that the projection of data is correct
     rng = np.random.RandomState(0)
@@ -265,7 +254,6 @@ def test_pca_check_projection(setup):
         assert_almost_equal(mt.abs(Yt[0][0]).to_numpy(), 1., 1)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_inverse(setup):
     # Test that the projection of data can be inverted
     rng = np.random.RandomState(0)
@@ -290,7 +278,6 @@ def test_pca_inverse(setup):
         assert_almost_equal(X.to_numpy(), Y_inverse.to_numpy(), decimal=3)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_validation(setup):
     for solver in solver_list:
         # Ensures that solver-specific extreme inputs for the n_components
@@ -322,7 +309,6 @@ def test_pca_validation(setup):
                              PCA(n_components, svd_solver=solver).fit, data)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_n_components_none(setup):
     for solver in solver_list:
         # Ensures that n_components == None is handled correctly
@@ -334,7 +320,6 @@ def test_n_components_none(setup):
             assert pca.n_components_ == min(data.shape)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_randomized_pca_check_projection(setup):
     # Test that the projection by randomized PCA on dense data is correct
     rng = np.random.RandomState(0)
@@ -350,7 +335,6 @@ def test_randomized_pca_check_projection(setup):
     assert_almost_equal(mt.abs(Yt[0][0]).to_numpy(), 1., 1)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_randomized_pca_check_list(setup):
     # Test that the projection by randomized PCA on list data is correct
     X = mt.tensor([[1.0, 0.0], [0.0, 1.0]])
@@ -361,7 +345,6 @@ def test_randomized_pca_check_list(setup):
     assert_almost_equal(X_transformed.std().to_numpy(), 0.71, 2)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_randomized_pca_inverse(setup):
     # Test that randomized PCA is inversible on dense data
     rng = np.random.RandomState(0)
@@ -386,7 +369,6 @@ def test_randomized_pca_inverse(setup):
     assert relative_max_delta.to_numpy() < 1e-5
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_n_components_mle(setup):
     # Ensure that n_components == 'mle' doesn't raise error for auto/full
     # svd_solver and raises error for arpack/randomized svd_solver
@@ -407,7 +389,6 @@ def test_n_components_mle(setup):
     assert n_components_dict['auto'] == n_components_dict['full']
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_dim(setup):
     # Check automated dimensionality setting
     rng = np.random.RandomState(0)
@@ -419,7 +400,6 @@ def test_pca_dim(setup):
     assert pca.n_components_ == 1
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_infer_dim_1(setup):
     # TODO: explain what this is testing
     # Or at least use explicit variable names...
@@ -434,7 +414,6 @@ def test_infer_dim_1(setup):
     assert ll[1] > ll.max() - .01 * n
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_infer_dim_2(setup):
     # TODO: explain what this is testing
     # Or at least use explicit variable names...
@@ -449,7 +428,6 @@ def test_infer_dim_2(setup):
     assert _infer_dimension(spect, n) > 1
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_infer_dim_3(setup):
     n, p = 100, 5
     rng = np.random.RandomState(0)
@@ -463,7 +441,6 @@ def test_infer_dim_3(setup):
     assert _infer_dimension(spect, n) > 2
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_infer_dim_by_explained_variance(setup):
     X = iris
     pca = PCA(n_components=0.95, svd_solver='full')
@@ -484,7 +461,6 @@ def test_infer_dim_by_explained_variance(setup):
     assert pca.n_components_ == 2
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_score(setup):
     # Test that probabilistic PCA scoring yields a reasonable score
     n, p = 1000, 3
@@ -498,7 +474,6 @@ def test_pca_score(setup):
         np.testing.assert_almost_equal((ll1 / h).to_numpy(), 1, 0)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_score2(setup):
     # Test that probabilistic PCA correctly separated different datasets
     n, p = 100, 3
@@ -518,7 +493,6 @@ def test_pca_score2(setup):
         assert ll1.fetch() > ll2.fetch()
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_score3(setup):
     # Check that probabilistic PCA selects the right model
     n, p = 200, 3
@@ -536,7 +510,6 @@ def test_pca_score3(setup):
     assert ll.argmax().to_numpy() == 1
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_score_with_different_solvers(setup):
     digits = datasets.load_digits()
     X_digits = mt.tensor(digits.data)
@@ -560,7 +533,6 @@ def test_pca_score_with_different_solvers(setup):
                         decimal=3)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_zero_noise_variance_edge_cases(setup):
     # ensure that noise_variance_ is 0 in edge cases
     # when n_components == min(n_samples, n_features)
@@ -581,7 +553,6 @@ def test_pca_zero_noise_variance_edge_cases(setup):
         assert pca.noise_variance_ == 0
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_svd_solver_auto(setup):
     rng = np.random.RandomState(0)
     X = mt.tensor(rng.uniform(size=(1000, 50)))
@@ -616,7 +587,6 @@ def test_svd_solver_auto(setup):
     assert_array_almost_equal(pca.components_.to_numpy(), pca_test.components_.to_numpy())
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_sparse_input(setup):
     for svd_solver in solver_list:
         X = np.random.RandomState(0).rand(5, 4)
@@ -628,7 +598,6 @@ def test_pca_sparse_input(setup):
         assert_raises(TypeError, pca.fit, X)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_bad_solver(setup):
     X = mt.tensor(np.random.RandomState(0).rand(5, 4))
     pca = PCA(n_components=3, svd_solver='bad_argument')
@@ -636,7 +605,6 @@ def test_pca_bad_solver(setup):
         pca.fit(X)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_dtype_preservation(setup):
     for svd_solver in solver_list:
         _check_pca_float_dtype_preservation(svd_solver)
@@ -684,7 +652,6 @@ def _check_pca_int_dtype_upcast_to_double(svd_solver):
                               decimal=5)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pca_deterministic_output(setup):
     rng = np.random.RandomState(0)
     X = mt.tensor(rng.rand(10, 10))

--- a/mars/learn/decomposition/tests/test_truncated_svd.py
+++ b/mars/learn/decomposition/tests/test_truncated_svd.py
@@ -14,17 +14,12 @@
 
 import numpy as np
 import pytest
-try:
-    import sklearn
-    import scipy.sparse as sp
-    from sklearn.utils import check_random_state
-    from sklearn.utils._testing import assert_array_almost_equal, assert_array_less
-except ImportError:
-    sklearn = None
+import scipy.sparse as sp
+from sklearn.utils import check_random_state
+from sklearn.utils._testing import assert_array_almost_equal, assert_array_less
 
 import mars.tensor as mt
-if sklearn:
-    from mars.learn.decomposition import TruncatedSVD
+from mars.learn.decomposition import TruncatedSVD
 
 
 # Make an X that looks somewhat like a small tf-idf matrix.
@@ -40,7 +35,6 @@ n_samples = n_samples
 n_features = n_features
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_attributes(setup):
     for n_components in (10, 25, 41):
         tsvd = TruncatedSVD(n_components).fit(X)
@@ -48,7 +42,6 @@ def test_attributes(setup):
         assert tsvd.components_.shape == (n_components, n_features)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_too_many_components(setup):
     for n_components in (n_features, n_features + 1):
         tsvd = TruncatedSVD(n_components=n_components, algorithm='randomized')
@@ -56,7 +49,6 @@ def test_too_many_components(setup):
             tsvd.fit(X)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_sparse_formats(setup):
     tsvd = TruncatedSVD(n_components=11)
     Xtrans = tsvd.fit_transform(Xdense)
@@ -65,7 +57,6 @@ def test_sparse_formats(setup):
     assert Xtrans.shape == (n_samples, 11)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_inverse_transform(setup):
     # We need a lot of components for the reconstruction to be "almost
     # equal" in all positions. XXX Test means or sums instead?
@@ -75,7 +66,6 @@ def test_inverse_transform(setup):
     assert_array_almost_equal(Xinv.fetch(), Xdense, decimal=1)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_integers(setup):
     Xint = X.astype(np.int64)
     tsvd = TruncatedSVD(n_components=6)
@@ -83,7 +73,6 @@ def test_integers(setup):
     assert Xtrans.shape == (n_samples, tsvd.n_components)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_explained_variance(setup):
     # Test sparse data
     svd_r_10_sp = TruncatedSVD(10, algorithm="randomized", random_state=42)
@@ -151,7 +140,6 @@ def test_explained_variance(setup):
         )
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_singular_values(setup):
     # Check that the TruncatedSVD output has the correct singular values
 

--- a/mars/learn/metrics/pairwise/tests/test_cosine_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_cosine_distances.py
@@ -15,12 +15,7 @@
 import numpy as np
 import scipy.sparse as sps
 import pytest
-try:
-    import sklearn
-
-    from sklearn.metrics.pairwise import cosine_distances as sk_cosine_distances
-except ImportError:
-    sklearn = None
+from sklearn.metrics.pairwise import cosine_distances as sk_cosine_distances
 
 from mars import tensor as mt
 from mars.learn.metrics.pairwise import cosine_distances
@@ -38,7 +33,6 @@ raw_x_ys = [
 ]
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 @pytest.mark.parametrize('raw_x, raw_y', raw_x_ys)
 @pytest.mark.parametrize('chunk_size', [25, 6])
 def test_cosine_distances_execution(setup, raw_x, raw_y, chunk_size):

--- a/mars/learn/metrics/pairwise/tests/test_euclidean_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_euclidean_distances.py
@@ -15,12 +15,7 @@
 import numpy as np
 import scipy.sparse as sps
 import pytest
-try:
-    import sklearn
-
-    from sklearn.metrics import euclidean_distances as sk_euclidean_distances
-except ImportError:  # pragma: no cover
-    sklearn = None
+from sklearn.metrics import euclidean_distances as sk_euclidean_distances
 
 from mars import tensor as mt
 from mars.config import option_context
@@ -29,7 +24,6 @@ from mars.learn.metrics import euclidean_distances
 from mars.learn.utils import check_array
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_euclidean_distances_op():
     x = mt.random.rand(10, 3)
     xx = mt.random.rand(1, 10)
@@ -56,7 +50,6 @@ def test_euclidean_distances_op():
         euclidean_distances(x, y, Y_norm_squared=mt.random.rand(10))
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_euclidean_distances_execution(setup):
     dense_raw_x = np.random.rand(30, 10)
     dense_raw_y = np.random.rand(40, 10)

--- a/mars/learn/metrics/pairwise/tests/test_haversine_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_haversine_distances.py
@@ -14,18 +14,12 @@
 
 import numpy as np
 import pytest
-try:
-    import sklearn
-
-    from sklearn.metrics.pairwise import haversine_distances as sk_haversine_distances
-except ImportError:  # pragma: no cover
-    sklearn = None
+from sklearn.metrics.pairwise import haversine_distances as sk_haversine_distances
 
 from mars import tensor as mt
 from mars.learn.metrics.pairwise import haversine_distances
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_haversine_distances_op():
     # shape[1] != 2
     with pytest.raises(ValueError):
@@ -52,7 +46,6 @@ x2 = mt.tensor(raw_x, chunk_size=(11, 1))
 y2 = mt.tensor(raw_y, chunk_size=(17, 1))
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 @pytest.mark.parametrize('x, y', [(x1, y1), (x2, y2)])
 @pytest.mark.parametrize('use_sklearn', [True, False])
 def test_haversine_distances_execution(setup, x, y, use_sklearn):

--- a/mars/learn/metrics/pairwise/tests/test_manhattan_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_manhattan_distances.py
@@ -15,18 +15,12 @@
 import numpy as np
 import scipy.sparse as sps
 import pytest
-try:
-    import sklearn
-
-    from sklearn.metrics.pairwise import manhattan_distances as sk_manhattan_distances
-except ImportError:  # pragma: no cover
-    sklearn = None
+from sklearn.metrics.pairwise import manhattan_distances as sk_manhattan_distances
 
 from mars import tensor as mt
 from mars.learn.metrics.pairwise import manhattan_distances
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_manhattan_distances():
     x = mt.random.randint(10, size=(10, 3), density=0.4)
     y = mt.random.randint(10, size=(11, 3), density=0.5)
@@ -62,7 +56,6 @@ x4 = mt.tensor(raw_sparse_x, chunk_size=11)
 y4 = mt.tensor(raw_sparse_y, chunk_size=12)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 @pytest.mark.parametrize('x, y, is_sparse',
                          [(x1, y1, False),
                           (x2, y2, False),

--- a/mars/learn/metrics/pairwise/tests/test_pariwise_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_pariwise_distances.py
@@ -14,22 +14,16 @@
 
 import numpy as np
 import pytest
-try:
-    import sklearn
-
-    from sklearn.metrics import pairwise_distances as sk_pairwise_distances
-    from sklearn.neighbors import NearestNeighbors as SkNearestNeighbors
-    from sklearn.exceptions import DataConversionWarning
-    from sklearn.utils._testing import assert_warns
-except ImportError:
-    sklearn = None
+from sklearn.metrics import pairwise_distances as sk_pairwise_distances
+from sklearn.neighbors import NearestNeighbors as SkNearestNeighbors
+from sklearn.exceptions import DataConversionWarning
+from sklearn.utils._testing import assert_warns
 
 from mars import tensor as mt
 from mars.learn.metrics import pairwise_distances, pairwise_distances_topk
 from mars.session import execute, fetch
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pairwise_distances_execution(setup):
     raw_x = np.random.rand(20, 5)
     raw_y = np.random.rand(21, 5)
@@ -78,7 +72,6 @@ def test_pairwise_distances_execution(setup):
         _ = pairwise_distances(x, y, metric='unknown')
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_pairwise_distances_topk_execution(setup):
     rs = np.random.RandomState(0)
     raw_x = rs.rand(20, 5)

--- a/mars/learn/metrics/pairwise/tests/test_rbf_kernel.py
+++ b/mars/learn/metrics/pairwise/tests/test_rbf_kernel.py
@@ -13,18 +13,11 @@
 # limitations under the License.
 
 import numpy as np
-import pytest
-try:
-    import sklearn
-
-    from sklearn.metrics.pairwise import rbf_kernel as sklearn_rbf_kernel
-except ImportError:  # pragma: no cover
-    sklearn = None
+from sklearn.metrics.pairwise import rbf_kernel as sklearn_rbf_kernel
 
 from mars.learn.metrics.pairwise import rbf_kernel
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_rbf_kernel(setup):
     rs = np.random.RandomState(0)
     raw_X = rs.rand(10, 4)

--- a/mars/learn/metrics/tests/test_classification.py
+++ b/mars/learn/metrics/tests/test_classification.py
@@ -14,11 +14,7 @@
 
 import numpy as np
 import pytest
-try:
-    import sklearn
-    from sklearn.metrics import accuracy_score as sklearn_accuracy_score
-except ImportError:  # pragma: no cover
-    sklearn = None
+from sklearn.metrics import accuracy_score as sklearn_accuracy_score
 
 import mars.tensor as mt
 from mars.learn.metrics import accuracy_score
@@ -112,7 +108,6 @@ def test__check_targets(setup, type1, y1, type2, y2):
             _check_targets(y1[:-1], y2).execute()
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_accuracy_score(setup):
     y_pred = [0, 2, 1, 3]
     y_true = [0, 1, 2, 3]

--- a/mars/learn/preprocessing/tests/test_data.py
+++ b/mars/learn/preprocessing/tests/test_data.py
@@ -13,18 +13,12 @@
 # limitations under the License.
 
 import pytest
-try:
-    import sklearn
-
-    from sklearn.datasets import load_iris
-    from sklearn.utils import gen_batches
-    from sklearn.utils._testing import assert_array_almost_equal, assert_allclose
-except ImportError:
-    sklearn = None
+from sklearn.datasets import load_iris
+from sklearn.utils import gen_batches
+from sklearn.utils._testing import assert_array_almost_equal, assert_allclose
 
 from mars import tensor as mt
-if sklearn:
-    from mars.learn.preprocessing import MinMaxScaler, minmax_scale
+from mars.learn.preprocessing import MinMaxScaler, minmax_scale
 
 
 def assert_correct_incr(i, batch_start, batch_stop, n, chunk_size,
@@ -51,7 +45,6 @@ X_1col = X_2d[:, 0].reshape(n_samples, 1)
 iris = mt.tensor(load_iris().data)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 @pytest.mark.parametrize('chunk_size', [200, X_2d.shape[0], X_2d.shape[0] + 42])
 def test_min_max_scaler_partial_fit(setup, chunk_size):
     # Test if partial_fit run over many batches of size 1 and 50
@@ -102,7 +95,6 @@ def test_min_max_scaler_partial_fit(setup, chunk_size):
                             n_samples_seen=scaler_incr.n_samples_seen_)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_min_max_scaler_iris(setup):
     X = iris
     scaler = MinMaxScaler()
@@ -135,7 +127,6 @@ def test_min_max_scaler_iris(setup):
         scaler.fit(X)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_min_max_scaler_zero_variance_features(setup):
     # Check min max scaler on toy data with zero variance features
     X = [[0., 1., +0.5],
@@ -177,7 +168,6 @@ def test_min_max_scaler_zero_variance_features(setup):
     assert_array_almost_equal(X_trans, X_expected_1_2)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_minmax_scale_axis1(setup):
     X = iris
     X_trans = minmax_scale(X, axis=1)
@@ -185,7 +175,6 @@ def test_minmax_scale_axis1(setup):
     assert_array_almost_equal(mt.max(X_trans, axis=1), 1)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_min_max_scaler1d(setup):
     X_list_1row = X_1row.to_numpy().tolist()
     X_list_1col = X_1col.to_numpy().tolist()
@@ -229,7 +218,6 @@ def test_min_max_scaler1d(setup):
                               minmax_scale(X_1d, copy=True))
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 @pytest.mark.parametrize('feature_range', [(0, 1), (-10, 10)])
 def test_minmax_scaler_clip(setup, feature_range):
     # test behaviour of the parameter 'clip' in MinMaxScaler

--- a/mars/learn/preprocessing/tests/test_normalize.py
+++ b/mars/learn/preprocessing/tests/test_normalize.py
@@ -15,18 +15,12 @@
 import numpy as np
 import scipy.sparse as sps
 import pytest
-try:
-    import sklearn
-
-    from sklearn.preprocessing import normalize as sk_normalize
-except ImportError:
-    sklearn = None
+from sklearn.preprocessing import normalize as sk_normalize
 
 from mars import tensor as mt
 from mars.learn.preprocessing import normalize
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_normalize_op():
     with pytest.raises(ValueError):
         normalize(mt.random.random(10, 3), norm='unknown')
@@ -38,7 +32,6 @@ def test_normalize_op():
         normalize(mt.random.rand(10, 3, 3))
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_normalize_execution(setup):
     raw_dense = np.random.rand(10, 10)
     raw_sparse = sps.random(10, 10, density=0.4, format='csr')

--- a/mars/learn/semi_supervised/tests/test_label_propagation.py
+++ b/mars/learn/semi_supervised/tests/test_label_propagation.py
@@ -14,15 +14,10 @@
 
 import numpy as np
 import pytest
-try:
-    import sklearn
-
-    from sklearn.datasets import make_classification
-    from sklearn.model_selection import train_test_split
-    from sklearn.exceptions import ConvergenceWarning
-    from sklearn.utils._testing import assert_no_warnings, assert_warns
-except ImportError:  # pragma: no cover
-    sklearn = None
+from sklearn.datasets import make_classification
+from sklearn.model_selection import train_test_split
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.utils._testing import assert_no_warnings, assert_warns
 
 from mars import tensor as mt
 from mars.learn.metrics.pairwise import rbf_kernel
@@ -76,7 +71,6 @@ def test_predict_proba(setup, estimator, parameters):
                                    np.array([[0.5, 0.5]]))
 
 
-@pytest.mark.skipif(sklearn is None, reason='sklearn not installed')
 def test_label_propagation_closed_form(setup):
     n_classes = 2
     X, y = make_classification(n_classes=n_classes, n_samples=200,
@@ -107,7 +101,6 @@ def test_label_propagation_closed_form(setup):
         expected, clf.label_distributions_.fetch(), 4)
 
 
-@pytest.mark.skipif(sklearn is None, reason='sklearn not installed')
 def test_convergence_warning(setup):
     # This is a non-regression test for #5774
     X = np.array([[1., 0.], [0., 1.], [1., 2.5]])
@@ -121,7 +114,6 @@ def test_convergence_warning(setup):
     assert_no_warnings(mdl.fit, X, y)
 
 
-@pytest.mark.skipif(sklearn is None, reason='sklearn not installed')
 def test_predict_sparse_callable_kernel(setup):
     # This is a non-regression test for #15866
 

--- a/mars/learn/utils/tests/test_validation.py
+++ b/mars/learn/utils/tests/test_validation.py
@@ -16,23 +16,17 @@ from itertools import product
 
 import numpy as np
 import pytest
-try:
-    import scipy.sparse as sp
-    import sklearn
-    from sklearn.utils.estimator_checks import NotAnArray
-    from sklearn.utils.mocking import MockDataFrame
-    from sklearn.utils._testing import assert_raise_message, assert_raises_regex
-except ImportError:
-    sklearn = None
+import scipy.sparse as sp
+from sklearn.utils.estimator_checks import _NotAnArray
+from sklearn.utils._mocking import MockDataFrame
+from sklearn.utils._testing import assert_raise_message, assert_raises_regex
 
 import mars.tensor as mt
 import mars.dataframe as md
 from mars.tensor.core import Tensor
-if sklearn:
-    from mars.learn.utils.validation import check_array, check_consistent_length
+from mars.learn.utils.validation import check_array, check_consistent_length
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_ordering():
     # Check that ordering is enforced correctly by validation utilities.
     # We need to check each validation utility, because a 'copy' without
@@ -48,7 +42,6 @@ def test_ordering():
                 assert A is not B
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_check_array(setup):
     # accept_sparse == False
     # raise error on sparse inputs
@@ -118,7 +111,7 @@ def test_check_array(setup):
         check_array(X_ndim.to_numpy().tolist())
     check_array(X_ndim.to_numpy().tolist(), allow_nd=True)  # doesn't raise
     # convert weird stuff to arrays
-    X_no_array = NotAnArray(X_dense.to_numpy())
+    X_no_array = _NotAnArray(X_dense.to_numpy())
     result = check_array(X_no_array)
     assert isinstance(result, Tensor)
 
@@ -141,7 +134,6 @@ def test_check_array(setup):
         _ = check_array(X).execute()
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_check_array_pandas_dtype_object_conversion():
     # test that data-frame like objects with dtype object
     # get converted
@@ -154,13 +146,11 @@ def test_check_array_pandas_dtype_object_conversion():
     assert check_array(X_df, ensure_2d=False).dtype.kind == "f"
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_check_array_from_dataframe():
     X = md.DataFrame({'a': [1.0, 2.0, 3.0]})
     assert check_array(X).dtype.kind == 'f'
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_check_array_accept_sparse_type_exception():
     X = [[1, 2], [3, 4]]
     X_csr = sp.csr_matrix(X)
@@ -181,7 +171,6 @@ def test_check_array_accept_sparse_type_exception():
         check_array(X_csr, accept_sparse=object)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_check_array_accept_sparse_no_exception():
     X = [[1, 2], [3, 4]]
     X_csr = sp.csr_matrix(X)
@@ -191,7 +180,6 @@ def test_check_array_accept_sparse_no_exception():
     assert array.issparse() is True
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_check_array_min_samples_and_features_messages():
     # empty list is considered 2D by default:
     msg = "0 feature(s) (shape=(1, 0)) while a minimum of 1 is required."
@@ -207,7 +195,6 @@ def test_check_array_min_samples_and_features_messages():
     assert_raise_message(TypeError, msg, check_array, 42, ensure_2d=False)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_check_array_complex_data_error():
     X = mt.array([[1 + 2j, 3 + 4j, 5 + 7j], [2 + 3j, 4 + 5j, 6 + 7j]])
     assert_raises_regex(
@@ -247,7 +234,6 @@ def test_check_array_complex_data_error():
         ValueError, "Complex data not supported", check_array, X)
 
 
-@pytest.mark.skipif(sklearn is None, reason='scikit-learn not installed')
 def test_check_consistent_length(setup):
     t = mt.random.RandomState(0).rand(10, 5)
     t2 = t[t[:, 0] < 0.5]

--- a/mars/services/context.py
+++ b/mars/services/context.py
@@ -81,7 +81,7 @@ class ThreadedServiceContext(Context):
     def get_current_session(self) -> SessionType:
         from ..deploy.oscar.session import new_session
 
-        return new_session(self.supervisor_address, self.session_id)
+        return new_session(self.supervisor_address, self.session_id, default=False)
 
     @implements(Context.get_supervisor_addresses)
     def get_supervisor_addresses(self) -> List[str]:

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -13,27 +13,21 @@
 # limitations under the License.
 
 import numpy as np
-import pytest
-try:
-    import scipy
-    from scipy.special import (
-        gammaln as scipy_gammaln,
-        erf as scipy_erf,
-        betainc as scipy_betainc,
-    )
-    from mars.tensor.special.gamma_funcs import (
-        gammaln, TensorGammaln,
-        betainc, TensorBetaInc,
-    )
-    from mars.tensor.special.err_fresnel import erf, TensorErf
-except ImportError:
-    scipy = None
+from scipy.special import (
+    gammaln as scipy_gammaln,
+    erf as scipy_erf,
+    betainc as scipy_betainc,
+)
 
 from mars.core import tile
 from mars.tensor import tensor
+from mars.tensor.special.err_fresnel import erf, TensorErf
+from mars.tensor.special.gamma_funcs import (
+    gammaln, TensorGammaln,
+    betainc, TensorBetaInc,
+)
 
 
-@pytest.mark.skipif(scipy is None, reason='scipy not installed')
 def test_gammaln():
     raw = np.random.rand(10, 8, 5)
     t = tensor(raw, chunk_size=3)
@@ -53,7 +47,6 @@ def test_gammaln():
         assert c.shape == c.inputs[0].shape
 
 
-@pytest.mark.skipif(scipy is None, reason='scipy not installed')
 def test_elf():
     raw = np.random.rand(10, 8, 5)
     t = tensor(raw, chunk_size=3)
@@ -73,7 +66,6 @@ def test_elf():
         assert c.shape == c.inputs[0].shape
 
 
-@pytest.mark.skipif(scipy is None, reason='scipy not installed')
 def test_beta_inc():
     raw1 = np.random.rand(4, 3, 2)
     raw2 = np.random.rand(4, 3, 2)

--- a/mars/tensor/special/tests/test_special_execute.py
+++ b/mars/tensor/special/tests/test_special_execute.py
@@ -14,142 +14,128 @@
 
 import numpy as np
 import pytest
-try:
-    import scipy
-    import scipy.sparse as sps
-    import scipy.special as spspecial
-
-    from mars.tensor import special as mt_special
-except ImportError:
-    scipy = None
+import scipy.sparse as sps
+import scipy.special as spspecial
 
 from mars.tensor import tensor
+from mars.tensor import special as mt_special
 
 
-@pytest.mark.skipif(scipy is None, reason='scipy not installed')
-def test_unary_execution(setup):
-    funcs = [
-        'gamma',
-        'gammaln',
-        'loggamma',
-        'gammasgn',
-        'psi',
-        'rgamma',
-        'digamma',
-        'erf',
-        'entr',
-    ]
+@pytest.mark.parametrize('func', [
+    'gamma',
+    'gammaln',
+    'loggamma',
+    'gammasgn',
+    'psi',
+    'rgamma',
+    'digamma',
+    'erf',
+    'entr',
+])
+def test_unary_execution(setup, func):
+    sp_func = getattr(spspecial, func)
+    mt_func = getattr(mt_special, func)
 
-    for func in funcs:
-        sp_func = getattr(spspecial, func)
-        mt_func = getattr(mt_special, func)
+    raw = np.random.rand(10, 8, 6)
+    a = tensor(raw, chunk_size=3)
 
-        raw = np.random.rand(10, 8, 6)
-        a = tensor(raw, chunk_size=3)
+    r = mt_func(a)
 
-        r = mt_func(a)
+    result = r.execute().fetch()
+    expected = sp_func(raw)
 
-        result = r.execute().fetch()
-        expected = sp_func(raw)
+    np.testing.assert_array_equal(result, expected)
 
-        np.testing.assert_array_equal(result, expected)
+    # test sparse
+    raw = sps.csr_matrix(np.array([0, 1.0, 1.01, np.nan]))
+    a = tensor(raw, chunk_size=3)
 
-        # test sparse
-        raw = sps.csr_matrix(np.array([0, 1.0, 1.01, np.nan]))
-        a = tensor(raw, chunk_size=3)
+    r = mt_func(a)
 
-        r = mt_func(a)
+    result = r.execute().fetch()
 
-        result = r.execute().fetch()
+    data = sp_func(raw.data)
+    expected = sps.csr_matrix((data, raw.indices, raw.indptr), raw.shape)
 
-        data = sp_func(raw.data)
-        expected = sps.csr_matrix((data, raw.indices, raw.indptr), raw.shape)
-
-        np.testing.assert_array_equal(result.toarray(), expected.toarray())
+    np.testing.assert_array_equal(result.toarray(), expected.toarray())
 
 
-@pytest.mark.skipif(scipy is None, reason='scipy not installed')
-def test_binary_execution(setup):
-    funcs = [
-        'gammainc',
-        'gammaincinv',
-        'gammaincc',
-        'gammainccinv',
-        'beta',
-        'betaln',
-        'polygamma',
-        'poch',
-        'rel_entr',
-        'kl_div',
-        'xlogy',
-    ]
+@pytest.mark.parametrize('func', [
+    'gammainc',
+    'gammaincinv',
+    'gammaincc',
+    'gammainccinv',
+    'beta',
+    'betaln',
+    'polygamma',
+    'poch',
+    'rel_entr',
+    'kl_div',
+    'xlogy',
+])
+def test_binary_execution(setup, func):
+    sp_func = getattr(spspecial, func)
+    mt_func = getattr(mt_special, func)
 
-    for func in funcs:
-        sp_func = getattr(spspecial, func)
-        mt_func = getattr(mt_special, func)
+    raw1 = np.random.rand(4, 3, 2)
+    raw2 = np.random.rand(4, 3, 2)
+    a = tensor(raw1, chunk_size=3)
+    b = tensor(raw2, chunk_size=3)
 
-        raw1 = np.random.rand(4, 3, 2)
-        raw2 = np.random.rand(4, 3, 2)
-        a = tensor(raw1, chunk_size=3)
-        b = tensor(raw2, chunk_size=3)
+    r = mt_func(a, b)
 
-        r = mt_func(a, b)
+    result = r.execute().fetch()
+    expected = sp_func(raw1, raw2)
 
-        result = r.execute().fetch()
-        expected = sp_func(raw1, raw2)
+    np.testing.assert_array_equal(result, expected)
 
-        np.testing.assert_array_equal(result, expected)
+    # test sparse
+    raw1 = sps.csr_matrix(np.array([0, 1.0, 1.01, np.nan] * 3).reshape(4, 3))
+    a = tensor(raw1, chunk_size=3)
+    raw2 = np.random.rand(4, 3)
+    b = tensor(raw2, chunk_size=3)
 
-        # test sparse
-        raw1 = sps.csr_matrix(np.array([0, 1.0, 1.01, np.nan] * 3).reshape(4, 3))
-        a = tensor(raw1, chunk_size=3)
-        raw2 = np.random.rand(4, 3)
-        b = tensor(raw2, chunk_size=3)
+    r = mt_func(a, b)
 
-        r = mt_func(a, b)
+    result = r.execute().fetch()
 
-        result = r.execute().fetch()
-
-        expected = sp_func(raw1.toarray(), raw2)
-        np.testing.assert_array_equal(result.toarray(), expected)
+    expected = sp_func(raw1.toarray(), raw2)
+    np.testing.assert_array_equal(result.toarray(), expected)
 
 
-@pytest.mark.skipif(scipy is None, reason='scipy not installed')
-def test_triple_execution(setup):
-    funcs = [
-        'betainc',
-        'betaincinv',
-    ]
+@pytest.mark.parametrize('func', [
+    'betainc',
+    'betaincinv',
+])
+def test_triple_execution(setup, func):
+    sp_func = getattr(spspecial, func)
+    mt_func = getattr(mt_special, func)
 
-    for func in funcs:
-        sp_func = getattr(spspecial, func)
-        mt_func = getattr(mt_special, func)
+    raw1 = np.random.rand(4, 3, 2)
+    raw2 = np.random.rand(4, 3, 2)
+    raw3 = np.random.rand(4, 3, 2)
+    a = tensor(raw1, chunk_size=3)
+    b = tensor(raw2, chunk_size=3)
+    c = tensor(raw3, chunk_size=3)
 
-        raw1 = np.random.rand(4, 3, 2)
-        raw2 = np.random.rand(4, 3, 2)
-        raw3 = np.random.rand(4, 3, 2)
-        a = tensor(raw1, chunk_size=3)
-        b = tensor(raw2, chunk_size=3)
-        c = tensor(raw3, chunk_size=3)
+    r = mt_func(a, b, c)
 
-        r = mt_func(a, b, c)
+    result = r.execute().fetch()
+    expected = sp_func(raw1, raw2, raw3)
 
-        result = r.execute().fetch()
-        expected = sp_func(raw1, raw2, raw3)
+    np.testing.assert_array_equal(result, expected)
 
-        np.testing.assert_array_equal(result, expected)
+    # test sparse
+    raw1 = sps.csr_matrix(np.array([0, 1.0, 1.01, np.nan] * 3).reshape(4, 3))
+    a = tensor(raw1, chunk_size=3)
+    raw2 = np.random.rand(4, 3)
+    b = tensor(raw2, chunk_size=3)
+    raw3 = np.random.rand(4, 3)
+    c = tensor(raw3, chunk_size=3)
 
-        # test sparse
-        raw1 = sps.csr_matrix(np.array([0, 1.0, 1.01, np.nan] * 3).reshape(4, 3))
-        a = tensor(raw1, chunk_size=3)
-        raw2 = np.random.rand(4, 3)
-        b = tensor(raw2, chunk_size=3)
-        raw3 = np.random.rand(4, 3)
-        c = tensor(raw3, chunk_size=3)
+    r = mt_func(a, b, c)
 
-        r = mt_func(a, b, c)
+    result = r.execute().fetch()
 
-        result = r.execute().fetch()
-
-        expected = sp_func(raw1.toarray(), raw2, raw3)
-        np.testing.assert_array_equal(result.toarray(), expected)
+    expected = sp_func(raw1.toarray(), raw2, raw3)
+    np.testing.assert_array_equal(result.toarray(), expected)

--- a/mars/tensor/stats/tests/test_stats_execute.py
+++ b/mars/tensor/stats/tests/test_stats_execute.py
@@ -17,30 +17,25 @@ import functools
 
 import numpy as np
 import pytest
-try:
-    import scipy
-    from scipy.stats import (
-        entropy as sp_entropy,
-        power_divergence as sp_power_divergence,
-        chisquare as sp_chisquare,
-        ttest_rel as sp_ttest_rel,
-        ttest_ind as sp_ttest_ind,
-        ttest_ind_from_stats as sp_ttest_ind_from_stats,
-        ttest_1samp as sp_ttest_1samp,
-    )
-
-    from mars.tensor.stats import (
-        entropy, power_divergence, chisquare,
-        ttest_ind, ttest_rel, ttest_1samp, ttest_ind_from_stats,
-    )
-except ImportError:
-    scipy = None
+import scipy
+from scipy.stats import (
+    entropy as sp_entropy,
+    power_divergence as sp_power_divergence,
+    chisquare as sp_chisquare,
+    ttest_rel as sp_ttest_rel,
+    ttest_ind as sp_ttest_ind,
+    ttest_ind_from_stats as sp_ttest_ind_from_stats,
+    ttest_1samp as sp_ttest_1samp,
+)
 
 from mars.lib.version import parse as parse_version
 from mars.tensor import tensor
+from mars.tensor.stats import (
+    entropy, power_divergence, chisquare,
+    ttest_ind, ttest_rel, ttest_1samp, ttest_ind_from_stats,
+)
 
 
-@pytest.mark.skipif(scipy is None, reason='scipy not installed')
 def test_entropy_execution(setup):
     rs = np.random.RandomState(0)
     a = rs.rand(10)
@@ -82,7 +77,6 @@ def test_entropy_execution(setup):
         entropy(t1, t2[:7])
 
 
-@pytest.mark.skipif(scipy is None, reason='scipy not installed')
 def test_power_divergence_execution(setup):
     f_obs_raw = np.array([16, 18, 16, 14, 12, 12])
     f_exp_raw = np.array([16, 16, 16, 16, 16, 8])
@@ -118,7 +112,6 @@ def test_power_divergence_execution(setup):
         np.testing.assert_almost_equal(expected[1], result[1])
 
 
-@pytest.mark.skipif(scipy is None, reason='scipy not installed')
 def test_chisquare_execution(setup):
     f_obs_raw = np.array([16, 18, 16, 14, 12, 12])
     f_exp_raw = np.array([16, 16, 16, 16, 16, 8])
@@ -134,7 +127,6 @@ def test_chisquare_execution(setup):
     np.testing.assert_almost_equal(expected[1], result[1])
 
 
-@pytest.mark.skipif(scipy is None, reason='scipy not installed')
 def test_t_test_execution(setup):
     if parse_version(scipy.__version__) >= parse_version('1.6.0'):
         alternatives = ['less', 'greater', 'two-sided']

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -443,8 +443,8 @@ def test_fetch_log(fetch_log_setup):
 
     ds = [mr.spawn(test_host, n, retry_when_fail=False)
           for n in np.random.rand(4)]
-    xtp = execute(*ds)
-    for log in fetch_log(*xtp):
+    xtp = execute(ds)
+    for log in fetch_log(xtp):
         assert str(log).strip() == 'log_content'
 
     def test_threaded():

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,9 @@ install_requires =
     numpy>=1.14.0
     pandas>=1.0.0,<1.2.0; python_version<"3.7"
     pandas>=1.0.0; python_version>="3.7"
+    scipy>=1.0.0
+    scikit-learn>=0.20
+    numexpr>=2.6.4
     requests>=2.4.0
     cloudpickle>=1.5.0
     pyyaml>=5.1
@@ -39,6 +42,10 @@ install_requires =
     dataclasses; python_version<"3.7"
     shared-memory38>=0.1.1; python_version<"3.8"
     asyncio37>=0.1.3; python_version<"3.7"
+    bokeh>=1.0.0
+    tornado>=6.0
+    sqlalchemy>=1.2.0
+    uvloop>=0.14.0; sys.platform!="win32" and python_version>="3.7"
 
 [options.packages.find]
 exclude =
@@ -52,43 +59,22 @@ console_scripts =
 
 [options.extras_require]
 dev =
-    pyarrow>=0.11.0,!=0.16.*
     cython>=0.29
     pytest>=3.5.0
     pytest-cov>=2.5.0
     pytest-timeout>=1.2.0
     pytest-forked>=1.0
     pytest-asyncio>=0.14.0
-    sqlalchemy>=1.2.0
-    scipy>=1.0.0
-    scikit-learn>=0.20
-    numexpr>=2.6.4
-    bokeh>=1.0.0
     mock>=4.0.0; python_version<"3.8"
-    tornado>=6.0
-distributed =
-    scipy>=1.0.0
-    scikit-learn>=0.20
-    numexpr>=2.6.4
-    pyarrow>=0.11.0,!=0.16.*
-    lz4>=1.0.0
-    bokeh>=1.0.0
-    sqlalchemy>=1.2.0
-    tornado>=6.0
-    uvloop>=0.14.0; sys.platform!="win32" and python_version>="3.7"
 extra =
-    scipy>=1.0.0
-    scikit-learn>=0.20
-    numexpr>=2.6.4
     pyarrow>=0.11.0,!=0.16.*
     lz4>=1.0.0
-    bokeh>=1.0.0
-    sqlalchemy>=1.2.0
-    jinja2>=2.0
-    tornado>=6.0
-    uvloop>=0.14.0; sys.platform!="win32" and python_version>="3.7"
 vineyard =
     vineyard==0.2.4; sys.platform != "win32"
+kubernetes =
+    kubernetes>=10.0.0
+ray =
+    ray<1.4
 
 [tool:pytest]
 markers =


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR did a few things.

* Merge default & distributed requirements, so that after `pip install pymars`, distributed deployment is ready.
* `new_session` will set the session as default.
* Make sure `mars.execute` & `mars.fetch_log` is able to accept list of tileables.
* Refine tests.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
