### PR TITLE
Refactor tileable visualization classes

### DIFF
--- a/mars/services/web/ui/.eslintrc.yml
+++ b/mars/services/web/ui/.eslintrc.yml
@@ -16,6 +16,7 @@ rules:
   new-cap: 'error'
   semi: ['error', 'always']
   quotes: ['error', 'single']
+  no-var: 'error'
 settings:
   react:
     version: 'detect'

--- a/mars/services/web/ui/src/Utils.js
+++ b/mars/services/web/ui/src/Utils.js
@@ -70,10 +70,3 @@ export function getNodeStatusText(statusCode) {
     };
     return mapping[statusCode];
 }
-
-export function OptionalElement(props) {
-    if (props.condition) {
-        return props.children;
-    }
-    return null;
-}

--- a/mars/services/web/ui/src/node_info/NodeEnvTab.js
+++ b/mars/services/web/ui/src/node_info/NodeEnvTab.js
@@ -22,7 +22,7 @@ import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 import TableBody from '@material-ui/core/TableBody';
 import PropTypes from 'prop-types';
-import { OptionalElement } from '../Utils';
+
 
 export default class NodeEnvTab extends React.Component {
     constructor(props) {
@@ -62,23 +62,23 @@ export default class NodeEnvTab extends React.Component {
                         <TableCell>Endpoint</TableCell>
                         <TableCell>{this.props.endpoint}</TableCell>
                     </TableRow>
-                    <OptionalElement condition={this.state.k8s_pod_name}>
+                    {this.state.k8s_pod_name &&
                         <TableRow>
                             <TableCell>Kubernetes Pod</TableCell>
                             <TableCell>{this.state.k8s_pod_name}</TableCell>
                         </TableRow>
-                    </OptionalElement>
-                    <OptionalElement condition={this.state.yarn_container_id}>
+                    }
+                    {this.state.yarn_container_id &&
                         <TableRow>
                             <TableCell>Yarn Container ID</TableCell>
                             <TableCell>{this.state.yarn_container_id}</TableCell>
                         </TableRow>
-                    </OptionalElement>
+                    }
                     <TableRow>
                         <TableCell>Platform</TableCell>
                         <TableCell>{this.state.platform}</TableCell>
                     </TableRow>
-                    <OptionalElement condition={this.state.cuda_info}>
+                    {this.state.cuda_info &&
                         <TableRow>
                             <TableCell>CUDA</TableCell>
                             <TableCell>
@@ -93,7 +93,7 @@ export default class NodeEnvTab extends React.Component {
                                 </div>
                             </TableCell>
                         </TableRow>
-                    </OptionalElement>
+                    }
                     <TableRow>
                         <TableCell>Git Branch</TableCell>
                         <TableCell>{`${this.state.git_info.hash} ${this.state.git_info.ref}`}</TableCell>

--- a/mars/services/web/ui/src/node_info/NodeListPage.js
+++ b/mars/services/web/ui/src/node_info/NodeListPage.js
@@ -29,6 +29,7 @@ import Title from '../Title';
 import { useStyles } from '../Style';
 import { formatTime, toReadableSize, getNodeStatusText } from '../Utils';
 
+
 class NodeList extends React.Component {
     constructor(props) {
         super(props);

--- a/mars/services/web/ui/src/node_info/NodeResourceTab.js
+++ b/mars/services/web/ui/src/node_info/NodeResourceTab.js
@@ -22,7 +22,7 @@ import TableCell from '@material-ui/core/TableCell';
 import TableBody from '@material-ui/core/TableBody';
 import PropTypes from 'prop-types';
 import Title from '../Title';
-import { OptionalElement, toReadableSize } from '../Utils';
+import { toReadableSize } from '../Utils';
 
 export default class NodeResourceTab extends React.Component {
     constructor(props) {
@@ -194,12 +194,12 @@ export default class NodeResourceTab extends React.Component {
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        <OptionalElement condition={this.state.detail.iowait}>
+                        {this.state.detail.iowait &&
                             <TableRow>
                                 <TableCell>IO Wait</TableCell>
                                 <TableCell>{this.state.detail.iowait}</TableCell>
                             </TableRow>
-                        </OptionalElement>
+                        }
                         <TableRow>
                             <TableCell>Disk</TableCell>
                             <TableCell>
@@ -224,27 +224,30 @@ export default class NodeResourceTab extends React.Component {
                         </TableRow>
                     </TableBody>
                 </Table>
-                <OptionalElement condition={this.state.detail.disk.partitions}>
+                {this.state.detail.disk.partitions &&
+                <React.Fragment>
                     <Title component="h3">Disks</Title>
                     <Table>
                         <TableHead>
                             <TableRow>
-                                <TableCell style={{ fontWeight: 'bolder' }}>Item</TableCell>
-                                <TableCell style={{ fontWeight: 'bolder' }}>Value</TableCell>
+                                <TableCell style={{fontWeight: 'bolder'}}>Item</TableCell>
+                                <TableCell style={{fontWeight: 'bolder'}}>Value</TableCell>
                             </TableRow>
                         </TableHead>
                         <TableBody>
                             {this.generateDiskRows()}
                         </TableBody>
                     </Table>
-                </OptionalElement>
-                <OptionalElement condition={Object.keys(this.state.detail.quota).length}>
+                </React.Fragment>
+                }
+                {Object.keys(this.state.detail.quota).length &&
+                <React.Fragment>
                     <Title component="h3">Quota</Title>
                     <Table>
                         <TableHead>
                             <TableRow>
-                                <TableCell style={{ fontWeight: 'bolder' }}>Band</TableCell>
-                                <TableCell style={{ fontWeight: 'bolder' }}>Value</TableCell>
+                                <TableCell style={{fontWeight: 'bolder'}}>Band</TableCell>
+                                <TableCell style={{fontWeight: 'bolder'}}>Value</TableCell>
                             </TableRow>
                         </TableHead>
                         <TableBody>
@@ -253,27 +256,29 @@ export default class NodeResourceTab extends React.Component {
                                     <TableCell>{band}</TableCell>
                                     <TableCell>
                                         <div>
-                      Total:{toReadableSize(this.state.detail.quota[band].quota_size)}
+                                            Total: {toReadableSize(this.state.detail.quota[band].quota_size)}
                                         </div>
                                         <div>
-                      Allocated:{toReadableSize(this.state.detail.quota[band].allocated_size)}
+                                            Allocated: {toReadableSize(this.state.detail.quota[band].allocated_size)}
                                         </div>
                                         <div>
-                      Hold:{toReadableSize(this.state.detail.quota[band].hold_size)}
+                                            Hold: {toReadableSize(this.state.detail.quota[band].hold_size)}
                                         </div>
                                     </TableCell>
                                 </TableRow>
                             ))}
                         </TableBody>
                     </Table>
-                </OptionalElement>
-                <OptionalElement condition={Object.keys(this.state.detail.slot).length}>
+                </React.Fragment>
+                }
+                {Object.keys(this.state.detail.slot).length &&
+                <React.Fragment>
                     <Title component="h3">Slot</Title>
                     <Table>
                         <TableHead>
                             <TableRow>
-                                <TableCell style={{ fontWeight: 'bolder' }}>Band</TableCell>
-                                <TableCell style={{ fontWeight: 'bolder' }}>Slots</TableCell>
+                                <TableCell style={{fontWeight: 'bolder'}}>Band</TableCell>
+                                <TableCell style={{fontWeight: 'bolder'}}>Slots</TableCell>
                             </TableRow>
                         </TableHead>
                         <TableBody>
@@ -285,7 +290,8 @@ export default class NodeResourceTab extends React.Component {
                             ))}
                         </TableBody>
                     </Table>
-                </OptionalElement>
+                </React.Fragment>
+                }
             </div>
         );
     }

--- a/mars/services/web/ui/src/node_info/SupervisorDetailPage.js
+++ b/mars/services/web/ui/src/node_info/SupervisorDetailPage.js
@@ -26,6 +26,7 @@ import { useStyles } from '../Style';
 import NodeEnvTab from './NodeEnvTab';
 import NodeResourceTab from './NodeResourceTab';
 
+
 export default function SupervisorDetailPage(props) {
     const classes = useStyles();
     const [value, setValue] = React.useState(0);

--- a/mars/services/web/ui/src/node_info/TabPanel.js
+++ b/mars/services/web/ui/src/node_info/TabPanel.js
@@ -18,6 +18,7 @@ import React from 'react';
 import Box from '@material-ui/core/Box';
 import PropTypes from 'prop-types';
 
+
 export default function TabPanel(props) {
     const {
         children, value, index, ...other

--- a/mars/services/web/ui/src/node_info/WorkerDetailPage.js
+++ b/mars/services/web/ui/src/node_info/WorkerDetailPage.js
@@ -26,6 +26,7 @@ import { useStyles } from '../Style';
 import NodeEnvTab from './NodeEnvTab';
 import NodeResourceTab from './NodeResourceTab';
 
+
 export default function WorkerDetailPage(props) {
     const classes = useStyles();
     const [value, setValue] = React.useState(0);

--- a/mars/services/web/ui/src/task_info/TaskDetail.js
+++ b/mars/services/web/ui/src/task_info/TaskDetail.js
@@ -17,151 +17,61 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
-import { Grid, Paper } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
+import Divider from '@material-ui/core/Divider';
 import Title from '../Title';
-import { select as d3Select } from 'd3-selection';
-import { zoom as d3Zoom, zoomIdentity as d3ZoomIdentity} from 'd3-zoom';
-import { graphlib as dagGraphLib, render as DagRender } from 'dagre-d3';
+import TaskTileableGraph from './TaskTileableGraph';
 import TileableDetail from './TileableDetail';
 
-class TaskTileableChart extends React.Component {
+
+class TaskDetail extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
             selectedTileable: null,
-            tileables: [],
-            dependencies: [],
         };
     }
 
-    fetchGraphDetail() {
-        const { session_id, task_id } = this.props;
-
-        fetch('api/session/' + session_id + '/task/' + task_id + '/tileable_graph?action=get_tileable_graph_as_json')
-            .then(res => res.json())
-            .then((res) => {
-                console.log(res);
-
-                this.setState({
-                    tileables: res.tileables,
-                    dependencies: res.dependencies,
-                });
-            });
-    }
-
-    componentDidMount() {
-        this.g =  new dagGraphLib.Graph().setGraph({});
-        this.fetchGraphDetail();
-    }
-
-    componentDidUpdate(prevProps, prevStates) {
-        if (prevStates.tileables !== this.state.tileables && prevStates.dependencies !== this.state.dependencies) {
-            d3Select('#svg-canvas').selectAll('*').remove();
-
-            this.g = new dagGraphLib.Graph().setGraph({});
-            this.state.tileables.forEach((tileable) => {
-                var value = { tileable };
-
-                let nameEndIndex = tileable.tileable_name.indexOf('key') - 1;
-                value.label = tileable.tileable_name.substring(0, nameEndIndex);
-                value.rx = value.ry = 5;
-                this.g.setNode(tileable.tileable_id, value);
-
-                // In future fill color based on progress
-                this.g.node(tileable.tileable_id).style = 'fill: #9fb4c2; cursor: pointer;';
-            });
-
-            this.state.dependencies.forEach((dependency) => {
-                // In future label may be named based on linkType?
-                this.g.setEdge(dependency.from_tileable_id, dependency.to_tileable_id, { label: '' });
-            });
-
-            let gInstance = this.g;
-            // Round the corners of the nodes
-            gInstance.nodes().forEach(function (v) {
-                var node = gInstance.node(v);
-                node.rx = node.ry = 5;
-            });
-
-            //makes the lines smooth
-            gInstance.edges().forEach(function (e) {
-                var edge = gInstance.edge(e.v, e.w);
-                edge.style = 'stroke: #333; fill: none';
-            });
-
-            // Create the renderer
-            var render = new DagRender();
-
-            // Set up an SVG group so that we can translate the final graph.
-            var svg = d3Select('#svg-canvas'),
-                inner = svg.append('g');
-
-            // Set up zoom support
-            var zoom = d3Zoom().on('zoom', function (e) {
-                inner.attr('transform', e.transform);
-            });
-            svg.call(zoom);
-
-            if (this.state.tileables.length !== 0) {
-                // Run the renderer. This is what draws the final graph.
-                render(inner, this.g);
-            }
-
-            const handleClick = (e, node) => {
-                const selectedTileable = this.state.tileables.filter((tileable) => tileable.tileable_id == node)[0];
-                this.setState({ selectedTileable: selectedTileable});
-            };
-
-            inner.selectAll('g.node').on('click', handleClick);
-
-            // Center the graph
-            var initialScale = 0.75;
-            svg.call(
-                zoom.transform,
-                d3ZoomIdentity.scale(initialScale)
-            );
-
-            if (this.g.graph() !== null || this.g.graph() !== undefined) {
-                svg.attr('height', this.g.graph().height * initialScale + 40);
-            } else {
-                svg.attr('height', 40);
-            }
-        }
-    }
-
     render() {
+        if (this.props === undefined) {
+            return null;
+        }
+        const tileableClick = (e, tileable) => {
+            this.setState({
+                selectedTileable: tileable
+            });
+        };
         return (
-            <React.Fragment>
-                <Grid item xs={12} md={6}>
+            <Grid container spacing={3}>
+                <Grid item xs={12}>
+                    <Title>Task {this.props.match.params.task_id}</Title>
+                </Grid>
+                <Grid item xs={12}>
                     <Paper>
-                        <Grid item xs={12}>
-                            <svg
-                                id="svg-canvas"
-                                style={{ margin: 30, width: '90%', height: '100%' }}
+                        <Grid container spacing={3}>
+                            <Grid item xs={12} sm={6}>
+                                <TaskTileableGraph
+                                    sessionId={this.props.match.params.session_id}
+                                    taskId={this.props.match.params.task_id}
+                                    onTileableClick={tileableClick}
+                                />
+                            </Grid>
+                            <Divider
+                                orientation='vertical' flexItem
+                                style={{marginRight:'-1px'}}
                             />
+                            <Grid item xs={12} sm={6}>
+                                <Grid item xs={12}>
+                                    <TileableDetail tileable={this.state.selectedTileable} />
+                                </Grid>
+                            </Grid>
                         </Grid>
                     </Paper>
                 </Grid>
-                <TileableDetail tileable={this.state.selectedTileable} />
-            </React.Fragment>
+            </Grid>
         );
     }
-}
-
-TaskTileableChart.propTypes = {
-    session_id: PropTypes.string.isRequired,
-    task_id: PropTypes.string.isRequired,
-};
-
-function TaskDetail(props) {
-    return (
-        <Grid container spacing={3} >
-            <Grid item xs={12}>
-                <Title>Task</Title>
-            </Grid>
-            <TaskTileableChart session_id={props.match.params.session_id} task_id={props.match.params.task_id} />
-        </Grid>
-    );
 }
 
 TaskDetail.propTypes = {

--- a/mars/services/web/ui/src/task_info/TaskListPage.js
+++ b/mars/services/web/ui/src/task_info/TaskListPage.js
@@ -28,6 +28,7 @@ import {useStyles} from '../Style';
 import {formatTime, getTaskStatusText} from '../Utils';
 import { Link } from 'react-router-dom';
 
+
 class TaskList extends React.Component {
     constructor(props) {
         super(props);
@@ -109,8 +110,7 @@ export default function TaskListPage(props) {
         <Grid container spacing={3}>
             <Grid item xs={12}>
                 <Title>
-          Session
-                    {props.sessionId}
+                    Session {props.sessionId}
                 </Title>
             </Grid>
             <Grid item xs={12}>

--- a/mars/services/web/ui/src/task_info/TaskTileableGraph.js
+++ b/mars/services/web/ui/src/task_info/TaskTileableGraph.js
@@ -1,0 +1,160 @@
+/*
+ * Copyright 1999-2021 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { select as d3Select } from 'd3-selection';
+import {
+    zoom as d3Zoom,
+    zoomIdentity as d3ZoomIdentity
+} from 'd3-zoom';
+import {
+    graphlib as dagGraphLib,
+    render as DagRender
+} from 'dagre-d3';
+import PropTypes from 'prop-types';
+
+
+export default class TaskTileableGraph extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            selectedTileable: null,
+            tileables: [],
+            dependencies: [],
+        };
+    }
+
+    fetchGraphDetail() {
+        const { sessionId, taskId } = this.props;
+
+        fetch(`api/session/${sessionId}/task/${taskId
+        }/tileable_graph?action=get_tileable_graph_as_json`)
+            .then(res => res.json())
+            .then((res) => {
+                this.setState({
+                    tileables: res.tileables,
+                    dependencies: res.dependencies,
+                });
+            });
+    }
+
+    componentDidMount() {
+        this.g = new dagGraphLib.Graph().setGraph({});
+        this.fetchGraphDetail();
+    }
+
+    /* eslint no-unused-vars: ["error", { "args": "none" }] */
+    componentDidUpdate(prevProps, prevStates, snapshot) {
+        if (prevStates.tileables !== this.state.tileables
+                && prevStates.dependencies !== this.state.dependencies) {
+            d3Select('#svg-canvas').selectAll('*').remove();
+
+            this.g = new dagGraphLib.Graph().setGraph({});
+            this.state.tileables.forEach((tileable) => {
+                const value = { tileable };
+
+                let nameEndIndex = tileable.tileable_name.indexOf('key') - 1;
+                value.label = tileable.tileable_name.substring(0, nameEndIndex);
+                value.rx = value.ry = 5;
+                this.g.setNode(tileable.tileable_id, value);
+
+                // In future fill color based on progress
+                const node = this.g.node(tileable.tileable_id);
+                node.style = 'fill: #f4b400; cursor: pointer;';
+                node.labelStyle = 'cursor: pointer';
+            });
+
+            this.state.dependencies.forEach((dependency) => {
+                // In future label may be named based on linkType?
+                this.g.setEdge(
+                    dependency.from_tileable_id,
+                    dependency.to_tileable_id,
+                    { label: '' }
+                );
+            });
+
+            let gInstance = this.g;
+            // Round the corners of the nodes
+            gInstance.nodes().forEach(function (v) {
+                const node = gInstance.node(v);
+                node.rx = node.ry = 5;
+            });
+
+            //makes the lines smooth
+            gInstance.edges().forEach(function (e) {
+                const edge = gInstance.edge(e.v, e.w);
+                edge.style = 'stroke: #333; fill: none';
+            });
+
+            // Create the renderer
+            const render = new DagRender();
+
+            // Set up an SVG group so that we can translate the final graph.
+            const svg = d3Select('#svg-canvas'),
+                inner = svg.append('g');
+
+            // Set up zoom support
+            const zoom = d3Zoom().on('zoom', function (e) {
+                inner.attr('transform', e.transform);
+            });
+            svg.call(zoom);
+
+            if (this.state.tileables.length !== 0) {
+                // Run the renderer. This is what draws the final graph.
+                render(inner, this.g);
+            }
+
+            const handleClick = (e, node) => {
+                if (this.props.onTileableClick) {
+                    const selectedTileable = this.state.tileables.filter(
+                        (tileable) => tileable.tileable_id == node
+                    )[0];
+                    this.props.onTileableClick(e, selectedTileable);
+                }
+            };
+
+            inner.selectAll('g.node').on('click', handleClick);
+
+            // Center the graph
+            const initialScale = 0.9;
+            svg.call(
+                zoom.transform,
+                d3ZoomIdentity.scale(initialScale)
+            );
+
+            if (this.g.graph() !== null || this.g.graph() !== undefined) {
+                svg.attr('height', this.g.graph().height * initialScale + 40);
+            } else {
+                svg.attr('height', 40);
+            }
+        }
+    }
+
+    render() {
+        return (
+            <svg
+                id="svg-canvas"
+                style={{ margin: 30, width: '90%', height: '100%' }}
+            />
+        );
+    }
+}
+
+TaskTileableGraph.propTypes = {
+    sessionId: PropTypes.string.isRequired,
+    taskId: PropTypes.string.isRequired,
+    onTileableClick: PropTypes.func,
+};

--- a/mars/services/web/ui/src/task_info/TileableDetail.js
+++ b/mars/services/web/ui/src/task_info/TileableDetail.js
@@ -16,8 +16,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Paper } from '@material-ui/core';
-import Title from '../Title';
+
 
 class TileableDetail extends React.Component {
     constructor(props) {
@@ -27,32 +26,20 @@ class TileableDetail extends React.Component {
 
     render() {
         if (this.props === undefined) {
-            return <div></div>;
+            return null;
         }
 
         return (
-            <Grid item xs={12} md={6}>
-                <Paper style={{ padding: 10 }}>
-                    <Grid item xs={12}>
-                        <Title>Tileable Detail: </Title>
-                    </Grid>
-                    <Grid item xs={12}>
-                        {
-                            this.props.tileable
-                                ?
-                                <div>
-                                    <br/>
-                                    <div>Tileable ID: <br/>{this.props.tileable.tileable_id}</div><br/>
-                                    <div>Tileable Name: <br/>{this.props.tileable.tileable_name}</div><br/>
-                                </div>
-                                :
-                                <div>
-                                    Select a tileable to view its detail
-                                </div>
-                        }
-                    </Grid>
-                </Paper>
-            </Grid>
+            this.props.tileable
+                ?
+                <div>
+                    <div>Tileable ID: <br/>{this.props.tileable.tileable_id}</div><br/>
+                    <div>Tileable Name: <br/>{this.props.tileable.tileable_name}</div><br/>
+                </div>
+                :
+                <div>
+                    Select a tileable to view its detail
+                </div>
         );
     }
 }


### PR DESCRIPTION
## What do these changes do?

This PR makes changes below:
1. Remove `OptionalElement`;
2. Extract `TaskTileableGraph` and `TileableDetail` to separate pane layout from component rendering;
3. Minor style fixes.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
