### PR TITLE
Stop inferring outputs when args provided

### DIFF
--- a/mars/dataframe/base/tests/test_base.py
+++ b/mars/dataframe/base/tests/test_base.py
@@ -376,6 +376,12 @@ def test_series_apply():
     pd.testing.assert_series_equal(r.dtypes, dtypes)
     assert r.shape == (2, 3)
 
+    def apply_with_error(_):
+        raise ValueError
+
+    r = series.apply(apply_with_error, output_type="dataframe", dtypes=dtypes)
+    assert r.ndim == 2
+
     r = series.apply(
         pd.Series, output_type="dataframe", dtypes=dtypes, index=pd.RangeIndex(2)
     )

--- a/mars/dataframe/groupby/apply.py
+++ b/mars/dataframe/groupby/apply.py
@@ -139,9 +139,14 @@ class GroupByApply(DataFrameOperand, DataFrameOperandMixin):
             return [auto_merge_chunks(get_context(), ret)]
 
     def _infer_df_func_returns(
-        self, in_groupby, in_df, dtypes, dtype=None, name=None, index=None
+        self, in_groupby, in_df, dtypes=None, dtype=None, name=None, index=None
     ):
         index_value, output_type, new_dtypes = None, None, None
+
+        if self.output_types is not None and (dtypes is not None or dtype is not None):
+            ret_dtypes = dtypes if dtypes is not None else (dtype, name)
+            ret_index_value = parse_index(index) if index is not None else None
+            return ret_dtypes, ret_index_value
 
         try:
             infer_df = in_groupby.op.build_mock_groupby().apply(

--- a/mars/dataframe/groupby/tests/test_groupby.py
+++ b/mars/dataframe/groupby/tests/test_groupby.py
@@ -153,6 +153,9 @@ def test_groupby_apply():
         }
     )
 
+    def apply_call_with_err(_):
+        raise ValueError
+
     def apply_df(df):
         return df.sort_index()
 
@@ -164,6 +167,14 @@ def test_groupby_apply():
         return s.sort_index()
 
     mdf = md.DataFrame(df1, chunk_size=3)
+
+    # when dtype and output_type specified, apply function
+    # shall not be called
+    applied = mdf.groupby("b").apply(
+        apply_call_with_err, output_type="series", dtype=int
+    )
+    assert applied.dtype == int
+    assert applied.op.output_types[0] == OutputType.series
 
     with pytest.raises(TypeError):
         mdf.groupby("b").apply(apply_df_with_error)

--- a/mars/deploy/oscar/tests/test_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_fault_injection.py
@@ -283,8 +283,10 @@ async def test_rerun_subtask_fail(fault_cluster, fault_config):
 
     with expect_raises as e:
         b.execute(extra_config=extra_config)
-    assert e.typename == exception_typename, "".join(traceback.format_tb(e.tb))
-    assert e.traceback[-1].name == stack_string, "".join(traceback.format_tb(e.tb))
+
+    tb_str = "".join(traceback.format_tb(e.tb))
+    assert e.value.__basename__ == exception_typename, tb_str
+    assert e.traceback[-1].name == stack_string, tb_str
 
 
 @pytest.mark.parametrize(
@@ -325,7 +327,7 @@ async def test_retryable(fault_cluster, fault_config):
     r = spawn(f, args=(1,), retry_when_fail=False)
     with expect_raises as e:
         r.execute(extra_config=extra_config)
-    assert e.typename == exception_typename, "".join(traceback.format_tb(e.tb))
-    assert stack_string == "*" or e.traceback[-1].name == stack_string, "".join(
-        traceback.format_tb(e.tb)
-    )
+
+    tb_str = "".join(traceback.format_tb(e.tb))
+    assert e.value.__basename__ == exception_typename, tb_str
+    assert stack_string == "*" or e.traceback[-1].name == stack_string, tb_str

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1566,7 +1566,12 @@ def wrap_exception(
         return message
 
     return type(
-        name,
+        bases[-1].__name__,
         bases,
-        {"__init__": __init__, "__getattr__": __getattr__, "__str__": __str__},
+        {
+            "__init__": __init__,
+            "__getattr__": __getattr__,
+            "__str__": __str__,
+            "__basename__": name,
+        },
     )().with_traceback(traceback)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Stop inferring outputs when args provided

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2758

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
