### PR TITLE
Fix duplicate decref of subtask input chunk

### DIFF
--- a/mars/services/task/supervisor/stage.py
+++ b/mars/services/task/supervisor/stage.py
@@ -67,6 +67,9 @@ class TaskStageProcessor:
         self.subtask_results: Dict[Subtask, SubtaskResult] = dict()
         self._submitted_subtask_ids = set()
 
+        # All subtask IDs whose input chunk reference count is reduced.
+        self.decref_subtask = set()
+
         self._band_manager: Dict[BandType, mo.ActorRef] = dict()
 
         # result


### PR DESCRIPTION
* fix decrease subtask input chunk

This is a race condition.

Let us suppose stage A have two Subtask S1 and S2, and they have the same input chunk C

1. S1 got an error, and stage_processor.done has been set.
2. S2 call set_subtask_result, it already reduces reference count of C  but not set `stage_processor.results[C.key]`
3. `TaskProcessorActor` find `stage_processor` got an error and call `self._cur_processor.incref_stage(stage_processor)` in function `TaskProcessorActor.start`, it will also reduce the reference count of C which is input of S2.

<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2610

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
