### PR TITLE
Eliminate redundant eval node in optimization

### DIFF
--- a/mars/optimization/logical/core.py
+++ b/mars/optimization/logical/core.py
@@ -162,8 +162,12 @@ class OptimizationRule(ABC):
         node = self._records.get_optimization_result(node) or node
         preds_opt_to_remove = []
         for pred in self._graph.predecessors(node):
-            pred_original = self._records.get_original_chunk(pred) or pred
-            pred_opt = self._records.get_optimization_result(pred) or pred
+            pred_original = self._records.get_original_chunk(pred)
+            pred_original = pred_original if pred_original is not None else pred
+
+            pred_opt = self._records.get_optimization_result(pred)
+            pred_opt = pred_opt if pred_opt is not None else pred
+
             if pred_opt in self._graph.results or pred_original in self._graph.results:
                 continue
             affect_succ = self._preds_to_remove.get(pred_original) or []


### PR DESCRIPTION
## What do these changes do?

Fix redundant evaluation node when result of `__bool__` of predecessor node is False.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2682

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
