### PR TITLE
[BACKPORT] Fix wrong result of `df.merge` (#2774)

### DIFF
--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -370,7 +370,9 @@ class DataFrameShuffleMerge(_DataFrameMergeBase):
         left = build_concatenated_rows_frame(op.inputs[0])
         right = build_concatenated_rows_frame(op.inputs[1])
 
-        if len(left.chunks) == 1 or len(right.chunks) == 1:
+        if (len(left.chunks) == 1 and op.how in ["right", "inner"]) or (
+            len(right.chunks) == 1 and op.how in ["left", "inner"]
+        ):
             return cls._tile_one_chunk(op, left, right)
 
         left_row_chunk_size = left.chunk_shape[0]

--- a/mars/dataframe/merge/tests/test_merge_execution.py
+++ b/mars/dataframe/merge/tests/test_merge_execution.py
@@ -340,6 +340,20 @@ def test_merge_one_chunk(setup):
         result.sort_values(by=result.columns[1]).reset_index(drop=True),
     )
 
+    # left have one chunk and how="left", then one chunk tile
+    # will results in wrong results, see #GH 2107
+    mdf1 = from_pandas(df1, chunk_size=2)
+    mdf2 = from_pandas(df2)
+
+    expected = df2.merge(df1, left_on="rkey", right_on="lkey", how="left")
+    jdf = mdf2.merge(mdf1, left_on="rkey", right_on="lkey", how="left")
+    result = jdf.execute().fetch()
+
+    pd.testing.assert_frame_equal(
+        expected.sort_values(by=expected.columns[1]).reset_index(drop=True),
+        result.sort_values(by=result.columns[1]).reset_index(drop=True),
+    )
+
 
 def test_merge_on_duplicate_columns(setup):
     raw1 = pd.DataFrame(


### PR DESCRIPTION
Backport of #2774 