### PR TITLE
Fix backward compatibility for pandas 1.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
               statsmodels\<0.13.0 tsfresh
           fi
           if [[ "$(mars.test.module)" == "dataframe" ]]; then
-            pip install pandas==1.0.5 pyarrow==4.0.1
+            pip install pandas==1.0.5
           fi
         fi
         conda list -n test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,6 +87,9 @@ jobs:
             pip install xgboost lightgbm keras==2.6.0 tensorflow faiss-cpu torch torchvision \
               statsmodels\<0.13.0 tsfresh
           fi
+          if [[ "$(mars.test.module)" == "dataframe" ]]; then
+            pip install pandas==1.0.5 pyarrow==4.0.1
+          fi
         fi
         conda list -n test
       displayName: 'Install dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,9 +87,6 @@ jobs:
             pip install xgboost lightgbm keras==2.6.0 tensorflow faiss-cpu torch torchvision \
               statsmodels\<0.13.0 tsfresh
           fi
-          if [[ "$(mars.test.module)" == "dataframe" ]]; then
-            pip install pandas==1.0.5
-          fi
         fi
         conda list -n test
       displayName: 'Install dependencies'
@@ -97,8 +94,18 @@ jobs:
     - bash: |
         set -e
         source ci/reload-env.sh
+        mkdir -p build
         pytest $PYTEST_CONFIG mars/$(mars.test.module)
-        coverage report
+        mv .coverage build/.coverage.main.file
+        
+        # do compatibility test for earliest supported pandas release
+        if [[ "$(mars.test.module)" == "dataframe" ]]; then
+          pip install pandas==1.0.5
+          pytest $PYTEST_CONFIG -m pd_compat mars/dataframe
+          mv .coverage build/.coverage.pd_compat.file
+        fi
+        
+        coverage combine build/ && coverage report
         coverage xml
       displayName: 'Run tests'
 

--- a/mars/conftest.py
+++ b/mars/conftest.py
@@ -167,9 +167,9 @@ def _new_gpu_test_session(_stop_isolation):  # pragma: no cover
 
 @pytest.fixture
 def setup(_new_test_session):
-    assert not (is_build_mode() or is_kernel_mode())
     _new_test_session.as_default()
     yield _new_test_session
+    assert not (is_build_mode() or is_kernel_mode())
 
 
 @pytest.fixture

--- a/mars/conftest.py
+++ b/mars/conftest.py
@@ -18,6 +18,7 @@ import subprocess
 import pytest
 
 from mars.config import option_context
+from mars.core.mode import is_kernel_mode, is_build_mode
 from mars.lib.aio import stop_isolation
 from mars.oscar.backends.router import Router
 from mars.oscar.backends.ray.communication import RayServer
@@ -166,6 +167,7 @@ def _new_gpu_test_session(_stop_isolation):  # pragma: no cover
 
 @pytest.fixture
 def setup(_new_test_session):
+    assert not (is_build_mode() or is_kernel_mode())
     _new_test_session.as_default()
     yield _new_test_session
 

--- a/mars/core/graph/builder/chunk.py
+++ b/mars/core/graph/builder/chunk.py
@@ -259,8 +259,14 @@ class ChunkGraphBuilder(AbstractGraphBuilder):
         return node not in visited and node not in self._processed_chunks
 
     def _build(self) -> Iterable[Union[TileableGraph, ChunkGraph]]:
-        yield from self.tiler
+        tile_iterator = iter(self.tiler)
+        while True:
+            try:
+                with enter_mode(build=True, kernel=True):
+                    graph = next(tile_iterator)
+                yield graph
+            except StopIteration:
+                break
 
     def build(self) -> Generator[Union[TileableGraph, ChunkGraph], None, None]:
-        with enter_mode(build=True, kernel=True):
-            yield from self._build()
+        yield from self._build()

--- a/mars/core/graph/core.pyx
+++ b/mars/core/graph/core.pyx
@@ -143,7 +143,7 @@ cdef class DirectedGraph:
         try:
             return list(self._successors[n])
         except KeyError:
-            return KeyError(f'Node {n} does not exist in the directed graph')
+            raise KeyError(f'Node {n} does not exist in the directed graph')
 
     def iter_predecessors(self, n):
         try:

--- a/mars/core/mode.py
+++ b/mars/core/mode.py
@@ -18,7 +18,6 @@ import threading
 
 from ..config import options
 
-
 _internal_mode = threading.local()
 
 

--- a/mars/core/mode.py
+++ b/mars/core/mode.py
@@ -69,18 +69,19 @@ class _EnterModeFuncWrapper:
             setattr(_internal_mode, mode_name, mode_name_to_old_value[mode_name])
 
     def __call__(self, func):
+        mode_name_to_value = self.mode_name_to_value.copy()
         if not inspect.iscoroutinefunction(func):
             # sync
             @functools.wraps(func)
             def _inner(*args, **kwargs):
-                with self:
+                with enter_mode(**mode_name_to_value):
                     return func(*args, **kwargs)
 
         else:
             # async
             @functools.wraps(func)
             async def _inner(*args, **kwargs):
-                with self:
+                with enter_mode(**mode_name_to_value):
                     return await func(*args, **kwargs)
 
         return _inner

--- a/mars/dataframe/arrays.py
+++ b/mars/dataframe/arrays.py
@@ -54,10 +54,9 @@ except ImportError:  # pragma: no cover
 
 from ..config import options
 from ..core import is_kernel_mode
-from ..lib.version import parse as parse_version
-from ..utils import tokenize
+from ..utils import pd_release_version, tokenize
 
-_use_bool_any_all = parse_version(pd.__version__) >= parse_version("1.3.0")
+_use_bool_any_all = pd_release_version >= (1, 3, 0)
 
 
 class ArrowDtype(ExtensionDtype):

--- a/mars/dataframe/base/astype.py
+++ b/mars/dataframe/base/astype.py
@@ -18,14 +18,14 @@ from pandas.api.types import CategoricalDtype
 
 from ... import opcodes as OperandDef
 from ...core import recursive_tile
-from ...lib.version import parse as parse_version
 from ...serialization.serializables import AnyField, StringField, ListField
 from ...tensor.base import sort
+from ...utils import pd_release_version
 from ..core import DATAFRAME_TYPE, SERIES_TYPE
 from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import build_empty_df, build_empty_series, parse_index
 
-_need_astype_contiguous = parse_version(pd.__version__) == parse_version("1.3.0")
+_need_astype_contiguous = pd_release_version == (1, 3, 0)
 
 
 class DataFrameAstype(DataFrameOperand, DataFrameOperandMixin):

--- a/mars/dataframe/base/duplicated.py
+++ b/mars/dataframe/base/duplicated.py
@@ -157,7 +157,7 @@ class DataFrameDuplicated(DuplicateOperand):
         inp = ctx[op.input.key]
         result = inp.copy()
         duplicated_filter = ~inp.iloc[:, -1]
-        duplicates = inp[duplicated_filter]
+        duplicates = inp.loc[duplicated_filter]
         dup_on_duplicated = cls._duplicated(duplicates, op)
         result.iloc[duplicated_filter.values, -1] = dup_on_duplicated
         duplicated = result.iloc[:, -1]

--- a/mars/dataframe/base/duplicated.py
+++ b/mars/dataframe/base/duplicated.py
@@ -148,7 +148,7 @@ class DataFrameDuplicated(DuplicateOperand):
         duplicated = cls._duplicated(inp, op)
         if not duplicated.name:
             duplicated.name = "_duplicated_"
-        result.iloc[duplicated] = None
+        result.iloc[duplicated.values] = None
         result = xdf.concat([result, duplicated], axis=1)
         ctx[op.outputs[0].key] = result
 
@@ -156,11 +156,12 @@ class DataFrameDuplicated(DuplicateOperand):
     def _execute_tree_combine(cls, ctx, op):
         inp = ctx[op.input.key]
         result = inp.copy()
-        duplicates = inp[~inp.iloc[:, -1]]
+        duplicated_filter = ~inp.iloc[:, -1]
+        duplicates = inp[duplicated_filter]
         dup_on_duplicated = cls._duplicated(duplicates, op)
-        result.iloc[~inp.iloc[:, -1], -1] = dup_on_duplicated
+        result.iloc[duplicated_filter.values, -1] = dup_on_duplicated
         duplicated = result.iloc[:, -1]
-        result.iloc[duplicated, :-1] = None
+        result.iloc[duplicated.values, :-1] = None
         ctx[op.outputs[0].key] = result
 
     @classmethod

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -26,11 +26,10 @@ except ImportError:  # pragma: no cover
 
 from ....config import options, option_context
 from ....dataframe import DataFrame
-from ....lib.version import parse as parse_version
 from ....tensor import arange, tensor
 from ....tensor.random import rand
 from ....tests.core import require_cudf
-from ....utils import lazy_import
+from ....utils import lazy_import, pd_release_version
 from ... import eval as mars_eval, cut, qcut, get_dummies
 from ...datasource.dataframe import from_pandas as from_pandas_df
 from ...datasource.series import from_pandas as from_pandas_series
@@ -41,7 +40,7 @@ from ..rebalance import DataFrameRebalance
 
 cudf = lazy_import("cudf", globals=globals())
 
-_explode_with_ignore_index = parse_version(pd.__version__).release >= (1, 1)
+_explode_with_ignore_index = pd_release_version[:2] >= (1, 1)
 
 
 @require_cudf

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -38,6 +38,8 @@ from .. import to_gpu, to_cpu
 from ..to_numeric import to_numeric
 from ..rebalance import DataFrameRebalance
 
+pytestmark = pytest.mark.pd_compat
+
 cudf = lazy_import("cudf", globals=globals())
 
 _explode_with_ignore_index = pd_release_version[:2] >= (1, 1)

--- a/mars/dataframe/base/transform.py
+++ b/mars/dataframe/base/transform.py
@@ -19,9 +19,8 @@ from ... import opcodes
 from ...config import options
 from ...core import OutputType, recursive_tile
 from ...core.custom_log import redirect_custom_log
-from ...lib.version import parse as parse_version
 from ...serialization.serializables import AnyField, BoolField, TupleField, DictField
-from ...utils import enter_current_session, quiet_stdio
+from ...utils import enter_current_session, quiet_stdio, pd_release_version
 from ..core import DATAFRAME_CHUNK_TYPE, DATAFRAME_TYPE
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..utils import (
@@ -32,6 +31,8 @@ from ..utils import (
     filter_dtypes_by_index,
     make_dtypes,
 )
+
+_with_convert_dtype = pd_release_version < (1, 2, 0)
 
 
 class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
@@ -236,7 +237,7 @@ class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
                     if self.call_agg:
                         infer_df = test_df.agg(self._func, args=self.args, **self.kwds)
                     else:
-                        if parse_version(pd.__version__) >= parse_version("1.2.0"):
+                        if not _with_convert_dtype:
                             infer_df = test_df.transform(
                                 self._func, *self.args, **self.kwds
                             )

--- a/mars/dataframe/base/value_counts.py
+++ b/mars/dataframe/base/value_counts.py
@@ -18,14 +18,13 @@ import pandas as pd
 from ... import opcodes
 from ...core import OutputType, recursive_tile
 from ...core.operand import OperandStage
-from ...lib.version import parse as parse_version
 from ...serialization.serializables import KeyField, BoolField, Int64Field, StringField
-from ...utils import has_unknown_shape
+from ...utils import has_unknown_shape, pd_release_version
 from ..core import Series
 from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import build_series, parse_index
 
-_keep_original_order = parse_version(pd.__version__) >= parse_version("1.3.0")
+_keep_original_order = pd_release_version >= (1, 3, 0)
 
 
 class DataFrameValueCounts(DataFrameOperand, DataFrameOperandMixin):

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -25,12 +25,11 @@ except ImportError:  # pragma: no cover
 
 from .... import dataframe as md
 from ....core.operand import OperandStage
-from ....lib.version import parse as parse_version
 from ....tests.core import assert_groupby_equal, require_cudf
-from ....utils import arrow_array_to_objects
+from ....utils import arrow_array_to_objects, pd_release_version
 from ..aggregation import DataFrameGroupByAgg
 
-_agg_size_as_frame = parse_version(pd.__version__).release[:2] > (1, 0)
+_agg_size_as_frame = pd_release_version[:2] > (1, 0)
 
 
 class MockReduction1(md.CustomReduction):
@@ -220,7 +219,11 @@ def test_groupby_getitem(setup):
         r = mdf.groupby("b", as_index=False).b.count(method=method)
         result = r.execute().fetch().sort_values("b", ignore_index=True)
         try:
-            expected = raw.groupby("b", as_index=False).b.count().sort_values("b", ignore_index=True)
+            expected = (
+                raw.groupby("b", as_index=False)
+                .b.count()
+                .sort_values("b", ignore_index=True)
+            )
         except ValueError:
             expected = raw.groupby("b").b.count().to_frame()
             expected.index.names = [None] * expected.index.nlevels
@@ -230,7 +233,11 @@ def test_groupby_getitem(setup):
         r = mdf.groupby("b", as_index=False).b.agg({"cnt": "count"}, method=method)
         result = r.execute().fetch().sort_values("b", ignore_index=True)
         try:
-            expected = raw.groupby("b", as_index=False).b.agg({"cnt": "count"}).sort_values("b", ignore_index=True)
+            expected = (
+                raw.groupby("b", as_index=False)
+                .b.agg({"cnt": "count"})
+                .sort_values("b", ignore_index=True)
+            )
         except ValueError:
             expected = raw.groupby("b").b.agg({"cnt": "count"}).to_frame()
             expected.index.names = [None] * expected.index.nlevels
@@ -361,7 +368,11 @@ def test_dataframe_groupby_agg(setup):
         r = mdf.groupby("c2", as_index=False).agg("size", method=method)
         if _agg_size_as_frame:
             result = r.execute().fetch().sort_values("c2", ignore_index=True)
-            expected = raw.groupby("c2", as_index=False).agg("size").sort_values("c2", ignore_index=True)
+            expected = (
+                raw.groupby("c2", as_index=False)
+                .agg("size")
+                .sort_values("c2", ignore_index=True)
+            )
             pd.testing.assert_frame_equal(result, expected)
         else:
             result = r.execute().fetch().sort_index()

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -25,9 +25,12 @@ except ImportError:  # pragma: no cover
 
 from .... import dataframe as md
 from ....core.operand import OperandStage
+from ....lib.version import parse as parse_version
 from ....tests.core import assert_groupby_equal, require_cudf
 from ....utils import arrow_array_to_objects
 from ..aggregation import DataFrameGroupByAgg
+
+_agg_size_as_frame = parse_version(pd.__version__).release[:2] > (1, 0)
 
 
 class MockReduction1(md.CustomReduction):
@@ -215,20 +218,24 @@ def test_groupby_getitem(setup):
         )
 
         r = mdf.groupby("b", as_index=False).b.count(method=method)
-        pd.testing.assert_frame_equal(
-            r.execute().fetch().sort_values("b", ignore_index=True),
-            raw.groupby("b", as_index=False)
-            .b.count()
-            .sort_values("b", ignore_index=True),
-        )
+        result = r.execute().fetch().sort_values("b", ignore_index=True)
+        try:
+            expected = raw.groupby("b", as_index=False).b.count().sort_values("b", ignore_index=True)
+        except ValueError:
+            expected = raw.groupby("b").b.count().to_frame()
+            expected.index.names = [None] * expected.index.nlevels
+            expected = expected.sort_values("b", ignore_index=True)
+        pd.testing.assert_frame_equal(result, expected)
 
         r = mdf.groupby("b", as_index=False).b.agg({"cnt": "count"}, method=method)
-        pd.testing.assert_frame_equal(
-            r.execute().fetch().sort_values("b", ignore_index=True),
-            raw.groupby("b", as_index=False)
-            .b.agg({"cnt": "count"})
-            .sort_values("b", ignore_index=True),
-        )
+        result = r.execute().fetch().sort_values("b", ignore_index=True)
+        try:
+            expected = raw.groupby("b", as_index=False).b.agg({"cnt": "count"}).sort_values("b", ignore_index=True)
+        except ValueError:
+            expected = raw.groupby("b").b.agg({"cnt": "count"}).to_frame()
+            expected.index.names = [None] * expected.index.nlevels
+            expected = expected.sort_values("b", ignore_index=True)
+        pd.testing.assert_frame_equal(result, expected)
 
     r = mdf.groupby("b").a.apply(lambda x: x + 1)
     pd.testing.assert_series_equal(
@@ -352,12 +359,14 @@ def test_dataframe_groupby_agg(setup):
     # test as_index=False
     for method in ["tree", "shuffle"]:
         r = mdf.groupby("c2", as_index=False).agg("size", method=method)
-        pd.testing.assert_frame_equal(
-            r.execute().fetch().sort_values("c2", ignore_index=True),
-            raw.groupby("c2", as_index=False)
-            .agg("size")
-            .sort_values("c2", ignore_index=True),
-        )
+        if _agg_size_as_frame:
+            result = r.execute().fetch().sort_values("c2", ignore_index=True)
+            expected = raw.groupby("c2", as_index=False).agg("size").sort_values("c2", ignore_index=True)
+            pd.testing.assert_frame_equal(result, expected)
+        else:
+            result = r.execute().fetch().sort_index()
+            expected = raw.groupby("c2", as_index=False).agg("size").sort_index()
+            pd.testing.assert_series_equal(result, expected)
 
         r = mdf.groupby("c2", as_index=False).agg("mean", method=method)
         pd.testing.assert_frame_equal(

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -29,6 +29,8 @@ from ....tests.core import assert_groupby_equal, require_cudf
 from ....utils import arrow_array_to_objects, pd_release_version
 from ..aggregation import DataFrameGroupByAgg
 
+pytestmark = pytest.mark.pd_compat
+
 _agg_size_as_frame = pd_release_version[:2] > (1, 0)
 
 

--- a/mars/dataframe/indexing/getitem.py
+++ b/mars/dataframe/indexing/getitem.py
@@ -482,7 +482,10 @@ class DataFrameIndex(DataFrameOperand, DataFrameOperandMixin):
             for i, (columns, column_idx) in enumerate(
                 zip(column_splits, column_indexes)
             ):
-                dtypes = in_df.dtypes[columns]
+                try:
+                    dtypes = in_df.dtypes[columns]
+                except ValueError:  # pragma: no cover
+                    dtypes = in_df.dtypes[list(columns)]
                 column_nsplits.append(len(dtypes))
                 for j in range(in_df.chunk_shape[0]):
                     c = in_df.cix[(j, column_idx[0])]

--- a/mars/dataframe/indexing/reindex.py
+++ b/mars/dataframe/indexing/reindex.py
@@ -23,6 +23,7 @@ except ImportError:  # pragma: no cover
 from ... import opcodes
 from ...core import ENTITY_TYPE, recursive_tile
 from ...core.operand import OperandStage
+from ...lib.version import parse as parse_version
 from ...serialization.serializables import (
     KeyField,
     AnyField,
@@ -40,6 +41,9 @@ from .index_lib import DataFrameReindexHandler
 
 
 cudf = lazy_import("cudf", globals=globals())
+
+# under pandas<1.1, SparseArray ignores zeros on creation
+_pd_sparse_miss_zero = parse_version(pd.__version__).release[:2] < (1, 1)
 
 
 class DataFrameReindex(DataFrameOperand, DataFrameOperandMixin):
@@ -268,15 +272,24 @@ class DataFrameReindex(DataFrameOperand, DataFrameOperandMixin):
                             shape=(index_shape, 1),
                             dtype=inp[col].dtype,
                         )
-                        sparse_array = pd.arrays.SparseArray.from_spmatrix(spmatrix)
                         # convert to SparseDtype(xxx, np.nan)
                         # to ensure 0 in sparse_array not converted to np.nan
-                        sparse_array = pd.arrays.SparseArray(
-                            sparse_array.sp_values,
-                            sparse_index=sparse_array.sp_index,
-                            fill_value=np.nan,
-                            dtype=pd.SparseDtype(sparse_array.dtype, np.nan),
-                        )
+                        if not _pd_sparse_miss_zero:
+                            sparse_array = pd.arrays.SparseArray.from_spmatrix(spmatrix)
+                            sparse_array = pd.arrays.SparseArray(
+                                sparse_array.sp_values,
+                                sparse_index=sparse_array.sp_index,
+                                fill_value=np.nan,
+                                dtype=pd.SparseDtype(sparse_array.dtype, np.nan),
+                            )
+                        else:
+                            from pandas._libs.sparse import IntIndex
+                            sparse_array = pd.arrays.SparseArray(
+                                data,
+                                sparse_index=IntIndex(index_shape, ind),
+                                fill_value=np.nan,
+                                dtype=pd.SparseDtype(data.dtype, np.nan),
+                            )
                         series = pd.Series(sparse_array, index=index)
 
                         i_to_columns[i] = series

--- a/mars/dataframe/indexing/reindex.py
+++ b/mars/dataframe/indexing/reindex.py
@@ -23,7 +23,6 @@ except ImportError:  # pragma: no cover
 from ... import opcodes
 from ...core import ENTITY_TYPE, recursive_tile
 from ...core.operand import OperandStage
-from ...lib.version import parse as parse_version
 from ...serialization.serializables import (
     KeyField,
     AnyField,
@@ -32,7 +31,7 @@ from ...serialization.serializables import (
     BoolField,
 )
 from ...tensor import tensor as astensor
-from ...utils import lazy_import
+from ...utils import lazy_import, pd_release_version
 from ..core import Index as DataFrameIndexType, INDEX_TYPE
 from ..initializer import Index as asindex
 from ..operands import DataFrameOperand, DataFrameOperandMixin
@@ -43,7 +42,7 @@ from .index_lib import DataFrameReindexHandler
 cudf = lazy_import("cudf", globals=globals())
 
 # under pandas<1.1, SparseArray ignores zeros on creation
-_pd_sparse_miss_zero = parse_version(pd.__version__).release[:2] < (1, 1)
+_pd_sparse_miss_zero = pd_release_version[:2] < (1, 1)
 
 
 class DataFrameReindex(DataFrameOperand, DataFrameOperandMixin):
@@ -284,6 +283,7 @@ class DataFrameReindex(DataFrameOperand, DataFrameOperandMixin):
                             )
                         else:
                             from pandas._libs.sparse import IntIndex
+
                             sparse_array = pd.arrays.SparseArray(
                                 data,
                                 sparse_index=IntIndex(index_shape, ind),

--- a/mars/dataframe/indexing/setitem.py
+++ b/mars/dataframe/indexing/setitem.py
@@ -18,16 +18,16 @@ from pandas.api.types import is_list_like
 
 from ... import opcodes
 from ...core import OutputType, recursive_tile
-from ...lib.version import parse as parse_version
 from ...serialization.serializables import KeyField, AnyField
 from ...tensor.core import TENSOR_TYPE
+from ...utils import pd_release_version
 from ..core import DATAFRAME_TYPE, SERIES_TYPE, DataFrame
 from ..initializer import DataFrame as asframe, Series as asseries
 from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index
 
 # in pandas 1.0.x, __setitem__ with a list with missing items are not allowed
-_allow_set_missing_list = parse_version(pd.__version__).release >= (1, 1)
+_allow_set_missing_list = pd_release_version[:2] >= (1, 1)
 
 
 class DataFrameSetitem(DataFrameOperand, DataFrameOperandMixin):

--- a/mars/dataframe/indexing/setitem.py
+++ b/mars/dataframe/indexing/setitem.py
@@ -18,12 +18,16 @@ from pandas.api.types import is_list_like
 
 from ... import opcodes
 from ...core import OutputType, recursive_tile
+from ...lib.version import parse as parse_version
 from ...serialization.serializables import KeyField, AnyField
 from ...tensor.core import TENSOR_TYPE
 from ..core import DATAFRAME_TYPE, SERIES_TYPE, DataFrame
 from ..initializer import DataFrame as asframe, Series as asseries
 from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import parse_index
+
+# in pandas 1.0.x, __setitem__ with a list with missing items are not allowed
+_allow_set_missing_list = parse_version(pd.__version__).release >= (1, 1)
 
 
 class DataFrameSetitem(DataFrameOperand, DataFrameOperandMixin):
@@ -268,7 +272,20 @@ class DataFrameSetitem(DataFrameOperand, DataFrameOperandMixin):
     def execute(cls, ctx, op: "DataFrameSetitem"):
         target = ctx[op.target.key].copy()
         value = ctx[op.value.key] if not np.isscalar(op.value) else op.value
-        target[op.indexes] = value
+        try:
+
+            target[op.indexes] = value
+        except KeyError:
+            if _allow_set_missing_list:  # pragma: no cover
+                raise
+            else:
+                existing = set(target.columns)
+                new_columns = target.columns.append(
+                    pd.Index([idx for idx in op.indexes if idx not in existing])
+                )
+                target = target.reindex(new_columns, axis=1)
+                target[op.indexes] = value
+
         ctx[op.outputs[0].key] = target
 
 

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -30,12 +30,12 @@ except ImportError:  # pragma: no cover
 
 from .... import dataframe as md
 from .... import tensor as mt
-from ....lib.version import parse as parse_version
+from ....utils import pd_release_version
 from ...datasource.read_csv import DataFrameReadCSV
 from ...datasource.read_sql import DataFrameReadSQL
 from ...datasource.read_parquet import DataFrameReadParquet
 
-_allow_set_missing_list = parse_version(pd.__version__).release >= (1, 1)
+_allow_set_missing_list = pd_release_version[:2] >= (1, 1)
 
 
 @pytest.mark.parametrize("chunk_size", [2, (2, 3)])

--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -383,6 +383,7 @@ def test_loc_getitem(setup):
     pd.testing.assert_frame_equal(result, expected)
 
 
+@pytest.mark.pd_compat
 def test_dataframe_getitem(setup):
     data = pd.DataFrame(np.random.rand(10, 5), columns=["c1", "c2", "c3", "c4", "c5"])
     df = md.DataFrame(data, chunk_size=2)
@@ -634,6 +635,7 @@ def test_iat(setup):
     assert result == data.iloc[:, 2].iat[3]
 
 
+@pytest.mark.pd_compat
 def test_setitem(setup):
     data = pd.DataFrame(
         np.random.rand(10, 5),
@@ -671,6 +673,8 @@ def test_setitem(setup):
             ["c" + str(i) for i in range(5)] + ["c10", "c11", "c12"],
             axis=1,
         )
+    else:
+        expected = data.copy()
     expected[["c0", "c2"]] = 1
     expected[["c1", "c10"]] = expected["c4"].mean()
     expected[["c11", "c12"]] = data3
@@ -1006,6 +1010,7 @@ def _wrap_execute_data_source_mixed(limit, usecols, op_cls):
     return _execute_data_source
 
 
+@pytest.mark.pd_compat
 def test_optimization(setup):
     import sqlalchemy as sa
 

--- a/mars/dataframe/reduction/aggregation.py
+++ b/mars/dataframe/reduction/aggregation.py
@@ -27,7 +27,6 @@ from ...config import options
 from ...core import OutputType, ENTITY_TYPE, enter_mode, recursive_tile
 from ...core.custom_log import redirect_custom_log
 from ...core.operand import OperandStage
-from ...lib.version import parse as parse_version
 from ...serialization.serializables import (
     BoolField,
     AnyField,
@@ -35,7 +34,7 @@ from ...serialization.serializables import (
     ListField,
     DictField,
 )
-from ...utils import ceildiv, lazy_import, enter_current_session
+from ...utils import ceildiv, lazy_import, enter_current_session, pd_release_version
 from ..core import INDEX_CHUNK_TYPE
 from ..merge import DataFrameConcat
 from ..operands import DataFrameOperand, DataFrameOperandMixin
@@ -52,7 +51,7 @@ from .core import (
 cp = lazy_import("cupy", globals=globals(), rename="cp")
 cudf = lazy_import("cudf", globals=globals())
 
-_agg_size_as_series = parse_version(pd.__version__) >= parse_version("1.3.0")
+_agg_size_as_series = pd_release_version >= (1, 3, 0)
 
 
 def where_function(cond, var1, var2):

--- a/mars/dataframe/reduction/aggregation.py
+++ b/mars/dataframe/reduction/aggregation.py
@@ -971,6 +971,8 @@ class DataFrameAggregate(DataFrameOperand, DataFrameOperandMixin):
                     result = op.func[0](in_data)
                 else:
                     result = in_data.agg(op.raw_func, axis=op.axis)
+                    if op.outputs[0].ndim == 1:
+                        result = result.astype(op.outputs[0].dtype, copy=False)
 
                 if op.output_types[0] == OutputType.tensor:
                     result = xp.array(result)

--- a/mars/dataframe/reduction/core.py
+++ b/mars/dataframe/reduction/core.py
@@ -28,7 +28,6 @@ from ...core import (
     recursive_tile,
 )
 from ...core.operand import OperandStage
-from ...lib.version import parse as parse_version
 from ...serialization.serializables import (
     BoolField,
     AnyField,
@@ -36,7 +35,7 @@ from ...serialization.serializables import (
     Int32Field,
     StringField,
 )
-from ...utils import tokenize
+from ...utils import pd_release_version, tokenize
 from ..core import SERIES_TYPE
 from ..utils import (
     parse_index,
@@ -48,13 +47,12 @@ from ..utils import (
 )
 from ..operands import DataFrameOperandMixin, DataFrameOperand, DATAFRAME_TYPE
 
-_pd_release = parse_version(pd.__version__).release[:2]
 # in pandas<1.3, when aggregating with multiple levels and numeric_only is True,
 # object cols not ignored with min-max funcs
-_level_reduction_keep_object = _pd_release < (1, 3)
+_level_reduction_keep_object = pd_release_version[:2] < (1, 3)
 # in pandas>=1.3, when dataframes are reduced into series, mixture of float and bool
 # results in object.
-_reduce_bool_as_object = _pd_release != (1, 2)
+_reduce_bool_as_object = pd_release_version[:2] != (1, 2)
 
 
 class DataFrameReductionOperand(DataFrameOperand):

--- a/mars/dataframe/reduction/core.py
+++ b/mars/dataframe/reduction/core.py
@@ -54,7 +54,7 @@ _pd_release = parse_version(pd.__version__).release[:2]
 _level_reduction_keep_object = _pd_release < (1, 3)
 # in pandas>=1.3, when dataframes are reduced into series, mixture of float and bool
 # results in object.
-_reduce_bool_as_object = _pd_release >= (1, 3)
+_reduce_bool_as_object = _pd_release != (1, 2)
 
 
 class DataFrameReductionOperand(DataFrameOperand):
@@ -362,8 +362,11 @@ class DataFrameReductionMixin(DataFrameOperandMixin):
             elif all(dt == dtypes[0] for dt in dtypes):
                 reduced_dtype = dtypes[0]
             else:
-                has_bool = any(dt == bool for dt in dtypes)
-                if _reduce_bool_as_object and has_bool:
+                # as we already bypassed dtypes with same values,
+                # when has_mixed_bool is True, there are other dtypes
+                # other than bool.
+                has_mixed_bool = any(dt == np.dtype(bool) for dt in dtypes)
+                if _reduce_bool_as_object and has_mixed_bool:
                     reduced_dtype = np.dtype("O")
                 elif not all(isinstance(dt, np.dtype) for dt in dtypes):
                     # todo currently we return mixed dtypes as np.dtype('O').

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -53,6 +53,8 @@ from .. import (
 from ..aggregation import where_function
 from ..core import ReductionCompiler
 
+pytestmark = pytest.mark.pd_compat
+
 
 class FunctionOptions(NamedTuple):
     has_skipna: bool = True

--- a/mars/dataframe/reduction/tests/test_reduction_execution.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execution.py
@@ -986,7 +986,8 @@ class MockReduction2(CustomReduction):
 
 
 def test_custom_dataframe_aggregate(setup, check_ref_counts):
-    data = pd.DataFrame(np.random.rand(30, 20))
+    rs = np.random.RandomState(0)
+    data = pd.DataFrame(rs.rand(30, 20))
 
     df = md.DataFrame(data)
     result = df.agg(MockReduction1())
@@ -1004,7 +1005,8 @@ def test_custom_dataframe_aggregate(setup, check_ref_counts):
 
 
 def test_custom_series_aggregate(setup, check_ref_counts):
-    data = pd.Series(np.random.rand(20))
+    rs = np.random.RandomState(0)
+    data = pd.Series(rs.rand(20))
 
     s = md.Series(data)
     result = s.agg(MockReduction1())

--- a/mars/dataframe/reduction/tests/test_reduction_execution.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execution.py
@@ -31,6 +31,8 @@ from ....utils import lazy_import, pd_release_version
 from ... import CustomReduction, NamedAgg
 from ...base import to_gpu
 
+pytestmark = pytest.mark.pd_compat
+
 cp = lazy_import("cupy", rename="cp", globals=globals())
 _agg_size_as_series = pd_release_version >= (1, 3)
 _support_kw_agg = pd_release_version >= (1, 1)

--- a/mars/dataframe/reduction/tests/test_reduction_execution.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execution.py
@@ -26,15 +26,14 @@ except ImportError:  # pragma: no cover
 from .... import dataframe as md
 from ....config import option_context
 from ....deploy.oscar.session import get_default_session
-from ....lib.version import parse as parse_version
 from ....tests.core import require_cudf, require_cupy
-from ....utils import lazy_import
+from ....utils import lazy_import, pd_release_version
 from ... import CustomReduction, NamedAgg
 from ...base import to_gpu
 
 cp = lazy_import("cupy", rename="cp", globals=globals())
-_agg_size_as_series = parse_version(pd.__version__).release >= (1, 3)
-_support_kw_agg = parse_version(pd.__version__).release >= (1, 1)
+_agg_size_as_series = pd_release_version >= (1, 3)
+_support_kw_agg = pd_release_version >= (1, 1)
 
 
 @pytest.fixture
@@ -301,7 +300,7 @@ def test_dataframe_level_reduction(
 
     # behavior of 'skew', 'kurt' differs for cases with and without level
     skip_funcs = ("skew", "kurt")
-    if parse_version(pd.__version__).release <= (1, 2, 0):
+    if pd_release_version <= (1, 2, 0):
         # fails under pandas 1.2. see pandas-dev/pandas#38774 for more details
         skip_funcs += ("sem",)
 

--- a/mars/dataframe/tests/test_core.py
+++ b/mars/dataframe/tests/test_core.py
@@ -18,11 +18,11 @@ import pytest
 
 from ...core import tile
 from ...lib.groupby_wrapper import wrapped_groupby
-from ...lib.version import parse as parse_version
+from ...utils import pd_release_version
 from .. import cut
 from ..initializer import DataFrame, Series, Index
 
-_with_inclusive_bounds = parse_version(pd.__version__) >= parse_version("1.3.0")
+_with_inclusive_bounds = pd_release_version >= (1, 3, 0)
 
 
 def test_dataframe_params():

--- a/mars/dataframe/tests/test_core.py
+++ b/mars/dataframe/tests/test_core.py
@@ -301,6 +301,7 @@ def test_key_value(setup):
     np.testing.assert_array_equal(result, raw.values)
 
 
+@pytest.mark.pd_compat
 def test_between(setup):
     pd_series = pd.Series(pd.date_range("1/1/2000", periods=10))
     pd_left, pd_right = pd_series[3], pd_series[7]

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -1252,10 +1252,7 @@ def make_dtypes(dtypes):
     if dtypes is None:
         return None
     if not isinstance(dtypes, pd.Series):
-        if isinstance(dtypes, dict):
-            dtypes = pd.Series(dtypes.values(), index=dtypes.keys())
-        else:
-            dtypes = pd.Series(dtypes)
+        dtypes = pd.Series(dtypes)
     return dtypes.apply(make_dtype)
 
 

--- a/mars/dataframe/window/ewm/core.py
+++ b/mars/dataframe/window/ewm/core.py
@@ -15,20 +15,18 @@
 import math
 from collections import OrderedDict
 
-import pandas as pd
-
-from ....lib.version import parse as parse_version
 from ....serialization.serializables import (
     Int64Field,
     BoolField,
     Int32Field,
     Float64Field,
 )
+from ....utils import pd_release_version
 from ...utils import validate_axis
 from ..core import Window
 
-_default_min_period_1 = parse_version(pd.__version__) >= parse_version("1.1.0")
-_pd_1_3_repr = parse_version(pd.__version__) >= parse_version("1.3.0")
+_default_min_period_1 = pd_release_version >= (1, 1, 0)
+_pd_1_3_repr = pd_release_version >= (1, 3, 0)
 
 
 class EWM(Window):

--- a/mars/dataframe/window/expanding/core.py
+++ b/mars/dataframe/window/expanding/core.py
@@ -14,19 +14,17 @@
 
 from collections import OrderedDict
 
-import pandas as pd
-
-from ....lib.version import parse as parse_version
 from ....serialization.serializables import (
     BoolField,
     Int32Field,
     Int64Field,
     StringField,
 )
+from ....utils import pd_release_version
 from ...utils import validate_axis
 from ..core import Window
 
-_window_has_method = parse_version(pd.__version__) >= parse_version("1.3.0")
+_window_has_method = pd_release_version >= (1, 3, 0)
 
 
 class Expanding(Window):

--- a/mars/dataframe/window/rolling/aggregation.py
+++ b/mars/dataframe/window/rolling/aggregation.py
@@ -17,7 +17,6 @@ import pandas as pd
 
 from .... import opcodes
 from ....core import recursive_tile
-from ....lib.version import parse as parse_version
 from ....serialization.serializables import (
     FieldTypes,
     AnyField,
@@ -30,12 +29,13 @@ from ....serialization.serializables import (
     DictField,
     ListField,
 )
-from ....utils import lazy_import, has_unknown_shape
+from ....utils import lazy_import, has_unknown_shape, pd_release_version
 from ...operands import DataFrameOperand, DataFrameOperandMixin
 from ...core import DATAFRAME_TYPE
 from ...utils import build_empty_df, build_empty_series, parse_index
 
 cudf = lazy_import("cudf", globals=globals())
+_with_pandas_issue_38908 = pd_release_version == (1, 2, 0)
 
 
 class DataFrameRollingAgg(DataFrameOperand, DataFrameOperandMixin):
@@ -465,7 +465,7 @@ class DataFrameRollingAgg(DataFrameOperand, DataFrameOperandMixin):
             # df.rolling().aggregate('skew') modified original data
             # so we copy it first for skew only
             if (
-                parse_version(pd.__version__) == parse_version("1.2.0")
+                _with_pandas_issue_38908
                 and op.func in ["skew", "kurt"]
                 and op.outputs[0].index[0] == 0
             ):

--- a/mars/dataframe/window/rolling/core.py
+++ b/mars/dataframe/window/rolling/core.py
@@ -14,9 +14,6 @@
 
 from collections import OrderedDict
 
-import pandas as pd
-
-from ....lib.version import parse as parse_version
 from ....serialization.serializables import (
     AnyField,
     Int64Field,
@@ -24,11 +21,12 @@ from ....serialization.serializables import (
     StringField,
     Int32Field,
 )
+from ....utils import pd_release_version
 from ...core import DATAFRAME_TYPE
 from ...utils import build_empty_df, build_empty_series, validate_axis
 from ..core import Window
 
-_window_has_method = parse_version(pd.__version__) >= parse_version("1.3.0")
+_window_has_method = pd_release_version >= (1, 3, 0)
 
 
 class Rolling(Window):

--- a/mars/lib/groupby_wrapper.py
+++ b/mars/lib/groupby_wrapper.py
@@ -17,13 +17,11 @@ from collections.abc import Iterable
 
 import cloudpickle
 import numpy as np
-import pandas as pd
 from pandas.core.groupby import DataFrameGroupBy, SeriesGroupBy
 
-from ..utils import estimate_pandas_size
-from .version import parse as parse_version
+from ..utils import estimate_pandas_size, pd_release_version
 
-_HAS_SQUEEZE = parse_version(pd.__version__) < parse_version("1.1.0")
+_HAS_SQUEEZE = pd_release_version < (1, 1, 0)
 
 
 class GroupByWrapper:

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -55,10 +55,12 @@ from ._utils import (  # noqa: F401 # pylint: disable=unused-import
     ceildiv,
     Timer,
 )
+from .lib.version import parse as parse_version
 from .typing import ChunkType, TileableType, EntityType, OperandType
 
 logger = logging.getLogger(__name__)
 random.seed(int(time.time()) * os.getpid())
+pd_release_version: Tuple[int] = parse_version(pd.__version__).release
 
 OBJECT_FIELD_OVERHEAD = 50
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ markers =
     cuda: mark a test as a cuda case.
     hadoop: mark test as a hadoop case.
     ray: mark test as a ray case.
+    pd_compat: mark test as a pandas-compatibility test
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Fix backward compatibility for pandas 1.0 and add tests for backward compatibility.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2623

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
