### PR TITLE
Basic reschedule subtask

### DIFF
--- a/mars/deploy/oscar/tests/fault_injection_config_with_rerun.yml
+++ b/mars/deploy/oscar/tests/fault_injection_config_with_rerun.yml
@@ -3,6 +3,7 @@ third_party_modules:
   - mars.services.tests.fault_injection_patch
 scheduling:
   subtask_max_retries: 2
+  subtask_max_reschedules: 2
 storage:
   # shared-memory38 may lose object if the process crash after put success.
   backends: [plasma]

--- a/mars/deploy/oscar/tests/test_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_fault_injection.py
@@ -112,7 +112,9 @@ async def test_fault_inject_subtask_processor(fault_cluster, fault_and_exception
                          [[FaultType.Exception, {FaultPosition.ON_EXECUTE_OPERAND: 1},
                            pytest.raises(FaultInjectionError, match='Fault Injection')],
                           [FaultType.ProcessExit, {FaultPosition.ON_EXECUTE_OPERAND: 1},
-                           pytest.raises(ServerClosed)]])
+                           pytest.raises(ServerClosed)],
+                          [FaultType.Exception, {FaultPosition.ON_RUN_SUBTASK: 1},
+                           pytest.raises(FaultInjectionError, match='Fault Injection')]])
 @pytest.mark.asyncio
 async def test_rerun_subtask(fault_cluster, fault_config):
     fault_type, fault_count, expect_raises = fault_config
@@ -142,6 +144,7 @@ async def test_rerun_subtask(fault_cluster, fault_config):
 
     # the extra config overwrites the default config.
     extra_config['subtask_max_retries'] = 0
+    extra_config['subtask_max_reschedules'] = 0
     info = await session.execute(b, extra_config=extra_config)
     with expect_raises:
         await info

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -58,7 +58,6 @@ CONFIG_THIRD_PARTY_MODULES_TEST_FILE = os.path.join(
 
 
 params = ['default']
-params = []
 if vineyard is not None:
     params.append('vineyard')
 

--- a/mars/deploy/oscar/tests/test_ray_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_ray_fault_injection.py
@@ -77,7 +77,9 @@ async def test_fault_inject_subtask_processor(ray_start_regular, fault_cluster, 
                          [[FaultType.Exception, {FaultPosition.ON_EXECUTE_OPERAND: 1},
                            pytest.raises(FaultInjectionError, match='Fault Injection')],
                           [FaultType.ProcessExit, {FaultPosition.ON_EXECUTE_OPERAND: 1},
-                           pytest.raises(ServerClosed)]])
+                           pytest.raises(ServerClosed)],
+                          [FaultType.Exception, {FaultPosition.ON_RUN_SUBTASK: 1},
+                           pytest.raises(FaultInjectionError, match='Fault Injection')]])
 @pytest.mark.asyncio
 async def test_rerun_subtask(ray_start_regular, fault_cluster, fault_config):
     await test_fault_injection.test_rerun_subtask(fault_cluster, fault_config)

--- a/mars/deploy/oscar/tests/test_ray_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_ray_fault_injection.py
@@ -36,7 +36,12 @@ RAY_CONFIG_FILE = os.path.join(
 FAULT_INJECTION_CONFIG = {
     "third_party_modules": ["mars.services.tests.fault_injection_patch"],
 }
-SUBTASK_RERUN_CONFIG = {"scheduling": {"subtask_max_retries": 2}}
+SUBTASK_RERUN_CONFIG = {
+    "scheduling": {
+        "subtask_max_retries": 2,
+        "subtask_max_reschedules": 2,
+    }
+}
 
 
 @pytest.fixture

--- a/mars/services/scheduling/supervisor/manager.py
+++ b/mars/services/scheduling/supervisor/manager.py
@@ -112,15 +112,13 @@ class SubtaskManagerActor(mo.Actor):
     async def submit_subtask_to_band(self, subtask_id: str, band: BandType):
         async with redirect_subtask_errors(self, self._get_subtasks_by_ids([subtask_id])):
             subtask_info = self._subtask_infos[subtask_id]
-            task = asyncio.create_task(self._await_subtask_result(subtask_info.subtask, band))
-            subtask_info.band_futures[band] = task
-
-    async def _await_subtask_result(self, subtask: Subtask, band: BandType):
-        """To capture the run_subtask error, e.g. exception, process crash."""
-        async with redirect_subtask_errors(self, [subtask]):
             execution_ref = await self._get_execution_ref(band)
-            await execution_ref.run_subtask(
-                subtask, band[1], self.address)
+            task = asyncio.create_task(execution_ref.run_subtask(
+                subtask_info.subtask, band[1], self.address))
+            subtask_info.band_futures[band] = task
+            result = yield task
+            task_api = await self._get_task_api()
+            await task_api.set_subtask_result(result)
 
     async def cancel_subtasks(self, subtask_ids: List[str],
                               kill_timeout: Union[float, int] = 5):

--- a/mars/services/scheduling/supervisor/manager.py
+++ b/mars/services/scheduling/supervisor/manager.py
@@ -18,7 +18,6 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple, Union
 
-from ...cluster import ClusterAPI
 from .... import oscar as mo
 from ....lib.aio import alru_cache
 from ....oscar.errors import MarsError
@@ -70,10 +69,6 @@ class SubtaskManagerActor(mo.Actor):
     @alru_cache
     async def _get_task_api(self):
         return await TaskAPI.create(self._session_id, self.address)
-
-    @alru_cache
-    async def _get_cluster_api(self):
-        return await ClusterAPI.create(self.address)
 
     async def add_subtasks(self, subtasks: List[Subtask], priorities: List[Tuple]):
         async with redirect_subtask_errors(self, subtasks):

--- a/mars/services/scheduling/supervisor/service.py
+++ b/mars/services/scheduling/supervisor/service.py
@@ -17,6 +17,7 @@ import asyncio
 from .... import oscar as mo
 from ...core import AbstractService
 from .autoscale import AutoscalerActor
+from .manager import DEFAULT_SUBTASK_MAX_RESCHEDULES
 
 
 class SchedulingSupervisorService(AbstractService):
@@ -63,6 +64,7 @@ class SchedulingSupervisorService(AbstractService):
     async def create_session(self, session_id: str):
         service_config = self._config or dict()
         scheduling_config = service_config.get('scheduling', {})
+        subtask_max_reschedules = scheduling_config.get('subtask_max_reschedules', DEFAULT_SUBTASK_MAX_RESCHEDULES)
 
         from .assigner import AssignerActor
         assigner_coro = mo.create_actor(
@@ -78,7 +80,8 @@ class SchedulingSupervisorService(AbstractService):
 
         from .manager import SubtaskManagerActor
         await mo.create_actor(
-            SubtaskManagerActor, session_id, address=self._address,
+            SubtaskManagerActor, session_id, subtask_max_reschedules,
+            address=self._address,
             uid=SubtaskManagerActor.gen_uid(session_id)
         )
 

--- a/mars/services/scheduling/utils.py
+++ b/mars/services/scheduling/utils.py
@@ -33,6 +33,7 @@ async def redirect_subtask_errors(actor: mo.Actor, subtasks):
         yield
     except:  # noqa: E722  # pylint: disable=bare-except
         _, error, traceback = sys.exc_info()
+        status = SubtaskStatus.cancelled if isinstance(error, asyncio.CancelledError) else SubtaskStatus.errored
         task_api = await _get_task_api(actor)
         coros = []
         for subtask in subtasks:
@@ -43,7 +44,7 @@ async def redirect_subtask_errors(actor: mo.Actor, subtasks):
                 session_id=subtask.session_id,
                 task_id=subtask.task_id,
                 progress=1.0,
-                status=SubtaskStatus.errored,
+                status=status,
                 error=error, traceback=traceback
             )))
         await asyncio.wait(coros)

--- a/mars/services/scheduling/worker/execution.py
+++ b/mars/services/scheduling/worker/execution.py
@@ -267,8 +267,9 @@ class SubtaskExecutionActor(mo.StatelessActor):
                 await slot_manager_ref.upload_slot_usages(periodical=False)
             except:  # noqa: E722  # pylint: disable=bare-except
                 _fill_subtask_result_with_exception(subtask, subtask_info)
-            # pop the subtask info at the end is to cancel the job.
-            self._subtask_info.pop(subtask.subtask_id, None)
+            finally:
+                # pop the subtask info at the end is to cancel the job.
+                self._subtask_info.pop(subtask.subtask_id, None)
         return subtask_info.result
 
     async def _retry_run_subtask(self, subtask: Subtask, band_name: str,

--- a/mars/services/scheduling/worker/execution.py
+++ b/mars/services/scheduling/worker/execution.py
@@ -262,7 +262,7 @@ class SubtaskExecutionActor(mo.StatelessActor):
             # make sure new slot usages are uploaded in time
             slot_manager_ref = await self._get_slot_manager_ref(band_name)
             slot_manager_ref.upload_slot_usages(periodical=False)
-            return subtask_info.result
+        return subtask_info.result
 
     async def _retry_run_subtask(self, subtask: Subtask, band_name: str,
                                  subtask_api: SubtaskAPI, batch_quota_req):

--- a/mars/services/scheduling/worker/execution.py
+++ b/mars/services/scheduling/worker/execution.py
@@ -261,7 +261,7 @@ class SubtaskExecutionActor(mo.StatelessActor):
             self._subtask_info.pop(subtask.subtask_id, None)
             # make sure new slot usages are uploaded in time
             slot_manager_ref = await self._get_slot_manager_ref(band_name)
-            slot_manager_ref.upload_slot_usages(periodical=False)
+            await slot_manager_ref.upload_slot_usages(periodical=False)
         return subtask_info.result
 
     async def _retry_run_subtask(self, subtask: Subtask, band_name: str,

--- a/mars/services/scheduling/worker/tests/test_execution.py
+++ b/mars/services/scheduling/worker/tests/test_execution.py
@@ -324,8 +324,8 @@ async def test_cancel_without_kill(actor_pool):
         execution_ref.cancel_subtask(subtask.subtask_id, kill_timeout=1),
         timeout=30,
     )
-    with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(aiotask, timeout=30)
+    r = await asyncio.wait_for(aiotask, timeout=30)
+    assert r.status == SubtaskStatus.cancelled
 
     remote_result = RemoteFunction(function=check_fun, function_args=[],
                                    function_kwargs={}).new_chunk([])

--- a/mars/services/subtask/core.py
+++ b/mars/services/subtask/core.py
@@ -44,6 +44,7 @@ class Subtask(Serializable):
     chunk_graph: ChunkGraph = ReferenceField('chunk_graph', ChunkGraph)
     expect_bands: List[BandType] = ListField('expect_bands', FieldTypes.tuple)
     virtual: bool = BoolField('virtual')
+    retryable: bool = BoolField('retryable')
     priority: Tuple[int, int] = TupleField('priority', FieldTypes.int32)
     rerun_time: int = Int32Field('rerun_time')
     extra_config: dict = DictField('extra_config')
@@ -57,6 +58,7 @@ class Subtask(Serializable):
                  expect_bands: List[BandType] = None,
                  priority: Tuple[int, int] = None,
                  virtual: bool = False,
+                 retryable: bool = True,
                  rerun_time: int = 0,
                  extra_config: dict = None):
         super().__init__(subtask_id=subtask_id,
@@ -67,6 +69,7 @@ class Subtask(Serializable):
                          expect_bands=expect_bands,
                          priority=priority,
                          virtual=virtual,
+                         retryable=retryable,
                          rerun_time=rerun_time,
                          extra_config=extra_config)
 

--- a/mars/services/task/analyzer/analyzer.py
+++ b/mars/services/task/analyzer/analyzer.py
@@ -224,6 +224,7 @@ class GraphAnalyzer:
             expect_bands=[band] if band is not None else None,
             virtual=virtual,
             priority=priority,
+            retryable=all(getattr(chunk.op, 'retryable', True) for chunk in subtask_chunk_graph),
             extra_config=self._extra_config)
         return subtask
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

- Handle subtask result in one place, the `SubtaskManagerActor`.
  - before
    - The `SubtaskExecutionActor` calls `TaskAPI.set_subtask_result` to set the subtask result.
    - The `SubtaskManagerActor` handles `run_subtask` exceptions.
  - after
    - The `SubtaskManagerActor` gets and sets the subtask result, also handles the `run_subtask` exceptions.
- Acquire and release global slots in supervisor.
  - before
    - The `SubtaskExecutionActor` releases global slots.
  - after
    - The `SubtaskManagerActor` releases global slots.
- Add an option `subtask_max_reschedules` to reschedule failed subtask. _(This PR can't handle worker main pool crash)_

<!-- Please give a short brief about these changes. -->

## Related issue number
N/A

<!-- Are there any issues opened that will be resolved by merging this change? -->
