### PR TITLE
Fix output of df.groupby(as_index=False).size()

### DIFF
--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -630,7 +630,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
         return concat_result
 
     @staticmethod
-    def _do_predefined_agg(input_obj, agg_func, **kwds):
+    def _do_predefined_agg(input_obj, agg_func, single_func=False, **kwds):
         ndim = getattr(input_obj, 'ndim', None) or input_obj.obj.ndim
         if agg_func == 'str_concat':
             agg_func = lambda x: x.str.cat(**kwds)
@@ -640,8 +640,14 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
             agg_func.__name__ = func_name
 
         if ndim == 2:
-            result = input_obj.agg([agg_func])
-            result.columns = result.columns.droplevel(-1)
+            if single_func:
+                result = input_obj.agg(agg_func)
+                if result.ndim == 1:
+                    # when agg_func == size, agg only returns one single series.
+                    result = result.to_frame(agg_func)
+            else:
+                result = input_obj.agg([agg_func])
+                result.columns = result.columns.droplevel(-1)
             return result
         else:
             return input_obj.agg(agg_func)
@@ -704,7 +710,9 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
             if map_func_name == 'custom_reduction':
                 agg_dfs.extend(cls._do_custom_agg(op, custom_reduction, input_obj))
             else:
-                agg_dfs.append(cls._do_predefined_agg(input_obj, map_func_name, **kwds))
+                single_func = map_func_name == op.raw_func
+                agg_dfs.append(cls._do_predefined_agg(
+                    input_obj, map_func_name, single_func, **kwds))
 
         if op._size_recorder_name is not None:
             # record_size

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -282,6 +282,11 @@ def test_dataframe_groupby_agg(setup):
 
     # test as_index=False
     for method in ['tree', 'shuffle']:
+        r = mdf.groupby('c2', as_index=False).agg('size', method=method)
+        pd.testing.assert_frame_equal(
+            r.execute().fetch().sort_values('c2', ignore_index=True),
+            raw.groupby('c2', as_index=False).agg('size').sort_values('c2', ignore_index=True))
+
         r = mdf.groupby('c2', as_index=False).agg('mean', method=method)
         pd.testing.assert_frame_equal(
             r.execute().fetch().sort_values('c2', ignore_index=True),


### PR DESCRIPTION
## What do these changes do?

Fix output of `df.groupby(as_index=False).size()` by adding special logic for single aggregation functions.

## Related issue number

Fixes #2506 
