### PR TITLE
Add API to retrieve progress and status of tileables

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -63,20 +63,7 @@ jobs:
           fi
 
           conda install -n test --quiet --yes -c pkgs/main python=$PYTHON certifi
-
-          if [[ ! "$PYTHON" =~ "3.9" ]]; then
-            conda install --quiet --yes -n test -c conda-forge --no-deps python=$PYTHON \
-              libxgboost py-xgboost xgboost lightgbm tensorflow
-          fi
-          if [[ "$PYTHON" =~ "3.6" ]]; then
-            pip install torch==1.4.0 torchvision==0.5.0 faiss-cpu fastparquet
-          fi
-          if [[ ! "$PYTHON" =~ "3.6" ]] && [[ ! "$PYTHON" =~ "3.9" ]]; then
-            pip install torch torchvision
-            pip install statsmodels tsfresh
-          fi
         fi
-        retry ./.github/workflows/download-etcd.sh
         conda list -n test
 
     - name: Test with pytest

--- a/mars/services/task/api/oscar.py
+++ b/mars/services/task/api/oscar.py
@@ -69,10 +69,13 @@ class TaskAPI(AbstractTaskAPI):
         except mo.ActorNotExist:
             raise RuntimeError('Session closed already')
 
-    async def get_tileable_graph_dict_by_task_id(self, task_id: str):
+    async def get_tileable_graph_as_json(self, task_id: str):
         return await self._task_manager_ref.get_tileable_graph_dict_by_task_id(
             task_id
         )
+
+    async def get_tileable_details(self, task_id: str):
+        return await self._task_manager_ref.get_tileable_details(task_id)
 
     async def wait_task(self, task_id: str, timeout: float = None):
         return await self._task_manager_ref.wait_task(

--- a/mars/services/task/api/web.py
+++ b/mars/services/task/api/web.py
@@ -104,10 +104,17 @@ class TaskWebAPIHandler(MarsServiceWebAPIHandler):
         res = await oscar_api.get_task_result(task_id)
         self.write(json.dumps(_json_serial_task_result(res)))
 
-    @web_api('(?P<task_id>[^/]+)' + '/tileable_graph', method='get', arg_filter={'action': 'get_tileable_graph_as_json'})
-    async def get_tileable_graph_dict_by_task_id(self, session_id: str, task_id: str):
+    @web_api('(?P<task_id>[^/]+)/tileable_graph', method='get',
+             arg_filter={'action': 'get_tileable_graph_as_json'})
+    async def get_tileable_graph_as_json(self, session_id: str, task_id: str):
         oscar_api = await self._get_oscar_task_api(session_id)
-        res = await oscar_api.get_tileable_graph_dict_by_task_id(task_id)
+        res = await oscar_api.get_tileable_graph_as_json(task_id)
+        self.write(json.dumps(res))
+
+    @web_api('(?P<task_id>[^/]+)/tileable_detail', method='get')
+    async def get_tileable_details(self, session_id: str, task_id: str):
+        oscar_api = await self._get_oscar_task_api(session_id)
+        res = await oscar_api.get_tileable_details(task_id)
         self.write(json.dumps(res))
 
     @web_api('(?P<task_id>[^/]+)', method='get', arg_filter={'action': 'progress'})
@@ -210,8 +217,13 @@ class WebTaskAPI(AbstractTaskAPI, MarsWebAPIClientMixin):
         path = f'{self._address}/api/session/{self._session_id}/task/{task_id}'
         await self._request_url(path=path, method='DELETE')
 
-    async def get_tileable_graph_dict_by_task_id(self, task_id: str):
+    async def get_tileable_graph_as_json(self, task_id: str):
         path = f'{self._address}/api/session/{self._session_id}/task/{task_id}/tileable_graph'
         params = dict(action='get_tileable_graph_as_json')
         res = await self._request_url(path=path, params=params, method='GET')
+        return json.loads(res.body.decode())
+
+    async def get_tileable_details(self, task_id: str):
+        path = f'{self._address}/api/session/{self._session_id}/task/{task_id}/tileable_detail'
+        res = await self._request_url(path=path, method='GET')
         return json.loads(res.body.decode())

--- a/mars/services/task/supervisor/manager.py
+++ b/mars/services/task/supervisor/manager.py
@@ -181,6 +181,14 @@ class TaskManagerActor(mo.Actor):
         res = await processor_ref.get_tileable_graph_as_dict()
         return res
 
+    async def get_tileable_details(self, task_id):
+        try:
+            processor_ref = self._task_id_to_processor_ref[task_id]
+        except KeyError:
+            raise TaskNotExist(f'Task {task_id} does not exist')
+
+        return await processor_ref.get_tileable_details()
+
     async def _gen_tiled_context(self, graph: TileableGraph) -> \
             Dict[TileableType, TileableType]:
         # process graph, add fetch node to tiled context

--- a/mars/services/task/supervisor/stage.py
+++ b/mars/services/task/supervisor/stage.py
@@ -21,7 +21,7 @@ from .... import oscar as mo
 from ....core import ChunkGraph
 from ....core.operand import Fuse
 from ....optimization.logical import OptimizationRecords
-from ....typing import BandType
+from ....typing import BandType, TileableType
 from ....utils import get_params_fields
 from ...scheduling import SchedulingAPI
 from ...subtask import Subtask, SubtaskGraph, SubtaskResult, SubtaskStatus
@@ -38,6 +38,7 @@ class TaskStageProcessor:
                  chunk_graph: ChunkGraph,
                  subtask_graph: SubtaskGraph,
                  bands: List[BandType],
+                 tileable_to_subtasks: Dict[TileableType, List[Subtask]],
                  optimization_records: OptimizationRecords,
                  scheduling_api: SchedulingAPI,
                  meta_api: MetaAPI):
@@ -45,6 +46,7 @@ class TaskStageProcessor:
         self.task = task
         self.chunk_graph = chunk_graph
         self.subtask_graph = subtask_graph
+        self.tileable_to_subtasks = tileable_to_subtasks
         self._bands = bands
         self._optimization_records = optimization_records
 
@@ -56,7 +58,7 @@ class TaskStageProcessor:
         self.subtask_id_to_subtask = {subtask.subtask_id: subtask
                                       for subtask in subtask_graph}
         self._subtask_to_bands: Dict[Subtask, BandType] = dict()
-        self.subtask_temp_result: Dict[Subtask, SubtaskResult] = dict()
+        self.subtask_temp_results: Dict[Subtask, SubtaskResult] = dict()
         self.subtask_results: Dict[Subtask, SubtaskResult] = dict()
         self._submitted_subtask_ids = set()
 

--- a/mars/services/task/tests/test_service.py
+++ b/mars/services/task/tests/test_service.py
@@ -25,6 +25,7 @@ from mars.core.context import get_context
 from mars.services import start_services, NodeRole
 from mars.services.session import SessionAPI
 from mars.services.storage import MockStorageAPI
+from mars.services.subtask import SubtaskStatus
 from mars.services.web import WebActor
 from mars.services.meta import MetaAPI
 from mars.services.task import TaskAPI, TaskStatus, WebTaskAPI
@@ -88,7 +89,7 @@ async def start_test_service(actor_pools, request):
     session_api = await SessionAPI.create(sv_pool.external_address)
     await session_api.create_session(session_id)
 
-    if not request:
+    if not request.param:
         task_api = await TaskAPI.create(session_id,
                                         sv_pool.external_address)
     else:
@@ -228,7 +229,7 @@ async def test_task_progress(start_test_service):
 
     await task_api.submit_tileable_graph(graph, fuse_enabled=False)
 
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(0.2)
     results = await task_api.get_task_results(progress=True)
     assert results[0].progress == 0.0
 
@@ -244,7 +245,7 @@ async def test_task_progress(start_test_service):
 
 
 @pytest.mark.asyncio
-async def test_get_tileables(start_test_service):
+async def test_get_tileable_graph(start_test_service):
     _sv_pool_address, task_api, storage_api = start_test_service
 
     def f1():
@@ -266,14 +267,14 @@ async def test_get_tileables(start_test_service):
     task_id = await task_api.submit_tileable_graph(graph, fuse_enabled=False)
 
     with pytest.raises(TaskNotExist):
-        await task_api.get_tileable_graph_dict_by_task_id("qffw2")
+        await task_api.get_tileable_graph_as_json('non_exist')
 
-    tileable_detail = await task_api.get_tileable_graph_dict_by_task_id(task_id)
+    tileable_detail = await task_api.get_tileable_graph_as_json(task_id)
 
-    num_tileable = len(tileable_detail.get("tileables"))
-    num_dependencies = len(tileable_detail.get("dependencies"))
-    assert  num_tileable > 0
-    assert  num_dependencies <= (num_tileable / 2) * (num_tileable / 2)
+    num_tileable = len(tileable_detail.get('tileables'))
+    num_dependencies = len(tileable_detail.get('dependencies'))
+    assert num_tileable > 0
+    assert num_dependencies <= (num_tileable / 2) * (num_tileable / 2)
 
     assert (num_tileable == 1 and num_dependencies == 0) or (num_tileable > 1 and num_dependencies > 0)
 
@@ -284,33 +285,94 @@ async def test_get_tileables(start_test_service):
 
         for node_successor in graph.iter_successors(node):
             graph_dependencies.append({
-                "from_tileable_id": node.key,
-                "from_tileable_name": str(node.op),
-
-                "to_tileable_id": node_successor.key,
-                "to_tileable_name": str(node_successor.op),
-
-                "linkType": 0,
+                'fromTileableId': node.key,
+                'toTileableId': node_successor.key,
+                'linkType': 0,
             })
 
-    for tileable in tileable_detail.get("tileables"):
-        graph_nodes.remove(tileable.get("tileable_id"))
+    for tileable in tileable_detail.get('tileables'):
+        graph_nodes.remove(tileable.get('tileableId'))
 
     assert len(graph_nodes) == 0
 
     for i in range(num_dependencies):
-        dependency = tileable_detail.get("dependencies")[i]
-        assert graph_dependencies[i].get("from_tileable_id") == \
-               dependency.get("from_tileable_id")
+        dependency = tileable_detail.get('dependencies')[i]
+        assert graph_dependencies[i] == dependency
 
-        assert graph_dependencies[i].get("from_tileable_name") == \
-               dependency.get("from_tileable_name")
 
-        assert graph_dependencies[i].get("to_tileable_id") == \
-               dependency.get("to_tileable_id")
+@pytest.mark.asyncio
+async def test_get_tileable_details(start_test_service):
+    sv_pool_address, task_api, storage_api = start_test_service
 
-        assert graph_dependencies[i].get("to_tileable_name") == \
-               dependency.get("to_tileable_name")
+    session_api = await SessionAPI.create(address=sv_pool_address)
+    ref = await session_api.create_remote_object(
+        task_api._session_id, 'progress_controller', _ProgressController)
 
-        assert graph_dependencies[i].get("linkType") == \
-               dependency.get("linkType")
+    with pytest.raises(TaskNotExist):
+        await task_api.get_tileable_details('non_exist')
+
+    def f(*_args, raises=False):
+        get_context().set_progress(0.5)
+        if raises:
+            raise ValueError
+        progress_controller = get_context().get_remote_object('progress_controller')
+        progress_controller.wait()
+        get_context().set_progress(1.0)
+        return 'RET'
+
+    # test non-fused DAGs
+    r1 = mr.spawn(f)
+    r2 = mr.spawn(f, args=(r1, 0))
+    r3 = mr.spawn(f, args=(r1, 1))
+
+    graph = TileableGraph([r2.data, r3.data])
+    next(TileableGraphBuilder(graph).build())
+
+    task_id = await task_api.submit_tileable_graph(graph, fuse_enabled=False)
+
+    def _get_fields(details, field, wrapper=None):
+        rs = [r1, r2, r3]
+        ret = [details[r.key][field] for r in rs]
+        if wrapper:
+            ret = [wrapper(v) for v in ret]
+        return ret
+
+    await asyncio.sleep(1)
+    details = await task_api.get_tileable_details(task_id)
+    assert _get_fields(details, 'progress') == [0.5, 0.0, 0.0]
+    assert _get_fields(details, 'status', SubtaskStatus) \
+        == [SubtaskStatus.running] + [SubtaskStatus.pending] * 2
+
+    await ref.set()
+    await asyncio.sleep(1)
+    details = await task_api.get_tileable_details(task_id)
+    assert _get_fields(details, 'progress') == [1.0, 0.5, 0.5]
+    assert _get_fields(details, 'status', SubtaskStatus) \
+        == [SubtaskStatus.succeeded] + [SubtaskStatus.running] * 2
+
+    await ref.set()
+    await task_api.wait_task(task_id)
+
+    # test fused DAGs
+    r5 = mr.spawn(f, args=(0,))
+    r6 = mr.spawn(f, args=(r5,))
+
+    graph = TileableGraph([r6.data])
+    next(TileableGraphBuilder(graph).build())
+
+    task_id = await task_api.submit_tileable_graph(graph, fuse_enabled=True)
+
+    await asyncio.sleep(1)
+    details = await task_api.get_tileable_details(task_id)
+    assert details[r5.key]['progress'] == details[r6.key]['progress'] == 0.25
+
+    # test raises
+    r7 = mr.spawn(f, kwargs={'raises': 1})
+
+    graph = TileableGraph([r7.data])
+    next(TileableGraphBuilder(graph).build())
+
+    task_id = await task_api.submit_tileable_graph(graph, fuse_enabled=True)
+    await task_api.wait_task(task_id)
+    details = await task_api.get_tileable_details(task_id)
+    assert details[r7.key]['status'] == SubtaskStatus.errored.value

--- a/mars/services/web/ui/src/task_info/TaskTileableGraph.js
+++ b/mars/services/web/ui/src/task_info/TaskTileableGraph.js
@@ -66,13 +66,13 @@ export default class TaskTileableGraph extends React.Component {
             this.state.tileables.forEach((tileable) => {
                 const value = { tileable };
 
-                let nameEndIndex = tileable.tileable_name.indexOf('key') - 1;
-                value.label = tileable.tileable_name.substring(0, nameEndIndex);
+                let nameEndIndex = tileable.tileableName.indexOf('key') - 1;
+                value.label = tileable.tileableName.substring(0, nameEndIndex);
                 value.rx = value.ry = 5;
-                this.g.setNode(tileable.tileable_id, value);
+                this.g.setNode(tileable.tileableId, value);
 
                 // In future fill color based on progress
-                const node = this.g.node(tileable.tileable_id);
+                const node = this.g.node(tileable.tileableId);
                 node.style = 'fill: #f4b400; cursor: pointer;';
                 node.labelStyle = 'cursor: pointer';
             });
@@ -80,8 +80,8 @@ export default class TaskTileableGraph extends React.Component {
             this.state.dependencies.forEach((dependency) => {
                 // In future label may be named based on linkType?
                 this.g.setEdge(
-                    dependency.from_tileable_id,
-                    dependency.to_tileable_id,
+                    dependency.fromTileableId,
+                    dependency.toTileableId,
                     { label: '' }
                 );
             });
@@ -120,7 +120,7 @@ export default class TaskTileableGraph extends React.Component {
             const handleClick = (e, node) => {
                 if (this.props.onTileableClick) {
                     const selectedTileable = this.state.tileables.filter(
-                        (tileable) => tileable.tileable_id == node
+                        (tileable) => tileable.tileableId == node
                     )[0];
                     this.props.onTileableClick(e, selectedTileable);
                 }

--- a/mars/services/web/ui/src/task_info/TileableDetail.js
+++ b/mars/services/web/ui/src/task_info/TileableDetail.js
@@ -33,8 +33,8 @@ class TileableDetail extends React.Component {
             this.props.tileable
                 ?
                 <div>
-                    <div>Tileable ID: <br/>{this.props.tileable.tileable_id}</div><br/>
-                    <div>Tileable Name: <br/>{this.props.tileable.tileable_name}</div><br/>
+                    <div>Tileable ID: <br/>{this.props.tileable.tileableId}</div><br/>
+                    <div>Tileable Name: <br/>{this.props.tileable.tileableName}</div><br/>
                 </div>
                 :
                 <div>
@@ -46,8 +46,8 @@ class TileableDetail extends React.Component {
 
 TileableDetail.propTypes = {
     tileable: PropTypes.shape({
-        tileable_id: PropTypes.string,
-        tileable_name: PropTypes.string,
+        tileableId: PropTypes.string,
+        tileableName: PropTypes.string,
     }),
 };
 

--- a/mars/tensor/stats/tests/test_stats_execute.py
+++ b/mars/tensor/stats/tests/test_stats_execute.py
@@ -199,22 +199,15 @@ def test_t_test_execution(setup):
 
 
 @pytest.mark.parametrize('chunk_size', [5, 15])
-@pytest.mark.parametrize('mode', ['auto', 'asymp', 'approx'])
-def test_ks_1samp(setup, chunk_size, mode):
+@pytest.mark.parametrize('mode, alternative', [
+    ('auto', 'greater'),
+    ('auto', 'less'),
+    ('auto', 'two-sided'),
+    ('asymp', 'two-sided'),
+    ('approx', 'two-sided'),
+])
+def test_ks_1samp(setup, chunk_size, mode, alternative):
     x = tensor(np.linspace(-15, 15, 9), chunk_size=5)
-
-    if mode == 'auto':
-        result = ks_1samp(x, sp_norm.cdf,
-                          alternative='greater').execute().fetch()
-        expected = sp_ks_1samp(x, sp_norm.cdf,
-                               alternative='greater')
-        assert result == expected
-
-        result = ks_1samp(x, sp_norm.cdf,
-                          alternative='less').execute().fetch()
-        expected = sp_ks_1samp(x, sp_norm.cdf,
-                               alternative='less')
-        assert result == expected
 
     result = ks_1samp(x, sp_norm.cdf, mode=mode).execute().fetch()
     expected = sp_ks_1samp(x, sp_norm.cdf, mode=mode)


### PR DESCRIPTION
## What do these changes do?

Add API support for #2342. Subtasks are binded to tileables to get progresses. If chunks of a tileable is fused with chunks of another tileable, progresses are shared between different tileables.

## Related issue number

Deal with API part of #2342.