### PR TITLE
[BACKPORT] Fix misuse of `name` parameter in DataFrame align (#2469)

### DIFF
--- a/mars/dataframe/align.py
+++ b/mars/dataframe/align.py
@@ -154,7 +154,7 @@ class DataFrameIndexAlign(MapReduceOperand, DataFrameOperandMixin):
             if kw.get('dtype', None) is None and getattr(inputs[0], 'dtype', None) is not None:
                 kw['dtype'] = inputs[0].dtype
             if kw.get('name', None) is None and getattr(inputs[0], 'name', None) is not None:
-                kw['name'] = inputs[0].dtype
+                kw['name'] = inputs[0].name
         return kw
 
     def build_reduce_chunk_kw(self, inputs, index, **kw):
@@ -192,7 +192,7 @@ class DataFrameIndexAlign(MapReduceOperand, DataFrameOperandMixin):
             if kw.get('dtype', None) is None and getattr(inputs[0].inputs[0], 'dtype', None) is not None:
                 kw['dtype'] = inputs[0].inputs[0].dtype
             if kw.get('name', None) is None and getattr(inputs[0].inputs[0], 'name', None) is not None:
-                kw['name'] = inputs[0].inputs[0].dtype
+                kw['name'] = inputs[0].inputs[0].name
         return kw
 
     @classmethod

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -472,3 +472,12 @@ def test_fetch_log(fetch_log_setup):
     rm.execute()
     logs = str(rm.fetch_log()).strip()
     assert logs == 'inner\nafter'
+
+
+def test_align_series(setup):
+    t = np.random.rand(10, 3)
+    pdf = pd.DataFrame(t)
+    df = md.DataFrame(pdf, chunk_size=(5, 3))
+    r = df[0] != df.sort_index()[0].shift(-1)
+    expected = pdf[0] != pdf.sort_index()[0].shift(-1)
+    pd.testing.assert_series_equal(r.execute().fetch(), expected)


### PR DESCRIPTION
Backport of #2469