### PR TITLE
Stop using asdict to handle dataclasses

### DIFF
--- a/mars/services/meta/store/tests/test_meta_store.py
+++ b/mars/services/meta/store/tests/test_meta_store.py
@@ -38,9 +38,15 @@ async def test_mock_meta_store():
         ),
     )
 
+    meta = await meta_store.get_meta(t.key)
+    assert meta["shape"] == t.shape
+    assert meta["order"] == t.order
+    assert meta["dtype"] == t.dtype
+
     meta = await meta_store.get_meta(t.key, fields=["shape", "order"])
     assert meta["shape"] == t.shape
     assert meta["order"] == t.order
+    assert "dtype" not in meta
 
     await meta_store.del_meta(t.key)
 


### PR DESCRIPTION
## What do these changes do?

Stop using std function `dataclasses.asdict` to handle dataclasses as it uses `deepcopy` for non-collection objects, see

https://github.com/python/cpython/blob/0a68b3603fbc0aaf9eeb8ce8b42b78d6fa7cfa78/Lib/dataclasses.py#L1273

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
