### PR TITLE
[BACKPORT] Support specified vineyard socket and skip the launching vineyardd process (#2481)

### DIFF
--- a/mars/services/storage/tests/test_api.py
+++ b/mars/services/storage/tests/test_api.py
@@ -66,7 +66,6 @@ if ray is not None:
 if vineyard is not None:
     storage_configs.append({'vineyard': dict(
         vineyard_size='256M',
-        vineyard_socket='/tmp/vineyard.sock'
     )})
 
 # shared_memory

--- a/mars/storage/tests/test_libs.py
+++ b/mars/storage/tests/test_libs.py
@@ -92,10 +92,8 @@ async def storage_context(ray_start_regular, request):
         await PlasmaStorage.teardown(**teardown_params)
     elif request.param == 'vineyard':
         vineyard_size = '256M'
-        vineyard_socket = '/tmp/vineyard.sock'
         params, teardown_params = await VineyardStorage.setup(
-            vineyard_size=vineyard_size,
-            vineyard_socket=vineyard_socket)
+            vineyard_size=vineyard_size)
         storage = VineyardStorage(**params)
         assert storage.level == StorageLevel.MEMORY
 


### PR DESCRIPTION
Backport of #2481 .