### PR TITLE
Optimize in-process actor calls

### DIFF
--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -163,6 +163,7 @@ class AbstractSession(ABC):
     def __init__(self, address: str, session_id: str):
         self._address = address
         self._session_id = session_id
+        self._closed = False
 
     @property
     def address(self):
@@ -227,6 +228,7 @@ class AbstractAsyncSession(AbstractSession, metaclass=ABCMeta):
         Destroy a session.
         """
         self.reset_default()
+        self._closed = True
 
     @abstractmethod
     async def execute(self, *tileables, **kwargs) -> ExecutionInfo:
@@ -916,6 +918,8 @@ class _IsolatedSession(AbstractAsyncSession):
                 tileable.params = fetch_tileable.params
 
     async def execute(self, *tileables, **kwargs) -> ExecutionInfo:
+        if self._closed:
+            raise RuntimeError("Session closed already")
         fuse_enabled: bool = kwargs.pop("fuse_enabled", True)
         task_name: str = kwargs.pop("task_name", None)
         extra_config: dict = kwargs.pop("extra_config", None)

--- a/mars/deploy/oscar/tests/test_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_fault_injection.py
@@ -107,7 +107,7 @@ async def create_fault_injection_manager(
             FaultType.Exception,
             {FaultPosition.ON_RUN_SUBTASK: 1},
             pytest.raises(FaultInjectionError, match="Fault Injection"),
-            True,
+            False,
         ],
     ],
 )

--- a/mars/oscar/__init__.py
+++ b/mars/oscar/__init__.py
@@ -34,7 +34,7 @@ from .backends import allocate_strategy
 from .backends.pool import MainActorPoolType
 from .batch import extensible
 from .core import ActorRef
-from .debug import set_debug_options, DebugOptions
+from .debug import set_debug_options, get_debug_options, DebugOptions
 from .errors import ActorNotExist, ActorAlreadyExist, ServerClosed, Return
 from .utils import create_actor_ref
 

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -17,7 +17,7 @@ from typing import Tuple, Union, Type
 
 from ...utils import to_binary
 from ..api import Actor
-from ..core import ActorRef, ActorProxy
+from ..core import ActorRef, get_local_actor
 from ..context import BaseActorContext
 from ..debug import debug_async_timeout, detect_cycle_send
 from ..errors import CannotCancelTask
@@ -41,7 +41,6 @@ from .message import (
     ProfilingContext,
 )
 from .router import Router
-from .pool import get_local_actor
 
 
 class MarsActorContext(BaseActorContext):
@@ -151,9 +150,9 @@ class MarsActorContext(BaseActorContext):
 
     async def actor_ref(self, *args, **kwargs):
         actor_ref = create_actor_ref(*args, **kwargs)
-        actor = get_local_actor(actor_ref)
+        actor = get_local_actor(actor_ref.address, actor_ref.uid)
         if actor is not None:
-            return ActorProxy(actor_ref, actor)
+            return actor
         message = ActorRefMessage(
             new_message_id(), actor_ref, protocol=DEFAULT_PROTOCOL
         )

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -17,7 +17,7 @@ from typing import Tuple, Union, Type
 
 from ...utils import to_binary
 from ..api import Actor
-from ..core import ActorRef, ActorLocalRef, create_actor_local_ref
+from ..core import ActorRef, create_actor_local_ref
 from ..context import BaseActorContext
 from ..debug import debug_async_timeout, detect_cycle_send
 from ..errors import CannotCancelTask

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -17,7 +17,7 @@ from typing import Tuple, Union, Type
 
 from ...utils import to_binary
 from ..api import Actor
-from ..core import ActorRef, create_actor_local_ref
+from ..core import ActorRef, create_local_actor_ref
 from ..context import BaseActorContext
 from ..debug import debug_async_timeout, detect_cycle_send
 from ..errors import CannotCancelTask
@@ -150,9 +150,9 @@ class MarsActorContext(BaseActorContext):
 
     async def actor_ref(self, *args, **kwargs):
         actor_ref = create_actor_ref(*args, **kwargs)
-        actor_local_ref = create_actor_local_ref(actor_ref.address, actor_ref.uid)
-        if actor_local_ref is not None:
-            return actor_local_ref
+        local_actor_ref = create_local_actor_ref(actor_ref.address, actor_ref.uid)
+        if local_actor_ref is not None:
+            return local_actor_ref
         message = ActorRefMessage(
             new_message_id(), actor_ref, protocol=DEFAULT_PROTOCOL
         )

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -17,7 +17,7 @@ from typing import Tuple, Union, Type
 
 from ...utils import to_binary
 from ..api import Actor
-from ..core import ActorRef, get_local_actor
+from ..core import ActorRef, ActorLocalRef, get_local_actor
 from ..context import BaseActorContext
 from ..debug import debug_async_timeout, detect_cycle_send
 from ..errors import CannotCancelTask
@@ -152,7 +152,7 @@ class MarsActorContext(BaseActorContext):
         actor_ref = create_actor_ref(*args, **kwargs)
         actor = get_local_actor(actor_ref.address, actor_ref.uid)
         if actor is not None:
-            return actor
+            return ActorLocalRef(actor)
         message = ActorRefMessage(
             new_message_id(), actor_ref, protocol=DEFAULT_PROTOCOL
         )

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -17,7 +17,7 @@ from typing import Tuple, Union, Type
 
 from ...utils import to_binary
 from ..api import Actor
-from ..core import ActorRef
+from ..core import ActorRef, ActorProxy
 from ..context import BaseActorContext
 from ..debug import debug_async_timeout, detect_cycle_send
 from ..errors import CannotCancelTask
@@ -41,6 +41,7 @@ from .message import (
     ProfilingContext,
 )
 from .router import Router
+from .pool import get_local_actor
 
 
 class MarsActorContext(BaseActorContext):
@@ -150,6 +151,9 @@ class MarsActorContext(BaseActorContext):
 
     async def actor_ref(self, *args, **kwargs):
         actor_ref = create_actor_ref(*args, **kwargs)
+        actor = get_local_actor(actor_ref)
+        if actor is not None:
+            return ActorProxy(actor_ref, actor)
         message = ActorRefMessage(
             new_message_id(), actor_ref, protocol=DEFAULT_PROTOCOL
         )

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -17,7 +17,7 @@ from typing import Tuple, Union, Type
 
 from ...utils import to_binary
 from ..api import Actor
-from ..core import ActorRef, ActorLocalRef, get_local_actor
+from ..core import ActorRef, ActorLocalRef, create_actor_local_ref
 from ..context import BaseActorContext
 from ..debug import debug_async_timeout, detect_cycle_send
 from ..errors import CannotCancelTask
@@ -150,9 +150,9 @@ class MarsActorContext(BaseActorContext):
 
     async def actor_ref(self, *args, **kwargs):
         actor_ref = create_actor_ref(*args, **kwargs)
-        actor = get_local_actor(actor_ref.address, actor_ref.uid)
-        if actor is not None:
-            return ActorLocalRef(actor)
+        actor_local_ref = create_actor_local_ref(actor_ref.address, actor_ref.uid)
+        if actor_local_ref is not None:
+            return actor_local_ref
         message = ActorRefMessage(
             new_message_id(), actor_ref, protocol=DEFAULT_PROTOCOL
         )

--- a/mars/oscar/backends/mars/tests/test_debug.py
+++ b/mars/oscar/backends/mars/tests/test_debug.py
@@ -98,6 +98,7 @@ async def debug_logger():
     finally:
         mo.set_debug_options(None)
         logger.removeHandler(log_handler)
+        assert mo.get_debug_options() is None
 
 
 @contextmanager

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -85,8 +85,14 @@ class DummyActor(mo.Actor):
 
     async def send(self, uid, method, *args):
         actor_ref = await mo.actor_ref(uid, address=self.address)
-        tp = ActorProxy if actor_ref.address == self.address and get_debug_options() is None else ActorRef
-        assert type(actor_ref) is tp, f"Expect type of actor ref is {tp}, but got {actor_ref} instead."
+        tp = (
+            ActorProxy
+            if actor_ref.address == self.address and get_debug_options() is None
+            else ActorRef
+        )
+        assert (
+            type(actor_ref) is tp
+        ), f"Expect type of actor ref is {tp}, but got {actor_ref} instead."
         return await getattr(actor_ref, method)(*args)
 
     async def tell(self, uid, method, *args):

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -368,7 +368,7 @@ async def test_mars_tell(actor_pool_context):
     assert await ref2.get_value() == 5
     await asyncio.sleep(0.45)
     assert await ref2.get_value() == 5
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(0.2)
     assert await ref2.get_value() == 9
 
     # error needed when illegal uids are passed

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -24,7 +24,7 @@ import pandas as pd
 import pytest
 
 from ..... import oscar as mo
-from .....oscar.core import ActorRef, ActorLocalRef
+from .....oscar.core import ActorRef, LocalActorRef
 from ....backends.allocate_strategy import RandomSubPool
 from ....debug import set_debug_options, get_debug_options, DebugOptions
 from ...router import Router
@@ -86,7 +86,7 @@ class DummyActor(mo.Actor):
     async def send(self, uid, method, *args):
         actor_ref = await mo.actor_ref(uid, address=self.address)
         tp = (
-            ActorLocalRef
+            LocalActorRef
             if actor_ref.address == self.address and get_debug_options() is None
             else ActorRef
         )
@@ -118,7 +118,7 @@ class DummyActor(mo.Actor):
 
     def get_ref(self):
         ref = self.ref()
-        tp = ActorLocalRef if get_debug_options() is None else ActorRef
+        tp = LocalActorRef if get_debug_options() is None else ActorRef
         assert (
             type(ref) is tp
         ), f"Expect type of actor ref is {tp}, but got {ref} instead."
@@ -456,7 +456,7 @@ async def test_mars_destroy_has_actor(actor_pool_context):
     # there will be memory leak if the actor create and destroy multiple times.
     DummyActor.__dict__["add"].__get__.__func__.cache_clear()
 
-    if isinstance(ref2, ActorLocalRef):
+    if isinstance(ref2, LocalActorRef):
         assert "weakref" in str(ref2)
         assert "dead" in str(ref2)
 

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -26,7 +26,7 @@ from ...core.entrypoints import init_extension_entrypoints
 from ...utils import implements, to_binary
 from ...utils import lazy_import, register_asyncio_task_timeout_detector
 from ..api import Actor
-from ..core import ActorRef, ActorPool
+from ..core import ActorRef, register_local_pool
 from ..debug import record_message_trace, debug_async_timeout
 from ..errors import ActorAlreadyExist, ActorNotExist, ServerClosed, CannotCancelTask
 from ..utils import create_actor_ref
@@ -98,7 +98,7 @@ def _register_message_handler(pool_type: Type["AbstractActorPool"]):
     return pool_type
 
 
-class AbstractActorPool(ABC, ActorPool):
+class AbstractActorPool(ABC):
     __slots__ = (
         "process_index",
         "label",
@@ -126,7 +126,6 @@ class AbstractActorPool(ABC, ActorPool):
         config: ActorPoolConfig,
         servers: List[Server],
     ):
-        super().__init__(external_address)
         self.process_index = process_index
         self.label = label
         self.external_address = external_address
@@ -151,6 +150,8 @@ class AbstractActorPool(ABC, ActorPool):
         )
         # load third party extensions.
         init_extension_entrypoints()
+        # register local pool for local actor lookup.
+        register_local_pool(external_address, self)
 
     @property
     def router(self):

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -19,7 +19,6 @@ import logging
 import multiprocessing
 import os
 import threading
-import weakref
 from abc import ABC, ABCMeta, abstractmethod
 from typing import Dict, List, Type, TypeVar, Coroutine, Callable, Union, Optional
 

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -126,6 +126,9 @@ class AbstractActorPool(ABC):
         config: ActorPoolConfig,
         servers: List[Server],
     ):
+        # register local pool for local actor lookup.
+        # The pool is weakrefed, so we don't need to unregister it.
+        register_local_pool(external_address, self)
         self.process_index = process_index
         self.label = label
         self.external_address = external_address
@@ -150,8 +153,6 @@ class AbstractActorPool(ABC):
         )
         # load third party extensions.
         init_extension_entrypoints()
-        # register local pool for local actor lookup.
-        register_local_pool(external_address, self)
 
     @property
     def router(self):

--- a/mars/oscar/context.pxd
+++ b/mars/oscar/context.pxd
@@ -15,3 +15,6 @@
 
 cdef class BaseActorContext:
     pass
+
+
+cpdef get_context()

--- a/mars/oscar/context.pyx
+++ b/mars/oscar/context.pyx
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 
 from .core cimport ActorRef
 from .utils cimport new_actor_id
+from .utils import create_actor_ref
 
 cdef dict _backend_context_cls = dict()
 
@@ -188,7 +189,6 @@ cdef class ClientActorContext(BaseActorContext):
         return context.kill_actor(actor_ref)
 
     def actor_ref(self, *args, **kwargs):
-        from .utils import create_actor_ref
         actor_ref = create_actor_ref(*args, **kwargs)
         context = self._get_backend_context(actor_ref.address)
         return context.actor_ref(actor_ref)

--- a/mars/oscar/context.pyx
+++ b/mars/oscar/context.pyx
@@ -207,7 +207,7 @@ def register_backend_context(scheme, cls):
     _backend_context_cls[scheme] = cls
 
 
-def get_context():
+cpdef get_context():
     """
     Get an actor context. If not in an actor environment,
     ClientActorContext will be used

--- a/mars/oscar/core.pxd
+++ b/mars/oscar/core.pxd
@@ -20,7 +20,7 @@ cdef class ActorRef:
     cdef dict _methods
 
 
-cdef class ActorLocalRef(ActorRef):
+cdef class LocalActorRef(ActorRef):
     cdef object _actor_weakref
     cdef _weakref_local_actor(self)
 

--- a/mars/oscar/core.pxd
+++ b/mars/oscar/core.pxd
@@ -22,6 +22,14 @@ cdef class ActorRef:
     cdef __tell__(self, object message, object options)
 
 
+cdef class ActorProxy:
+    cdef object __weakref__
+    cdef public str address
+    cdef public object uid
+    cdef _BaseActor _actor
+    cdef dict _methods
+
+
 cdef class _BaseActor:
     cdef object __weakref__
     cdef str _address

--- a/mars/oscar/core.pxd
+++ b/mars/oscar/core.pxd
@@ -20,8 +20,9 @@ cdef class ActorRef:
     cdef dict _methods
 
 
-cdef class ActorProxy(ActorRef):
-    cdef _BaseActor _actor
+cdef class ActorLocalRef(ActorRef):
+    cdef object _actor_weakref
+    cdef _weakref_local_actor(self)
 
 
 cdef class _BaseActor:
@@ -29,7 +30,6 @@ cdef class _BaseActor:
     cdef str _address
     cdef object _lock
     cdef object _uid
-    cdef object _handle_actor_result_ref
 
     cpdef ActorRef ref(self)
 

--- a/mars/oscar/core.pxd
+++ b/mars/oscar/core.pxd
@@ -29,6 +29,7 @@ cdef class _BaseActor:
     cdef str _address
     cdef object _lock
     cdef object _uid
+    cdef object _handle_actor_result_ref
 
     cpdef ActorRef ref(self)
 

--- a/mars/oscar/core.pxd
+++ b/mars/oscar/core.pxd
@@ -18,16 +18,10 @@ cdef class ActorRef:
     cdef public str address
     cdef public object uid
     cdef dict _methods
-    cdef __send__(self, object message, object options)
-    cdef __tell__(self, object message, object options)
 
 
-cdef class ActorProxy:
-    cdef object __weakref__
-    cdef public str address
-    cdef public object uid
+cdef class ActorProxy(ActorRef):
     cdef _BaseActor _actor
-    cdef dict _methods
 
 
 cdef class _BaseActor:

--- a/mars/oscar/core.pyx
+++ b/mars/oscar/core.pyx
@@ -233,6 +233,7 @@ cdef class LocalActorRef(ActorRef):
             actor = self._actor_weakref() or self._weakref_local_actor()
             if actor is None:
                 raise ActorNotExist(f"Actor {self.uid} does not exist") from None
+            # For detecting the attribute error.
             getattr(actor, item)
             method = self._methods[item] = LocalActorRefMethod(self, item)
             return method

--- a/mars/oscar/core.pyx
+++ b/mars/oscar/core.pyx
@@ -47,6 +47,9 @@ def set_debug_options(options):
 
 
 cdef _get_local_actor(address, uid):
+    # Do not expose this method to Python to avoid actor being
+    # referenced everywhere.
+    #
     # The cycle send detection relies on send message, so we
     # disabled the local actor proxy if the debug option is on.
     if _log_cycle_send:
@@ -62,6 +65,20 @@ cdef _get_local_actor(address, uid):
 cdef class ActorPool:
     def __init__(self, address):
         _local_pool_map[address] = self
+
+
+cpdef create_actor_local_ref(address, uid):
+    """
+    Create an actor local reference.
+
+    Returns
+    -------
+    ActorLocalRef or None
+    """
+    actor = _get_local_actor(address, uid)
+    if actor is not None:
+        return ActorLocalRef(actor)
+    return None
 
 
 cpdef create_actor_ref(address, uid):

--- a/mars/oscar/core.pyx
+++ b/mars/oscar/core.pyx
@@ -23,7 +23,6 @@ from typing import AsyncGenerator
 from .context cimport get_context
 from .errors import Return, ActorNotExist
 from .utils cimport is_async_generator
-from .utils import create_actor_ref
 
 
 CALL_METHOD_DEFAULT = 0
@@ -65,7 +64,7 @@ cdef class ActorPool:
         _local_pool_map[address] = self
 
 
-def __pyx_unpickle_ActorRef(address, uid):
+cpdef __pyx_unpickle_ActorRef(address, uid):
     actor = get_local_actor(address, uid)
     return ActorRef(address, uid) if actor is None else ActorLocalRef(actor)
 
@@ -317,7 +316,7 @@ cdef class _BaseActor:
         self._address = addr
 
     cpdef ActorRef ref(self):
-        return create_actor_ref(self._address, self._uid)
+        return __pyx_unpickle_ActorRef(self._address, self._uid)
 
     async def _handle_actor_result(self, result):
         cdef int idx

--- a/mars/oscar/utils.pyx
+++ b/mars/oscar/utils.pyx
@@ -17,7 +17,7 @@ from typing import AsyncGenerator
 import numpy as np
 
 from .._utils cimport to_str
-from .core cimport ActorRef, ActorLocalRef
+from .core cimport ActorRef, LocalActorRef
 
 
 cpdef bytes new_actor_id():
@@ -49,7 +49,7 @@ def create_actor_ref(*args, **kwargs):
         uid = args[1]
     elif len(args) == 1:
         tp0 = type(args[0])
-        if tp0 is ActorRef or tp0 is ActorLocalRef:
+        if tp0 is ActorRef or tp0 is LocalActorRef:
             uid = args[0].uid
             address = to_str(address or args[0].address)
         else:

--- a/mars/oscar/utils.pyx
+++ b/mars/oscar/utils.pyx
@@ -17,6 +17,7 @@ from typing import AsyncGenerator
 import numpy as np
 
 from .._utils cimport to_str
+from .core cimport ActorRef, ActorProxy
 
 
 cpdef bytes new_actor_id():
@@ -31,7 +32,6 @@ def create_actor_ref(*args, **kwargs):
     -------
     ActorRef
     """
-    from .core import ActorRef
 
     cdef str address
     cdef object uid
@@ -47,11 +47,13 @@ def create_actor_ref(*args, **kwargs):
             raise ValueError('address has been specified')
         address = to_str(args[0])
         uid = args[1]
-    elif len(args) == 1 and isinstance(args[0], ActorRef):
-        uid = args[0].uid
-        address = to_str(address or args[0].address)
     elif len(args) == 1:
-        uid = args[0]
+        tp0 = type(args[0])
+        if tp0 is ActorRef or tp0 is ActorProxy:
+            uid = args[0].uid
+            address = to_str(address or args[0].address)
+        else:
+            uid = args[0]
 
     if uid is None:
         raise ValueError('Actor uid should be provided')

--- a/mars/oscar/utils.pyx
+++ b/mars/oscar/utils.pyx
@@ -17,7 +17,7 @@ from typing import AsyncGenerator
 import numpy as np
 
 from .._utils cimport to_str
-from .core cimport ActorRef, ActorProxy
+from .core cimport ActorRef, ActorLocalRef
 
 
 cpdef bytes new_actor_id():
@@ -49,7 +49,7 @@ def create_actor_ref(*args, **kwargs):
         uid = args[1]
     elif len(args) == 1:
         tp0 = type(args[0])
-        if tp0 is ActorRef or tp0 is ActorProxy:
+        if tp0 is ActorRef or tp0 is ActorLocalRef:
             uid = args[0].uid
             address = to_str(address or args[0].address)
         else:

--- a/mars/services/cluster/tests/test_locator.py
+++ b/mars/services/cluster/tests/test_locator.py
@@ -53,7 +53,7 @@ class MockNodeInfoCollectorActor(mo.Actor):
 
 @pytest.fixture
 async def actor_pool():
-    pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
+    pool = await mo.create_actor_pool("127.0.0.1", n_process=1)
     await pool.start()
 
     await mo.create_actor(
@@ -156,12 +156,14 @@ async def test_worker_supervisor_locator(actor_pool, temp_address_file):
     with open(temp_address_file, "w") as file_obj:
         file_obj.write("\n".join(addresses))
 
+    locator_address = next(iter(actor_pool.sub_processes.keys()))
+
     locator_ref = await mo.create_actor(
         WorkerSupervisorLocatorActor,
         "test",
         temp_address_file,
         uid=WorkerSupervisorLocatorActor.default_uid(),
-        address=actor_pool.external_address,
+        address=locator_address,
     )
 
     info_ref = await mo.actor_ref(

--- a/mars/services/cluster/tests/test_locator.py
+++ b/mars/services/cluster/tests/test_locator.py
@@ -27,7 +27,11 @@ from ..supervisor.node_info import NodeInfoCollectorActor
 from ..tests import backend
 from ..worker.locator import WorkerSupervisorLocatorActor
 
-del backend
+
+class TestWorkerSupervisorLocatorActor(WorkerSupervisorLocatorActor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._load_backend = backend.TestClusterBackend
 
 
 class MockNodeInfoCollectorActor(mo.Actor):
@@ -159,10 +163,10 @@ async def test_worker_supervisor_locator(actor_pool, temp_address_file):
     locator_address = next(iter(actor_pool.sub_processes.keys()))
 
     locator_ref = await mo.create_actor(
-        WorkerSupervisorLocatorActor,
+        TestWorkerSupervisorLocatorActor,
         "test",
         temp_address_file,
-        uid=WorkerSupervisorLocatorActor.default_uid(),
+        uid=TestWorkerSupervisorLocatorActor.default_uid(),
         address=locator_address,
     )
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Mars in-process actor call will go through the communication logic:
```txt
  actor_ref.foo()                                           actor.foo()                 
            \                                                  -/                                  
             -\                                               /                                    
           ActorCaller                              pool.process_message    
                 -\                                      -                                         
                   -                                   -/                                          
                 Client.send                  Server.on_connected   
                       -\                         -                                                
                         -                      -/                                                 
                        Channel.send --- Channel.recv   
```
This PR introduces a `LocalActorRef` type for direct call in-process actors:
```txt
actor_ref.foo() ----------------------------------------- actor.foo()  
```

With this PR, we can get

- Better performance.
- Simpler traceback.

## ActorRef and LocalActorRef

Mars actor is created and managed by the Mars actor pool, and the `ActorRef` is the handle to access the actor. So, the `LocalActorRef` follows the rules of Mars actor management _(The `mo.extensible` breaks the rule: https://github.com/mars-project/mars/issues/2781)_, it weakrefs the in-process actor instance and provides all the APIs the `ActorRef` owns.

The `LocalActorRef` can replace the `ActorRef` if the actor is in-process, so this PR do

- [x] Deserializer of the `LocalActorRef` or `ActorRef` auto choose the type. e.g. Send a `LocalActorRef` object to remote will get an `ActorRef` at the receiving side, then send back the `ActorRef` will get a `LocalActorRef`.
- [x] `mo.actor_ref` auto choose the type.
- [x] `Actor.ref()` auto choose the type.

This auto choose type feature NOT covers all the actor ref creations because too many minor code changes will mess up the code review. So, I will create new PRs after this PR is merged. In the future, all the handles of in-process actors will be `LocalActorRef` automatically.

## Performance

The direct in-process actor call will improve the performance obviously in high workload.

Simple code to simulate high workload of supervisor:

```python
import numpy as np
import pandas as pd
import mars
import mars.dataframe as md

if __name__ == "__main__":
    with mars.new_session():
        s = np.random.RandomState(0)
        raw = pd.DataFrame(s.rand(1000, 4), columns=list("abcd"))
        df = md.DataFrame(raw, chunk_size=1)

        r = df.describe().execute(extra_config={"enable_profiling": True})
        print(r)
```

Profiling output before this PR (0c3d18a82f10490260fc34fab4afdb42fab00774)
``` json
"general": {
    "optimize": 0.0012850761413574219,
    "incref_fetch_tileables": 0.0008420944213867188,
    "stage_hVMzV7kEThRlKQVsKr66pvXf": {
        "tile(24152)": 14.326375246047974,
        "gen_subtask_graph(8184)": 17.73131823539734,
        "run": 168.89859890937805,
        "total": 201.31535816192627
    },
    "total": 201.3857638835907
},
"most_calls": {
    "DataManagerActor.get_data_infos": 24103,
    "NodeInfoUploaderActor.set_band_quota_info": 16416,
    "JCdYex0S5ilvqkKQMtaUyOqH_subtask_queueing.submit_subtasks": 11864,
    "GlobalSlotManagerActor.apply_subtask_slots": 11864,
    "JCdYex0S5ilvqkKQMtaUyOqH_meta.get_meta": 11373,
    "numa-0_band_slot_manager.upload_slot_usages": 8360,
    "NodeInfoUploaderActor.set_band_slot_infos": 8360,
    "task_processor_JCdYex0S5ilvqkKQMtaUyOqH_0lWUjSKwXMObYvFdk9gGAPQs.set_subtask_result": 8206,
    "JCdYex0S5ilvqkKQMtaUyOqH_lifecycle_tracker.decref_chunks": 8185,
    "JCdYex0S5ilvqkKQMtaUyOqH_task_manager.set_subtask_result": 8184
}
```

Profiling output with this PR
``` json
"general": {
    "optimize": 0.0016069412231445312,
    "incref_fetch_tileables": 9.560585021972656e-05,
    "stage_6d0nje1CubSoLaHzZX95gnjN": {
        "tile(24152)": 14.224598407745361,
        "gen_subtask_graph(8184)": 17.095839500427246,
        "run": 136.2143750190735,
        "total": 167.9307713508606
    },
    "total": 168.00183057785034
},
"most_calls": {
    "task_processor_bb0dliuQklFZGBJMDEcrLfJI_FvnKWcRuYqhfvRItaYxTTv88.set_subtask_result": 8210,
    "DataManagerActor.get_data_info": 6170,
    "DataManagerActor.pin": 6170,
    "DataManagerActor.get_data_infos": 1646,
    "DataManagerActor.delete_data_info": 1646,
    "storage_quota_numa-0_StorageLevel.MEMORY.release_quota": 1646,
    "slot_numa-0_5_subtask_runner.run_subtask": 1038,
    "slot_numa-0_4_subtask_runner.run_subtask": 1037,
    "slot_numa-0_3_subtask_runner.run_subtask": 1028,
    "slot_numa-0_0_subtask_runner.run_subtask": 1027
}
```

Besides, this PR fixes,

- [x] More reliable session close.
- [x] Fix hangs if fault occurred and the `submit_subtasks` runs faster than `release_subtask_slots`.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Related issue: https://github.com/mars-project/mars/issues/2691

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
