### PR TITLE
Improve profiling

### DIFF
--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -37,7 +37,7 @@ from ....lib.aio import new_isolation
 from ....storage import StorageLevel
 from ....services.storage import StorageAPI
 from ....tensor.arithmetic.add import TensorAdd
-from ....tests.core import check_dict_structure_same
+from ....tests.core import check_dict_structure_same, DICT_NOT_EMPTY
 from ..local import new_cluster
 from ..service import load_config
 from ..session import (
@@ -74,14 +74,18 @@ EXPECT_PROFILING_STRUCTURE = {
             "optimize": 0.0005879402160644531,
             "incref_fetch_tileables": 0.0010840892791748047,
             "stage_*": {
-                "tile": 0.008243083953857422,
-                "gen_subtask_graph": 0.012202978134155273,
+                "tile(*)": 0.008243083953857422,
+                "gen_subtask_graph(*)": 0.012202978134155273,
                 "run": 0.27870702743530273,
                 "total": 0.30318617820739746,
             },
             "total": 0.30951380729675293,
         },
         "serialization": {},
+        "most_calls": DICT_NOT_EMPTY,
+        "slowest_calls": DICT_NOT_EMPTY,
+        "band_subtasks": DICT_NOT_EMPTY,
+        "slowest_subtasks": DICT_NOT_EMPTY,
     }
 }
 

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -83,9 +83,9 @@ EXPECT_PROFILING_STRUCTURE = {
         },
         "serialization": {},
         "most_calls": DICT_NOT_EMPTY,
-        "slowest_calls": DICT_NOT_EMPTY,
+        "slow_calls": DICT_NOT_EMPTY,
         "band_subtasks": DICT_NOT_EMPTY,
-        "slowest_subtasks": DICT_NOT_EMPTY,
+        "slow_subtasks": DICT_NOT_EMPTY,
     }
 }
 
@@ -171,7 +171,15 @@ async def test_vineyard_operators(create_cluster):
 @pytest.mark.parametrize(
     "config",
     [
-        [{"enable_profiling": True}, EXPECT_PROFILING_STRUCTURE],
+        [
+            {
+                "enable_profiling": {
+                    "slow_calls_duration_threshold": 0,
+                    "slow_subtasks_duration_threshold": 0,
+                }
+            },
+            EXPECT_PROFILING_STRUCTURE,
+        ],
         [{}, {}],
     ],
 )

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -341,7 +341,15 @@ async def _run_web_session_test(web_address):
 @pytest.mark.parametrize(
     "config",
     [
-        [{"enable_profiling": True}, EXPECT_PROFILING_STRUCTURE],
+        [
+            {
+                "enable_profiling": {
+                    "slow_calls_duration_threshold": 0,
+                    "slow_subtasks_duration_threshold": 0,
+                }
+            },
+            EXPECT_PROFILING_STRUCTURE,
+        ],
         [{}, {}],
     ],
 )

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -33,7 +33,7 @@ from ....oscar.errors import ReconstructWorkerError
 from ....serialization.ray import register_ray_serializers
 from ....services.cluster import ClusterAPI
 from ....services.scheduling.supervisor.autoscale import AutoscalerActor
-from ....tests.core import require_ray, mock
+from ....tests.core import require_ray, mock, DICT_NOT_EMPTY
 from ....utils import lazy_import
 from ..ray import (
     new_cluster,
@@ -62,8 +62,8 @@ EXPECT_PROFILING_STRUCTURE = {
             "optimize": 0.0005879402160644531,
             "incref_fetch_tileables": 0.0010840892791748047,
             "stage_*": {
-                "tile": 0.008243083953857422,
-                "gen_subtask_graph": 0.012202978134155273,
+                "tile(*)": 0.008243083953857422,
+                "gen_subtask_graph(*)": 0.012202978134155273,
                 "run": 0.27870702743530273,
                 "total": 0.30318617820739746,
             },
@@ -74,6 +74,10 @@ EXPECT_PROFILING_STRUCTURE = {
             "deserialize": 0.0011813640594482422,
             "total": 0.016109704971313477,
         },
+        "most_calls": DICT_NOT_EMPTY,
+        "slowest_calls": DICT_NOT_EMPTY,
+        "band_subtasks": DICT_NOT_EMPTY,
+        "slowest_subtasks": DICT_NOT_EMPTY,
     }
 }
 

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -75,9 +75,9 @@ EXPECT_PROFILING_STRUCTURE = {
             "total": 0.016109704971313477,
         },
         "most_calls": DICT_NOT_EMPTY,
-        "slowest_calls": DICT_NOT_EMPTY,
+        "slow_calls": DICT_NOT_EMPTY,
         "band_subtasks": DICT_NOT_EMPTY,
-        "slowest_subtasks": DICT_NOT_EMPTY,
+        "slow_subtasks": DICT_NOT_EMPTY,
     }
 }
 
@@ -91,7 +91,7 @@ async def create_cluster(request):
         "test_cluster",
         worker_num=2,
         worker_cpu=2,
-        worker_mem=1 * 1024**3,
+        worker_mem=1 * 1024 ** 3,
         config=ray_config,
     )
     async with client:
@@ -217,7 +217,7 @@ async def test_optional_supervisor_node(ray_large_cluster, test_option):
         "test_cluster",
         worker_num=2,
         worker_cpu=2,
-        worker_mem=1 * 1024**3,
+        worker_mem=1 * 1024 ** 3,
         config=config,
     )
     async with client:
@@ -268,7 +268,7 @@ async def test_load_third_party_modules(ray_large_cluster, config_exception):
             "test_cluster",
             worker_num=2,
             worker_cpu=2,
-            worker_mem=1 * 1024**3,
+            worker_mem=1 * 1024 ** 3,
             config=config,
         )
 
@@ -313,7 +313,7 @@ async def test_load_third_party_modules_from_config(
         "test_cluster",
         worker_num=2,
         worker_cpu=2,
-        worker_mem=1 * 1024**3,
+        worker_mem=1 * 1024 ** 3,
         config=CONFIG_THIRD_PARTY_MODULES_TEST_FILE,
     )
     async with client:
@@ -346,7 +346,7 @@ def test_load_config():
 @require_ray
 @pytest.mark.asyncio
 async def test_request_worker(ray_large_cluster):
-    worker_cpu, worker_mem = 1, 100 * 1024**2
+    worker_cpu, worker_mem = 1, 100 * 1024 ** 2
     client = await new_cluster(
         "test_cluster", worker_num=0, worker_cpu=worker_cpu, worker_mem=worker_mem
     )
@@ -376,7 +376,7 @@ async def test_request_worker(ray_large_cluster):
 @require_ray
 @pytest.mark.asyncio
 async def test_reconstruct_worker(ray_large_cluster):
-    worker_cpu, worker_mem = 1, 100 * 1024**2
+    worker_cpu, worker_mem = 1, 100 * 1024 ** 2
     client = await new_cluster(
         "test_cluster", worker_num=0, worker_cpu=worker_cpu, worker_mem=worker_mem
     )
@@ -484,7 +484,7 @@ async def test_auto_scale_out(ray_large_cluster, init_workers: int):
         "test_cluster",
         worker_num=init_workers,
         worker_cpu=2,
-        worker_mem=100 * 1024**2,
+        worker_mem=100 * 1024 ** 2,
         config={
             "scheduling.autoscale.enabled": True,
             "scheduling.autoscale.scheduler_backlog_timeout": 1,
@@ -528,7 +528,7 @@ async def test_auto_scale_in(ray_large_cluster):
         "test_cluster",
         worker_num=0,
         worker_cpu=2,
-        worker_mem=100 * 1024**2,
+        worker_mem=100 * 1024 ** 2,
         config=config,
     )
     async with client:
@@ -562,7 +562,7 @@ async def test_ownership_when_scale_in(ray_large_cluster):
         "test_cluster",
         worker_num=0,
         worker_cpu=2,
-        worker_mem=100 * 1024**2,
+        worker_mem=100 * 1024 ** 2,
         config={
             "scheduling.autoscale.enabled": True,
             "scheduling.autoscale.scheduler_check_interval": 1,

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -102,7 +102,15 @@ async def create_cluster(request):
 @pytest.mark.parametrize(
     "config",
     [
-        [{"enable_profiling": True}, EXPECT_PROFILING_STRUCTURE],
+        [
+            {
+                "enable_profiling": {
+                    "slow_calls_duration_threshold": 0,
+                    "slow_subtasks_duration_threshold": 0,
+                }
+            },
+            EXPECT_PROFILING_STRUCTURE,
+        ],
         [{}, {}],
     ],
 )
@@ -229,7 +237,15 @@ async def test_optional_supervisor_node(ray_large_cluster, test_option):
 @pytest.mark.parametrize(
     "config",
     [
-        [{"enable_profiling": True}, EXPECT_PROFILING_STRUCTURE],
+        [
+            {
+                "enable_profiling": {
+                    "slow_calls_duration_threshold": 0,
+                    "slow_subtasks_duration_threshold": 0,
+                }
+            },
+            EXPECT_PROFILING_STRUCTURE,
+        ],
         [{}, {}],
     ],
 )

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -91,7 +91,7 @@ async def create_cluster(request):
         "test_cluster",
         worker_num=2,
         worker_cpu=2,
-        worker_mem=1 * 1024 ** 3,
+        worker_mem=1 * 1024**3,
         config=ray_config,
     )
     async with client:
@@ -217,7 +217,7 @@ async def test_optional_supervisor_node(ray_large_cluster, test_option):
         "test_cluster",
         worker_num=2,
         worker_cpu=2,
-        worker_mem=1 * 1024 ** 3,
+        worker_mem=1 * 1024**3,
         config=config,
     )
     async with client:
@@ -268,7 +268,7 @@ async def test_load_third_party_modules(ray_large_cluster, config_exception):
             "test_cluster",
             worker_num=2,
             worker_cpu=2,
-            worker_mem=1 * 1024 ** 3,
+            worker_mem=1 * 1024**3,
             config=config,
         )
 
@@ -313,7 +313,7 @@ async def test_load_third_party_modules_from_config(
         "test_cluster",
         worker_num=2,
         worker_cpu=2,
-        worker_mem=1 * 1024 ** 3,
+        worker_mem=1 * 1024**3,
         config=CONFIG_THIRD_PARTY_MODULES_TEST_FILE,
     )
     async with client:
@@ -346,7 +346,7 @@ def test_load_config():
 @require_ray
 @pytest.mark.asyncio
 async def test_request_worker(ray_large_cluster):
-    worker_cpu, worker_mem = 1, 100 * 1024 ** 2
+    worker_cpu, worker_mem = 1, 100 * 1024**2
     client = await new_cluster(
         "test_cluster", worker_num=0, worker_cpu=worker_cpu, worker_mem=worker_mem
     )
@@ -376,7 +376,7 @@ async def test_request_worker(ray_large_cluster):
 @require_ray
 @pytest.mark.asyncio
 async def test_reconstruct_worker(ray_large_cluster):
-    worker_cpu, worker_mem = 1, 100 * 1024 ** 2
+    worker_cpu, worker_mem = 1, 100 * 1024**2
     client = await new_cluster(
         "test_cluster", worker_num=0, worker_cpu=worker_cpu, worker_mem=worker_mem
     )
@@ -484,7 +484,7 @@ async def test_auto_scale_out(ray_large_cluster, init_workers: int):
         "test_cluster",
         worker_num=init_workers,
         worker_cpu=2,
-        worker_mem=100 * 1024 ** 2,
+        worker_mem=100 * 1024**2,
         config={
             "scheduling.autoscale.enabled": True,
             "scheduling.autoscale.scheduler_backlog_timeout": 1,
@@ -528,7 +528,7 @@ async def test_auto_scale_in(ray_large_cluster):
         "test_cluster",
         worker_num=0,
         worker_cpu=2,
-        worker_mem=100 * 1024 ** 2,
+        worker_mem=100 * 1024**2,
         config=config,
     )
     async with client:
@@ -562,7 +562,7 @@ async def test_ownership_when_scale_in(ray_large_cluster):
         "test_cluster",
         worker_num=0,
         worker_cpu=2,
-        worker_mem=100 * 1024 ** 2,
+        worker_mem=100 * 1024**2,
         config={
             "scheduling.autoscale.enabled": True,
             "scheduling.autoscale.scheduler_check_interval": 1,

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -159,7 +159,7 @@ class _CallStats:
         for duration, uid, address, content in sorted(
             self._slow_calls, key=operator.itemgetter(0), reverse=True
         ):
-            method_name, batch, args, kwargs = content
+            method_name, _batch, args, kwargs = content
             slow_calls[
                 f"[{address}]{uid.decode('utf-8')}.{method_name}(args={args}, kwargs={kwargs})"
             ] = duration
@@ -238,8 +238,8 @@ class _ProfilingData:
                         logger.info("Profiling debug log break.")
                         break
                     r = copy.copy(r)  # shadow copy is enough.
-                    r and r.update(self._call_stats.get(task_id).to_dict())
-                    r and r.update(self._subtask_stats.get(task_id).to_dict())
+                    r.update(self._call_stats.get(task_id).to_dict())
+                    r.update(self._subtask_stats.get(task_id).to_dict())
                     logger.warning("Profiling debug:\n%s", json.dumps(r, indent=4))
                 except Exception:
                     logger.exception("Profiling debug log failed.")
@@ -255,8 +255,9 @@ class _ProfilingData:
         if debug_task is not None:
             debug_task.cancel()
         r = self._data.pop(task_id, None)
-        r and r.update(self._call_stats.pop(task_id).to_dict())
-        r and r.update(self._subtask_stats.pop(task_id).to_dict())
+        if r is not None:
+            r.update(self._call_stats.pop(task_id).to_dict())
+            r.update(self._subtask_stats.pop(task_id).to_dict())
         return r
 
     def collect_actor_call(self, message, duration):

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import collections
 import os
 import asyncio
 import copy
@@ -23,6 +24,55 @@ from .backends.message import SendMessage, TellMessage
 
 
 logger = logging.getLogger(__name__)
+
+MARS_ENABLE_PROFILING = bool(os.environ.get("MARS_ENABLE_PROFILING", 0))
+
+
+class _ProfilingOptionDescriptor:
+    def __init__(self, _type, default):
+        self._name = None
+        self._type = _type
+        self._default = default
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self
+        v = obj._options.get(self._name)
+        if v is None:
+            v = os.environ.get(f"MARS_PROFILING_{self._name.upper()}", self._default)
+        if v is not None:
+            v = self._type(v)
+        # Cache the value.
+        obj.__dict__[self._name] = v
+        return v
+
+    def set_name(self, name):
+        self._name = name
+
+
+class _ProfilingOptionsMeta(type):
+    def __init__(cls, name, bases, classdict):
+        super(_ProfilingOptionsMeta, cls).__init__(name, bases, classdict)
+        for k, v in classdict.items():
+            if isinstance(v, _ProfilingOptionDescriptor):
+                v.set_name(k)
+
+
+class _ProfilingOptions(metaclass=_ProfilingOptionsMeta):
+    debug_interval_seconds = _ProfilingOptionDescriptor(float, default=None)
+    slow_calls_duration_threshold = _ProfilingOptionDescriptor(int, default=1)
+    slow_subtasks_duration_threshold = _ProfilingOptionDescriptor(int, default=10)
+
+    def __init__(self, options):
+        if isinstance(options, collections.Mapping):
+            invalid_keys = options.keys() - type(self).__dict__.keys()
+            if invalid_keys:
+                raise ValueError(f"Invalid profiling options: {invalid_keys}")
+            self._options = options
+        elif options in (True, False):
+            self._options = {}
+        else:
+            raise ValueError(f"Invalid profiling options: {options}")
 
 
 class DummyOperator:
@@ -75,12 +125,15 @@ class ProfilingDataOperator:
         return len(self._target) == 0
 
 
-class _ActorCallStats:
-    def __init__(self):
+class _CallStats:
+    def __init__(self, options: _ProfilingOptions):
+        self._options = options
         self._call_counter = Counter()
         self._slow_calls = []
 
     def collect(self, message, duration):
+        if duration < self._options.slow_calls_duration_threshold:
+            return
         key = (message.actor_ref.uid, message.content[0])
         self._call_counter[key] += 1
         key = (
@@ -102,23 +155,26 @@ class _ActorCallStats:
         for name_tuple, count in self._call_counter.most_common(10):
             uid, method_name = name_tuple
             most_calls[f"{uid.decode('utf-8')}.{method_name}"] = count
-        slowest_calls = {}
+        slow_calls = {}
         for duration, uid, address, content in sorted(
             self._slow_calls, key=operator.itemgetter(0), reverse=True
         ):
             method_name, batch, args, kwargs = content
-            slowest_calls[
+            slow_calls[
                 f"[{address}]{uid.decode('utf-8')}.{method_name}(args={args}, kwargs={kwargs})"
             ] = duration
-        return {"most_calls": most_calls, "slowest_calls": slowest_calls}
+        return {"most_calls": most_calls, "slow_calls": slow_calls}
 
 
 class _SubtaskStats:
-    def __init__(self):
+    def __init__(self, options: _ProfilingOptions):
+        self._options = options
         self._band_counter = Counter()
         self._slow_subtasks = []
 
     def collect(self, subtask, band, duration):
+        if duration < self._options.slow_subtasks_duration_threshold:
+            return
         band_address = band[0]
         self._band_counter[band_address] += 1
         key = (duration, band_address, subtask)
@@ -146,32 +202,33 @@ class _SubtaskStats:
             self._slow_subtasks, key=operator.itemgetter(0), reverse=True
         ):
             slow_subtasks[f"[{band}]{subtask}"] = duration
-        return {"band_subtasks": band_subtasks, "slowest_subtasks": slow_subtasks}
+        return {"band_subtasks": band_subtasks, "slow_subtasks": slow_subtasks}
 
 
 class _ProfilingData:
     def __init__(self):
         self._data = {}
-        self._actor_call_stats = {}
+        self._call_stats = {}
         self._subtask_stats = {}
         self._debug_task = {}
 
-    def init(self, task_id: str, debug_interval_seconds=None):
+    def init(self, task_id: str, options=None):
+        options = _ProfilingOptions(options)
         logger.info(
             "Init profiling data for task %s with debug interval seconds %s.",
             task_id,
-            debug_interval_seconds,
+            options.debug_interval_seconds,
         )
         self._data[task_id] = {
             "general": {},
             "serialization": {},
             "most_calls": {},
-            "slowest_calls": {},
+            "slow_calls": {},
             "band_subtasks": {},
-            "slowest_subtasks": {},
+            "slow_subtasks": {},
         }
-        self._actor_call_stats[task_id] = _ActorCallStats()
-        self._subtask_stats[task_id] = _SubtaskStats()
+        self._call_stats[task_id] = _CallStats(options)
+        self._subtask_stats[task_id] = _SubtaskStats(options)
 
         async def _debug_profiling_log():
             while True:
@@ -181,18 +238,15 @@ class _ProfilingData:
                         logger.info("Profiling debug log break.")
                         break
                     r = copy.copy(r)  # shadow copy is enough.
-                    r and r.update(self._actor_call_stats.get(task_id).to_dict())
+                    r and r.update(self._call_stats.get(task_id).to_dict())
                     r and r.update(self._subtask_stats.get(task_id).to_dict())
                     logger.warning("Profiling debug:\n%s", json.dumps(r, indent=4))
                 except Exception:
                     logger.exception("Profiling debug log failed.")
                 finally:
-                    await asyncio.sleep(debug_interval_seconds)
+                    await asyncio.sleep(options.debug_interval_seconds)
 
-        if debug_interval_seconds is not None:
-            logger.info(
-                "Profiling debug log interval second: %s", debug_interval_seconds
-            )
+        if options.debug_interval_seconds is not None:
             self._debug_task[task_id] = asyncio.create_task(_debug_profiling_log())
 
     def pop(self, task_id: str):
@@ -201,15 +255,15 @@ class _ProfilingData:
         if debug_task is not None:
             debug_task.cancel()
         r = self._data.pop(task_id, None)
-        r and r.update(self._actor_call_stats.pop(task_id).to_dict())
+        r and r.update(self._call_stats.pop(task_id).to_dict())
         r and r.update(self._subtask_stats.pop(task_id).to_dict())
         return r
 
     def collect_actor_call(self, message, duration):
-        if self._actor_call_stats:
+        if self._call_stats:
             message_type = type(message)
             if message_type is SendMessage or message_type is TellMessage:
-                for stats in self._actor_call_stats.values():
+                for stats in self._call_stats.values():
                     stats.collect(message, duration)
 
     def collect_subtask(self, subtask, band, duration):
@@ -232,9 +286,3 @@ class _ProfilingData:
 
 
 ProfilingData = _ProfilingData()
-
-MARS_ENABLE_PROFILING = bool(os.environ.get("MARS_ENABLE_PROFILING", 0))
-MARS_DEBUG_PROFILING_INTERVAL = os.environ.get("MARS_DEBUG_PROFILING_INTERVAL")
-MARS_DEBUG_PROFILING_INTERVAL = MARS_DEBUG_PROFILING_INTERVAL and int(
-    MARS_DEBUG_PROFILING_INTERVAL
-)

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -11,6 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+import asyncio
+import copy
+import json
+import heapq
+import logging
+import operator
+from collections import Counter
+from .backends.message import SendMessage, TellMessage
+
+
+logger = logging.getLogger(__name__)
 
 
 class DummyOperator:
@@ -63,18 +75,148 @@ class ProfilingDataOperator:
         return len(self._target) == 0
 
 
+class _ActorCallStats:
+    def __init__(self):
+        self._call_counter = Counter()
+        self._slow_calls = []
+
+    def collect(self, message, duration):
+        key = (message.actor_ref.uid, message.content[0])
+        self._call_counter[key] += 1
+        key = (
+            duration,
+            message.actor_ref.uid,
+            message.actor_ref.address,
+            message.content,
+        )
+        try:
+            if len(self._slow_calls) < 10:
+                heapq.heappush(self._slow_calls, key)
+            else:
+                heapq.heapreplace(self._slow_calls, key)
+        except TypeError:
+            pass
+
+    def to_dict(self):
+        most_calls = {}
+        for name_tuple, count in self._call_counter.most_common(10):
+            uid, method_name = name_tuple
+            most_calls[f"{uid.decode('utf-8')}.{method_name}"] = count
+        slowest_calls = {}
+        for duration, uid, address, content in sorted(
+            self._slow_calls, key=operator.itemgetter(0), reverse=True
+        ):
+            method_name, batch, args, kwargs = content
+            slowest_calls[
+                f"[{address}]{uid.decode('utf-8')}.{method_name}(args={args}, kwargs={kwargs})"
+            ] = duration
+        return {"most_calls": most_calls, "slowest_calls": slowest_calls}
+
+
+class _SubtaskStats:
+    def __init__(self):
+        self._band_counter = Counter()
+        self._slow_subtasks = []
+
+    def collect(self, subtask, band, duration):
+        band_address = band[0]
+        self._band_counter[band_address] += 1
+        key = (duration, band_address, subtask)
+        try:
+            if len(self._slow_subtasks) < 10:
+                heapq.heappush(self._slow_subtasks, key)
+            else:
+                heapq.heapreplace(self._slow_subtasks, key)
+        except TypeError:
+            pass
+
+    def to_dict(self):
+        band_subtasks = {}
+        key = operator.itemgetter(1)
+        if len(self._band_counter) > 10:
+            items = self._band_counter.items()
+            band_subtasks.update(heapq.nlargest(5, items, key=key))
+            band_subtasks.update(reversed(heapq.nsmallest(5, items, key=key)))
+        else:
+            band_subtasks.update(
+                sorted(self._band_counter.items(), key=key, reverse=True)
+            )
+        slow_subtasks = {}
+        for duration, band, subtask in sorted(
+            self._slow_subtasks, key=operator.itemgetter(0), reverse=True
+        ):
+            slow_subtasks[f"[{band}]{subtask}"] = duration
+        return {"band_subtasks": band_subtasks, "slowest_subtasks": slow_subtasks}
+
+
 class _ProfilingData:
     def __init__(self):
         self._data = {}
+        self._actor_call_stats = {}
+        self._subtask_stats = {}
+        self._debug_task = {}
 
-    def init(self, task_id: str):
+    def init(self, task_id: str, debug_interval_seconds=None):
+        logger.info(
+            "Init profiling data for task %s with debug interval seconds %s.",
+            task_id,
+            debug_interval_seconds,
+        )
         self._data[task_id] = {
             "general": {},
             "serialization": {},
+            "most_calls": {},
+            "slowest_calls": {},
+            "band_subtasks": {},
+            "slowest_subtasks": {},
         }
+        self._actor_call_stats[task_id] = _ActorCallStats()
+        self._subtask_stats[task_id] = _SubtaskStats()
+
+        async def _debug_profiling_log():
+            while True:
+                try:
+                    r = self._data.get(task_id, None)
+                    if r is None:
+                        logger.info("Profiling debug log break.")
+                        break
+                    r = copy.copy(r)  # shadow copy is enough.
+                    r and r.update(self._actor_call_stats.get(task_id).to_dict())
+                    r and r.update(self._subtask_stats.get(task_id).to_dict())
+                    logger.warning("Profiling debug:\n%s", json.dumps(r, indent=4))
+                except Exception:
+                    logger.exception("Profiling debug log failed.")
+                finally:
+                    await asyncio.sleep(debug_interval_seconds)
+
+        if debug_interval_seconds is not None:
+            logger.info(
+                "Profiling debug log interval second: %s", debug_interval_seconds
+            )
+            self._debug_task[task_id] = asyncio.create_task(_debug_profiling_log())
 
     def pop(self, task_id: str):
-        return self._data.pop(task_id, None)
+        logger.info("Pop profiling data of task %s.", task_id)
+        debug_task = self._debug_task.pop(task_id, None)
+        if debug_task is not None:
+            debug_task.cancel()
+        r = self._data.pop(task_id, None)
+        r and r.update(self._actor_call_stats.pop(task_id).to_dict())
+        r and r.update(self._subtask_stats.pop(task_id).to_dict())
+        return r
+
+    def collect_actor_call(self, message, duration):
+        if self._actor_call_stats:
+            message_type = type(message)
+            if message_type is SendMessage or message_type is TellMessage:
+                for stats in self._actor_call_stats.values():
+                    stats.collect(message, duration)
+
+    def collect_subtask(self, subtask, band, duration):
+        if self._subtask_stats:
+            stats = self._subtask_stats.get(subtask.task_id)
+            if stats is not None:
+                stats.collect(subtask, band, duration)
 
     def __getitem__(self, item):
         key = item if isinstance(item, tuple) else (item,)
@@ -90,3 +232,9 @@ class _ProfilingData:
 
 
 ProfilingData = _ProfilingData()
+
+MARS_ENABLE_PROFILING = bool(os.environ.get("MARS_ENABLE_PROFILING", 0))
+MARS_DEBUG_PROFILING_INTERVAL = os.environ.get("MARS_DEBUG_PROFILING_INTERVAL")
+MARS_DEBUG_PROFILING_INTERVAL = MARS_DEBUG_PROFILING_INTERVAL and int(
+    MARS_DEBUG_PROFILING_INTERVAL
+)

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -69,7 +69,7 @@ class _ProfilingOptions(metaclass=_ProfilingOptionsMeta):
             if invalid_keys:
                 raise ValueError(f"Invalid profiling options: {invalid_keys}")
             self._options = options
-        elif options in (True, False):
+        elif options in (True, False, None):
             self._options = {}
         else:
             raise ValueError(f"Invalid profiling options: {options}")

--- a/mars/oscar/tests/test_profiling.py
+++ b/mars/oscar/tests/test_profiling.py
@@ -93,3 +93,15 @@ async def test_profiling_options():
         assert options.debug_interval_seconds == 1.0
     finally:
         os.environ.pop(env_key)
+
+    # Test option value cache.
+    d = {"debug_interval_seconds": 1.0}
+    options = _ProfilingOptions(d)
+    assert options.debug_interval_seconds == 1.0
+    d["debug_interval_seconds"] = 2.0
+    assert options.debug_interval_seconds == 1.0
+    try:
+        os.environ[env_key] = "2"
+        assert options.debug_interval_seconds == 1.0
+    finally:
+        os.environ.pop(env_key)

--- a/mars/services/scheduling/supervisor/manager.py
+++ b/mars/services/scheduling/supervisor/manager.py
@@ -183,8 +183,6 @@ class SubtaskManagerActor(mo.Actor):
                         ).send(subtask_info.subtask, band[1], self.address)
                     )
                     subtask_info.band_futures[band] = task
-                    subtask_info.start_time = time.time()
-                    self._speculation_execution_scheduler.add_subtask(subtask_info)
                     result = yield task
                 ProfilingData.collect_subtask(
                     subtask_info.subtask, band, timer.duration

--- a/mars/services/scheduling/supervisor/manager.py
+++ b/mars/services/scheduling/supervisor/manager.py
@@ -22,8 +22,9 @@ from .... import oscar as mo
 from ....lib.aio import alru_cache
 from ....oscar.backends.message import ProfilingContext
 from ....oscar.errors import MarsError
+from ....oscar.profiling import ProfilingData, MARS_ENABLE_PROFILING
 from ....typing import BandType
-from ....utils import dataslots
+from ....utils import dataslots, Timer
 from ...subtask import Subtask, SubtaskResult, SubtaskStatus
 from ...task import TaskAPI
 from ..core import SubtaskScheduleSummary
@@ -167,18 +168,27 @@ class SubtaskManagerActor(mo.Actor):
                 subtask_info = self._subtask_infos[subtask_id]
                 execution_ref = await self._get_execution_ref(band)
                 extra_config = subtask_info.subtask.extra_config
+                enable_profiling = MARS_ENABLE_PROFILING or (
+                    extra_config and extra_config.get("enable_profiling")
+                )
                 profiling_context = (
                     ProfilingContext(subtask_info.subtask.task_id)
-                    if extra_config and extra_config.get("enable_profiling")
+                    if enable_profiling
                     else None
                 )
-                task = asyncio.create_task(
-                    execution_ref.run_subtask.options(
-                        profiling_context=profiling_context
-                    ).send(subtask_info.subtask, band[1], self.address)
+                with Timer() as timer:
+                    task = asyncio.create_task(
+                        execution_ref.run_subtask.options(
+                            profiling_context=profiling_context
+                        ).send(subtask_info.subtask, band[1], self.address)
+                    )
+                    subtask_info.band_futures[band] = task
+                    subtask_info.start_time = time.time()
+                    self._speculation_execution_scheduler.add_subtask(subtask_info)
+                    result = yield task
+                ProfilingData.collect_subtask(
+                    subtask_info.subtask, band, timer.duration
                 )
-                subtask_info.band_futures[band] = task
-                result = yield task
                 task_api = await self._get_task_api()
                 await task_api.set_subtask_result(result)
             except (OSError, MarsError) as ex:

--- a/mars/services/subtask/api.py
+++ b/mars/services/subtask/api.py
@@ -15,6 +15,7 @@
 from ... import oscar as mo
 from ...lib.aio import alru_cache
 from ...oscar.backends.message import ProfilingContext
+from ...oscar.profiling import MARS_ENABLE_PROFILING
 from .core import Subtask
 
 
@@ -58,10 +59,11 @@ class SubtaskAPI:
         """
         ref = await self._get_runner_ref(band_name, slot_id)
         extra_config = subtask.extra_config
+        enable_profiling = MARS_ENABLE_PROFILING or (
+            extra_config and extra_config.get("enable_profiling")
+        )
         profiling_context = (
-            ProfilingContext(task_id=subtask.task_id)
-            if extra_config and extra_config.get("enable_profiling")
-            else None
+            ProfilingContext(task_id=subtask.task_id) if enable_profiling else None
         )
         return await ref.run_subtask.options(profiling_context=profiling_context).send(
             subtask

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -33,7 +33,11 @@ from ....core.operand import (
     OperandStage,
 )
 from ....optimization.logical import OptimizationRecords
-from ....oscar.profiling import ProfilingData
+from ....oscar.profiling import (
+    ProfilingData,
+    MARS_ENABLE_PROFILING,
+    MARS_DEBUG_PROFILING_INTERVAL,
+)
 from ....typing import TileableType, BandType
 from ....utils import build_fetch, Timer
 from ...cluster.api import ClusterAPI
@@ -87,8 +91,15 @@ class TaskProcessor:
         self._scheduling_api = scheduling_api
         self._meta_api = meta_api
 
-        if task.extra_config and task.extra_config.get("enable_profiling"):
-            ProfilingData.init(task.task_id)
+        if MARS_ENABLE_PROFILING or (
+            task.extra_config and task.extra_config.get("enable_profiling")
+        ):
+            interval = task.extra_config and task.extra_config.get(
+                "debug_profiling_interval", None
+            )
+            if interval is None:
+                interval = MARS_DEBUG_PROFILING_INTERVAL
+            ProfilingData.init(task.task_id, interval)
 
         self.result = TaskResult(
             task_id=task.task_id,
@@ -343,7 +354,7 @@ class TaskProcessor:
         stage_profiling = ProfilingData[self._task.task_id, "general"].nest(
             f"stage_{stage_id}"
         )
-        stage_profiling.set("tile", timer.duration)
+        stage_profiling.set(f"tile({len(chunk_graph)})", timer.duration)
 
         # gen subtask graph
         available_bands = await self._get_available_band_slots()
@@ -354,7 +365,7 @@ class TaskProcessor:
                 chunk_graph,
                 available_bands,
             )
-        stage_profiling.set("gen_subtask_graph", timer.duration)
+        stage_profiling.set(f"gen_subtask_graph({len(subtask_graph)})", timer.duration)
 
         tileable_to_subtasks = await asyncio.to_thread(
             self._get_tileable_to_subtasks, subtask_graph
@@ -396,7 +407,9 @@ class TaskProcessor:
 
     def finish(self):
         self.done.set()
-        if self._task.extra_config and self._task.extra_config.get("enable_profiling"):
+        if MARS_ENABLE_PROFILING or (
+            self._task.extra_config and self._task.extra_config.get("enable_profiling")
+        ):
             ProfilingData[self._task.task_id, "general"].set(
                 "total", time.time() - self.result.start_time
             )

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -36,7 +36,6 @@ from ....optimization.logical import OptimizationRecords
 from ....oscar.profiling import (
     ProfilingData,
     MARS_ENABLE_PROFILING,
-    MARS_DEBUG_PROFILING_INTERVAL,
 )
 from ....typing import TileableType, BandType
 from ....utils import build_fetch, Timer
@@ -91,15 +90,10 @@ class TaskProcessor:
         self._scheduling_api = scheduling_api
         self._meta_api = meta_api
 
-        if MARS_ENABLE_PROFILING or (
-            task.extra_config and task.extra_config.get("enable_profiling")
-        ):
-            interval = task.extra_config and task.extra_config.get(
-                "debug_profiling_interval", None
-            )
-            if interval is None:
-                interval = MARS_DEBUG_PROFILING_INTERVAL
-            ProfilingData.init(task.task_id, interval)
+        if MARS_ENABLE_PROFILING:
+            ProfilingData.init(task.task_id)
+        elif task.extra_config and task.extra_config.get("enable_profiling"):
+            ProfilingData.init(task.task_id, task.extra_config["enable_profiling"])
 
         self.result = TaskResult(
             task_id=task.task_id,

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -499,6 +499,9 @@ class ObjectCheckMixin:
             self.assert_categorical_consistent(expected, real)
 
 
+DICT_NOT_EMPTY = object()
+
+
 def check_dict_structure_same(a, b, prefix=None):
     def _p(k):
         if prefix is None:
@@ -517,6 +520,20 @@ def check_dict_structure_same(a, b, prefix=None):
                 raise KeyError(f"Key {_p(ai[0])} != {_p(bi[0])}")
             if not fnmatch.fnmatch(target, pattern):
                 raise KeyError(f"Key {_p(target)} not match {_p(pattern)}")
+
+        if ai[1] is DICT_NOT_EMPTY:
+            target = bi[1]
+        elif bi[1] is DICT_NOT_EMPTY:
+            target = ai[1]
+        else:
+            target = None
+        if target is not None:
+            if not isinstance(target, dict):
+                raise TypeError(f"Value type of {_p(ai[0])} is not a dict.")
+            if not target:
+                raise TypeError(f"Value of {_p(ai[0])} empty.")
+            continue
+
         if type(ai[1]) is not type(bi[1]):
             raise TypeError(f"Value type of {_p(ai[0])} mismatch {ai[1]} != {bi[1]}")
         if isinstance(ai[1], dict):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
- New most_calls _(top 10)_ / slow_calls _(top 10, default >= 1s)_ / band_subtasks _(most 5 + least 5)_ / slow_subtasks _(top 10, default >= 10s)_ in profile result.
- Read environment var `MARS_ENABLE_PROFILING` to enable / disable profiling.
- Read environment var `MARS_PROFILING_DEBUG_INTERVAL_SECONDS` to log profiling when executing task.
- Read environment var `MARS_PROFILING_SLOW_CALLS_DURATION_THRESHOLD` to change the default threshold of slow calls in seconds.
- Read environment var `MARS_PROFILING_SLOW_SUBTASKS_DURATION_THRESHOLD` to change the default threshold of slow subtasks in seconds.
- The value of `enable_profiling` extra config can be `True`, `False` and a dict of profiling options, e.g.
```python
df.execute(extra_config={"enable_profiling": True})  # It's OK, enable profiling with default options.
df.execute(extra_config={
    "enable_profiling": {
        "slow_calls_duration_threshold": 0,
        "slow_subtasks_duration_threshold": 0
    }
})  # It's OK, enable profiling with options.
```
**_The extra config options overwrites environment var._**

An example output _("slow_calls_duration_threshold": 0, "slow_subtasks_duration_threshold": 0)_:
``` python
{
  'supervisor': {
    'general': {
      'optimize': 0.0015969276428222656,
      'incref_fetch_tileables': 0.001672983169555664,
      'stage_vgQZGcLoTN3cIOM4E3yLorFE': {
        'tile(8)': 0.011889934539794922,
        'gen_subtask_graph(4)': 0.009729146957397461,
        'run': 1.4176759719848633,
        'total': 1.4448819160461426
      },
      'total': 1.452484130859375
    },
    'serialization': {},
    'most_calls': {
      'NodeInfoUploaderActor.set_band_quota_info': 10,
      'numa-0_band_slot_manager.upload_slot_usages': 6,
      'NodeInfoUploaderActor.set_band_slot_infos': 6,
      'aQET2ycNefBqXLrSnVcSuXIq_subtask_queueing.submit_subtasks': 5,
      'GlobalSlotManagerActor.apply_subtask_slots': 5,
      'storage_quota_numa-0_StorageLevel.MEMORY.get_quota': 5,
      'NodeInfoUploaderActor.set_band_storage_info': 5,
      'task_processor_aQET2ycNefBqXLrSnVcSuXIq_EAvyoFy1p8r093R3IbaXBBDs.set_subtask_result': 5,
      'aQET2ycNefBqXLrSnVcSuXIq_lifecycle_tracker.decref_chunks': 5,
      'NodeInfoCollectorActor.update_node_info': 5
    },
    'slow_calls': {
      "[0.0.0.0:56082]slot_numa-0_0_subtask_runner.run_subtask(args=(Subtask(_FIELD_VALUES={'subtask_id': '0QtGXW5vBzvSf3M0420yn780', 'subtask_name': None, 'session_id': 'aQET2ycNefBqXLrSnVcSuXIq', 'task_id': 'cmyGue4L4ZzYJ0qNKz8wGCbU', 'chunk_graph': <mars.core.graph.entity.ChunkGraph object at 0x134f60350>, 'expect_bands': [('0.0.0.0:53184', 'numa-0')], 'priority': (0, 0), 'virtual': False, 'retryable': True, 'rerun_time': 0, 'extra_config': {'enable_profiling': {'slow_calls_duration_threshold': 0, 'slow_subtasks_duration_threshold': 0}}}),), kwargs={})": 0.0243988037109375,
      "[0.0.0.0:25309]slot_numa-0_0_subtask_runner.run_subtask(args=(Subtask(_FIELD_VALUES={'subtask_id': 'bQ5rVnLxvCVlJjAKSaF1cbBX', 'subtask_name': None, 'session_id': 'aQET2ycNefBqXLrSnVcSuXIq', 'task_id': 'cmyGue4L4ZzYJ0qNKz8wGCbU', 'chunk_graph': <mars.core.graph.entity.ChunkGraph object at 0x134f56e30>, 'expect_bands': [('0.0.0.0:54768', 'numa-0')], 'priority': (0, 0), 'virtual': False, 'retryable': True, 'rerun_time': 0, 'extra_config': {'enable_profiling': {'slow_calls_duration_threshold': 0, 'slow_subtasks_duration_threshold': 0}}}),), kwargs={})": 0.00333404541015625,
      "[0.0.0.0:56082]slot_numa-0_0_subtask_runner.run_subtask(args=(Subtask(_FIELD_VALUES={'subtask_id': 'eVtg8YnBr2erLoBBLDkFPeW3', 'subtask_name': None, 'session_id': 'aQET2ycNefBqXLrSnVcSuXIq', 'task_id': 'cmyGue4L4ZzYJ0qNKz8wGCbU', 'chunk_graph': <mars.core.graph.entity.ChunkGraph object at 0x134f567d0>, 'expect_bands': [('0.0.0.0:53184', 'numa-0')], 'priority': (0, 0), 'virtual': False, 'retryable': True, 'rerun_time': 0, 'extra_config': {'enable_profiling': {'slow_calls_duration_threshold': 0, 'slow_subtasks_duration_threshold': 0}}}),), kwargs={})": 0.0032148361206054688,
      "[0.0.0.0:25309]slot_numa-0_0_subtask_runner.run_subtask(args=(Subtask(_FIELD_VALUES={'subtask_id': 'CH9QNUWWxxBgN91aWotlOBKD', 'subtask_name': None, 'session_id': 'aQET2ycNefBqXLrSnVcSuXIq', 'task_id': 'cmyGue4L4ZzYJ0qNKz8wGCbU', 'chunk_graph': <mars.core.graph.entity.ChunkGraph object at 0x134f56fb0>, 'expect_bands': [('0.0.0.0:54768', 'numa-0')], 'priority': (0, 0), 'virtual': False, 'retryable': True, 'rerun_time': 0, 'extra_config': {'enable_profiling': {'slow_calls_duration_threshold': 0, 'slow_subtasks_duration_threshold': 0}}}),), kwargs={})": 0.003125905990600586,
      "[0.0.0.0:53184]NodeInfoUploaderActor.set_band_slot_infos(args=('numa-0', []), kwargs={})": 7.700920104980469e-05,
      "[0.0.0.0:53184]numa-0_band_slot_manager.release_free_slot(args=(0, ('aQET2ycNefBqXLrSnVcSuXIq', '0QtGXW5vBzvSf3M0420yn780')), kwargs={})": 6.604194641113281e-05,
      "[0.0.0.0:25945]aQET2ycNefBqXLrSnVcSuXIq_task_manager.get_task_progress(args=('cmyGue4L4ZzYJ0qNKz8wGCbU',), kwargs={})": 6.508827209472656e-05,
      '[0.0.0.0:25945]NodeInfoCollectorActor.check_dead_nodes(args=(), kwargs={})': 5.888938903808594e-05,
      '[0.0.0.0:25945]aQET2ycNefBqXLrSnVcSuXIq_lifecycle_tracker.decref_tileables(args=([],), kwargs={})': 2.7894973754882812e-05
    },
    'band_subtasks': {
      '0.0.0.0:53184': 2,
      '0.0.0.0:54768': 2
    },
    'slow_subtasks': {
      "[0.0.0.0:54768]Subtask(_FIELD_VALUES={'subtask_id': 'CH9QNUWWxxBgN91aWotlOBKD', 'subtask_name': None, 'session_id': 'aQET2ycNefBqXLrSnVcSuXIq', 'task_id': 'cmyGue4L4ZzYJ0qNKz8wGCbU', 'chunk_graph': <mars.core.graph.entity.ChunkGraph object at 0x134f56fb0>, 'expect_bands': [('0.0.0.0:54768', 'numa-0')], 'priority': (0, 0), 'virtual': False, 'retryable': True, 'rerun_time': 0, 'extra_config': {'enable_profiling': {'slow_calls_duration_threshold': 0, 'slow_subtasks_duration_threshold': 0}}})": 1.345404863357544,
      "[0.0.0.0:53184]Subtask(_FIELD_VALUES={'subtask_id': '0QtGXW5vBzvSf3M0420yn780', 'subtask_name': None, 'session_id': 'aQET2ycNefBqXLrSnVcSuXIq', 'task_id': 'cmyGue4L4ZzYJ0qNKz8wGCbU', 'chunk_graph': <mars.core.graph.entity.ChunkGraph object at 0x134f60350>, 'expect_bands': [('0.0.0.0:53184', 'numa-0')], 'priority': (0, 0), 'virtual': False, 'retryable': True, 'rerun_time': 0, 'extra_config': {'enable_profiling': {'slow_calls_duration_threshold': 0, 'slow_subtasks_duration_threshold': 0}}})": 0.18786978721618652,
      "[0.0.0.0:53184]Subtask(_FIELD_VALUES={'subtask_id': 'eVtg8YnBr2erLoBBLDkFPeW3', 'subtask_name': None, 'session_id': 'aQET2ycNefBqXLrSnVcSuXIq', 'task_id': 'cmyGue4L4ZzYJ0qNKz8wGCbU', 'chunk_graph': <mars.core.graph.entity.ChunkGraph object at 0x134f567d0>, 'expect_bands': [('0.0.0.0:53184', 'numa-0')], 'priority': (0, 0), 'virtual': False, 'retryable': True, 'rerun_time': 0, 'extra_config': {'enable_profiling': {'slow_calls_duration_threshold': 0, 'slow_subtasks_duration_threshold': 0}}})": 0.04774785041809082,
      "[0.0.0.0:54768]Subtask(_FIELD_VALUES={'subtask_id': 'bQ5rVnLxvCVlJjAKSaF1cbBX', 'subtask_name': None, 'session_id': 'aQET2ycNefBqXLrSnVcSuXIq', 'task_id': 'cmyGue4L4ZzYJ0qNKz8wGCbU', 'chunk_graph': <mars.core.graph.entity.ChunkGraph object at 0x134f56e30>, 'expect_bands': [('0.0.0.0:54768', 'numa-0')], 'priority': (0, 0), 'virtual': False, 'retryable': True, 'rerun_time': 0, 'extra_config': {'enable_profiling': {'slow_calls_duration_threshold': 0, 'slow_subtasks_duration_threshold': 0}}})": 0.04388689994812012
    }
  }
}
```

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
