### PR TITLE
Fix NameError: name 'pq' is not defined if pyarrow is not installed

### DIFF
--- a/mars/dataframe/datasource/read_parquet.py
+++ b/mars/dataframe/datasource/read_parquet.py
@@ -115,7 +115,7 @@ class ParquetEngine:
     def read_partitioned_to_pandas(
         self,
         f,
-        partitions: pq.ParquetPartitions,
+        partitions: "pyarrow.parquet.ParquetPartitions",
         partition_keys: List[Tuple],
         columns=None,
         nrows=None,


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Fix NameError: name 'pq' is not defined if pyarrow is not installed

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes https://github.com/mars-project/mars/issues/2746

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
