### PR TITLE
Fix shuffle when ndim of input tensors are different

### DIFF
--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -214,7 +214,8 @@ class LearnShuffle(MapReduceOperand, LearnOperandMixin):
         ax_nsplit = {ax: decide_unify_split(*ns) for ax, ns in axis_to_nsplits.items()}
         rechunked_inputs = []
         for inp in inputs:
-            inp = yield from cls._safe_rechunk(inp, ax_nsplit)
+            inp_ax_nsplit = {ax: ns for ax, ns in ax_nsplit.items() if ax < inp.ndim}
+            inp = yield from cls._safe_rechunk(inp, inp_ax_nsplit)
             rechunked_inputs.append(inp)
         inputs = rechunked_inputs
 

--- a/mars/learn/utils/tests/test_shuffle.py
+++ b/mars/learn/utils/tests/test_shuffle.py
@@ -142,18 +142,20 @@ def test_shuffle_execution(setup):
     # tensor + dataframe + series
     raw5 = np.random.rand(10, 15, 20)
     t5 = mt.array(raw5, chunk_size=8)
+    t6 = mt.array(raw5[:, 0, 0], chunk_size=6)
     raw6 = pd.DataFrame(np.random.rand(10, 15))
     df = md.DataFrame(raw6, chunk_size=(8, 15))
     raw7 = pd.Series(np.random.rand(10))
     series = md.Series(raw7, chunk_size=8)
 
     for axes in [(0,), (1,), (0, 1), (1, 2), [0, 1, 2]]:
-        ret = shuffle(t5, df, series, axes=axes, random_state=0)
+        ret = shuffle(t5, df, series, t6, axes=axes, random_state=0)
         # skip check nsplits because it's updated
-        res5, res_df, res_series = ret.execute(
+        res5, res_df, res_series, res6 = ret.execute(
             extra_config={"check_nsplits": False}
         ).fetch(extra_config={"check_nsplits": False})
 
         assert res5.shape == raw5.shape
         assert res_df.shape == df.shape
         assert res_series.shape == series.shape
+        assert res6.shape == (raw5.shape[0],)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixed shuffle when ndim of input tensors are different.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2720 .

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
