### PR TITLE
Add support for reading partitioned parquet for fastparquet

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,11 +57,6 @@ jobs:
           conda install -n test --quiet --yes -c conda-forge python=$PYTHON numba
         fi
 
-        # todo remove this when fastparquet release new version
-        if [[ "$PYTHON" =~ "3.6" ]]; then
-          pip install numpy\<1.20.0
-        fi
-
         source ./ci/rewrite-cov-config.sh
 
         if [[ "$(mars.test.module)" == "learn" ]]; then
@@ -74,7 +69,7 @@ jobs:
 
         if [ -z "$NO_COMMON_TESTS" ]; then
           if [[ ! "$PYTHON" =~ "3.6" ]] && [[ ! "$PYTHON" =~ "3.9" ]]; then
-            pip install h5py zarr matplotlib fastparquet\<0.7.0
+            pip install h5py zarr matplotlib fastparquet
             conda install -n test --quiet --yes -c conda-forge python=$PYTHON \
               "tiledb-py>=0.4.3,<0.6.0" "tiledb<2.0.0" || true
           fi
@@ -97,14 +92,14 @@ jobs:
         mkdir -p build
         pytest $PYTEST_CONFIG mars/$(mars.test.module)
         mv .coverage build/.coverage.main.file
-        
+
         # do compatibility test for earliest supported pandas release
         if [[ "$(mars.test.module)" == "dataframe" ]]; then
           pip install pandas==1.0.5
           pytest $PYTEST_CONFIG -m pd_compat mars/dataframe
           mv .coverage build/.coverage.pd_compat.file
         fi
-        
+
         coverage combine build/ && coverage report
         coverage xml
       displayName: 'Run tests'

--- a/mars/dataframe/datasource/read_parquet.py
+++ b/mars/dataframe/datasource/read_parquet.py
@@ -34,7 +34,7 @@ except ImportError:
 
 from ... import opcodes as OperandDef
 from ...config import options
-from ...lib.filesystem import file_size, get_fs, glob, open_file
+from ...lib.filesystem import file_size, get_fs, glob, open_file, FileSystem
 from ...serialization.serializables import (
     AnyField,
     BoolField,
@@ -112,6 +112,55 @@ class ParquetEngine:
     ):
         raise NotImplementedError
 
+    def read_partitioned_to_pandas(
+        self,
+        f,
+        partitions,
+        partition_keys,
+        columns=None,
+        nrows=None,
+        use_arrow_dtype=None,
+        **kwargs,
+    ):
+        raw_df = self.read_to_pandas(
+            f, columns=columns, nrows=nrows, use_arrow_dtype=use_arrow_dtype, **kwargs
+        )
+        for i, (name, index) in enumerate(partition_keys):
+            dictionary = partitions[i].dictionary
+            value = dictionary[index]
+            raw_df[name] = pd.Categorical(
+                np.full(raw_df.shape[0], value.as_py()), categories=dictionary.tolist()
+            )
+        return raw_df
+
+    def read_partitioned_dtypes(self, fs: FileSystem, directory, storage_options):
+        # As ParquetDataset will iterate all files,
+        # here we just find one file to infer dtypes
+        current_path = directory
+        partition_cols = []
+        while fs.isdir(current_path):
+            _, dirs, files = next(fs.walk(current_path))
+            dirs = [d for d in dirs if not d.startswith(".")]
+            files = [f for f in files if not f.startswith(".")]
+            if len(files) == 0:
+                # directory as partition
+                partition_cols.append(dirs[0].split("=", 1)[0])
+                current_path = os.path.join(current_path, dirs[0])
+            elif len(dirs) == 0:
+                # parquet files in deepest directory
+                current_path = os.path.join(current_path, files[0])
+            else:  # pragma: no cover
+                raise ValueError(
+                    "Files and directories are mixed " "in an intermediate directory"
+                )
+
+        # current path is now a parquet file
+        with open_file(current_path, storage_options=storage_options) as f:
+            dtypes = self.read_dtypes(f)
+        for partition in partition_cols:
+            dtypes[partition] = pd.CategoricalDtype()
+        return dtypes
+
 
 class ArrowEngine(ParquetEngine):
     def get_row_num(self, f):
@@ -150,7 +199,7 @@ class ArrowEngine(ParquetEngine):
 class FastpaquetEngine(ParquetEngine):
     def get_row_num(self, f):
         file = fastparquet.ParquetFile(f)
-        return file.count
+        return file.count()
 
     def read_dtypes(self, f, **kwargs):
         file = fastparquet.ParquetFile(f)
@@ -161,12 +210,11 @@ class FastpaquetEngine(ParquetEngine):
         self, f, columns=None, nrows=None, use_arrow_dtype=None, **kwargs
     ):
         file = fastparquet.ParquetFile(f)
-        df = file.to_pandas(**kwargs)
+        df = file.to_pandas(columns, **kwargs)
         if nrows is not None:
             df = df.head(nrows)
         if use_arrow_dtype:
             df = df.astype(to_arrow_dtypes(df.dtypes).to_dict())
-
         return df
 
 
@@ -186,6 +234,7 @@ class DataFrameReadParquet(
     read_kwargs = DictField("read_kwargs")
     incremental_index = BoolField("incremental_index")
     storage_options = DictField("storage_options")
+    is_partitioned = BoolField("is_partitioned")
     merge_small_files = BoolField("merge_small_files")
     merge_small_file_options = DictField("merge_small_file_options")
     # for chunk
@@ -336,7 +385,7 @@ class DataFrameReadParquet(
 
     @classmethod
     def _tile(cls, op: "DataFrameReadParquet"):
-        if get_fs(op.path, op.storage_options).isdir(op.path):
+        if op.is_partitioned:
             tiled = cls._tile_partitioned(op)
         else:
             tiled = cls._tile_no_partitioned(op)
@@ -349,14 +398,18 @@ class DataFrameReadParquet(
     @classmethod
     def _execute_partitioned(cls, ctx, op: "DataFrameReadParquet"):
         out = op.outputs[0]
+        engine = get_engine(op.engine)
         partitions = pickle.loads(op.partitions)
-        piece = pq.ParquetDatasetPiece(
-            op.path, partition_keys=op.partition_keys, open_file_func=open_file
-        )
-        table = piece.read(partitions=partitions)
-        if op.nrows is not None:
-            table = table.slice(0, op.nrows)
-        ctx[out.key] = arrow_table_to_pandas_dataframe(table, op.use_arrow_dtype)
+        with open_file(op.path, storage_options=op.storage_options) as f:
+            ctx[out.key] = engine.read_partitioned_to_pandas(
+                f,
+                partitions,
+                op.partition_keys,
+                columns=op.columns,
+                nrows=op.nrows,
+                use_arrow_dtype=op.use_arrow_dtype,
+                **op.read_kwargs or dict(),
+            )
 
     @classmethod
     def execute(cls, ctx, op: "DataFrameReadParquet"):
@@ -483,16 +536,19 @@ def read_parquet(
     engine_type = check_engine(engine)
     engine = get_engine(engine_type)
 
-    if get_fs(path, storage_options).isdir(path):
-        # If path is a directory, we will read as a partitioned datasets.
-        if engine_type != "pyarrow":
-            raise TypeError(
-                "Only support pyarrow engine when reading from" "partitioned datasets."
-            )
-        dataset = pq.ParquetDataset(path)
-        dtypes = dataset.schema.to_arrow_schema().empty_table().to_pandas().dtypes
-        for partition in dataset.partitions:
-            dtypes[partition.name] = pd.CategoricalDtype()
+    single_path = path[0] if isinstance(path, list) else path
+    fs = get_fs(single_path, storage_options)
+    is_partitioned = False
+    if fs.isdir(single_path):
+        paths = fs.ls(path)
+        if all(fs.isdir(p) for p in paths):
+            # If all are directories, it is read as a partitioned dataset.
+            dtypes = engine.read_partitioned_dtypes(fs, path, storage_options)
+            is_partitioned = True
+        else:
+            path = paths
+            with open_file(paths[0], storage_options=storage_options) as f:
+                dtypes = engine.read_dtypes(f)
     else:
         if not isinstance(path, list):
             file_path = glob(path, storage_options=storage_options)[0]
@@ -502,8 +558,8 @@ def read_parquet(
         with open_file(file_path, storage_options=storage_options) as f:
             dtypes = engine.read_dtypes(f)
 
-        if columns:
-            dtypes = dtypes[columns]
+    if columns:
+        dtypes = dtypes[columns]
 
     if use_arrow_dtype is None:
         use_arrow_dtype = options.dataframe.use_arrow_dtype
@@ -521,6 +577,7 @@ def read_parquet(
         read_kwargs=kwargs,
         incremental_index=incremental_index,
         storage_options=storage_options,
+        is_partitioned=is_partitioned,
         memory_scale=memory_scale,
         merge_small_files=merge_small_files,
         merge_small_file_options=merge_small_file_options,

--- a/mars/dataframe/datasource/read_parquet.py
+++ b/mars/dataframe/datasource/read_parquet.py
@@ -16,6 +16,7 @@
 
 import os
 import pickle
+from typing import List, Tuple
 from urllib.parse import urlparse
 
 import numpy as np
@@ -114,8 +115,8 @@ class ParquetEngine:
     def read_partitioned_to_pandas(
         self,
         f,
-        partitions,
-        partition_keys,
+        partitions: pq.ParquetPartitions,
+        partition_keys: List[Tuple],
         columns=None,
         nrows=None,
         use_arrow_dtype=None,
@@ -150,7 +151,7 @@ class ParquetEngine:
                 current_path = os.path.join(current_path, files[0])
             else:  # pragma: no cover
                 raise ValueError(
-                    "Files and directories are mixed " "in an intermediate directory"
+                    "Files and directories are mixed in an intermediate directory"
                 )
 
         # current path is now a parquet file


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Add implementation for reading partitioned parquet for `fastparquet`.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2713 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
