### PR TITLE
Add wheel support for Python 3.10 and drop Python 3.6

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.8-cython]
+        python-version: [3.7, 3.8, 3.9, 3.8-cython]
         include:
           - { os: ubuntu-latest, python-version: 3.8-cython, no-common-tests: 1,
               no-deploy: 1, with-cython: 1 }

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -110,6 +110,7 @@ jobs:
 
           if [ -n "$WITH_HADOOP" ]; then
             source $CONDA/bin/activate test
+            source ./ci/reload-env.sh
             pytest $PYTEST_CONFIG -m hadoop
             coverage report
           fi

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -12,14 +12,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        node-version: [14.x]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        node-version: ["14.x"]
         include:
-          - { os: ubuntu-latest, python-version: 3.6, python-abis: "cp36-cp36m" }
-          - { os: ubuntu-latest, python-version: 3.7, python-abis: "cp37-cp37m" }
-          - { os: ubuntu-latest, python-version: 3.8, python-abis: "cp38-cp38" }
-          - { os: ubuntu-latest, python-version: 3.9, python-abis: "cp39-cp39" }
-          - { os: windows-latest, python-version: 3.9, build-static: 1 }
+          - { os: ubuntu-latest, python-version: "3.6", python-abis: "cp36-cp36m" }
+          - { os: ubuntu-latest, python-version: "3.7", python-abis: "cp37-cp37m" }
+          - { os: ubuntu-latest, python-version: "3.8", python-abis: "cp38-cp38" }
+          - { os: ubuntu-latest, python-version: "3.9", python-abis: "cp39-cp39" }
+          - { os: ubuntu-latest, python-version: "3.10", python-abis: "cp310-cp310" }
+          - { os: windows-latest, python-version: "3.10", build-static: 1 }
 
     steps:
       - name: Check out code

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -61,10 +61,14 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') && matrix.no-deploy != '1'
         shell: bash
         env:
-          DOCKER_IMAGE: "quay.io/pypa/manylinux1_x86_64"
           PYABI: ${{ matrix.python-abis }}
           BUILD_STATIC: ${{ matrix.build-static }}
           PYPI_PWD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           source ./ci/reload-env.sh
+          if [[ "$PYTHON" =~ "3.10" ]]; then
+            export DOCKER_IMAGE="quay.io/pypa/manylinux2014_x86_64"
+          else
+            export DOCKER_IMAGE="quay.io/pypa/manylinux1_x86_64"
+          fi
           source ./.github/workflows/upload-packages.sh

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -12,10 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         node-version: ["14.x"]
         include:
-          - { os: ubuntu-latest, python-version: "3.6", python-abis: "cp36-cp36m" }
           - { os: ubuntu-latest, python-version: "3.7", python-abis: "cp37-cp37m" }
           - { os: ubuntu-latest, python-version: "3.8", python-abis: "cp38-cp38" }
           - { os: ubuntu-latest, python-version: "3.9", python-abis: "cp39-cp39" }

--- a/ci/install-conda.sh
+++ b/ci/install-conda.sh
@@ -16,7 +16,7 @@ fi
 
 CONDA_FILE="Miniconda3-latest-${CONDA_OS}-x86_64.${FILE_EXT}"
 
-TEST_PACKAGES="virtualenv psutil pyyaml"
+TEST_PACKAGES="virtualenv"
 
 if [[ "$FILE_EXT" == "sh" ]]; then
   curl -L -o "miniconda.${FILE_EXT}" https://repo.continuum.io/miniconda/$CONDA_FILE

--- a/ci/install-conda.sh
+++ b/ci/install-conda.sh
@@ -32,6 +32,11 @@ else
 fi
 $CONDA_BIN_PATH/conda create --quiet --yes -n test python=$PYTHON $TEST_PACKAGES
 
+# deploy pythonx.dll into windows system directory
+if [[ "$CONDA_OS" == "Windows" ]]; then
+  cp "$CONDA/libs/python*.dll" "/c/Windows/System32"
+fi
+
 #check python version
 export PYTHON=$(python -c "import sys; print('.'.join(str(v) for v in sys.version_info[:3]))")
 echo "Installed Python version: $PYTHON"

--- a/ci/install-conda.sh
+++ b/ci/install-conda.sh
@@ -28,13 +28,11 @@ else
   CONDA=$(echo "/$CONDA" | sed -e 's/\\/\//g' -e 's/://')
   echo "Using installed conda at $CONDA"
   CONDA_BIN_PATH=$CONDA/Scripts
-  export PATH="$CONDA/envs/test/Scripts:$CONDA/envs/test:$CONDA/Scripts:$CONDA:$PATH"
 fi
 $CONDA_BIN_PATH/conda create --quiet --yes -n test python=$PYTHON $TEST_PACKAGES
 
-# deploy pythonx.dll into windows system directory
 if [[ "$CONDA_OS" == "Windows" ]]; then
-  cp "$CONDA/libs/python*.dll" "/c/Windows/System32"
+  source "$CONDA/Scripts/activate" test
 fi
 
 #check python version

--- a/ci/requirements-wheel.txt
+++ b/ci/requirements-wheel.txt
@@ -1,9 +1,15 @@
 numpy==1.14.5; python_version<'3.9'
-numpy==1.19.3; python_version>='3.9'
+numpy==1.19.3; python_version>='3.9' and python_version<'3.10'
+numpy==1.21.4; python_version>='3.10'
+
 pandas==1.0.4; python_version<'3.9'
-pandas==1.1.3; python_version>='3.9'
+pandas==1.1.3; python_version>='3.9' and python_version<'3.10'
+pandas==1.3.4; python_version>='3.10'
+
 scipy==1.4.1; python_version<'3.9'
-scipy==1.5.4; python_version>='3.9'
+scipy==1.5.4; python_version>='3.9' and python_version<'3.10'
+scipy==1.7.2; python_version>='3.10'
+
 cython==0.29.21
 requests>=2.4.0
 cloudpickle>=1.5.0


### PR DESCRIPTION
## What do these changes do?

Add wheel support for Python 3.10 and drop Python 3.6. Build results see https://github.com/wjsi/mars/runs/4548270645?check_suite_focus=true.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
