### PR TITLE
Fix aggregation with comparison

### DIFF
--- a/mars/dataframe/indexing/reset_index.py
+++ b/mars/dataframe/indexing/reset_index.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...core import OutputType
-from ...serialization.serializables import BoolField, AnyField, StringField
+from ...serialization.serializables import AnyField, BoolField
 from ...utils import no_default
 from ..core import IndexValue
 from ..operands import DataFrameOperandMixin, DataFrameOperand, DATAFRAME_TYPE
@@ -36,7 +36,7 @@ class DataFrameResetIndex(DataFrameOperand, DataFrameOperandMixin):
 
     _level = AnyField("level")
     _drop = BoolField("drop")
-    _name = StringField("name")
+    _name = AnyField("name")
     _col_level = AnyField("col_level")
     _col_fill = AnyField("col_fill")
     _incremental_index = BoolField("incremental_index")

--- a/mars/dataframe/reduction/aggregation.py
+++ b/mars/dataframe/reduction/aggregation.py
@@ -987,7 +987,7 @@ def is_funcs_aggregate(func, func_kw=None, ndim=2):
 
     to_check = []
     if func is not None:
-        if isinstance(func, list):
+        if isinstance(func, (list, tuple)):
             to_check.extend(func)
         elif isinstance(func, dict):
             if ndim == 2:

--- a/mars/dataframe/reduction/core.py
+++ b/mars/dataframe/reduction/core.py
@@ -664,7 +664,7 @@ class CustomReduction:
         return self.name
 
     def __call__(self, value):
-        if is_build_mode():
+        if isinstance(value, ENTITY_TYPE):
             from .custom_reduction import build_custom_reduction_result
 
             return build_custom_reduction_result(value, self)
@@ -1210,11 +1210,17 @@ class ReductionCompiler:
             else:
                 post_cols = cols
 
+            func_name = step.func_name
+            if self._lambda_counter == 1 and step.func_name == "<lambda_0>":
+                func_name = "<lambda>"
+            if self._custom_counter == 1 and step.func_name == "<custom_0>":
+                func_name = "<custom>"
+
             post_funcs.append(
                 ReductionPostStep(
                     step.input_keys,
                     step.output_key,
-                    step.func_name,
+                    func_name,
                     post_cols,
                     step.func,
                 )

--- a/mars/dataframe/reduction/core.py
+++ b/mars/dataframe/reduction/core.py
@@ -889,7 +889,7 @@ class ReductionCompiler:
             mock_obj = MarsDataFrame(mock_df)
 
         # calc target tileable to generate DAG
-        with enter_mode(kernel=True):
+        with enter_mode(kernel=True, build=False):
             return func(mock_obj)
 
     @enter_mode(build=True)

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -539,6 +539,20 @@ def test_compile_function():
             assert "np.where" not in result.post_funcs[0].func.__source__
             assert ".where" in result.post_funcs[0].func.__source__
 
+        # check boolean expressions
+        compiler = ReductionCompiler(store_source=True)
+        compiler.add_function(
+            lambda x: (x == "1").sum(), ndim=ndim
+        )
+        result = compiler.compile()
+        # check pre_funcs
+        assert len(result.pre_funcs) == 1
+        assert "eq" in result.pre_funcs[0].func.__source__
+        # check agg_funcs
+        assert len(result.agg_funcs) == 1
+        assert result.agg_funcs[0].map_func_name == "sum"
+        assert result.agg_funcs[0].agg_func_name == "sum"
+
     # test agg for specific columns
     compiler = ReductionCompiler(store_source=True)
     compiler.add_function(lambda x: 1 + x.sum(), ndim=2, cols=["a", "b"])

--- a/mars/dataframe/reduction/tests/test_reduction.py
+++ b/mars/dataframe/reduction/tests/test_reduction.py
@@ -480,7 +480,7 @@ def test_compile_function():
         assert result.agg_funcs[0].agg_func_name == "sum"
         # check post_funcs
         assert len(result.post_funcs) == 1
-        assert result.post_funcs[0].func_name == "<lambda_0>"
+        assert result.post_funcs[0].func_name == "<lambda>"
         assert "add" in result.post_funcs[0].func.__source__
 
         compiler.add_function(
@@ -541,9 +541,7 @@ def test_compile_function():
 
         # check boolean expressions
         compiler = ReductionCompiler(store_source=True)
-        compiler.add_function(
-            lambda x: (x == "1").sum(), ndim=ndim
-        )
+        compiler.add_function(lambda x: (x == "1").sum(), ndim=ndim)
         result = compiler.compile()
         # check pre_funcs
         assert len(result.pre_funcs) == 1


### PR DESCRIPTION
## What do these changes do?

Fix aggregation with comparison, for inst., 

```python
df.groupby('b', as_index=False)['a'].agg(lambda x: (x == "1").sum())
```

Fix aggregation over multi-level group-bys.

## Related issue number

Fixes #2646
Fixes #2648

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
