### PR TITLE
Optimize tileable graph construction

### DIFF
--- a/mars/core/base.py
+++ b/mars/core/base.py
@@ -47,10 +47,23 @@ class Base(Serializable):
             return slots
 
     @property
+    def _copy_tags_(self):
+        cls = type(self)
+        member = f"__copy_tags_{cls.__name__}"
+        try:
+            return getattr(cls, member)
+        except AttributeError:
+            slots = sorted(
+                f.attr_name
+                for k, f in self._FIELDS.items()
+                if k not in self._no_copy_attrs_
+            )
+            setattr(cls, member, slots)
+            return slots
+
+    @property
     def _values_(self):
-        return [
-            v for k, v in self.__field_values__.items() if k not in self._no_copy_attrs_
-        ]
+        return [self._FIELD_VALUES.get(k) for k in self._copy_tags_]
 
     def __mars_tokenize__(self):
         try:

--- a/mars/core/base.py
+++ b/mars/core/base.py
@@ -68,7 +68,7 @@ class Base(Serializable):
     def __mars_tokenize__(self):
         try:
             return self._key
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             self._update_key()
             return self._key
 

--- a/mars/core/base.py
+++ b/mars/core/base.py
@@ -49,14 +49,15 @@ class Base(Serializable):
     @property
     def _values_(self):
         return [
-            getattr(self, k, None) for k in self._keys_ if k not in self._no_copy_attrs_
+            v for k, v in self.__field_values__.items() if k not in self._no_copy_attrs_
         ]
 
     def __mars_tokenize__(self):
-        if hasattr(self, "_key"):
+        try:
             return self._key
-        else:
-            return (type(self), *self._values_)
+        except AttributeError:
+            self._update_key()
+            return self._key
 
     def _obj_set(self, k, v):
         object.__setattr__(self, k, v)

--- a/mars/core/entity/tileables.py
+++ b/mars/core/entity/tileables.py
@@ -284,7 +284,7 @@ class TileableData(EntityData, _ExecutableMixin):
             chunks = self._chunks
             if chunks:
                 self._chunks = sorted(chunks, key=attrgetter("index"))
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             pass
 
         self._entities = WeakSet()
@@ -416,7 +416,7 @@ class HasShapeTileableData(TileableData):
     def __len__(self):
         try:
             return int(self.shape[0])
-        except (IndexError, ValueError):
+        except (IndexError, ValueError):  # pragma: no cover
             return 0
 
     @property

--- a/mars/core/mode.py
+++ b/mars/core/mode.py
@@ -91,5 +91,6 @@ def enter_mode(kernel=None, build=None):
         "kernel": kernel,
         "build": build,
     }
+    mode_name_to_value = {k: v for k, v in mode_name_to_value.items() if v is not None}
 
     return _EnterModeFuncWrapper(mode_name_to_value)

--- a/mars/core/operand/base.py
+++ b/mars/core/operand/base.py
@@ -127,6 +127,7 @@ class Operand(Base, metaclass=OperandMetaclass):
     attr_tag = "attr"
     _init_update_key_ = False
     _output_type_ = None
+    _no_copy_attrs_ = Base._no_copy_attrs_ | {"scheduling_hint"}
 
     sparse = BoolField("sparse", default=False)
     device = Int32Field("device", default=None)

--- a/mars/core/operand/core.py
+++ b/mars/core/operand/core.py
@@ -23,7 +23,7 @@ except ImportError:  # pragma: no cover
     UFuncTypeError = None
 
 from ...typing import TileableType, ChunkType, OperandType
-from ...utils import calc_data_size
+from ...utils import calc_data_size, tokenize
 from ..context import Context
 from ..mode import is_eager_mode
 from ..entity import (
@@ -189,6 +189,10 @@ class TileableOperandMixin:
 
         if isinstance(output_type, (list, tuple)):
             output_type = output_type[output_idx]
+
+        if '_key' not in kw:
+            kw['_key'] = tokenize(self._key, output_idx, output_type.value)
+
         tileable_type, tileable_data_type = get_tileable_types(output_type)
         kw["_i"] = output_idx
         kw["op"] = self

--- a/mars/dataframe/__init__.py
+++ b/mars/dataframe/__init__.py
@@ -52,21 +52,21 @@ from . import datastore
 from . import window
 from . import plotting
 
-del (
-    reduction,
-    statistics,
-    arithmetic,
-    indexing,
-    merge_,
-    base,
-    groupby,
-    missing,
-    ufunc,
-    datastore,
-    sort,
-    window,
-    plotting,
-)
+# del (
+#     reduction,
+#     statistics,
+#     arithmetic,
+#     indexing,
+#     merge_,
+#     base,
+#     groupby,
+#     missing,
+#     ufunc,
+#     datastore,
+#     sort,
+#     window,
+#     plotting,
+# )
 del DataFrameFetch, DataFrameFetchShuffle
 
 # noinspection PyUnresolvedReferences

--- a/mars/dataframe/__init__.py
+++ b/mars/dataframe/__init__.py
@@ -52,21 +52,21 @@ from . import datastore
 from . import window
 from . import plotting
 
-# del (
-#     reduction,
-#     statistics,
-#     arithmetic,
-#     indexing,
-#     merge_,
-#     base,
-#     groupby,
-#     missing,
-#     ufunc,
-#     datastore,
-#     sort,
-#     window,
-#     plotting,
-# )
+del (
+    reduction,
+    statistics,
+    arithmetic,
+    indexing,
+    merge_,
+    base,
+    groupby,
+    missing,
+    ufunc,
+    datastore,
+    sort,
+    window,
+    plotting,
+)
 del DataFrameFetch, DataFrameFetchShuffle
 
 # noinspection PyUnresolvedReferences

--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -434,8 +434,8 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
         ):
             x2_dtype = x2.dtype if hasattr(x2, "dtype") else type(x2)
             x2_dtype = get_dtype(x2_dtype)
-            if hasattr(cls, "dtype"):
-                dtype = cls.dtype
+            if hasattr(cls, "return_dtype"):
+                dtype = cls.return_dtype
             else:
                 dtype = infer_dtype(x1.dtype, x2_dtype, cls._operator)
             ret = {"shape": x1.shape, "dtype": dtype, "index_value": x1.index_value}

--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -434,7 +434,10 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
         ):
             x2_dtype = x2.dtype if hasattr(x2, "dtype") else type(x2)
             x2_dtype = get_dtype(x2_dtype)
-            dtype = infer_dtype(x1.dtype, x2_dtype, cls._operator)
+            if hasattr(cls, "dtype"):
+                dtype = cls.dtype
+            else:
+                dtype = infer_dtype(x1.dtype, x2_dtype, cls._operator)
             ret = {"shape": x1.shape, "dtype": dtype, "index_value": x1.index_value}
             if pd.api.types.is_scalar(x2) or (
                 hasattr(x2, "ndim") and (x2.ndim == 0 or x2.ndim == 1)

--- a/mars/dataframe/arithmetic/equal.py
+++ b/mars/dataframe/arithmetic/equal.py
@@ -26,7 +26,7 @@ class DataFrameEqual(DataFrameBinopUfunc):
     _func_name = "eq"
     _rfunc_name = "eq"
 
-    dtype = np.dtype(bool)
+    return_dtype = np.dtype(bool)
 
     @classproperty
     def _operator(self):

--- a/mars/dataframe/arithmetic/equal.py
+++ b/mars/dataframe/arithmetic/equal.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from ... import opcodes as OperandDef
 from ...utils import classproperty
 from .core import DataFrameBinopUfunc
@@ -23,6 +25,8 @@ class DataFrameEqual(DataFrameBinopUfunc):
 
     _func_name = "eq"
     _rfunc_name = "eq"
+
+    dtype = np.dtype(bool)
 
     @classproperty
     def _operator(self):

--- a/mars/dataframe/arithmetic/greater.py
+++ b/mars/dataframe/arithmetic/greater.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from ... import opcodes as OperandDef
 from ...utils import classproperty
 from .core import DataFrameBinopUfunc
@@ -23,6 +25,8 @@ class DataFrameGreater(DataFrameBinopUfunc):
 
     _func_name = "gt"
     _rfunc_name = "lt"
+
+    return_dtype = np.dtype(bool)
 
     @classproperty
     def _operator(self):

--- a/mars/dataframe/arithmetic/greater_equal.py
+++ b/mars/dataframe/arithmetic/greater_equal.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from ... import opcodes as OperandDef
 from ...utils import classproperty
 from .core import DataFrameBinopUfunc
@@ -23,6 +25,8 @@ class DataFrameGreaterEqual(DataFrameBinopUfunc):
 
     _func_name = "ge"
     _rfunc_name = "le"
+
+    dtype = np.dtype(bool)
 
     @classproperty
     def _operator(self):

--- a/mars/dataframe/arithmetic/greater_equal.py
+++ b/mars/dataframe/arithmetic/greater_equal.py
@@ -26,7 +26,7 @@ class DataFrameGreaterEqual(DataFrameBinopUfunc):
     _func_name = "ge"
     _rfunc_name = "le"
 
-    dtype = np.dtype(bool)
+    return_dtype = np.dtype(bool)
 
     @classproperty
     def _operator(self):

--- a/mars/dataframe/arithmetic/less.py
+++ b/mars/dataframe/arithmetic/less.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 
 from ... import opcodes as OperandDef
 from ...utils import classproperty
@@ -24,6 +25,8 @@ class DataFrameLess(DataFrameBinopUfunc):
 
     _func_name = "lt"
     _rfunc_name = "gt"
+
+    return_dtype = np.dtype(bool)
 
     @classproperty
     def _operator(self):

--- a/mars/dataframe/arithmetic/less_equal.py
+++ b/mars/dataframe/arithmetic/less_equal.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from ... import opcodes as OperandDef
 from ...utils import classproperty
 from .core import DataFrameBinopUfunc
@@ -23,6 +25,8 @@ class DataFrameLessEqual(DataFrameBinopUfunc):
 
     _func_name = "le"
     _rfunc_name = "ge"
+
+    dtype = np.dtype(bool)
 
     @classproperty
     def _operator(self):

--- a/mars/dataframe/arithmetic/less_equal.py
+++ b/mars/dataframe/arithmetic/less_equal.py
@@ -26,7 +26,7 @@ class DataFrameLessEqual(DataFrameBinopUfunc):
     _func_name = "le"
     _rfunc_name = "ge"
 
-    dtype = np.dtype(bool)
+    return_dtype = np.dtype(bool)
 
     @classproperty
     def _operator(self):

--- a/mars/dataframe/arithmetic/not_equal.py
+++ b/mars/dataframe/arithmetic/not_equal.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from ... import opcodes as OperandDef
 from ...utils import classproperty
 from .core import DataFrameBinopUfunc
@@ -23,6 +25,8 @@ class DataFrameNotEqual(DataFrameBinopUfunc):
 
     _func_name = "ne"
     _rfunc_name = "ne"
+
+    return_dtype = np.dtype(bool)
 
     @classproperty
     def _operator(self):

--- a/mars/dataframe/arrays.py
+++ b/mars/dataframe/arrays.py
@@ -55,6 +55,7 @@ except ImportError:  # pragma: no cover
 from ..config import options
 from ..core import is_kernel_mode
 from ..lib.version import parse as parse_version
+from ..utils import tokenize
 
 _use_bool_any_all = parse_version(pd.__version__) >= parse_version("1.3.0")
 
@@ -581,12 +582,14 @@ class ArrowArray(ExtensionArray):
 
     def __mars_tokenize__(self):
         if self._use_arrow:
-            return [
-                memoryview(x)
-                for chunk in self._arrow_array.chunks
-                for x in chunk.buffers()
-                if x is not None
-            ]
+            return tokenize(
+                [
+                    memoryview(x)
+                    for chunk in self._arrow_array.chunks
+                    for x in chunk.buffers()
+                    if x is not None
+                ]
+            )
         else:
             return self._ndarray
 

--- a/mars/dataframe/base/map_chunk.py
+++ b/mars/dataframe/base/map_chunk.py
@@ -172,6 +172,7 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
 
         out_chunks = []
         nsplits = [[]] if out.ndim == 1 else [[], [out.shape[1]]]
+        pd_out_index = out.index_value.to_pandas()
         for chunk in inp.chunks:
             chunk_op = op.copy().reset_key()
             chunk_op.tileable_op_key = op.key
@@ -180,9 +181,7 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
                     shape = (np.nan, out.shape[1])
                 else:
                     shape = (chunk.shape[0], out.shape[1])
-                index_value = parse_index(
-                    out.index_value.to_pandas(), chunk, op.func, op.args, op.kwargs
-                )
+                index_value = parse_index(pd_out_index, chunk, op.key)
                 out_chunk = chunk_op.new_chunk(
                     [chunk],
                     shape=shape,
@@ -198,9 +197,7 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
                     shape = (np.nan,)
                 else:
                     shape = (chunk.shape[0],)
-                index_value = parse_index(
-                    out.index_value.to_pandas(), chunk, op.func, op.args, op.kwargs
-                )
+                index_value = parse_index(pd_out_index, chunk, op.key)
                 out_chunk = chunk_op.new_chunk(
                     [chunk],
                     shape=shape,

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -1597,6 +1597,7 @@ class Series(HasShapeTileable, _ToPandasMixin):
 
 class BaseDataFrameChunkData(ChunkData):
     __slots__ = ("_dtypes_value",)
+    _no_copy_attrs_ = ChunkData._no_copy_attrs_ | {"_dtypes"}
 
     # required fields
     _shape = TupleField(

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+import operator
 import weakref
 from collections.abc import Iterable
 from io import StringIO
@@ -1730,7 +1732,7 @@ class DataFrameChunk(Chunk):
 
 
 class BaseDataFrameData(HasShapeTileableData, _ToPandasMixin):
-    __slots__ = "_accessors", "_dtypes_value"
+    __slots__ = "_accessors", "_dtypes_value", "_dtypes_dict"
 
     # optional fields
     _dtypes = SeriesField("dtypes")
@@ -1770,6 +1772,7 @@ class BaseDataFrameData(HasShapeTileableData, _ToPandasMixin):
         )
         self._accessors = dict()
         self._dtypes_value = None
+        self._dtypes_dict = None
 
     def _get_params(self) -> Dict[str, Any]:
         # params return the properties which useful to rebuild a new tileable object
@@ -1878,6 +1881,27 @@ class BaseDataFrameData(HasShapeTileableData, _ToPandasMixin):
     @property
     def axes(self):
         return [self.index, self.columns]
+
+    def _get_dtypes_dict(self):
+        if self._dtypes_dict is None:
+            self._dtypes_dict = d = dict()
+            for k, v in self.dtypes.items():
+                try:
+                    obj_list = d[k]
+                except KeyError:
+                    obj_list = d[k] = []
+                obj_list.append(v)
+        return self._dtypes_dict
+
+    def _get_dtypes_by_columns(self, columns: list):
+        dtypes_dict = self._get_dtypes_dict()
+        return functools.reduce(operator.add, (dtypes_dict[c] for c in columns), [])
+
+    def _get_columns_by_columns(self, columns: list):
+        dtypes_dict = self._get_dtypes_dict()
+        return functools.reduce(
+            operator.add, ([c] * len(dtypes_dict[c]) for c in columns), []
+        )
 
 
 class DataFrameData(_BatchedFetcher, BaseDataFrameData):

--- a/mars/dataframe/datasource/dataframe.py
+++ b/mars/dataframe/datasource/dataframe.py
@@ -33,6 +33,10 @@ class DataFrameDataSource(DataFrameOperand, DataFrameOperandMixin):
     data = DataFrameField("data")
     dtypes = SeriesField("dtypes")
 
+    def _tokenize_output(self, output_idx: int, **kw):
+        # make sure all necessary arguments tokenized
+        return None
+
     def __init__(self, data=None, dtypes=None, gpu=None, **kw):
         if dtypes is None and data is not None:
             dtypes = data.dtypes

--- a/mars/dataframe/datasource/from_tensor.py
+++ b/mars/dataframe/datasource/from_tensor.py
@@ -71,6 +71,10 @@ class DataFrameFromTensor(DataFrameOperand, DataFrameOperandMixin):
     def index(self):
         return self._index
 
+    def _tokenize_output(self, output_idx: int, **kw):
+        # make sure all necessary arguments tokenized
+        return None
+
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
         inputs_iter = iter(self._inputs)

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -605,8 +605,15 @@ def build_empty_series(dtype, index=None, name=None):
     )
 
 
-def build_series(series_obj=None, fill_value=1, size=1, name=None, ensure_string=False,
-                 dtype=None, index=None):
+def build_series(
+    series_obj=None,
+    fill_value=1,
+    size=1,
+    name=None,
+    ensure_string=False,
+    dtype=None,
+    index=None,
+):
     seriess = []
     if not isinstance(size, (list, tuple)):
         sizes = [size]

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -605,7 +605,8 @@ def build_empty_series(dtype, index=None, name=None):
     )
 
 
-def build_series(series_obj, fill_value=1, size=1, name=None, ensure_string=False):
+def build_series(series_obj=None, fill_value=1, size=1, name=None, ensure_string=False,
+                 dtype=None, index=None):
     seriess = []
     if not isinstance(size, (list, tuple)):
         sizes = [size]
@@ -617,11 +618,18 @@ def build_series(series_obj, fill_value=1, size=1, name=None, ensure_string=Fals
     else:
         fill_values = fill_value
 
+    if series_obj is not None:
+        dtype = series_obj.dtype
+        try:
+            series_index = series_obj.index_value.to_pandas()[:0]
+        except AttributeError:
+            series_index = series_obj.index[:0]
+    else:
+        series_index = index[:0] if index else None
+
     for size, fill_value in zip(sizes, fill_values):
-        empty_series = build_empty_series(
-            series_obj.dtype, name=name, index=series_obj.index_value.to_pandas()[:0]
-        )
-        record = _generate_value(series_obj.dtype, fill_value)
+        empty_series = build_empty_series(dtype, name=name, index=series_index)
+        record = _generate_value(dtype, fill_value)
         if isinstance(empty_series.index, pd.MultiIndex):
             index = tuple(
                 _generate_value(level.dtype, fill_value)
@@ -640,7 +648,7 @@ def build_series(series_obj, fill_value=1, size=1, name=None, ensure_string=Fals
 
         empty_series = pd.concat([empty_series] * size)
         # make sure dtype correct for MultiIndex
-        empty_series = empty_series.astype(series_obj.dtype, copy=False)
+        empty_series = empty_series.astype(dtype, copy=False)
         seriess.append(empty_series)
 
     if len(seriess) == 1:
@@ -648,7 +656,7 @@ def build_series(series_obj, fill_value=1, size=1, name=None, ensure_string=Fals
     else:
         ret_series = pd.concat(seriess)
 
-    if ensure_string and series_obj.dtype == np.dtype("O"):
+    if ensure_string and dtype == np.dtype("O"):
         ret_series = ret_series.radd("O")
     return ret_series
 
@@ -884,6 +892,7 @@ def infer_dtypes(left_dtypes, right_dtypes, operator):
     return operator(left, right).dtypes
 
 
+@functools.lru_cache(100)
 def infer_dtype(left_dtype, right_dtype, operator):
     left = build_empty_series(left_dtype)
     right = build_empty_series(right_dtype)

--- a/mars/serialization/serializables/core.py
+++ b/mars/serialization/serializables/core.py
@@ -58,10 +58,9 @@ class Serializable(metaclass=SerializableMeta):
         if args:  # pragma: no cover
             values = dict(zip(self.__slots__, args))
             values.update(kwargs)
+            self._FIELD_VALUES = values
         else:
-            values = kwargs
-
-        self._FIELD_VALUES = values
+            self._FIELD_VALUES = kwargs
 
     def __repr__(self):
         values = ", ".join(

--- a/mars/serialization/serializables/field.py
+++ b/mars/serialization/serializables/field.py
@@ -565,7 +565,7 @@ class OneOfField(Field):
         return FieldTypes.any
 
     def __set__(self, instance, value):
-        if not _is_ci:
+        if not _is_ci:  # pragma: no cover
             return super().__set__(instance, value)
 
         field_values = instance._FIELD_VALUES

--- a/mars/serialization/serializables/tests/test_serializable.py
+++ b/mars/serialization/serializables/tests/test_serializable.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+import os
 from collections import namedtuple
 from datetime import timezone
 
@@ -63,6 +65,22 @@ from .. import (
 )
 
 my_namedtuple = namedtuple("my_namedtuple", "a, b")
+
+
+@pytest.fixture(autouse=True)
+def set_environ():
+    from .. import field
+
+    _notset = field._notset
+    try:
+        os.environ["CI"] = "true"
+        importlib.reload(field)
+        field._notset = _notset
+        yield
+    finally:
+        os.environ.pop("CI", None)
+        importlib.reload(field)
+        field._notset = _notset
 
 
 class MyHasKey(EntityData):
@@ -174,7 +192,7 @@ def test_serializable():
 
 def _assert_serializable_eq(my_serializable, my_serializable2):
     for field_name, field in my_serializable._FIELDS.items():
-        if field.tag not in my_serializable.__field_values__:
+        if field.tag not in my_serializable._FIELD_VALUES:
             continue
         expect_value = getattr(my_serializable, field_name)
         actual_value = getattr(my_serializable2, field_name)

--- a/mars/serialization/serializables/tests/test_serializable.py
+++ b/mars/serialization/serializables/tests/test_serializable.py
@@ -174,7 +174,7 @@ def test_serializable():
 
 def _assert_serializable_eq(my_serializable, my_serializable2):
     for field_name, field in my_serializable._FIELDS.items():
-        if field.tag not in my_serializable._FIELD_VALUES:
+        if field.tag not in my_serializable.__field_values__:
             continue
         expect_value = getattr(my_serializable, field_name)
         actual_value = getattr(my_serializable2, field_name)

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -646,7 +646,7 @@ class TaskProcessorActor(mo.Actor):
 
             props = {
                 k: v
-                for k, v in getattr(tileable.op, "_FIELD_VALUES").items()
+                for k, v in getattr(tileable.op, "__field_values__").items()
                 if k != "key" and isinstance(v, (int, float, str))
             }
 

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -644,10 +644,13 @@ class TaskProcessorActor(mo.Actor):
             else:
                 status = SubtaskStatus.running
 
+            fields = tileable.op._FIELDS
+            field_values = tileable.op._FIELD_VALUES
             props = {
-                k: v
-                for k, v in getattr(tileable.op, "__field_values__").items()
-                if k != "key" and isinstance(v, (int, float, str))
+                fields[attr_name].tag: value
+                for attr_name, value in field_values.items()
+                if attr_name not in ("_key", "_id")
+                and isinstance(value, (int, float, str))
             }
 
             tileable_infos[tileable.key] = {

--- a/mars/services/task/tests/test_service.py
+++ b/mars/services/task/tests/test_service.py
@@ -393,18 +393,13 @@ async def test_get_tileable_details(start_test_service):
     details = await task_api.get_tileable_details(task_id)
     assert details[r7.key]["status"] == SubtaskStatus.errored.value
 
-    contain_id_property = False
     for tileable in details.keys():
         for property_key, property_value in (
             details.get(tileable).get("properties").items()
         ):
             assert property_key != "key"
+            assert property_key != "id"
             assert isinstance(property_value, (int, float, str))
-
-            if property_key == "id":
-                contain_id_property = True
-
-    assert contain_id_property == True
 
 
 @pytest.mark.asyncio

--- a/mars/tensor/datasource/core.py
+++ b/mars/tensor/datasource/core.py
@@ -32,6 +32,10 @@ class TensorDataSource(TensorOperand, TensorOperandMixin):
 
     __slots__ = ()
 
+    def _tokenize_output(self, output_idx: int, **kw):
+        # make sure all necessary arguments tokenized
+        return None
+
     def to_chunk_op(self, *args):
         chunk_shape = args[0]
         chunk_op = self.copy().reset_key()

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -233,6 +233,8 @@ def test_chunks_indexer():
     expected = a.chunks[0].key
     assert chunk_key == expected
 
+    # as chunks[9] and chunks[10] shares the same shape,
+    #  their keys should be equal.
     chunk_key = a.cix[1, 1, 1].key
     expected = a.chunks[9].key
     assert chunk_key == expected


### PR DESCRIPTION
## What do these changes do?

This PR did things below:

1. Put dicts of attribute names directly instead of tags
2. Use dtype of arithmetic operands if specified
3. Optimize obtaining dtypes of aggregation
4. Reduce costs of tokenize by using output indices for tileable objects

## Related issue number

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
