### PR TITLE
[Ray] Rerun subtask for ray backend

### DIFF
--- a/mars/deploy/oscar/tests/test_ray_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_ray_fault_injection.py
@@ -1,0 +1,101 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from mars.deploy.oscar.ray import new_cluster, _load_config
+from mars.deploy.oscar.tests import test_fault_injection
+from mars.oscar.errors import ServerClosed
+from mars.services.tests.fault_injection_manager import (
+    FaultType,
+    FaultInjectionError,
+    FaultInjectionUnhandledError
+)
+from mars.tests.core import require_ray
+from mars.utils import lazy_import
+
+ray = lazy_import('ray')
+
+RAY_CONFIG_FILE = os.path.join(
+    os.path.dirname(__file__), 'local_test_with_ray_config.yml')
+FAULT_INJECTION_CONFIG = {"subtask": {
+    "subtask_processor_cls": "mars.services.subtask.worker.tests.FaultInjectionSubtaskProcessor"}}
+SUBTASK_RERUN_CONFIG = {"scheduling": {"subtask_max_retries": 2}}
+
+
+@pytest.fixture
+async def fault_cluster(request):
+    param = getattr(request, "param", {})
+    ray_config = _load_config(RAY_CONFIG_FILE)
+    ray_config.update(FAULT_INJECTION_CONFIG)
+    ray_config.update(param.get('config', {}))
+    client = await new_cluster('test_cluster',
+                               worker_num=2,
+                               worker_cpu=2,
+                               worker_mem=1 * 1024 ** 3,
+                               config=ray_config)
+    async with client:
+        yield client
+
+
+@require_ray
+@pytest.mark.parametrize('fault_and_exception',
+                         [[FaultType.Exception,
+                           pytest.raises(FaultInjectionError, match='Fault Injection')],
+                          [FaultType.UnhandledException,
+                           pytest.raises(FaultInjectionUnhandledError, match='Fault Injection Unhandled')],
+                          [FaultType.ProcessExit,
+                           pytest.raises(ServerClosed)]])
+@pytest.mark.asyncio
+async def test_fault_inject_subtask_processor(ray_start_regular, fault_cluster, fault_and_exception):
+    await test_fault_injection.test_fault_inject_subtask_processor(fault_cluster, fault_and_exception)
+
+
+@require_ray
+@pytest.mark.parametrize('fault_cluster',
+                         [{'config': SUBTASK_RERUN_CONFIG}],
+                         indirect=True)
+@pytest.mark.parametrize('fault_config',
+                         [[FaultType.Exception, 1,
+                           pytest.raises(FaultInjectionError, match='Fault Injection')],
+                          [FaultType.ProcessExit, 1,
+                           pytest.raises(ServerClosed)]])
+@pytest.mark.asyncio
+async def test_rerun_subtask(ray_start_regular, fault_cluster, fault_config):
+    await test_fault_injection.test_rerun_subtask(fault_cluster, fault_config)
+
+
+@require_ray
+@pytest.mark.parametrize('fault_cluster',
+                         [{'config': SUBTASK_RERUN_CONFIG}],
+                         indirect=True)
+@pytest.mark.asyncio
+async def test_rerun_subtask_unhandled(ray_start_regular, fault_cluster):
+    await test_fault_injection.test_rerun_subtask_unhandled(fault_cluster)
+
+
+@require_ray
+@pytest.mark.parametrize('fault_cluster',
+                         [{'config': SUBTASK_RERUN_CONFIG}],
+                         indirect=True)
+@pytest.mark.parametrize('fault_config',
+                         [[FaultType.Exception, 1,
+                           pytest.raises(FaultInjectionError, match='Fault Injection')],
+                          [FaultType.ProcessExit, 1,
+                           pytest.raises(ServerClosed)]])
+@pytest.mark.asyncio
+async def test_retryable(ray_start_regular, fault_cluster, fault_config):
+    await test_fault_injection.test_retryable(fault_cluster, fault_config)

--- a/mars/oscar/api.py
+++ b/mars/oscar/api.py
@@ -20,8 +20,6 @@ from collections import defaultdict
 from .backend import get_backend
 from .context import get_context
 from .core import _Actor, _StatelessActor, ActorRef
-import logging
-logging.basicConfig(level=logging.DEBUG)
 
 
 async def create_actor(actor_cls, *args, uid=None, address=None, **kwargs) -> ActorRef:

--- a/mars/oscar/api.py
+++ b/mars/oscar/api.py
@@ -23,6 +23,7 @@ from .core import _Actor, _StatelessActor, ActorRef
 import logging
 logging.basicConfig(level=logging.DEBUG)
 
+
 async def create_actor(actor_cls, *args, uid=None, address=None, **kwargs) -> ActorRef:
     ctx = get_context()
     return await ctx.create_actor(actor_cls, *args, uid=uid, address=address, **kwargs)

--- a/mars/oscar/api.py
+++ b/mars/oscar/api.py
@@ -20,7 +20,8 @@ from collections import defaultdict
 from .backend import get_backend
 from .context import get_context
 from .core import _Actor, _StatelessActor, ActorRef
-
+import logging
+logging.basicConfig(level=logging.DEBUG)
 
 async def create_actor(actor_cls, *args, uid=None, address=None, **kwargs) -> ActorRef:
     ctx = get_context()

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -175,8 +175,8 @@ class MarsActorContext(BaseActorContext):
                 protocol=DEFAULT_PROTOCOL)
             main_address = self._process_result_message(
                 await self._call(address, control_message))
+
         # if address is main pool, it is never recovered
-        print('wait ready:', address, main_address)
         if address == main_address:
             return
 
@@ -186,6 +186,5 @@ class MarsActorContext(BaseActorContext):
             None,
             protocol=DEFAULT_PROTOCOL
         )
-        result = self._process_result_message(
+        self._process_result_message(
             await self._call(main_address, control_message))
-        print('wait ok:', result)

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -166,16 +166,17 @@ class MarsActorContext(BaseActorContext):
 
     async def wait_actor_pool_recovered(self, address: str,
                                         main_address: str = None):
-        # get main_pool_address
-        control_message = ControlMessage(
-            new_message_id(), main_address,
-            ControlMessageType.get_config,
-            'main_pool_address',
-            protocol=DEFAULT_PROTOCOL)
-        main_address = self._process_result_message(
-            await self._call(main_address, control_message))
-
+        if main_address is None:
+            # get main_pool_address
+            control_message = ControlMessage(
+                new_message_id(), address,
+                ControlMessageType.get_config,
+                'main_pool_address',
+                protocol=DEFAULT_PROTOCOL)
+            main_address = self._process_result_message(
+                await self._call(address, control_message))
         # if address is main pool, it is never recovered
+        print('wait ready:', address, main_address)
         if address == main_address:
             return
 
@@ -185,5 +186,6 @@ class MarsActorContext(BaseActorContext):
             None,
             protocol=DEFAULT_PROTOCOL
         )
-        self._process_result_message(
+        result = self._process_result_message(
             await self._call(main_address, control_message))
+        print('wait ok:', result)

--- a/mars/oscar/backends/mars/pool.py
+++ b/mars/oscar/backends/mars/pool.py
@@ -211,7 +211,6 @@ class MainActorPool(MainActorPoolBase):
             for _, message in self._allocated_actors[address].values():
                 create_actor_message: CreateActorMessage = message
                 await self.call(address, create_actor_message)
-        print('recover done!')
 
 
 @_register_message_handler

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -425,7 +425,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
             if actor_id in self._actors:
                 raise ActorAlreadyExist(f'Actor {actor_id} already exist, '
                                         f'cannot create')
-
+            print('create actor:', message.actor_id, message.actor_cls, message.args, message.kwargs)
             actor = message.actor_cls(*message.args, **message.kwargs)
             actor.uid = actor_id
             actor.address = address = self.external_address
@@ -573,7 +573,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
             create_server_tasks.append(task)
         await asyncio.gather(*create_server_tasks)
         kw['servers'] = [f.result() for f in create_server_tasks]
-
+        print('create pool:', cls, actor_pool_config.as_dict(), kw)
         # create pool
         pool = cls(**kw)
         return pool
@@ -1032,6 +1032,7 @@ class MainActorPoolBase(ActorPoolBase):
             for _, message in self._allocated_actors[address].values():
                 create_actor_message: CreateActorMessage = message
                 await self.call(address, create_actor_message)
+        print('recover done!')
 
     async def monitor_sub_pools(self):
         try:
@@ -1039,6 +1040,7 @@ class MainActorPoolBase(ActorPoolBase):
                 for address in self.sub_processes:
                     process = self.sub_processes[address]
                     if not await self.is_sub_pool_alive(process):  # pragma: no cover
+                        print(f'found the death of {process}!')
                         if self._on_process_down is not None:
                             self._on_process_down(self, address)
                         self.process_sub_pool_lost(address)

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -425,7 +425,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
             if actor_id in self._actors:
                 raise ActorAlreadyExist(f'Actor {actor_id} already exist, '
                                         f'cannot create')
-            print('create actor:', message.actor_id, message.actor_cls, message.args, message.kwargs)
+
             actor = message.actor_cls(*message.args, **message.kwargs)
             actor.uid = actor_id
             actor.address = address = self.external_address
@@ -573,7 +573,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
             create_server_tasks.append(task)
         await asyncio.gather(*create_server_tasks)
         kw['servers'] = [f.result() for f in create_server_tasks]
-        print('create pool:', cls.__name__, internal_address, external_addresses)
+
         # create pool
         pool = cls(**kw)
         return pool
@@ -869,15 +869,13 @@ class MainActorPoolBase(ActorPoolBase):
                 processor.result = ResultMessage(message.message_id, True,
                                                  protocol=message.protocol)
             elif message.control_message_type == ControlMessageType.wait_pool_recovered:
-                print('receive wait_pool_recovered')
-                # check the aliveness of sub pool in case monitor task haven't found it.
+                # check the aliveness of sub pool first, in case monitor task haven't found it.
                 if not await self.is_sub_pool_alive(self.sub_processes[message.address]):
                     if self._auto_recover and message.address not in self._recover_events:
                         self._recover_events[message.address] = asyncio.Event()
 
                 event = self._recover_events.get(message.address, None)
                 if event is not None:
-                    print('wait recover event')
                     await event.wait()
                 processor.result = ResultMessage(message.message_id, True,
                                                  protocol=message.protocol)
@@ -1033,7 +1031,6 @@ class MainActorPoolBase(ActorPoolBase):
                 for address in self.sub_processes:
                     process = self.sub_processes[address]
                     if not await self.is_sub_pool_alive(process):  # pragma: no cover
-                        print(f'found the death of {process}!')
                         if self._on_process_down is not None:
                             self._on_process_down(self, address)
                         self.process_sub_pool_lost(address)

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -870,9 +870,11 @@ class MainActorPoolBase(ActorPoolBase):
                                                  protocol=message.protocol)
             elif message.control_message_type == ControlMessageType.wait_pool_recovered:
                 print('receive wait_pool_recovered')
-                while not await self.is_sub_pool_alive(self.sub_processes[message.address]):
-                    print('sub pool not alive')
-                    await asyncio.sleep(.5)
+                # check the aliveness of sub pool in case monitor task haven't found it.
+                if not await self.is_sub_pool_alive(self.sub_processes[message.address]):
+                    if self._auto_recover and message.address not in self._recover_events:
+                        self._recover_events[message.address] = asyncio.Event()
+
                 event = self._recover_events.get(message.address, None)
                 if event is not None:
                     print('wait recover event')
@@ -1024,20 +1026,6 @@ class MainActorPoolBase(ActorPoolBase):
             # process down, when not auto_recover
             # or only recover process, remove all created actors
             self._allocated_actors[address] = dict()
-
-    async def recover_sub_pool(self, address: str):
-        process_index = self._config.get_process_index(address)
-        # process dead, restart it
-        # remember always use spawn to recover sub pool
-        self.sub_processes[address] = await self.__class__.start_sub_pool(
-            self._config, process_index, 'spawn')
-
-        if self._auto_recover == 'actor':
-            # need to recover all created actors
-            for _, message in self._allocated_actors[address].values():
-                create_actor_message: CreateActorMessage = message
-                await self.call(address, create_actor_message)
-        print('recover done!')
 
     async def monitor_sub_pools(self):
         try:

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -88,7 +88,8 @@ class RayChannelBase(Channel, ABC):
 
 
 class RayClientChannel(RayChannelBase):
-    """A channel from ray driver/actor to ray actor. Use ray call reply for client channel recv.
+    """
+    A channel from ray driver/actor to ray actor. Use ray call reply for client channel recv.
     """
     __slots__ = '_peer_actor',
 
@@ -130,10 +131,11 @@ class RayClientChannel(RayChannelBase):
 
 
 class RayServerChannel(RayChannelBase):
-    """A channel from ray actor to ray driver/actor. Since ray actor can't call ray driver,
-     we use ray call reply for server channel send. Note that there can't be multiple
-     channel message sends for one received message, or else it will be taken as next
-     message's reply.
+    """
+    A channel from ray actor to ray driver/actor. Since ray actor can't call ray driver,
+    we use ray call reply for server channel send. Note that there can't be multiple
+    channel message sends for one received message, or else it will be taken as next
+    message's reply.
     """
     __slots__ = '_out_queue', '_msg_recv_counter', '_msg_sent_counter'
 
@@ -288,7 +290,7 @@ class RayServer(Server):
                                f'from channel {channel_id}')
         channel = self._channels.get(channel_id)
         if not channel:
-            peer_local_address, _, peer_channel_index, peer_dest_address = channel_id
+            _, _, peer_channel_index, peer_dest_address = channel_id
             channel = RayServerChannel(peer_dest_address, peer_channel_index, channel_id)
             self._channels[channel_id] = channel
             self._tasks[channel_id] = asyncio.create_task(self.on_connected(channel))

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -124,6 +124,7 @@ class RayClientChannel(RayChannelBase):
             return deserialize(*result)
         except ray.exceptions.RayActorError:
             if not self._closed.is_set():
+                # raise a EOFError as the SocketChannel does
                 raise EOFError('Server may be closed')
         except (RuntimeError, ServerClosed) as e:  # pragma: no cover
             if not self._closed.is_set():

--- a/mars/oscar/backends/ray/driver.py
+++ b/mars/oscar/backends/ray/driver.py
@@ -63,7 +63,6 @@ class RayActorDriver(BaseActorDriver):
                 try:
                     if 'COV_CORE_SOURCE' in os.environ:  # pragma: no cover
                         # must clean up first, or coverage info lost
-                        print('address:', address, ray.get_actor(address))
                         ray.get(ray.get_actor(address).cleanup.remote())
                     ray.kill(ray.get_actor(address))
                 except:  # noqa: E722  # nosec  # pylint: disable=bare-except

--- a/mars/oscar/backends/ray/driver.py
+++ b/mars/oscar/backends/ray/driver.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 from numbers import Number
 from typing import Dict
 
@@ -56,10 +57,14 @@ class RayActorDriver(BaseActorDriver):
         pg_name = cls._cluster_info['pg_name']
         pg = cls._cluster_info['pg_group']
         for index, bundle_spec in enumerate(pg.bundle_specs):
-            n_process = int(bundle_spec["CPU"])
+            n_process = int(bundle_spec["CPU"]) + 1
             for process_index in range(n_process):
                 address = process_placement_to_address(pg_name, index, process_index=process_index)
                 try:
+                    if 'COV_CORE_SOURCE' in os.environ:  # pragma: no cover
+                        # must clean up first, or coverage info lost
+                        print('address:', address, ray.get_actor(address))
+                        ray.get(ray.get_actor(address).cleanup.remote())
                     ray.kill(ray.get_actor(address))
                 except:  # noqa: E722  # nosec  # pylint: disable=bare-except
                     pass

--- a/mars/oscar/backends/ray/pool.py
+++ b/mars/oscar/backends/ray/pool.py
@@ -112,14 +112,13 @@ class RayMainActorPool(MainActorPoolBase):
             await self._kill_actor_forcibly(process)
 
     async def _kill_actor_forcibly(self, process: 'ray.actor.ActorHandle'):
-        print('Dont really kill', self)
-        # ray.kill(process)
-        # wait_time, waited_time = 30, 0
-        # while await self.is_sub_pool_alive(process):  # pragma: no cover
-        #     if waited_time > wait_time:
-        #         raise Exception(f'''Can't kill process {process} in {wait_time} seconds.''')
-        #     await asyncio.sleep(1)
-        #     logger.info(f'Waited {waited_time} seconds for {process} to be killed.')
+        ray.kill(process, no_restart=False)
+        wait_time, waited_time = 30, 0
+        while await self.is_sub_pool_alive(process):  # pragma: no cover
+            if waited_time > wait_time:
+                raise Exception(f'''Can't kill process {process} in {wait_time} seconds.''')
+            await asyncio.sleep(1)
+            logger.info(f'Waited {waited_time} seconds for {process} to be killed.')
 
     async def is_sub_pool_alive(self, process: 'ray.actor.ActorHandle'):
         try:
@@ -166,7 +165,6 @@ class RayPoolBase(ABC):
         return super().__new__(cls, *args, **kwargs)
 
     def __init__(self):
-        print('Constrcting Ray Actor', self)
         self._actor_pool = None
         self._ray_server = None
         register_ray_serializers()

--- a/mars/oscar/backends/ray/pool.py
+++ b/mars/oscar/backends/ray/pool.py
@@ -85,7 +85,6 @@ class RayMainActorPool(MainActorPoolBase):
 
     async def recover_sub_pool(self, address: str):
         process = self.sub_processes[address]
-        print('try to recover:', address, process)
         process_index = self._config.get_process_index(address)
         await process.start.remote(self._config, process_index)
 
@@ -94,7 +93,6 @@ class RayMainActorPool(MainActorPoolBase):
             for _, message in self._allocated_actors[address].values():
                 create_actor_message: CreateActorMessage = message
                 await self.call(address, create_actor_message)
-        print('recover done!')
 
     async def kill_sub_pool(self, process: 'ray.actor.ActorHandle', force: bool = False):
         if 'COV_CORE_SOURCE' in os.environ and not force:  # pragma: no cover

--- a/mars/oscar/backends/ray/tests/test_ray_pool.py
+++ b/mars/oscar/backends/ray/tests/test_ray_pool.py
@@ -47,6 +47,7 @@ async def test_main_pool(ray_start_regular):
         assert not (await main_actor_pool.is_sub_pool_alive(sub_processes[1]))
 
 
+@pytest.mark.skip("This test will not success because of auto recover.")
 @require_ray
 @pytest.mark.asyncio
 async def test_shutdown_sub_pool(ray_start_regular):

--- a/mars/oscar/backends/ray/tests/test_ray_pool.py
+++ b/mars/oscar/backends/ray/tests/test_ray_pool.py
@@ -47,7 +47,6 @@ async def test_main_pool(ray_start_regular):
         assert not (await main_actor_pool.is_sub_pool_alive(sub_processes[1]))
 
 
-@pytest.mark.skip("This test will not success because of auto recover.")
 @require_ray
 @pytest.mark.asyncio
 async def test_shutdown_sub_pool(ray_start_regular):
@@ -61,14 +60,14 @@ async def test_shutdown_sub_pool(ray_start_regular):
     address = process_placement_to_address(pg_name, 0, process_index=0)
     actor_handle = ray.remote(RayMainPool).options(
         name=address, placement_group=pg, placement_group_bundle_index=bundle_index).remote()
-    await actor_handle.start.remote(address, n_process)
+    await actor_handle.start.remote(address, n_process, auto_recover=False)
     sub_pool_address1 = process_placement_to_address(pg_name, 0, process_index=1)
     sub_pool_handle1 = ray.get_actor(sub_pool_address1)
     sub_pool_address2 = process_placement_to_address(pg_name, 0, process_index=2)
     sub_pool_handle2 = ray.get_actor(sub_pool_address2)
     await actor_handle.actor_pool.remote('stop_sub_pool', sub_pool_address1, sub_pool_handle1, force=True)
     await actor_handle.actor_pool.remote('stop_sub_pool', sub_pool_address2, sub_pool_handle2, force=False)
-    import ray.exceptions
-    with pytest.raises(ray.exceptions.RayActorError):
-        await sub_pool_handle1.health_check.remote()
-        await sub_pool_handle2.health_check.remote()
+    with pytest.raises(AttributeError, match='NoneType'):
+        await sub_pool_handle1.actor_pool.remote('health_check')
+    with pytest.raises(AttributeError, match='NoneType'):
+        await sub_pool_handle2.actor_pool.remote('health_check')

--- a/mars/oscar/context.pyx
+++ b/mars/oscar/context.pyx
@@ -196,7 +196,6 @@ cdef class ClientActorContext(BaseActorContext):
         return context.send(actor_ref, message, wait_response=wait_response)
 
     def wait_actor_pool_recovered(self, str address, str main_address = None):
-        main_address = main_address or address
         context = self._get_backend_context(address)
         return context.wait_actor_pool_recovered(address, main_address)
 

--- a/mars/services/scheduling/worker/execution.py
+++ b/mars/services/scheduling/worker/execution.py
@@ -271,7 +271,7 @@ class SubtaskExecutionActor(mo.StatelessActor):
                                             task_id=subtask.task_id,
                                             status=SubtaskStatus.pending)
         batch_quota_req = quota_ref = slot_manager_ref = None
-        print('subtask:', subtask)
+
         try:
             quota_ref = await self._get_band_quota_ref(band_name)
             slot_manager_ref = await self._get_slot_manager_ref(band_name)
@@ -288,7 +288,6 @@ class SubtaskExecutionActor(mo.StatelessActor):
 
             subtask_info.result = await self._retry_run_subtask(
                 subtask, band_name, subtask_api, batch_quota_req)
-            print('subtask ok')
         except asyncio.CancelledError as ex:
             subtask_info.result.status = SubtaskStatus.cancelled
             subtask_info.result.progress = 1.0
@@ -330,7 +329,6 @@ class SubtaskExecutionActor(mo.StatelessActor):
         assert subtask_info.max_retries >= 0
 
         async def _run_subtask_once():
-            print(f'retry run {subtask_info.num_retries}')
             # check quota each retry.
             await quota_ref.request_batch_quota(batch_quota_req)
 
@@ -359,9 +357,6 @@ class SubtaskExecutionActor(mo.StatelessActor):
                     finally:
                         raise ex
                 except (OSError, MarsError) as ex:
-                    print('caught excepthion:', type(ex), ex)
-                    # if subtask_info.num_retries < subtask_info.max_retries:
-                    #     ctx.kill_slot_when_exit()
                     sub_pool_address = await ctx.get_slot_address()
                     await mo.wait_actor_pool_recovered(sub_pool_address, self.address)
                     raise ex

--- a/mars/services/scheduling/worker/execution.py
+++ b/mars/services/scheduling/worker/execution.py
@@ -268,7 +268,7 @@ class SubtaskExecutionActor(mo.StatelessActor):
                                             task_id=subtask.task_id,
                                             status=SubtaskStatus.pending)
         batch_quota_req = quota_ref = slot_manager_ref = None
-
+        print('subtask:', subtask)
         try:
             quota_ref = await self._get_band_quota_ref(band_name)
             slot_manager_ref = await self._get_slot_manager_ref(band_name)
@@ -285,6 +285,7 @@ class SubtaskExecutionActor(mo.StatelessActor):
 
             subtask_info.result = await self._retry_run_subtask(
                 subtask, band_name, subtask_api, batch_quota_req)
+            print('subtask ok')
         except asyncio.CancelledError as ex:
             subtask_info.result.status = SubtaskStatus.cancelled
             subtask_info.result.progress = 1.0
@@ -326,6 +327,7 @@ class SubtaskExecutionActor(mo.StatelessActor):
         assert subtask_info.max_retries >= 0
 
         async def _run_subtask_once():
+            print(f'retry run {subtask_info.num_retries}')
             # check quota each retry.
             await quota_ref.request_batch_quota(batch_quota_req)
 
@@ -354,6 +356,7 @@ class SubtaskExecutionActor(mo.StatelessActor):
                     finally:
                         raise ex
                 except (OSError, MarsError) as ex:
+                    print('caught excepthion:', type(ex))
                     # TODO(fyrestone): Handle slot exception correctly.
                     if subtask_info.num_retries < subtask_info.max_retries:
                         ctx.kill_slot_when_exit()

--- a/mars/services/scheduling/worker/execution.py
+++ b/mars/services/scheduling/worker/execution.py
@@ -64,11 +64,16 @@ class SlotContext:
         self._slot_manager_ref = slot_manager_ref
         self._slot_id = None
         self._enable_kill_slot = enable_kill_slot
+        self._slot_address = None
         self._should_kill_slot = False
 
     @property
     def slot_id(self):
         return self._slot_id
+
+    @property
+    def slot_address(self):
+        return self._slot_address
 
     def kill_slot_when_exit(self):
         if self._enable_kill_slot:  # pragma: no branch
@@ -77,6 +82,7 @@ class SlotContext:
     async def __aenter__(self):
         self._slot_id = await self._slot_manager_ref.acquire_free_slot(
                 (self._subtask.session_id, self._subtask.subtask_id))
+        self._slot_address = await self._slot_manager_ref.get_slot_address(self.slot_id)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
@@ -356,10 +362,10 @@ class SubtaskExecutionActor(mo.StatelessActor):
                     finally:
                         raise ex
                 except (OSError, MarsError) as ex:
-                    print('caught excepthion:', type(ex))
-                    # TODO(fyrestone): Handle slot exception correctly.
-                    if subtask_info.num_retries < subtask_info.max_retries:
-                        ctx.kill_slot_when_exit()
+                    print('caught excepthion:', type(ex), ex)
+                    # if subtask_info.num_retries < subtask_info.max_retries:
+                    #     ctx.kill_slot_when_exit()
+                    await mo.wait_actor_pool_recovered(ctx.slot_address, self.address)
                     raise ex
 
         retryable = all(getattr(chunk.op, 'retryable', True) for chunk in subtask.chunk_graph)

--- a/mars/services/scheduling/worker/workerslot.py
+++ b/mars/services/scheduling/worker/workerslot.py
@@ -131,6 +131,9 @@ class BandSlotManagerActor(mo.Actor):
         self._slot_to_session_stid[slot_id] = session_stid
         raise mo.Return(slot_id)
 
+    async def get_slot_address(self, slot_id: int):
+        return self._slot_control_refs[slot_id].address
+
     def release_free_slot(self, slot_id: int, pid: Optional[int] = None):
         if pid is not None:
             self._slot_to_proc[slot_id] = proc = psutil.Process(pid)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR generally adds support of basic rerun subtask for ray backend, and is basically the subsequent work for #2198. The details are as follows.

* Fix the hanging problem when recovering ray sub pool.
* Raise a ServerClosed when sub pool dies, which is the same as the original backend.
* Fix the wait_actor_pool_recovered logic.
* Fix coverage of some ray subprocesses.

<!-- Please give a short brief about these changes. -->

**Note**: This PR changes back to one way channel for ray backend communication, which can have some side effects. If there are better ways to achieve the ServerClosed support, it's ok to change this.

<!-- Are there any issues opened that will be resolved by merging this change? -->
