### PR TITLE
Fix default value of `gpu` property for some operands

### DIFF
--- a/mars/dataframe/datasource/dataframe.py
+++ b/mars/dataframe/datasource/dataframe.py
@@ -118,6 +118,6 @@ class DataFrameDataSource(DataFrameOperand, DataFrameOperandMixin):
         ctx[op.outputs[0].key] = op.data
 
 
-def from_pandas(data, chunk_size=None, gpu=False, sparse=False):
+def from_pandas(data, chunk_size=None, gpu=None, sparse=False):
     op = DataFrameDataSource(data=data, gpu=gpu, sparse=sparse)
     return op(data.shape, chunk_size=chunk_size)

--- a/mars/dataframe/datasource/from_records.py
+++ b/mars/dataframe/datasource/from_records.py
@@ -156,7 +156,7 @@ def from_records(
     columns=None,
     coerce_float=False,
     nrows=None,
-    gpu=False,
+    gpu=None,
     sparse=False,
     **kw
 ):

--- a/mars/dataframe/datasource/from_vineyard.py
+++ b/mars/dataframe/datasource/from_vineyard.py
@@ -251,7 +251,7 @@ def from_vineyard(df, vineyard_socket=None):
         vineyard_socket=vineyard_socket,
         object_id=object_id,
         dtype=np.dtype("byte"),
-        gpu=False,
+        gpu=None,
     )
     meta = metaop(
         shape=(np.nan,),
@@ -260,6 +260,6 @@ def from_vineyard(df, vineyard_socket=None):
         columns_value=parse_index(pd.Index([])),
     )
     op = DataFrameFromVineyardChunk(
-        vineyard_socket=vineyard_socket, object_id=object_id, gpu=False
+        vineyard_socket=vineyard_socket, object_id=object_id, gpu=None
     )
     return op(meta)

--- a/mars/dataframe/datasource/index.py
+++ b/mars/dataframe/datasource/index.py
@@ -248,7 +248,7 @@ class IndexDataSource(DataFrameOperand, DataFrameOperandMixin):
                 ctx[out.key] = pd.Index(inp, dtype=dtype, name=out.name)
 
 
-def from_pandas(data, chunk_size=None, gpu=False, sparse=False, store_data=False):
+def from_pandas(data, chunk_size=None, gpu=None, sparse=False, store_data=False):
     op = IndexDataSource(
         data=data, gpu=gpu, sparse=sparse, dtype=data.dtype, store_data=store_data
     )

--- a/mars/dataframe/datasource/series.py
+++ b/mars/dataframe/datasource/series.py
@@ -99,6 +99,6 @@ class SeriesDataSource(DataFrameOperand, DataFrameOperandMixin):
         ctx[op.outputs[0].key] = op.data
 
 
-def from_pandas(data, chunk_size=None, gpu=False, sparse=False):
+def from_pandas(data, chunk_size=None, gpu=None, sparse=False):
     op = SeriesDataSource(data=data, gpu=gpu, sparse=sparse)
     return op(data.shape, chunk_size=chunk_size)

--- a/mars/dataframe/indexing/iloc.py
+++ b/mars/dataframe/indexing/iloc.py
@@ -253,7 +253,7 @@ class DataFrameIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
     _input = KeyField("input")
     _indexes = ListField("indexes")
 
-    def __init__(self, indexes=None, gpu=False, sparse=False, output_types=None, **kw):
+    def __init__(self, indexes=None, gpu=None, sparse=False, output_types=None, **kw):
         super().__init__(
             _indexes=indexes, gpu=gpu, sparse=sparse, _output_types=output_types, **kw
         )
@@ -406,7 +406,7 @@ class DataFrameIlocSetItem(DataFrameOperand, DataFrameOperandMixin):
     _value = AnyField("value")
 
     def __init__(
-        self, indexes=None, value=None, gpu=False, sparse=False, output_types=None, **kw
+        self, indexes=None, value=None, gpu=None, sparse=False, output_types=None, **kw
     ):
         super().__init__(
             _indexes=indexes,
@@ -502,7 +502,7 @@ class SeriesIlocGetItem(DataFrameOperand, HeadTailOptimizedOperandMixin):
     _input = KeyField("input")
     _indexes = ListField("indexes")
 
-    def __init__(self, indexes=None, gpu=False, sparse=False, output_types=None, **kw):
+    def __init__(self, indexes=None, gpu=None, sparse=False, output_types=None, **kw):
         super().__init__(
             _indexes=indexes, gpu=gpu, sparse=sparse, _output_types=output_types, **kw
         )
@@ -582,7 +582,7 @@ class SeriesIlocSetItem(DataFrameOperand, DataFrameOperandMixin):
     _indexes = ListField("indexes")
     _value = AnyField("value")
 
-    def __init__(self, indexes=None, value=None, gpu=False, sparse=False, **kw):
+    def __init__(self, indexes=None, value=None, gpu=None, sparse=False, **kw):
         super().__init__(
             _indexes=indexes,
             _value=value,
@@ -666,7 +666,7 @@ class IndexIlocGetItem(DataFrameOperand, DataFrameOperandMixin):
     _input = KeyField("input")
     _indexes = ListField("indexes")
 
-    def __init__(self, indexes=None, gpu=False, sparse=False, output_types=None, **kw):
+    def __init__(self, indexes=None, gpu=None, sparse=False, output_types=None, **kw):
         super().__init__(
             _indexes=indexes, gpu=gpu, sparse=sparse, _output_types=output_types, **kw
         )

--- a/mars/dataframe/indexing/loc.py
+++ b/mars/dataframe/indexing/loc.py
@@ -115,7 +115,7 @@ class DataFrameLocGetItem(DataFrameOperand, DataFrameOperandMixin):
     _input = KeyField("input")
     _indexes = ListField("indexes")
 
-    def __init__(self, indexes=None, gpu=False, sparse=False, output_types=None, **kw):
+    def __init__(self, indexes=None, gpu=None, sparse=False, output_types=None, **kw):
         super().__init__(
             _indexes=indexes, gpu=gpu, sparse=sparse, _output_types=output_types, **kw
         )

--- a/mars/dataframe/reduction/core.py
+++ b/mars/dataframe/reduction/core.py
@@ -654,7 +654,7 @@ class CustomReduction:
     # set to True when pre() already performs aggregation
     pre_with_agg = False
 
-    def __init__(self, name=None, is_gpu=False):
+    def __init__(self, name=None, is_gpu=None):
         self.name = name or "<custom>"
         self.output_limit = 1
         self._is_gpu = is_gpu
@@ -1189,7 +1189,7 @@ class ReductionCompiler:
         args_str = ", ".join(input_key_to_var.values())
         lines_str = "\n    ".join(local_lines)
         return (
-            f"def expr_function({args_str}, gpu=False):\n"
+            f"def expr_function({args_str}, gpu=None):\n"
             f"    {lines_str}\n"
             f"    return {local_key_to_var[out_tileable.key]}",
             list(input_key_to_var.keys()),

--- a/mars/dataframe/sort/core.py
+++ b/mars/dataframe/sort/core.py
@@ -52,7 +52,7 @@ class DataFrameSortOperand(DataFrameOperand):
         parallel_kind=None,
         psrs_kinds=None,
         nrows=None,
-        gpu=False,
+        gpu=None,
         **kw
     ):
         super().__init__(

--- a/mars/learn/neighbors/_faiss.py
+++ b/mars/learn/neighbors/_faiss.py
@@ -477,7 +477,7 @@ class FaissTrainSampledIndex(LearnOperand, LearnOperandMixin):
 
 
 def _gen_index_string_and_sample_count(
-    shape, n_sample, accuracy, memory_require, gpu=False, **kw
+    shape, n_sample, accuracy, memory_require, gpu=None, **kw
 ):
     """
     Generate index string and sample count according to guidance of faiss:

--- a/mars/services/task/analyzer/tests/test_fusion.py
+++ b/mars/services/task/analyzer/tests/test_fusion.py
@@ -78,6 +78,50 @@ def test_simple_coloring():
     assert chunk_to_colors[chunks[2]] == chunk_to_colors[chunks[3]]
 
 
+def test_coloring_with_gpu_attr():
+    chunks = [
+        TensorTreeAdd(args=[], _key=str(n)).new_chunk(None, None).data for n in range(8)
+    ]
+    graph = ChunkGraph([chunks[3], chunks[7]])
+    for c in chunks:
+        graph.add_node(c)
+
+    # two lines, one line can be fused as one task,
+    # the other cannot, because gpu attributes are different
+    chunks[0].op.gpu = True
+    chunks[1].op.gpu = True
+    chunks[1].op._inputs = [chunks[0]]
+    graph.add_edge(chunks[0], chunks[1])
+    chunks[2].op._inputs = [chunks[1]]
+    graph.add_edge(chunks[1], chunks[2])
+    chunks[3].op._inputs = [chunks[2]]
+    graph.add_edge(chunks[2], chunks[3])
+    chunks[5].op._inputs = [chunks[4]]
+    graph.add_edge(chunks[4], chunks[5])
+    chunks[6].op._inputs = [chunks[5]]
+    graph.add_edge(chunks[5], chunks[6])
+    chunks[7].op._inputs = [chunks[6]]
+    graph.add_edge(chunks[6], chunks[7])
+
+    all_bands = [("127.0.0.1", "0"), ("127.0.0.1", "1")]
+    chunk_to_bands = {
+        chunks[0]: all_bands[0],
+        chunks[4]: all_bands[1],
+    }
+
+    coloring = Coloring(graph, all_bands, chunk_to_bands)
+    chunk_to_colors = coloring.color()
+    assert len(set(chunk_to_colors.values())) == 3
+    assert chunk_to_colors[chunks[0]] == chunk_to_colors[chunks[1]]
+    assert chunk_to_colors[chunks[2]] == chunk_to_colors[chunks[3]]
+    assert (
+        chunk_to_colors[chunks[4]]
+        == chunk_to_colors[chunks[5]]
+        == chunk_to_colors[chunks[6]]
+        == chunk_to_colors[chunks[7]]
+    )
+
+
 def test_complex_coloring():
     # graph: https://user-images.githubusercontent.com/357506/132340055-f08106dd-b507-4e24-bc79-8364d6e1ef79.png
     chunks = [

--- a/mars/tensor/arithmetic/tests/test_arithmetic.py
+++ b/mars/tensor/arithmetic/tests/test_arithmetic.py
@@ -96,7 +96,7 @@ def test_add():
     t1 = tensor([[0, 1, 0], [1, 0, 0]], chunk_size=2).tosparse()
 
     t = t1 + 1
-    assert t.op.gpu is False
+    assert t.op.gpu is None
     assert t.issparse() is True
     assert type(t) is SparseTensor
 
@@ -416,7 +416,7 @@ def test_negative():
     t1 = tensor([[0, 1, 0], [1, 0, 0]], chunk_size=2).tosparse()
 
     t = negative(t1)
-    assert t.op.gpu is False
+    assert t.op.gpu is None
     assert t.issparse() is True
     assert type(t) is SparseTensor
 

--- a/mars/tensor/arithmetic/tests/test_arithmetic.py
+++ b/mars/tensor/arithmetic/tests/test_arithmetic.py
@@ -51,7 +51,7 @@ def test_add():
     t2 = ones(4, chunk_size=2)
     t3 = t1 + t2
     k1 = t3.key
-    assert t3.op.gpu is False
+    assert t3.op.gpu is None
     t1, t2, t3 = tile(t1, t2, t3)
     assert t3.key != k1
     assert t3.shape == (3, 4)

--- a/mars/tensor/datasource/array.py
+++ b/mars/tensor/datasource/array.py
@@ -178,8 +178,6 @@ def tensor(
         if gpu is None:
             if cp is not None and m is cp:
                 gpu = True
-            elif m is np:
-                gpu = False
 
     if is_array(data):
         if data.ndim == 0:

--- a/mars/tensor/datasource/diag.py
+++ b/mars/tensor/datasource/diag.py
@@ -214,7 +214,7 @@ class TensorDiag(TensorDiagBase, TensorHasInput):
             ctx[chunk.key] = create_array(op)("diag", ctx[op.inputs[0].key], k=op.k)
 
 
-def diag(v, k=0, sparse=None, gpu=False, chunk_size=None):
+def diag(v, k=0, sparse=None, gpu=None, chunk_size=None):
     """
     Extract a diagonal or construct a diagonal tensor.
 

--- a/mars/tensor/datasource/diagflat.py
+++ b/mars/tensor/datasource/diagflat.py
@@ -19,7 +19,7 @@ from .array import tensor as astensor
 from .diag import diag
 
 
-def diagflat(v, k=0, sparse=None, gpu=False, chunk_size=None):
+def diagflat(v, k=0, sparse=None, gpu=None, chunk_size=None):
     """
     Create a two-dimensional tensor with the flattened input as a diagonal.
 

--- a/mars/tensor/datasource/empty.py
+++ b/mars/tensor/datasource/empty.py
@@ -66,7 +66,7 @@ class TensorEmpty(TensorEmptyBase, TensorNoInput):
         )
 
 
-def empty(shape, dtype=None, chunk_size=None, gpu=False, order="C"):
+def empty(shape, dtype=None, chunk_size=None, gpu=None, order="C"):
     """
     Return a new tensor of given shape and type, without initializing entries.
 

--- a/mars/tensor/datasource/eye.py
+++ b/mars/tensor/datasource/eye.py
@@ -77,9 +77,7 @@ class TensorEye(TensorNoInput, TensorDiagBase):
             )
 
 
-def eye(
-    N, M=None, k=0, dtype=None, sparse=False, gpu=False, chunk_size=None, order="C"
-):
+def eye(N, M=None, k=0, dtype=None, sparse=False, gpu=None, chunk_size=None, order="C"):
     """
     Return a 2-D tensor with ones on the diagonal and zeros elsewhere.
 

--- a/mars/tensor/datasource/from_tiledb.py
+++ b/mars/tensor/datasource/from_tiledb.py
@@ -154,7 +154,7 @@ class TensorTileDBDataSource(TensorNoInput):
                     ctx[chunk.key] = SparseNDArray(spmatrix, shape=chunk.shape)
 
 
-def fromtiledb(uri, ctx=None, key=None, timestamp=None, gpu=False):
+def fromtiledb(uri, ctx=None, key=None, timestamp=None, gpu=None):
     import tiledb
 
     raw_ctx = ctx

--- a/mars/tensor/datasource/from_vineyard.py
+++ b/mars/tensor/datasource/from_vineyard.py
@@ -185,10 +185,10 @@ def fromvineyard(tensor, vineyard_socket=None):
         vineyard_socket=vineyard_socket,
         object_id=object_id,
         dtype=np.dtype("byte"),
-        gpu=False,
+        gpu=None,
     )
     meta = metaop(shape=(np.nan,), chunk_size=(np.nan,))
     op = TensorFromVineyardChunk(
-        vineyard_socket=vineyard_socket, object_id=object_id, gpu=False
+        vineyard_socket=vineyard_socket, object_id=object_id, gpu=None
     )
     return op(meta)

--- a/mars/tensor/datasource/full.py
+++ b/mars/tensor/datasource/full.py
@@ -57,7 +57,7 @@ class TensorFull(TensorNoInput):
         )
 
 
-def full(shape, fill_value, dtype=None, chunk_size=None, gpu=False, order="C"):
+def full(shape, fill_value, dtype=None, chunk_size=None, gpu=None, order="C"):
     """
     Return a new tensor of given shape and type, filled with `fill_value`.
 

--- a/mars/tensor/datasource/identity.py
+++ b/mars/tensor/datasource/identity.py
@@ -17,7 +17,7 @@
 from .eye import eye
 
 
-def identity(n, dtype=None, sparse=False, gpu=False, chunk_size=None):
+def identity(n, dtype=None, sparse=False, gpu=None, chunk_size=None):
     """
     Return the identity tensor.
 

--- a/mars/tensor/datasource/linspace.py
+++ b/mars/tensor/datasource/linspace.py
@@ -123,7 +123,7 @@ def linspace(
     endpoint=True,
     retstep=False,
     dtype=None,
-    gpu=False,
+    gpu=None,
     chunk_size=None,
 ):
     """

--- a/mars/tensor/datasource/ones.py
+++ b/mars/tensor/datasource/ones.py
@@ -57,7 +57,7 @@ class TensorOnes(TensorNoInput):
             ctx[chunk.key] = convert_order(x, op.order)
 
 
-def ones(shape, dtype=None, chunk_size=None, gpu=False, order="C"):
+def ones(shape, dtype=None, chunk_size=None, gpu=None, order="C"):
     """
     Return a new tensor of given shape and type, filled with ones.
 

--- a/mars/tensor/datasource/scalar.py
+++ b/mars/tensor/datasource/scalar.py
@@ -54,7 +54,7 @@ class Scalar(TensorNoInput):
         ctx[chunk.key] = create_array(op)("asarray", op.data)
 
 
-def scalar(data, dtype=None, gpu=False):
+def scalar(data, dtype=None, gpu=None):
     try:
         arr = np.array(data, dtype=dtype)
         op = Scalar(arr, dtype=arr.dtype, gpu=gpu)

--- a/mars/tensor/datasource/tests/test_datasource.py
+++ b/mars/tensor/datasource/tests/test_datasource.py
@@ -286,7 +286,7 @@ def test_diag():
     t = diag(v)
 
     assert t.shape == (4,)
-    assert t.op.gpu is False
+    assert t.op.gpu is None
     t = tile(t)
     assert t.nsplits == ((2, 2),)
 
@@ -382,7 +382,7 @@ def test_triu_tril():
 
     t = triu(a)
 
-    assert t.op.gpu is False
+    assert t.op.gpu is None
 
     t = tile(t)
     assert len(t.chunks) == 4
@@ -420,7 +420,7 @@ def test_triu_tril():
 
     t = tril(a)
 
-    assert t.op.gpu is False
+    assert t.op.gpu is None
 
     t = tile(t)
     assert len(t.chunks) == 4
@@ -528,7 +528,7 @@ def test_ones_like():
     assert isinstance(t, SparseTensor)
     assert isinstance(t.op, TensorOnesLike)
     assert t.issparse() is True
-    assert t.op.gpu is False
+    assert t.op.gpu is None
 
     t = tile(t)
     assert t.chunks[0].index == (0, 0)

--- a/mars/tensor/datasource/tests/test_datasource.py
+++ b/mars/tensor/datasource/tests/test_datasource.py
@@ -178,7 +178,7 @@ def test_ones():
 def test_zeros():
     tensor = zeros((2, 3, 4))
     assert len(list(tensor)) == 2
-    assert tensor.op.gpu is False
+    assert tensor.op.gpu is None
 
     tensor2 = zeros((2, 3, 4), chunk_size=1)
     # tensor's op key must be equal to tensor2
@@ -208,7 +208,7 @@ def test_data_source():
 
     data = np.random.random((10, 3))
     t = tensor(data, chunk_size=2)
-    assert t.op.gpu is False
+    assert t.op.gpu is None
     t = tile(t)
     assert (t.chunks[0].op.data == data[:2, :2]).all()
     assert (t.chunks[1].op.data == data[:2, 2:3]).all()
@@ -226,7 +226,7 @@ def test_data_source():
     assert t.chunks[0].op.gpu is True
 
     t = full((2, 2), 2, dtype="f4")
-    assert t.op.gpu is False
+    assert t.op.gpu is None
     assert t.shape == (2, 2)
     assert t.dtype == np.float32
 

--- a/mars/tensor/datasource/zeros.py
+++ b/mars/tensor/datasource/zeros.py
@@ -57,7 +57,7 @@ class TensorZeros(TensorNoInput):
             )
 
 
-def zeros(shape, dtype=None, chunk_size=None, gpu=False, sparse=False, order="C"):
+def zeros(shape, dtype=None, chunk_size=None, gpu=None, sparse=False, order="C"):
     """
     Return a new tensor of given shape and type, filled with zeros.
 

--- a/mars/tensor/fft/fftfreq.py
+++ b/mars/tensor/fft/fftfreq.py
@@ -115,7 +115,7 @@ class TensorFFTFreqChunk(TensorHasInput, TensorOperandMixin):
         ctx[op.outputs[0].key] = x
 
 
-def fftfreq(n, d=1.0, gpu=False, chunk_size=None):
+def fftfreq(n, d=1.0, gpu=None, chunk_size=None):
     """
     Return the Discrete Fourier Transform sample frequencies.
 

--- a/mars/tensor/fft/rfftfreq.py
+++ b/mars/tensor/fft/rfftfreq.py
@@ -70,7 +70,7 @@ class TensorRFFTFreq(TensorOperand, TensorOperandMixin):
         )
 
 
-def rfftfreq(n, d=1.0, gpu=False, chunk_size=None):
+def rfftfreq(n, d=1.0, gpu=None, chunk_size=None):
     """
     Return the Discrete Fourier Transform sample frequencies
     (for usage with rfft, irfft).


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
For some operands, `gpu` property is set to `False` as default, it's all changed to `None` in this PR.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2809 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
