### PR TITLE
Add airy function implementations

### DIFF
--- a/mars/tensor/arithmetic/core.py
+++ b/mars/tensor/arithmetic/core.py
@@ -108,7 +108,7 @@ class TensorElementWiseWithInputs(TensorElementWise):
 
 
 def _handle_out_dtype(val, dtype):
-    if val.dtype != dtype:
+    if not isinstance(val, tuple) and val.dtype != dtype:
         return val.astype(dtype)
     return val
 

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -147,7 +147,10 @@ class TensorChunkData(ChunkData):
 
     @property
     def dtype(self):
-        return getattr(self, "_dtype", None) or self.op.dtype
+        try:
+            return getattr(self, "_dtype", None) or self.op.dtype
+        except AttributeError:
+            return None
 
     @property
     def order(self):
@@ -286,7 +289,10 @@ class TensorData(HasShapeTileableData, _ExecuteAndFetchMixin):
 
     @property
     def dtype(self):
-        return getattr(self, "_dtype", None) or self.op.dtype
+        try:
+            return getattr(self, "_dtype", None) or self.op.dtype
+        except AttributeError:
+            return None
 
     @property
     def order(self):

--- a/mars/tensor/special/__init__.py
+++ b/mars/tensor/special/__init__.py
@@ -106,5 +106,11 @@ try:
         hyp0f1,
         TensorHYP0F1,
     )
+    from .airy_funcs import (
+        airy,
+        TensorAiry,
+        airye,
+        TensorAirye,
+    )
 except ImportError:  # pragma: no cover
     pass

--- a/mars/tensor/special/airy_funcs.py
+++ b/mars/tensor/special/airy_funcs.py
@@ -1,0 +1,48 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import scipy.special as spspecial
+
+from ..arithmetic.utils import arithmetic_operand
+from ..utils import infer_dtype, implement_scipy
+from .core import (
+    TensorSpecialUnaryOp,
+    _register_special_op,
+)
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="unary")
+class TensorAiry(TensorSpecialUnaryOp):
+    _func_name = "airy"
+
+
+@implement_scipy(spspecial.airy)
+@infer_dtype(spspecial.airy)
+def airy(x, **kwargs):
+    op = TensorAiry(**kwargs)
+    return op(x)
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="unary")
+class TensorAirye(TensorSpecialUnaryOp):
+    _func_name = "airye"
+
+
+@implement_scipy(spspecial.airye)
+@infer_dtype(spspecial.airye)
+def airye(x, **kwargs):
+    op = TensorAirye(**kwargs)
+    return op(x)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Added airy and airye function implementations from https://docs.scipy.org/doc/scipy/reference/special.html#airy-functions.

## Related issue number

Fixes #750 

## Check code requirements

- What tested:
`from mars.tensor.special import airy, airye
w = airy([1,2,3])
w.execute()  # Return tuple of ndarray

x = airye([1,2,3])
x.execute() # Return tuple of ndarray`

Output matched against original scipy implementation.
