### PR TITLE
Improve subtask details in logs

### DIFF
--- a/mars/services/scheduling/supervisor/queueing.py
+++ b/mars/services/scheduling/supervisor/queueing.py
@@ -241,11 +241,7 @@ class SubtaskQueueingActor(mo.Actor):
                         if stid not in submitted_ids:
                             continue
                         item = submit_items[stid]
-                        logger.debug(
-                            "Submit subtask %s to band %r",
-                            item.subtask.subtask_id,
-                            band,
-                        )
+                        logger.debug("Submit subtask %r to band %r", item.subtask, band)
                         submit_aio_tasks.append(
                             asyncio.create_task(
                                 manager_ref.submit_subtask_to_band.tell(

--- a/mars/services/scheduling/worker/execution.py
+++ b/mars/services/scheduling/worker/execution.py
@@ -136,11 +136,13 @@ class SubtaskExecutionActor(mo.StatelessActor):
         self,
         subtask_max_retries: int = DEFAULT_SUBTASK_MAX_RETRIES,
         enable_kill_slot: bool = True,
+        data_prepare_timeout: int = 600,
     ):
         self._cluster_api = None
         self._global_slot_ref = None
         self._subtask_max_retries = subtask_max_retries
         self._enable_kill_slot = enable_kill_slot
+        self._data_prepare_timeout = data_prepare_timeout
 
         self._subtask_info = dict()
 
@@ -316,8 +318,14 @@ class SubtaskExecutionActor(mo.StatelessActor):
             status=SubtaskStatus.pending,
         )
         try:
-            await _retry_run(
-                subtask, subtask_info, self._prepare_input_data, subtask, band_name
+            logger.debug("Preparing data for subtask %s", subtask.subtask_id)
+            prepare_data_task = asyncio.create_task(
+                _retry_run(
+                    subtask, subtask_info, self._prepare_input_data, subtask, band_name
+                )
+            )
+            await asyncio.wait_for(
+                prepare_data_task, timeout=self._data_prepare_timeout
             )
 
             input_sizes = await self._collect_input_sizes(
@@ -329,6 +337,7 @@ class SubtaskExecutionActor(mo.StatelessActor):
             self._check_cancelling(subtask_info)
 
             batch_quota_req = {(subtask.session_id, subtask.subtask_id): calc_size}
+            logger.debug("Start actual running of subtask %s", subtask.subtask_id)
             subtask_info.result = await self._retry_run_subtask(
                 subtask, band_name, subtask_api, batch_quota_req
             )
@@ -466,6 +475,7 @@ class SubtaskExecutionActor(mo.StatelessActor):
                 self.ref().internal_run_subtask(subtask, band_name)
             )
 
+        logger.debug("Subtask %r accepted in worker %s", subtask, self.address)
         # the extra_config may be None. the extra config overwrites the default value.
         subtask_max_retries = (
             subtask.extra_config.get("subtask_max_retries")

--- a/mars/services/scheduling/worker/service.py
+++ b/mars/services/scheduling/worker/service.py
@@ -31,6 +31,7 @@ class SchedulingWorkerService(AbstractService):
             "mem_quota_size": "80%",
             "mem_hard_limit": "95%",
             "enable_kill_slot": true,
+            "data_prepare_timeout": 600,
             "subtask_max_retries": 1
         }
     }
@@ -53,6 +54,7 @@ class SchedulingWorkerService(AbstractService):
         subtask_max_retries = scheduling_config.get(
             "subtask_max_retries", DEFAULT_SUBTASK_MAX_RETRIES
         )
+        data_prepare_timeout = scheduling_config.get("data_prepare_timeout", 600)
 
         await mo.create_actor(
             WorkerSlotManagerActor,
@@ -73,6 +75,7 @@ class SchedulingWorkerService(AbstractService):
             SubtaskExecutionActor,
             subtask_max_retries=subtask_max_retries,
             enable_kill_slot=enable_kill_slot,
+            data_prepare_timeout=data_prepare_timeout,
             uid=SubtaskExecutionActor.default_uid(),
             address=address,
         )

--- a/mars/services/subtask/core.py
+++ b/mars/services/subtask/core.py
@@ -50,6 +50,8 @@ class SubtaskStatus(Enum):
 
 
 class Subtask(Serializable):
+    __slots__ = ("_repr",)
+
     subtask_id: str = StringField("subtask_id")
     subtask_name: str = StringField("subtask_name")
     session_id: str = StringField("session_id")
@@ -108,11 +110,28 @@ class Subtask(Serializable):
             logic_parallelism=logic_parallelism,
             bands_specified=bands_specified,
         )
+        self._repr = None
 
     @property
     def expect_band(self):
         if self.expect_bands:
             return self.expect_bands[0]
+
+    def __repr__(self):
+        if self._repr is not None:
+            return self._repr
+
+        if self.chunk_graph:
+            result_chunk_repr = " ".join(
+                [
+                    f"{type(chunk.op).__name__}({chunk.key})"
+                    for chunk in self.chunk_graph.result_chunks
+                ]
+            )
+        else:  # pragma: no cover
+            result_chunk_repr = None
+        self._repr = f"<Subtask id={self.subtask_id} results=[{result_chunk_repr}]>"
+        return self._repr
 
 
 class SubtaskResult(Serializable):

--- a/mars/services/subtask/tests/test_service.py
+++ b/mars/services/subtask/tests/test_service.py
@@ -117,6 +117,7 @@ async def test_subtask_service(actor_pools):
     b = a + 1
 
     subtask = _gen_subtask(b, session_id)
+    assert "TensorAdd" in repr(subtask)
     await subtask_api.run_subtask_in_slot("numa-0", 0, subtask)
 
     # check storage

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -590,7 +590,7 @@ class SubtaskProcessorActor(mo.Actor):
         set_context(context)
 
     async def run(self, subtask: Subtask):
-        logger.info("Start to run subtask: %s on %s.", subtask.subtask_id, self.address)
+        logger.info("Start to run subtask: %r on %s.", subtask, self.address)
 
         assert subtask.session_id == self._session_id
 


### PR DESCRIPTION
## What do these changes do?

Add subtask details when handling in subtasks and workers. `repr(subtask)` will look like

```
<Subtask id=C2Yl0r1tAIAA1RIdwCfA5ANN results=[TensorAdd(e2e822e32d0931a0be7c1646fe873dde_0)]>
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
