### PR TITLE
Fix long exception of asyncio.gather

### DIFF
--- a/mars/oscar/backends/core.py
+++ b/mars/oscar/backends/core.py
@@ -20,7 +20,7 @@ from .communication import Client
 from .message import _MessageBase, ResultMessage, ErrorMessage, DeserializeMessageFailed
 from .router import Router
 from ...oscar.profiling import ProfilingData
-from ...utils import Timer
+from ...utils import Timer, wrap_exception
 
 
 result_message_type = Union[ResultMessage, ErrorMessage]
@@ -67,7 +67,11 @@ class ActorCaller:
                 message_futures = self._client_to_message_futures.get(client)
                 self._client_to_message_futures[client] = dict()
                 for future in message_futures.values():
-                    future.set_exception(e)
+                    future.set_exception(
+                        wrap_exception(
+                            type(e).__name__, (type(e),), str(e), e, e.__traceback__
+                        )
+                    )
             finally:
                 await asyncio.sleep(0)
 

--- a/mars/oscar/backends/core.py
+++ b/mars/oscar/backends/core.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import copy
 from typing import Dict, Union
 
 from ..errors import ServerClosed
@@ -20,7 +21,7 @@ from .communication import Client
 from .message import _MessageBase, ResultMessage, ErrorMessage, DeserializeMessageFailed
 from .router import Router
 from ...oscar.profiling import ProfilingData
-from ...utils import Timer, wrap_exception
+from ...utils import Timer
 
 
 result_message_type = Union[ResultMessage, ErrorMessage]
@@ -67,11 +68,7 @@ class ActorCaller:
                 message_futures = self._client_to_message_futures.get(client)
                 self._client_to_message_futures[client] = dict()
                 for future in message_futures.values():
-                    future.set_exception(
-                        wrap_exception(
-                            type(e).__name__, (type(e),), str(e), e, e.__traceback__
-                        )
-                    )
+                    future.set_exception(copy.copy(e))
             finally:
                 await asyncio.sleep(0)
 

--- a/mars/oscar/backends/core.py
+++ b/mars/oscar/backends/core.py
@@ -76,7 +76,7 @@ class ActorCaller:
         self._client_to_message_futures[client] = dict()
         error = ServerClosed(f"Remote server {client.dest_address} closed")
         for future in message_futures.values():
-            future.set_exception(error)
+            future.set_exception(copy.copy(error))
 
     async def call(
         self,

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -387,6 +387,7 @@ async def test_mars_batch_method(actor_pool_context):
 @pytest.mark.asyncio
 async def test_gather_exception(actor_pool_context):
     try:
+        Router.get_instance_or_empty()._cache.clear()
         pool = actor_pool_context
         ref1 = await mo.create_actor(DummyActor, 1, address=pool.external_address)
         router = Router.get_instance_or_empty()

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -17,6 +17,7 @@ import logging
 import os
 import sys
 import time
+import traceback
 from collections import deque
 
 import pandas as pd
@@ -25,6 +26,7 @@ import pytest
 from ..... import oscar as mo
 from ....backends.allocate_strategy import RandomSubPool
 from ....debug import set_debug_options, DebugOptions
+from ...router import Router
 
 logger = logging.getLogger(__name__)
 
@@ -380,6 +382,43 @@ async def test_mars_batch_method(actor_pool_context):
 
     with pytest.raises(ValueError):
         await ref1.add_ret.batch(ref1.add_ret.delay(1), ref1.add.delay(2))
+
+
+@pytest.mark.asyncio
+async def test_gather_exception(actor_pool_context):
+    try:
+        pool = actor_pool_context
+        ref1 = await mo.create_actor(DummyActor, 1, address=pool.external_address)
+        router = Router.get_instance_or_empty()
+        client = next(iter(router._cache.values()))
+
+        future = asyncio.Future()
+        client_channel = client.channel
+
+        class FakeChannel(type(client_channel)):
+            def __init__(self):
+                pass
+
+            def __getattr__(self, item):
+                return getattr(client_channel, item)
+
+            async def recv(self):
+                return await future
+
+        client.channel = FakeChannel()
+
+        class MyException(Exception):
+            pass
+
+        await ref1.add(1)
+        tasks = [ref1.add(i) for i in range(200)]
+        future.set_exception(MyException("Test recv exception!!"))
+        with pytest.raises(MyException) as ex:
+            await asyncio.gather(*tasks)
+        s = traceback.format_tb(ex.tb)
+        assert 10 > "\n".join(s).count("send") > 0
+    finally:
+        Router.get_instance_or_empty()._cache.clear()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Long exception will be raised when all the following conditions are met,
- asyncio.gather
- all the gathering coroutines / tasks are set to the same exception instance.

## Minimal reproduce code

```python
import asyncio

futures = [asyncio.Future() for x in range(10)]


async def foo(i):
    await futures[i]


async def bar(i):
    await foo(i)


async def set_exception_loop():
    try:
        raise Exception("Got Exception!!!")
    except Exception as e:
        for fut in futures:
            # All the futures are sharing the same exception instance.
            fut.set_exception(e)


async def wait_in_loop():
    tasks = []
    for _ in range(10):
        task = asyncio.create_task(bar(_))
        tasks.append(task)

    asyncio.create_task(set_exception_loop())
    await asyncio.gather(*tasks)


loop = asyncio.get_event_loop()
loop.run_until_complete(wait_in_loop())
```
output of long exception
``` python
Traceback (most recent call last):
  File "/home/admin/mars/reproduce5.py", line 34, in <module>
    loop.run_until_complete(wait_in_loop())
  File "/home/admin/.pyenv/versions/3.8.12/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/admin/mars/reproduce5.py", line 30, in wait_in_loop
    await asyncio.gather(*tasks)
  File "/home/admin/mars/reproduce5.py", line 11, in bar
    await foo(i)
  File "/home/admin/mars/reproduce5.py", line 7, in foo
    await futures[i]
  File "/home/admin/mars/reproduce5.py", line 11, in bar
    await foo(i)
  File "/home/admin/mars/reproduce5.py", line 7, in foo
    await futures[i]
  File "/home/admin/mars/reproduce5.py", line 11, in bar
    await foo(i)
  File "/home/admin/mars/reproduce5.py", line 7, in foo
    await futures[i]
  File "/home/admin/mars/reproduce5.py", line 11, in bar
    await foo(i)
  File "/home/admin/mars/reproduce5.py", line 7, in foo
    await futures[i]
  File "/home/admin/mars/reproduce5.py", line 11, in bar
    await foo(i)
  File "/home/admin/mars/reproduce5.py", line 7, in foo
    await futures[i]
  File "/home/admin/mars/reproduce5.py", line 11, in bar
    await foo(i)
  File "/home/admin/mars/reproduce5.py", line 7, in foo
    await futures[i]
  File "/home/admin/mars/reproduce5.py", line 11, in bar
    await foo(i)
  File "/home/admin/mars/reproduce5.py", line 7, in foo
    await futures[i]
  File "/home/admin/mars/reproduce5.py", line 11, in bar
    await foo(i)
  File "/home/admin/mars/reproduce5.py", line 7, in foo
    await futures[i]
  File "/home/admin/mars/reproduce5.py", line 11, in bar
    await foo(i)
  File "/home/admin/mars/reproduce5.py", line 7, in foo
    await futures[i]
  File "/home/admin/mars/reproduce5.py", line 11, in bar
    await foo(i)
  File "/home/admin/mars/reproduce5.py", line 7, in foo
    await futures[i]
  File "/home/admin/mars/reproduce5.py", line 16, in set_exception_loop
    raise Exception("Got Exception!!!")
Exception: Got Exception!!
```
## Fixed code (give each gathering future a copy of exception)

```python
import asyncio
import copy

futures = [asyncio.Future() for x in range(10)]


async def foo(i):
    await futures[i]


async def bar(i):
    await foo(i)


async def set_exception_loop():
    try:
        raise Exception("Got Exception!!!")
    except Exception as e:
        for fut in futures:
            # We give each future a different exception instance.
            fut.set_exception(copy.copy(e))


async def wait_in_loop():
    tasks = []
    for _ in range(10):
        task = asyncio.create_task(bar(_))
        tasks.append(task)

    asyncio.create_task(set_exception_loop())
    await asyncio.gather(*tasks)


loop = asyncio.get_event_loop()
loop.run_until_complete(wait_in_loop())
```
output exception is short as expected
```python
Traceback (most recent call last):
  File "/home/admin/mars/reproduce4.py", line 35, in <module>
    loop.run_until_complete(wait_in_loop())
  File "/home/admin/.pyenv/versions/3.8.12/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/admin/mars/reproduce4.py", line 31, in wait_in_loop
    await asyncio.gather(*tasks)
  File "/home/admin/mars/reproduce4.py", line 12, in bar
    await foo(i)
  File "/home/admin/mars/reproduce4.py", line 8, in foo
    await futures[i]
Exception: Got Exception!!!
```

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes https://github.com/mars-project/mars/issues/2744

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
