### PR TITLE
Fix race condition of `set_subtask_result`

### DIFF
--- a/mars/services/scheduling/worker/workerslot.py
+++ b/mars/services/scheduling/worker/workerslot.py
@@ -166,7 +166,9 @@ class BandSlotManagerActor(mo.Actor):
                 f"the releasing session_stid: {session_stid}"
             )
         acquired_slot_id = self._session_stid_to_slot.pop(acquired_session_stid)
-        assert acquired_slot_id == slot_id
+        assert (
+            acquired_slot_id == slot_id
+        ), f"{acquired_session_stid}: acquired_slot_id {acquired_slot_id} != slot_id {slot_id}"
 
         logger.debug("Slot %d released", slot_id)
 

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -887,6 +887,11 @@ class TaskProcessorActor(mo.Actor):
             stage_processor.subtask_snapshots.get(subtask)
         )
         if subtask_result.status.is_done:
+            # update stage_processor.subtask_results to avoid concurrent set_subtask_result
+            # since we release lock when `_decref_input_subtasks`.
+            stage_processor.subtask_results[subtask] = subtask_result.update(
+                stage_processor.subtask_results.get(subtask)
+            )
             try:
                 # Since every worker will call supervisor to set subtask result,
                 # we need to release actor lock to make `decref_chunks` parallel to avoid blocking

--- a/mars/services/task/supervisor/stage.py
+++ b/mars/services/task/supervisor/stage.py
@@ -96,6 +96,11 @@ class TaskStageProcessor:
         return self._cancelled.is_set()
 
     async def _schedule_subtasks(self, subtasks: List[Subtask]):
+        subtasks = [
+            subtask
+            for subtask in subtasks
+            if subtask.subtask_id not in self._submitted_subtask_ids
+        ]
         if not subtasks:
             return
         self._submitted_subtask_ids.update(subtask.subtask_id for subtask in subtasks)
@@ -125,7 +130,7 @@ class TaskStageProcessor:
 
     async def set_subtask_result(self, result: SubtaskResult):
         subtask = self.subtask_id_to_subtask[result.subtask_id]
-        self.subtask_results[subtask] = result.update(self.subtask_results.get(subtask))
+        #  update subtask_results in `TaskProcessorActor.set_subtask_result`
         self._submitted_subtask_ids.difference_update([result.subtask_id])
 
         all_done = len(self.subtask_results) == len(self.subtask_graph)


### PR DESCRIPTION
## What do these changes do?
* Fix set_subtask_result race condition since we  release lock when `_decref_input_subtasks`.
* Fix duplicate subtasks submit.
## Check code requirements
## Related issue number
Closes #2814 
- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
