### PR TITLE
[BACKPORT] Stop inferring outputs when args provided (#2759)

### DIFF
--- a/mars/dataframe/base/tests/test_base.py
+++ b/mars/dataframe/base/tests/test_base.py
@@ -376,6 +376,12 @@ def test_series_apply():
     pd.testing.assert_series_equal(r.dtypes, dtypes)
     assert r.shape == (2, 3)
 
+    def apply_with_error(_):
+        raise ValueError
+
+    r = series.apply(apply_with_error, output_type="dataframe", dtypes=dtypes)
+    assert r.ndim == 2
+
     r = series.apply(
         pd.Series, output_type="dataframe", dtypes=dtypes, index=pd.RangeIndex(2)
     )

--- a/mars/dataframe/groupby/apply.py
+++ b/mars/dataframe/groupby/apply.py
@@ -138,9 +138,14 @@ class GroupByApply(DataFrameOperand, DataFrameOperandMixin):
         return new_op.new_tileables([in_groupby], **kw)
 
     def _infer_df_func_returns(
-        self, in_groupby, in_df, dtypes, dtype=None, name=None, index=None
+        self, in_groupby, in_df, dtypes=None, dtype=None, name=None, index=None
     ):
         index_value, output_type, new_dtypes = None, None, None
+
+        if self.output_types is not None and (dtypes is not None or dtype is not None):
+            ret_dtypes = dtypes if dtypes is not None else (dtype, name)
+            ret_index_value = parse_index(index) if index is not None else None
+            return ret_dtypes, ret_index_value
 
         try:
             infer_df = in_groupby.op.build_mock_groupby().apply(

--- a/mars/dataframe/groupby/tests/test_groupby.py
+++ b/mars/dataframe/groupby/tests/test_groupby.py
@@ -153,6 +153,9 @@ def test_groupby_apply():
         }
     )
 
+    def apply_call_with_err(_):
+        raise ValueError
+
     def apply_df(df):
         return df.sort_index()
 
@@ -164,6 +167,14 @@ def test_groupby_apply():
         return s.sort_index()
 
     mdf = md.DataFrame(df1, chunk_size=3)
+
+    # when dtype and output_type specified, apply function
+    # shall not be called
+    applied = mdf.groupby("b").apply(
+        apply_call_with_err, output_type="series", dtype=int
+    )
+    assert applied.dtype == int
+    assert applied.op.output_types[0] == OutputType.series
 
     with pytest.raises(TypeError):
         mdf.groupby("b").apply(apply_df_with_error)


### PR DESCRIPTION
Backport of #2759