### PR TITLE
Fixes the failure on Vineyard CI by ensure the input tensor chunk is a numpy's ndarray

### DIFF
--- a/mars/tensor/datastore/to_vineyard.py
+++ b/mars/tensor/datastore/to_vineyard.py
@@ -109,7 +109,7 @@ class TensorVineyardDataStoreChunk(TensorDataStore):
                 needs_put = True
         if needs_put:
             tensor_id = client.put(
-                ctx[op.inputs[0].key], partition_index=op.inputs[0].index
+                np.asarray(ctx[op.inputs[0].key]), partition_index=op.inputs[0].index
             )
         else:  # pragma: no cover
             meta = client.get_meta(tensor_id)


### PR DESCRIPTION
## What do these changes do?

Here the tensor mighe be some subclass of numpy's `np.ndarray`.

## Related issue number

Found during debugging CI failure in #2576 

## Check code requirements

- [ ] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
