### PR TITLE
Add address and pid prefix to the mars exception message

### DIFF
--- a/mars/deploy/oscar/tests/test_ray_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_ray_fault_injection.py
@@ -70,6 +70,7 @@ async def fault_cluster(request):
             FaultType.Exception,
             {FaultPosition.ON_EXECUTE_OPERAND: 1},
             pytest.raises(FaultInjectionError, match="Fault Injection"),
+            True,
         ],
         [
             FaultType.UnhandledException,
@@ -77,16 +78,19 @@ async def fault_cluster(request):
             pytest.raises(
                 FaultInjectionUnhandledError, match="Fault Injection Unhandled"
             ),
+            True,
         ],
         [
             FaultType.ProcessExit,
             {FaultPosition.ON_EXECUTE_OPERAND: 1},
             pytest.raises(ServerClosed),
+            False,  # The ServerClosed raised from current process directly.
         ],
         [
             FaultType.Exception,
             {FaultPosition.ON_RUN_SUBTASK: 1},
             pytest.raises(FaultInjectionError, match="Fault Injection"),
+            True,
         ],
     ],
 )

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -67,7 +67,7 @@ class MarsActorContext(BaseActorContext):
         if isinstance(message, ResultMessage):
             return message.result
         else:
-            raise message.error.with_traceback(message.traceback)
+            raise message.as_instanceof_cause()
 
     async def _wait(self, future: asyncio.Future, address: str, message: _MessageBase):
         try:

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -60,8 +60,8 @@ ray = lazy_import("ray")
 
 class _ErrorProcessor:
     def __init__(self, address: str, message_id: bytes, protocol):
-        self._message_id = message_id
         self._address = address
+        self._message_id = message_id
         self._protocol = protocol
         self.result = None
 

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -59,8 +59,9 @@ ray = lazy_import("ray")
 
 
 class _ErrorProcessor:
-    def __init__(self, message_id: bytes, protocol):
+    def __init__(self, message_id: bytes, address: str, protocol):
         self._message_id = message_id
+        self._address = address
         self._protocol = protocol
         self.result = None
 
@@ -70,7 +71,13 @@ class _ErrorProcessor:
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.result is None:
             self.result = ErrorMessage(
-                self._message_id, exc_type, exc_val, exc_tb, protocol=self._protocol
+                self._message_id,
+                self._address,
+                os.getpid(),
+                exc_type,
+                exc_val,
+                exc_tb,
+                protocol=self._protocol,
             )
             return True
 
@@ -277,7 +284,7 @@ class AbstractActorPool(ABC):
             result or error message.
         """
         with _ErrorProcessor(
-            message.message_id, protocol=message.protocol
+            message.message_id, self.external_address, protocol=message.protocol
         ) as processor:
             content = True
             if message.control_message_type == ControlMessageType.stop:
@@ -322,7 +329,9 @@ class AbstractActorPool(ABC):
 
     async def process_message(self, message: _MessageBase, channel: Channel):
         handler = self._message_handler[message.message_type]
-        with _ErrorProcessor(message.message_id, message.protocol) as processor:
+        with _ErrorProcessor(
+            message.message_id, self.external_address, message.protocol
+        ) as processor:
             with debug_async_timeout(
                 "process_message_timeout",
                 "Process message %s of channel %s timeout.",
@@ -449,7 +458,9 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
 
     @implements(AbstractActorPool.create_actor)
     async def create_actor(self, message: CreateActorMessage) -> result_message_type:
-        with _ErrorProcessor(message.message_id, message.protocol) as processor:
+        with _ErrorProcessor(
+            message.message_id, self.external_address, message.protocol
+        ) as processor:
             actor_id = message.actor_id
             if actor_id in self._actors:
                 raise ActorAlreadyExist(
@@ -480,7 +491,9 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
 
     @implements(AbstractActorPool.destroy_actor)
     async def destroy_actor(self, message: DestroyActorMessage) -> result_message_type:
-        with _ErrorProcessor(message.message_id, message.protocol) as processor:
+        with _ErrorProcessor(
+            message.message_id, self.external_address, message.protocol
+        ) as processor:
             actor_id = message.actor_ref.uid
             try:
                 actor = self._actors[actor_id]
@@ -496,7 +509,9 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
 
     @implements(AbstractActorPool.actor_ref)
     async def actor_ref(self, message: ActorRefMessage) -> result_message_type:
-        with _ErrorProcessor(message.message_id, message.protocol) as processor:
+        with _ErrorProcessor(
+            message.message_id, self.external_address, message.protocol
+        ) as processor:
             actor_id = message.actor_ref.uid
             if actor_id not in self._actors:
                 raise ActorNotExist(f"Actor {actor_id} does not exist")
@@ -511,7 +526,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
     @implements(AbstractActorPool.send)
     async def send(self, message: SendMessage) -> result_message_type:
         with _ErrorProcessor(
-            message.message_id, message.protocol
+            message.message_id, self.external_address, message.protocol
         ) as processor, record_message_trace(message):
             actor_id = message.actor_ref.uid
             if actor_id not in self._actors:
@@ -528,7 +543,9 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
 
     @implements(AbstractActorPool.tell)
     async def tell(self, message: TellMessage) -> result_message_type:
-        with _ErrorProcessor(message.message_id, message.protocol) as processor:
+        with _ErrorProcessor(
+            message.message_id, self.external_address, message.protocol
+        ) as processor:
             actor_id = message.actor_ref.uid
             if actor_id not in self._actors:  # pragma: no cover
                 raise ActorNotExist(f"Actor {actor_id} does not exist")
@@ -546,11 +563,13 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
 
     @implements(AbstractActorPool.cancel)
     async def cancel(self, message: CancelMessage) -> result_message_type:
-        with _ErrorProcessor(message.message_id, message.protocol) as processor:
+        with _ErrorProcessor(
+            message.message_id, self.external_address, message.protocol
+        ) as processor:
             future = self._process_messages.get(message.cancel_message_id)
             if future is None or future.done():  # pragma: no cover
                 raise CannotCancelTask(
-                    "Task not exists, maybe it is done " "or cancelled already"
+                    "Task not exists, maybe it is done or cancelled already"
                 )
             future.cancel()
             processor.result = ResultMessage(
@@ -761,7 +780,9 @@ class MainActorPoolBase(ActorPoolBase):
     @implements(AbstractActorPool.create_actor)
     async def create_actor(self, message: CreateActorMessage) -> result_message_type:
         with _ErrorProcessor(
-            message_id=message.message_id, protocol=message.protocol
+            message_id=message.message_id,
+            address=self.external_address,
+            protocol=message.protocol,
         ) as processor:
             allocate_strategy = message.allocate_strategy
             with self._allocation_lock:
@@ -902,7 +923,7 @@ class MainActorPoolBase(ActorPoolBase):
                 return ResultMessage(message.message_id, ref, protocol=message.protocol)
 
         with _ErrorProcessor(
-            message.message_id, protocol=message.protocol
+            message.message_id, self.external_address, protocol=message.protocol
         ) as processor:
             raise ActorNotExist(
                 f"Actor {actor_ref.uid} does not exist in {actor_ref.address}"
@@ -922,7 +943,9 @@ class MainActorPoolBase(ActorPoolBase):
     async def handle_control_command(
         self, message: ControlMessage
     ) -> result_message_type:
-        with _ErrorProcessor(message.message_id, message.protocol) as processor:
+        with _ErrorProcessor(
+            message.message_id, self.external_address, message.protocol
+        ) as processor:
             if message.address == self.external_address:
                 if message.control_message_type == ControlMessageType.sync_config:
                     # sync config, need to notify all sub pools
@@ -1098,7 +1121,7 @@ class MainActorPoolBase(ActorPoolBase):
             if timeout is None:
                 message = await self.call(address, stop_message)
                 if isinstance(message, ErrorMessage):  # pragma: no cover
-                    raise message.error.with_traceback(message.traceback)
+                    raise message.as_instanceof_cause()
             else:
                 call = asyncio.create_task(self.call(address, stop_message))
                 try:

--- a/mars/oscar/backends/test/tests/test_message.py
+++ b/mars/oscar/backends/test/tests/test_message.py
@@ -1,0 +1,65 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cloudpickle as pickle
+
+from ...message import ErrorMessage
+
+
+def test_as_instanceof_cause():
+    fake_address = "Fake address"
+    fake_pid = 123
+    value = 3
+
+    class CustomException(Exception):
+        def __init__(self, i):
+            self.i = i
+
+        def __str__(self):
+            return "Custom Exception."
+
+    try:
+        raise CustomException(value)
+    except Exception as e:
+        em = ErrorMessage(
+            b"Fake message id", fake_address, fake_pid, type(e), e, e.__traceback__
+        )
+        try:
+            cause = em.as_instanceof_cause()
+            # Test serialization.
+            cause1 = pickle.loads(pickle.dumps(cause))
+            assert type(cause) is type(cause1)
+            raise cause
+        except Exception as e1:
+            # Check cause exception.
+            assert isinstance(e1, CustomException)
+            assert e1.i == value
+            assert fake_address in str(e1)
+            assert str(fake_pid) in str(e1)
+            em1 = ErrorMessage(
+                b"Fake message id",
+                fake_address,
+                fake_pid,
+                type(e1),
+                e1,
+                e1.__traceback__,
+            )
+            try:
+                raise em1.as_instanceof_cause()
+            except Exception as e2:
+                # Check recursive cause exception.
+                assert isinstance(e2, CustomException)
+                assert e2.i == value
+                assert str(e2).count(fake_address) == 1
+                assert str(e2).count(str(fake_pid)) == 1

--- a/mars/oscar/core.pyx
+++ b/mars/oscar/core.pyx
@@ -368,7 +368,7 @@ cdef class _BaseActor:
         except Exception as ex:
             if _log_unhandled_errors:
                 from .debug import logger as debug_logger
-                debug_logger.exception('Got unhandled error when handling message %r'
+                debug_logger.exception('Got unhandled error when handling message %r '
                                        'in actor %s at %s', message, self.uid, self.address)
             raise ex
 

--- a/mars/services/scheduling/worker/execution.py
+++ b/mars/services/scheduling/worker/execution.py
@@ -28,7 +28,7 @@ from ....core.operand import Fetch, FetchShuffle
 from ....lib.aio import alru_cache
 from ....oscar.errors import MarsError
 from ....storage import StorageLevel
-from ....utils import dataslots, get_chunk_key_to_data_keys
+from ....utils import dataslots, get_chunk_key_to_data_keys, wrap_exception
 from ...cluster import ClusterAPI
 from ...meta import MetaAPI
 from ...storage import StorageAPI
@@ -84,10 +84,9 @@ async def _retry_run(
                 )
                 logger.error(message)
 
-                class _ExceedMaxRerun(type(ex)):
-                    pass
-
-                raise _ExceedMaxRerun(message).with_traceback(ex.__traceback__)
+                raise wrap_exception(
+                    "_ExceedMaxRerun", (type(ex),), message, ex, ex.__traceback__
+                )
             else:
                 raise ex
         except asyncio.CancelledError:
@@ -101,10 +100,9 @@ async def _retry_run(
                 )
                 logger.error(message)
 
-                class _UnhandledException(type(ex)):
-                    pass
-
-                raise _UnhandledException(message).with_traceback(ex.__traceback__)
+                raise wrap_exception(
+                    "_UnhandledException", (type(ex),), message, ex, ex.__traceback__
+                )
             else:
                 raise ex
 
@@ -436,10 +434,9 @@ class SubtaskExecutionActor(mo.StatelessActor):
                 )
                 logger.error(message)
 
-                class _UnretryableException(type(e)):
-                    pass
-
-                raise _UnretryableException(message).with_traceback(e.__traceback__)
+                raise wrap_exception(
+                    "_UnretryableException", (type(e),), message, e, e.__traceback__
+                )
 
     async def run_subtask(
         self, subtask: Subtask, band_name: str, supervisor_address: str

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -39,6 +39,7 @@ import zlib
 from abc import ABC
 from contextlib import contextmanager
 from typing import Any, List, Dict, Set, Tuple, Type, Union, Callable, Optional
+from types import TracebackType
 
 import numpy as np
 import pandas as pd
@@ -1544,3 +1545,28 @@ def is_full_slice(slc: Any) -> bool:
         and slc.stop is None
         and slc.step is None
     )
+
+
+def wrap_exception(
+    name: str,
+    bases: Tuple[Type],
+    message: str,
+    cause: BaseException,
+    traceback: Optional[TracebackType] = None,
+):
+    """Generate an exception wraps the cause exception."""
+
+    def __init__(self):
+        pass
+
+    def __getattr__(self, item):
+        return getattr(cause, item)
+
+    def __str__(self):
+        return message
+
+    return type(
+        name,
+        bases,
+        {"__init__": __init__, "__getattr__": __getattr__, "__str__": __str__},
+    )().with_traceback(traceback)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Developers need the address and pid for debug in a large distributed cluster, so this PR,

- [x] Add address and pid prefix to the mars exception message.

An example exception,

``` python
  File "mars/oscar/core.pyx", line 226, in _handle_actor_result
    result = await result
  File "/Users/admin/mars/services/tests/fault_injection_patch.py", line 86, in run
    return await super().run()
  File "/Users/admin/mars/services/subtask/worker/processor.py", line 457, in run
    await self._execute_graph(chunk_graph)
  File "/Users/admin/mars/services/subtask/worker/processor.py", line 195, in _execute_graph
    await self._async_execute_operand(self._datastore, chunk.op)
  File "/Users/admin/mars/services/tests/fault_injection_patch.py", line 94, in _async_execute_operand
    handle_fault(fault)
  File "/Users/admin/mars/services/tests/fault_injection_manager.py", line 50, in handle_fault
    raise FaultInjectionError("Fault Injection")
types._MarsError: [address=ray://test_cluster/1/2, pid=35418] Fault Injection
```



<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
