### PR TITLE
Fix branch confuse of CodeCov

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -83,4 +83,11 @@ jobs:
     - name: Report coverage data
       shell: bash
       run: |
+        if [[ "$GITHUB_REF" =~ ^"refs/pull/" ]]; then
+          # reject PRs with master branch
+          if [[ "$GITHUB_HEAD_REF" == "master" ]]; then
+            >&2 echo "Cannot upload coverage using master branch. Try using another branch instead."
+            exit 1
+          fi
+        fi
         bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/os-compat-ci.yml
+++ b/.github/workflows/os-compat-ci.yml
@@ -80,4 +80,11 @@ jobs:
     - name: Report coverage data
       shell: bash
       run: |
+        if [[ "$GITHUB_REF" =~ ^"refs/pull/" ]]; then
+          # reject PRs with master branch
+          if [[ "$GITHUB_HEAD_REF" == "master" ]]; then
+            >&2 echo "Cannot upload coverage using master branch. Try using another branch instead."
+            exit 1
+          fi
+        fi
         bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -149,4 +149,11 @@ jobs:
       - name: Report coverage data
         shell: bash
         run: |
+          if [[ "$GITHUB_REF" =~ ^"refs/pull/" ]]; then
+            # reject PRs with master branch
+            if [[ "$GITHUB_HEAD_REF" == "master" ]]; then
+              >&2 echo "Cannot upload coverage using master branch. Try using another branch instead."
+              exit 1
+            fi
+          fi
           bash <(curl -s https://codecov.io/bash)

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -1303,7 +1303,9 @@ class Series(HasShapeTileable, _ToPandasMixin):
         --------
         >>> import mars.dataframe as md
         >>> s = md.Series([2, 0, 4, 8, np.nan])
+
         Boundary values are included by default:
+
         >>> s.between(1, 4).execute()
         0     True
         1    False
@@ -1313,6 +1315,7 @@ class Series(HasShapeTileable, _ToPandasMixin):
         dtype: bool
 
         With `inclusive` set to ``"neither"`` boundary values are excluded:
+
         >>> s.between(1, 4, inclusive="neither").execute()
         0     True
         1    False
@@ -1322,6 +1325,7 @@ class Series(HasShapeTileable, _ToPandasMixin):
         dtype: bool
 
         `left` and `right` can be any scalar value:
+
         >>> s = md.Series(['Alice', 'Bob', 'Carol', 'Eve'])
         >>> s.between('Anna', 'Daniel').execute()
         0    False


### PR DESCRIPTION
## What do these changes do?

Use `GITHUB_REF` instead of `GITHUB_HEAD_REF` to pass coverage.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
