### PR TITLE
Add app_queue in new_cluster

### DIFF
--- a/mars/deploy/yarn/client.py
+++ b/mars/deploy/yarn/client.py
@@ -150,7 +150,10 @@ def new_cluster(
         cmd_tmpl=cmd_tmpl,
     )
     app_config = MarsApplicationConfig(
-        app_name, app_queue, supervisor_config=supervisor_config, worker_config=worker_config
+        app_name,
+        app_queue,
+        supervisor_config=supervisor_config,
+        worker_config=worker_config,
     )
 
     skein_client = skein_client or skein.Client()


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
add parameter such as app_queue in new_cluster,so it can set queue when create a new cluster
<!-- Please give a short brief about these changes. -->

## Related issue number
Fixes #2549
<!-- Are there any issues opened that will be resolved by merging this change? -->
