### PR TITLE
Fix profiling band_subtasks and most_calls are empty if the slow duration is large

### DIFF
--- a/mars/dataframe/datasource/read_parquet.py
+++ b/mars/dataframe/datasource/read_parquet.py
@@ -115,7 +115,7 @@ class ParquetEngine:
     def read_partitioned_to_pandas(
         self,
         f,
-        partitions: "pyarrow.parquet.ParquetPartitions",
+        partitions: "pq.ParquetPartitions",
         partition_keys: List[Tuple],
         columns=None,
         nrows=None,

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import copy
 import os
 import threading
 import tempfile
@@ -92,6 +93,9 @@ EXPECT_PROFILING_STRUCTURE = {
         "slow_subtasks": DICT_NOT_EMPTY,
     }
 }
+EXPECT_PROFILING_STRUCTURE_NO_SLOW = copy.deepcopy(EXPECT_PROFILING_STRUCTURE)
+EXPECT_PROFILING_STRUCTURE_NO_SLOW["supervisor"]["slow_calls"] = {}
+EXPECT_PROFILING_STRUCTURE_NO_SLOW["supervisor"]["slow_subtasks"] = {}
 
 params = ["default"]
 if vineyard is not None:
@@ -183,6 +187,15 @@ async def test_vineyard_operators(create_cluster):
                 }
             },
             EXPECT_PROFILING_STRUCTURE,
+        ],
+        [
+            {
+                "enable_profiling": {
+                    "slow_calls_duration_threshold": 1000,
+                    "slow_subtasks_duration_threshold": 1000,
+                }
+            },
+            EXPECT_PROFILING_STRUCTURE_NO_SLOW,
         ],
         [{}, {}],
     ],
@@ -353,6 +366,15 @@ async def _run_web_session_test(web_address):
                 }
             },
             EXPECT_PROFILING_STRUCTURE,
+        ],
+        [
+            {
+                "enable_profiling": {
+                    "slow_calls_duration_threshold": 1000,
+                    "slow_subtasks_duration_threshold": 1000,
+                }
+            },
+            EXPECT_PROFILING_STRUCTURE_NO_SLOW,
         ],
         [{}, {}],
     ],

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import asyncio
+import copy
+import os
 import time
 
-import os
 import numpy as np
 import pandas as pd
 import pytest
@@ -80,6 +81,9 @@ EXPECT_PROFILING_STRUCTURE = {
         "slow_subtasks": DICT_NOT_EMPTY,
     }
 }
+EXPECT_PROFILING_STRUCTURE_NO_SLOW = copy.deepcopy(EXPECT_PROFILING_STRUCTURE)
+EXPECT_PROFILING_STRUCTURE_NO_SLOW["supervisor"]["slow_calls"] = {}
+EXPECT_PROFILING_STRUCTURE_NO_SLOW["supervisor"]["slow_subtasks"] = {}
 
 
 @pytest.fixture
@@ -110,6 +114,15 @@ async def create_cluster(request):
                 }
             },
             EXPECT_PROFILING_STRUCTURE,
+        ],
+        [
+            {
+                "enable_profiling": {
+                    "slow_calls_duration_threshold": 1000,
+                    "slow_subtasks_duration_threshold": 1000,
+                }
+            },
+            EXPECT_PROFILING_STRUCTURE_NO_SLOW,
         ],
         [{}, {}],
     ],
@@ -245,6 +258,15 @@ async def test_optional_supervisor_node(ray_large_cluster, test_option):
                 }
             },
             EXPECT_PROFILING_STRUCTURE,
+        ],
+        [
+            {
+                "enable_profiling": {
+                    "slow_calls_duration_threshold": 1000,
+                    "slow_subtasks_duration_threshold": 1000,
+                }
+            },
+            EXPECT_PROFILING_STRUCTURE_NO_SLOW,
         ],
         [{}, {}],
     ],

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -133,10 +133,10 @@ class _CallStats:
         self._slow_calls = []
 
     def collect(self, message, duration: float):
-        if duration < self._options.slow_calls_duration_threshold:
-            return
         key = (message.actor_ref.uid, message.content[0])
         self._call_counter[key] += 1
+        if duration < self._options.slow_calls_duration_threshold:
+            return
         key = (
             duration,
             message.actor_ref.uid,
@@ -174,10 +174,10 @@ class _SubtaskStats:
         self._slow_subtasks = []
 
     def collect(self, subtask, band: BandType, duration: float):
-        if duration < self._options.slow_subtasks_duration_threshold:
-            return
         band_address = band[0]
         self._band_counter[band_address] += 1
+        if duration < self._options.slow_subtasks_duration_threshold:
+            return
         key = (duration, band_address, subtask)
         try:
             if len(self._slow_subtasks) < 10:

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -499,7 +499,7 @@ class ObjectCheckMixin:
             self.assert_categorical_consistent(expected, real)
 
 
-DICT_NOT_EMPTY = object()
+DICT_NOT_EMPTY = type("DICT_NOT_EMPTY", (object,), {})  # is check works for deepcopy
 
 
 def check_dict_structure_same(a, b, prefix=None):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

- Fix band_subtasks and most_calls are empty if the slow duration is large

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
