### PR TITLE
Support Series.median()

### DIFF
--- a/docs/source/reference/dataframe/series.rst
+++ b/docs/source/reference/dataframe/series.rst
@@ -123,6 +123,7 @@ Computations / descriptive stats
    Series.kurtosis
    Series.max
    Series.mean
+   Series.median
    Series.min
    Series.pct_change
    Series.prod

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -61,6 +61,7 @@ from ..utils import (
     tokenize,
 )
 from .utils import fetch_corner_data, ReprSeries, parse_index, merge_index_value
+from ..tensor import statistics
 
 
 class IndexValue(Serializable):
@@ -1522,6 +1523,74 @@ class Series(HasShapeTileable, _ToPandasMixin):
             )
 
         return lmask & rmask
+
+    def median(
+        self, axis=None, skipna=True, out=None, overwrite_input=False, keepdims=False
+    ):
+        """
+        Return the median of the values over the requested axis.
+
+        Parameters
+        ----------
+        axis : {index (0)}
+            Axis or axes along which the medians are computed. The default
+            is to compute the median along a flattened version of the tensor.
+            A sequence of axes is supported since version 1.9.0.
+        skipna : bool, optional, default True
+            Exclude NA/null values when computing the result.
+        out : Tensor, default None
+            Output tensor in which to place the result. It must
+            have the same shape and buffer length as the expected output,
+            but the type (of the output) will be cast if necessary.
+        overwrite_input : bool, default False
+            Just for compatibility with Numpy, would not take effect.
+        keepdims : bool, default False
+            If this is set to True, the axes which are reduced are left
+            in the result as dimensions with size one. With this option,
+            the result will broadcast correctly against the original `arr`.
+
+        Returns
+        -------
+        median : scalar
+            Return the median of the values over the requested axis.
+
+        See Also
+        --------
+        tensor.mean, tensor.percentile
+
+        Notes
+        -----
+        Given a vector ``V`` of length ``N``, the median of ``V`` is the
+        middle value of a sorted copy of ``V``, ``V_sorted`` - i
+        e., ``V_sorted[(N-1)/2]``, when ``N`` is odd, and the average of the
+        two middle values of ``V_sorted`` when ``N`` is even.
+
+        Examples
+        --------
+        >>> import mars.dataframe as md
+        >>> a = md.Series([10, 7, 4, 3, 2, 1])
+        >>> a.median().execute()
+        2.0
+        >>> mt.median(a).execute()
+        3.5
+        >>> a = md.Series([10, 7, 4, None, 2, 1])
+        >>> a.median().execute()
+        4.0
+        >>> a.median(skipna=False).execute()
+        nan
+        """
+        if skipna:
+            return statistics.median(
+                self.dropna(),
+                axis=None,
+                out=None,
+                overwrite_input=False,
+                keepdims=False,
+            )
+        else:
+            return statistics.median(
+                self, axis=None, out=None, overwrite_input=False, keepdims=False
+            )
 
 
 class BaseDataFrameChunkData(ChunkData):

--- a/mars/dataframe/tests/test_core.py
+++ b/mars/dataframe/tests/test_core.py
@@ -359,3 +359,35 @@ def test_between(setup):
     result = series.between(left, right).execute().fetch()
     expected = pd_series.between(pd_left, pd_right)
     pd.testing.assert_series_equal(result, expected)
+
+
+def test_series_median(setup):
+    raw = pd.Series(np.random.rand(10), name="col")
+    series = Series(raw)
+    
+    r = series.median()
+    result = r.execute().fetch()
+    assert np.isclose(raw.median(), result)
+    
+    raw = pd.Series(np.random.rand(100), name="col")
+    series = Series(raw)
+    
+    r = series.median()
+    result = r.execute().fetch()
+    assert np.isclose(raw.median(), result)
+    
+    raw = pd.Series(np.random.rand(10), name="col")
+    raw[np.random.randint(0,10)] = None
+    series = Series(raw)
+    
+    r = series.median()
+    result = r.execute().fetch()
+    assert np.isclose(raw.median(), result)
+    
+    raw = pd.Series(np.random.rand(10), name="col")
+    raw[np.random.randint(0,10)] = None
+    series = Series(raw)
+    
+    r = series.median(skipna=False)
+    result = r.execute().fetch()
+    assert np.isnan(raw.median(skipna=False)) and np.isnan(result)

--- a/mars/dataframe/tests/test_core.py
+++ b/mars/dataframe/tests/test_core.py
@@ -364,30 +364,30 @@ def test_between(setup):
 def test_series_median(setup):
     raw = pd.Series(np.random.rand(10), name="col")
     series = Series(raw)
-    
+
     r = series.median()
     result = r.execute().fetch()
     assert np.isclose(raw.median(), result)
-    
+
     raw = pd.Series(np.random.rand(100), name="col")
     series = Series(raw)
-    
+
     r = series.median()
     result = r.execute().fetch()
     assert np.isclose(raw.median(), result)
-    
+
     raw = pd.Series(np.random.rand(10), name="col")
-    raw[np.random.randint(0,10)] = None
+    raw[np.random.randint(0, 10)] = None
     series = Series(raw)
-    
+
     r = series.median()
     result = r.execute().fetch()
     assert np.isclose(raw.median(), result)
-    
+
     raw = pd.Series(np.random.rand(10), name="col")
-    raw[np.random.randint(0,10)] = None
+    raw[np.random.randint(0, 10)] = None
     series = Series(raw)
-    
+
     r = series.median(skipna=False)
     result = r.execute().fetch()
     assert np.isnan(raw.median(skipna=False)) and np.isnan(result)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Support Series.median() plus testings
<!-- Please give a short brief about these changes. -->

## Related issue number
Resolves #1345
<!-- Are there any issues opened that will be resolved by merging this change? -->
---
Series.median() is mainly supported by ```tensor.statistics.median``` based on ```tensor.statistics.quantile```

In addition to the parameters  from ```tensor.statistics.median```, I also added ```skipna``` for handling nan values just like [pandas series()](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.median.html?highlight=median#pandas.Series.median)

4 test cases work fine.

However, I had trouble when Building Documentations. 
I ran
```make html```
then 
![image](https://user-images.githubusercontent.com/31856209/139522547-aff4e33f-c666-44bc-ab3a-a1581a9dd0aa.png)
It seems my VM ubuntu suffers from its 8 GB memory. Is there a good way to solve this? 