### PR TITLE
Support generating a DOT file for subtask graph

### DIFF
--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -724,7 +724,7 @@ def build_concatenated_rows_frame(df):
     return DataFrameConcat(axis=1, output_types=[OutputType.dataframe]).new_dataframe(
         [df],
         chunks=out_chunks,
-        nsplits=((chunk.shape[0] for chunk in out_chunks), (df.shape[1],)),
+        nsplits=(tuple(chunk.shape[0] for chunk in out_chunks), (df.shape[1],)),
         shape=df.shape,
         dtypes=df.dtypes,
         index_value=df.index_value,

--- a/mars/oscar/profiling.py
+++ b/mars/oscar/profiling.py
@@ -27,7 +27,7 @@ from ..typing import BandType
 
 logger = logging.getLogger(__name__)
 
-MARS_ENABLE_PROFILING = bool(os.environ.get("MARS_ENABLE_PROFILING", 0))
+MARS_ENABLE_PROFILING = int(os.environ.get("MARS_ENABLE_PROFILING", 0))
 
 
 class _ProfilingOptionDescriptor:

--- a/mars/services/lifecycle/supervisor/tracker.py
+++ b/mars/services/lifecycle/supervisor/tracker.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import logging
 
 from collections import defaultdict
 from typing import Dict, List, Optional
@@ -21,6 +22,8 @@ from .... import oscar as mo
 from ...meta.api import MetaAPI
 from ...storage.api import StorageAPI
 from ..errors import TileableNotTracked
+
+logger = logging.getLogger(__name__)
 
 
 class LifecycleTrackerActor(mo.Actor):
@@ -67,6 +70,7 @@ class LifecycleTrackerActor(mo.Actor):
             self.incref_chunks(incref_chunk_keys)
 
     def incref_chunks(self, chunk_keys: List[str]):
+        logger.debug("Increase reference count for chunks %s", chunk_keys)
         for chunk_key in chunk_keys:
             self._chunk_ref_counts[chunk_key] += 1
 
@@ -83,6 +87,7 @@ class LifecycleTrackerActor(mo.Actor):
         return to_remove_chunk_keys
 
     async def decref_chunks(self, chunk_keys: List[str]):
+        logger.debug("Decrease reference count for chunks %s", chunk_keys)
         to_remove_chunk_keys = self._get_remove_chunk_keys(chunk_keys)
         # make _remove_chunks release actor lock so that multiple `decref_chunks` can run concurrently.
         yield self._remove_chunks(to_remove_chunk_keys)
@@ -91,6 +96,7 @@ class LifecycleTrackerActor(mo.Actor):
         if not to_remove_chunk_keys:
             return
         # get meta
+        logger.debug("Remove chunks %s with a refcount of zero", to_remove_chunk_keys)
         get_metas = []
         for to_remove_chunk_key in to_remove_chunk_keys:
             get_metas.append(
@@ -171,6 +177,11 @@ class LifecycleTrackerActor(mo.Actor):
             self._tileable_ref_counts[tileable_key] -= 1
 
             decref_chunk_keys.extend(self._tileable_key_to_chunk_keys[tileable_key])
+        logger.debug(
+            "Decref chunks %s while decrefing tileables %s",
+            decref_chunk_keys,
+            tileable_keys,
+        )
         yield self.decref_chunks(decref_chunk_keys)
 
     def get_tileable_ref_counts(self, tileable_keys: List[str]) -> List[int]:

--- a/mars/services/task/supervisor/graph_visualizer.py
+++ b/mars/services/task/supervisor/graph_visualizer.py
@@ -90,7 +90,9 @@ class GraphVisualizer:
             if op.key in visited:
                 continue
             for input_chunk in op.inputs or []:
-                if input_chunk.key not in visited:
+                if input_chunk.key not in visited and not isinstance(
+                    input_chunk.op, (Fetch, FetchShuffle)
+                ):
                     node_name = f'"Chunk:{input_chunk.key[:trunc_key]}"'
                     sio.write(f"{node_name} {chunk_style}\n")
                     all_nodes.append(node_name)

--- a/mars/services/task/supervisor/graph_visualizer.py
+++ b/mars/services/task/supervisor/graph_visualizer.py
@@ -1,0 +1,127 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from io import StringIO
+from typing import Dict, List
+
+from ....core.operand import Fetch, FetchShuffle
+from ...subtask import Subtask
+from .processor import TaskProcessor
+
+
+class GraphVisualizer:
+    task_processor: TaskProcessor
+
+    def __init__(self, task_processor):
+        self.task_processor = task_processor
+
+    def to_dot(self):
+        sio = StringIO()
+        sio.write("digraph {\n")
+        sio.write("splines=curved\n")
+        sio.write("rankdir=BT\n")
+        sio.write("graph [compound=true];\n")
+        subgraph_index = 0
+        current_stage = 0
+        result_chunk_to_subtask = {}
+        for stage_processor in self.task_processor.stage_processors:
+            for subtask in stage_processor.subtask_graph.topological_iter():
+                current_cluster = f"cluster_{subgraph_index}"
+                sio.write(
+                    self._export_subtask_to_dot(
+                        subtask, current_cluster, current_stage, result_chunk_to_subtask
+                    )
+                )
+                for c in subtask.chunk_graph.results:
+                    result_chunk_to_subtask[c.key] = [current_stage, current_cluster]
+                subgraph_index += 1
+            current_stage += 1
+        sio.write("}")
+        return sio.getvalue()
+
+    @classmethod
+    def _export_subtask_to_dot(
+        cls,
+        subtask: Subtask,
+        subgraph_name: str,
+        current_stage: int,
+        chunk_key_to_subtask: Dict[str, List],
+        trunc_key: int = 5,
+    ):
+
+        chunk_graph = subtask.chunk_graph
+        sio = StringIO()
+        chunk_style = "[shape=box]"
+        operand_style = "[shape=circle]"
+
+        visited = set()
+        all_nodes = []
+        for node in chunk_graph.iter_nodes():
+            op = node.op
+            if isinstance(node.op, (Fetch, FetchShuffle)):
+                continue
+            op_name = type(op).__name__
+            if op.stage is not None:
+                op_name = f"{op_name}:{op.stage.name}"
+            if op.key in visited:
+                continue
+            for input_chunk in op.inputs or []:
+                if input_chunk.key not in visited:
+                    node_name = f'"Chunk:{input_chunk.key[:trunc_key]}"'
+                    sio.write(f"{node_name} {chunk_style}\n")
+                    all_nodes.append(node_name)
+                    visited.add(input_chunk.key)
+                if op.key not in visited:
+                    node_name = f'"{op_name}:{op.key[:trunc_key]}"'
+                    sio.write(f"{node_name} {operand_style}\n")
+                    all_nodes.append(node_name)
+                    visited.add(op.key)
+                if (
+                    isinstance(input_chunk.op, (Fetch, FetchShuffle))
+                    and input_chunk.key in chunk_key_to_subtask
+                ):
+                    stage, tail_cluster = chunk_key_to_subtask[input_chunk.key]
+                    if stage == current_stage:
+                        line_style = "style=bold"
+                    else:
+                        line_style = "style=dotted"
+                    sio.write(
+                        f'"Chunk:{input_chunk.key[:trunc_key]}" -> "{op_name}:{op.key[:trunc_key]}" '
+                        f"[lhead={subgraph_name} ltail={tail_cluster} {line_style}];\n"
+                    )
+                else:
+                    sio.write(
+                        f'"Chunk:{input_chunk.key[:trunc_key]}" -> "{op_name}:{op.key[:trunc_key]}"\n'
+                    )
+
+            for output_chunk in op.outputs or []:
+                if output_chunk.key not in visited:
+                    node_name = f'"Chunk:{output_chunk.key[:trunc_key]}"'
+                    sio.write(f"{node_name} {chunk_style}\n")
+                    all_nodes.append(node_name)
+                    visited.add(output_chunk.key)
+                if op.key not in visited:
+                    node_name = f'"{op_name}:{op.key[:trunc_key]}"'
+                    sio.write(f"{node_name} {operand_style}\n")
+                    all_nodes.append(node_name)
+                    visited.add(op.key)
+                sio.write(
+                    f'"{op_name}:{op.key[:trunc_key]}" -> "Chunk:{output_chunk.key[:5]}"\n'
+                )
+        # write subgraph info
+        sio.write(f"subgraph {subgraph_name} {{\n")
+        nodes_str = " ".join(all_nodes)
+        sio.write(f"{nodes_str};\n}}")
+        sio.write("\n")
+        return sio.getvalue()

--- a/mars/services/task/supervisor/graph_visualizer.py
+++ b/mars/services/task/supervisor/graph_visualizer.py
@@ -139,6 +139,7 @@ class GraphVisualizer:
         # write subgraph info
         sio.write(f"subgraph {subgraph_name} {{\n")
         nodes_str = " ".join(all_nodes)
-        sio.write(f"{nodes_str};\n}}")
+        sio.write(f"{nodes_str};\n")
+        sio.write(f'label="{subtask.subtask_id}";\n}}')
         sio.write("\n")
         return sio.getvalue()

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -53,7 +53,7 @@ from .stage import TaskStageProcessor
 
 logger = logging.getLogger(__name__)
 
-MARS_ENABLE_DUMPING_SUBTASK_GRAPH = bool(os.environ.get("MARS_DUMP_SUBTASK_GRAPH", 0))
+MARS_ENABLE_DUMPING_SUBTASK_GRAPH = int(os.environ.get("MARS_DUMP_SUBTASK_GRAPH", 0))
 
 
 def _record_error(func: Union[Callable, Coroutine] = None, log_when_error=True):

--- a/mars/services/task/supervisor/tests/test_task_manager.py
+++ b/mars/services/task/supervisor/tests/test_task_manager.py
@@ -445,7 +445,8 @@ async def test_dump_subtask_graph(actor_pool):
     file_path = os.path.join(tempfile.gettempdir(), f"mars-{task_id}")
     with open(file_path) as f:
         text = f.read()
-        assert "style=dotted" in text
+        assert "style=bold" in text
+        assert 'color="/spectral9/' in text
         for c in result_tileable.chunks:
             assert c.key[:5] in text
     os.remove(file_path)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Add an optional config `dump_subtask_graph` when submitting graphs, it will generate the complete chunk graph, those chunks be colored with same color will be united as a subgraph in DOT, and then connect subgraphs according to the subtask dependences. Specially, if one task has multiple stages, the edge's style will be "dotted" if the connected subtasks belong to different stages.

Here are some examples:

- Example1
```
In [12]: a = mt.random.rand(10, 10, chunk_size=3)

In [13]: b = a + 1 - 2

In [14]: c = b.sum(axis=1)

In [15]: c.execute(extra_config={"dump_subtask_graph": True})
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:00<00:00, 360.90it/s]
Out[15]:
array([-4.79605122, -4.17584986, -3.62345371, -6.74078572, -5.11383525,
       -6.32972501, -4.45877359, -6.85511891, -4.79619598, -4.21884735])
```
![image](https://user-images.githubusercontent.com/14146443/157439572-fc4a7e0b-ada8-4221-9f6a-836f7a03d8c1.png)

- example2
```
In [3]: a = mt.random.rand(10, 10, chunk_size=3)

In [4]: df = md.DataFrame(a)

In [5]: df[df > 0.5].sort_values(by=1).execute(extra_config={"dump_subtask_graph": True})
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:00<00:00, 148.39it/s]
Out[5]:
          0         1         2         3         4         5         6         7         8         9
8       NaN  0.559153  0.991407       NaN  0.579143  0.592087       NaN       NaN  0.731116  0.842489
2  0.676814  0.803772  0.881030       NaN       NaN       NaN       NaN       NaN       NaN       NaN
9       NaN  0.892045  0.537926       NaN  0.760115  0.729152       NaN  0.558372  0.810266       NaN
7  0.868231  0.910737       NaN       NaN  0.720215  0.635155  0.588498  0.972826  0.558915       NaN
0       NaN       NaN  0.810465  0.609881       NaN       NaN  0.950973       NaN       NaN  0.610496
1       NaN       NaN       NaN  0.876199  0.903854       NaN  0.985229       NaN  0.779864       NaN
3       NaN       NaN       NaN       NaN  0.946391  0.652453       NaN       NaN  0.938840  0.538927
4  0.850098       NaN  0.872272  0.882686  0.667572       NaN       NaN       NaN       NaN  0.535971
5       NaN       NaN  0.691697       NaN  0.857972  0.808739  0.522473       NaN       NaN       NaN
6       NaN       NaN       NaN       NaN       NaN       NaN  0.737246  0.565483  0.914582       NaN
```
![image](https://user-images.githubusercontent.com/14146443/157443445-a6fd1685-8fdf-45b7-a72b-c5103bcb3ba3.png)

- Example3 (has two stages)
``` Python
In [17]: rs = np.random.RandomState(0)
    ...: raw = pd.DataFrame(
    ...:     {
    ...:         "c1": rs.randint(20, size=100),
    ...:         "c2": rs.choice(["a", "b", "c"], (100,)),
    ...:         "c3": rs.rand(100),
    ...:     }
    ...: )
    ...: mdf = md.DataFrame(raw, chunk_size=20)

In [18]: r = mdf.groupby("c2").agg("sum")

In [19]: r.execute(extra_config={"dump_subtask_graph": True})
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:00<00:00, 288.89it/s]
Out[19]:
     c1         c3
c2
a   305  16.312997
b   254  14.502106
c   329  18.307300
```
![image](https://user-images.githubusercontent.com/14146443/157443839-88602753-e133-4bc7-8429-db3b1dde9235.png)




## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
