### PR TITLE
Fix lifecycle that decref chunks when tileable ref count equals 0

### DIFF
--- a/mars/dataframe/datastore/tests/test_datastore_execution.py
+++ b/mars/dataframe/datastore/tests/test_datastore_execution.py
@@ -41,6 +41,7 @@ except ImportError:
     vineyard = None
 
 from .... import dataframe as md
+from ....tests.core import flaky
 from ... import DataFrame
 
 
@@ -165,6 +166,7 @@ def test_to_sql():
 
 
 @pytest.mark.skipif(pa is None, reason="pyarrow not installed")
+@flaky(max_runs=3)
 def test_to_parquet_arrow_execution(setup):
     raw = pd.DataFrame(
         {

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -276,6 +276,11 @@ class TaskProcessor:
     @_record_error
     async def decref_stage(self, stage_processor: "TaskStageProcessor"):
         decref_chunk_keys = self._get_decref_stage_chunk_keys(stage_processor)
+        logger.debug(
+            "Decref chunks %s when stage %s finish",
+            decref_chunk_keys,
+            stage_processor.stage_id,
+        )
         await self._lifecycle_api.decref_chunks(decref_chunk_keys)
 
     @decref_stage.batch
@@ -284,6 +289,7 @@ class TaskProcessor:
         decref_chunk_keys = []
         for args, kwargs in zip(args_list, kwargs_list):
             decref_chunk_keys.extend(self._get_decref_stage_chunk_keys(*args, **kwargs))
+        logger.debug("Decref chunks %s when stage finish", decref_chunk_keys)
         await self._lifecycle_api.decref_chunks(decref_chunk_keys)
 
     async def _get_next_chunk_graph(
@@ -897,6 +903,11 @@ class TaskProcessorActor(mo.Actor):
                             # decref main key as well
                             decref_chunk_keys.extend([key[0] for key in data_keys])
                 decref_chunk_keys.append(result_chunk.key)
+        logger.debug(
+            "Decref chunks %s when subtask %s finish",
+            decref_chunk_keys,
+            subtask.subtask_id,
+        )
         await self._lifecycle_api.decref_chunks(decref_chunk_keys)
 
         # `set_subtask_result` will be called when subtask finished


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixed lifecycle that decref chunks when tileable ref count equals 0.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes xxxx .

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
