### PR TITLE
Simplify rechunk implementation

### DIFF
--- a/mars/core/operand/core.py
+++ b/mars/core/operand/core.py
@@ -99,7 +99,7 @@ class TileableOperandMixin:
         return chunk_type(data)
 
     def _new_chunks(
-        self, inputs: List[ChunkType], kws: dict = None, **kw
+        self, inputs: List[ChunkType], kws: List[Dict] = None, **kw
     ) -> List[ChunkType]:
         output_limit = kw.pop("output_limit", None)
         if output_limit is None:
@@ -132,7 +132,7 @@ class TileableOperandMixin:
         return chunks
 
     def new_chunks(
-        self, inputs: List[ChunkType], kws: dict = None, **kwargs
+        self, inputs: List[ChunkType], kws: List[Dict] = None, **kwargs
     ) -> List[ChunkType]:
         """
         Create chunks.
@@ -162,7 +162,9 @@ class TileableOperandMixin:
         """
         return self._new_chunks(inputs, kws=kws, **kwargs)
 
-    def new_chunk(self, inputs: List[ChunkType], kws: dict = None, **kw) -> ChunkType:
+    def new_chunk(
+        self, inputs: List[ChunkType], kws: List[Dict] = None, **kw
+    ) -> ChunkType:
         if getattr(self, "output_limit") != 1:
             raise TypeError("cannot new chunk with more than 1 outputs")
 
@@ -274,7 +276,7 @@ class TileableOperandMixin:
         return tileables
 
     def new_tileable(
-        self, inputs: List[TileableType], kws: dict = None, **kw
+        self, inputs: List[TileableType], kws: List[Dict] = None, **kw
     ) -> TileableType:
         if getattr(self, "output_limit") != 1:
             raise TypeError("cannot new chunk with more than 1 outputs")

--- a/mars/dataframe/base/rechunk.py
+++ b/mars/dataframe/base/rechunk.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import itertools
+from typing import Tuple
 
+import numpy as np
 import pandas as pd
 
 from ... import opcodes as OperandDef
 from ...core import OutputType
-from ...serialization.serializables import KeyField, AnyField, Int32Field, Int64Field
-from ...tensor.rechunk.core import get_nsplits, plan_rechunks, compute_rechunk_slices
-from ...tensor.utils import calc_sliced_size
+from ...serialization.serializables import AnyField
+from ...tensor.rechunk.core import get_nsplits, gen_rechunk_infos, chunk_size_type
+from ...typing import TileableType
 from ...utils import has_unknown_shape
-from ..initializer import DataFrame as asdataframe, Series as asseries
+from ..initializer import DataFrame as asdataframe, Series as asseries, Index as asindex
 from ..operands import DataFrameOperand, DataFrameOperandMixin, DATAFRAME_TYPE
 from ..utils import indexing_index_value, merge_index_value
 
@@ -30,46 +31,7 @@ from ..utils import indexing_index_value, merge_index_value
 class DataFrameRechunk(DataFrameOperand, DataFrameOperandMixin):
     _op_type_ = OperandDef.RECHUNK
 
-    _input = KeyField("input")
-    _chunk_size = AnyField("chunk_size")
-    _threshold = Int32Field("threshold")
-    _chunk_size_limit = Int64Field("chunk_size_limit")
-
-    def __init__(
-        self,
-        chunk_size=None,
-        threshold=None,
-        chunk_size_limit=None,
-        output_types=None,
-        **kw
-    ):
-        super().__init__(
-            _chunk_size=chunk_size,
-            _threshold=threshold,
-            _chunk_size_limit=chunk_size_limit,
-            _output_types=output_types,
-            **kw
-        )
-
-    @property
-    def input(self):
-        return self._input
-
-    @property
-    def chunk_size(self):
-        return self._chunk_size
-
-    @property
-    def threshold(self):
-        return self._threshold
-
-    @property
-    def chunk_size_limit(self):
-        return self._chunk_size_limit
-
-    def _set_inputs(self, inputs):
-        super()._set_inputs(inputs)
-        self._input = self._inputs[0]
+    chunk_size = AnyField("chunk_size")
 
     def __call__(self, x):
         if isinstance(x, DATAFRAME_TYPE):
@@ -96,40 +58,124 @@ class DataFrameRechunk(DataFrameOperand, DataFrameOperandMixin):
             )
 
     @classmethod
-    def tile(cls, op):
+    def tile(cls, op: "DataFrameRechunk"):
+        from ..indexing.iloc import (
+            DataFrameIlocGetItem,
+            SeriesIlocGetItem,
+            IndexIlocGetItem,
+        )
+        from ..merge.concat import DataFrameConcat
+
         if has_unknown_shape(*op.inputs):
             yield
 
-        a = op.input
-        a = asdataframe(a) if a.ndim == 2 else asseries(a)
-        chunk_size = _get_chunk_size(a, op.chunk_size)
-        if chunk_size == a.nsplits:
-            return [a]
-
         out = op.outputs[0]
-        new_chunk_size = tuple(tuple(s for s in cs if s != 0) for cs in chunk_size)
-        if isinstance(out, DATAFRAME_TYPE):
-            itemsize = max(getattr(dt, "itemsize", 8) for dt in out.dtypes)
+        inp = op.inputs[0]
+        if inp.ndim == 2:
+            inp = asdataframe(inp)
+        elif inp.op.output_types[0] == OutputType.series:
+            inp = asseries(inp)
         else:
-            itemsize = out.dtype.itemsize
-        steps = plan_rechunks(
-            op.inputs[0],
-            new_chunk_size,
-            itemsize,
-            threshold=op.threshold,
-            chunk_size_limit=op.chunk_size_limit,
-        )
-        for c in steps:
-            out = compute_rechunk(out.inputs[0], c)
+            inp = asindex(inp)
+        chunk_size = _get_chunk_size(inp, op.chunk_size)
+        if chunk_size == inp.nsplits:
+            return [inp]
+
+        rechunk_infos = gen_rechunk_infos(inp, chunk_size)
+        out_chunks = []
+        for rechunk_info in rechunk_infos:
+            chunk_index = rechunk_info.out_index
+            shape = rechunk_info.shape
+            inp_chunks = rechunk_info.input_chunks
+            inp_chunk_slices = rechunk_info.input_slices
+            inp_slice_chunks = []
+            for inp_chunk, inp_chunk_slice in zip(inp_chunks, inp_chunk_slices):
+                if all(slc == slice(None) for slc in inp_chunk_slice):
+                    inp_slice_chunks.append(inp_chunk)
+                else:
+                    index_value = indexing_index_value(
+                        inp_chunk.index_value, inp_chunk_slice[0], rechunk=True
+                    )
+                    if inp_chunk.ndim == 1:
+                        # Series or Index
+                        slc_chunk_op_type = (
+                            SeriesIlocGetItem
+                            if op.output_types[0] == OutputType.series
+                            else IndexIlocGetItem
+                        )
+                        slc_chunk = slc_chunk_op_type(
+                            indexes=inp_chunk_slice,
+                            output_types=op.output_types,
+                            sparse=inp_chunk.op.sparse,
+                        ).new_chunk(
+                            [inp_chunk],
+                            index_value=index_value,
+                            dtype=inp_chunk.dtype,
+                            name=inp_chunk.name,
+                            index=inp_chunk.index,
+                        )
+                    else:
+                        # DataFrame
+                        columns_value = indexing_index_value(
+                            inp_chunk.columns_value,
+                            inp_chunk_slice[1],
+                            store_data=True,
+                            rechunk=True,
+                        )
+                        dtypes = inp_chunk.dtypes.iloc[inp_chunk_slice[1]]
+                        slc_chunk = DataFrameIlocGetItem(
+                            indexes=inp_chunk_slice,
+                            output_types=[OutputType.dataframe],
+                            sparse=inp_chunk.op.sparse,
+                        ).new_chunk(
+                            [inp_chunk],
+                            index_value=index_value,
+                            columns_value=columns_value,
+                            dtypes=dtypes,
+                            index=inp_chunk.index,
+                        )
+                    inp_slice_chunks.append(slc_chunk)
+
+            chunk_shape = rechunk_info.input_chunk_shape
+            inp_chunks_arr = np.empty(chunk_shape, dtype=object)
+            inp_chunks_arr.ravel()[:] = inp_slice_chunks
+            params = dict(index=chunk_index, shape=shape)
+            if inp_chunks_arr.ndim == 1:
+                params["index_value"] = merge_index_value(
+                    {i: c.index_value for i, c in enumerate(inp_chunks_arr)}
+                )
+                params["dtype"] = inp_slice_chunks[0].dtype
+                params["name"] = inp_slice_chunks[0].name
+            else:
+                params["index_value"] = merge_index_value(
+                    {i: c.index_value for i, c in enumerate(inp_chunks_arr[:, 0])}
+                )
+                params["columns_value"] = merge_index_value(
+                    {i: c.columns_value for i, c in enumerate(inp_chunks_arr[0])},
+                    store_data=True,
+                )
+                params["dtypes"] = pd.concat([c.dtypes for c in inp_chunks_arr[0]])
+            out_chunk = DataFrameConcat(
+                output_types=[out.op.output_types[0]]
+            ).new_chunk(inp_slice_chunks, kws=[params])
+            out_chunks.append(out_chunk)
+
+        new_op = op.copy()
+        params = out.params
+        params["nsplits"] = chunk_size
+        params["chunks"] = out_chunks
+        df_or_series = new_op.new_tileable(op.inputs, kws=[params])
 
         if op.reassign_worker:
-            for c in out.chunks:
+            for c in df_or_series.chunks:
                 c.op.reassign_worker = True
 
-        return [out]
+        return [df_or_series]
 
 
-def _get_chunk_size(a, chunk_size):
+def _get_chunk_size(
+    a: TileableType, chunk_size: chunk_size_type
+) -> Tuple[Tuple[int], ...]:
     if isinstance(a, DATAFRAME_TYPE):
         itemsize = max(getattr(dt, "itemsize", 8) for dt in a.dtypes)
     else:
@@ -137,9 +183,7 @@ def _get_chunk_size(a, chunk_size):
     return get_nsplits(a, chunk_size, itemsize)
 
 
-def rechunk(
-    a, chunk_size, threshold=None, chunk_size_limit=None, reassign_worker=False
-):
+def rechunk(a: TileableType, chunk_size: chunk_size_type, reassign_worker=False):
     if not any(pd.isna(s) for s in a.shape) and not a.is_coarse():
         if not has_unknown_shape(a):
             # do client check only when no unknown shape,
@@ -150,171 +194,6 @@ def rechunk(
 
     op = DataFrameRechunk(
         chunk_size=chunk_size,
-        threshold=threshold,
-        chunk_size_limit=chunk_size_limit,
         reassign_worker=reassign_worker,
     )
     return op(a)
-
-
-def _concat_dataframe_meta(to_concat_chunks):
-    if to_concat_chunks[0].index_value.to_pandas().empty:
-        index_value = to_concat_chunks[0].index_value
-    else:
-        idx_to_index_value = dict(
-            (c.index[0], c.index_value) for c in to_concat_chunks if c.index[1] == 0
-        )
-        index_value = merge_index_value(idx_to_index_value)
-
-    idx_to_columns_value = dict(
-        (c.index[1], c.columns_value) for c in to_concat_chunks if c.index[0] == 0
-    )
-    columns_value = merge_index_value(idx_to_columns_value, store_data=True)
-
-    idx_to_dtypes = dict(
-        (c.index[1], c.dtypes) for c in to_concat_chunks if c.index[0] == 0
-    )
-    dtypes = pd.concat([v[1] for v in list(sorted(idx_to_dtypes.items()))])
-    return index_value, columns_value, dtypes
-
-
-def _concat_series_index(to_concat_chunks):
-    if to_concat_chunks[0].index_value.to_pandas().empty:
-        index_value = to_concat_chunks[0].index_value
-    else:
-        idx_to_index_value = dict((c.index[0], c.index_value) for c in to_concat_chunks)
-        index_value = merge_index_value(idx_to_index_value)
-    return index_value
-
-
-def compute_rechunk(a, chunk_size):
-    from ..indexing.iloc import DataFrameIlocGetItem, SeriesIlocGetItem
-    from ..merge.concat import DataFrameConcat
-
-    result_slices = compute_rechunk_slices(a, chunk_size)
-    result_chunks = []
-    idxes = itertools.product(*[range(len(c)) for c in chunk_size])
-    chunk_slices = itertools.product(*result_slices)
-    chunk_shapes = itertools.product(*chunk_size)
-    is_dataframe = isinstance(a, DATAFRAME_TYPE)
-    for idx, chunk_slice, chunk_shape in zip(idxes, chunk_slices, chunk_shapes):
-        to_merge = []
-        merge_idxes = itertools.product(*[range(len(i)) for i in chunk_slice])
-        for merge_idx, index_slices in zip(
-            merge_idxes, itertools.product(*chunk_slice)
-        ):
-            chunk_index, chunk_slice = zip(*index_slices)
-            old_chunk = a.cix[chunk_index]
-            merge_chunk_shape = tuple(
-                calc_sliced_size(s, slc) for s, slc in zip(old_chunk.shape, chunk_slice)
-            )
-            new_index_value = indexing_index_value(
-                old_chunk.index_value, chunk_slice[0], rechunk=True
-            )
-            if is_dataframe:
-                new_columns_value = indexing_index_value(
-                    old_chunk.columns_value,
-                    chunk_slice[1],
-                    store_data=True,
-                    rechunk=True,
-                )
-                merge_chunk_op = DataFrameIlocGetItem(
-                    list(chunk_slice),
-                    sparse=old_chunk.op.sparse,
-                    output_types=[OutputType.dataframe],
-                )
-                merge_chunk = merge_chunk_op.new_chunk(
-                    [old_chunk],
-                    shape=merge_chunk_shape,
-                    index=merge_idx,
-                    index_value=new_index_value,
-                    columns_value=new_columns_value,
-                    dtypes=old_chunk.dtypes.iloc[chunk_slice[1]],
-                )
-            else:
-                merge_chunk_op = SeriesIlocGetItem(
-                    list(chunk_slice),
-                    sparse=old_chunk.op.sparse,
-                    output_types=a.op.output_types,
-                )
-                merge_chunk = merge_chunk_op.new_chunk(
-                    [old_chunk],
-                    shape=merge_chunk_shape,
-                    index=merge_idx,
-                    index_value=new_index_value,
-                    dtype=old_chunk.dtype,
-                    name=old_chunk.name,
-                )
-            to_merge.append(merge_chunk)
-        if len(to_merge) == 1:
-            chunk_op = to_merge[0].op.copy()
-            if is_dataframe:
-                out_chunk = chunk_op.new_chunk(
-                    to_merge[0].op.inputs,
-                    shape=chunk_shape,
-                    index=idx,
-                    index_value=to_merge[0].index_value,
-                    columns_value=to_merge[0].columns_value,
-                    dtypes=to_merge[0].dtypes,
-                )
-            else:
-                out_chunk = chunk_op.new_chunk(
-                    to_merge[0].op.inputs,
-                    shape=chunk_shape,
-                    index=idx,
-                    index_value=to_merge[0].index_value,
-                    name=to_merge[0].name,
-                    dtype=to_merge[0].dtype,
-                )
-            result_chunks.append(out_chunk)
-        else:
-            if is_dataframe:
-                chunk_op = DataFrameConcat(output_types=[OutputType.dataframe])
-                index_value, columns_value, dtypes = _concat_dataframe_meta(to_merge)
-                out_chunk = chunk_op.new_chunk(
-                    to_merge,
-                    shape=chunk_shape,
-                    index=idx,
-                    index_value=index_value,
-                    columns_value=columns_value,
-                    dtypes=dtypes,
-                )
-            else:
-                chunk_op = DataFrameConcat(output_types=a.op.output_types)
-                index_value = _concat_series_index(to_merge)
-                out_chunk = chunk_op.new_chunk(
-                    to_merge,
-                    shape=chunk_shape,
-                    index=idx,
-                    index_value=index_value,
-                    dtype=to_merge[0].dtype,
-                    name=to_merge[0].name,
-                )
-            result_chunks.append(out_chunk)
-
-    if is_dataframe:
-        op = DataFrameRechunk(chunk_size, output_types=[OutputType.dataframe])
-        return op.new_dataframe(
-            [a],
-            a.shape,
-            dtypes=a.dtypes,
-            columns_value=a.columns_value,
-            index_value=a.index_value,
-            nsplits=chunk_size,
-            chunks=result_chunks,
-        )
-    else:
-        op = DataFrameRechunk(chunk_size, output_types=a.op.output_types)
-        if a.op.output_types[0] == OutputType.index:
-            f = op.new_index
-        else:
-            f = op.new_series
-        return f(
-            [a],
-            a.shape,
-            dtype=a.dtype,
-            index_value=a.index_value,
-            nsplits=chunk_size,
-            chunks=result_chunks,
-            name=a.name,
-        )

--- a/mars/lib/sparse/__init__.py
+++ b/mars/lib/sparse/__init__.py
@@ -816,3 +816,15 @@ def solve_triangular(a, b, lower=False, sparse=True):
     from .matrix import solve_triangular_sparse_matrix
 
     return solve_triangular_sparse_matrix(a, b, lower=lower, sparse=sparse)
+
+
+def block(arrs):
+    arr = arrs[0]
+    while isinstance(arr, list):
+        arr = arr[0]
+    if arr.ndim != 2:  # pragma: no cover
+        raise NotImplementedError
+
+    from .matrix import block
+
+    return block(arrs)

--- a/mars/lib/sparse/matrix.py
+++ b/mars/lib/sparse/matrix.py
@@ -16,6 +16,7 @@
 
 import numpy as np
 from collections.abc import Iterable
+from typing import List
 
 from .core import (
     issparse,
@@ -125,6 +126,13 @@ def solve_triangular_sparse_matrix(a, b, lower=False, sparse=True):
         return SparseNDArray(spx, shape=x.shape)
     else:
         return x
+
+
+def block(arrs: List[List[SparseArray]]) -> SparseArray:
+    mats = []
+    for dim_arrs in arrs:
+        mats.append([naked(a) for a in dim_arrs])
+    return SparseNDArray(sps.bmat(mats, format="csr"))
 
 
 class SparseMatrix(SparseArray):

--- a/mars/lib/sparse/tests/test_sparse.py
+++ b/mars/lib/sparse/tests/test_sparse.py
@@ -31,7 +31,7 @@ v2 = sps.csr_matrix(v2_data)
 d1 = np.array([1, 2, 3])
 
 
-def assertArrayEqual(a, b, almost=False):
+def assert_array_equal(a, b, almost=False):
     if issparse(a):
         a = a.toarray()
     else:
@@ -50,167 +50,167 @@ def test_sparse_creation():
     s = SparseNDArray(s1_data)
     assert s.ndim == 2
     assert isinstance(s, SparseMatrix)
-    assertArrayEqual(s.toarray(), s1_data.A)
-    assertArrayEqual(s.todense(), s1_data.A)
+    assert_array_equal(s.toarray(), s1_data.A)
+    assert_array_equal(s.todense(), s1_data.A)
 
     v = SparseNDArray(v1, shape=(3,))
     assert s.ndim
     assert isinstance(v, SparseVector)
     assert v.shape == (3,)
-    assertArrayEqual(v.todense(), v1_data)
-    assertArrayEqual(v.toarray(), v1_data)
-    assertArrayEqual(v, v1_data)
+    assert_array_equal(v.todense(), v1_data)
+    assert_array_equal(v.toarray(), v1_data)
+    assert_array_equal(v, v1_data)
 
 
 def test_sparse_add():
     s1 = SparseNDArray(s1_data)
     s2 = SparseNDArray(s2_data)
 
-    assertArrayEqual(s1 + s2, s1 + s2)
-    assertArrayEqual(s1 + d1, s1 + d1)
-    assertArrayEqual(d1 + s1, d1 + s1)
+    assert_array_equal(s1 + s2, s1 + s2)
+    assert_array_equal(s1 + d1, s1 + d1)
+    assert_array_equal(d1 + s1, d1 + s1)
     r = sps.csr_matrix(((s1.data + 1), s1.indices, s1.indptr), s1.shape)
-    assertArrayEqual(s1 + 1, r)
+    assert_array_equal(s1 + 1, r)
     r = sps.csr_matrix(((1 + s1.data), s1.indices, s1.indptr), s1.shape)
-    assertArrayEqual(1 + s1, r)
+    assert_array_equal(1 + s1, r)
 
     # test sparse vector
     v = SparseNDArray(v1, shape=(3,))
-    assertArrayEqual(v + v, v1_data + v1_data)
-    assertArrayEqual(v + d1, v1_data + d1)
-    assertArrayEqual(d1 + v, d1 + v1_data)
+    assert_array_equal(v + v, v1_data + v1_data)
+    assert_array_equal(v + d1, v1_data + d1)
+    assert_array_equal(d1 + v, d1 + v1_data)
     r = sps.csr_matrix(((v1.data + 1), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(v + 1, r.toarray().reshape(3))
+    assert_array_equal(v + 1, r.toarray().reshape(3))
     r = sps.csr_matrix(((1 + v1.data), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(1 + v, r.toarray().reshape(3))
+    assert_array_equal(1 + v, r.toarray().reshape(3))
 
 
 def test_sparse_subtract():
     s1 = SparseNDArray(s1_data)
     s2 = SparseNDArray(s2_data)
 
-    assertArrayEqual(s1 - s2, s1 - s2)
-    assertArrayEqual(s1 - d1, s1 - d1)
-    assertArrayEqual(d1 - s1, d1 - s1)
+    assert_array_equal(s1 - s2, s1 - s2)
+    assert_array_equal(s1 - d1, s1 - d1)
+    assert_array_equal(d1 - s1, d1 - s1)
     r = sps.csr_matrix(((s1.data - 1), s1.indices, s1.indptr), s1.shape)
-    assertArrayEqual(s1 - 1, r)
+    assert_array_equal(s1 - 1, r)
     r = sps.csr_matrix(((1 - s1.data), s1.indices, s1.indptr), s1.shape)
-    assertArrayEqual(1 - s1, r)
+    assert_array_equal(1 - s1, r)
 
     # test sparse vector
     v = SparseNDArray(v1, shape=(3,))
-    assertArrayEqual(v - v, v1_data - v1_data)
-    assertArrayEqual(v - d1, v1_data - d1)
-    assertArrayEqual(d1 - v, d1 - v1_data)
+    assert_array_equal(v - v, v1_data - v1_data)
+    assert_array_equal(v - d1, v1_data - d1)
+    assert_array_equal(d1 - v, d1 - v1_data)
     r = sps.csr_matrix(((v1.data - 1), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(v - 1, r.toarray().reshape(3))
+    assert_array_equal(v - 1, r.toarray().reshape(3))
     r = sps.csr_matrix(((1 - v1.data), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(1 - v, r.toarray().reshape(3))
+    assert_array_equal(1 - v, r.toarray().reshape(3))
 
 
 def test_sparse_multiply():
     s1 = SparseNDArray(s1_data)
     s2 = SparseNDArray(s2_data)
 
-    assertArrayEqual(s1 * s2, s1_data.multiply(s2_data))
-    assertArrayEqual(s1 * d1, s1_data.multiply(d1))
-    assertArrayEqual(d1 * s1, s1_data.multiply(d1))
-    assertArrayEqual(s1 * 2, s1 * 2)
-    assertArrayEqual(2 * s1, s1 * 2)
+    assert_array_equal(s1 * s2, s1_data.multiply(s2_data))
+    assert_array_equal(s1 * d1, s1_data.multiply(d1))
+    assert_array_equal(d1 * s1, s1_data.multiply(d1))
+    assert_array_equal(s1 * 2, s1 * 2)
+    assert_array_equal(2 * s1, s1 * 2)
 
     # test sparse vector
     v = SparseNDArray(v1, shape=(3,))
-    assertArrayEqual(v * v, v1_data * v1_data)
-    assertArrayEqual(v * d1, v1_data * d1)
-    assertArrayEqual(d1 * v, d1 * v1_data)
+    assert_array_equal(v * v, v1_data * v1_data)
+    assert_array_equal(v * d1, v1_data * d1)
+    assert_array_equal(d1 * v, d1 * v1_data)
     r = sps.csr_matrix(((v1.data * 1), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(v * 1, r.toarray().reshape(3))
+    assert_array_equal(v * 1, r.toarray().reshape(3))
     r = sps.csr_matrix(((1 * v1.data), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(1 * v, r.toarray().reshape(3))
+    assert_array_equal(1 * v, r.toarray().reshape(3))
 
 
 def test_sparse_divide():
     s1 = SparseNDArray(s1_data)
     s2 = SparseNDArray(s2_data)
 
-    assertArrayEqual(s1 / s2, s1 / s2)
-    assertArrayEqual(s1 / d1, s1 / d1)
-    assertArrayEqual(d1 / s1, d1 / s1.toarray())
-    assertArrayEqual(s1 / 2, s1 / 2)
-    assertArrayEqual(2 / s1, 2 / s1.toarray())
+    assert_array_equal(s1 / s2, s1 / s2)
+    assert_array_equal(s1 / d1, s1 / d1)
+    assert_array_equal(d1 / s1, d1 / s1.toarray())
+    assert_array_equal(s1 / 2, s1 / 2)
+    assert_array_equal(2 / s1, 2 / s1.toarray())
 
     # test sparse vector
     v = SparseNDArray(v1, shape=(3,))
-    assertArrayEqual(v / v, v1_data / v1_data)
-    assertArrayEqual(v / d1, v1_data / d1)
-    assertArrayEqual(d1 / v, d1 / v1_data)
+    assert_array_equal(v / v, v1_data / v1_data)
+    assert_array_equal(v / d1, v1_data / d1)
+    assert_array_equal(d1 / v, d1 / v1_data)
     r = sps.csr_matrix(((v1.data / 1), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(v / 1, r.toarray().reshape(3))
+    assert_array_equal(v / 1, r.toarray().reshape(3))
     r = sps.csr_matrix(((1 / v1.data), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(1 / v, r.toarray().reshape(3))
+    assert_array_equal(1 / v, r.toarray().reshape(3))
 
 
 def test_sparse_floor_divide():
     s1 = SparseNDArray(s1_data)
     s2 = SparseNDArray(s2_data)
 
-    assertArrayEqual(s1 // s2, s1.toarray() // s2.toarray())
-    assertArrayEqual(s1 // d1, s1.toarray() // d1)
-    assertArrayEqual(d1 // s1, d1 // s1.toarray())
-    assertArrayEqual(s1 // 2, s1.toarray() // 2)
-    assertArrayEqual(2 // s1, 2 // s1.toarray())
+    assert_array_equal(s1 // s2, s1.toarray() // s2.toarray())
+    assert_array_equal(s1 // d1, s1.toarray() // d1)
+    assert_array_equal(d1 // s1, d1 // s1.toarray())
+    assert_array_equal(s1 // 2, s1.toarray() // 2)
+    assert_array_equal(2 // s1, 2 // s1.toarray())
 
     # test sparse vector
     v = SparseNDArray(v1, shape=(3,))
-    assertArrayEqual(v // v, v1_data // v1_data)
-    assertArrayEqual(v // d1, v1_data // d1)
-    assertArrayEqual(d1 // v, d1 // v1_data)
+    assert_array_equal(v // v, v1_data // v1_data)
+    assert_array_equal(v // d1, v1_data // d1)
+    assert_array_equal(d1 // v, d1 // v1_data)
     r = sps.csr_matrix(((v1.data // 1), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(v // 1, r.toarray().reshape(3))
+    assert_array_equal(v // 1, r.toarray().reshape(3))
     r = sps.csr_matrix(((1 // v1.data), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(1 // v, r.toarray().reshape(3))
+    assert_array_equal(1 // v, r.toarray().reshape(3))
 
 
 def test_sparse_power():
     s1 = SparseNDArray(s1_data)
     s2 = SparseNDArray(s2_data)
 
-    assertArrayEqual(s1**s2, s1.toarray() ** s2.toarray())
-    assertArrayEqual(s1**d1, s1.toarray() ** d1)
-    assertArrayEqual(d1**s1, d1 ** s1.toarray())
-    assertArrayEqual(s1**2, s1_data.power(2))
-    assertArrayEqual(2**s1, 2 ** s1.toarray())
+    assert_array_equal(s1**s2, s1.toarray() ** s2.toarray())
+    assert_array_equal(s1**d1, s1.toarray() ** d1)
+    assert_array_equal(d1**s1, d1 ** s1.toarray())
+    assert_array_equal(s1**2, s1_data.power(2))
+    assert_array_equal(2**s1, 2 ** s1.toarray())
 
     # test sparse vector
     v = SparseNDArray(v1, shape=(3,))
-    assertArrayEqual(v**v, v1_data**v1_data)
-    assertArrayEqual(v**d1, v1_data**d1)
-    assertArrayEqual(d1**v, d1**v1_data)
+    assert_array_equal(v**v, v1_data**v1_data)
+    assert_array_equal(v**d1, v1_data**d1)
+    assert_array_equal(d1**v, d1**v1_data)
     r = sps.csr_matrix(((v1.data**1), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(v**1, r.toarray().reshape(3))
+    assert_array_equal(v**1, r.toarray().reshape(3))
     r = sps.csr_matrix(((1**v1.data), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(1**v, r.toarray().reshape(3))
+    assert_array_equal(1**v, r.toarray().reshape(3))
 
 
 def test_sparse_mod():
     s1 = SparseNDArray(s1_data)
     s2 = SparseNDArray(s2_data)
 
-    assertArrayEqual(s1 % s2, s1.toarray() % s2.toarray())
-    assertArrayEqual(s1 % d1, s1.toarray() % d1)
-    assertArrayEqual(d1 % s1, d1 % s1.toarray())
-    assertArrayEqual(s1 % 2, s1.toarray() % 2)
-    assertArrayEqual(2 % s1, 2 % s1.toarray())
+    assert_array_equal(s1 % s2, s1.toarray() % s2.toarray())
+    assert_array_equal(s1 % d1, s1.toarray() % d1)
+    assert_array_equal(d1 % s1, d1 % s1.toarray())
+    assert_array_equal(s1 % 2, s1.toarray() % 2)
+    assert_array_equal(2 % s1, 2 % s1.toarray())
 
     # test sparse vector
     v = SparseNDArray(v1, shape=(3,))
-    assertArrayEqual(v % v, v1_data % v1_data)
-    assertArrayEqual(v % d1, v1_data % d1)
-    assertArrayEqual(d1 % v, d1 % v1_data)
+    assert_array_equal(v % v, v1_data % v1_data)
+    assert_array_equal(v % d1, v1_data % d1)
+    assert_array_equal(d1 % v, d1 % v1_data)
     r = sps.csr_matrix(((v1.data % 1), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(v % 1, r.toarray().reshape(3))
+    assert_array_equal(v % 1, r.toarray().reshape(3))
     r = sps.csr_matrix(((1 % v1.data), v1.indices, v1.indptr), v1.shape)
-    assertArrayEqual(1 % v, r.toarray().reshape(3))
+    assert_array_equal(1 % v, r.toarray().reshape(3))
 
 
 def test_sparse_bin():
@@ -232,20 +232,20 @@ def test_sparse_bin():
         "arctan2",
     ):
         lm, rm = getattr(mls, method), getattr(np, method)
-        assertArrayEqual(lm(s1, s2), rm(s1.toarray(), s2.toarray()))
-        assertArrayEqual(lm(s1, d1), rm(s1.toarray(), d1))
-        assertArrayEqual(lm(d1, s1), rm(d1, s1.toarray()))
+        assert_array_equal(lm(s1, s2), rm(s1.toarray(), s2.toarray()))
+        assert_array_equal(lm(s1, d1), rm(s1.toarray(), d1))
+        assert_array_equal(lm(d1, s1), rm(d1, s1.toarray()))
         r1 = sps.csr_matrix((rm(s1.data, 2), s1.indices, s1.indptr), s1.shape)
-        assertArrayEqual(lm(s1, 2), r1)
+        assert_array_equal(lm(s1, 2), r1)
         r2 = sps.csr_matrix((rm(2, s1.data), s1.indices, s1.indptr), s1.shape)
-        assertArrayEqual(lm(2, s1), r2)
+        assert_array_equal(lm(2, s1), r2)
 
         # test sparse
-        assertArrayEqual(lm(v, v), rm(v1_data, v1_data))
-        assertArrayEqual(lm(v, d1), rm(v1_data, d1))
-        assertArrayEqual(lm(d1, v), rm(d1, v1_data))
-        assertArrayEqual(lm(v, 2), rm(v1_data, 2))
-        assertArrayEqual(lm(2, v), rm(2, v1_data))
+        assert_array_equal(lm(v, v), rm(v1_data, v1_data))
+        assert_array_equal(lm(v, d1), rm(v1_data, d1))
+        assert_array_equal(lm(d1, v), rm(d1, v1_data))
+        assert_array_equal(lm(v, 2), rm(v1_data, 2))
+        assert_array_equal(lm(2, v), rm(2, v1_data))
 
 
 def test_sparse_unary():
@@ -293,8 +293,8 @@ def test_sparse_unary():
     ):
         lm, rm = getattr(mls, method), getattr(np, method)
         r = sps.csr_matrix((rm(s1.data), s1.indices, s1.indptr), s1.shape)
-        assertArrayEqual(lm(s1), r)
-        assertArrayEqual(lm(v), rm(v1_data))
+        assert_array_equal(lm(s1), r)
+        assert_array_equal(lm(v), rm(v1_data))
 
 
 def test_sparse_dot():
@@ -303,25 +303,25 @@ def test_sparse_dot():
     v1_s = SparseNDArray(v1, shape=(3,))
     v2_s = SparseNDArray(v2, shape=(2,))
 
-    assertArrayEqual(mls.dot(s1, s2.T), s1.dot(s2.T))
-    assertArrayEqual(s1.dot(d1), s1.dot(d1))
-    assertArrayEqual(d1.dot(s1.T), d1.dot(s1.T.toarray()))
+    assert_array_equal(mls.dot(s1, s2.T), s1.dot(s2.T))
+    assert_array_equal(s1.dot(d1), s1.dot(d1))
+    assert_array_equal(d1.dot(s1.T), d1.dot(s1.T.toarray()))
 
-    assertArrayEqual(s1 @ s2.T, s1_data @ s2_data.T)
+    assert_array_equal(s1 @ s2.T, s1_data @ s2_data.T)
 
-    assertArrayEqual(mls.tensordot(s1, s2.T, axes=(1, 0)), s1.dot(s2.T))
-    assertArrayEqual(mls.tensordot(s1, d1, axes=(1, -1)), s1.dot(d1))
-    assertArrayEqual(mls.tensordot(d1, s1.T, axes=(0, 0)), d1.dot(s1.T.toarray()))
+    assert_array_equal(mls.tensordot(s1, s2.T, axes=(1, 0)), s1.dot(s2.T))
+    assert_array_equal(mls.tensordot(s1, d1, axes=(1, -1)), s1.dot(d1))
+    assert_array_equal(mls.tensordot(d1, s1.T, axes=(0, 0)), d1.dot(s1.T.toarray()))
 
-    assertArrayEqual(mls.dot(s1, v1_s), s1.dot(v1_data))
-    assertArrayEqual(mls.dot(s2, v1_s), s2.dot(v1_data))
-    assertArrayEqual(mls.dot(v2_s, s1), v2_data.dot(s1_data.A))
-    assertArrayEqual(mls.dot(v2_s, s2), v2_data.dot(s2_data.A))
-    assertArrayEqual(mls.dot(v1_s, v1_s), v1_data.dot(v1_data), almost=True)
-    assertArrayEqual(mls.dot(v2_s, v2_s), v2_data.dot(v2_data), almost=True)
+    assert_array_equal(mls.dot(s1, v1_s), s1.dot(v1_data))
+    assert_array_equal(mls.dot(s2, v1_s), s2.dot(v1_data))
+    assert_array_equal(mls.dot(v2_s, s1), v2_data.dot(s1_data.A))
+    assert_array_equal(mls.dot(v2_s, s2), v2_data.dot(s2_data.A))
+    assert_array_equal(mls.dot(v1_s, v1_s), v1_data.dot(v1_data), almost=True)
+    assert_array_equal(mls.dot(v2_s, v2_s), v2_data.dot(v2_data), almost=True)
 
-    assertArrayEqual(mls.dot(v2_s, s1, sparse=False), v2_data.dot(s1_data.A))
-    assertArrayEqual(mls.dot(v1_s, v1_s, sparse=False), v1_data.dot(v1_data))
+    assert_array_equal(mls.dot(v2_s, s1, sparse=False), v2_data.dot(s1_data.A))
+    assert_array_equal(mls.dot(v1_s, v1_s, sparse=False), v1_data.dot(v1_data))
 
 
 def test_sparse_sum():
@@ -445,3 +445,16 @@ def test_sparse_fill_diagonal():
     np.fill_diagonal(expected, val, wrap=True)
 
     np.testing.assert_array_equal(arr.toarray(), expected)
+
+
+def test_sparse_block():
+    r1 = sps.rand(10, 5)
+    r2 = sps.rand(10, 3)
+    r3 = sps.rand(3, 5)
+    r4 = sps.rand(3, 3)
+
+    result = mls.block(
+        [[SparseNDArray(r1), SparseNDArray(r2)], [SparseNDArray(r3), SparseNDArray(r4)]]
+    )
+    expected = sps.bmat([[r1, r2], [r3, r4]])
+    assert_array_equal(result, expected)

--- a/mars/tensor/indexing/tests/test_indexing.py
+++ b/mars/tensor/indexing/tests/test_indexing.py
@@ -313,7 +313,7 @@ def test_setitem_structured():
     t[1:3] = np.arange(5)
     tt = tile(t)
     slices_op = tt.cix[0, 0].op.value.op
-    assert slices_op.slices == [slice(None, None, None), slice(None, 3, None)]
+    assert slices_op.slices == [slice(None, None, None), slice(0, 3, None)]
     broadcast_op = slices_op.inputs[0].op.inputs[0].op
     assert isinstance(broadcast_op, TensorBroadcastTo)
     assert broadcast_op.shape == (2, 5)
@@ -323,7 +323,7 @@ def test_setitem_structured():
     t[2:4] = np.arange(10).reshape(2, 5)
     tt = tile(t)
     slices_op = tt.cix[0, 0].op.value.op
-    assert slices_op.slices == [slice(None, 1, None), slice(None, 3, None)]
+    assert slices_op.slices == [slice(0, 1, None), slice(0, 3, None)]
     np.testing.assert_array_equal(
         slices_op.inputs[0].op.inputs[0].op.data, np.arange(10).reshape(2, 5)
     )

--- a/mars/tensor/utils.py
+++ b/mars/tensor/utils.py
@@ -330,7 +330,7 @@ def replace_ellipsis(index, ndim):
     )
 
 
-def calc_sliced_size(size, sliceobj):
+def calc_sliced_size(size: int, sliceobj: slice) -> int:
     if np.isnan(size):
         return np.nan
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR simplifies the `rechunk` implementation while the older version is really complicated and hard to understand.

Master branch:

```
In [1]: import numpy as np; import mars; import mars.tensor as mt

In [2]: mars.new_session()
Web service started at http://0.0.0.0:30452
Out[2]: <mars.deploy.oscar.session.SyncSession at 0x7f8441101250>

In [3]: r = np.random.RandomState(0).rand(12000, 12000)

In [4]: a = mt.array(r, chunk_size=1680).execute()
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:04<00:00, 23.39it/s]

In [5]: %time a.rechunk(2111).execute()
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:02<00:00, 34.07it/s]
CPU times: user 1.48 s, sys: 302 ms, total: 1.78 s
Wall time: 2.95 s
Out[5]: 
array([[0.5488135 , 0.71518937, 0.60276338, ..., 0.84348096, 0.94290928,
        0.83282242],
       [0.5646904 , 0.83974605, 0.37688365, ..., 0.40347954, 0.46089504,
        0.01048474],
       [0.15319619, 0.0328116 , 0.2287953 , ..., 0.90022341, 0.49806663,
        0.77000204],
       ...,
       [0.81724816, 0.69873782, 0.06925849, ..., 0.67440032, 0.90861683,
        0.80968811],
       [0.45391215, 0.72735698, 0.11037642, ..., 0.45976168, 0.62173263,
        0.12291647],
       [0.96026503, 0.01277616, 0.49155639, ..., 0.29565832, 0.12990437,
        0.82810578]])
```

Current branch

```
In [1]: import numpy as np; import mars; import mars.tensor as mt

In [2]: mars.new_session()
Web service started at http://0.0.0.0:27007
Out[2]: <mars.deploy.oscar.session.SyncSession at 0x7ff911701970>

In [3]: r = np.random.RandomState(0).rand(12000, 12000)

In [4]: a = mt.array(r, chunk_size=1680).execute()
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:04<00:00, 23.36it/s]

In [5]: %time a.rechunk(2111).execute()
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:02<00:00, 49.79it/s]
CPU times: user 1.39 s, sys: 209 ms, total: 1.6 s
Wall time: 2.02 s
Out[5]: 
array([[0.5488135 , 0.71518937, 0.60276338, ..., 0.84348096, 0.94290928,
        0.83282242],
       [0.5646904 , 0.83974605, 0.37688365, ..., 0.40347954, 0.46089504,
        0.01048474],
       [0.15319619, 0.0328116 , 0.2287953 , ..., 0.90022341, 0.49806663,
        0.77000204],
       ...,
       [0.81724816, 0.69873782, 0.06925849, ..., 0.67440032, 0.90861683,
        0.80968811],
       [0.45391215, 0.72735698, 0.11037642, ..., 0.45976168, 0.62173263,
        0.12291647],
       [0.96026503, 0.01277616, 0.49155639, ..., 0.29565832, 0.12990437,
        0.82810578]])
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
