### PR TITLE
Display tileable progress, status and dependency link type on task detail page

### DIFF
--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -527,9 +527,10 @@ class TaskProcessorActor(mo.Actor):
                     'toTileableId': chunk.key,
                     'linkType': 1 if is_pure_dep else 0,
                 })
+
         graph_dict = {
-            'tileables': node_list,
-            'dependencies': edge_list
+            'tileables': [i for n, i in enumerate(node_list) if i not in node_list[n + 1:]],
+            'dependencies': [i for n, i in enumerate(edge_list) if i not in edge_list[n + 1:]]
         }
         return graph_dict
 

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -512,7 +512,13 @@ class TaskProcessorActor(mo.Actor):
         node_list = []
         edge_list = []
 
+        visited = set()
+
         for chunk in tileable_graph:
+            if chunk.key in visited:
+                continue
+            visited.add(chunk.key)
+
             node_name = str(chunk.op)
 
             node_list.append({
@@ -529,8 +535,8 @@ class TaskProcessorActor(mo.Actor):
                 })
 
         graph_dict = {
-            'tileables': [i for n, i in enumerate(node_list) if i not in node_list[n + 1:]],
-            'dependencies': [i for n, i in enumerate(edge_list) if i not in edge_list[n + 1:]]
+            'tileables': node_list,
+            'dependencies': edge_list
         }
         return graph_dict
 

--- a/mars/services/web/ui/src/task_info/TaskTileableGraph.js
+++ b/mars/services/web/ui/src/task_info/TaskTileableGraph.js
@@ -34,19 +34,32 @@ export default class TaskTileableGraph extends React.Component {
             selectedTileable: null,
             tileables: [],
             dependencies: [],
+            tileableDetails: {},
         };
     }
 
     fetchGraphDetail() {
         const { sessionId, taskId } = this.props;
 
+        const tileableStatus = ['succeeded', 'running', 'cancelled', 'failed', 'pending'];
+
         fetch(`api/session/${sessionId}/task/${taskId
         }/tileable_graph?action=get_tileable_graph_as_json`)
             .then(res => res.json())
             .then((res) => {
+                console.log(res);
+                let newTileableDetails = {};
+                for (let i = 0; i < res.tileables.length; i++) {
+                    newTileableDetails[res.tileables[i].tileable_id] = {
+                        progress: Math.random(),
+                        status: tileableStatus[Math.floor(Math.random()*tileableStatus.length)],
+                    };
+                }
+
                 this.setState({
                     tileables: res.tileables,
                     dependencies: res.dependencies,
+                    tileableDetails: newTileableDetails,
                 });
             });
     }
@@ -62,6 +75,79 @@ export default class TaskTileableGraph extends React.Component {
                 && prevStates.dependencies !== this.state.dependencies) {
             d3Select('#svg-canvas').selectAll('*').remove();
 
+            // Set up an SVG group so that we can translate the final graph.
+            const svg = d3Select('#svg-canvas'),
+                inner = svg.append('g');
+
+            svg
+                .append("circle")
+                .attr("cx", 400)
+                .attr("cy", 20)
+                .attr("r", 6)
+                .style("fill", "#f4b400");
+            svg
+                .append("circle")
+                .attr("cx", 400)
+                .attr("cy", 40)
+                .attr("r", 6)
+                .style("fill", "#00ff00");
+            svg
+                .append("circle")
+                .attr("cx", 400)
+                .attr("cy", 60)
+                .attr("r", 6)
+                .style("fill", "#808080");
+            svg
+                .append("circle")
+                .attr("cx", 400)
+                .attr("cy", 80)
+                .attr("r", 6)
+                .style("fill", "#ff0000");
+            svg
+                .append("circle")
+                .attr("cx", 400)
+                .attr("cy", 100)
+                .attr("r", 6)
+                .attr("stroke", "#333")
+                .style("fill", "#ffffff");
+
+            svg
+                .append("text")
+                .attr("x", 420)
+                .attr("y", 100)
+                .text("Pending")
+                .style("font-size", "15px")
+                .attr("alignment-baseline", "middle");
+            svg
+                .append("text")
+                .attr("x", 420)
+                .attr("y", 20)
+                .text("Running")
+                .style("font-size", "15px")
+                .attr("alignment-baseline", "middle");
+            svg
+                .append("text")
+                .attr("x", 420)
+                .attr("y", 40)
+                .text("Succeeded")
+                .style("font-size", "15px")
+                .attr("alignment-baseline", "middle");
+            svg
+                .append("text")
+                .attr("x", 420)
+                .attr("y", 60)
+                .text("Cancelled")
+                .style("font-size", "15px")
+                .attr("alignment-baseline", "middle");
+            svg
+                .append("text")
+                .attr("x", 420)
+                .attr("y", 80)
+                .text("Failed")
+                .style("font-size", "15px")
+                .attr("alignment-baseline", "middle");
+
+
             this.g = new dagGraphLib.Graph().setGraph({});
             this.state.tileables.forEach((tileable) => {
                 const value = { tileable };
@@ -71,9 +157,43 @@ export default class TaskTileableGraph extends React.Component {
                 value.rx = value.ry = 5;
                 this.g.setNode(tileable.tileable_id, value);
 
+                const tileableDetail = this.state.tileableDetails[tileable.tileable_id];
+
+                var nodeProgressGradient = inner.append('linearGradient')
+                    .attr('id', 'progress-' + tileable.tileable_id);
+
+                if (tileableDetail.status === 'pending') {
+                    nodeProgressGradient.append('stop')
+                    .attr('stop-color', '#ffffff')
+                    .attr('offset', '0%');
+                } else if (tileableDetail.status === 'running') {
+                    nodeProgressGradient.append('stop')
+                    .attr('stop-color', '#f4b400')
+                    .attr('offset', tileableDetail.progress * 100 + '%');
+                } else if (tileableDetail.status === 'succeeded') {
+                    nodeProgressGradient.append('stop')
+                    .attr('stop-color', '#00ff00')
+                    .attr('offset', '100%');
+                } else if (tileableDetail.status === 'failed') {
+                    nodeProgressGradient.append('stop')
+                    .attr('stop-color', '#ff0000')
+                    .attr('offset', tileableDetail.progress * 100 + '%');
+                } else {
+                    nodeProgressGradient.append('stop')
+                    .attr('stop-color', '#808080')
+                    .attr('offset', tileableDetail.progress * 100 + '%');
+                }
+
+                nodeProgressGradient.append('stop')
+                    .attr('stop-color', '#ffffff')
+                    .attr('offset', '0%');
+
                 // In future fill color based on progress
                 const node = this.g.node(tileable.tileable_id);
-                node.style = 'fill: #f4b400; cursor: pointer;';
+                node.style = `
+                    cursor: pointer;
+                    stroke: #333;
+                    fill: url(#progress-` + tileable.tileable_id + `)`;
                 node.labelStyle = 'cursor: pointer';
             });
 
@@ -101,10 +221,6 @@ export default class TaskTileableGraph extends React.Component {
 
             // Create the renderer
             const render = new DagRender();
-
-            // Set up an SVG group so that we can translate the final graph.
-            const svg = d3Select('#svg-canvas'),
-                inner = svg.append('g');
 
             // Set up zoom support
             const zoom = d3Zoom().on('zoom', function (e) {

--- a/mars/services/web/ui/src/task_info/TaskTileableGraph.js
+++ b/mars/services/web/ui/src/task_info/TaskTileableGraph.js
@@ -103,7 +103,7 @@ export default class TaskTileableGraph extends React.Component {
             .then((res) => {
                 this.setState({
                     tileableDetails: res,
-                })
+                });
             });
     }
 
@@ -118,9 +118,7 @@ export default class TaskTileableGraph extends React.Component {
         this.fetchGraphDetail();
     }
 
-    componentWillUnmount() {
-        clearInterval(this.interval);
-    }
+
 
     /**
      * Creates one status entry for the legend of DAG
@@ -211,7 +209,7 @@ export default class TaskTileableGraph extends React.Component {
                  * should be filled with color. The second stop adds a white color to
                  * the rest of the node
                  */
-                var nodeProgressGradient = inner.append('linearGradient')
+                let nodeProgressGradient = inner.append('linearGradient')
                     .attr('id', 'progress-' + tileable.tileableId);
 
                 nodeProgressGradient.append('stop')
@@ -270,12 +268,6 @@ export default class TaskTileableGraph extends React.Component {
             // Create the renderer
             const render = new DagRender();
 
-            // Set up zoom support
-            const zoom = d3Zoom().on('zoom', function (e) {
-                inner.attr('transform', e.transform);
-            });
-            svg.call(zoom);
-
             if (this.state.tileables.length !== 0) {
                 // Run the renderer. This is what draws the final graph.
                 render(inner, this.g);
@@ -294,8 +286,23 @@ export default class TaskTileableGraph extends React.Component {
             inner.selectAll('g.node').on('click', handleClick);
 
             // Center the graph
-            const initialScale = 0.9;
+            const bounds = inner.node().getBBox();
+            const parent = inner.node().parentElement;
+            const width = bounds.width,
+                height = bounds.height;
+            const fullWidth = parent.clientWidth,
+                fullHeight = parent.clientHeight;
+            const initialScale = fullHeight >= height ? 1 : fullHeight / height;
+
+            d3Select('.output').attr('transform', 'translate(' + (fullWidth - width * initialScale) / 2 + ', ' + (fullHeight - height * initialScale) / 2 + ')');
+
+            // Set up zoom support
+            const zoom = d3Zoom().on('zoom', function (e) {
+                inner.attr('transform', e.transform);
+            });
+
             svg.call(
+                zoom,
                 zoom.transform,
                 d3ZoomIdentity.scale(initialScale)
             );
@@ -325,7 +332,7 @@ export default class TaskTileableGraph extends React.Component {
                     .attr('offset', tileableDetail.progress);
             })
         }
-    }
+    };
 
     render() {
         return (

--- a/mars/services/web/ui/src/task_info/TaskTileableGraph.js
+++ b/mars/services/web/ui/src/task_info/TaskTileableGraph.js
@@ -118,6 +118,10 @@ export default class TaskTileableGraph extends React.Component {
         this.fetchGraphDetail();
     }
 
+    componentWillUnmount() {
+        clearInterval(this.interval);
+    }
+
     /**
      * Creates one status entry for the legend of DAG
      *

--- a/mars/services/web/ui/src/task_info/TaskTileableGraph.js
+++ b/mars/services/web/ui/src/task_info/TaskTileableGraph.js
@@ -226,10 +226,7 @@ export default class TaskTileableGraph extends React.Component {
                  * to nodes.
                  */
                 const node = this.g.node(tileable.tileableId);
-                node.style = `
-                    cursor: pointer;
-                    stroke: #333;
-                    fill: url(#progress-` + tileable.tileableId + `)`;
+                node.style = 'cursor: pointer; stroke: #333; fill: url(#progress-' + tileable.tileableId + ')';
                 node.labelStyle = 'cursor: pointer';
             });
 
@@ -330,9 +327,9 @@ export default class TaskTileableGraph extends React.Component {
                 svg.select('#progress-' + tileable.tileableId + '-stop')
                     .attr('stop-color', this.state.tileableStatus[tileableDetail.status].color)
                     .attr('offset', tileableDetail.progress);
-            })
+            });
         }
-    };
+    }
 
     render() {
         return (

--- a/mars/services/web/ui/src/task_info/TaskTileableGraph.js
+++ b/mars/services/web/ui/src/task_info/TaskTileableGraph.js
@@ -45,7 +45,6 @@ export default class TaskTileableGraph extends React.Component {
         }/tileable_detail`)
             .then(res => res.json())
             .then((res) => {
-                console.log('res', res, Object.keys(res).length)
                 this.setState({
                     tileableDetails: res,
                 })
@@ -55,7 +54,6 @@ export default class TaskTileableGraph extends React.Component {
         }/tileable_graph?action=get_tileable_graph_as_json`)
             .then(res => res.json())
             .then((res) => {
-                console.log('res', res, res.tileables.length);
                 this.setState({
                     tileables: res.tileables,
                     dependencies: res.dependencies,


### PR DESCRIPTION
## What do these changes do?

Now the tileables will be colored based on their status:
- white = pending
- yellow = running
- green = finished
- gray = cancelled
- red = failed

and the tileables will be colored based on the percentage of subtasks they have finished. A sample graph may look like this:

![11629380137_ pic_hd](https://user-images.githubusercontent.com/69881587/130215621-e3ad42fe-da9d-499b-9ed0-1a50ce330fb2.jpg)

Lastly, the dependency between two tileables will be dashed if the dependency has a linkType of 1.

## Related issue number

Resolves #2342
