### PR TITLE
Added DataFrame.assign

### DIFF
--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -1837,6 +1837,63 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
         """
         return self._data.itertuples(batch_size=batch_size, session=session,
                                      index=index, name=name)
+    
+    def assign(self, **kwargs) -> DataFrame:
+        r"""
+        Assign new columns to a DataFrame.
+        Returns a new object with all original columns in addition to new ones.
+        Existing columns that are re-assigned will be overwritten.
+        Parameters
+        ----------
+        **kwargs : dict of {str: callable or Series}
+            The column names are keywords. If the values are
+            callable, they are computed on the DataFrame and
+            assigned to the new columns. The callable must not
+            change input DataFrame (though pandas doesn't check it).
+            If the values are not callable, (e.g. a Series, scalar, or array),
+            they are simply assigned.
+        Returns
+        -------
+        DataFrame
+            A new DataFrame with the new columns in addition to
+            all the existing columns.
+        Notes
+        -----
+        Assigning multiple columns within the same ``assign`` is possible.
+        Later items in '\*\*kwargs' may refer to newly created or modified
+        columns in 'df'; items are computed and assigned into 'df' in order.
+        Examples
+        --------
+        >>> df = pd.DataFrame({'temp_c': [17.0, 25.0]},
+        ...                   index=['Portland', 'Berkeley'])
+        >>> df
+                  temp_c
+        Portland    17.0
+        Berkeley    25.0
+        Where the value is a callable, evaluated on `df`:
+        >>> df.assign(temp_f=lambda x: x.temp_c * 9 / 5 + 32)
+                  temp_c  temp_f
+        Portland    17.0    62.6
+        Berkeley    25.0    77.0
+        Alternatively, the same behavior can be achieved by directly
+        referencing an existing Series or sequence:
+        >>> df.assign(temp_f=df['temp_c'] * 9 / 5 + 32)
+                  temp_c  temp_f
+        Portland    17.0    62.6
+        Berkeley    25.0    77.0
+        You can create multiple columns within the same assign where one
+        of the columns depends on another one defined within the same assign:
+        >>> df.assign(temp_f=lambda x: x['temp_c'] * 9 / 5 + 32,
+        ...           temp_k=lambda x: (x['temp_f'] +  459.67) * 5 / 9)
+                  temp_c  temp_f  temp_k
+        Portland    17.0    62.6  290.15
+        Berkeley    25.0    77.0  298.15
+        """
+        data = self.copy()
+
+        for k, v in kwargs.items():
+            data[k] = pd.core.common.apply_if_callable(v, data)
+        return data
 
 
 class DataFrameGroupByChunkData(BaseDataFrameChunkData):

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -1838,7 +1838,7 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
         return self._data.itertuples(batch_size=batch_size, session=session,
                                      index=index, name=name)
     
-    def assign(self, **kwargs) -> DataFrame:
+    def assign(self, **kwargs):
         r"""
         Assign new columns to a DataFrame.
         Returns a new object with all original columns in addition to new ones.


### PR DESCRIPTION
Added assign to DataFrame Class

<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This will enable the **assign** function to the DataFrame Class. This fix has been referenced the Pandas DataFrame.assign() function found here https://github.com/pandas-dev/pandas/blob/v1.3.2/pandas/core/frame.py#L4416-L4482

## Related issue number

https://github.com/mars-project/mars/issues/1336
