### PR TITLE
[hotfix][ray] fix ray dataset compatibility

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -82,7 +82,8 @@ jobs:
               rm -fr /tmp/etcd-$ETCD_VER-linux-amd64.tar.gz /tmp/etcd-download-test
             fi
             if [ -n "$WITH_RAY" ]; then
-              pip install pip install ray[default]
+              # relax version after refactoring ray dfataset integration useing ray dataset source api.
+              pip install "ray[default]<1.10.0"
               pip install xgboost_ray==0.1.5
               pip install --upgrade numpy
             fi

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -82,7 +82,7 @@ jobs:
               rm -fr /tmp/etcd-$ETCD_VER-linux-amd64.tar.gz /tmp/etcd-download-test
             fi
             if [ -n "$WITH_RAY" ]; then
-              #TODO relax version after refactoring ray dataset integration using ray datasource api.
+              # TODO: relax version after refactoring ray dataset integration using ray datasource api.
               pip install "ray[default]<1.10.0"
               pip install xgboost_ray==0.1.5
               pip install --upgrade numpy

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -82,7 +82,7 @@ jobs:
               rm -fr /tmp/etcd-$ETCD_VER-linux-amd64.tar.gz /tmp/etcd-download-test
             fi
             if [ -n "$WITH_RAY" ]; then
-              # relax version after refactoring ray dfataset integration useing ray dataset source api.
+              #TODO relax version after refactoring ray dataset integration using ray datasource api.
               pip install "ray[default]<1.10.0"
               pip install xgboost_ray==0.1.5
               pip install --upgrade numpy


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Ray dataset in ray 1.10.0 has an incompatible change and it's not easy to fix unless we rewrite the dataset integration using datasource api of ray dataset. So we downgrade ray version to 1.9 and will relax version when we finished the rewrite.
<!-- Please give a short brief about these changes. -->


## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
