### PR TITLE
Add checks for file mode changes and absolute imports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+* text=auto
+# enforce text on certain files
+*.py text
+*.pyx text
+*.pyi text
+*.pxd text
+*.c text
+*.cpp text
+*.h text
+*.hpp text
+*.html text
+*.csv text
+*.js text
+*.jsx text
+*.ts text
+*.json text
+*.yaml text
+*.yml text

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,6 +51,19 @@ jobs:
           source ./ci/reload-env.sh
           codespell
 
+      - name: Check file mode changes
+        shell: bash
+        run: |
+          source ./ci/reload-env.sh
+          git fetch origin master
+          bash ci/modecheck.sh
+
+      - name: Check imports
+        shell: bash
+        run: |
+          source ./ci/reload-env.sh
+          python ci/importcheck.py
+
       - name: Check copyright headers
         shell: bash
         run: |

--- a/ci/importcheck.py
+++ b/ci/importcheck.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+import ast
+import os
+import sys
+import textwrap
+from pathlib import PurePath
+from typing import List, NamedTuple, Optional, Tuple
+
+_IGNORES = [
+    'mars/lib/**/*.py',
+    'conftest.py',
+]
+
+
+class CheckResult(NamedTuple):
+    path: str
+    lines: List
+    absolute_imports: List[Tuple[int, int]]
+    head_disorder: Optional[Tuple[int, int]]
+    block_disorders: Optional[List[Tuple[int, int]]]
+
+    @property
+    def has_faults(self) -> bool:
+        return bool(self.absolute_imports) or bool(self.head_disorder) \
+            or bool(self.block_disorders)
+
+
+def _check_absolute_import(node: ast.AST) -> List[Tuple[int, int]]:
+    res = set()
+    if isinstance(node, ast.Import):
+        for import_name in node.names:
+            if import_name.name.startswith('mars.'):
+                res.add((node.lineno, node.end_lineno))
+    elif isinstance(node, ast.ImportFrom):
+        if node.level == 0 and node.module.startswith('mars.'):
+            res.add((node.lineno, node.end_lineno))
+    elif getattr(node, 'body', []):
+        for body_item in node.body:
+            res.update(_check_absolute_import(body_item))
+    return sorted(res)
+
+
+def check_imports(file_path) -> CheckResult:
+    with open(file_path, 'rb') as src_file:
+        body = src_file.read()
+        lines = body.splitlines()
+        parsed = ast.parse(body, filename=file_path)
+    # scan for imports
+    abs_faults = _check_absolute_import(parsed)
+
+    return CheckResult(file_path, lines, abs_faults, None, None)
+
+
+def _extract_line_block(lines: List, lineno: int, end_lineno: int, indent: str):
+    grab_lines = '\n'.join(line.decode() for line in lines[lineno - 1:end_lineno])
+    return textwrap.indent(textwrap.dedent(grab_lines), indent)
+
+
+def format_results(results: List[CheckResult], root_path):
+    rel_import_count = sum(len(res.absolute_imports) for res in results)
+    if rel_import_count > 0:
+        print(f'Do not use absolute imports for mars module in non-test '
+              f'code ({rel_import_count}):', file=sys.stderr)
+        for res in results:
+            if not res.absolute_imports:
+                continue
+            rel_path = os.path.relpath(res.path, root_path)
+            print('  ' + rel_path, file=sys.stderr)
+            for lineno, end_lineno in res.absolute_imports:
+                print(f'    Line {lineno}-{end_lineno}', file=sys.stderr)
+                print(_extract_line_block(res.lines, lineno, end_lineno, '      '),
+                      file=sys.stderr)
+
+
+def main():
+    root_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    results = []
+    for root, _dirs, files in os.walk(os.path.join(root_path, 'mars')):
+        if 'tests' in root:
+            continue
+        for fn in files:
+            abs_path = os.path.join(root, fn)
+            rel_path = os.path.relpath(abs_path, root_path)
+
+            if not fn.endswith('.py'):
+                continue
+            if any(PurePath(rel_path).match(patt) for patt in _IGNORES):
+                continue
+
+            check_result = check_imports(abs_path)
+            if check_result.has_faults:
+                results.append(check_result)
+    if results:
+        results = sorted(results, key=lambda x: x.path)
+        format_results(results, root_path)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/modecheck.sh
+++ b/ci/modecheck.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if git diff master -- mars | grep -q "old mode"; then
+  echo "Unexpected file mode changed. You may call"
+  echo "    git config core.fileMode false"
+  echo "before committing to the repo."
+  git diff | grep -B 2 -A 2 "old mode"
+  exit 1
+fi

--- a/ci/modecheck.sh
+++ b/ci/modecheck.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-if git diff master -- mars | grep -q "old mode"; then
+if git diff origin/master -- mars | grep -q "old mode"; then
   echo "Unexpected file mode changed. You may call"
   echo "    git config core.fileMode false"
   echo "before committing to the repo."
-  git diff | grep -B 2 -A 2 "old mode"
+  git diff origin/master -- mars | grep -B 2 -A 2 "old mode"
   exit 1
 fi

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -804,7 +804,7 @@ class _IsolatedSession(AbstractAsyncSession):
     @alru_cache(cache_exceptions=False)
     async def _get_storage_api(self, band: BandType):
         if urlparse(self.address).scheme == 'http':
-            from mars.services.storage.api import WebStorageAPI
+            from ...services.storage.api import WebStorageAPI
             storage_api = WebStorageAPI(self._session_id, self.address, band[1])
         else:
             storage_api = await StorageAPI.create(self._session_id, band[0], band[1])

--- a/mars/deploy/utils.py
+++ b/mars/deploy/utils.py
@@ -19,7 +19,7 @@ from typing import Callable, Dict, List, Union, TextIO
 
 import yaml
 
-from mars.services import NodeRole
+from ..services import NodeRole
 
 DEFAULT_CONFIG_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), 'oscar/config.yml')

--- a/mars/learn/proxima/simple_index/recall.py
+++ b/mars/learn/proxima/simple_index/recall.py
@@ -15,8 +15,9 @@
 import math
 
 import numpy as np
-import mars.remote as mr
-from mars.learn.proxima.simple_index.knn import sample_data, linear_build_and_search
+
+from .... import remote as mr
+from .knn import sample_data, linear_build_and_search
 
 
 def recall_one(linear_score, ann_score, topk_ids, epsilon=1e-6):

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 from typing import Any, Callable, Coroutine, Dict, Type
 from urllib.parse import urlparse
 
+from ....serialization import serialize, deserialize
 from ....utils import implements, classproperty
 from ....utils import lazy_import
 from ...debug import debug_async_timeout
@@ -28,7 +29,6 @@ from ...errors import ServerClosed
 from ..communication.base import Channel, ChannelType, Server, Client
 from ..communication.core import register_client, register_server
 from ..communication.errors import ChannelClosed
-from mars.serialization import serialize, deserialize
 
 ray = lazy_import("ray")
 logger = logging.getLogger(__name__)

--- a/mars/oscar/errors.py
+++ b/mars/oscar/errors.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mars.core.base import MarsError
+from ..core.base import MarsError
 
 
 class ActorPoolNotStarted(MarsError):

--- a/mars/services/lifecycle/api/oscar.py
+++ b/mars/services/lifecycle/api/oscar.py
@@ -166,7 +166,7 @@ class MockLifecycleAPI(LifecycleAPI):
     async def create(cls,
                      session_id: str,
                      address: str) -> "LifecycleAPI":
-        from mars.services.lifecycle.supervisor.service import LifecycleSupervisorService
+        from ..supervisor.service import LifecycleSupervisorService
         service = LifecycleSupervisorService({}, address)
         await service.create_session(session_id)
         return await super().create(session_id=session_id, address=address)

--- a/mars/services/scheduling/supervisor/autoscale.py
+++ b/mars/services/scheduling/supervisor/autoscale.py
@@ -126,8 +126,9 @@ class AutoscalerActor(mo.Actor):
         """Move data from `bands` to other available bands"""
         session_ids = list(self.queueing_refs.keys())
         for session_id in session_ids:
-            from mars.services.meta import MetaAPI
+            from ...meta import MetaAPI
             meta_api = await MetaAPI.create(session_id, self.address)
+
             batch_fetch, batch_delete = defaultdict(list), defaultdict(list)
             batch_add_chunk_bands, batch_remove_chunk_bands = [], []
             for src_band in bands:
@@ -162,7 +163,7 @@ class AutoscalerActor(mo.Actor):
 
     @alru_cache(cache_exceptions=False)
     async def _get_storage_api(self, session_id: str, address: str):
-        from mars.services.storage import StorageAPI
+        from ...storage import StorageAPI
         return await StorageAPI.create(session_id, address)
 
 


### PR DESCRIPTION
## What do these changes do?

Add checks below:
1. File mode changes. This forces commiters to ignore fileMode in Windows.
2. Absolute imports in non-test source code.

Also add a `.gitattributes` to avoid CRLF line endings in Windows.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
