### PR TITLE
Implements `LocElimination` optimization rule

### DIFF
--- a/mars/core/graph/entity.py
+++ b/mars/core/graph/entity.py
@@ -34,6 +34,21 @@ class EntityGraph(DAG, metaclass=ABCMeta):
         results
         """
 
+    @results.setter
+    @abstractmethod
+    def results(self, new_results):
+        """
+        Set result tileables or chunks.
+
+        Parameters
+        ----------
+        new_results
+
+        Returns
+        -------
+
+        """
+
     def copy(self) -> "EntityGraph":
         graph = super().copy()
         graph.results = self.results.copy()

--- a/mars/optimization/logical/common/column_pruning.py
+++ b/mars/optimization/logical/common/column_pruning.py
@@ -78,7 +78,7 @@ class PruneDataSource(OptimizationRule, metaclass=ABCMeta):
 
     def _merge_selected_columns(self, selected_columns: List[Any], op: OperandType):
         input_node = self._graph.predecessors(op.outputs[0])[0]
-        original_node = self._records.get_original_chunk(input_node)
+        original_node = self._records.get_original_entity(input_node)
         if original_node is None:
             # not pruned before
             original_all_columns = input_node.dtypes.index.tolist()
@@ -150,7 +150,7 @@ class PruneDataSource(OptimizationRule, metaclass=ABCMeta):
             new_outputs = [new_data_source_node]
         else:
             selected_columns: List[Any] = self._get_selected_columns(op)
-            original_node = self._records.get_original_chunk(data_source_node)
+            original_node = self._records.get_original_entity(data_source_node)
             if original_node is not None:
                 # pruned before
                 dtypes = original_node.dtypes

--- a/mars/optimization/logical/common/head.py
+++ b/mars/optimization/logical/common/head.py
@@ -121,7 +121,7 @@ class HeadPushDown(OptimizationRule):
             new_entity = (
                 new_op.new_tileable
                 if not isinstance(node, CHUNK_TYPE)
-                else new_op.new_entity
+                else new_op.new_chunk
             )
             new_node = new_entity([new_input_node], kws=[params]).data
             self._replace_node(node, new_node)

--- a/mars/optimization/logical/common/head.py
+++ b/mars/optimization/logical/common/head.py
@@ -121,7 +121,7 @@ class HeadPushDown(OptimizationRule):
             new_entity = (
                 new_op.new_tileable
                 if not isinstance(node, CHUNK_TYPE)
-                else new_op.new_chunk
+                else new_op.new_entity
             )
             new_node = new_entity([new_input_node], kws=[params]).data
             self._replace_node(node, new_node)

--- a/mars/optimization/logical/tileable/__init__.py
+++ b/mars/optimization/logical/tileable/__init__.py
@@ -16,3 +16,4 @@ from .arithmetic_query import SeriesArithmeticToEval
 from .column_pruning import GroupByPruneDataSource, GetitemPruneDataSource
 from .core import optimize
 from .head import HeadPushDown
+from .loc_elimination import LocElimination

--- a/mars/optimization/logical/tileable/arithmetic_query.py
+++ b/mars/optimization/logical/tileable/arithmetic_query.py
@@ -246,17 +246,10 @@ class _DataFrameEvalRewriteRule(OptimizationRule):
         for in_tileable in new_node.inputs:
             self._graph.add_edge(in_tileable, new_node)
 
-        original_node = self._records.get_original_chunk(old_node, old_node)
+        original_node = self._records.get_original_entity(old_node, old_node)
         self._records.append_record(
             OptimizationRecord(original_node, new_node, OptimizationRecordType.replace)
         )
-
-        # check node if it's in result
-        try:
-            i = self._graph.results.index(old_node)
-            self._graph.results[i] = new_node
-        except ValueError:
-            pass
 
     def apply(self, op: DataFrameIndex):
         node = op.outputs[0]

--- a/mars/optimization/logical/tileable/loc_elimination.py
+++ b/mars/optimization/logical/tileable/loc_elimination.py
@@ -1,0 +1,118 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from ....core import OperandType, TileableType
+from ....dataframe.indexing.getitem import DataFrameIndex
+from ....dataframe.indexing.iloc import DataFrameIlocGetItem
+from ....dataframe.indexing.loc import DataFrameLocGetItem
+from ....dataframe.merge import DataFrameMerge
+from ....utils import is_full_slice
+from ..core import OptimizationRecord, OptimizationRecordType
+from .core import (
+    OptimizationRule,
+    register_tileable_optimization_rule,
+)
+
+
+@register_tileable_optimization_rule([DataFrameMerge])
+class LocElimination(OptimizationRule):
+    def match(self, op: OperandType) -> bool:
+        node = op.outputs[0]
+        input_nodes = self._graph.predecessors(node)
+        if any(self._can_be_eliminated(n) for n in input_nodes):
+            return True
+        else:
+            return False
+
+    def apply(self, op: OperandType):
+        node = op.outputs[0]
+        input_nodes = node.inputs
+        eliminated_nodes = []
+        for input_node in input_nodes:
+            input_node = self._records.get_optimization_result(input_node, input_node)
+            cur_node = input_node
+            to_be_eliminated_nodes = []
+            while self._can_be_eliminated(cur_node):
+                to_be_eliminated_nodes.insert(0, cur_node)
+                cur_node = self._graph.predecessors(cur_node)[0]
+            eliminated_nodes.append(to_be_eliminated_nodes)
+        self._eliminate_loc_nodes(node, eliminated_nodes)
+
+    def _can_be_eliminated(self, node: TileableType):
+        op = node.op
+        if len(self._graph.successors(node)) == 1:
+            if isinstance(op, DataFrameIndex) and op.mask is None:
+                return True
+            elif isinstance(
+                op, (DataFrameLocGetItem, DataFrameIlocGetItem)
+            ) and is_full_slice(op.indexes[0]):
+                return True
+            else:
+                return False
+        else:
+            return False
+
+    def _eliminate_loc_nodes(
+        self, node: TileableType, loc_nodes_list: List[List[TileableType]]
+    ):
+        new_input_tileables = []
+        index_functions_list = []
+        for loc_nodes, input_node in zip(loc_nodes_list, node.inputs):
+            if loc_nodes:
+                new_input_tileables.append(self._graph.predecessors(loc_nodes[0])[0])
+                index_functions = []
+                for loc_node in loc_nodes:
+                    index_functions.append(self._loc_op_to_func(loc_node.op))
+                    self._records.append_record(
+                        OptimizationRecord(
+                            loc_node, None, OptimizationRecordType.delete
+                        )
+                    )
+                    self._graph.remove_node(loc_node)
+                index_functions_list.append(index_functions)
+            else:
+                new_input_tileables.append(
+                    self._records.get_optimization_result(input_node, input_node)
+                )
+                index_functions_list.append([])
+
+        new_op = node.op.copy()
+        new_op.index_functions = index_functions_list
+        params = node.params.copy()
+        new_tileable = new_op.new_tileable(new_input_tileables, kws=[params]).data
+
+        self._graph.add_node(new_tileable)
+        for succ in self._graph.successors(node):
+            self._graph.add_edge(new_tileable, succ)
+        for input_tileable in new_input_tileables:
+            self._graph.add_edge(input_tileable, new_tileable)
+        self._graph.remove_node(node)
+        self._records.append_record(
+            OptimizationRecord(node, new_tileable, OptimizationRecordType.replace)
+        )
+
+    @classmethod
+    def _loc_op_to_func(cls, op: OperandType):
+        if isinstance(op, DataFrameIndex):
+            col_names = op.col_names
+            return lambda df: df[col_names]
+        elif isinstance(op, DataFrameIlocGetItem):
+            column_iloc_index = op.indexes[1]
+            return lambda df: df.iloc[:, column_iloc_index]
+        else:
+            assert isinstance(op, DataFrameLocGetItem)
+            column_loc_index = op.indexes[1]
+            return lambda df: df.loc[:, column_loc_index]

--- a/mars/optimization/logical/tileable/tests/test_loc_elimination.py
+++ b/mars/optimization/logical/tileable/tests/test_loc_elimination.py
@@ -1,0 +1,97 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+
+from ..... import dataframe as md
+from .....core import enter_mode, TileableGraph, TileableGraphBuilder
+from .. import optimize
+
+
+@enter_mode(build=True)
+def test_loc_elimination_for_merge(setup):
+    ns = np.random.RandomState(0)
+    # small dataframe
+    raw1 = pd.DataFrame(
+        {
+            "key": ns.randint(0, 10, size=10),
+            "value": np.arange(10),
+        },
+        index=[f"a{i}" for i in range(10)],
+    )
+    # big dataframe
+    raw2 = pd.DataFrame(
+        {
+            "key": ns.randint(0, 100, size=100),
+            "value": np.arange(100, 200),
+            "other": ns.randint(0, 100, size=100),
+        },
+        index=[f"a{i}" for i in range(100)],
+    )
+
+    raw3 = pd.DataFrame(
+        {
+            "key": ns.randint(0, 100, size=100),
+            "value": np.arange(100, 200),
+            "other": ns.randint(0, 100, size=100),
+        },
+        index=[f"a{i}" for i in range(100)],
+    )
+
+    df1 = md.DataFrame(raw2, chunk_size=30)
+    df2 = md.DataFrame(raw3, chunk_size=30)
+    indexed_df1 = df1[["key", "value"]]
+    indexes_df2 = df2.loc[:, ["key", "value"]]
+    merged = indexed_df1.merge(indexes_df2, on="key")
+    graph = TileableGraph([merged.data])
+    next(TileableGraphBuilder(graph).build())
+    assert len(graph) == 5
+    records = optimize(graph)
+    opt_merged = records.get_optimization_result(merged.data)
+    assert len(graph) == 3
+    assert len(records._records) == 3
+    assert opt_merged.op.index_functions is not None
+    assert opt_merged.inputs == [df1.data, df2.data]
+
+    pd.testing.assert_frame_equal(
+        merged.execute()
+        .fetch()
+        .sort_values(by=["key", "value_x"])
+        .reset_index(drop=True),
+        raw2[["key", "value"]]
+        .merge(raw3.loc[:, ["key", "value"]], on="key")
+        .sort_values(by=["key", "value_x"])
+        .reset_index(drop=True),
+    )
+
+    df1 = md.DataFrame(raw2, chunk_size=30)
+    df2 = md.DataFrame(raw1)
+    indexed_df1 = df1.iloc[:, :2][["key", "value"]]
+    merged = indexed_df1.merge(df2, on="key")
+    r = merged.sum()
+    graph = TileableGraph([r.data])
+    next(TileableGraphBuilder(graph).build())
+    assert len(graph) == 6
+    records = optimize(graph)
+    opt_merged = records.get_optimization_result(merged.data)
+    assert len(graph) == 4
+    assert len(records._records) == 3
+    assert opt_merged.op.index_functions is not None
+    assert opt_merged.inputs == [df1.data, df2.data]
+
+    pd.testing.assert_series_equal(
+        r.execute().fetch().reset_index(drop=True),
+        raw2.iloc[:, :2].merge(raw1, on="key").sum().reset_index(drop=True),
+    )

--- a/mars/services/task/supervisor/stage.py
+++ b/mars/services/task/supervisor/stage.py
@@ -121,7 +121,7 @@ class TaskStageProcessor:
         metas = await self._meta_api.get_chunk_meta.batch(*get_meta)
         for chunk, meta in zip(chunks, metas):
             chunk.params = meta
-            original_chunk = self._optimization_records.get_original_chunk(chunk)
+            original_chunk = self._optimization_records.get_original_entity(chunk)
             if original_chunk is not None:
                 original_chunk.params = chunk.params
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This PR implements a new optimization rule, it will remove loc operand when it follows by merge operand. For pattern like this:
``` Python
indexed = df1[['col1', 'col2']]
merged = indexd.merge(df2, on='col1')
```
Coloring algorithm won't color Index node and merge node as one color,  so `indexed` data will be put into storage and brings overhead for storing, loading and transferring. This rule removes these indexing operands and move indexing into merge's execution.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
