### PR TITLE
Fix `IndexError` raise by aggregation of DataFrameGroupBy

### DIFF
--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -825,7 +825,10 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
 
         for input_key, output_key, cols, func in op.pre_funcs:
             if input_key == output_key:
-                ret_map_groupbys[output_key] = grouped
+                if cols is None or grouped._selection is not None:
+                    ret_map_groupbys[output_key] = grouped
+                else:
+                    ret_map_groupbys[output_key] = grouped[cols]
             else:
 
                 def _wrapped_func(col):

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -825,9 +825,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
 
         for input_key, output_key, cols, func in op.pre_funcs:
             if input_key == output_key:
-                ret_map_groupbys[output_key] = (
-                    grouped if cols is None else grouped[cols]
-                )
+                ret_map_groupbys[output_key] = grouped
             else:
 
                 def _wrapped_func(col):

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -273,6 +273,30 @@ def test_groupby_getitem(setup):
         raw.groupby(0, as_index=False)[0].agg({"cnt": "count"}),
     )
 
+    # test groupby getitem then agg(#GH 2640)
+    rs = np.random.RandomState(0)
+    raw = pd.DataFrame(
+        {
+            "c1": np.arange(100).astype(np.int64),
+            "c2": rs.choice(["a", "b", "c"], (100,)),
+            "c3": rs.rand(100),
+            "c4": rs.rand(100)
+        }
+    )
+    mdf = md.DataFrame(raw, chunk_size=20)
+    r = mdf.groupby(['c2'])[['c1', 'c3']].agg({'c1': 'max', 'c3': 'min'}, method='tree')
+    pd.testing.assert_frame_equal(
+        r.execute().fetch(),
+        raw.groupby(['c2'])[['c1', 'c3']].agg({'c1': 'max', 'c3': 'min'}),
+    )
+
+    mdf = md.DataFrame(raw.copy(), chunk_size=30)
+    r = mdf.groupby(['c2'])[['c1', 'c4']].agg({'c1': 'max', 'c4': 'mean'}, method='shuffle')
+    pd.testing.assert_frame_equal(
+        r.execute().fetch(),
+        raw.groupby(['c2'])[['c1', 'c4']].agg({'c1': 'max', 'c4': 'mean'}),
+    )
+
 
 def test_dataframe_groupby_agg(setup):
     agg_funs = [

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -280,21 +280,23 @@ def test_groupby_getitem(setup):
             "c1": np.arange(100).astype(np.int64),
             "c2": rs.choice(["a", "b", "c"], (100,)),
             "c3": rs.rand(100),
-            "c4": rs.rand(100)
+            "c4": rs.rand(100),
         }
     )
     mdf = md.DataFrame(raw, chunk_size=20)
-    r = mdf.groupby(['c2'])[['c1', 'c3']].agg({'c1': 'max', 'c3': 'min'}, method='tree')
+    r = mdf.groupby(["c2"])[["c1", "c3"]].agg({"c1": "max", "c3": "min"}, method="tree")
     pd.testing.assert_frame_equal(
         r.execute().fetch(),
-        raw.groupby(['c2'])[['c1', 'c3']].agg({'c1': 'max', 'c3': 'min'}),
+        raw.groupby(["c2"])[["c1", "c3"]].agg({"c1": "max", "c3": "min"}),
     )
 
     mdf = md.DataFrame(raw.copy(), chunk_size=30)
-    r = mdf.groupby(['c2'])[['c1', 'c4']].agg({'c1': 'max', 'c4': 'mean'}, method='shuffle')
+    r = mdf.groupby(["c2"])[["c1", "c4"]].agg(
+        {"c1": "max", "c4": "mean"}, method="shuffle"
+    )
     pd.testing.assert_frame_equal(
         r.execute().fetch(),
-        raw.groupby(['c2'])[['c1', 'c4']].agg({'c1': 'max', 'c4': 'mean'}),
+        raw.groupby(["c2"])[["c1", "c4"]].agg({"c1": "max", "c4": "mean"}),
     )
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
As pandas DataFrame will raise `IndexError` for code like `df.groupby(['A'])[['B','C']]['B']`, remove the repeated getitem to solve it.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2640 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
