### PR TITLE
[Metric]Add ray metrics implementation

### DIFF
--- a/mars/metric/api.py
+++ b/mars/metric/api.py
@@ -17,12 +17,14 @@ import logging
 from typing import Dict, Any, Optional, Tuple
 
 from .backends.console import console_metric
+from .backends.ray import ray_metric
 
 logger = logging.getLogger(__name__)
 
 _metric_backend = "console"
 _backends_cls = {
     "console": console_metric,
+    "ray": ray_metric,
 }
 
 

--- a/mars/metric/backends/ray/__init__.py
+++ b/mars/metric/backends/ray/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mars/metric/backends/ray/ray_metric.py
+++ b/mars/metric/backends/ray/ray_metric.py
@@ -32,7 +32,7 @@ RAY_GAUGE_SET_AVAILABLE = (
 )
 
 
-class RayMetric(AbstractMetric):
+class RayMetricMixin(AbstractMetric):
     def _init(self):
         if ray_metrics:
             self._metric = ray_metrics.Gauge(
@@ -46,17 +46,17 @@ class RayMetric(AbstractMetric):
             self._metric.record(value, tags)
 
 
-class Counter(RayMetric, AbstractCounter):
+class Counter(RayMetricMixin, AbstractCounter):
     pass
 
 
-class Gauge(RayMetric, AbstractGauge):
+class Gauge(RayMetricMixin, AbstractGauge):
     pass
 
 
-class Meter(RayMetric, AbstractMeter):
+class Meter(RayMetricMixin, AbstractMeter):
     pass
 
 
-class Histogram(RayMetric, AbstractHistogram):
+class Histogram(RayMetricMixin, AbstractHistogram):
     pass

--- a/mars/metric/backends/ray/ray_metric.py
+++ b/mars/metric/backends/ray/ray_metric.py
@@ -40,9 +40,9 @@ class RayMetricMixin(AbstractMetric):
             )
 
     def _record(self, value=1, tags: Optional[Dict[str, str]] = None):
-        if RAY_GAUGE_SET_AVAILABLE:  # pragma: no branch
+        if RAY_GAUGE_SET_AVAILABLE:
             self._metric.set(value, tags)
-        elif ray_metrics is not None:
+        elif ray_metrics is not None:  # pragma: no branch
             self._metric.record(value, tags)
 
 

--- a/mars/metric/backends/ray/ray_metric.py
+++ b/mars/metric/backends/ray/ray_metric.py
@@ -1,0 +1,62 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Dict
+
+from ....utils import lazy_import
+from ..metric import (
+    AbstractMetric,
+    AbstractCounter,
+    AbstractGauge,
+    AbstractMeter,
+    AbstractHistogram,
+)
+
+ray_metrics = lazy_import("ray.util.metrics")
+
+# Note: Gauge `record` method is deprecated in ray 1.3.0 version, so here
+# make it compatible with the old and new ray versions.
+RAY_GAUGE_SET_AVAILABLE = (
+    True if ray_metrics and hasattr(ray_metrics.Gauge, "set") else False
+)
+
+
+class RayMetric(AbstractMetric):
+    def _init(self):
+        if ray_metrics:
+            self._metric = ray_metrics.Gauge(
+                self._name, self._description, self._tag_keys
+            )
+
+    def _record(self, value=1, tags: Optional[Dict[str, str]] = None):
+        if RAY_GAUGE_SET_AVAILABLE:
+            self._metric.set(value, tags)
+        elif ray_metrics:
+            self._metric.record(value, tags)
+
+
+class Counter(RayMetric, AbstractCounter):
+    pass
+
+
+class Gauge(RayMetric, AbstractGauge):
+    pass
+
+
+class Meter(RayMetric, AbstractMeter):
+    pass
+
+
+class Histogram(RayMetric, AbstractHistogram):
+    pass

--- a/mars/metric/backends/ray/ray_metric.py
+++ b/mars/metric/backends/ray/ray_metric.py
@@ -34,15 +34,15 @@ RAY_GAUGE_SET_AVAILABLE = (
 
 class RayMetricMixin(AbstractMetric):
     def _init(self):
-        if ray_metrics:
+        if ray_metrics is not None:  # pragma: no branch
             self._metric = ray_metrics.Gauge(
                 self._name, self._description, self._tag_keys
             )
 
     def _record(self, value=1, tags: Optional[Dict[str, str]] = None):
-        if RAY_GAUGE_SET_AVAILABLE:
+        if RAY_GAUGE_SET_AVAILABLE:  # pragma: no branch
             self._metric.set(value, tags)
-        elif ray_metrics:
+        elif ray_metrics is not None:
             self._metric.record(value, tags)
 
 

--- a/mars/metric/backends/ray/tests/__init__.py
+++ b/mars/metric/backends/ray/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mars/metric/backends/ray/tests/test_ray_metric.py
+++ b/mars/metric/backends/ray/tests/test_ray_metric.py
@@ -1,0 +1,56 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .....tests.core import require_ray
+from ..ray_metric import Counter, Gauge, Meter, Histogram
+
+
+@require_ray
+def test_counter():
+    c = Counter("test_counter", "A test counter", ("service", "tenant"))
+    assert c.name == "test_counter"
+    assert c.description == "A test counter"
+    assert c.tag_keys == ("service", "tenant")
+    assert c.type == "counter"
+    assert c.record(1, {"service": "mars", "tenant": "test"}) is None
+
+
+@require_ray
+def test_gauge():
+    g = Gauge("test_gauge", "A test gauge")
+    assert g.name == "test_gauge"
+    assert g.description == "A test gauge"
+    assert g.tag_keys == ()
+    assert g.type == "gauge"
+    assert g.record(1) is None
+
+
+@require_ray
+def test_meter():
+    m = Meter("test_meter")
+    assert m.name == "test_meter"
+    assert m.description == ""
+    assert m.tag_keys == ()
+    assert m.type == "meter"
+    assert m.record(1) is None
+
+
+@require_ray
+def test_histogram():
+    h = Histogram("test_histogram")
+    assert h.name == "test_histogram"
+    assert h.description == ""
+    assert h.tag_keys == ()
+    assert h.type == "histogram"
+    assert h.record(1) is None

--- a/mars/metric/backends/ray/tests/test_ray_metric.py
+++ b/mars/metric/backends/ray/tests/test_ray_metric.py
@@ -21,8 +21,10 @@ def test_record():
     c = Counter("test_counter")
     from .. import ray_metric
 
+    original_value = ray_metric.RAY_GAUGE_SET_AVAILABLE
     ray_metric.RAY_GAUGE_SET_AVAILABLE = False
     assert c.record(1) is None
+    ray_metric.RAY_GAUGE_SET_AVAILABLE = original_value
 
 
 @require_ray

--- a/mars/metric/backends/ray/tests/test_ray_metric.py
+++ b/mars/metric/backends/ray/tests/test_ray_metric.py
@@ -17,6 +17,15 @@ from ..ray_metric import Counter, Gauge, Meter, Histogram
 
 
 @require_ray
+def test_record():
+    c = Counter("test_counter")
+    from .. import ray_metric
+
+    ray_metric.RAY_GAUGE_SET_AVAILABLE = False
+    assert c.record(1) is None
+
+
+@require_ray
 def test_counter():
     c = Counter("test_counter", "A test counter", ("service", "tenant"))
     assert c.name == "test_counter"

--- a/mars/metric/tests/test_metric_api.py
+++ b/mars/metric/tests/test_metric_api.py
@@ -14,7 +14,8 @@
 
 import pytest
 
-from ..api import init_metrics, Metrics, _metric_backend
+from .. import api
+from ..api import init_metrics, Metrics
 
 
 @pytest.fixture
@@ -24,11 +25,13 @@ def init():
 
 def test_init_metrics():
     init_metrics()
-    assert _metric_backend == "console"
+    assert api._metric_backend == "console"
     init_metrics({"metric": {}})
-    assert _metric_backend == "console"
+    assert api._metric_backend == "console"
     init_metrics({"metric": {"backend": "console"}})
-    assert _metric_backend == "console"
+    assert api._metric_backend == "console"
+    init_metrics({"metric": {"backend": "ray"}})
+    assert api._metric_backend == "ray"
     with pytest.raises(NotImplementedError):
         init_metrics({"metric": {"backend": "not_exist"}})
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This pr adds ray metrics implementation which can be used when mars on ray. And we can use ray's metric backend to record and report metrics data to external system in this scenario.

We can use ray metrics as follows:
```
from mars.metric.api import init_metrics, Metrics

init_metrics({"metric": {"backend": "ray"}})
c = Metrics.counter("test_counter", "A test counter", ("service", "tenant"))
c.record(1)

g = Metrics.gauge("test_gauge", "A test gauge")
g.record(1)

m = Metrics.meter("test_meter")
m.record(1)

h = Metrics.histogram("test_histogram")
h.record(1)
```

## Related issue number
Issue #2743

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
