### PR TITLE
Fix progress always is 0 or 100%

### DIFF
--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -827,7 +827,8 @@ class _IsolatedSession(AbstractAsyncSession):
                                 )
                             else:
                                 progress.value = 1.0
-                                break
+                        if task_result is not None:
+                            break
                     else:
                         # wait for task to finish
                         task_result: TaskResult = await self._task_api.wait_task(

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -814,17 +814,20 @@ class _IsolatedSession(AbstractAsyncSession):
             while True:
                 try:
                     if not cancelled:
-                        task_result: TaskResult = await self._task_api.wait_task(
-                            task_id, timeout=0.5
-                        )
-                        if task_result is None:
-                            # not finished, set progress
-                            progress.value = await self._task_api.get_task_progress(
-                                task_id
+                        task_result: Union[TaskResult, None] = None
+                        try:
+                            task_result = await self._task_api.wait_task(
+                                task_id, timeout=0.5
                             )
-                        else:
-                            progress.value = 1.0
-                            break
+                        finally:
+                            if task_result is None:
+                                # not finished, set progress
+                                progress.value = await self._task_api.get_task_progress(
+                                    task_id
+                                )
+                            else:
+                                progress.value = 1.0
+                                break
                     else:
                         # wait for task to finish
                         task_result: TaskResult = await self._task_api.wait_task(

--- a/mars/services/task/api/web.py
+++ b/mars/services/task/api/web.py
@@ -240,7 +240,9 @@ class WebTaskAPI(AbstractTaskAPI, MarsWebAPIClientMixin):
 
     async def wait_task(self, task_id: str, timeout: float = None):
         path = f"{self._address}/api/session/{self._session_id}/task/{task_id}"
-        params = {"action": "wait", "timeout": str(timeout or "")}
+        # client timeout should be longer than server timeout.
+        server_timeout = "" if timeout is None else str(max(timeout / 2.0, timeout - 1))
+        params = {"action": "wait", "timeout": server_timeout}
         res = await self._request_url(
             "GET", path, params=params, request_timeout=timeout or 0
         )


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
The web session use same timeout for client and server. Server timeout + RPC cost > client timeout, so the client call will always timeout, then the progress will not be updated.

- Always get progress even the previous call timeout.
- Set max(timeout / 2.0, timeout -1) for server.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes https://github.com/mars-project/mars/issues/2590

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
