### PR TITLE
Add pyproject.toml to config build packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,8 @@ global-exclude *.c
 global-exclude *.cpp
 global-exclude */**/tests/*.yml
 global-exclude */**/node_modules/**/*
+include setup.cfg
+include pyproject.toml
 include mars/.git-branch
 include mars/lib/mmh3_src/*
 include mars/services/web/index.html

--- a/docs/source/development/contributing.rst
+++ b/docs/source/development/contributing.rst
@@ -45,7 +45,6 @@ development, use the following steps:
 .. code-block:: bash
 
     pip install --upgrade setuptools pip
-    pip install cython
     git clone https://github.com/mars-project/mars.git
     cd mars
     pip install -e ".[dev]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "cython>=0.29",
+    "oldest-supported-numpy",
+    "scipy>=1.0.0",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## What do these changes do?

Add pyproject.toml to config build packages. Now these packages are not need when calling `pip install` from a new pyenv.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2673