### PR TITLE
Add basic profiling support for supervisor

### DIFF
--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -16,6 +16,7 @@ import importlib
 import os
 import pickle
 import pkgutil
+import time
 import types
 import uuid
 from collections import deque
@@ -401,6 +402,18 @@ cpdef tuple insert_reversed_tuple(tuple a, object x):
 @cython.cdivision(True)
 cpdef long long ceildiv(long long x, long long y) nogil:
     return x // y + (x % y != 0)
+
+
+cdef class Timer:
+    cdef object _start
+    cdef readonly object duration
+
+    def __enter__(self):
+        self._start = time.time()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.duration = time.time() - self._start
 
 
 __all__ = ['to_str', 'to_binary', 'to_text', 'TypeDispatcher', 'tokenize', 'tokenize_int',

--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -417,4 +417,4 @@ cdef class Timer:
 
 
 __all__ = ['to_str', 'to_binary', 'to_text', 'TypeDispatcher', 'tokenize', 'tokenize_int',
-           'register_tokenizer', 'insert_reversed_tuple', 'ceildiv']
+           'register_tokenizer', 'insert_reversed_tuple', 'ceildiv', 'Timer']

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -16,6 +16,7 @@ import asyncio
 import concurrent.futures
 import itertools
 import logging
+import json
 import random
 import string
 import threading
@@ -846,6 +847,12 @@ class _IsolatedSession(AbstractAsyncSession):
                         raise TimeoutError(
                             f"Task({task_id}) running time > {self.timeout}"
                         )
+            if task_result.profiling:
+                logger.warning(
+                    "Profile task %s execution result:\n%s",
+                    task_id,
+                    json.dumps(task_result.profiling, indent=4),
+                )
             if task_result.error:
                 raise task_result.error.with_traceback(task_result.traceback)
             if cancelled:

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -1558,7 +1558,10 @@ class SyncSession(AbstractSyncSession):
                 driver(), execution_info.loop
             ).result()
             new_execution_info = ExecutionInfo(
-                new_aio_task, execution_info._progress, execution_info.loop
+                new_aio_task,
+                execution_info._progress,
+                execution_info._profiling,
+                execution_info.loop,
             )
             return new_execution_info
 

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -321,8 +321,9 @@ async def _run_web_session_test(web_address):
     await session.destroy()
 
 
+@pytest.mark.parametrize("extra_config", [{"enable_profiling": True}, {}])
 @pytest.mark.asyncio
-async def test_web_session(create_cluster):
+async def test_web_session(create_cluster, extra_config):
     client = create_cluster[0]
     session_id = str(uuid.uuid4())
     web_address = client.web_address
@@ -330,7 +331,7 @@ async def test_web_session(create_cluster):
     assert await session.get_web_endpoint() == web_address
     session.as_default()
     assert isinstance(session._isolated_session, _IsolatedWebSession)
-    await test_execute(client)
+    await test_execute(client, extra_config)
     await test_iterative_tiling(client)
     AsyncSession.reset_default()
     await session.destroy()

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -36,7 +36,7 @@ from ....lib.aio import new_isolation
 from ....storage import StorageLevel
 from ....services.storage import StorageAPI
 from ....tensor.arithmetic.add import TensorAdd
-from ....tests.test_utils import test_dict_structure_same
+from ....tests.core import test_dict_structure_same
 from ..local import new_cluster
 from ..service import load_config
 from ..session import (

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -36,7 +36,7 @@ from ....lib.aio import new_isolation
 from ....storage import StorageLevel
 from ....services.storage import StorageAPI
 from ....tensor.arithmetic.add import TensorAdd
-from ....tests.core import test_dict_structure_same
+from ....tests.core import check_dict_structure_same
 from ..local import new_cluster
 from ..service import load_config
 from ..session import (
@@ -181,7 +181,7 @@ async def test_execute(create_cluster, extra_config):
                 },
             }
         }
-        test_dict_structure_same(info.profiling_result(), expect_structure)
+        check_dict_structure_same(info.profiling_result(), expect_structure)
     else:
         assert not info.profiling_result()
     assert info.result() is None

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -164,19 +164,20 @@ async def test_execute(create_cluster, extra_config):
         expect_structure = {
             "supervisor": {
                 "general": {
-                    "optimize": 0.0006198883056640625,
-                    "incref_fetch_tileables": 0.0011222362518310547,
+                    "optimize": 0.0005879402160644531,
+                    "incref_fetch_tileables": 0.0010840892791748047,
                     "stage_*": {
-                        "tile": 0.009758949279785156,
-                        "gen_subtask_graph": 0.008953094482421875,
-                        "run": 0.24303698539733887,
-                        "total": 0.2655649185180664,
+                        "tile": 0.008243083953857422,
+                        "gen_subtask_graph": 0.012202978134155273,
+                        "run": 0.27870702743530273,
+                        "total": 0.30318617820739746,
                     },
-                    "total": 0.2710378170013428,
+                    "total": 0.30951380729675293,
                 },
                 "serialization": {
-                    "serialize": 0.014154434204101562,
-                    "deserialize": 0.0011363029479980469,
+                    "serialize": 0.014928340911865234,
+                    "deserialize": 0.0011813640594482422,
+                    "total": 0.016109704971313477,
                 },
             }
         }

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -67,9 +67,10 @@ async def create_cluster(request):
 
 
 @require_ray
+@pytest.mark.parametrize("extra_config", [{"enable_profiling": True}, {}])
 @pytest.mark.asyncio
-async def test_execute(ray_large_cluster, create_cluster):
-    await test_local.test_execute(create_cluster)
+async def test_execute(ray_large_cluster, create_cluster, extra_config):
+    await test_local.test_execute(create_cluster, extra_config)
 
 
 @require_ray

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -165,10 +165,11 @@ async def test_optional_supervisor_node(ray_large_cluster, test_option):
 
 
 @require_ray
+@pytest.mark.parametrize("extra_config", [{"enable_profiling": True}, {}])
 @pytest.mark.asyncio
-async def test_web_session(ray_large_cluster, create_cluster):
+async def test_web_session(ray_large_cluster, create_cluster, extra_config):
     client = create_cluster[0]
-    await test_local.test_web_session(create_cluster)
+    await test_local.test_web_session(create_cluster, extra_config)
     web_address = client.web_address
     assert await ray.remote(_run_web_session).remote(web_address)
     assert await ray.remote(_sync_web_session_test).remote(web_address)

--- a/mars/oscar/backends/communication/socket.py
+++ b/mars/oscar/backends/communication/socket.py
@@ -14,12 +14,10 @@
 
 import asyncio
 import concurrent.futures as futures
-import logging
 import os
 import socket
 import sys
 import tempfile
-import time
 from abc import ABCMeta
 from asyncio import StreamReader, StreamWriter, AbstractServer
 from functools import lru_cache
@@ -27,7 +25,6 @@ from hashlib import md5
 from typing import Any, Dict, Callable, Coroutine, Type
 from urllib.parse import urlparse
 
-from ....oscar.profiling import ProfilingData
 from ....serialization import AioSerializer, AioDeserializer, deserialize
 from ....utils import implements, to_binary, classproperty
 from .base import Channel, ChannelType, Server, Client
@@ -35,7 +32,6 @@ from .core import register_client, register_server
 from .utils import read_buffers, write_buffers
 
 _is_windows: bool = sys.platform.startswith("win")
-logger = logging.getLogger(__name__)
 
 
 class SocketChannel(Channel):
@@ -72,22 +68,10 @@ class SocketChannel(Channel):
     @implements(Channel.send)
     async def send(self, message: Any):
         # get buffers
-        start_time = time.time()
         compress = self.compression or 0
         serializer = AioSerializer(message, compress=compress)
         buffers = await serializer.run()
-        try:
-            if message.profiling_context:
-                task_id = message.profiling_context.task_id
-                ProfilingData[task_id, "serialization"].inc(
-                    "serialize", time.time() - start_time
-                )
-        except AttributeError:
-            logger.debug(
-                "Profiling serialization got error, the send "
-                "message %s may not be an instance of message",
-                type(message),
-            )
+
         # write buffers
         write_buffers(self.writer, buffers)
         async with self._send_lock:
@@ -101,21 +85,7 @@ class SocketChannel(Channel):
         async with self._recv_lock:
             header = await deserializer.get_header()
             buffers = await read_buffers(header, self.reader)
-        start_time = time.time()
-        message = deserialize(header, buffers)
-        try:
-            if message.profiling_context is not None:
-                task_id = message.profiling_context.task_id
-                ProfilingData[task_id, "serialization"].inc(
-                    "deserialize", time.time() - start_time
-                )
-        except AttributeError:
-            logger.debug(
-                "Profiling serialization got error, the recv "
-                "message %s may not be an instance of message",
-                type(message),
-            )
-        return message
+        return deserialize(header, buffers)
 
     @implements(Channel.close)
     async def close(self):

--- a/mars/oscar/backends/communication/socket.py
+++ b/mars/oscar/backends/communication/socket.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import concurrent.futures as futures
+import logging
 import os
 import socket
 import sys
@@ -34,6 +35,7 @@ from .core import register_client, register_server
 from .utils import read_buffers, write_buffers
 
 _is_windows: bool = sys.platform.startswith("win")
+logger = logging.getLogger(__name__)
 
 
 class SocketChannel(Channel):

--- a/mars/oscar/backends/communication/socket.py
+++ b/mars/oscar/backends/communication/socket.py
@@ -76,7 +76,7 @@ class SocketChannel(Channel):
         buffers = await serializer.run()
         if message.profiling_context is not None:
             task_id = message.profiling_context.task_id
-            profiling = ProfilingData.serialization(task_id)
+            profiling = ProfilingData[task_id, "serialization"]
             if profiling is not None:
                 last = profiling.get("serialize", 0)
                 profiling["serialize"] = last + time.time() - start_time
@@ -98,7 +98,7 @@ class SocketChannel(Channel):
         message = deserialize(header, buffers)
         if message.profiling_context is not None:
             task_id = message.profiling_context.task_id
-            profiling = ProfilingData.serialization(task_id)
+            profiling = ProfilingData[task_id, "serialization"]
             if profiling is not None:
                 last = profiling.get("deserialize", 0)
                 profiling["deserialize"] = last + time.time() - start_time

--- a/mars/oscar/backends/communication/socket.py
+++ b/mars/oscar/backends/communication/socket.py
@@ -79,10 +79,9 @@ class SocketChannel(Channel):
         try:
             if message.profiling_context:
                 task_id = message.profiling_context.task_id
-                profiling = ProfilingData[task_id, "serialization"]
-                if profiling is not None:
-                    last = profiling.get("serialize", 0)
-                    profiling["serialize"] = last + time.time() - start_time
+                ProfilingData[task_id, "serialization"].inc(
+                    "serialize", time.time() - start_time
+                )
         except AttributeError:
             logger.debug(
                 "Profiling serialization got error, the send "
@@ -107,10 +106,9 @@ class SocketChannel(Channel):
         try:
             if message.profiling_context is not None:
                 task_id = message.profiling_context.task_id
-                profiling = ProfilingData[task_id, "serialization"]
-                if profiling is not None:
-                    last = profiling.get("deserialize", 0)
-                    profiling["deserialize"] = last + time.time() - start_time
+                ProfilingData[task_id, "serialization"].inc(
+                    "deserialize", time.time() - start_time
+                )
         except AttributeError:
             logger.debug(
                 "Profiling serialization got error, the recv "

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -38,6 +38,7 @@ from .message import (
     CancelMessage,
     ControlMessage,
     ControlMessageType,
+    ProfilingContext,
 )
 from .router import Router
 
@@ -155,10 +156,18 @@ class MarsActorContext(BaseActorContext):
         return self._process_result_message(result)
 
     async def send(
-        self, actor_ref: ActorRef, message: Tuple, wait_response: bool = True
+        self,
+        actor_ref: ActorRef,
+        message: Tuple,
+        wait_response: bool = True,
+        profiling_context: ProfilingContext = None,
     ):
         message = SendMessage(
-            new_message_id(), actor_ref, message, protocol=DEFAULT_PROTOCOL
+            new_message_id(),
+            actor_ref,
+            message,
+            protocol=DEFAULT_PROTOCOL,
+            profiling_context=profiling_context,
         )
 
         with debug_async_timeout(

--- a/mars/oscar/backends/message.py
+++ b/mars/oscar/backends/message.py
@@ -60,16 +60,24 @@ class MessageTraceItem:
     uid: str
     address: str
     method: str
+    task_id: str
+
+
+@dataslots
+@dataclass
+class ProfilingContext:
+    task_id: str
 
 
 class _MessageBase(ABC):
-    __slots__ = "protocol", "message_id", "message_trace"
+    __slots__ = "protocol", "message_id", "message_trace", "profiling_context"
 
     def __init__(
         self,
         message_id: bytes,
         protocol: int = None,
         message_trace: List[MessageTraceItem] = None,
+        profiling_context: ProfilingContext = None,
     ):
         self.message_id = message_id
         if protocol is None:
@@ -84,6 +92,7 @@ class _MessageBase(ABC):
         # `A` will find that id:1 already exists in inbox,
         # thus deadlock detected.
         self.message_trace = message_trace
+        self.profiling_context = profiling_context
 
     @classproperty
     @abstractmethod
@@ -137,8 +146,14 @@ class ResultMessage(_MessageBase):
         result: Any,
         protocol: int = None,
         message_trace: List[MessageTraceItem] = None,
+        profiling_context: ProfilingContext = None,
     ):
-        super().__init__(message_id, protocol=protocol, message_trace=message_trace)
+        super().__init__(
+            message_id,
+            protocol=protocol,
+            message_trace=message_trace,
+            profiling_context=profiling_context,
+        )
         self.result = result
 
     @classproperty
@@ -269,8 +284,14 @@ class SendMessage(_MessageBase):
         content: Any,
         protocol: int = None,
         message_trace: List[MessageTraceItem] = None,
+        profiling_context: ProfilingContext = None,
     ):
-        super().__init__(message_id, protocol=protocol, message_trace=message_trace)
+        super().__init__(
+            message_id,
+            protocol=protocol,
+            message_trace=message_trace,
+            profiling_context=profiling_context,
+        )
         self.actor_ref = actor_ref
         self.content = content
 

--- a/mars/oscar/backends/message.py
+++ b/mars/oscar/backends/message.py
@@ -60,7 +60,6 @@ class MessageTraceItem:
     uid: str
     address: str
     method: str
-    task_id: str
 
 
 @dataslots

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -523,7 +523,10 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
             with self._run_coro(message.message_id, coro) as future:
                 result = await future
             processor.result = ResultMessage(
-                message.message_id, result, protocol=message.protocol
+                message.message_id,
+                result,
+                protocol=message.protocol,
+                profiling_context=message.profiling_context,
             )
         return processor.result
 
@@ -538,7 +541,10 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
             asyncio.create_task(call)
             await asyncio.sleep(0)
             processor.result = ResultMessage(
-                message.message_id, None, protocol=message.protocol
+                message.message_id,
+                None,
+                protocol=message.protocol,
+                profiling_context=message.profiling_context,
             )
         return processor.result
 

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -58,7 +58,7 @@ def _serialize(self, value):
         serialized_object = _ray_serialize(self, value)
         if message.profiling_context is not None:
             task_id = message.profiling_context.task_id
-            profiling = ProfilingData.serialization(task_id)
+            profiling = ProfilingData[task_id, "serialization"]
             if profiling is not None:
                 last = profiling.get("serialize", 0)
                 profiling["serialize"] = last + time.time() - start_time
@@ -74,7 +74,7 @@ def _deserialize_object(self, data, metadata, object_ref):
         message = deserialize(*value.message)
         if message.profiling_context is not None:
             task_id = message.profiling_context.task_id
-            profiling = ProfilingData.serialization(task_id)
+            profiling = ProfilingData[task_id, "serialization"]
             if profiling is not None:
                 last = profiling.get("deserialize", 0)
                 profiling["deserialize"] = last + time.time() - start_time

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -75,7 +75,7 @@ if ray:
     def _deserialize_object(self, data, metadata, object_ref):
         start_time = time.time()
         value = _ray_deserialize_object(self, data, metadata, object_ref)
-        if type(value) is _ArgWrapper:
+        if type(value) is _ArgWrapper:  # pylint: disable=unidiomatic-typecheck
             message = deserialize(*value.message)
             try:
                 if message.profiling_context is not None:

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -50,7 +50,6 @@ if ray:
     _ray_serialize = ray.serialization.SerializationContext.serialize
     _ray_deserialize_object = ray.serialization.SerializationContext._deserialize_object
 
-
     def _serialize(self, value):
         if type(value) is _ArgWrapper:
             start_time = time.time()
@@ -60,10 +59,9 @@ if ray:
             try:
                 if message.profiling_context is not None:
                     task_id = message.profiling_context.task_id
-                    profiling = ProfilingData[task_id, "serialization"]
-                    if profiling is not None:
-                        last = profiling.get("serialize", 0)
-                        profiling["serialize"] = last + time.time() - start_time
+                    ProfilingData[task_id, "serialization"].inc(
+                        "serialize", time.time() - start_time
+                    )
             except AttributeError:
                 logger.debug(
                     "Profiling serialization got error, the send "
@@ -74,7 +72,6 @@ if ray:
             serialized_object = _ray_serialize(self, value)
         return serialized_object
 
-
     def _deserialize_object(self, data, metadata, object_ref):
         start_time = time.time()
         value = _ray_deserialize_object(self, data, metadata, object_ref)
@@ -83,10 +80,9 @@ if ray:
             try:
                 if message.profiling_context is not None:
                     task_id = message.profiling_context.task_id
-                    profiling = ProfilingData[task_id, "serialization"]
-                    if profiling is not None:
-                        last = profiling.get("deserialize", 0)
-                        profiling["deserialize"] = last + time.time() - start_time
+                    ProfilingData[task_id, "serialization"].inc(
+                        "deserialize", time.time() - start_time
+                    )
             except AttributeError:
                 logger.debug(
                     "Profiling serialization got error, the recv "
@@ -95,7 +91,6 @@ if ray:
                 )
             value = message
         return value
-
 
     ray.serialization.SerializationContext.serialize = _serialize
     ray.serialization.SerializationContext._deserialize_object = _deserialize_object

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -51,7 +51,7 @@ if ray:
     _ray_deserialize_object = ray.serialization.SerializationContext._deserialize_object
 
     def _serialize(self, value):
-        if type(value) is _ArgWrapper:
+        if type(value) is _ArgWrapper:  # pylint: disable=unidiomatic-typecheck
             start_time = time.time()
             message = value.message
             value.message = serialize(message)

--- a/mars/oscar/context.pyx
+++ b/mars/oscar/context.pyx
@@ -101,7 +101,7 @@ cdef class BaseActorContext:
         bool
         """
 
-    async def send(self, ActorRef actor_ref, object message, bint wait_response=True):
+    async def send(self, ActorRef actor_ref, object message, bint wait_response=True, object profiling_context=None):
         """
         Send a message to given actor by its reference
 
@@ -113,6 +113,8 @@ cdef class BaseActorContext:
             Message to send to an actor, need to comply to Actor.__on_receive__
         wait_response : bool
             Whether to wait for responses from the actor.
+        profiling_context: ProfilingContext
+            The profiling context.
 
         Returns
         -------

--- a/mars/oscar/context.pyx
+++ b/mars/oscar/context.pyx
@@ -191,9 +191,9 @@ cdef class ClientActorContext(BaseActorContext):
         context = self._get_backend_context(actor_ref.address)
         return context.actor_ref(actor_ref)
 
-    def send(self, ActorRef actor_ref, object message, bint wait_response=True):
+    def send(self, ActorRef actor_ref, object message, bint wait_response=True, object profiling_context=None):
         context = self._get_backend_context(actor_ref.address)
-        return context.send(actor_ref, message, wait_response=wait_response)
+        return context.send(actor_ref, message, wait_response=wait_response, profiling_context=profiling_context)
 
     def wait_actor_pool_recovered(self, str address, str main_address = None):
         context = self._get_backend_context(address)

--- a/mars/oscar/core.pxd
+++ b/mars/oscar/core.pxd
@@ -18,8 +18,8 @@ cdef class ActorRef:
     cdef public str address
     cdef public object uid
     cdef dict _methods
-    cdef __send__(self, object message)
-    cdef __tell__(self, object message, object delay=*)
+    cdef __send__(self, object message, object options)
+    cdef __tell__(self, object message, object options)
 
 
 cdef class _BaseActor:

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -15,6 +15,10 @@ class DummyOperator:
     def values():
         return []
 
+    @staticmethod
+    def empty():
+        return True
+
 
 class ProfilingDataOperator:
     __slots__ = ("_target",)
@@ -39,6 +43,9 @@ class ProfilingDataOperator:
 
     def values(self):
         return self._target.values()
+
+    def empty(self):
+        return len(self._target) == 0
 
 
 class _ProfilingData:

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -1,3 +1,18 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 class DummyOperator:
     @staticmethod
     def set(key, value):

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -8,12 +8,8 @@ class DummyOperator:
         pass
 
     @staticmethod
-    def setdefault(key, default=None):
+    def nest(key):
         return DummyOperator
-
-    @staticmethod
-    def get(key, default=None):
-        pass
 
     @staticmethod
     def values():
@@ -30,16 +26,16 @@ class ProfilingDataOperator:
         self._target[key] = value
 
     def inc(self, key, value):
-        old = getattr(self._target, key, 0)
+        old = self._target.get(key, 0)
         self._target[key] = old + value
 
-    def setdefault(self, key, default=None):
-        r = self._target.setdefault(key, default)
-        return DummyOperator if r is None else ProfilingDataOperator(r)
-
-    def get(self, key, default=None):
-        r = self._target.get(key, default)
-        return DummyOperator if r is None else ProfilingDataOperator(r)
+    def nest(self, key):
+        v = self._target.setdefault(key, {})
+        if not isinstance(v, dict):
+            raise TypeError(
+                f"The value type of key {key} is {type(v)}, but a dict is expected."
+            )
+        return ProfilingDataOperator(v)
 
     def values(self):
         return self._target.values()

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -1,3 +1,50 @@
+class DummyOperator:
+    @staticmethod
+    def set(key, value):
+        pass
+
+    @staticmethod
+    def inc(key, value):
+        pass
+
+    @staticmethod
+    def setdefault(key, default=None):
+        return DummyOperator
+
+    @staticmethod
+    def get(key, default=None):
+        pass
+
+    @staticmethod
+    def values():
+        return []
+
+
+class ProfilingDataOperator:
+    __slots__ = ("_target",)
+
+    def __init__(self, target):
+        self._target = target
+
+    def set(self, key, value):
+        self._target[key] = value
+
+    def inc(self, key, value):
+        old = getattr(self._target, key, 0)
+        self._target[key] = old + value
+
+    def setdefault(self, key, default=None):
+        r = self._target.setdefault(key, default)
+        return DummyOperator if r is None else ProfilingDataOperator(r)
+
+    def get(self, key, default=None):
+        r = self._target.get(key, default)
+        return DummyOperator if r is None else ProfilingDataOperator(r)
+
+    def values(self):
+        return self._target.values()
+
+
 class _ProfilingData:
     def __init__(self):
         self._data = {}
@@ -21,7 +68,7 @@ class _ProfilingData:
                 break
             else:
                 d = v
-        return v
+        return DummyOperator if v is None else ProfilingDataOperator(v)
 
 
 ProfilingData = _ProfilingData()

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -1,0 +1,30 @@
+from collections import OrderedDict
+
+
+class ProfilingData:
+    _data = {}
+
+    @classmethod
+    def init(cls, task_id: str):
+        cls._data[task_id] = {
+            "general": {},
+            "serialization": {},
+        }
+
+    @classmethod
+    def pop(cls, task_id: str):
+        return cls._data.pop(task_id, None)
+
+    @classmethod
+    def general(cls, task_id: str):
+        task_data = cls._data.get(task_id)
+        if task_data is not None:
+            return task_data["general"]
+        return None
+
+    @classmethod
+    def serialization(cls, task_id: str):
+        task_data = cls._data.get(task_id)
+        if task_data is not None:
+            return task_data["serialization"]
+        return None

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -1,30 +1,27 @@
-from collections import OrderedDict
+class _ProfilingData:
+    def __init__(self):
+        self._data = {}
 
-
-class ProfilingData:
-    _data = {}
-
-    @classmethod
-    def init(cls, task_id: str):
-        cls._data[task_id] = {
+    def init(self, task_id: str):
+        self._data[task_id] = {
             "general": {},
             "serialization": {},
         }
 
-    @classmethod
-    def pop(cls, task_id: str):
-        return cls._data.pop(task_id, None)
+    def pop(self, task_id: str):
+        return self._data.pop(task_id, None)
 
-    @classmethod
-    def general(cls, task_id: str):
-        task_data = cls._data.get(task_id)
-        if task_data is not None:
-            return task_data["general"]
-        return None
+    def __getitem__(self, item):
+        key = item if isinstance(item, tuple) else (item,)
+        v = None
+        d = self._data
+        for k in key:
+            v = d.get(k, None)
+            if v is None:
+                break
+            else:
+                d = v
+        return v
 
-    @classmethod
-    def serialization(cls, task_id: str):
-        task_data = cls._data.get(task_id)
-        if task_data is not None:
-            return task_data["serialization"]
-        return None
+
+ProfilingData = _ProfilingData()

--- a/mars/oscar/tests/test_profiling_data.py
+++ b/mars/oscar/tests/test_profiling_data.py
@@ -13,12 +13,14 @@ def test_profiling_data():
         assert ProfilingData["abc", "def", 1] is DummyOperator
         ProfilingData["def"].set("a", 1)
         ProfilingData["def"].inc("b", 1)
+        assert ProfilingData["def"].empty()
         assert sum(ProfilingData["def"].nest("a").values()) == 0
         ProfilingData["abc", "serialization"].set("a", 1)
         ProfilingData["abc", "serialization"].inc("b", 1)
         with pytest.raises(TypeError):
             assert ProfilingData["abc", "serialization"].nest("a")
         assert sum(ProfilingData["abc", "serialization"].nest("c").values()) == 0
+        assert not ProfilingData["abc", "serialization"].empty()
     finally:
         v = ProfilingData.pop("abc")
         check_dict_structure_same(

--- a/mars/oscar/tests/test_profiling_data.py
+++ b/mars/oscar/tests/test_profiling_data.py
@@ -1,3 +1,17 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 from ..profiling import ProfilingData, ProfilingDataOperator, DummyOperator
 from ...tests.core import check_dict_structure_same

--- a/mars/oscar/tests/test_profiling_data.py
+++ b/mars/oscar/tests/test_profiling_data.py
@@ -1,0 +1,14 @@
+from ..profiling import ProfilingData
+
+
+def test_profiling_data():
+    ProfilingData.init("abc")
+    try:
+        for n in ["general", "serialization"]:
+            assert n in ProfilingData["abc"]
+            assert type(ProfilingData["abc", n]) == dict
+        assert ProfilingData["def"] is None
+        assert ProfilingData["abc", "def"] is None
+        assert ProfilingData["abc", "def", 1] is None
+    finally:
+        ProfilingData.pop("abc")

--- a/mars/oscar/tests/test_profiling_data.py
+++ b/mars/oscar/tests/test_profiling_data.py
@@ -1,14 +1,26 @@
-from ..profiling import ProfilingData
+import pytest
+from ..profiling import ProfilingData, ProfilingDataOperator, DummyOperator
+from ...tests.core import check_dict_structure_same
 
 
 def test_profiling_data():
     ProfilingData.init("abc")
     try:
         for n in ["general", "serialization"]:
-            assert n in ProfilingData["abc"]
-            assert type(ProfilingData["abc", n]) == dict
-        assert ProfilingData["def"] is None
-        assert ProfilingData["abc", "def"] is None
-        assert ProfilingData["abc", "def", 1] is None
+            assert isinstance(ProfilingData["abc", n], ProfilingDataOperator)
+        assert ProfilingData["def"] is DummyOperator
+        assert ProfilingData["abc", "def"] is DummyOperator
+        assert ProfilingData["abc", "def", 1] is DummyOperator
+        ProfilingData["def"].set("a", 1)
+        ProfilingData["def"].inc("b", 1)
+        assert sum(ProfilingData["def"].nest("a").values()) == 0
+        ProfilingData["abc", "serialization"].set("a", 1)
+        ProfilingData["abc", "serialization"].inc("b", 1)
+        with pytest.raises(TypeError):
+            assert ProfilingData["abc", "serialization"].nest("a")
+        assert sum(ProfilingData["abc", "serialization"].nest("c").values()) == 0
     finally:
-        ProfilingData.pop("abc")
+        v = ProfilingData.pop("abc")
+        check_dict_structure_same(
+            v, {"general": {}, "serialization": {"a": 1, "b": 1, "c": {}}}
+        )

--- a/mars/services/subtask/api.py
+++ b/mars/services/subtask/api.py
@@ -14,6 +14,7 @@
 
 from ... import oscar as mo
 from ...lib.aio import alru_cache
+from ...oscar.backends.message import ProfilingContext
 from .core import Subtask
 
 
@@ -56,7 +57,15 @@ class SubtaskAPI:
 
         """
         ref = await self._get_runner_ref(band_name, slot_id)
-        return await ref.run_subtask(subtask)
+        extra_config = subtask.extra_config
+        profiling_context = (
+            ProfilingContext(task_id=subtask.task_id)
+            if extra_config and extra_config.get("enable_profiling")
+            else None
+        )
+        return await ref.run_subtask.options(profiling_context=profiling_context).send(
+            subtask
+        )
 
     async def cancel_subtask_in_slot(self, band_name: str, slot_id: int):
         """

--- a/mars/services/task/api/web.py
+++ b/mars/services/task/api/web.py
@@ -85,7 +85,7 @@ class TaskWebAPIHandler(MarsServiceWebAPIHandler):
         graph = body_args["graph"]
         extra_config = body_args.get("extra_config", None)
         if extra_config:
-            extra_config = deserialize_serializable(extra_config, client=True)
+            extra_config = deserialize_serializable(extra_config)
 
         oscar_api = await self._get_oscar_task_api(session_id)
         task_id = await oscar_api.submit_tileable_graph(

--- a/mars/services/task/api/web.py
+++ b/mars/services/task/api/web.py
@@ -41,6 +41,7 @@ def _json_serial_task_result(result: Optional[TaskResult]):
         "traceback": base64.b64encode(serialize_serializable(result.traceback)).decode()
         if result.traceback is not None
         else None,
+        "profiling": result.profiling,
     }
 
 
@@ -83,6 +84,8 @@ class TaskWebAPIHandler(MarsServiceWebAPIHandler):
 
         graph = body_args["graph"]
         extra_config = body_args.get("extra_config", None)
+        if extra_config:
+            extra_config = deserialize_serializable(extra_config, client=True)
 
         oscar_api = await self._get_oscar_task_api(session_id)
         task_id = await oscar_api.submit_tileable_graph(

--- a/mars/services/task/core.py
+++ b/mars/services/task/core.py
@@ -15,7 +15,7 @@
 import random
 from enum import Enum
 from string import ascii_letters, digits
-from typing import Any, Optional
+from typing import Any, Optional, Dict
 
 from ...core import TileableGraph
 from ...serialization.serializables import (
@@ -79,6 +79,7 @@ class TaskResult(Serializable):
     status: TaskStatus = ReferenceField("status", TaskStatus)
     error = AnyField("error")
     traceback = AnyField("traceback")
+    profiling: Dict = DictField("profiling")
 
     def __init__(
         self,
@@ -91,6 +92,7 @@ class TaskResult(Serializable):
         status: TaskStatus = None,
         error: Any = None,
         traceback: Any = None,
+        profiling: Dict = None,
     ):
         super().__init__(
             task_id=task_id,
@@ -102,6 +104,7 @@ class TaskResult(Serializable):
             status=status,
             error=error,
             traceback=traceback,
+            profiling=profiling,
         )
 
 

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -340,7 +340,7 @@ class TaskProcessor:
 
         stage_id = new_task_id()
         stage_profiling = None
-        profiling = ProfilingData.general(self._task.task_id)
+        profiling = ProfilingData[self._task.task_id, "general"]
         if profiling is not None:
             stage_profiling = profiling.setdefault(f"stage_{stage_id}", {})
 
@@ -397,7 +397,7 @@ class TaskProcessor:
     def finish(self):
         self.done.set()
         if self._task.extra_config and self._task.extra_config.get("enable_profiling"):
-            ProfilingData.general(self._task.task_id)["total"] = (
+            ProfilingData[self._task.task_id, "general"]["total"] = (
                 time.time() - self.result.start_time
             )
             data = ProfilingData.pop(self._task.task_id)
@@ -478,7 +478,7 @@ class TaskProcessorActor(mo.Actor):
         processor.result.status = TaskStatus.running
 
         incref_fetch, incref_result = False, False
-        profiling = ProfilingData.general(processor.task_id)
+        profiling = ProfilingData[processor.task_id, "general"]
         try:
             # optimization
             with timeit(profiling, "optimize"):

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -399,10 +399,12 @@ class TaskProcessor:
             ProfilingData[self._task.task_id, "general"].set(
                 "total", time.time() - self.result.start_time
             )
-            ProfilingData[self._task.task_id, "serialization"].set(
-                "total",
-                sum(ProfilingData[self._task.task_id, "serialization"].values()),
-            )
+            serialization = ProfilingData[self._task.task_id, "serialization"]
+            if not serialization.empty():
+                serialization.set(
+                    "total",
+                    sum(serialization.values()),
+                )
             data = ProfilingData.pop(self._task.task_id)
             self.result.profiling = {
                 "supervisor": data,

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -339,8 +339,8 @@ class TaskProcessor:
             return
 
         stage_id = new_task_id()
-        stage_profiling = ProfilingData[self._task.task_id, "general"].setdefault(
-            f"stage_{stage_id}", {}
+        stage_profiling = ProfilingData[self._task.task_id, "general"].nest(
+            f"stage_{stage_id}"
         )
         stage_profiling.set("tile", time.time() - start_time)
 
@@ -497,7 +497,7 @@ class TaskProcessorActor(mo.Actor):
                 stage_processor = yield processor.get_next_stage_processor()
                 if stage_processor is None:
                     break
-                stage_profiling = profiling.get(f"stage_{stage_processor.stage_id}")
+                stage_profiling = profiling.nest(f"stage_{stage_processor.stage_id}")
                 # track and incref result tileables
                 yield processor.incref_result_tileables()
                 incref_result = True

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -400,6 +400,9 @@ class TaskProcessor:
             ProfilingData[self._task.task_id, "general"]["total"] = (
                 time.time() - self.result.start_time
             )
+            ProfilingData[self._task.task_id, "serialization"]["total"] = sum(
+                ProfilingData[self._task.task_id, "serialization"].values()
+            )
             data = ProfilingData.pop(self._task.task_id)
             self.result.profiling = {
                 "supervisor": data,

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -363,7 +363,7 @@ class TaskProcessor:
             self._get_tileable_id_to_tileable
         )
         stage_processor = TaskStageProcessor(
-            new_task_id(),
+            stage_id,
             self._task,
             chunk_graph,
             subtask_graph,

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -12,9 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import fnmatch
 import functools
 import inspect
+import itertools
 import logging
 import os
 import sys
@@ -488,3 +489,27 @@ class ObjectCheckMixin:
             self.assert_index_consistent(expected, real)
         elif isinstance(expected, (CATEGORICAL_TYPE, CATEGORICAL_CHUNK_TYPE)):
             self.assert_categorical_consistent(expected, real)
+
+
+def test_dict_structure_same(a, b, prefix=None):
+    def _p(k):
+        return ".".join(str(i) for i in prefix + [k])
+
+    for ai, bi in itertools.zip_longest(
+        a.items(), b.items(), fillvalue=("_KEY_NOT_EXISTS_", None)
+    ):
+        if ai[0] != bi[0]:
+            if "*" in ai[0]:
+                pattern, target = ai[0], bi[0]
+            elif "*" in bi[0]:
+                pattern, target = bi[0], ai[0]
+            else:
+                raise KeyError(f"Key {_p(ai[0])} != {_p(bi[0])}")
+            if not fnmatch.fnmatch(target, pattern):
+                raise KeyError(f"Key {_p(target)} not match {_p(pattern)}")
+        if type(ai[1]) is not type(bi[1]):
+            raise TypeError(f"Value type of {_p(ai[0])} mismatch {ai[1]} != {bi[1]}")
+        if isinstance(ai[1], dict):
+            test_dict_structure_same(
+                ai[1], bi[1], [ai[0]] if prefix is None else prefix + [ai[0]]
+            )

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -493,6 +493,8 @@ class ObjectCheckMixin:
 
 def check_dict_structure_same(a, b, prefix=None):
     def _p(k):
+        if prefix is None:
+            return k
         return ".".join(str(i) for i in prefix + [k])
 
     for ai, bi in itertools.zip_longest(

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -491,7 +491,7 @@ class ObjectCheckMixin:
             self.assert_categorical_consistent(expected, real)
 
 
-def test_dict_structure_same(a, b, prefix=None):
+def check_dict_structure_same(a, b, prefix=None):
     def _p(k):
         return ".".join(str(i) for i in prefix + [k])
 
@@ -510,6 +510,6 @@ def test_dict_structure_same(a, b, prefix=None):
         if type(ai[1]) is not type(bi[1]):
             raise TypeError(f"Value type of {_p(ai[0])} mismatch {ai[1]} != {bi[1]}")
         if isinstance(ai[1], dict):
-            test_dict_structure_same(
+            check_dict_structure_same(
                 ai[1], bi[1], [ai[0]] if prefix is None else prefix + [ai[0]]
             )

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import copy
+import fnmatch
 import logging
 import multiprocessing
 import os
@@ -493,3 +494,18 @@ def test_web_serialize_lambda():
     s = utils.serialize_serializable(graph)
     f = utils.deserialize_serializable(s)
     assert isinstance(f, TileableGraph)
+
+
+def test_dict_structure_same(a, b):
+    for ai, bi in zip(a.items(), b.items()):
+        if ai[0] != bi[0]:
+            if "*" in ai[0]:
+                pattern, target = ai[0], bi[0]
+            elif "*" in bi[0]:
+                pattern, target = bi[0], ai[0]
+            else:
+                assert ai[0] == bi[0], f"Key {ai[0]} != {bi[0]}"
+            assert fnmatch.fnmatch(target, pattern), f"Key {target} not match {pattern}"
+        assert type(ai[1]) is type(bi[1]), f"Value type {ai[1]} != {bi[1]}"
+        if isinstance(ai[1], dict):
+            test_dict_structure_same(ai[1], bi[1])

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -16,6 +16,7 @@
 import asyncio
 import copy
 import fnmatch
+import itertools
 import logging
 import multiprocessing
 import os
@@ -496,16 +497,25 @@ def test_web_serialize_lambda():
     assert isinstance(f, TileableGraph)
 
 
-def test_dict_structure_same(a, b):
-    for ai, bi in zip(a.items(), b.items()):
+def test_dict_structure_same(a, b, prefix=None):
+    def _p(k):
+        return ".".join(str(i) for i in prefix + [k])
+
+    for ai, bi in itertools.zip_longest(
+        a.items(), b.items(), fillvalue=("_KEY_NOT_EXISTS_", None)
+    ):
         if ai[0] != bi[0]:
             if "*" in ai[0]:
                 pattern, target = ai[0], bi[0]
             elif "*" in bi[0]:
                 pattern, target = bi[0], ai[0]
             else:
-                assert ai[0] == bi[0], f"Key {ai[0]} != {bi[0]}"
-            assert fnmatch.fnmatch(target, pattern), f"Key {target} not match {pattern}"
-        assert type(ai[1]) is type(bi[1]), f"Value type {ai[1]} != {bi[1]}"
+                raise KeyError(f"Key {_p(ai[0])} != {_p(bi[0])}")
+            if not fnmatch.fnmatch(target, pattern):
+                raise KeyError(f"Key {_p(target)} not match {_p(pattern)}")
+        if type(ai[1]) is not type(bi[1]):
+            raise TypeError(f"Value type of {_p(ai[0])} mismatch {ai[1]} != {bi[1]}")
         if isinstance(ai[1], dict):
-            test_dict_structure_same(ai[1], bi[1])
+            test_dict_structure_same(
+                ai[1], bi[1], [ai[0]] if prefix is None else prefix + [ai[0]]
+            )

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -15,8 +15,6 @@
 
 import asyncio
 import copy
-import fnmatch
-import itertools
 import logging
 import multiprocessing
 import os
@@ -495,27 +493,3 @@ def test_web_serialize_lambda():
     s = utils.serialize_serializable(graph)
     f = utils.deserialize_serializable(s)
     assert isinstance(f, TileableGraph)
-
-
-def test_dict_structure_same(a, b, prefix=None):
-    def _p(k):
-        return ".".join(str(i) for i in prefix + [k])
-
-    for ai, bi in itertools.zip_longest(
-        a.items(), b.items(), fillvalue=("_KEY_NOT_EXISTS_", None)
-    ):
-        if ai[0] != bi[0]:
-            if "*" in ai[0]:
-                pattern, target = ai[0], bi[0]
-            elif "*" in bi[0]:
-                pattern, target = bi[0], ai[0]
-            else:
-                raise KeyError(f"Key {_p(ai[0])} != {_p(bi[0])}")
-            if not fnmatch.fnmatch(target, pattern):
-                raise KeyError(f"Key {_p(target)} not match {_p(pattern)}")
-        if type(ai[1]) is not type(bi[1]):
-            raise TypeError(f"Value type of {_p(ai[0])} mismatch {ai[1]} != {bi[1]}")
-        if isinstance(ai[1], dict):
-            test_dict_structure_same(
-                ai[1], bi[1], [ai[0]] if prefix is None else prefix + [ai[0]]
-            )

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1458,3 +1458,15 @@ def flatten_dict_to_nested_dict(flatten_dict: Dict, sep=".") -> Dict:
                 else:
                     sub_nested_dict = sub_nested_dict[sub_key]
     return nested_dict
+
+
+@contextmanager
+def timeit(result_dict, key):
+    if result_dict is None:
+        yield
+    else:
+        start_time = time.time()
+        try:
+            yield
+        finally:
+            result_dict[key] = time.time() - start_time

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -43,7 +43,7 @@ import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
 
-from ._utils import (  # noqa: F401; pylint: disable=unused-variable
+from ._utils import (  # noqa: F401 # pylint: disable=unused-import
     to_binary,
     to_str,
     to_text,

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -53,6 +53,7 @@ from ._utils import (
     register_tokenizer,
     insert_reversed_tuple,
     ceildiv,
+    Timer,
 )
 from .typing import ChunkType, TileableType, EntityType, OperandType
 
@@ -1067,16 +1068,6 @@ def enter_current_session(func: Callable):
         return result
 
     return wrapped
-
-
-class Timer:
-    def __enter__(self):
-        self._start = time.time()
-        return self
-
-    def __exit__(self, *_):
-        end = time.time()
-        self.duration = end - self._start
 
 
 _io_quiet_local = threading.local()

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -43,7 +43,7 @@ import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
 
-from ._utils import (
+from ._utils import (  # noqa: F401; pylint: disable=unused-variable
     to_binary,
     to_str,
     to_text,

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1458,15 +1458,3 @@ def flatten_dict_to_nested_dict(flatten_dict: Dict, sep=".") -> Dict:
                 else:
                     sub_nested_dict = sub_nested_dict[sub_key]
     return nested_dict
-
-
-@contextmanager
-def timeit(result_dict, key):
-    if result_dict is None:
-        yield
-    else:
-        start_time = time.time()
-        try:
-            yield
-        finally:
-            result_dict[key] = time.time() - start_time


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
- Add a `enable_profiling` extra config, default is False. e.g. `a.execute(show_progress=False, extra_config={"enable_profiling": True})`
- Fix `extra_config` for web session.
- Sample profile result for supervisor.

``` python
WARNING  mars.deploy.oscar.session:session.py:861 Profile task PO1e7wSe4DFpxzoFk5IKYiey execution result:
{
    "supervisor": {
        "general": {
            "optimize": 0.002045869827270508,
            "incref_fetch_tileables": 0.003548145294189453,
            "stage_g9ovAV2iVQQS20b2ym8lbrMt": {
                "tile": 0.02925896644592285,
                "gen_subtask_graph": 0.05370688438415527,
                "run": 0.19794082641601562,
                "total": 0.29035496711730957
            },
            "total": 0.299562931060791
        },
        "serialization": {
            "serialize": 0.014928340911865234,
            "deserialize": 0.0011813640594482422,
            "total": 0.016109704971313477
        }
    }
}
```

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
N/A

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
