### PR TITLE
Fix reduction result on empty series

### DIFF
--- a/docs/source/reference/learn/reference.rst
+++ b/docs/source/reference/learn/reference.rst
@@ -58,6 +58,7 @@ Samples generator
    datasets.make_blobs
    datasets.make_classification
    datasets.make_low_rank_matrix
+   datasets.make_regression
 
 .. _decomposition_ref:
 

--- a/mars/dataframe/reduction/aggregation.py
+++ b/mars/dataframe/reduction/aggregation.py
@@ -732,10 +732,14 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
             else:
                 xp = cp if op.gpu else np
                 in_obj = op.inputs[0]
+                in_data = ctx[in_obj.key]
                 if isinstance(in_obj, INDEX_CHUNK_TYPE):
-                    result = op.func[0](ctx[in_obj.key])
+                    result = op.func[0](in_data)
+                elif op.output_types[0] == OutputType.scalar \
+                        and in_data.shape == (0,) and callable(op.func[0]):
+                    result = op.func[0](in_data)
                 else:
-                    result = ctx[in_obj.key].agg(op.raw_func, axis=op.axis)
+                    result = in_data.agg(op.raw_func, axis=op.axis)
 
                 if op.output_types[0] == OutputType.tensor:
                     result = xp.array(result)

--- a/mars/dataframe/reduction/tests/test_reduction_execution.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execution.py
@@ -101,6 +101,11 @@ def test_series_reduction(setup, check_ref_counts, func_name, func_opts: Functio
         reduction_df5 = compute(md.Series(data, chunk_size=3), min_count=21)
         assert np.isnan(reduction_df5.execute().fetch())
 
+    # test reduction on empty series
+    data = pd.Series([], dtype=float, name='a')
+    r = compute(md.Series(data))
+    np.testing.assert_equal(r.execute().fetch(), compute(data))
+
 
 @pytest.mark.parametrize('func_name,func_opts', reduction_functions)
 def test_series_level_reduction(setup, func_name, func_opts: FunctionOptions):


### PR DESCRIPTION
## What do these changes do?

Fix reduction on empty series by calling reduction functions directly.

## Related issue number

Fixes #2519
