### PR TITLE
Optimize mars supervisor scheduling

### DIFF
--- a/mars/services/lifecycle/supervisor/tracker.py
+++ b/mars/services/lifecycle/supervisor/tracker.py
@@ -160,7 +160,7 @@ class LifecycleTrackerActor(mo.Actor):
             self._tileable_ref_counts[tileable_key] -= 1
 
             decref_chunk_keys.extend(self._tileable_key_to_chunk_keys[tileable_key])
-        return await self.decref_chunks(decref_chunk_keys)
+        yield self.decref_chunks(decref_chunk_keys)
 
     def get_tileable_ref_counts(self, tileable_keys: List[str]) -> List[int]:
         return [self._tileable_ref_counts[tileable_key]

--- a/mars/services/task/analyzer/analyzer.py
+++ b/mars/services/task/analyzer/analyzer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from collections import deque
 from typing import Dict, List, Tuple, Type, Union
 
@@ -23,6 +25,8 @@ from ...subtask import SubtaskGraph, Subtask
 from ..core import Task, new_task_id
 from .assigner import AbstractGraphAssigner, GraphAssigner
 from .fusion import Fusion
+
+logger = logging.getLogger(__name__)
 
 
 class GraphAnalyzer:
@@ -258,11 +262,15 @@ class GraphAnalyzer:
         # assign expect workers
         cur_assigns = {op.key: self._to_band(op.expect_worker)
                        for op in start_ops if op.expect_worker is not None}
+        logger.info('Start to assign %s start chunks.', len(start_ops))
         chunk_to_bands = assigner.assign(cur_assigns=cur_assigns)
+        logger.info('Assigned %s start chunks.', len(start_ops))
 
         # fuse node
         if self._fuse_enabled:
+            logger.info('Start to fuse chunks.')
             chunk_to_bands = self._fuse(chunk_to_bands)
+            logger.info('Fused chunks.')
 
         subtask_graph = SubtaskGraph()
         chunk_to_priorities = dict()

--- a/mars/services/task/analyzer/assigner.py
+++ b/mars/services/task/analyzer/assigner.py
@@ -114,7 +114,7 @@ class GraphAssigner(AbstractGraphAssigner):
             pos = (pos + 1) % len(counts)
         return dict(zip(bands, counts))
 
-    def _assign_by_dfs(self,
+    def _assign_by_bfs(self,
                        start: ChunkData,
                        band: BandType,
                        initial_sizes: Dict[BandType, int],
@@ -122,7 +122,7 @@ class GraphAssigner(AbstractGraphAssigner):
                        key_to_assign: Set[str],
                        assigned_record: Dict[str, int]):
         """
-        Assign initial nodes using breath-first search givin initial sizes and
+        Assign initial nodes using breath-first search given initial sizes and
         limitations of spread range.
         """
         if initial_sizes[band] <= 0:
@@ -130,9 +130,8 @@ class GraphAssigner(AbstractGraphAssigner):
 
         graph = self._chunk_graph
         if self._undirected_chunk_graph is None:
-            undirected_chunk_graph = graph.build_undirected()
-        else:
-            undirected_chunk_graph = self._undirected_chunk_graph
+            self._undirected_chunk_graph = graph.build_undirected()
+        undirected_chunk_graph = self._undirected_chunk_graph
 
         assigned = 0
         spread_range = 0
@@ -187,7 +186,7 @@ class GraphAssigner(AbstractGraphAssigner):
             cur = sorted_candidates.pop()
             while cur.op.key in cur_assigns:
                 cur = sorted_candidates.pop()
-            self._assign_by_dfs(cur, band, band_quotas, spread_ranges,
+            self._assign_by_bfs(cur, band, band_quotas, spread_ranges,
                                 op_keys, cur_assigns)
 
         key_to_assign = \

--- a/mars/services/task/supervisor/preprocessor.py
+++ b/mars/services/task/supervisor/preprocessor.py
@@ -14,6 +14,7 @@
 
 
 import asyncio
+import logging
 from functools import partial
 from typing import Callable, Dict, List, Iterable, Set, Tuple
 
@@ -28,6 +29,8 @@ from ....typing import BandType
 from ...subtask import SubtaskGraph
 from ..analyzer import GraphAnalyzer
 from ..core import Task
+
+logger = logging.getLogger(__name__)
 
 
 class CancellableTiler(Tiler):
@@ -147,9 +150,12 @@ class TaskPreprocessor:
     def analyze(self,
                 chunk_graph: ChunkGraph,
                 available_bands: Dict[BandType, int]) -> SubtaskGraph:
+        logger.info('Start to gen subtask graph.')
         task = self._task
         analyzer = GraphAnalyzer(chunk_graph, available_bands, task)
-        return analyzer.gen_subtask_graph()
+        graph = analyzer.gen_subtask_graph()
+        logger.info('Generated subtask graph of %s subtasks.', len(graph))
+        return graph
 
     def _get_done(self):
         return self._done.is_set()

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -547,7 +547,7 @@ class TaskProcessorActor(mo.Actor):
                     subtask_result.status = SubtaskStatus.errored
                     subtask_result.error = err
                     subtask_result.traceback = tb
-            yield stage_processor.set_subtask_result(subtask_result)
+            await stage_processor.set_subtask_result(subtask_result)
 
     def is_done(self) -> bool:
         for processor in self._task_id_to_processor.values():

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -537,7 +537,10 @@ class TaskProcessorActor(mo.Actor):
         stage_processor.subtask_temp_result[subtask] = subtask_result
         if subtask_result.status.is_done:
             try:
-                await self._decref_input_subtasks(subtask, stage_processor.subtask_graph)
+                # Since every worker will call supervisor to set subtask result,
+                # we need to release actor lock to make `decref_chunks` parallel to avoid blocking
+                # other `set_subtask_result` calls.
+                yield self._decref_input_subtasks(subtask, stage_processor.subtask_graph)
             except:  # noqa: E722  # nosec  # pylint: disable=bare-except  # pragma: no cover
                 _, err, tb = sys.exc_info()
                 if subtask_result.status not in (SubtaskStatus.errored, SubtaskStatus.cancelled):

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -547,7 +547,7 @@ class TaskProcessorActor(mo.Actor):
                     subtask_result.status = SubtaskStatus.errored
                     subtask_result.error = err
                     subtask_result.traceback = tb
-            await stage_processor.set_subtask_result(subtask_result)
+            yield stage_processor.set_subtask_result(subtask_result)
 
     def is_done(self) -> bool:
         for processor in self._task_id_to_processor.values():

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -254,8 +254,8 @@ class TaskProcessor:
 
         # gen subtask graph
         available_bands = await self._get_available_band_slots()
-        subtask_graph = self._preprocessor.analyze(
-            chunk_graph, available_bands)
+        subtask_graph = await asyncio.to_thread(self._preprocessor.analyze,
+                                                chunk_graph, available_bands)
         stage_processor = TaskStageProcessor(
             new_task_id(), self._task, chunk_graph, subtask_graph,
             list(available_bands), self._get_chunk_optimization_records(),


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Fix supervisor hang:
* Before this pr, if we have 1000 chunks need to `set_subtask_result` and each take 1 second, we'll need to wait 1000 seconds before we can schedule next subtask graph.
* Big sutask graph generation may take more than 3 minutes, this will block event loop 3 minutes. This PR moved the graph preparation into another thread to avoid event loop hang.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
