### PR TITLE
Fix the error when multiple subtasks fetch the same data

### DIFF
--- a/mars/oscar/backends/communication/socket.py
+++ b/mars/oscar/backends/communication/socket.py
@@ -35,7 +35,7 @@ _is_windows: bool = sys.platform.startswith('win')
 
 
 class SocketChannel(Channel):
-    __slots__ = 'reader', 'writer', '_channel_type', '_lock'
+    __slots__ = 'reader', 'writer', '_channel_type', '_send_lock', '_recv_lock'
 
     name = 'socket'
 
@@ -53,7 +53,8 @@ class SocketChannel(Channel):
         self.writer = writer
         self._channel_type = channel_type
 
-        self._lock = asyncio.Lock()
+        self._send_lock = asyncio.Lock()
+        self._recv_lock = asyncio.Lock()
 
     @property
     @implements(Channel.type)
@@ -69,7 +70,7 @@ class SocketChannel(Channel):
 
         # write buffers
         write_buffers(self.writer, buffers)
-        async with self._lock:
+        async with self._send_lock:
             # add lock, or when parallel send,
             # assertion error may be raised
             await self.writer.drain()
@@ -77,8 +78,9 @@ class SocketChannel(Channel):
     @implements(Channel.recv)
     async def recv(self):
         deserializer = AioDeserializer(self.reader)
-        header = await deserializer.get_header()
-        buffers = await read_buffers(header, self.reader)
+        async with self._recv_lock:
+            header = await deserializer.get_header()
+            buffers = await read_buffers(header, self.reader)
         return deserialize(header, buffers)
 
     @implements(Channel.close)

--- a/mars/oscar/backends/message.py
+++ b/mars/oscar/backends/message.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
 from types import TracebackType
 from typing import Any, Type, Tuple, Dict, List
+
+import numpy as np
 
 from ...lib.tblib import pickling_support
 from ...serialization.core import Serializer, pickle, buffered
@@ -358,4 +359,4 @@ def _get_slots(message_cls: Type[_MessageBase]):
 
 
 def new_message_id():
-    return os.urandom(32)
+    return np.random.bytes(32)

--- a/mars/oscar/backends/message.py
+++ b/mars/oscar/backends/message.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
 from types import TracebackType
 from typing import Any, Type, Tuple, Dict, List
-
-import numpy as np
 
 from ...lib.tblib import pickling_support
 from ...serialization.core import Serializer, pickle, buffered
@@ -359,4 +358,4 @@ def _get_slots(message_cls: Type[_MessageBase]):
 
 
 def new_message_id():
-    return np.random.bytes(32)
+    return os.urandom(32)

--- a/mars/services/meta/api/oscar.py
+++ b/mars/services/meta/api/oscar.py
@@ -216,6 +216,14 @@ class MetaAPI(AbstractMetaAPI):
                               bands: List[BandType]):
         return await self._meta_store.add_chunk_bands(object_id, bands)
 
+    @add_chunk_bands.batch
+    async def batch_add_chunk_bands(self, args_list, kwargs_list):
+        add_chunk_bands_tasks = []
+        for args, kwargs in zip(args_list, kwargs_list):
+            add_chunk_bands_tasks.append(
+                self._meta_store.add_chunk_bands.delay(*args, **kwargs))
+        return await self._meta_store.add_chunk_bands.batch(*add_chunk_bands_tasks)
+
 
 class MockMetaAPI(MetaAPI):
     @classmethod

--- a/mars/services/meta/store/dictionary.py
+++ b/mars/services/meta/store/dictionary.py
@@ -102,10 +102,21 @@ class DictMetaStore(AbstractMetaStore):
         for args, kwargs in zip(args_list, kwargs_list):
             self._del_meta(*args, **kwargs)
 
-    @implements(AbstractMetaStore.add_chunk_bands)
-    async def add_chunk_bands(self,
-                              object_id: str,
-                              bands: List[BandType]):
+    def _add_chunk_bands(self,
+                         object_id: str,
+                         bands: List[BandType]):
         meta = self._store[object_id]
         assert isinstance(meta, _ChunkMeta)
         meta.bands = list(set(meta.bands) | set(bands))
+
+    @implements(AbstractMetaStore.add_chunk_bands)
+    @mo.extensible
+    async def add_chunk_bands(self,
+                              object_id: str,
+                              bands: List[BandType]):
+        self._add_chunk_bands(object_id, bands)
+
+    @add_chunk_bands.batch
+    async def batch_add_chunk_bands(self, args_list, kwargs_list):
+        for args, kwargs in zip(args_list, kwargs_list):
+            self._add_chunk_bands(*args, **kwargs)

--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -144,7 +144,7 @@ class InternalDataInfo:
     object_info: ObjectInfo
 
 
-class DataManagerActor(mo.StatelessActor):
+class DataManagerActor(mo.Actor):
     _data_key_to_info: Dict[tuple, List[InternalDataInfo]]
 
     def __init__(self, bands: List):
@@ -264,6 +264,7 @@ class DataManagerActor(mo.StatelessActor):
         info = self.get_data_info(session_id, data_key, band_name)
         self._spill_strategy[info.level, info.band].pin_data((session_id, data_key))
 
+    @mo.extensible
     def unpin(self,
               session_id: str,
               data_keys: List[str],

--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -428,6 +428,7 @@ class StorageManagerActor(mo.StatelessActor):
                     if band_name.startswith('gpu-'):  # pragma: no cover
                         await mo.create_actor(
                             SenderManagerActor, band_name,
+                            data_manager_ref=self._data_manager,
                             storage_handler_ref=handler_ref,
                             uid=SenderManagerActor.gen_uid(band_name),
                             address=self.address, allocate_strategy=sender_strategy)
@@ -459,7 +460,9 @@ class StorageManagerActor(mo.StatelessActor):
                                                     address=self.address,
                                                     allocate_strategy=handler_strategy)
                 await mo.create_actor(
-                    SenderManagerActor, storage_handler_ref=handler_ref,
+                    SenderManagerActor,
+                    data_manager_ref=self._data_manager,
+                    storage_handler_ref=handler_ref,
                     uid=SenderManagerActor.gen_uid(default_band_name),
                     address=self.address, allocate_strategy=sender_strategy)
 

--- a/mars/services/storage/spill.py
+++ b/mars/services/storage/spill.py
@@ -186,5 +186,6 @@ async def spill(request_size: int,
         except KeyError:  # pragma: no cover
             # workaround for the case that the object
             # has been deleted during spill
+            logger.debug('Data %s %s is deleted during spill', session_id, key)
             await storage_handler.delete(session_id, key, error='ignore')
     logger.debug('Spill finishes, release %s bytes of %s', sum(spill_sizes), level)

--- a/mars/services/storage/spill.py
+++ b/mars/services/storage/spill.py
@@ -180,6 +180,11 @@ async def spill(request_size: int,
                         break
                     else:
                         await writer.write(block_data)
-        await storage_handler.delete_object(
-            session_id, key, size, reader.object_id, level)
+        try:
+            await storage_handler.delete_object(
+                session_id, key, size, reader.object_id, level)
+        except KeyError:  # pragma: no cover
+            # workaround for the case that the object
+            # has been deleted during spill
+            await storage_handler.delete(session_id, key, error='ignore')
     logger.debug('Spill finishes, release %s bytes of %s', sum(spill_sizes), level)

--- a/mars/services/storage/tests/test_transfer.py
+++ b/mars/services/storage/tests/test_transfer.py
@@ -146,7 +146,7 @@ class MockReceiverManagerActor2(ReceiverManagerActor):
                              data_sizes,
                              level):
         await asyncio.sleep(3)
-        await super().create_writers(session_id, data_keys, data_sizes, level)
+        return await super().create_writers(session_id, data_keys, data_sizes, level)
 
 
 class MockSenderManagerActor2(SenderManagerActor):

--- a/mars/services/storage/tests/test_transfer.py
+++ b/mars/services/storage/tests/test_transfer.py
@@ -226,7 +226,7 @@ async def test_cancel_transfer(create_actors, mock_sender, mock_receiver):
 
 
 @pytest.mark.asyncio
-async def test_transfer_same_tasks(create_actors):
+async def test_transfer_same_data(create_actors):
     worker_address_1, worker_address_2 = create_actors
 
     session_id = 'mock_session'


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

When multiple subtasks fetch the same key at the same time, the transfer task may fails. In this PR, `ReceiverManagerActor` holds a dict to record the data keys being fetched and create events to mark if transfer tasks are finished, `SenderManagerActor` will wait those events to make sure all data keys are sent.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2321 