### PR TITLE
Fix store duplicate chunk and meta per subtask

### DIFF
--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -284,20 +284,20 @@ class SubtaskProcessor:
         ]
 
         # store data into storage
-        puts = []
-        stored_keys = []
+        data_key_to_puts = {}
         for result_chunk in result_chunks:
             data_key = result_chunk.key
             if data_key in self._datastore:
                 # non shuffle op
-                stored_keys.append(data_key)
                 result_data = self._datastore[data_key]
                 # update meta
                 if not isinstance(result_data, tuple):
                     result_chunk.params = result_chunk.get_params_from_data(result_data)
-
+                # check data_key after update meta
+                if data_key in data_key_to_puts:
+                    continue
                 put = self._storage_api.put.delay(data_key, result_data)
-                puts.append(put)
+                data_key_to_puts[data_key] = put
             else:
                 assert isinstance(result_chunk.op, MapReduceOperand)
                 keys = [
@@ -306,20 +306,22 @@ class SubtaskProcessor:
                     if isinstance(store_key, tuple) and store_key[0] == data_key
                 ]
                 for key in keys:
-                    stored_keys.append(key)
+                    if key in data_key_to_puts:
+                        continue
                     result_data = self._datastore[key]
                     put = self._storage_api.put.delay(key, result_data)
-                    puts.append(put)
+                    data_key_to_puts[key] = put
+        stored_keys = list(data_key_to_puts.keys())
         logger.debug(
-            "Start putting data keys: %s, " "subtask id: %s",
+            "Start putting data keys: %s, subtask id: %s",
             stored_keys,
             self.subtask.subtask_id,
         )
         data_key_to_store_size = dict()
         data_key_to_memory_size = dict()
         data_key_to_object_id = dict()
-        if puts:
-            put_infos = asyncio.create_task(self._storage_api.put.batch(*puts))
+        if data_key_to_puts:
+            put_infos = asyncio.create_task(self._storage_api.put.batch(*data_key_to_puts.values()))
             try:
                 store_infos = await put_infos
                 for store_key, store_info in zip(stored_keys, store_infos):
@@ -327,20 +329,20 @@ class SubtaskProcessor:
                     data_key_to_memory_size[store_key] = store_info.memory_size
                     data_key_to_object_id[store_key] = store_info.object_id
                 logger.debug(
-                    "Finish putting data keys: %s, " "subtask id: %s",
+                    "Finish putting data keys: %s, subtask id: %s",
                     stored_keys,
                     self.subtask.subtask_id,
                 )
             except asyncio.CancelledError:
                 logger.debug(
-                    "Cancelling put data keys: %s, " "subtask id: %s",
+                    "Cancelling put data keys: %s, subtask id: %s",
                     stored_keys,
                     self.subtask.subtask_id,
                 )
                 put_infos.cancel()
 
                 logger.debug(
-                    "Cancelled put data keys: %s, " "subtask id: %s",
+                    "Cancelled put data keys: %s, subtask id: %s",
                     stored_keys,
                     self.subtask.subtask_id,
                 )

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -312,6 +312,7 @@ class SubtaskProcessor:
                     put = self._storage_api.put.delay(key, result_data)
                     data_key_to_puts[key] = put
         stored_keys = list(data_key_to_puts.keys())
+        puts = data_key_to_puts.values()
         logger.debug(
             "Start putting data keys: %s, subtask id: %s",
             stored_keys,
@@ -320,10 +321,8 @@ class SubtaskProcessor:
         data_key_to_store_size = dict()
         data_key_to_memory_size = dict()
         data_key_to_object_id = dict()
-        if data_key_to_puts:
-            put_infos = asyncio.create_task(
-                self._storage_api.put.batch(*data_key_to_puts.values())
-            )
+        if puts:
+            put_infos = asyncio.create_task(self._storage_api.put.batch(*puts))
             try:
                 store_infos = await put_infos
                 for store_key, store_info in zip(stored_keys, store_infos):

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -321,7 +321,9 @@ class SubtaskProcessor:
         data_key_to_memory_size = dict()
         data_key_to_object_id = dict()
         if data_key_to_puts:
-            put_infos = asyncio.create_task(self._storage_api.put.batch(*data_key_to_puts.values()))
+            put_infos = asyncio.create_task(
+                self._storage_api.put.batch(*data_key_to_puts.values())
+            )
             try:
                 store_infos = await put_infos
                 for store_key, store_info in zip(stored_keys, store_infos):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

There are duplicated data puts (same data key multiple puts),

1.  among different subtasks. _`A & B > 0`_
2. in one subtask. _`len(A) > len(set(A))`_

Mars put duplicate data due to duplicated result chunks. This PR dedup the result chunks by chunk key before put, so the  `#2` can be fixed.

The example code,
```python
import numpy as np
import pandas as pd
import mars
import mars.dataframe as md

if __name__ == "__main__":
    with mars.new_session():
        s = np.random.RandomState(0)
        raw = pd.DataFrame(s.rand(100, 4), columns=list("abcd"))
        df = md.DataFrame(raw, chunk_size=1)

        r = df.describe().execute(extra_config={"enable_profiling": True})
        print(r)
```

This PR can reduce,

- Data put count from 3070 to 2532.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
