### PR TITLE
Fix `as_index` when calling agg on SeriesGroupBy

### DIFF
--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -315,6 +315,13 @@ def test_groupby_getitem(setup):
         expected.sort_values(["c1", "c2"]).reset_index(drop=True),
     )
 
+    r = mdf.groupby(["c1", "c2"], as_index=False)["c3"].agg(["sum"])
+    expected = raw.groupby(["c1", "c2"], as_index=False)["c3"].agg(["sum"])
+    pd.testing.assert_frame_equal(
+        r.execute().fetch().sort_values(["c1", "c2"]),
+        expected.sort_values(["c1", "c2"]),
+    )
+
 
 def test_dataframe_groupby_agg(setup):
     agg_funs = [


### PR DESCRIPTION
## What do these changes do?

Fix as_index settings when calling agg on SeriesGroupBy object. This fixes missing indexes for aggregation results.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2675

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
