### PR TITLE
Fix [BUG] Failed to execute query when there are multiple arguments #2463

### DIFF
--- a/docs/source/locale/zh_CN/LC_MESSAGES/installation/deploy.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/installation/deploy.po
@@ -217,11 +217,11 @@ msgstr ""
 
 #: ../../source/installation/deploy.rst:112
 msgid "On Supervisor 1 (192.168.1.10):"
-msgstr "在 Worker 1（192.168.1.20）上"
+msgstr "在 Supervisor 1（192.168.1.10）上"
 
 #: ../../source/installation/deploy.rst:118
 msgid "On Supervisor 2 (192.168.1.11):"
-msgstr "在 Worker 2（192.168.1.21）上"
+msgstr "在 Supervisor 2（192.168.1.11）上"
 
 #: ../../source/installation/deploy.rst:124
 msgid "On Worker 1 (192.168.1.20):"

--- a/mars/dataframe/base/eval.py
+++ b/mars/dataframe/base/eval.py
@@ -30,7 +30,7 @@ import pandas as pd
 from ... import opcodes
 from ...core import ENTITY_TYPE, OutputType, get_output_types, recursive_tile
 from ...serialization.serializables import BoolField, DictField, StringField
-from ..core import DATAFRAME_TYPE
+from ..core import DATAFRAME_TYPE, SERIES_TYPE
 from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index
 
@@ -123,7 +123,7 @@ class CollectionVisitor(ast.NodeVisitor):
         raise KeyError(f'name {obj_name} is not defined')
 
     def visit(self, node):
-        if isinstance(node, DATAFRAME_TYPE):
+        if isinstance(node, DATAFRAME_TYPE) or isinstance(node, SERIES_TYPE):
             return node
         node_name = node.__class__.__name__
         method = 'visit_' + node_name


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Fix [BUG] Failed to execute query when there are multiple arguments #2463
By supporting SERIES_TYPE for dataframe.base.eval.CollectionVisitor.visit()

Bug happens when querying with more than two atomic condition expressions, as below
```python
import numpy as np
import mars.dataframe as md
df = md.DataFrame({'a': np.random.rand(100),
                   'b': np.random.rand(100),
                   'c c': np.random.rand(100)})
df.query('a < 0.5 and a != 0.1 and b != 0.2').execute()



Traceback (most recent call last):
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 131, in visit
    visitor = getattr(self, method)
AttributeError: 'CollectionVisitor' object has no attribute 'visit_Series'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/Users/wenjun.swj/miniconda3/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3417, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-5-f0b7eeac5829>", line 1, in <module>
    df.query('a < 0.5 and a != 0.1 and b != 0.2').execute()
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 773, in df_query
    predicate = mars_eval(expr, resolvers=(df,), level=level + 1, **kwargs)
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 507, in mars_eval
    result = visitor.eval(expr)
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 112, in eval
    return self.visit(node)
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 134, in visit
    return visitor(node)
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 141, in visit_Module
    result = self.visit(expr)
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 134, in visit
    return visitor(node)
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 145, in visit_Expr
    return self.visit(node.value)
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 134, in visit
    return visitor(node)
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 178, in visit_BoolOp
    return reduce(func, node.values)
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 177, in func
    return self.visit(binop)
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 134, in visit
    return visitor(node)
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 148, in visit_BinOp
    left = self.visit(node.left)
  File "/Users/wenjun.swj/Code/mars/mars/dataframe/base/eval.py", line 133, in visit
    raise SyntaxError('Query string contains unsupported syntax: {}'.format(node_name))
SyntaxError: Query string contains unsupported syntax: Series
```

The key reason is that dataframe.base.eval.CollectionVisitor.visit() does not support SERIES_TYPE
```
SERIES_TYPE =(Series, SeriesData)
```

After adding type support, this bug is well addressed, as the below shows.
```python
>>> import numpy as np
>>> import mars.dataframe as md
>>> df = md.DataFrame({'a': np.random.rand(100),'b': np.random.rand(100),'c c': np.random.rand(100)})
>>> df.query('a < 0.5 and a != 0.1 and b != 0.2').execute()
           a         b       c c
0   0.385509  0.441026  0.950278
1   0.412703  0.386704  0.002776
4   0.280908  0.098562  0.309283
5   0.164744  0.364552  0.292891
6   0.195790  0.944170  0.653790
8   0.322010  0.095338  0.163584
10  0.129747  0.162292  0.904699
11  0.351739  0.124027  0.098137
13  0.213469  0.912870  0.229358
15  0.480980  0.154703  0.330692
16  0.268900  0.084565  0.167768
20  0.144316  0.679124  0.544623
22  0.156903  0.077582  0.335868
24  0.488973  0.564780  0.878692
28  0.271576  0.978732  0.007744
31  0.446813  0.671235  0.103683
33  0.323263  0.358730  0.864071
34  0.123714  0.758012  0.974905
35  0.231321  0.042523  0.260384
36  0.161210  0.948433  0.569217
37  0.311590  0.338948  0.354738
39  0.312912  0.829889  0.446416
40  0.301717  0.018264  0.310472
42  0.315535  0.792631  0.202715
45  0.272704  0.192104  0.119337
46  0.032126  0.595038  0.380832
48  0.308186  0.788221  0.080091
49  0.266853  0.108976  0.492379
51  0.416537  0.585269  0.982781
59  0.368765  0.880367  0.554242
61  0.246360  0.109812  0.377478
62  0.183949  0.609077  0.890214
64  0.318250  0.512868  0.608051
65  0.459107  0.376621  0.253770
66  0.237597  0.379776  0.827282
68  0.402874  0.956666  0.441957
70  0.263144  0.901552  0.381242
72  0.218650  0.623446  0.773795
75  0.314948  0.181935  0.801919
76  0.214923  0.157466  0.493052
77  0.378646  0.562853  0.852832
79  0.074559  0.843526  0.936090
81  0.173659  0.872561  0.950733
82  0.340242  0.256600  0.014353
86  0.322746  0.987032  0.210265
89  0.391583  0.692540  0.583078
90  0.096801  0.466157  0.361595
91  0.241045  0.452441  0.174794
92  0.008451  0.075798  0.820568
93  0.021548  0.364346  0.880776
99  0.273657  0.143548  0.349023
```
<!-- Please give a short brief about these changes. -->

## Related issue number
#2463
<!-- Are there any issues opened that will be resolved by merging this change? -->
