### PR TITLE
[ray] Default enable fault tolerance for ray

### DIFF
--- a/mars/deploy/oscar/rayconfig.yml
+++ b/mars/deploy/oscar/rayconfig.yml
@@ -14,5 +14,7 @@ scheduling:
     enabled: false
     scheduler_backlog_timeout: 20
     worker_idle_timeout: 40
+  subtask_max_retries: 3
+  subtask_max_reschedules: 2
 metrics:
   backend: ray

--- a/mars/deploy/oscar/tests/local_test_with_ray_config.yml
+++ b/mars/deploy/oscar/tests/local_test_with_ray_config.yml
@@ -1,3 +1,6 @@
 "@inherits": '@mars/deploy/oscar/rayconfig.yml'
 session:
   custom_log_dir: auto
+scheduling:
+  subtask_max_retries: 0
+  subtask_max_reschedules: 0

--- a/mars/services/scheduling/worker/workerslot.py
+++ b/mars/services/scheduling/worker/workerslot.py
@@ -249,7 +249,7 @@ class BandSlotManagerActor(mo.Actor):
 
             try:
                 usage = proc.cpu_percent(interval=None) / 100.0
-            except psutil.NoSuchProcess:  # pragma: no cover
+            except (psutil.NoSuchProcess, psutil.AccessDenied):  # pragma: no cover
                 continue
 
             slot_infos.append(


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

The worker fault tolerance is well tested in ray, it can be enabled by default.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
