### PR TITLE
[WIP] use direct async call for in-process rpc

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -132,7 +132,7 @@ jobs:
             coverage combine build/ && coverage report
           fi
           if [ -n "$WITH_RAY" ]; then
-            pytest $PYTEST_CONFIG --timeout=120 -m ray
+            pytest $PYTEST_CONFIG --timeout=300 -m ray
             coverage report
           fi
           if [ -n "$RUN_DASK" ]; then

--- a/mars/oscar/backends/communication/__init__.py
+++ b/mars/oscar/backends/communication/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .base import Client, Server, Channel
-from .core import get_client_type, get_server_type, gen_local_address
+from .core import get_client_type, get_server_type, gen_local_address, is_local_address
 from .dummy import DummyClient, DummyServer, DummyChannel
 from .socket import (
     SocketClient,

--- a/mars/oscar/backends/communication/__init__.py
+++ b/mars/oscar/backends/communication/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .base import Client, Server, Channel
-from .core import get_client_type, get_server_type, gen_local_address, is_local_address
+from .core import get_client_type, get_server_type, gen_local_address, use_direct_call
 from .dummy import DummyClient, DummyServer, DummyChannel
 from .socket import (
     SocketClient,

--- a/mars/oscar/backends/communication/base.py
+++ b/mars/oscar/backends/communication/base.py
@@ -254,7 +254,7 @@ class Client(ABC):
         """
 
     @implements(Channel.send)
-    async def send(self, message):
+    async def send(self, message, wait_response: bool = False):
         return await self.channel.send(message)
 
     @implements(Channel.recv)

--- a/mars/oscar/backends/communication/core.py
+++ b/mars/oscar/backends/communication/core.py
@@ -66,5 +66,5 @@ def gen_local_address(process_index: int) -> str:
     return f"dummy://{process_index}"
 
 
-def is_local_address(address: str) -> bool:
-    return get_scheme(address) == "dummy"
+def use_direct_call(address: str) -> bool:
+    return get_scheme(address) == "dummy" or get_scheme(address) == "ray"

--- a/mars/oscar/backends/communication/core.py
+++ b/mars/oscar/backends/communication/core.py
@@ -64,3 +64,7 @@ def get_server_type(address: str) -> Type[Server]:
 
 def gen_local_address(process_index: int) -> str:
     return f"dummy://{process_index}"
+
+
+def is_local_address(address: str) -> bool:
+    return get_scheme(address) == "dummy"

--- a/mars/oscar/backends/communication/dummy.py
+++ b/mars/oscar/backends/communication/dummy.py
@@ -98,7 +98,7 @@ class DummyServer(Server):
     scheme = "dummy"
 
     def __init__(
-        self, address: str, message_handler: Callable[[Any, Channel], Coroutine] = None
+        self, address: str, message_handler: Callable[[Any], Coroutine] = None
     ):
         super().__init__(address, None)
         self._closed = asyncio.Event()

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -180,12 +180,11 @@ class MarsActorContext(BaseActorContext):
             actor_ref.address,
         ):
             detect_cycle_send(message, wait_response)
-            future = await self._call(actor_ref.address, message, wait=False)
+            result_or_future = await self._call(actor_ref.address, message, wait=wait_response)
             if wait_response:
-                result = await self._wait(future, actor_ref.address, message)
-                return self._process_result_message(result)
+                return self._process_result_message(result_or_future)
             else:
-                return future
+                return result_or_future
 
     async def cancel(self, address: str, cancel_message_id: bytes):
         message = CancelMessage(

--- a/mars/oscar/backends/core.py
+++ b/mars/oscar/backends/core.py
@@ -88,7 +88,7 @@ class ActorCaller:
         self._client_to_message_futures[client][message.message_id] = wait_response
 
         try:
-            await client.send(message)
+            await client.send(message, wait_response=wait)
         except ConnectionError:
             try:
                 await client.close()

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -237,7 +237,7 @@ async def actor_pool_context(request):
     )
 
     try:
-        if request:
+        if request.param:
             set_debug_options(DebugOptions())
 
         await pool.start()

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -374,7 +374,7 @@ async def test_mars_batch_method(actor_pool_context):
     assert all(r == 7 for r in batch_result)
 
     await ref1.add.batch(
-        ref1.add.delay(1), ref1.add.delay(2), ref1.add.delay(3), send=False
+        ref1.add.delay(1), ref1.add.delay(2), ref1.add.delay(3), send=True
     )
     assert await ref1.get_value() == 7
 

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -31,7 +31,7 @@ from ..debug import record_message_trace, debug_async_timeout
 from ..errors import ActorAlreadyExist, ActorNotExist, ServerClosed, CannotCancelTask
 from ..utils import create_actor_ref
 from .allocate_strategy import allocated_type, AddressSpecified
-from .communication import Channel, Server, get_server_type, gen_local_address, is_local_address
+from .communication import Channel, Server, get_server_type, gen_local_address, use_direct_call
 from .communication.errors import ChannelClosed
 from .config import ActorPoolConfig
 from .core import result_message_type, ActorCaller
@@ -603,7 +603,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
                 external_addresses + [internal_address, gen_local_address(process_index)]
         ):
             server_type = get_server_type(addr)
-            if is_local_address(addr):
+            if use_direct_call(addr):
                 def message_handler(message):
                     return pool._process_message(message)
                 create_server_coro = server_type.create(dict(address=addr, message_handler=message_handler))

--- a/mars/oscar/backends/ray/tests/test_communication.py
+++ b/mars/oscar/backends/ray/tests/test_communication.py
@@ -48,20 +48,12 @@ class ServerActor:
 
     async def start(self):
         RayServer.set_ray_actor_started()
-        self.server = await RayServer.create(
-            {"address": self.address, "handle_channel": self.on_new_channel}
-        )
 
-    async def on_new_channel(self, channel: Channel):
-        while True:
-            try:
-                message = await channel.recv()
-                await channel.send(message)
-            except EOFError:
-                # no data to read, check channel
-                await channel.close()
-                return
-            await asyncio.sleep(0.1)
+        async def message_handler(msg):
+            return msg
+        self.server = await RayServer.create(
+            {"address": self.address, "message_handler": message_handler}
+        )
 
     async def __on_ray_recv__(self, channel_id: ChannelID, message):
         """Method for communication based on ray actors"""

--- a/mars/oscar/backends/test/pool.py
+++ b/mars/oscar/backends/test/pool.py
@@ -17,7 +17,7 @@ import multiprocessing
 from typing import List, Dict
 
 from ..config import ActorPoolConfig
-from ..communication import gen_local_address, get_server_type, DummyServer, is_local_address
+from ..communication import gen_local_address, get_server_type, DummyServer, use_direct_call
 from ..mars.pool import MainActorPool, SubActorPool, SubpoolStatus
 from ..pool import ActorPoolType
 
@@ -94,7 +94,7 @@ class TestSubActorPool(SubActorPool):
         create_server_tasks = []
         for addr in set(external_addresses + [gen_local_address(process_index)]):
             server_type = get_server_type(addr)
-            if is_local_address(addr):
+            if use_direct_call(addr):
                 def message_handler(message):
                     return pool._process_message(message)
                 create_server_coro = server_type.create(dict(address=addr, message_handler=message_handler))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR use the direct async function call to speed up in-progress actor call, and gives a speed up about 2.6 times.

**Benchmark code**:
```python
import asyncio
from contextlib import asynccontextmanager
import datetime
import os
import sys
import time

import mars.oscar as mo


class BenchmarkActor(mo.Actor):

    def __init__(self, value):
        super().__init__()
        self.value = value

    async def send(self, uid, method, iternum, *args):
        actor_ref = await mo.actor_ref(uid, address=self.address)
        value = None
        for _ in range(iternum):
            value = await getattr(actor_ref, method)(*args)
        return value

    async def inc(self, delta):
        self.value += delta
        return self.value

    def get_value(self):
        return self.value


@asynccontextmanager
async def actor_pool_context():
    start_method = (
        os.environ.get("POOL_START_METHOD", "forkserver")
        if sys.platform != "win32"
        else None
    )
    pool = await mo.create_actor_pool(
        "127.0.0.1", n_process=2, subprocess_start_method=start_method
    )
    await pool.start()
    yield pool
    await pool.stop()


async def test_dummy_call_benchmark(pool):
    ref1 = await mo.create_actor(BenchmarkActor, 1, address=pool.external_address)
    ref2 = await mo.create_actor(BenchmarkActor, 2, address=pool.external_address)
    await ref1.send(ref2, "inc", 2, 2)
    iternum = 100000
    expect = await ref2.get_value() + iternum * 2
    start = time.time()
    print(f"Start with iternum {iternum} at {datetime.datetime.now()}")
    assert await ref1.send(ref2, "inc", iternum, 2) == expect
    print(f"End with iternum {iternum} at {datetime.datetime.now()}, took {time.time() - start} seconds.")


async def main():
    async with actor_pool_context() as ctx:
        await test_dummy_call_benchmark(ctx)


if __name__ == '__main__':
    asyncio.run(main())
```

**Benchmark Env**
* 2.2 GHz 6-Core Intel Core i7
* 16 GB 2400 MHz DDR4
* OS: macOS BigSur 11.5.2 (20G95)

**Benchmark result**
* Without this PR: 100000 actor calls in 21.88 seconds
* WIth this PR: 100000 actor calls in 8.19 seconds

## Related issue number
Closes #2691 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
