### PR TITLE
Added assign to DataFrame

### DIFF
--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -1837,6 +1837,63 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
         """
         return self._data.itertuples(batch_size=batch_size, session=session,
                                      index=index, name=name)
+    
+    def assign(self, **kwargs) -> DataFrame:
+        r"""
+        Assign new columns to a DataFrame.
+        Returns a new object with all original columns in addition to new ones.
+        Existing columns that are re-assigned will be overwritten.
+        Parameters
+        ----------
+        **kwargs : dict of {str: callable or Series}
+            The column names are keywords. If the values are
+            callable, they are computed on the DataFrame and
+            assigned to the new columns. The callable must not
+            change input DataFrame (though pandas doesn't check it).
+            If the values are not callable, (e.g. a Series, scalar, or array),
+            they are simply assigned.
+        Returns
+        -------
+        DataFrame
+            A new DataFrame with the new columns in addition to
+            all the existing columns.
+        Notes
+        -----
+        Assigning multiple columns within the same ``assign`` is possible.
+        Later items in '\*\*kwargs' may refer to newly created or modified
+        columns in 'df'; items are computed and assigned into 'df' in order.
+        Examples
+        --------
+        >>> df = pd.DataFrame({'temp_c': [17.0, 25.0]},
+        ...                   index=['Portland', 'Berkeley'])
+        >>> df
+                  temp_c
+        Portland    17.0
+        Berkeley    25.0
+        Where the value is a callable, evaluated on `df`:
+        >>> df.assign(temp_f=lambda x: x.temp_c * 9 / 5 + 32)
+                  temp_c  temp_f
+        Portland    17.0    62.6
+        Berkeley    25.0    77.0
+        Alternatively, the same behavior can be achieved by directly
+        referencing an existing Series or sequence:
+        >>> df.assign(temp_f=df['temp_c'] * 9 / 5 + 32)
+                  temp_c  temp_f
+        Portland    17.0    62.6
+        Berkeley    25.0    77.0
+        You can create multiple columns within the same assign where one
+        of the columns depends on another one defined within the same assign:
+        >>> df.assign(temp_f=lambda x: x['temp_c'] * 9 / 5 + 32,
+        ...           temp_k=lambda x: (x['temp_f'] +  459.67) * 5 / 9)
+                  temp_c  temp_f  temp_k
+        Portland    17.0    62.6  290.15
+        Berkeley    25.0    77.0  298.15
+        """
+        data = self.copy()
+
+        for k, v in kwargs.items():
+            data[k] = pd.core.common.apply_if_callable(v, data)
+        return data
 
 
 class DataFrameGroupByChunkData(BaseDataFrameChunkData):

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -17,7 +17,7 @@
 import weakref
 from collections.abc import Iterable
 from io import StringIO
-from typing import Union, Dict, Any
+from typing import Union, Dict, Any, Callable
 
 import numpy as np
 import pandas as pd
@@ -1904,10 +1904,16 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
         Berkeley    25.0    77.0  298.15
         """
         
+        def apply_if_callable(maybe_callable, obj, **kwargs):
+            if callable(maybe_callable):
+                return maybe_callable(obj, **kwargs)
+
+            return maybe_callable
+        
         data = self.copy()
 
         for k, v in kwargs.items():
-            data[k] = pd.core.common.apply_if_callable(v, data)
+            data[k] = apply_if_callable(v, data)
         return data
 
 

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -1839,10 +1839,11 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
                                      index=index, name=name)
     
     def assign(self, **kwargs):
-        r"""
+        """
         Assign new columns to a DataFrame.
         Returns a new object with all original columns in addition to new ones.
         Existing columns that are re-assigned will be overwritten.
+        
         Parameters
         ----------
         **kwargs : dict of {str: callable or Series}
@@ -1852,43 +1853,57 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
             change input DataFrame (though pandas doesn't check it).
             If the values are not callable, (e.g. a Series, scalar, or array),
             they are simply assigned.
+        
         Returns
         -------
         DataFrame
             A new DataFrame with the new columns in addition to
             all the existing columns.
+        
         Notes
         -----
         Assigning multiple columns within the same ``assign`` is possible.
         Later items in '\*\*kwargs' may refer to newly created or modified
         columns in 'df'; items are computed and assigned into 'df' in order.
+        
         Examples
         --------
-        >>> df = pd.DataFrame({'temp_c': [17.0, 25.0]},
+        >>> import mars.dataframe as md
+        >>> md = md.DataFrame({'temp_c': [17.0, 25.0]},
         ...                   index=['Portland', 'Berkeley'])
-        >>> df
+        >>> md.execute()
                   temp_c
         Portland    17.0
         Berkeley    25.0
-        Where the value is a callable, evaluated on `df`:
-        >>> df.assign(temp_f=lambda x: x.temp_c * 9 / 5 + 32)
+        
+        Where the value is a callable, evaluated on `md`:
+        
+        >>> md.assign(temp_f=lambda x: x.temp_c * 9 / 5 + 32)
+        >>> md.execute()
                   temp_c  temp_f
         Portland    17.0    62.6
         Berkeley    25.0    77.0
+        
         Alternatively, the same behavior can be achieved by directly
         referencing an existing Series or sequence:
-        >>> df.assign(temp_f=df['temp_c'] * 9 / 5 + 32)
+        
+        >>> md.assign(temp_f=df['temp_c'] * 9 / 5 + 32)
+        >>> md.execute()
                   temp_c  temp_f
         Portland    17.0    62.6
         Berkeley    25.0    77.0
+        
         You can create multiple columns within the same assign where one
         of the columns depends on another one defined within the same assign:
-        >>> df.assign(temp_f=lambda x: x['temp_c'] * 9 / 5 + 32,
+        
+        >>> md.assign(temp_f=lambda x: x['temp_c'] * 9 / 5 + 32,
         ...           temp_k=lambda x: (x['temp_f'] +  459.67) * 5 / 9)
+        >>> md.execute()
                   temp_c  temp_f  temp_k
         Portland    17.0    62.6  290.15
         Berkeley    25.0    77.0  298.15
         """
+        
         data = self.copy()
 
         for k, v in kwargs.items():

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -1838,7 +1838,7 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
         return self._data.itertuples(batch_size=batch_size, session=session,
                                      index=index, name=name)
     
-    def assign(self, **kwargs) -> DataFrame:
+    def assign(self, **kwargs):
         r"""
         Assign new columns to a DataFrame.
         Returns a new object with all original columns in addition to new ones.

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -17,7 +17,7 @@
 import weakref
 from collections.abc import Iterable
 from io import StringIO
-from typing import Union, Dict, Any, Callable
+from typing import Union, Dict, Any
 
 import numpy as np
 import pandas as pd
@@ -1837,13 +1837,13 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
         """
         return self._data.itertuples(batch_size=batch_size, session=session,
                                      index=index, name=name)
-    
+
     def assign(self, **kwargs):
         """
         Assign new columns to a DataFrame.
         Returns a new object with all original columns in addition to new ones.
         Existing columns that are re-assigned will be overwritten.
-        
+
         Parameters
         ----------
         **kwargs : dict of {str: callable or Series}
@@ -1853,19 +1853,19 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
             change input DataFrame (though pandas doesn't check it).
             If the values are not callable, (e.g. a Series, scalar, or array),
             they are simply assigned.
-        
+
         Returns
         -------
         DataFrame
             A new DataFrame with the new columns in addition to
             all the existing columns.
-        
+
         Notes
         -----
         Assigning multiple columns within the same ``assign`` is possible.
-        Later items in '\*\*kwargs' may refer to newly created or modified
+        Later items in 'kwargs' may refer to newly created or modified
         columns in 'df'; items are computed and assigned into 'df' in order.
-        
+
         Examples
         --------
         >>> import mars.dataframe as md
@@ -1875,27 +1875,27 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
                   temp_c
         Portland    17.0
         Berkeley    25.0
-        
+
         Where the value is a callable, evaluated on `md`:
-        
+
         >>> md.assign(temp_f=lambda x: x.temp_c * 9 / 5 + 32)
         >>> md.execute()
                   temp_c  temp_f
         Portland    17.0    62.6
         Berkeley    25.0    77.0
-        
+
         Alternatively, the same behavior can be achieved by directly
         referencing an existing Series or sequence:
-        
+
         >>> md.assign(temp_f=df['temp_c'] * 9 / 5 + 32)
         >>> md.execute()
                   temp_c  temp_f
         Portland    17.0    62.6
         Berkeley    25.0    77.0
-        
+
         You can create multiple columns within the same assign where one
         of the columns depends on another one defined within the same assign:
-        
+
         >>> md.assign(temp_f=lambda x: x['temp_c'] * 9 / 5 + 32,
         ...           temp_k=lambda x: (x['temp_f'] +  459.67) * 5 / 9)
         >>> md.execute()
@@ -1903,13 +1903,13 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
         Portland    17.0    62.6  290.15
         Berkeley    25.0    77.0  298.15
         """
-        
+
         def apply_if_callable(maybe_callable, obj, **kwargs):
             if callable(maybe_callable):
                 return maybe_callable(obj, **kwargs)
 
             return maybe_callable
-        
+
         data = self.copy()
 
         for k, v in kwargs.items():

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -1868,8 +1868,8 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
 
         Examples
         --------
-        >>> import mars.dataframe as df
-        >>> df = df.DataFrame({'temp_c': [17.0, 25.0]},
+        >>> import mars.dataframe as md
+        >>> df = md.DataFrame({'temp_c': [17.0, 25.0]},
         ...                   index=['Portland', 'Berkeley'])
         >>> df.execute()
                   temp_c

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -1868,18 +1868,18 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
 
         Examples
         --------
-        >>> import mars.dataframe as md
-        >>> md = md.DataFrame({'temp_c': [17.0, 25.0]},
+        >>> import mars.dataframe as df
+        >>> df = df.DataFrame({'temp_c': [17.0, 25.0]},
         ...                   index=['Portland', 'Berkeley'])
-        >>> md.execute()
+        >>> df.execute()
                   temp_c
         Portland    17.0
         Berkeley    25.0
 
-        Where the value is a callable, evaluated on `md`:
+        Where the value is a callable, evaluated on `df`:
 
-        >>> md.assign(temp_f=lambda x: x.temp_c * 9 / 5 + 32)
-        >>> md.execute()
+        >>> df.assign(temp_f=lambda x: x.temp_c * 9 / 5 + 32)
+        >>> df.execute()
                   temp_c  temp_f
         Portland    17.0    62.6
         Berkeley    25.0    77.0
@@ -1887,8 +1887,8 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
         Alternatively, the same behavior can be achieved by directly
         referencing an existing Series or sequence:
 
-        >>> md.assign(temp_f=df['temp_c'] * 9 / 5 + 32)
-        >>> md.execute()
+        >>> df.assign(temp_f=df['temp_c'] * 9 / 5 + 32)
+        >>> df.execute()
                   temp_c  temp_f
         Portland    17.0    62.6
         Berkeley    25.0    77.0
@@ -1896,9 +1896,9 @@ class DataFrame(HasShapeTileable, _ToPandasMixin):
         You can create multiple columns within the same assign where one
         of the columns depends on another one defined within the same assign:
 
-        >>> md.assign(temp_f=lambda x: x['temp_c'] * 9 / 5 + 32,
+        >>> df.assign(temp_f=lambda x: x['temp_c'] * 9 / 5 + 32,
         ...           temp_k=lambda x: (x['temp_f'] +  459.67) * 5 / 9)
-        >>> md.execute()
+        >>> df.execute()
                   temp_c  temp_f  temp_k
         Portland    17.0    62.6  290.15
         Berkeley    25.0    77.0  298.15

--- a/mars/dataframe/tests/test_core.py
+++ b/mars/dataframe/tests/test_core.py
@@ -199,7 +199,7 @@ def test_to_frame_or_series(setup):
     r = index.to_series(name='new_name')
     result = r.execute().fetch()
     pd.testing.assert_series_equal(raw.to_series(name='new_name'), result)
-   
+
 
 def test_assign():
     df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
@@ -225,7 +225,7 @@ def test_assign():
     result = df.assign(C=[4, 2.5, 2])
     result = result.execute().fetch()
     pd.testing.assert_frame_equal(result, expected_temp)
-    
+
     # original is unmodified
     original_temp = original.copy().execute().fetch()
     df_temp = df.copy().execute().fetch()
@@ -252,7 +252,7 @@ def test_assign():
     expected = expected.execute().fetch()
     pd.testing.assert_frame_equal(result, expected)
 
-    
+
 def test_assign_multiple():
     df = DataFrame([[1, 4], [2, 5], [3, 6]], columns=["A", "B"])
     result = df.assign(C=[7, 8, 9], D=df.A, E=lambda x: x.B)
@@ -264,7 +264,7 @@ def test_assign_multiple():
     expected = expected.execute().fetch()
     pd.testing.assert_frame_equal(result, expected)
 
-    
+
 def test_assign_order():
     df = DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
     result = df.assign(D=df.A + df.B, C=df.A - df.B)
@@ -272,7 +272,7 @@ def test_assign_order():
     expected = DataFrame([[1, 2, 3, -1], [3, 4, 7, -1]], columns=list("ABDC"))
     expected = expected.execute().fetch()
     pd.testing.assert_frame_equal(result, expected)
-    
+
     result = df.assign(C=df.A - df.B, D=df.A + df.B)
     result = result.execute().fetch()
     expected = DataFrame([[1, 2, -1, 3], [3, 4, -1, 7]], columns=list("ABCD"))

--- a/mars/dataframe/tests/test_core.py
+++ b/mars/dataframe/tests/test_core.py
@@ -279,19 +279,7 @@ def test_assign_order():
     expected = expected.execute().fetch()
     pd.testing.assert_frame_equal(result, expected)
 
-    
-def test_assign_bad():
-    df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
 
-    # non-keyword argument
-    msg = r"assign\(\) takes 1 positional argument but 2 were given"
-    with pytest.raises(TypeError, match=msg):
-        df.assign(lambda x: x.A)
-    msg = "'DataFrame' object has no attribute 'C'"
-    with pytest.raises(AttributeError, match=msg):
-        df.assign(C=df.A, D=df.A + df.C)
-
-        
 def test_assign_dependent():
     df = DataFrame({"A": [1, 2], "B": [3, 4]})
 

--- a/mars/dataframe/tests/test_core.py
+++ b/mars/dataframe/tests/test_core.py
@@ -201,7 +201,7 @@ def test_to_frame_or_series(setup):
     pd.testing.assert_series_equal(raw.to_series(name='new_name'), result)
    
 
- def test_assign():
+def test_assign():
     df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
     original = df.copy()
     result = df.assign(C=df.B / df.A)

--- a/mars/dataframe/tests/test_core.py
+++ b/mars/dataframe/tests/test_core.py
@@ -199,6 +199,113 @@ def test_to_frame_or_series(setup):
     r = index.to_series(name='new_name')
     result = r.execute().fetch()
     pd.testing.assert_series_equal(raw.to_series(name='new_name'), result)
+   
+
+ def test_assign():
+    df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+    original = df.copy()
+    result = df.assign(C=df.B / df.A)
+    result = result.execute().fetch()
+    expected = df.copy()
+    expected["C"] = [4, 2.5, 2]
+    expected_temp = expected.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected_temp)
+
+    # lambda syntax
+    result = df.assign(C=lambda x: x.B / x.A)
+    result = result.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected_temp)
+
+    # original is unmodified
+    original_temp = original.copy().execute().fetch()
+    df_temp = df.copy().execute().fetch()
+    pd.testing.assert_frame_equal(df_temp, original_temp)
+
+    # Non-Series array-like
+    result = df.assign(C=[4, 2.5, 2])
+    result = result.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected_temp)
+    
+    # original is unmodified
+    original_temp = original.copy().execute().fetch()
+    df_temp = df.copy().execute().fetch()
+    pd.testing.assert_frame_equal(original_temp, df_temp)
+
+    result = df.assign(B=df.B / df.A)
+    result = result.execute().fetch()
+    expected = expected.drop("B", axis=1).rename(columns={"C": "B"})
+    expected = expected.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected)
+
+    # overwrite
+    result = df.assign(A=df.A + df.B)
+    result = result.execute().fetch()
+    expected = df.copy()
+    expected["A"] = [5, 7, 9]
+    expected["A"] = expected["A"].astype('int64')
+    expected_temp = expected.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected_temp)
+
+    # lambda
+    result = df.assign(A=lambda x: x.A + x.B)
+    result = result.execute().fetch()
+    expected = expected.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected)
+
+    
+def test_assign_multiple():
+    df = DataFrame([[1, 4], [2, 5], [3, 6]], columns=["A", "B"])
+    result = df.assign(C=[7, 8, 9], D=df.A, E=lambda x: x.B)
+    result["C"] = result["C"].astype('int64')
+    result = result.execute().fetch()
+    expected = DataFrame(
+        [[1, 4, 7, 1, 4], [2, 5, 8, 2, 5], [3, 6, 9, 3, 6]], columns=list("ABCDE")
+    )
+    expected = expected.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected)
+
+    
+def test_assign_order():
+    df = DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
+    result = df.assign(D=df.A + df.B, C=df.A - df.B)
+    result = result.execute().fetch()
+    expected = DataFrame([[1, 2, 3, -1], [3, 4, 7, -1]], columns=list("ABDC"))
+    expected = expected.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected)
+    
+    result = df.assign(C=df.A - df.B, D=df.A + df.B)
+    result = result.execute().fetch()
+    expected = DataFrame([[1, 2, -1, 3], [3, 4, -1, 7]], columns=list("ABCD"))
+    expected = expected.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected)
+
+    
+def test_assign_bad():
+    df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+
+    # non-keyword argument
+    msg = r"assign\(\) takes 1 positional argument but 2 were given"
+    with pytest.raises(TypeError, match=msg):
+        df.assign(lambda x: x.A)
+    msg = "'DataFrame' object has no attribute 'C'"
+    with pytest.raises(AttributeError, match=msg):
+        df.assign(C=df.A, D=df.A + df.C)
+
+        
+def test_assign_dependent():
+    df = DataFrame({"A": [1, 2], "B": [3, 4]})
+
+    result = df.assign(C=df.A, D=lambda x: x["A"] + x["C"])
+    result = result.execute().fetch()
+    expected = DataFrame([[1, 3, 1, 2], [2, 4, 2, 4]], columns=list("ABCD"))
+    expected = expected.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected)
+
+    result = df.assign(C=lambda df: df.A, D=lambda df: df["A"] + df["C"])
+    result = result.execute().fetch()
+    expected = DataFrame([[1, 3, 1, 2], [2, 4, 2, 4]], columns=list("ABCD"))
+    expected = expected.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected)
 
 
 def test_key_value(setup):

--- a/mars/dataframe/tests/test_core.py
+++ b/mars/dataframe/tests/test_core.py
@@ -201,7 +201,7 @@ def test_to_frame_or_series(setup):
     pd.testing.assert_series_equal(raw.to_series(name='new_name'), result)
 
 
-def test_assign():
+def test_assign(setup):
     df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
     original = df.copy()
     result = df.assign(C=df.B / df.A)
@@ -253,7 +253,7 @@ def test_assign():
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_assign_multiple():
+def test_assign_multiple(setup):
     df = DataFrame([[1, 4], [2, 5], [3, 6]], columns=["A", "B"])
     result = df.assign(C=[7, 8, 9], D=df.A, E=lambda x: x.B)
     result["C"] = result["C"].astype('int64')
@@ -265,7 +265,7 @@ def test_assign_multiple():
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_assign_order():
+def test_assign_order(setup):
     df = DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
     result = df.assign(D=df.A + df.B, C=df.A - df.B)
     result = result.execute().fetch()
@@ -280,7 +280,7 @@ def test_assign_order():
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_assign_dependent():
+def test_assign_dependent(setup):
     df = DataFrame({"A": [1, 2], "B": [3, 4]})
 
     result = df.assign(C=df.A, D=lambda x: x["A"] + x["C"])


### PR DESCRIPTION
Added assign to DataFrame Class (Corrected the issues in the previous PR)

<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This will enable the **assign** function to the DataFrame Class. This fix has been referenced the Pandas DataFrame.assign() function found here https://github.com/pandas-dev/pandas/blob/v1.3.2/pandas/core/frame.py#L4416-L4482

## Related issue number

Fixes #1336 .