### PR TITLE
Fix missing DAGs when initializing with empty API results

### DIFF
--- a/mars/services/web/ui/src/task_info/TileableDetail.js
+++ b/mars/services/web/ui/src/task_info/TileableDetail.js
@@ -17,7 +17,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-
 class TileableDetail extends React.Component {
     constructor(props) {
         super(props);
@@ -46,8 +45,8 @@ class TileableDetail extends React.Component {
 
 TileableDetail.propTypes = {
     tileable: PropTypes.shape({
-        tileableId: PropTypes.string,
-        tileableName: PropTypes.string,
+        id: PropTypes.string,
+        name: PropTypes.string,
     }),
     sessionId: PropTypes.string.isRequired,
     taskId: PropTypes.string.isRequired,

--- a/mars/services/web/ui/src/task_info/TileableDetail.js
+++ b/mars/services/web/ui/src/task_info/TileableDetail.js
@@ -32,8 +32,8 @@ class TileableDetail extends React.Component {
             this.props.tileable
                 ?
                 <div>
-                    <div>Tileable ID: <br/>{this.props.tileable.tileableId}</div><br/>
-                    <div>Tileable Name: <br/>{this.props.tileable.tileableName}</div><br/>
+                    <div>Tileable ID: <br/>{this.props.tileable.id}</div><br/>
+                    <div>Tileable Name: <br/>{this.props.tileable.name}</div><br/>
                 </div>
                 :
                 <div>

--- a/mars/services/web/ui/src/task_info/charts/DAGChart.js
+++ b/mars/services/web/ui/src/task_info/charts/DAGChart.js
@@ -1,0 +1,297 @@
+/*
+ * Copyright 1999-2021 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { select as d3Select } from 'd3-selection';
+import {
+    zoom as d3Zoom,
+    zoomIdentity as d3ZoomIdentity
+} from 'd3-zoom';
+import {
+    graphlib as dagGraphLib,
+    render as DagRender
+} from 'dagre-d3';
+import PropTypes from 'prop-types';
+import {
+    nodeType,
+    nodesStatusType,
+    dependencyType,
+    dagType,
+} from './DAGPropTypes';
+
+
+export default class DAGChart extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            nodeStatusMap: [
+                {
+                    text: 'Pending',
+                    color: '#FFFFFF',
+                },
+                {
+                    text: 'Running',
+                    color: '#F4B400',
+                },
+                {
+                    text: 'Succeeded',
+                    color: '#00CD95',
+                },
+                {
+                    text: 'Failed',
+                    color: '#E74C3C',
+                },
+                {
+                    text: 'Cancelled',
+                    color: '#BFC9CA',
+                },
+            ],
+
+            inputNodeColor: '#3281a8',
+            outputNodeColor: '#c334eb',
+        };
+    }
+
+    componentDidMount() {
+        this.g = new dagGraphLib.Graph().setGraph({});
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.interval);
+    }
+
+    /* eslint no-unused-vars: ["error", { "args": "none" }] */
+    componentDidUpdate(prevProps, prevStates, snapshot) {
+        if (this.props === undefined || this.props.nodes === undefined || this.props.nodes.length === 0) {
+            return;
+        }
+
+        /**
+         * If the nodes and dependencies are different, this is a
+         * new DAG, so we will erase everything from the canvas and
+         * generate a new dag
+         */
+        if (prevProps.nodes !== this.props.nodes
+            && prevProps.dependencies !== this.props.dependencies) {
+            d3Select('#' + this.props.graphName).selectAll('*').remove();
+
+            // Set up an SVG group so that we can translate the final graph.
+            const svg = d3Select('#' + this.props.graphName),
+                inner = svg.append('g');
+
+            this.g = new dagGraphLib.Graph().setGraph({});
+
+            // Add the nodes to DAG
+            this.props.nodes.forEach((node) => {
+                const value = { node };
+                const nodeDetail = this.props.nodesStatus[node.id];
+
+                if (this.props.graphName === 'tileableGraph') {
+                    const nameEndIndex = node.name.indexOf('key') - 1;
+                    value.label = node.name.substring(0, nameEndIndex);
+                } else if (this.props.graphName === 'subtaskGraph') {
+                    value.label = '';
+                }
+
+                if (this.props.graphName === 'tileableGraph') {
+                    value.rx = value.ry = 5;
+                } else if (this.props.graphName === 'subtaskGraph') {
+                    value.r = 20;
+                }
+
+                this.g.setNode(node.id, value);
+
+                /**
+                 * Add the progress color using SVG linear gradient. The offset on
+                 * the first stop on the linear gradient marks how much of the node
+                 * should be filled with color. The second stop adds a white color to
+                 * the rest of the node
+                 */
+                let nodeProgressGradient = inner.append('linearGradient')
+                    .attr('id', 'progress-' + node.id);
+
+                const dagNode = this.g.node(node.id);
+
+                /**
+                 * apply the linear gradient and other css properties
+                 * to nodes.
+                 */
+                if (nodeDetail === undefined) {
+                    nodeProgressGradient.append('stop')
+                        .attr('id', 'progress-' + node.id + '-stop')
+                        .attr('stop-color', '#FFFFFF')
+                        .attr('offset', 1);
+                } else if (nodeDetail.status === -1 && nodeDetail.progress === -1) {
+                    nodeProgressGradient.append('stop')
+                        .attr('id', 'progress-' + node.id + '-stop')
+                        .attr('stop-color', this.state.inputNodeColor)
+                        .attr('offset', 1);
+                } else if (nodeDetail.status === -2 && nodeDetail.progress === -2) {
+                    nodeProgressGradient.append('stop')
+                        .attr('id', 'progress-' + node.id + '-stop')
+                        .attr('stop-color', this.state.outputNodeColor)
+                        .attr('offset', 1);
+                } else {
+                    nodeProgressGradient.append('stop')
+                        .attr('id', 'progress-' + node.id + '-stop')
+                        .attr('stop-color', this.state.nodeStatusMap[nodeDetail.status].color)
+                        .attr('offset', nodeDetail.progress);
+                }
+
+                nodeProgressGradient.append('stop')
+                    .attr('stop-color', '#FFFFFF')
+                    .attr('offset', '0');
+
+                dagNode.shape = this.props.nodeShape;
+                dagNode.style = 'cursor: pointer; stroke: #333; fill: url(#progress-' + node.id + ')';
+                dagNode.labelStyle = 'cursor: pointer';
+            });
+
+            /**
+             * Adds edges to the DAG. If an edge has a linkType of 1,
+             * the edge will be a dashed line.
+             */
+            this.props.dependencies.forEach((dependency) => {
+                if (dependency.linkType && dependency.linkType === 1) {
+                    this.g.setEdge(
+                        dependency.fromNodeId,
+                        dependency.toNodeId,
+                        {
+                            style: 'stroke: #333; fill: none; stroke-dasharray: 5, 5;'
+                        }
+                    );
+                } else {
+                    this.g.setEdge(
+                        dependency.fromNodeId,
+                        dependency.toNodeId,
+                        {
+                            style: 'stroke: #333; fill: none;'
+                        }
+                    );
+                }
+
+            });
+
+            let gInstance = this.g;
+            // Round the corners of the nodes
+            gInstance.nodes().forEach(function (v) {
+                const node = gInstance.node(v);
+                node.rx = node.ry = 5;
+            });
+
+            // Create the renderer
+            const render = new DagRender();
+
+            if (this.props.nodes.length !== 0) {
+                // Run the renderer. This is what draws the final graph.
+                render(inner, this.g);
+            }
+
+            // onClick function for the tileable
+            const handleClick = (e, dagNode) => {
+                if (this.props.onNodeClick) {
+                    const selectedNode = this.props.nodes.filter(
+                        (node) => node.id === dagNode
+                    )[0];
+                    this.props.onNodeClick(e, selectedNode);
+                }
+            };
+
+            inner.selectAll('g.node').on('click', handleClick);
+
+            console.log(inner);
+            console.log(inner.node());
+            // Center the graph
+            const bounds = inner.node().getBBox();
+            const parent = inner.node().parentElement;
+            const width = bounds.width,
+                height = bounds.height;
+            const fullWidth = parent.clientWidth,
+                fullHeight = parent.clientHeight;
+            const initialScale = fullHeight >= height ? 1 : fullHeight / height;
+
+            d3Select('#' + this.props.graphName).select('.output').attr('transform', 'translate(' + (fullWidth - width * initialScale) / 2 + ', ' + (fullHeight - height * initialScale) / 2 + ')');
+
+            // Set up zoom support
+            const zoom = d3Zoom().on('zoom', function (e) {
+                inner.attr('transform', e.transform);
+            });
+
+            svg.call(
+                zoom,
+                zoom.transform,
+                d3ZoomIdentity.scale(initialScale)
+            );
+
+            if (this.g.graph() !== null || this.g.graph() !== undefined) {
+                svg.attr('height', this.g.graph().height * initialScale + 40);
+            } else {
+                svg.attr('height', 40);
+            }
+        }
+
+        /**
+         * If the nodes and dependencies didn't change and
+         * only the tileable status changed, we know this is the
+         * old graph with updated tileable status, so we just
+         * need to update the color of nodes and the progress bar
+         */
+        if (prevProps.nodes === this.props.nodes
+            && prevProps.dependencies === this.props.dependencies
+            && prevProps.nodesStatus !== this.props.nodesStatus) {
+            const svg = d3Select('#' + this.props.graphName);
+
+            this.props.nodes.forEach((node) => {
+                const nodeDetail = this.props.nodesStatus[node.id];
+
+                if (nodeDetail !== undefined && nodeDetail.status >= 0 && nodeDetail.progress >= 0) {
+                    const dagNode = this.g.node(node.id);
+
+                    if (dagNode !== undefined) {
+                        if (dagNode.style === 'visibility: hidden') {
+                            dagNode.shape = this.props.nodeShape;
+                            dagNode.style = 'cursor: pointer; stroke: #333; fill: url(#progress-' + node.id + ')';
+                            dagNode.labelStyle = 'cursor: pointer';
+                        }
+
+                        svg.select('#progress-' + node.id + '-stop')
+                            .attr('stop-color', this.state.nodeStatusMap[nodeDetail.status].color)
+                            .attr('offset', nodeDetail.progress);
+                    }
+                }
+            });
+        }
+    }
+
+    render() {
+        return (
+            <svg
+                id={this.props.graphName}
+                style={this.props.dagStyle}
+            />
+        );
+    }
+}
+
+DAGChart.propTypes = {
+    graphName: PropTypes.string.isRequired,
+    dagStyle: dagType,
+    nodes: nodeType,
+    nodeShape: PropTypes.string.isRequired,
+    nodesStatus: nodesStatusType,
+    dependencies: dependencyType,
+    onNodeClick: PropTypes.func,
+};

--- a/mars/services/web/ui/src/task_info/charts/DAGPropTypes.js
+++ b/mars/services/web/ui/src/task_info/charts/DAGPropTypes.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 1999-2021 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import PropTypes from 'prop-types';
+
+export const nodeType = PropTypes.arrayOf(
+    PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        name: PropTypes.string,
+    })
+);
+
+export const nodesStatusType = PropTypes.shape({
+    id: PropTypes.shape({
+        status: PropTypes.number.isRequired,
+        progress: PropTypes.number.isRequired,
+        subtaskCount: PropTypes.number,
+    })
+});
+
+export const dependencyType = PropTypes.arrayOf(
+    PropTypes.shape({
+        fromNodeId: PropTypes.string.isRequired,
+        toNodeId: PropTypes.string.isRequired,
+        linkType: PropTypes.number,
+    })
+);
+
+export const dagType = PropTypes.shape({
+    margin: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string,
+    ]),
+    padding: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string,
+    ]),
+    width: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string,
+    ]),
+    height: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string,
+    ]),
+});


### PR DESCRIPTION
## What do these changes do?

The current tileable graph compares prevProp's tileables and dependencies with the current tileables and dependencies, and only if they are different, the dag will be rendered. However, there is also a check that states that the length of tileable details must match the length of tileables, and if the React setState for tileable detail takes some time and finishes setting the state after the tileables and dependencies have been passed to the graph component, the prevProp's tileables and dependencies have already become the new tileables and dependencies. As such, the dag will never be rendered. 

This PR removed the length check for tileable details. Instead, if the rendered tileable's detail is not in the passed nodesStatus prop, the tileable will just be rendered as a pending tileable. So now when the tileables and dependencies change, the dag will always be rendered. Then when the detail prop changes, the new status and progress will be changed accordingly.