### PR TITLE
[BACKPORT] Add `mars.learn.metrics.multilabel_confusion_matrix` and derivative metrics (#2554)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,9 @@ Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst 
 ## Related issue number
 
 <!-- Are there any issues opened that will be resolved by merging this change? -->
+Fixes #xxxx
+
+## Check code requirements
+
+- [ ] tests added / passed (if needed)
+- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them

--- a/docs/source/development/contributing.rst
+++ b/docs/source/development/contributing.rst
@@ -131,6 +131,8 @@ We also require relative import in code for all Mars modules. Use
 
 to check if your code meet the requirement.
 
+.. _build_documentation:
+
 Building Documentations
 -----------------------
 Mars uses ``sphinx`` to build documents. You need to install necessary packages

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -7,5 +7,6 @@ Development
 
    contributing
    overview
+   operand
    oscar/index
    services/index

--- a/docs/source/development/operand.rst
+++ b/docs/source/development/operand.rst
@@ -1,0 +1,253 @@
+.. _operand_implementation:
+
+Implement a Mars Operand
+========================
+
+Use ``read_csv`` as an example to illustrate how to implement a Mars operand.
+
+Define Operand Class
+--------------------
+
+All Mars operands inherit from the base class ``Operand``, it defines the
+basic properties of operand, each module has it's own child class, such as
+``DataFrameOperand``, ``TensorOperand``, etc. For tilebale operand, it also
+needs to inherit from ``TileableOperandMixin`` to implement ``tile`` and ``execute``
+functions. So we firstly define operand class and set output types in init method,
+the types could be DataFrame or Tensor which depends on the type of operand's output data,
+``__call__`` method is also needed for creating a Mars dataframe.
+
+.. code-block:: python
+
+    # NOTE: Use relative import if in Mars modules
+    from mars.dataframe.operands import DataFrameOperand, DataFrameOperandMixin
+    from mars.core import OutputType
+    from mars.serialization.serializables import StringField
+
+
+    class SimpleReadCSV(DataFrameOperand, DataFrameOperandMixin):
+        path = StringField('path')
+
+        def __init__(self, **kw):
+            super().__init__(**kw)
+            self._output_types=[OutputType.dataframe]
+
+        def __call__(self, index_value=None, columns_value=None,
+                     dtypes=None, chunk_bytes=None):
+            # np.nan means its size is unknown on axis 0
+            shape = (np.nan, len(dtypes))
+            return self.new_dataframe(
+                None,
+                shape,
+                dtypes=dtypes,
+                index_value=index_value,
+                columns_value=columns_value,
+                chunk_bytes=chunk_bytes,
+            )
+
+For the ``SimpleReadCSV`` operand, the property ``path`` means the path of csv file,
+we use a ``StringField`` to indicate the property's type which is useful for serialization.
+If the type is uncertain, ``AnyField`` will work.
+
+Implement Tile Method
+---------------------
+
+Tile method is the next goal, this method will split the computing task into
+several sub tasks. Ideally, these tasks can be assigned on different executors
+in parallel. In the specific case of ``read_csv``, each sub task read a block of bytes
+from the file, so we need calculate the offset and length of each block in the
+tile function. As we use the same class for both coarse-grained and fine-grained operand,
+``offset``, ``length`` and other properties are added to record information for
+fine-grained operand.
+
+.. code-block:: python
+
+    import os
+
+    import numpy as np
+
+    from mars.core import OutputType
+    from mars.dataframe.operands import DataFrameOperand, DataFrameOperandMixin
+    from mars.serialization.serializables import AnyField, StringField, Int64Field
+    from mars.utils import parse_readable_size
+
+
+    class SimpleReadCSV(DataFrameOperand, DataFrameOperandMixin):
+        path = StringField("path")
+        chunk_bytes = AnyFiled('chunk_bytes')
+        offset = Int64Field("offset")
+        length = Int64Field("length")
+
+        def __init__(self, **kw):
+            super().__init__(**kw)
+            self._output_types=[OutputType.dataframe]
+
+        @classmethod
+        def tile(cls, op: "SimpleReadCSV"):
+            # out is operand's output in coarse-grained graph
+            out = op.outputs[0]
+
+            file_path = op.path
+            file_size = os.path.getsize(file_path)
+
+            # split file into chunks
+            chunk_bytes = int(parse_readable_size(op.chunk_bytes)[0])
+            offset = 0
+            index_num = 0
+            out_chunks = []
+            while offset < file_size:
+                chunk_op = op.copy().reset_key()
+                chunk_op.path = file_path
+                # offset and length for current chunk
+                chunk_op.offset = offset
+                chunk_op.length = min(chunk_bytes, file_size - offset)
+                # calculate chunk's meta, including shape, index_value, columns_value
+                # here we use np.nan to represent unknown shape
+                shape = (np.nan, len(out.dtypes))
+                # use `op.new_chunk` to create a dataframe chunk
+                new_chunk = chunk_op.new_chunk(
+                    None,
+                    shape=shape,
+                    index=(index_num, 0),
+                    index_value=out.index_value,
+                    columns_value=out.columns_value,
+                    dtypes=out.dtypes,
+                )
+                offset += chunk_bytes
+                index_num += 1
+                out_chunks.append(new_chunk)
+
+            # create a new tileable which holds `chunks` for generating fine-grained graph
+            new_op = op.copy()
+            # `nsplits` records the split info for each axis. For read_csv,
+            # the output dataframe is split into multiple parts on axis 0 and
+            # keep one chunk on axis 1, so the nsplits will be
+            # like ((np.nan, np.nan, ...), (out.shape[1],))
+            nsplits = ((np.nan,) * len(out_chunks), (out.shape[1],))
+            return new_op.new_dataframes(
+                None,
+                out.shape,
+                dtypes=out.dtypes,
+                index_value=out.index_value,
+                columns_value=out.columns_value,
+                chunks=out_chunks,
+                nsplits=nsplits,
+            )
+
+
+Implement Execute Method
+------------------------
+
+When sub task is delivered to executor, Mars will call operand's execute method to
+perform calculations. When it comes to ``read_csv``, we need read the block from the file
+according to the ``offset`` and ``length``, however the ``offset`` is a rough position as
+we can't read a csv file from the middle of a line, using ``readline`` to find the starts
+and ends at delimiter boundaries.
+
+.. code-block:: python
+
+    from io import BytesIO
+
+    import pandas as pd
+
+    from mars.dataframe.utils import build_empty_df
+
+
+    def _find_chunk_start_end(f, offset, size):
+        f.seek(offset)
+        if f.tell() == 0:
+            start = 0
+        else:
+            f.readline()
+            start = f.tell()
+        f.seek(offset + size)
+        f.readline()
+        end = f.tell()
+        return start, end
+
+
+    class SimpleReadCSV(DataFrameOperand, DataFrameOperandMixin):
+        @classmethod
+        def execute(cls, ctx: Union[dict, Context], op: "SimpleReadCSV"):
+            out = op.outputs[0]
+            with open(op.path, 'rb') as f:
+                start, end = _find_chunk_start_end(f, op.offset, op.length)
+                if end == start:
+                    # the last chunk may be empty
+                    data = build_empty_df(out.dtypes)
+                else:
+                    f.seek(start)
+                    if start == 0:
+                        # The first chunk contains header, skip header rows
+                        data = pd.read_csv(BytesIO(f.read(end - start)),
+                                           skiprows=1,
+                                           names=out.dtypes.index)
+                    else:
+                        data = pd.read_csv(BytesIO(f.read(end - start)),
+                                           names=out.dtypes.index)
+
+            ctx[out.key] = data
+
+After reading the chunk data by ``pd.read_csv``, we store the results in ``ctx``.
+``SimpleReadCSV`` only has one output here, for operand like ``SVD`` that has multiple
+outputs, we can store them separately using output's keys.
+
+Define User Interface
+---------------------
+
+Finally, we need define function ``read_csv`` exposed to users. In this function, besides
+creating a ``SimpleReadCSV`` operand, a sample data is taken to infer some meta information
+of Mars DataFrame, such as dtypes, columns, index, etc.
+
+.. code-block:: python
+
+    from mars.dataframe.utils import parse_index
+
+    def read_csv(file_path, chunk_bytes='16M'):
+        # use first 10 lines to infer
+        with open(file_path, 'rb') as f:
+            head_lines = b"".join([f.readline() for _ in range(10)])
+
+        mini_df = pd.read_csv(BytesIO(head_lines))
+        index_value = parse_index(mini_df.index)
+        columns_value = parse_index(mini_df.columns, store_data=True)
+        dtypes = mini_df.dtypes
+        op = SimpleReadCSV(path=file_path, chunk_bytes=chunk_bytes)
+        return op(
+            index_value=index_value,
+            columns_value=columns_value,
+            dtypes=dtypes,
+            chunk_bytes=chunk_bytes,
+        )
+
+Write Tests
+-----------
+
+Mars uses pytest for testing, we can add tests under the ``tests`` subdirectory
+of the specific module and follow the current examples of tests. Define a test
+function and use the shared fixture ``setup`` to run your tests under the test
+environment.
+
+.. code-block:: python
+
+    def test_simple_read_csv_execution(setup):
+        with tempfile.TemporaryDirectory() as tempdir:
+            file_path = os.path.join(tempdir, "test.csv")
+            # write to a csv file
+            raw = pd.DataFrame({
+                'int': range(10),
+                'float': np.random.rand(10),
+                'str': [f'value_{i}' for i in range(10)]
+            }).to_csv(file_path, index=False)
+            mdf = read_csv(file_path).execute().fetch()
+            pd.testing.assert_frame_equal(raw, mdf)
+
+When tests pass locally, we can submit a pull requests on GitHub, the test suite
+will run automatically on GitHub Actions and Azure Pipelines continuous integration
+services, if all checks have passed, it means the pull request is up to the quality
+of merging.
+
+Documenting Your Code
+---------------------
+
+If the changes add APIs to Mars modules, we should document our code in ``docs``
+directory, it can be done following the regarding :ref:`documentation <build_documentation>`.

--- a/docs/source/locale/zh_CN/LC_MESSAGES/development/operand.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/development/operand.po
@@ -1,0 +1,159 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 1999-2020, The Alibaba Group Holding Ltd.
+# This file is distributed under the same license as the mars package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: mars 0.8.0rc1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-11-02 11:50+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../source/development/operand.rst:4
+msgid "Implement a Mars Operand"
+msgstr "实现 Mars 算子"
+
+#: ../../source/development/operand.rst:6
+msgid ""
+"Use ``read_csv`` as an example to illustrate how to implement a Mars "
+"operand."
+msgstr "这篇文档里使用 ``read_csv`` 作为例子介绍如何实现一个 Mars 算子"
+
+#: ../../source/development/operand.rst:9
+msgid "Define Operand Class"
+msgstr "定义算子类"
+
+#: ../../source/development/operand.rst:11
+msgid ""
+"All Mars operands inherit from the base class ``Operand``, it defines the"
+" basic properties of operand, each module has it's own child class, such "
+"as ``DataFrameOperand``, ``TensorOperand``, etc. For tilebale operand, it"
+" also needs to inherit from ``TileableOperandMixin`` to implement "
+"``tile`` and ``execute`` functions. So we firstly define operand class "
+"and set output types in init method, the types could be DataFrame or "
+"Tensor which depends on the type of operand's output data, ``__call__`` "
+"method is also needed for creating a Mars dataframe."
+msgstr ""
+"所有的 Mars 算子都继承自基类 ``Operand``，基类里定义了算子的基本属性，在每个大模块里都实现了对应的子类，比如 "
+"``DataFrameOperand``、 ``TensorOperand`` 等。对于一个可以被 tile 的算子，它还需要继承 "
+"``TileableOperandMixin`` 用以实现 ``tile`` 、``execute`` "
+"等必要的方法。所以首先我们可以先定义好算子类和它的初始化方法，指定算子的输出类型，并且在 ``__call__`` 函数里定义好创建 Mars "
+"DataFrame 的逻辑。"
+
+#: ../../source/development/operand.rst:47
+msgid ""
+"For the ``SimpleReadCSV`` operand, the property ``path`` means the path "
+"of csv file, we use a ``StringField`` to indicate the property's type "
+"which is useful for serialization. If the type is uncertain, ``AnyField``"
+" will work."
+msgstr ""
+"对于 ``SimpleReadCSV`` 算子，类持有的 ``path`` 属性记录 csv 的文件地址，这里使用``StringField`` "
+"表示改属性的类型是字符串，指定类型主要是为了方便序列化算子，如果某个属性的类型是不确定的，可以用 ``AnyField`` 表示。"
+
+#: ../../source/development/operand.rst:52
+msgid "Implement Tile Method"
+msgstr "实现 tile 方法"
+
+#: ../../source/development/operand.rst:54
+msgid ""
+"Tile method is the next goal, this method will split the computing task "
+"into several sub tasks. Ideally, these tasks can be assigned on different"
+" executors in parallel. In the specific case of ``read_csv``, each sub "
+"task read a block of bytes from the file, so we need calculate the offset"
+" and length of each block in the tile function. As we use the same class "
+"for both coarse-grained and fine-grained operand, ``offset``, ``length`` "
+"and other properties are added to record information for fine-grained "
+"operand."
+msgstr ""
+"接下来需要实现 Tile 方法， "
+"这个函数里主要是将该算子的计算任务分解成多个子任务。理想情况下，这些子任务可以并行的分发到不同的执行器中执行。对于当前的 ``read_csv``"
+" 计算任务，每个子任务需要读取文件的不同块，所以在 tile "
+"函数里我们需要计算出每个子任务读取文件块的偏移值以及读取长度。由于粗粒度算子与细粒度算子都使用同一个算子类表示，所以需要在刚刚定义好的算子中添加 "
+"``offset``、``length`` 等属性记录细粒度算子需要的一些信息。"
+
+#: ../../source/development/operand.rst:138
+msgid "Implement Execute Method"
+msgstr "实现 execute 方法"
+
+#: ../../source/development/operand.rst:140
+msgid ""
+"When sub task is delivered to executor, Mars will call operand's execute "
+"method to perform calculations. When it comes to ``read_csv``, we need "
+"read the block from the file according to the ``offset`` and ``length``, "
+"however the ``offset`` is a rough position as we can't read a csv file "
+"from the middle of a line, using ``readline`` to find the starts and ends"
+" at delimiter boundaries."
+msgstr ""
+"当拆分好的子任务被分发到执行器时，Mars 会调用算子的 ``execute`` 方法来做计算，对于 ``read_csv`` "
+"的子任务，在函数里需要根据 ``offset`` 和 ``length``读取对应的数据块，但是这两个值只是一个粗略的值，因为 csv "
+"文件不能从一行的中间读取，所以每次执行的时候需要计算出分隔符所在的起始位置。"
+
+#: ../../source/development/operand.rst:190
+msgid ""
+"After reading the chunk data by ``pd.read_csv``, we store the results in "
+"``ctx``. ``SimpleReadCSV`` only has one output here, for operand like "
+"``SVD`` that has multiple outputs, we can store them separately using "
+"output's keys."
+msgstr ""
+"当我们通过 ``pd.read_csv`` 读取当前数据块后，可以将读到的数据存储在 ``ctx`` 中，这里 ``SimpleReadCSV``"
+" 只有一个输出，对于 ``SVD`` 这样有多个输出的算子，可以通过outputs 不同的 key 存储对应的输出数据。"
+
+#: ../../source/development/operand.rst:195
+msgid "Define User Interface"
+msgstr "定义用户接口"
+
+#: ../../source/development/operand.rst:197
+msgid ""
+"Finally, we need define function ``read_csv`` exposed to users. In this "
+"function, besides creating a ``SimpleReadCSV`` operand, a sample data is "
+"taken to infer some meta information of Mars DataFrame, such as dtypes, "
+"columns, index, etc."
+msgstr ""
+"最后，需要定义一个暴露给用户的函数接口 ``read_csv``。在这个函数里，我们需要创建``SimpleReadCSV`` "
+"算子，并且需要读取一小块采样数据，推断出输出的 DataFrame 的dtypes, columns, index 等元信息。"
+
+#: ../../source/development/operand.rst:223
+msgid "Write Tests"
+msgstr "编写测试用例"
+
+#: ../../source/development/operand.rst:225
+msgid ""
+"Mars uses pytest for testing, we can add tests under the ``tests`` "
+"subdirectory of the specific module and follow the current examples of "
+"tests. Define a test function and use the shared fixture ``setup`` to run"
+" your tests under the test environment."
+msgstr ""
+"Mars 使用 pytest 运行测试用例，可以参考当前模块的单元测试，在 ``tests`` 目录下添加对应的用例。在测试函数里，需要使用共享的"
+" fixture ``setup`` 来使得你的测试跑在测试环境中。"
+
+#: ../../source/development/operand.rst:244
+msgid ""
+"When tests pass locally, we can submit a pull requests on GitHub, the "
+"test suite will run automatically on GitHub Actions and Azure Pipelines "
+"continuous integration services, if all checks have passed, it means the "
+"pull request is up to the quality of merging."
+msgstr ""
+"如果在本地测试通过，这时候我们可以在 GitHub 提交一个 pull requests，所有的测试会自动运行在 GitHub Actions 和"
+" Azure Pipelines 这两个持续集成的平台上，如果所有的检测都通过了，意味着这个 pull requests 达到了合并的要求。"
+
+#: ../../source/development/operand.rst:250
+msgid "Documenting Your Code"
+msgstr "添加文档"
+
+#: ../../source/development/operand.rst:252
+msgid ""
+"If the changes add APIs to Mars modules, we should document our code in "
+"``docs`` directory, it can be done following the regarding "
+":ref:`documentation <build_documentation>`."
+msgstr ""
+"如果代码里增加了 API，那我们需要在 ``docs`` 目录下添加说明，可以参考相关 :ref:`文档 "
+"<build_documentation>` 完成。"
+

--- a/docs/source/reference/learn/reference.rst
+++ b/docs/source/reference/learn/reference.rst
@@ -131,7 +131,13 @@ Classification metrics
 
    metrics.accuracy_score
    metrics.auc
+   metrics.f1_score
+   metrics.fbeta_score
    metrics.log_loss
+   metrics.multilabel_confusion_matrix
+   metrics.precision_score
+   metrics.precision_recall_fscore_support
+   metrics.recall_score
    metrics.roc_curve
 
 Regression metrics

--- a/mars/learn/metrics/__init__.py
+++ b/mars/learn/metrics/__init__.py
@@ -13,7 +13,16 @@
 # limitations under the License.
 
 from .pairwise import euclidean_distances, pairwise_distances, pairwise_distances_topk
-from ._classification import accuracy_score, log_loss
+from ._classification import (
+    accuracy_score,
+    log_loss,
+    multilabel_confusion_matrix,
+    precision_recall_fscore_support,
+    precision_score,
+    recall_score,
+    f1_score,
+    fbeta_score,
+)
 from ._ranking import roc_curve, auc
 from ._regresssion import r2_score
 from ._scorer import get_scorer

--- a/mars/learn/metrics/_classification.py
+++ b/mars/learn/metrics/_classification.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
+import warnings
 
+import numpy as np
+from sklearn.exceptions import UndefinedMetricWarning
+
+from ... import execute, fetch
 from ... import opcodes as OperandDef
 from ... import tensor as mt
 from ...core import ENTITY_TYPE, recursive_tile
@@ -21,8 +25,10 @@ from ...core.context import get_context
 from ...serialization.serializables import AnyField, BoolField, KeyField
 from ...tensor.core import TensorOrder
 from ..operands import LearnOperand, LearnOperandMixin, OutputType
-from ..preprocessing import LabelBinarizer
-from ..utils import check_array, check_consistent_length
+from ..preprocessing import LabelBinarizer, LabelEncoder
+from ..utils import check_array, check_consistent_length, column_or_1d
+from ..utils.multiclass import unique_labels
+from ..utils.sparsefuncs import count_nonzero
 from ._check_targets import _check_targets
 
 
@@ -331,3 +337,1139 @@ def log_loss(
     loss = -(transformed_labels * mt.log(y_pred)).sum(axis=1)
 
     return _weighted_sum(loss, sample_weight, normalize).execute()
+
+
+def multilabel_confusion_matrix(
+    y_true,
+    y_pred,
+    *,
+    sample_weight=None,
+    labels=None,
+    samplewise=False,
+    session=None,
+    run_kwargs=None
+):
+    """
+    Compute a confusion matrix for each class or sample.
+
+    Compute class-wise (default) or sample-wise (samplewise=True) multilabel
+    confusion matrix to evaluate the accuracy of a classification, and output
+    confusion matrices for each class or sample.
+
+    In multilabel confusion matrix :math:`MCM`, the count of true negatives
+    is :math:`MCM_{:,0,0}`, false negatives is :math:`MCM_{:,1,0}`,
+    true positives is :math:`MCM_{:,1,1}` and false positives is
+    :math:`MCM_{:,0,1}`.
+
+    Multiclass data will be treated as if binarized under a one-vs-rest
+    transformation. Returned confusion matrices will be in the order of
+    sorted unique labels in the union of (y_true, y_pred).
+
+    Read more in the :ref:`User Guide <multilabel_confusion_matrix>`.
+
+    Parameters
+    ----------
+    y_true : {array-like, sparse matrix} of shape (n_samples, n_outputs) or \
+            (n_samples,)
+        Ground truth (correct) target values.
+
+    y_pred : {array-like, sparse matrix} of shape (n_samples, n_outputs) or \
+            (n_samples,)
+        Estimated targets as returned by a classifier.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    labels : array-like of shape (n_classes,), default=None
+        A list of classes or column indices to select some (or to force
+        inclusion of classes absent from the data).
+
+    samplewise : bool, default=False
+        In the multilabel case, this calculates a confusion matrix per sample.
+
+    Returns
+    -------
+    multi_confusion : ndarray of shape (n_outputs, 2, 2)
+        A 2x2 confusion matrix corresponding to each output in the input.
+        When calculating class-wise multi_confusion (default), then
+        n_outputs = n_labels; when calculating sample-wise multi_confusion
+        (samplewise=True), n_outputs = n_samples. If ``labels`` is defined,
+        the results will be returned in the order specified in ``labels``,
+        otherwise the results will be returned in sorted order by default.
+
+    See Also
+    --------
+    confusion_matrix : Compute confusion matrix to evaluate the accuracy of a
+        classifier.
+
+    Notes
+    -----
+    The `multilabel_confusion_matrix` calculates class-wise or sample-wise
+    multilabel confusion matrices, and in multiclass tasks, labels are
+    binarized under a one-vs-rest way; while
+    :func:`~sklearn.metrics.confusion_matrix` calculates one confusion matrix
+    for confusion between every two classes.
+
+    Examples
+    --------
+    Multiclass case:
+
+    >>> import mars.tensor as mt
+    >>> from mars.learn.metrics import multilabel_confusion_matrix
+    >>> y_true = ["cat", "ant", "cat", "cat", "ant", "bird"]
+    >>> y_pred = ["ant", "ant", "cat", "cat", "ant", "cat"]
+    >>> multilabel_confusion_matrix(y_true, y_pred,
+    ...                             labels=["ant", "bird", "cat"])
+    array([[[3, 1],
+            [0, 2]],
+    <BLANKLINE>
+           [[5, 0],
+            [1, 0]],
+    <BLANKLINE>
+           [[2, 1],
+            [1, 2]]])
+
+    Multilabel-indicator case not implemented yet.
+    """
+    exec_kw = dict(session=session, **(run_kwargs or dict()))
+
+    y_type, y_true, y_pred = _check_targets(y_true, y_pred)
+    execute(y_type, y_true, y_pred, **exec_kw)
+    y_type = y_type.fetch()
+
+    if sample_weight is not None:
+        sample_weight = column_or_1d(sample_weight)
+    check_consistent_length(y_true, y_pred, sample_weight, **exec_kw)
+
+    if y_type not in ("binary", "multiclass", "multilabel-indicator"):
+        raise ValueError("%s is not supported" % y_type)
+
+    present_labels = unique_labels(y_true, y_pred)
+    if labels is None:
+        labels = present_labels
+        n_labels = None
+    else:
+        labels = mt.tensor(labels)
+        n_labels = labels.shape[0]
+        # todo simplify this when mt.setdiff1d is implemented.
+        labels = labels.rechunk(((np.nan,),)).map_chunk(
+            lambda l, pl: np.hstack([l, np.setdiff1d(pl, l, assume_unique=True)]),
+            args=(present_labels,),
+            dtype=labels.dtype,
+            shape=(np.nan,),
+        )
+
+    if y_true.ndim == 1:
+        if samplewise:
+            raise ValueError(
+                "Samplewise metrics are not available outside of "
+                "multilabel classification."
+            )
+
+        le = LabelEncoder()
+        le.fit(labels, execute=False)
+        y_true = le.transform(y_true, execute=False)
+        y_pred = le.transform(y_pred, execute=False)
+        sorted_labels = le.classes_
+
+        # labels are now from 0 to len(labels) - 1 -> use bincount
+        tp = y_true == y_pred
+        tp_bins = y_true[tp]
+        execute(labels, y_true, y_pred, tp_bins, **exec_kw)
+        if sample_weight is not None:
+            tp_bins_weights = mt.asarray(sample_weight)[tp]
+        else:
+            tp_bins_weights = None
+
+        if tp_bins.shape[0]:
+            tp_sum = mt.bincount(
+                tp_bins, weights=tp_bins_weights, minlength=labels.shape[0]
+            )
+        else:
+            # Pathological case
+            true_sum = pred_sum = tp_sum = mt.zeros(labels.shape[0])
+        if y_pred.shape[0]:
+            pred_sum = mt.bincount(
+                y_pred, weights=sample_weight, minlength=labels.shape[0]
+            )
+        if y_true.shape[0]:
+            true_sum = mt.bincount(
+                y_true, weights=sample_weight, minlength=labels.shape[0]
+            )
+
+        # Retain only selected labels
+        indices = mt.searchsorted(sorted_labels, labels[:n_labels])
+        tp_sum = tp_sum[indices]
+        true_sum = true_sum[indices]
+        pred_sum = pred_sum[indices]
+
+    else:
+        sum_axis = 1 if samplewise else 0
+
+        def _check_labels(labels, present_labels):
+            # All labels are index integers for multilabel.
+            # Select labels:
+            if not np.array_equal(labels, present_labels):
+                if np.max(labels) > np.max(present_labels):
+                    raise ValueError(
+                        "All labels must be in [0, n labels) for "
+                        "multilabel targets. "
+                        "Got %d > %d" % (np.max(labels), np.max(present_labels))
+                    )
+                if np.min(labels) < 0:
+                    raise ValueError(
+                        "All labels must be in [0, n labels) for "
+                        "multilabel targets. "
+                        "Got %d < 0" % np.min(labels)
+                    )
+            return labels
+
+        labels = labels.map_chunk(
+            _check_labels,
+            args=(present_labels,),
+            dtype=labels.dtype,
+            shape=labels.shape,
+        )
+
+        if n_labels is not None:
+            y_true = y_true[:, labels[:n_labels]]
+            y_pred = y_pred[:, labels[:n_labels]]
+
+        # calculate weighted counts
+        true_and_pred = mt.multiply(y_true, y_pred)
+        tp_sum = count_nonzero(
+            true_and_pred, axis=sum_axis, sample_weight=sample_weight
+        )
+        pred_sum = count_nonzero(y_pred, axis=sum_axis, sample_weight=sample_weight)
+        true_sum = count_nonzero(y_true, axis=sum_axis, sample_weight=sample_weight)
+
+    fp = pred_sum - tp_sum
+    fn = true_sum - tp_sum
+    tp = tp_sum
+
+    # we need to obtain correct shape of y_true for further computation
+    executables = (fp, fn, tp, y_true)
+    execute(*executables, **exec_kw)
+
+    if sample_weight is not None and samplewise:
+        sample_weight = mt.asarray(sample_weight)
+        tp = mt.asarray(tp)
+        fp = mt.asarray(fp)
+        fn = mt.asarray(fn)
+        tn = sample_weight * y_true.shape[1] - tp - fp - fn
+    elif sample_weight is not None:
+        tn = sum(sample_weight) - tp - fp - fn
+    elif samplewise:
+        tn = y_true.shape[1] - tp - fp - fn
+    else:
+        tn = y_true.shape[0] - tp - fp - fn
+
+    ret = mt.array([tn, fp, fn, tp]).T.reshape(-1, 2, 2)
+    return ret.execute(**exec_kw)
+
+
+def _check_zero_division(zero_division):  # pragma: no cover
+    if isinstance(zero_division, str) and zero_division == "warn":
+        return
+    elif isinstance(zero_division, (int, float)) and zero_division in [0, 1]:
+        return
+    raise ValueError(
+        "Got zero_division={0}." ' Must be one of ["warn", 0, 1]'.format(zero_division)
+    )
+
+
+def _warn_prf(average, modifier, msg_start, result_size):  # pragma: no cover
+    axis0, axis1 = "sample", "label"
+    if average == "samples":
+        axis0, axis1 = axis1, axis0
+    msg = (
+        "{0} ill-defined and being set to 0.0 {{0}} "
+        "no {1} {2}s. Use `zero_division` parameter to control"
+        " this behavior.".format(msg_start, modifier, axis0)
+    )
+    if result_size == 1:
+        msg = msg.format("due to")
+    else:
+        msg = msg.format("in {0}s with".format(axis1))
+    warnings.warn(msg, UndefinedMetricWarning, stacklevel=2)
+
+
+def _prf_divide(
+    numerator, denominator, metric, modifier, average, warn_for, zero_division="warn"
+):  # pragma: no cover
+    """Performs division and handles divide-by-zero.
+
+    On zero-division, sets the corresponding result elements equal to
+    0 or 1 (according to ``zero_division``). Plus, if
+    ``zero_division != "warn"`` raises a warning.
+
+    The metric, modifier and average arguments are used only for determining
+    an appropriate warning.
+    """
+    mask = denominator == 0.0
+    denominator = denominator.copy()
+    denominator[mask] = 1  # avoid infs/nans
+    result = numerator / denominator
+
+    # if ``zero_division=1``, set those with denominator == 0 equal to 1
+    result[mask] = 0.0 if zero_division in ["warn", 0] else 1.0
+
+    # the user will be removing warnings if zero_division is set to something
+    # different than its default value. If we are computing only f-score
+    # the warning will be raised only if precision and recall are ill-defined
+    if zero_division != "warn" or metric not in warn_for:
+        return result
+
+    # build appropriate warning
+    # E.g. "Precision and F-score are ill-defined and being set to 0.0 in
+    # labels with no predicted samples. Use ``zero_division`` parameter to
+    # control this behavior."
+
+    if metric in warn_for and "f-score" in warn_for:
+        msg_start = "{0} and F-score are".format(metric.title())
+    elif metric in warn_for:
+        msg_start = "{0} is".format(metric.title())
+    elif "f-score" in warn_for:
+        msg_start = "F-score is"
+    else:
+        return result
+
+    _warn_prf(average, modifier, msg_start, len(result))
+
+    return result
+
+
+def _check_set_wise_labels(
+    y_true, y_pred, average, labels, pos_label, session=None, run_kwargs=None
+):  # pragma: no cover
+    """Validation associated with set-wise metrics
+
+    Returns identified labels
+    """
+    exec_kwargs = dict(session=session, **(run_kwargs or dict()))
+    average_options = (None, "micro", "macro", "weighted", "samples")
+    if average not in average_options and average != "binary":
+        raise ValueError("average has to be one of " + str(average_options))
+
+    y_type, y_true, y_pred = _check_targets(y_true, y_pred)
+    present_labels = unique_labels(y_true, y_pred)
+    execute(y_type, y_true, y_pred, **exec_kwargs)
+    y_type = y_type.fetch(**exec_kwargs)
+
+    if average == "binary":
+        if y_type == "binary":
+            t_pos_in_labels = mt.any(mt.isin(present_labels, pos_label))
+            execute(t_pos_in_labels, present_labels, **exec_kwargs)
+            pos_in_labels = t_pos_in_labels.fetch(**exec_kwargs)
+            if pos_in_labels:
+                if present_labels.shape[0] >= 2:
+                    raise ValueError(
+                        "pos_label=%r is not a valid label: "
+                        "%r" % (pos_label, present_labels)
+                    )
+            labels = [pos_label]
+        else:
+            average_options = list(average_options)
+            if y_type == "multiclass":
+                average_options.remove("samples")
+            raise ValueError(
+                "Target is %s but average='binary'. Please "
+                "choose another average setting, one of %r." % (y_type, average_options)
+            )
+    elif pos_label not in (None, 1):
+        warnings.warn(
+            "Note that pos_label (set to %r) is ignored when "
+            "average != 'binary' (got %r). You may use "
+            "labels=[pos_label] to specify a single positive class."
+            % (pos_label, average),
+            UserWarning,
+        )
+    return labels
+
+
+def precision_recall_fscore_support(
+    y_true,
+    y_pred,
+    *,
+    beta=1.0,
+    labels=None,
+    pos_label=1,
+    average=None,
+    warn_for=("precision", "recall", "f-score"),
+    sample_weight=None,
+    zero_division="warn",
+    session=None,
+    run_kwargs=None
+):
+    """Compute precision, recall, F-measure and support for each class
+
+    The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
+    true positives and ``fp`` the number of false positives. The precision is
+    intuitively the ability of the classifier not to label as positive a sample
+    that is negative.
+
+    The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
+    true positives and ``fn`` the number of false negatives. The recall is
+    intuitively the ability of the classifier to find all the positive samples.
+
+    The F-beta score can be interpreted as a weighted harmonic mean of
+    the precision and recall, where an F-beta score reaches its best
+    value at 1 and worst score at 0.
+
+    The F-beta score weights recall more than precision by a factor of
+    ``beta``. ``beta == 1.0`` means recall and precision are equally important.
+
+    The support is the number of occurrences of each class in ``y_true``.
+
+    If ``pos_label is None`` and in binary classification, this function
+    returns the average precision, recall and F-measure if ``average``
+    is one of ``'micro'``, ``'macro'``, ``'weighted'`` or ``'samples'``.
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or label indicator array / sparse matrix
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like, or label indicator array / sparse matrix
+        Estimated targets as returned by a classifier.
+
+    beta : float, 1.0 by default
+        The strength of recall versus precision in the F-score.
+
+    labels : list, optional
+        The set of labels to include when ``average != 'binary'``, and their
+        order if ``average is None``. Labels present in the data can be
+        excluded, for example to calculate a multiclass average ignoring a
+        majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in ``y_true`` and
+        ``y_pred`` are used in sorted order.
+
+    pos_label : str or int, 1 by default
+        The class to report if ``average='binary'`` and the data is binary.
+        If the data are multiclass or multilabel, this will be ignored;
+        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
+        scores for that label only.
+
+    average : string, [None (default), 'binary', 'micro', 'macro', 'samples', \
+                       'weighted']
+        If ``None``, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+
+        ``'binary'``:
+            Only report results for the class specified by ``pos_label``.
+            This is applicable only if targets (``y_{true,pred}``) are binary.
+        ``'micro'``:
+            Calculate metrics globally by counting the total true positives,
+            false negatives and false positives.
+        ``'macro'``:
+            Calculate metrics for each label, and find their unweighted
+            mean.  This does not take label imbalance into account.
+        ``'weighted'``:
+            Calculate metrics for each label, and find their average weighted
+            by support (the number of true instances for each label). This
+            alters 'macro' to account for label imbalance; it can result in an
+            F-score that is not between precision and recall.
+        ``'samples'``:
+            Calculate metrics for each instance, and find their average (only
+            meaningful for multilabel classification where this differs from
+            :func:`accuracy_score`).
+
+    warn_for : tuple or set, for internal use
+        This determines which warnings will be made in the case that this
+        function is being used to return only one of its metrics.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    zero_division : "warn", 0 or 1, default="warn"
+        Sets the value to return when there is a zero division:
+           - recall: when there are no positive labels
+           - precision: when there are no positive predictions
+           - f-score: both
+
+        If set to "warn", this acts as 0, but warnings are also raised.
+
+    Returns
+    -------
+    precision : float (if average is not None) or array of float, shape =\
+        [n_unique_labels]
+
+    recall : float (if average is not None) or array of float, , shape =\
+        [n_unique_labels]
+
+    fbeta_score : float (if average is not None) or array of float, shape =\
+        [n_unique_labels]
+
+    support : None (if average is not None) or array of int, shape =\
+        [n_unique_labels]
+        The number of occurrences of each label in ``y_true``.
+
+    References
+    ----------
+    .. [1] `Wikipedia entry for the Precision and recall
+           <https://en.wikipedia.org/wiki/Precision_and_recall>`_
+
+    .. [2] `Wikipedia entry for the F1-score
+           <https://en.wikipedia.org/wiki/F1_score>`_
+
+    .. [3] `Discriminative Methods for Multi-labeled Classification Advances
+           in Knowledge Discovery and Data Mining (2004), pp. 22-30 by Shantanu
+           Godbole, Sunita Sarawagi
+           <http://www.godbole.net/shantanu/pubs/multilabelsvm-pakdd04.pdf>`_
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from mars.learn.metrics import precision_recall_fscore_support
+    >>> y_true = np.array(['cat', 'dog', 'pig', 'cat', 'dog', 'pig'])
+    >>> y_pred = np.array(['cat', 'pig', 'dog', 'cat', 'cat', 'dog'])
+    >>> precision_recall_fscore_support(y_true, y_pred, average='macro')
+    (0.22..., 0.33..., 0.26..., None)
+    >>> precision_recall_fscore_support(y_true, y_pred, average='micro')
+    (0.33..., 0.33..., 0.33..., None)
+    >>> precision_recall_fscore_support(y_true, y_pred, average='weighted')
+    (0.22..., 0.33..., 0.26..., None)
+
+    It is possible to compute per-label precisions, recalls, F1-scores and
+    supports instead of averaging:
+
+    >>> precision_recall_fscore_support(y_true, y_pred, average=None,
+    ... labels=['pig', 'dog', 'cat'])
+    (array([0.        , 0.        , 0.66...]),
+     array([0., 0., 1.]), array([0. , 0. , 0.8]),
+     array([2, 2, 2]))
+
+    Notes
+    -----
+    When ``true positive + false positive == 0``, precision is undefined;
+    When ``true positive + false negative == 0``, recall is undefined.
+    In such cases, by default the metric will be set to 0, as will f-score,
+    and ``UndefinedMetricWarning`` will be raised. This behavior can be
+    modified with ``zero_division``.
+    """
+    exec_kw = dict(session=session, **(run_kwargs or dict()))
+
+    _check_zero_division(zero_division)
+    if beta < 0:
+        raise ValueError("beta should be >=0 in the F-beta score")
+    labels = _check_set_wise_labels(
+        y_true,
+        y_pred,
+        average,
+        labels,
+        pos_label,
+        session=session,
+        run_kwargs=run_kwargs,
+    )
+
+    # Calculate tp_sum, pred_sum, true_sum ###
+    samplewise = average == "samples"
+    MCM = multilabel_confusion_matrix(
+        y_true,
+        y_pred,
+        sample_weight=sample_weight,
+        labels=labels,
+        samplewise=samplewise,
+        session=session,
+        run_kwargs=run_kwargs,
+    )
+    tp_sum = MCM[:, 1, 1]
+    pred_sum = tp_sum + MCM[:, 0, 1]
+    true_sum = tp_sum + MCM[:, 1, 0]
+
+    if average == "micro":
+        tp_sum = mt.array([tp_sum.sum()])
+        pred_sum = mt.array([pred_sum.sum()])
+        true_sum = mt.array([true_sum.sum()])
+
+    execute(true_sum, **exec_kw)
+
+    # Finally, we have all our sufficient statistics. Divide! #
+    beta2 = beta ** 2
+
+    # Divide, and on zero-division, set scores and/or warn according to
+    # zero_division:
+    precision = _prf_divide(
+        tp_sum, pred_sum, "precision", "predicted", average, warn_for, zero_division
+    )
+    recall = _prf_divide(
+        tp_sum, true_sum, "recall", "true", average, warn_for, zero_division
+    )
+
+    # warn for f-score only if zero_division is warn, it is in warn_for
+    # and BOTH prec and rec are ill-defined
+    if zero_division == "warn" and ("f-score",) == warn_for:
+        any_pred_sum_zero = (
+            (pred_sum[true_sum == 0] == 0).any().execute(**exec_kw).fetch(**exec_kw)
+        )
+        if any_pred_sum_zero:
+            _warn_prf(average, "true nor predicted", "F-score is", len(true_sum))
+
+    # if tp == 0 F will be 1 only if all predictions are zero, all labels are
+    # zero, and zero_division=1. In all other case, 0
+    if np.isposinf(beta):
+        f_score = recall
+    else:
+        denom = beta2 * precision + recall
+
+        denom[denom == 0.0] = 1  # avoid division by 0
+        f_score = (1 + beta2) * precision * recall / denom
+
+    # Average the results
+    if average == "weighted":
+        weights = true_sum
+        sum_weights, sum_pred_sum = fetch(
+            execute(weights.sum(), pred_sum.sum(), **exec_kw), **exec_kw
+        )
+        if sum_weights == 0:
+            zero_division_value = 0.0 if zero_division in ["warn", 0] else 1.0
+            # precision is zero_division if there are no positive predictions
+            # recall is zero_division if there are no positive labels
+            # fscore is zero_division if all labels AND predictions are
+            # negative
+            return (
+                mt.scalar(zero_division_value if sum_pred_sum == 0 else 0),
+                mt.scalar(zero_division_value),
+                mt.scalar(zero_division_value if sum_pred_sum == 0 else 0),
+                None,
+            )
+
+    elif average == "samples":
+        weights = sample_weight
+    else:
+        weights = None
+
+    if average is not None:
+        assert average != "binary" or len(precision) == 1
+        precision = mt.average(precision, weights=weights)
+        recall = mt.average(recall, weights=weights)
+        f_score = mt.average(f_score, weights=weights)
+        true_sum = None  # return no support
+
+    return precision, recall, f_score, true_sum
+
+
+def precision_score(
+    y_true,
+    y_pred,
+    *,
+    labels=None,
+    pos_label=1,
+    average="binary",
+    sample_weight=None,
+    zero_division="warn"
+):
+    """Compute the precision
+
+    The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
+    true positives and ``fp`` the number of false positives. The precision is
+    intuitively the ability of the classifier not to label as positive a sample
+    that is negative.
+
+    The best value is 1 and the worst value is 0.
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or label indicator array / sparse matrix
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like, or label indicator array / sparse matrix
+        Estimated targets as returned by a classifier.
+
+    labels : list, optional
+        The set of labels to include when ``average != 'binary'``, and their
+        order if ``average is None``. Labels present in the data can be
+        excluded, for example to calculate a multiclass average ignoring a
+        majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in ``y_true`` and
+        ``y_pred`` are used in sorted order.
+
+    pos_label : str or int, 1 by default
+        The class to report if ``average='binary'`` and the data is binary.
+        If the data are multiclass or multilabel, this will be ignored;
+        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
+        scores for that label only.
+
+    average : string, [None, 'binary' (default), 'micro', 'macro', 'samples', \
+                       'weighted']
+        This parameter is required for multiclass/multilabel targets.
+        If ``None``, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+
+        ``'binary'``:
+            Only report results for the class specified by ``pos_label``.
+            This is applicable only if targets (``y_{true,pred}``) are binary.
+        ``'micro'``:
+            Calculate metrics globally by counting the total true positives,
+            false negatives and false positives.
+        ``'macro'``:
+            Calculate metrics for each label, and find their unweighted
+            mean.  This does not take label imbalance into account.
+        ``'weighted'``:
+            Calculate metrics for each label, and find their average weighted
+            by support (the number of true instances for each label). This
+            alters 'macro' to account for label imbalance; it can result in an
+            F-score that is not between precision and recall.
+        ``'samples'``:
+            Calculate metrics for each instance, and find their average (only
+            meaningful for multilabel classification where this differs from
+            :func:`accuracy_score`).
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    zero_division : "warn", 0 or 1, default="warn"
+        Sets the value to return when there is a zero division. If set to
+        "warn", this acts as 0, but warnings are also raised.
+
+    Returns
+    -------
+    precision : float (if average is not None) or array of float, shape =\
+        [n_unique_labels]
+        Precision of the positive class in binary classification or weighted
+        average of the precision of each class for the multiclass task.
+
+    See also
+    --------
+    precision_recall_fscore_support, multilabel_confusion_matrix
+
+    Examples
+    --------
+    >>> from mars.learn.metrics import precision_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> precision_score(y_true, y_pred, average='macro')
+    0.22...
+    >>> precision_score(y_true, y_pred, average='micro')
+    0.33...
+    >>> precision_score(y_true, y_pred, average='weighted')
+    0.22...
+    >>> precision_score(y_true, y_pred, average=None)
+    array([0.66..., 0.        , 0.        ])
+    >>> y_pred = [0, 0, 0, 0, 0, 0]
+    >>> precision_score(y_true, y_pred, average=None)
+    array([0.33..., 0.        , 0.        ])
+    >>> precision_score(y_true, y_pred, average=None, zero_division=1)
+    array([0.33..., 1.        , 1.        ])
+
+    Notes
+    -----
+    When ``true positive + false positive == 0``, precision returns 0 and
+    raises ``UndefinedMetricWarning``. This behavior can be
+    modified with ``zero_division``.
+
+    """
+    p, _, _, _ = precision_recall_fscore_support(
+        y_true,
+        y_pred,
+        labels=labels,
+        pos_label=pos_label,
+        average=average,
+        warn_for=("precision",),
+        sample_weight=sample_weight,
+        zero_division=zero_division,
+    )
+    return p
+
+
+def recall_score(
+    y_true,
+    y_pred,
+    *,
+    labels=None,
+    pos_label=1,
+    average="binary",
+    sample_weight=None,
+    zero_division="warn"
+):
+    """Compute the recall
+
+    The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
+    true positives and ``fn`` the number of false negatives. The recall is
+    intuitively the ability of the classifier to find all the positive samples.
+
+    The best value is 1 and the worst value is 0.
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or label indicator array / sparse matrix
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like, or label indicator array / sparse matrix
+        Estimated targets as returned by a classifier.
+
+    labels : list, optional
+        The set of labels to include when ``average != 'binary'``, and their
+        order if ``average is None``. Labels present in the data can be
+        excluded, for example to calculate a multiclass average ignoring a
+        majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in ``y_true`` and
+        ``y_pred`` are used in sorted order.
+
+    pos_label : str or int, 1 by default
+        The class to report if ``average='binary'`` and the data is binary.
+        If the data are multiclass or multilabel, this will be ignored;
+        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
+        scores for that label only.
+
+    average : string, [None, 'binary' (default), 'micro', 'macro', 'samples', \
+                       'weighted']
+        This parameter is required for multiclass/multilabel targets.
+        If ``None``, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+
+        ``'binary'``:
+            Only report results for the class specified by ``pos_label``.
+            This is applicable only if targets (``y_{true,pred}``) are binary.
+        ``'micro'``:
+            Calculate metrics globally by counting the total true positives,
+            false negatives and false positives.
+        ``'macro'``:
+            Calculate metrics for each label, and find their unweighted
+            mean.  This does not take label imbalance into account.
+        ``'weighted'``:
+            Calculate metrics for each label, and find their average weighted
+            by support (the number of true instances for each label). This
+            alters 'macro' to account for label imbalance; it can result in an
+            F-score that is not between precision and recall.
+        ``'samples'``:
+            Calculate metrics for each instance, and find their average (only
+            meaningful for multilabel classification where this differs from
+            :func:`accuracy_score`).
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    zero_division : "warn", 0 or 1, default="warn"
+        Sets the value to return when there is a zero division. If set to
+        "warn", this acts as 0, but warnings are also raised.
+
+    Returns
+    -------
+    recall : float (if average is not None) or array of float, shape =\
+        [n_unique_labels]
+        Recall of the positive class in binary classification or weighted
+        average of the recall of each class for the multiclass task.
+
+    See also
+    --------
+    precision_recall_fscore_support, balanced_accuracy_score,
+    multilabel_confusion_matrix
+
+    Examples
+    --------
+    >>> from mars.learn.metrics import recall_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> recall_score(y_true, y_pred, average='macro')
+    0.33...
+    >>> recall_score(y_true, y_pred, average='micro')
+    0.33...
+    >>> recall_score(y_true, y_pred, average='weighted')
+    0.33...
+    >>> recall_score(y_true, y_pred, average=None)
+    array([1., 0., 0.])
+    >>> y_true = [0, 0, 0, 0, 0, 0]
+    >>> recall_score(y_true, y_pred, average=None)
+    array([0.5, 0. , 0. ])
+    >>> recall_score(y_true, y_pred, average=None, zero_division=1)
+    array([0.5, 1. , 1. ])
+
+    Notes
+    -----
+    When ``true positive + false negative == 0``, recall returns 0 and raises
+    ``UndefinedMetricWarning``. This behavior can be modified with
+    ``zero_division``.
+    """
+    _, r, _, _ = precision_recall_fscore_support(
+        y_true,
+        y_pred,
+        labels=labels,
+        pos_label=pos_label,
+        average=average,
+        warn_for=("recall",),
+        sample_weight=sample_weight,
+        zero_division=zero_division,
+    )
+    return r
+
+
+def f1_score(
+    y_true,
+    y_pred,
+    *,
+    labels=None,
+    pos_label=1,
+    average="binary",
+    sample_weight=None,
+    zero_division="warn"
+):
+    """Compute the F1 score, also known as balanced F-score or F-measure
+
+    The F1 score can be interpreted as a weighted average of the precision and
+    recall, where an F1 score reaches its best value at 1 and worst score at 0.
+    The relative contribution of precision and recall to the F1 score are
+    equal. The formula for the F1 score is::
+
+        F1 = 2 * (precision * recall) / (precision + recall)
+
+    In the multi-class and multi-label case, this is the average of
+    the F1 score of each class with weighting depending on the ``average``
+    parameter.
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or label indicator array / sparse matrix
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like, or label indicator array / sparse matrix
+        Estimated targets as returned by a classifier.
+
+    labels : list, optional
+        The set of labels to include when ``average != 'binary'``, and their
+        order if ``average is None``. Labels present in the data can be
+        excluded, for example to calculate a multiclass average ignoring a
+        majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in ``y_true`` and
+        ``y_pred`` are used in sorted order.
+
+    pos_label : str or int, 1 by default
+        The class to report if ``average='binary'`` and the data is binary.
+        If the data are multiclass or multilabel, this will be ignored;
+        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
+        scores for that label only.
+
+    average : string, [None, 'binary' (default), 'micro', 'macro', 'samples', \
+                       'weighted']
+        This parameter is required for multiclass/multilabel targets.
+        If ``None``, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+
+        ``'binary'``:
+            Only report results for the class specified by ``pos_label``.
+            This is applicable only if targets (``y_{true,pred}``) are binary.
+        ``'micro'``:
+            Calculate metrics globally by counting the total true positives,
+            false negatives and false positives.
+        ``'macro'``:
+            Calculate metrics for each label, and find their unweighted
+            mean.  This does not take label imbalance into account.
+        ``'weighted'``:
+            Calculate metrics for each label, and find their average weighted
+            by support (the number of true instances for each label). This
+            alters 'macro' to account for label imbalance; it can result in an
+            F-score that is not between precision and recall.
+        ``'samples'``:
+            Calculate metrics for each instance, and find their average (only
+            meaningful for multilabel classification where this differs from
+            :func:`accuracy_score`).
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    zero_division : "warn", 0 or 1, default="warn"
+        Sets the value to return when there is a zero division, i.e. when all
+        predictions and labels are negative. If set to "warn", this acts as 0,
+        but warnings are also raised.
+
+    Returns
+    -------
+    f1_score : float or array of float, shape = [n_unique_labels]
+        F1 score of the positive class in binary classification or weighted
+        average of the F1 scores of each class for the multiclass task.
+
+    See also
+    --------
+    fbeta_score, precision_recall_fscore_support, jaccard_score,
+    multilabel_confusion_matrix
+
+    References
+    ----------
+    .. [1] `Wikipedia entry for the F1-score
+           <https://en.wikipedia.org/wiki/F1_score>`_
+
+    Examples
+    --------
+    >>> from mars.learn.metrics import f1_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> f1_score(y_true, y_pred, average='macro')
+    0.26...
+    >>> f1_score(y_true, y_pred, average='micro')
+    0.33...
+    >>> f1_score(y_true, y_pred, average='weighted')
+    0.26...
+    >>> f1_score(y_true, y_pred, average=None)
+    array([0.8, 0. , 0. ])
+    >>> y_true = [0, 0, 0, 0, 0, 0]
+    >>> y_pred = [0, 0, 0, 0, 0, 0]
+    >>> f1_score(y_true, y_pred, zero_division=1)
+    1.0...
+
+    Notes
+    -----
+    When ``true positive + false positive == 0``, precision is undefined;
+    When ``true positive + false negative == 0``, recall is undefined.
+    In such cases, by default the metric will be set to 0, as will f-score,
+    and ``UndefinedMetricWarning`` will be raised. This behavior can be
+    modified with ``zero_division``.
+    """
+    return fbeta_score(
+        y_true,
+        y_pred,
+        beta=1,
+        labels=labels,
+        pos_label=pos_label,
+        average=average,
+        sample_weight=sample_weight,
+        zero_division=zero_division,
+    )
+
+
+def fbeta_score(
+    y_true,
+    y_pred,
+    *,
+    beta,
+    labels=None,
+    pos_label=1,
+    average="binary",
+    sample_weight=None,
+    zero_division="warn"
+):
+    """Compute the F-beta score
+
+    The F-beta score is the weighted harmonic mean of precision and recall,
+    reaching its optimal value at 1 and its worst value at 0.
+
+    The `beta` parameter determines the weight of recall in the combined
+    score. ``beta < 1`` lends more weight to precision, while ``beta > 1``
+    favors recall (``beta -> 0`` considers only precision, ``beta -> +inf``
+    only recall).
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or label indicator array / sparse matrix
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like, or label indicator array / sparse matrix
+        Estimated targets as returned by a classifier.
+
+    beta : float
+        Determines the weight of recall in the combined score.
+
+    labels : list, optional
+        The set of labels to include when ``average != 'binary'``, and their
+        order if ``average is None``. Labels present in the data can be
+        excluded, for example to calculate a multiclass average ignoring a
+        majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in ``y_true`` and
+        ``y_pred`` are used in sorted order.
+
+    pos_label : str or int, 1 by default
+        The class to report if ``average='binary'`` and the data is binary.
+        If the data are multiclass or multilabel, this will be ignored;
+        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
+        scores for that label only.
+
+    average : string, [None, 'binary' (default), 'micro', 'macro', 'samples', \
+                       'weighted']
+        This parameter is required for multiclass/multilabel targets.
+        If ``None``, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+
+        ``'binary'``:
+            Only report results for the class specified by ``pos_label``.
+            This is applicable only if targets (``y_{true,pred}``) are binary.
+        ``'micro'``:
+            Calculate metrics globally by counting the total true positives,
+            false negatives and false positives.
+        ``'macro'``:
+            Calculate metrics for each label, and find their unweighted
+            mean.  This does not take label imbalance into account.
+        ``'weighted'``:
+            Calculate metrics for each label, and find their average weighted
+            by support (the number of true instances for each label). This
+            alters 'macro' to account for label imbalance; it can result in an
+            F-score that is not between precision and recall.
+        ``'samples'``:
+            Calculate metrics for each instance, and find their average (only
+            meaningful for multilabel classification where this differs from
+            :func:`accuracy_score`).
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    zero_division : "warn", 0 or 1, default="warn"
+        Sets the value to return when there is a zero division, i.e. when all
+        predictions and labels are negative. If set to "warn", this acts as 0,
+        but warnings are also raised.
+
+    Returns
+    -------
+    fbeta_score : float (if average is not None) or array of float, shape =\
+        [n_unique_labels]
+        F-beta score of the positive class in binary classification or weighted
+        average of the F-beta score of each class for the multiclass task.
+
+    See also
+    --------
+    precision_recall_fscore_support, multilabel_confusion_matrix
+
+    References
+    ----------
+    .. [1] R. Baeza-Yates and B. Ribeiro-Neto (2011).
+           Modern Information Retrieval. Addison Wesley, pp. 327-328.
+
+    .. [2] `Wikipedia entry for the F1-score
+           <https://en.wikipedia.org/wiki/F1_score>`_
+
+    Examples
+    --------
+    >>> from mars.learn.metrics import fbeta_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> fbeta_score(y_true, y_pred, average='macro', beta=0.5)
+    0.23...
+    >>> fbeta_score(y_true, y_pred, average='micro', beta=0.5)
+    0.33...
+    >>> fbeta_score(y_true, y_pred, average='weighted', beta=0.5)
+    0.23...
+    >>> fbeta_score(y_true, y_pred, average=None, beta=0.5)
+    array([0.71..., 0.        , 0.        ])
+
+    Notes
+    -----
+    When ``true positive + false positive == 0`` or
+    ``true positive + false negative == 0``, f-score returns 0 and raises
+    ``UndefinedMetricWarning``. This behavior can be
+    modified with ``zero_division``.
+    """
+
+    _, _, f, _ = precision_recall_fscore_support(
+        y_true,
+        y_pred,
+        beta=beta,
+        labels=labels,
+        pos_label=pos_label,
+        average=average,
+        warn_for=("f-score",),
+        sample_weight=sample_weight,
+        zero_division=zero_division,
+    )
+    return f

--- a/mars/learn/utils/sparsefuncs.py
+++ b/mars/learn/utils/sparsefuncs.py
@@ -1,0 +1,175 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import numpy as np
+
+from ... import opcodes, tensor as mt
+from ...core import OutputType, recursive_tile
+from ...serialization.serializables import Int16Field, ReferenceField
+from ...utils import has_unknown_shape
+from ..operands import LearnOperand, LearnOperandMixin
+
+
+class LearnCountNonzero(LearnOperand, LearnOperandMixin):
+    _op_code_ = opcodes.COUNT_NONZERO
+
+    axis = Int16Field("axis")
+    sample_weight = ReferenceField("sample_weight")
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        if self.sample_weight is not None:
+            self.sample_weight = inputs[-1]
+
+    def __call__(self, x, sample_weight=None):
+        self.sample_weight = sample_weight
+        self._output_types = [
+            OutputType.scalar if self.axis is None else OutputType.tensor
+        ]
+        dtype = np.dtype(int)
+        inputs = [x]
+        if sample_weight is not None:
+            dtype = sample_weight.dtype
+            inputs = [x, sample_weight]
+
+        if self.axis is None:
+            shape = ()
+        else:
+            shape = (x.shape[1 - self.axis],)
+
+        return self.new_tileable(inputs, shape=shape, dtype=dtype)
+
+    @classmethod
+    def tile(cls, op: "LearnCountNonzero"):
+        input_tensor = op.inputs[0]
+        out_tensor = op.outputs[0]
+
+        if op.sample_weight is not None:
+            if has_unknown_shape(input_tensor):
+                yield
+            sample_weight = yield from recursive_tile(
+                op.sample_weight.rechunk({0: input_tensor.nsplits[0]})
+            )
+        else:
+            sample_weight = None
+
+        chunks = []
+        for input_chunk in input_tensor.chunks:
+            if sample_weight is None:
+                weight_chunk = None
+            else:
+                weight_chunk = sample_weight.cix[(input_chunk.index[0],)]
+
+            new_op = op.copy().reset_key()
+            new_op.sample_weight = weight_chunk
+
+            inputs = [input_chunk] if not weight_chunk else [input_chunk, weight_chunk]
+            if op.axis is None:
+                shape = (1, 1)
+            elif op.axis == 0:
+                shape = (1, input_chunk.shape[1])
+            else:
+                shape = (input_chunk.shape[0], 1)
+            chunks.append(
+                new_op.new_chunk(
+                    inputs, shape=shape, dtype=out_tensor.dtype, index=input_chunk.index
+                )
+            )
+
+        new_op = op.copy().reset_key()
+        if op.axis is None:
+            nsplits = tuple((1,) * len(split) for split in input_tensor.nsplits)
+            shape = tuple(len(split) for split in input_tensor.nsplits)
+        elif op.axis == 0:
+            nsplits = ((1,) * len(input_tensor.nsplits[0]), input_tensor.nsplits[1])
+            shape = (len(input_tensor.nsplits[0]), input_tensor.shape[1])
+        else:
+            nsplits = (input_tensor.nsplits[0], (1,) * len(input_tensor.nsplits[1]))
+            shape = (input_tensor.shape[0], len(input_tensor.nsplits[1]))
+
+        tileable = new_op.new_tileable(
+            out_tensor.inputs,
+            chunks=chunks,
+            nsplits=nsplits,
+            shape=shape,
+            dtype=out_tensor.dtype,
+        )
+        return [(yield from recursive_tile(mt.sum(tileable, axis=op.axis)))]
+
+    @classmethod
+    def execute(cls, ctx, op: "LearnCountNonzero"):
+        axis = op.axis
+        X = ctx[op.inputs[0].key]
+        sample_weight = (
+            ctx[op.sample_weight.key] if op.sample_weight is not None else None
+        )
+
+        # We rely here on the fact that np.diff(Y.indptr) for a CSR
+        # will return the number of nonzero entries in each row.
+        # A bincount over Y.indices will return the number of nonzeros
+        # in each column. See ``csr_matrix.getnnz`` in scipy >= 0.14.
+        if axis is None:
+            if sample_weight is None:
+                res = X.nnz
+            else:
+                res = np.dot(np.diff(X.indptr), sample_weight)
+        elif axis == 1:
+            out = np.diff(X.indptr)
+            if sample_weight is None:
+                # astype here is for consistency with axis=0 dtype
+                res = out.astype("intp")
+            else:
+                res = out * sample_weight
+        else:
+            if sample_weight is None:
+                res = np.bincount(X.indices, minlength=X.shape[1])
+            else:
+                weights = np.repeat(sample_weight, np.diff(X.indptr))
+                res = np.bincount(X.indices, minlength=X.shape[1], weights=weights)
+        if np.isscalar(res):
+            res = np.array([res])
+        ctx[op.outputs[0].key] = res.reshape(op.outputs[0].shape)
+
+
+def count_nonzero(X, axis: Optional[int] = None, sample_weight=None):
+    """A variant of X.getnnz() with extension to weighting on axis 0
+
+    Useful in efficiently calculating multilabel metrics.
+
+    Parameters
+    ----------
+    X : CSR sparse matrix of shape (n_samples, n_labels)
+        Input data.
+
+    axis : None, 0 or 1
+        The axis on which the data is aggregated.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Weight for each row of X.
+    """
+    if axis == -1:
+        axis = 1
+    elif axis == -2:
+        axis = 0
+    if axis is not None and axis not in (0, 1):
+        raise ValueError(f"Unsupported axis: {axis}")
+
+    X = mt.asarray(X)
+    if sample_weight is not None:
+        sample_weight = mt.asarray(sample_weight)
+
+    op = LearnCountNonzero(axis=axis)
+    return op(X, sample_weight=sample_weight)

--- a/mars/learn/utils/tests/test_sparsefuncs.py
+++ b/mars/learn/utils/tests/test_sparsefuncs.py
@@ -1,0 +1,71 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import scipy.sparse as sp
+import pytest
+
+from .... import tensor as mt
+from ..sparsefuncs import count_nonzero
+
+
+def test_count_nonzero(setup):
+    X = np.array(
+        [[0, 3, 0], [2, -1, 0], [0, 0, 0], [9, 8, 7], [4, 0, 5]], dtype=np.float64
+    )
+    X_nonzero = X != 0
+
+    X_csr = sp.csr_matrix(X)
+    X_csr_t = mt.tensor(X_csr, chunk_size=3)
+
+    sample_weight = [0.5, 0.2, 0.3, 0.1, 0.1]
+    X_nonzero_weighted = X_nonzero * np.array(sample_weight)[:, None]
+
+    for axis in [0, 1, -1, -2, None]:
+        np.testing.assert_array_almost_equal(
+            count_nonzero(X_csr_t, axis=axis).execute().fetch(),
+            X_nonzero.sum(axis=axis),
+        )
+        np.testing.assert_array_almost_equal(
+            count_nonzero(X_csr_t, axis=axis, sample_weight=sample_weight)
+            .execute()
+            .fetch(),
+            X_nonzero_weighted.sum(axis=axis),
+        )
+
+    with pytest.raises(ValueError):
+        count_nonzero(X_csr_t, axis=2).execute()
+
+    assert count_nonzero(X_csr_t, axis=0).dtype == count_nonzero(X_csr_t, axis=1).dtype
+    assert (
+        count_nonzero(X_csr_t, axis=0, sample_weight=sample_weight).dtype
+        == count_nonzero(X_csr_t, axis=1, sample_weight=sample_weight).dtype
+    )
+
+    # Check dtypes with large sparse matrices too
+    # XXX: test fails on 32bit (Windows/Linux)
+    try:
+        X_csr.indices = X_csr.indices.astype(np.int64)
+        X_csr.indptr = X_csr.indptr.astype(np.int64)
+        X_csr_t = mt.tensor(X_csr, chunk_size=3)
+
+        assert (
+            count_nonzero(X_csr_t, axis=0).dtype == count_nonzero(X_csr_t, axis=1).dtype
+        )
+        assert (
+            count_nonzero(X_csr_t, axis=0, sample_weight=sample_weight).dtype
+            == count_nonzero(X_csr_t, axis=1, sample_weight=sample_weight).dtype
+        )
+    except TypeError as e:
+        assert "according to the rule 'safe'" in e.args[0] and np.intp().nbytes < 8, e


### PR DESCRIPTION
Backport of #2554 and #2562