### PR TITLE
[WIP] Integrate Mars DataFrame with Ray MLDataset

### DIFF
--- a/mars/deploy/oscar/dataset.py
+++ b/mars/deploy/oscar/dataset.py
@@ -1,0 +1,121 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Iterable, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from ...dataframe import DataFrame
+from ...utils import lazy_import
+import ray.util.data as ml_dataset
+import ray.util.iter as parallel_it
+from ray.util.iter import ParallelIteratorWorker
+from ray.util.data import MLDataset
+from ray.util.data.interface import _SourceShard
+
+
+ray = lazy_import('ray')
+
+
+class RayObjectPiece:
+    def __init__(self,
+                 addr: str,
+                 obj_ref: ray.ObjectRef,
+                 row_ids: Optional[List[int]]):
+        self.row_ids = row_ids
+        self.addr = addr
+        self.obj_ref = obj_ref
+
+    def read(self, shuffle: bool) -> pd.DataFrame:
+        df: pd.DataFrame = ray.get(self.obj_ref)
+        if self.row_ids:
+            df = df.loc[self.row_ids]
+
+        if shuffle:
+            df = df.sample(frac=1.0)
+        return df
+
+
+class RecordBatch(_SourceShard):
+    def __init__(self,
+                 shard_id: int,
+                 prefix: str,
+                 record_pieces: List[RayObjectPiece],
+                 shuffle: bool,
+                 shuffle_seed: int):
+        self._shard_id = shard_id
+        self._prefix = prefix
+        self.record_pieces = record_pieces
+        self.shuffle = shuffle
+        self.shuffle_seed = shuffle_seed
+
+    def prefix(self) -> str:
+        return self._prefix
+
+    @property
+    def shard_id(self) -> int:
+        return self._shard_id
+
+    def __iter__(self) -> Iterable[pd.DataFrame]:
+        if self.shuffle:
+            np.random.seed(self.shuffle_seed)
+            np.random.shuffle(self.record_pieces)
+
+        for piece in self.record_pieces:
+            yield piece.read(self.shuffle)
+
+
+def _create_ml_dataset(name: str,
+                       record_pieces: List[RayObjectPiece],
+                       num_shards: int,
+                       shuffle: bool,
+                       shuffle_seed: int,
+                       RecordBatchCls) -> MLDataset:
+    if shuffle_seed:
+        np.random.seed(shuffle_seed)
+    else:
+        np.random.seed(0)
+
+    # TODO: (maybe) combine some chunks according to num_shards
+    record_batches = []
+    for rank, pieces in enumerate(record_pieces):
+        record_batches.append(RecordBatchCls(shard_id=rank,
+                                             prefix=name,
+                                             record_pieces=[pieces],
+                                             shuffle=shuffle,
+                                             shuffle_seed=shuffle_seed))
+    worker_cls = ray.remote(ParallelIteratorWorker)
+    actors = [worker_cls.remote(g, False) for g in record_batches]
+    it = parallel_it.from_actors(actors, name)
+    ds = ml_dataset.from_parallel_iter(
+        it, need_convert=False, batch_size=0, repeated=False)
+    return ds
+
+
+class RayMLDataset:
+    @staticmethod
+    def from_mars(df: DataFrame,
+                  num_shards: int = None,
+                  shuffle: bool = False,
+                  shuffle_seed: int = None) -> MLDataset:
+        if num_shards:
+            df = df.rebalance(axis=1, num_partitions=1)
+            df = df.rebalance(axis=0, num_partitions=num_shards)
+            df.execute()
+        # it's ensured that df has been executed
+        chunk_addr_refs: List[Tuple(str, ray.ObjectRef)] = df.fetch(only_refs=True)
+        record_pieces = [RayObjectPiece(addr, obj_ref, None) for addr, obj_ref in chunk_addr_refs]
+        return _create_ml_dataset("from_mars", record_pieces, num_shards,
+                                  shuffle, shuffle_seed, RecordBatch)

--- a/mars/deploy/oscar/tests/test_mldataset.py
+++ b/mars/deploy/oscar/tests/test_mldataset.py
@@ -1,0 +1,106 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import numpy as np
+import pandas as pd
+import pytest
+
+import mars.dataframe as md
+from mars.deploy.oscar.dataset import RayMLDataset
+from mars.deploy.oscar.ray import new_cluster, _load_config
+from mars.deploy.oscar.session import new_session
+from mars.tests.conftest import *  # noqa
+from mars.tests.core import require_ray
+from mars.utils import lazy_import
+from ray.util.data import MLDataset
+
+
+ray = lazy_import('ray')
+xgboost_ray = lazy_import('ray')
+
+
+def require_xgboost_ray(func):
+    if pytest:
+        func = pytest.mark.xgboost_ray(func)
+    func = pytest.mark.skipif(xgboost_ray is None, reason='xgboost_ray not installed')(func)
+    return func
+
+
+@pytest.fixture
+async def create_cluster(request):
+    param = getattr(request, "param", {})
+    ray_config = _load_config()
+    ray_config.update(param.get('config', {}))
+    client = await new_cluster('test_cluster',
+                               worker_num=4,
+                               worker_cpu=2,
+                               worker_mem=1 * 1024 ** 3,
+                               config=ray_config)
+    async with client:
+        yield client
+
+
+@require_ray
+@pytest.mark.asyncio
+async def test_convert_to_mldataset(ray_large_cluster, create_cluster):
+    assert create_cluster.session
+    session = new_session(address=create_cluster.address, backend='oscar', default=True)
+    with session:
+        value = np.random.rand(10, 10)
+        df: md.DataFrame = md.DataFrame(value, chunk_size=5)
+        df.execute()
+
+        ds = RayMLDataset.from_mars(df, num_shards=4)
+        assert isinstance(ds, MLDataset)
+
+
+@require_ray
+@pytest.mark.asyncio
+async def test_mars_with_xgboost(ray_large_cluster, create_cluster):
+    from sklearn.datasets import load_breast_cancer
+    from xgboost_ray import RayDMatrix, RayParams, train
+
+    assert create_cluster.session
+    session = new_session(address=create_cluster.address, backend='oscar', default=True)
+    with session:
+        train_x, train_y = load_breast_cancer(return_X_y=True, as_frame=True)
+        pd_df = pd.concat([train_x, train_y], axis=1)
+        df: md.DataFrame = md.DataFrame(pd_df)
+
+        num_shards = 4
+        ds = RayMLDataset.from_mars(df, num_shards=num_shards)
+        assert isinstance(ds, MLDataset)
+
+        # train
+        train_set = RayDMatrix(ds, "target")
+        evals_result = {}
+        bst = train(
+            {
+                "objective": "binary:logistic",
+                "eval_metric": ["logloss", "error"],
+            },
+            train_set,
+            evals_result=evals_result,
+            evals=[(train_set, "train")],
+            verbose_eval=False,
+            ray_params=RayParams(
+                num_actors=num_shards,  # Number of remote actors
+                cpus_per_actor=1)
+            )
+        bst.save_model("model.xgb")
+        assert os.path.exists("model.xgb")
+        os.remove("model.xgb")
+        print("Final training error: {:.4f}".format(
+            evals_result["train"]["error"][-1]))


### PR DESCRIPTION
## What do these changes do?

In order that Mars can support converting Mars DataFrame to Ray MLDataset, the following changes were made.

- Introduced a new class named `RayMLDataset` to take over the entire process where Ray MLDataset is created from ParallelIterator.
- Modified the `fetch` procedure so that `ray.ObjectRef` is now reachable.

Furthermore, `xgboost_ray` is initially tested working with Mars DataFrame 

## Related issue number

Fixes #2230 
