### PR TITLE
Remove deprecate warnings when import mars.tensor

### DIFF
--- a/docs/source/reference/dataframe/general_functions.rst
+++ b/docs/source/reference/dataframe/general_functions.rst
@@ -11,10 +11,11 @@ Data manipulations
    :toctree: generated/
 
    cut
-   qcut
    concat
+   get_dummies
    melt
    merge
+   qcut
 
 Top-level missing data
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/mars/conftest.py
+++ b/mars/conftest.py
@@ -150,6 +150,9 @@ def _new_integrated_test_session(_stop_isolation):
                 for proc in subprocesses:
                     try:
                         proc.wait(1)
+                    except (psutil.TimeoutExpired, psutil.NoSuchProcess):
+                        pass
+                    try:
                         proc.kill()
                     except psutil.NoSuchProcess:
                         pass

--- a/mars/deploy/oscar/tests/test_cmdline.py
+++ b/mars/deploy/oscar/tests/test_cmdline.py
@@ -210,13 +210,11 @@ def test_cmdline_run(supervisor_args, worker_args, use_web_addr):
         env["MARS_CPU_TOTAL"] = "2"
 
         for trial in range(restart_trial):
-            logger.warning(
-                "Cluster start attempt %d / %d", restart_trial + 1, restart_trial
-            )
+            logger.warning("Cluster start attempt %d / %d", trial + 1, restart_trial)
             _test_port_cache.clear()
 
             sv_args = _reload_args(supervisor_args)
-            sv_proc = subprocess.Popen(sv_args, env=env, text=True)
+            sv_proc = subprocess.Popen(sv_args, env=env)
 
             oscar_port = _get_labelled_port("supervisor", create=False)
             if not oscar_port:
@@ -232,7 +230,7 @@ def test_cmdline_run(supervisor_args, worker_args, use_web_addr):
 
             w_procs = []
             for idx in range(2):
-                proc = subprocess.Popen(_reload_args(worker_args), env=env, text=True)
+                proc = subprocess.Popen(_reload_args(worker_args), env=env)
                 w_procs.append(proc)
                 # make sure worker ports does not collide
                 time.sleep(2)

--- a/mars/oscar/backends/message.py
+++ b/mars/oscar/backends/message.py
@@ -212,7 +212,7 @@ class ErrorMessage(_MessageBase):
         cause = self.error
 
         return wrap_exception(
-            "_MarsError",
+            type(self.error).__name__,
             (ErrorMessage.AsCauseBase, type(self.error)),
             message,
             cause,

--- a/mars/oscar/backends/ray/tests/test_ray_pool.py
+++ b/mars/oscar/backends/ray/tests/test_ray_pool.py
@@ -30,6 +30,8 @@ ray = lazy_import("ray")
 
 
 class TestActor(mo.Actor):
+    __test__ = False
+
     async def kill(self, address, uid):
         actor_ref = await mo.actor_ref(address, uid)
         task = asyncio.create_task(actor_ref.crash())

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import collections
+
 import os
 import asyncio
 import copy
@@ -20,6 +20,7 @@ import heapq
 import logging
 import operator
 from collections import Counter
+from collections.abc import Mapping
 from .backends.message import SendMessage, TellMessage
 from ..typing import BandType
 
@@ -65,7 +66,7 @@ class _ProfilingOptions(metaclass=_ProfilingOptionsMeta):
     slow_subtasks_duration_threshold = _ProfilingOptionDescriptor(int, default=10)
 
     def __init__(self, options):
-        if isinstance(options, collections.Mapping):
+        if isinstance(options, Mapping):
             invalid_keys = options.keys() - type(self).__dict__.keys()
             if invalid_keys:
                 raise ValueError(f"Invalid profiling options: {invalid_keys}")

--- a/mars/services/subtask/core.py
+++ b/mars/services/subtask/core.py
@@ -110,7 +110,7 @@ class SubtaskResult(Serializable):
     execution_start_time: float = Float64Field("execution_start_time")
     execution_end_time: float = Float64Field("execution_end_time")
 
-    def merge_bands(self, result: Optional["SubtaskResult"]):
+    def update(self, result: Optional["SubtaskResult"]):
         if result and result.bands:
             bands = self.bands or []
             self.bands = sorted(set(bands + result.bands))

--- a/mars/services/subtask/worker/tests/test_subtask.py
+++ b/mars/services/subtask/worker/tests/test_subtask.py
@@ -256,6 +256,6 @@ def test_update_subtask_result():
         execution_start_time=1646125099.622051,
         execution_end_time=1646125104.448726,
     )
-    subtask_result.merge_bands(new_result)
+    subtask_result.update(new_result)
     assert subtask_result.execution_start_time == new_result.execution_start_time
     assert subtask_result.execution_end_time == new_result.execution_end_time

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -883,7 +883,7 @@ class TaskProcessorActor(mo.Actor):
             # set before
             return
 
-        stage_processor.subtask_snapshots[subtask] = subtask_result.merge_bands(
+        stage_processor.subtask_snapshots[subtask] = subtask_result.update(
             stage_processor.subtask_snapshots.get(subtask)
         )
         if subtask_result.status.is_done:

--- a/mars/services/task/supervisor/stage.py
+++ b/mars/services/task/supervisor/stage.py
@@ -125,9 +125,7 @@ class TaskStageProcessor:
 
     async def set_subtask_result(self, result: SubtaskResult):
         subtask = self.subtask_id_to_subtask[result.subtask_id]
-        self.subtask_results[subtask] = result.merge_bands(
-            self.subtask_results.get(subtask)
-        )
+        self.subtask_results[subtask] = result.update(self.subtask_results.get(subtask))
         self._submitted_subtask_ids.difference_update([result.subtask_id])
 
         all_done = len(self.subtask_results) == len(self.subtask_graph)

--- a/mars/tensor/__init__.py
+++ b/mars/tensor/__init__.py
@@ -323,7 +323,6 @@ from numpy import (
 # noinspection PyUnresolvedReferences
 from numpy import (
     dtype,
-    object,
     number,
     inexact,
     floating,
@@ -334,9 +333,7 @@ from numpy import (
     character,
     generic,
     flexible,
-    int,
     int_,
-    bool,
     bool_,
     float_,
     cfloat,
@@ -355,7 +352,6 @@ from numpy import (
     uint32,
     uint64,
     uint,
-    float,
     float16,
     float32,
     float64,
@@ -373,6 +369,19 @@ from numpy import finfo
 from .fuse import TensorFuseChunk, TensorCpFuseChunk, TensorNeFuseChunk
 from .fetch import TensorFetch, TensorFetchShuffle
 from . import ufunc
+
+try:
+    import warnings
+
+    # suppress numpy warnings on types
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        # noinspection PyUnresolvedReferences
+        from numpy import object, int, bool, float
+except ImportError:  # pragma: no cover
+    pass
+finally:
+    del warnings
 
 del (
     TensorFuseChunk,

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1533,5 +1533,6 @@ def wrap_exception(
             "__getattr__": __getattr__,
             "__str__": __str__,
             "__basename__": name,
+            "__module__": bases[-1].__module__,
         },
     )().with_traceback(traceback)


### PR DESCRIPTION
## What do these changes do?

Remove deprecate warnings when import mars.tensor. Also do other minor fixes.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
