### PR TITLE
Reduce RPC cost of oscar by removing unnecessary tasks

### DIFF
--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -870,15 +870,16 @@ class _IsolatedSession(AbstractAsyncSession):
                     progress.value = await self._task_api.get_task_progress(task_id)
                 if self.timeout is not None and time.time() - start_time > self.timeout:
                     raise TimeoutError(f"Task({task_id}) running time > {self.timeout}")
-            profiling.result = task_result.profiling
-            if task_result.profiling:
-                logger.warning(
-                    "Profile task %s execution result:\n%s",
-                    task_id,
-                    json.dumps(task_result.profiling, indent=4),
-                )
-            if task_result is not None and task_result.error:
-                raise task_result.error.with_traceback(task_result.traceback)
+            if task_result is not None:
+                profiling.result = task_result.profiling
+                if task_result.profiling:
+                    logger.warning(
+                        "Profile task %s execution result:\n%s",
+                        task_id,
+                        json.dumps(task_result.profiling, indent=4),
+                    )
+                if task_result.error:
+                    raise task_result.error.with_traceback(task_result.traceback)
             if cancelled:
                 return
             fetch_tileables = await self._task_api.get_fetch_tileables(task_id)

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -815,6 +815,28 @@ class _IsolatedSession(AbstractAsyncSession):
         else:
             return await cls._init(address, session_id, new=new, timeout=timeout)
 
+    async def _update_progress(self, task_id: str, progress: Progress):
+        zero_acc_time = 0
+        delay = 0.5
+        while True:
+            try:
+                last_progress_value = progress.value
+                progress.value = await self._task_api.get_task_progress(task_id)
+                if abs(progress.value - last_progress_value) < 1e-4:
+                    # if percentage does not change, we add delay time by 0.5 seconds every time
+                    zero_acc_time = min(5, zero_acc_time + 0.5)
+                    delay = zero_acc_time
+                else:
+                    # percentage changes, we use percentage speed to calc progress time
+                    zero_acc_time = 0
+                    speed = abs(progress.value - last_progress_value) / delay
+                    # one percent for one second
+                    delay = 0.01 / speed
+                delay = max(0.5, min(delay, 5.0))
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                break
+
     async def _run_in_background(
         self,
         tileables: list,
@@ -826,45 +848,28 @@ class _IsolatedSession(AbstractAsyncSession):
             # wait for task to finish
             cancelled = False
             start_time = time.time()
-            while True:
-                try:
-                    if not cancelled:
-                        task_result: Union[TaskResult, None] = None
-                        try:
-                            task_result = await self._task_api.wait_task(
-                                task_id, timeout=0.5
-                            )
-                        finally:
-                            if task_result is None:
-                                # not finished, set progress
-                                progress.value = await self._task_api.get_task_progress(
-                                    task_id
-                                )
-                            else:
-                                progress.value = 1.0
-                        if task_result is not None:
-                            break
-                    else:
-                        # wait for task to finish
-                        task_result: TaskResult = await self._task_api.wait_task(
-                            task_id
-                        )
-                        break
-                except asyncio.CancelledError:
-                    # cancelled
-                    cancelled = True
-                    await self._task_api.cancel_task(task_id)
-                except TimeoutError:  # pragma: no cover
-                    # ignore timeout when waiting for subtask progresses
-                    pass
-                finally:
-                    if (
-                        self.timeout is not None
-                        and time.time() - start_time > self.timeout
-                    ):
-                        raise TimeoutError(
-                            f"Task({task_id}) running time > {self.timeout}"
-                        )
+            progress_task = asyncio.create_task(
+                self._update_progress(task_id, progress)
+            )
+            task_result: Optional[TaskResult] = None
+            try:
+                task_result = await self._task_api.wait_task(task_id)
+            except asyncio.CancelledError:
+                # cancelled
+                cancelled = True
+                await self._task_api.cancel_task(task_id)
+            except TimeoutError:  # pragma: no cover
+                # ignore timeout when waiting for subtask progresses
+                pass
+            finally:
+                progress_task.cancel()
+                if task_result is not None:
+                    progress.value = 1.0
+                else:
+                    # not finished, set progress
+                    progress.value = await self._task_api.get_task_progress(task_id)
+                if self.timeout is not None and time.time() - start_time > self.timeout:
+                    raise TimeoutError(f"Task({task_id}) running time > {self.timeout}")
             profiling.result = task_result.profiling
             if task_result.profiling:
                 logger.warning(
@@ -872,7 +877,7 @@ class _IsolatedSession(AbstractAsyncSession):
                     task_id,
                     json.dumps(task_result.profiling, indent=4),
                 )
-            if task_result.error:
+            if task_result is not None and task_result.error:
                 raise task_result.error.with_traceback(task_result.traceback)
             if cancelled:
                 return

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -436,7 +436,7 @@ async def test_session_progress(create_cluster):
             break
         await asyncio.sleep(0.1)
     else:
-        raise Exception("progress test failed.")
+        raise Exception(f"progress test failed, actual value {info.progress()}.")
 
     await info
     assert info.result() is None

--- a/mars/oscar/backends/mars/pool.py
+++ b/mars/oscar/backends/mars/pool.py
@@ -240,7 +240,7 @@ class MainActorPool(MainActorPoolBase):
         await asyncio.to_thread(process.join, 5)
 
     async def is_sub_pool_alive(self, process: multiprocessing.Process):
-        return process.is_alive()
+        return await asyncio.to_thread(process.is_alive)
 
     async def recover_sub_pool(self, address: str):
         process_index = self._config.get_process_index(address)

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -14,7 +14,6 @@
 
 import asyncio
 import concurrent.futures as futures
-import contextlib
 import itertools
 import logging
 import os
@@ -311,12 +310,10 @@ class AbstractActorPool(ABC):
 
         return processor.result
 
-    @contextlib.contextmanager
-    def _run_coro(self, message_id: bytes, coro: Coroutine):
-        future = asyncio.create_task(coro)
-        self._process_messages[message_id] = future
+    async def _run_coro(self, message_id: bytes, coro: Coroutine):
+        self._process_messages[message_id] = asyncio.tasks.current_task()
         try:
-            yield future
+            return await coro
         finally:
             self._process_messages.pop(message_id, None)
 
@@ -329,10 +326,9 @@ class AbstractActorPool(ABC):
                 message,
                 channel,
             ):
-                with self._run_coro(
+                processor.result = await self._run_coro(
                     message.message_id, handler(self, message)
-                ) as future:
-                    processor.result = await future
+                )
         try:
             await channel.send(processor.result)
         except (ChannelClosed, ConnectionResetError):
@@ -461,8 +457,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
             actor.uid = actor_id
             actor.address = address = self.external_address
             self._actors[actor_id] = actor
-            with self._run_coro(message.message_id, actor.__post_create__()) as future:
-                await future
+            await self._run_coro(message.message_id, actor.__post_create__())
 
             result = ActorRef(address, actor_id)
             # ensemble result message
@@ -488,8 +483,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
                 actor = self._actors[actor_id]
             except KeyError:
                 raise ActorNotExist(f"Actor {actor_id} does not exist")
-            with self._run_coro(message.message_id, actor.__pre_destroy__()) as future:
-                await future
+            await self._run_coro(message.message_id, actor.__pre_destroy__())
             del self._actors[actor_id]
 
             processor.result = ResultMessage(
@@ -520,8 +514,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
             if actor_id not in self._actors:
                 raise ActorNotExist(f"Actor {actor_id} does not exist")
             coro = self._actors[actor_id].__on_receive__(message.content)
-            with self._run_coro(message.message_id, coro) as future:
-                result = await future
+            result = await self._run_coro(message.message_id, coro)
             processor.result = ResultMessage(
                 message.message_id,
                 result,

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -261,9 +261,9 @@ class RayServerChannel(RayChannelBase):
         return _ArgWrapper(result_message)
 
     @implements(Channel.close)
-    def close(self):
-        super().close()
-        self._out_queue.put(None)
+    async def close(self):
+        await super().close()
+        self._out_queue.put_nowait(None)
 
 
 @register_server

--- a/mars/oscar/batch.py
+++ b/mars/oscar/batch.py
@@ -134,7 +134,10 @@ class _ExtensibleWrapper(_ExtensibleCallable):
         return args_list, kwargs_list
 
     async def _async_batch(self, *delays):
-        if self.batch_func:
+        if len(delays) == 1:
+            d = delays[0]
+            return [await self.func(*d.args, **d.kwargs)]
+        elif self.batch_func:
             args_list, kwargs_list = self._gen_args_kwargs_list(delays)
             return await self.batch_func(args_list, kwargs_list)
         else:

--- a/mars/oscar/batch.py
+++ b/mars/oscar/batch.py
@@ -134,6 +134,8 @@ class _ExtensibleWrapper(_ExtensibleCallable):
         return args_list, kwargs_list
 
     async def _async_batch(self, *delays):
+        # when there is only one call in batch, calling one-pass method
+        # will be more efficient
         if len(delays) == 1:
             d = delays[0]
             return [await self.func(*d.args, **d.kwargs)]

--- a/mars/oscar/core.pyx
+++ b/mars/oscar/core.pyx
@@ -212,9 +212,9 @@ cdef class _BaseActor:
         return create_actor_ref(self._address, self._uid)
 
     async def _handle_actor_result(self, result):
-        cdef int result_pos
+        cdef int idx
         cdef tuple res_tuple
-        cdef list tasks, values
+        cdef list tasks, coros, coro_poses, values
         cdef object coro
         cdef bint extract_tuple = False
         cdef bint cancelled = False
@@ -228,20 +228,30 @@ cdef class _BaseActor:
 
         if type(result) is tuple:
             res_tuple = result
-            tasks = []
+            coros = []
+            coro_poses = []
             values = []
-            for res_item in res_tuple:
+            for idx, res_item in enumerate(res_tuple):
                 if is_async_generator(res_item):
-                    value = asyncio.create_task(self._run_actor_async_generator(res_item))
-                    tasks.append(value)
+                    value = self._run_actor_async_generator(res_item)
+                    coros.append(value)
+                    coro_poses.append(idx)
                 elif inspect.isawaitable(res_item):
-                    value = asyncio.create_task(res_item)
-                    tasks.append(value)
+                    value = res_item
+                    coros.append(value)
+                    coro_poses.append(idx)
                 else:
                     value = res_item
                 values.append(value)
 
-            if len(tasks) > 0:
+            if len(coros) == 1:
+                task_result = await coros[0]
+                if extract_tuple:
+                    result = task_result
+                else:
+                    result = tuple(task_result if t is coros[0] else t for t in values)
+            elif len(coros) > 0:
+                tasks = [asyncio.create_task(t) for t in coros]
                 try:
                     dones, pending = await asyncio.wait(tasks)
                 except asyncio.CancelledError:
@@ -254,7 +264,10 @@ cdef class _BaseActor:
                 if extract_tuple:
                     result = list(dones)[0].result()
                 else:
-                    result = tuple(t.result() if t in dones else t for t in values)
+                    for pos in coro_poses:
+                        task = tasks[pos]
+                        values[pos] = task.result()
+                    result = tuple(values)
 
                 if cancelled:
                     # raise in case no CancelledError raised

--- a/mars/oscar/core.pyx
+++ b/mars/oscar/core.pyx
@@ -244,6 +244,8 @@ cdef class _BaseActor:
                     value = res_item
                 values.append(value)
 
+            # when there is only one coroutine, we do not need to use
+            # asyncio.wait as it introduces much overhead
             if len(coros) == 1:
                 task_result = await coros[0]
                 if extract_tuple:

--- a/mars/services/scheduling/supervisor/assigner.py
+++ b/mars/services/scheduling/supervisor/assigner.py
@@ -92,6 +92,12 @@ class AssignerActor(mo.Actor):
     async def assign_subtasks(self, subtasks: List[Subtask]):
         inp_keys = set()
         selected_bands = dict()
+
+        if not self._bands:
+            self._update_bands(
+                list(await self._cluster_api.get_all_bands(NodeRole.WORKER))
+            )
+
         for subtask in subtasks:
             is_gpu = any(c.op.gpu for c in subtask.chunk_graph)
             if subtask.expect_bands:
@@ -116,10 +122,6 @@ class AssignerActor(mo.Actor):
                 if isinstance(indep_chunk.op, Fetch):
                     inp_keys.add(indep_chunk.key)
                 elif isinstance(indep_chunk.op, FetchShuffle):
-                    if not self._bands:
-                        self._update_bands(
-                            list(await self._cluster_api.get_all_bands(NodeRole.WORKER))
-                        )
                     selected_bands[subtask.subtask_id] = [self._get_random_band(is_gpu)]
                     break
 

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -546,6 +546,8 @@ class TaskProcessorActor(mo.Actor):
         _, pending = yield asyncio.wait(fs, timeout=timeout)
         if not pending:
             raise mo.Return(self.result())
+        else:
+            [fut.cancel() for fut in pending]
 
     async def cancel(self):
         if self._cur_processor:


### PR DESCRIPTION
## What do these changes do?

Reduce RPC cost of oscar by removing unnecessary tasks. Now Oscar can handle 4500 calls pser sec instead of 2500 before optimization.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
