### PR TITLE
[Bug] Fix duplicate dec object ref

### DIFF
--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -812,7 +812,14 @@ class TaskProcessorActor(mo.Actor):
                             decref_chunk_keys.extend([key[0] for key in data_keys])
                 decref_chunk_keys.append(result_chunk.key)
         await self._lifecycle_api.decref_chunks(decref_chunk_keys)
-        self._subtask_decref_events.pop(subtask.subtask_id).set()
+
+        # `set_subtask_result` will be called when subtask finished
+        # but report progress will call set_subtask_result too,
+        # so it have risk to duplicate decrease some subtask input object reference,
+        # it will cause object reference count lower zero
+        # TODO(buniu): Pop asyncio.Event when current subtask `set_subtask_result`
+        # will never be called
+        self._subtask_decref_events[subtask.subtask_id].set()
 
     async def set_subtask_result(self, subtask_result: SubtaskResult):
         stage_processor = self._cur_processor.cur_stage_processor

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -817,7 +817,7 @@ class TaskProcessorActor(mo.Actor):
         # but report progress will call set_subtask_result too,
         # so it have risk to duplicate decrease some subtask input object reference,
         # it will cause object reference count lower zero
-        # TODO(buniu): Pop asyncio.Event when current subtask `set_subtask_result`
+        # TODO(Catch-Bull): Pop asyncio.Event when current subtask `set_subtask_result`
         # will never be called
         self._subtask_decref_events[subtask.subtask_id].set()
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Since the `report progress` will also set the subtask result, when the supervisor load is relatively high, the arrival time of the two set subtask results will be longer, resulting in the object ref being decremented one more time

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
