### PR TITLE
Use batched request to apply for slots

### DIFF
--- a/mars/dataframe/contrib/raydataset/dataset.py
+++ b/mars/dataframe/contrib/raydataset/dataset.py
@@ -39,7 +39,6 @@ if ray:
 
         # The default __setstate__ will update _MLDataset's __dict__;
 
-
 else:
     _Dataset = None
 

--- a/mars/dataframe/contrib/raydataset/mldataset.py
+++ b/mars/dataframe/contrib/raydataset/mldataset.py
@@ -99,7 +99,6 @@ if ray:
 
         # The default __setstate__ will update _MLDataset's __dict__;
 
-
 else:
     _MLDataset = None
 

--- a/mars/services/scheduling/supervisor/globalslot.py
+++ b/mars/services/scheduling/supervisor/globalslot.py
@@ -62,6 +62,7 @@ class GlobalSlotManagerActor(mo.Actor):
     async def refresh_bands(self):
         self._band_total_slots = await self._cluster_api.get_all_bands()
 
+    @mo.extensible
     async def apply_subtask_slots(
         self,
         band: BandType,

--- a/mars/services/scheduling/supervisor/queueing.py
+++ b/mars/services/scheduling/supervisor/queueing.py
@@ -169,6 +169,10 @@ class SubtaskQueueingActor(mo.Actor):
         submit_aio_tasks = []
         manager_ref = await self._get_manager_ref()
 
+        apply_delays = []
+        submit_items_list = []
+        submitted_bands = []
+
         for band in bands:
             band_limit = limit or self._band_slot_nums[band]
             task_queue = self._band_queues[band]
@@ -181,17 +185,40 @@ class SubtaskQueueingActor(mo.Actor):
             subtask_ids = list(submit_items)
             if not subtask_ids:
                 continue
+
+            submitted_bands.append(band)
+            submit_items_list.append(submit_items)
+
             # todo it is possible to provide slot data with more accuracy
             subtask_slots = [1] * len(subtask_ids)
+
+            apply_delays.append(
+                self._slots_ref.apply_subtask_slots.delay(
+                    band, self._session_id, subtask_ids, subtask_slots
+                )
+            )
+
+        async with redirect_subtask_errors(
+            self,
+            [
+                item.subtask
+                for submit_items in submit_items_list
+                for item in submit_items.values()
+            ],
+        ):
+            submitted_ids_list = await self._slots_ref.apply_subtask_slots.batch(
+                *apply_delays
+            )
+
+        for band, submit_items, submitted_ids in zip(
+            submitted_bands, submit_items_list, submitted_ids_list
+        ):
+            subtask_ids = list(submit_items)
+            task_queue = self._band_queues[band]
 
             async with redirect_subtask_errors(
                 self, [item.subtask for item in submit_items.values()]
             ):
-                submitted_ids = set(
-                    await self._slots_ref.apply_subtask_slots(
-                        band, self._session_id, subtask_ids, subtask_slots
-                    )
-                )
                 non_submitted_ids = [k for k in submit_items if k not in submitted_ids]
                 if submitted_ids:
                     for stid in subtask_ids:

--- a/mars/services/scheduling/supervisor/tests/test_queue_balance.py
+++ b/mars/services/scheduling/supervisor/tests/test_queue_balance.py
@@ -99,6 +99,7 @@ class FakeClusterAPI(ClusterAPI):
 
 
 class MockSlotsActor(mo.Actor):
+    @mo.extensible
     def apply_subtask_slots(
         self,
         band: Tuple,

--- a/mars/services/scheduling/supervisor/tests/test_queueing.py
+++ b/mars/services/scheduling/supervisor/tests/test_queueing.py
@@ -33,6 +33,7 @@ class MockSlotsActor(mo.Actor):
     def set_capacity(self, capacity: int):
         self._capacity = capacity
 
+    @mo.extensible
     def apply_subtask_slots(
         self,
         band: Tuple,

--- a/mars/storage/shared_memory.py
+++ b/mars/storage/shared_memory.py
@@ -36,7 +36,6 @@ try:
             if os.name != "nt" and fd >= 0:
                 os.close(fd)
 
-
 except ImportError:  # pragma: no cover
     # allow shared_memory package to be absent
     SharedMemory = SharedMemoryForRead = None


### PR DESCRIPTION
## What do these changes do?

Request global slots in batches. This reduces potential time cost when a number of slots are to be allocated.

## Related issue number

Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
