### PR TITLE
[BACKPORT] Added support for `mars.learn.metrics.roc_auc_score` (#2832)

### DIFF
--- a/docs/source/reference/learn/reference.rst
+++ b/docs/source/reference/learn/reference.rst
@@ -138,6 +138,7 @@ Classification metrics
    metrics.precision_score
    metrics.precision_recall_fscore_support
    metrics.recall_score
+   metrics.roc_auc_score
    metrics.roc_curve
 
 Regression metrics

--- a/mars/learn/metrics/__init__.py
+++ b/mars/learn/metrics/__init__.py
@@ -23,6 +23,6 @@ from ._classification import (
     f1_score,
     fbeta_score,
 )
-from ._ranking import roc_curve, auc
+from ._ranking import roc_curve, auc, roc_auc_score
 from ._regresssion import r2_score
 from ._scorer import get_scorer

--- a/mars/learn/metrics/_base.py
+++ b/mars/learn/metrics/_base.py
@@ -1,0 +1,131 @@
+# Copyright 1999-2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from itertools import combinations
+
+from ... import tensor as mt
+from ..utils import check_array, check_consistent_length
+from ..utils.multiclass import type_of_target
+
+
+def _average_binary_score(
+    binary_metric,
+    y_true,
+    y_score,
+    average,
+    sample_weight=None,
+    session=None,
+    run_kwargs=None,
+):
+    average_options = (None, "micro", "macro", "weighted", "samples")
+    if average not in average_options:  # pragma: no cover
+        raise ValueError("average has to be one of {0}".format(average_options))
+
+    y_type = type_of_target(y_true).to_numpy(session=session, **(run_kwargs or dict()))
+    if y_type not in ("binary", "multilabel-indicator"):  # pragma: no cover
+        raise ValueError("{0} format is not supported".format(y_type))
+
+    if y_type == "binary":
+        return binary_metric(y_true, y_score, sample_weight=sample_weight)
+
+    check_consistent_length(
+        y_true, y_score, sample_weight, session=session, run_kwargs=run_kwargs
+    )
+    y_true = check_array(y_true)
+    y_score = check_array(y_score)
+
+    not_average_axis = 1
+    score_weight = sample_weight
+    average_weight = None
+
+    if average == "micro":
+        if score_weight is not None:  # pragma: no cover
+            score_weight = mt.repeat(score_weight, y_true.shape[1])
+        y_true = y_true.ravel()
+        y_score = y_score.ravel()
+
+    elif average == "weighted":
+        if score_weight is not None:  # pragma: no cover
+            average_weight = mt.sum(
+                mt.multiply(y_true, mt.reshape(score_weight, (-1, 1))), axis=0
+            )
+        else:
+            average_weight = mt.sum(y_true, axis=0)
+        if mt.isclose(average_weight.sum(), 0.0).to_numpy(
+            session=session, **(run_kwargs or dict())
+        ):
+            return 0
+
+    elif average == "samples":
+        # swap average_weight <-> score_weight
+        average_weight = score_weight
+        score_weight = None
+        not_average_axis = 0
+
+    if y_true.ndim == 1:
+        y_true = y_true.reshape((-1, 1))
+
+    if y_score.ndim == 1:
+        y_score = y_score.reshape((-1, 1))
+
+    n_classes = y_score.shape[not_average_axis]
+    score = mt.zeros((n_classes,))
+    for c in range(n_classes):
+        y_true_c = y_true.take([c], axis=not_average_axis).ravel()
+        y_score_c = y_score.take([c], axis=not_average_axis).ravel()
+        score[c] = binary_metric(y_true_c, y_score_c, sample_weight=score_weight)
+
+    # Average the results
+    if average is not None:
+        if average_weight is not None:
+            # Scores with 0 weights are forced to be 0, preventing the average
+            # score from being affected by 0-weighted NaN elements.
+            average_weight = mt.asarray(average_weight)
+            score[average_weight == 0] = 0
+        return mt.average(score, weights=average_weight)
+    else:
+        return score
+
+
+def _average_multiclass_ovo_score(
+    binary_metric, y_true, y_score, average="macro", session=None, run_kwargs=None
+):
+    check_consistent_length(y_true, y_score, session=session, run_kwargs=run_kwargs)
+
+    y_true_unique = mt.unique(y_true).to_numpy()
+    n_classes = y_true_unique.shape[0]
+    n_pairs = n_classes * (n_classes - 1) // 2
+    pair_scores = mt.empty(n_pairs)
+
+    is_weighted = average == "weighted"
+    prevalence = mt.empty(n_pairs) if is_weighted else None
+
+    # Compute scores treating a as positive class and b as negative class,
+    # then b as positive class and a as negative class
+    for ix, (a, b) in enumerate(combinations(y_true_unique, 2)):
+        a_mask = y_true == a
+        b_mask = y_true == b
+        ab_mask = mt.logical_or(a_mask, b_mask)
+
+        if is_weighted:
+            prevalence[ix] = mt.average(ab_mask)
+
+        a_true = a_mask[ab_mask]
+        b_true = b_mask[ab_mask]
+
+        a_true_score = binary_metric(a_true, y_score[ab_mask, a])
+        b_true_score = binary_metric(b_true, y_score[ab_mask, b])
+        pair_scores[ix] = (a_true_score + b_true_score) / 2
+
+    return mt.average(pair_scores, weights=prevalence)

--- a/mars/learn/preprocessing/_label.py
+++ b/mars/learn/preprocessing/_label.py
@@ -472,8 +472,15 @@ class LabelBinarize(LearnOperand, LearnOperandMixin):
             inputs.append(classes)
         self.sparse = self.sparse_output
         self.output_types = [OutputType.tensor]
+        if len(classes) == 2:
+            n_dim1 = 1
+        else:
+            n_dim1 = len(classes)
         return self.new_tileable(
-            inputs, shape=(np.nan,), dtype=np.dtype(int), order=TensorOrder.C_ORDER
+            inputs,
+            shape=(np.nan, n_dim1),
+            dtype=np.dtype(int),
+            order=TensorOrder.C_ORDER,
         )
 
     def _set_inputs(self, inputs):

--- a/mars/learn/utils/_encode.py
+++ b/mars/learn/utils/_encode.py
@@ -64,7 +64,7 @@ def _unique(values, *, return_inverse=False):
         lambda c, idx: c[: idx + 1],
         args=(nan_idx,),
         dtype=uniques.dtype,
-        shape=((np.nan,),) * uniques.ndim,
+        shape=(np.nan,) * uniques.ndim,
     )
     if return_inverse:
 

--- a/mars/learn/utils/multiclass.py
+++ b/mars/learn/utils/multiclass.py
@@ -184,6 +184,11 @@ class IsMultilabel(LearnOperand, LearnOperandMixin):
             inputs, shape=(), dtype=np.dtype(bool), order=TensorOrder.C_ORDER
         )
 
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        if self._inputs:
+            self.y = self._inputs[0]
+
     @classmethod
     def _tile(cls, op: "IsMultilabel"):
         y = op.y
@@ -275,6 +280,11 @@ class TypeOfTarget(LearnOperand, LearnOperandMixin):
         return self.new_tileable(
             inputs, shape=(), order=TensorOrder.C_ORDER, dtype=np.dtype(object)
         )
+
+    def _set_inputs(self, inputs):
+        super()._set_inputs(inputs)
+        if self._inputs:
+            self.y = self._inputs[0]
 
     @classmethod
     def _tile(cls, op: "TypeOfTarget"):

--- a/mars/services/lifecycle/supervisor/tracker.py
+++ b/mars/services/lifecycle/supervisor/tracker.py
@@ -170,7 +170,7 @@ class LifecycleTrackerActor(mo.Actor):
             incref_chunk_keys = self._tileable_key_to_chunk_keys[tileable_key]
             # incref chunks for this tileable
             logger.debug(
-                "Incref chunks %s while decrefing tileable %s",
+                "Incref chunks %s while increfing tileable %s",
                 incref_chunk_keys,
                 tileable_key,
             )

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -208,6 +208,7 @@ class TaskProcessor:
                     incref_chunk_keys.extend([key[0] for key in data_keys])
         result_chunks = stage_processor.chunk_graph.result_chunks
         incref_chunk_keys.extend([c.key for c in result_chunks])
+        logger.debug("Incref chunks %s for stage", incref_chunk_keys)
         await self._lifecycle_api.incref_chunks(incref_chunk_keys)
 
     @classmethod

--- a/mars/tensor/base/map_chunk.py
+++ b/mars/tensor/base/map_chunk.py
@@ -148,7 +148,7 @@ class TensorMapChunk(TensorOperand, TensorOperandMixin):
         nsplits = inp.nsplits[: out.ndim]
         if not op.elementwise:
             nsplits = tuple((np.nan,) * len(sp) for sp in nsplits)
-        return new_op.new_tileables([inp], chunks=chunks, nsplits=nsplits, **params)
+        return new_op.new_tileables(op.inputs, chunks=chunks, nsplits=nsplits, **params)
 
     @classmethod
     @redirect_custom_log


### PR DESCRIPTION
Backport of #2832