### PR TITLE
Fix running xgboost on Ray cluster

### DIFF
--- a/mars/core/context.py
+++ b/mars/core/context.py
@@ -34,7 +34,7 @@ class Context(ABC):
         session_id: str = None,
         supervisor_address: str = None,
         worker_address: str = None,
-        current_address: str = None,
+        local_address: str = None,
         band: BandType = None,
     ):
         if session_id is None:
@@ -53,7 +53,7 @@ class Context(ABC):
         self.session_id = session_id
         self.supervisor_address = supervisor_address
         self.worker_address = worker_address
-        self.current_address = current_address
+        self.local_address = local_address
         self.band = band
 
     @abstractmethod
@@ -64,6 +64,16 @@ class Context(ABC):
         Returns
         -------
         session
+        """
+
+    @abstractmethod
+    def get_local_host_ip(self) -> str:
+        """
+        Get local worker's host ip
+
+        Returns
+        -------
+        host_ip : str
         """
 
     @abstractmethod

--- a/mars/core/custom_log.py
+++ b/mars/core/custom_log.py
@@ -58,7 +58,7 @@ class _LogWrapper:
         session_id = self.ctx.session_id
         tileable_op_key = self.op.tileable_op_key
         chunk_op_key = self.op.key
-        worker_addr = self.ctx.current_address
+        worker_addr = self.ctx.local_address
         log_path = self.log_path
 
         self.ctx.register_custom_log_path(

--- a/mars/learn/contrib/pytorch/run_script.py
+++ b/mars/learn/contrib/pytorch/run_script.py
@@ -95,7 +95,7 @@ class RunPyTorch(RunScript):
 
     @classmethod
     def execute(cls, ctx, op):
-        assert ctx.current_address.split(":")[0] == op.expect_worker.split(":")[0]
+        assert ctx.local_address.split(":")[0] == op.expect_worker.split(":")[0]
 
         super().execute(ctx, op)
 

--- a/mars/learn/contrib/tensorflow/run_script.py
+++ b/mars/learn/contrib/tensorflow/run_script.py
@@ -152,7 +152,7 @@ class RunTensorFlow(RunScript):
         if op.merge:
             return super().execute(ctx, op)
 
-        assert ctx.current_address.split(":")[0] == op.expect_worker.split(":")[0]
+        assert ctx.local_address.split(":")[0] == op.expect_worker.split(":")[0]
 
         super().execute(ctx, op)
 

--- a/mars/learn/contrib/xgboost/start_tracker.py
+++ b/mars/learn/contrib/xgboost/start_tracker.py
@@ -52,7 +52,7 @@ class StartTracker(LearnOperand, LearnOperandMixin):
 
         env = {"DMLC_NUM_WORKER": op.n_workers}
         rabit_context = RabitTracker(
-            hostIP=ctx.current_address.split(":", 1)[0], nslave=op.n_workers
+            hostIP=ctx.get_local_host_ip(), nslave=op.n_workers
         )
         env.update(rabit_context.slave_envs())
 

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -52,6 +52,7 @@ from typing import (
     Optional,
 )
 from types import TracebackType
+from urllib.parse import urlparse
 
 import numpy as np
 import pandas as pd
@@ -1592,3 +1593,12 @@ def create_task_with_error_log(coro, *args, **kwargs):  # pragma: no cover
     else:
         call_site = None
     return _create_task(_run_task_with_error_log(coro, call_site), *args, **kwargs)
+
+
+def is_ray_address(address: str) -> bool:
+    from .oscar.backends.ray.communication import RayServer
+
+    if urlparse(address).scheme == RayServer.scheme:
+        return True
+    else:
+        return False


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Add `get_current_host_ip` method for `Context` to get host ip instead of using `ctx.current_address` directly, current_address will return address like "ray://xx" which is invalid for xgboost.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2816 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
