### PR TITLE
Compatible with scikit-learn 1.0

### DIFF
--- a/mars/learn/metrics/pairwise/tests/test_manhattan_distances.py
+++ b/mars/learn/metrics/pairwise/tests/test_manhattan_distances.py
@@ -73,7 +73,7 @@ def test_manhattan_distances_execution(setup, x, y, is_sparse):
         d = manhattan_distances(x, y, sum_over_features)
 
         result = d.execute().fetch()
-        expected = sk_manhattan_distances(rx, ry, sum_over_features)
+        expected = sk_manhattan_distances(rx, ry, sum_over_features=sum_over_features)
 
         np.testing.assert_almost_equal(result, expected)
 

--- a/mars/lib/sparse/array.py
+++ b/mars/lib/sparse/array.py
@@ -361,6 +361,16 @@ class SparseArray(SparseNDArray):
             return SparseNDArray(x, shape=self.shape)
         return get_array_module(x).asarray(x)
 
+    def __matmul__(self, other):
+        from . import matmul
+
+        return matmul(self, other)
+
+    def __rmatmul__(self, other):
+        from . import matmul
+
+        return matmul(other, self)
+
     def __div__(self, other):
         return self.__truediv__(other)
 

--- a/mars/lib/sparse/tests/test_sparse.py
+++ b/mars/lib/sparse/tests/test_sparse.py
@@ -263,6 +263,8 @@ def test_sparse_dot():
     assertArrayEqual(s1.dot(d1), s1.dot(d1))
     assertArrayEqual(d1.dot(s1.T), d1.dot(s1.T.toarray()))
 
+    assertArrayEqual(s1 @ s2.T, s1_data @ s2_data.T)
+
     assertArrayEqual(mls.tensordot(s1, s2.T, axes=(1, 0)), s1.dot(s2.T))
     assertArrayEqual(mls.tensordot(s1, d1, axes=(1, -1)), s1.dot(d1))
     assertArrayEqual(mls.tensordot(d1, s1.T, axes=(0, 0)), d1.dot(s1.T.toarray()))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix compatibility issues for scikit-learn 1.0. 

Including two cases, `test_elkan_results_sparse` and `test_manhattan_distances_execution`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #2485.