### PR TITLE
Raise ActorNotExist when no supervisors available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ test*.ipynb
 *.log
 *.swp
 
+# nfs temp file
+.nfs*
+
 # docs
 *.mo
 docs/**/generated

--- a/mars/services/cluster/api/oscar.py
+++ b/mars/services/cluster/api/oscar.py
@@ -114,6 +114,10 @@ class ClusterAPI(AbstractClusterAPI):
             references of the actors
         """
         addrs = await self.get_supervisors_by_keys(uids)
+        if any(addr is None for addr in addrs):
+            none_uid = next(uid for addr, uid in zip(addrs, uids) if addr is None)
+            raise mo.ActorNotExist(f"Actor {none_uid} not exist as no supervisors")
+
         return await asyncio.gather(
             *[mo.actor_ref(uid, address=addr) for addr, uid in zip(addrs, uids)]
         )
@@ -155,7 +159,7 @@ class ClusterAPI(AbstractClusterAPI):
         detail: bool = False,
         statuses: Set[NodeStatus] = None,
         exclude_statuses: Set[NodeStatus] = None,
-    ):
+    ) -> Dict[str, Dict]:
         statuses = self._calc_statuses(statuses, exclude_statuses)
         node_info_ref = await self._get_node_info_ref()
         return await node_info_ref.get_nodes_info(

--- a/mars/services/cluster/backends/fixed.py
+++ b/mars/services/cluster/backends/fixed.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import AsyncGenerator, List, Optional
+from typing import AsyncGenerator, List, Optional, Union
 
 from ..core import NodeRole
 from .base import AbstractClusterBackend, register_cluster_backend
@@ -22,8 +22,10 @@ from .base import AbstractClusterBackend, register_cluster_backend
 class FixedClusterBackend(AbstractClusterBackend):
     name = "fixed"
 
-    def __init__(self, lookup_address: str):
-        self._supervisors = [n.strip() for n in lookup_address.split(",")]
+    def __init__(self, lookup_address: Union[List[str], str]):
+        if isinstance(lookup_address, str):
+            lookup_address = lookup_address.split(",")
+        self._supervisors = [n.strip() for n in lookup_address]
 
     @classmethod
     async def create(

--- a/mars/services/cluster/locator.py
+++ b/mars/services/cluster/locator.py
@@ -79,7 +79,7 @@ class SupervisorLocatorActor(mo.Actor):
 
     @mo.extensible
     def get_supervisor(self, key: str, size=1):
-        if self._supervisors is None:  # pragma: no cover
+        if not self._supervisors:
             return None
         elif size == 1:
             return self._hash_ring.get_node(key)

--- a/mars/services/scheduling/worker/tests/test_execution.py
+++ b/mars/services/scheduling/worker/tests/test_execution.py
@@ -127,6 +127,7 @@ class MockGlobalResourceManagerActor(
     async def __pre_destroy__(self):
         pass
 
+    @mo.extensible
     async def update_subtask_resources(
         self, band, session_id: str, subtask_id: str, resources: Resource
     ):

--- a/mars/services/scheduling/worker/workerslot.py
+++ b/mars/services/scheduling/worker/workerslot.py
@@ -118,9 +118,7 @@ class BandSlotManagerActor(mo.Actor):
             )
             self._fresh_slots.add(slot_id)
 
-        self._usage_upload_task = self.ref().upload_slot_usages.tell_delay(
-            periodical=True, delay=1
-        )
+        self._upload_slot_usage_with_delay()
 
     async def __pre_destroy__(self):
         self._usage_upload_task.cancel()
@@ -131,9 +129,12 @@ class BandSlotManagerActor(mo.Actor):
 
         from ..supervisor import GlobalResourceManagerActor
 
-        [self._global_resource_ref] = await self._cluster_api.get_supervisor_refs(
-            [GlobalResourceManagerActor.default_uid()]
-        )
+        try:
+            [self._global_resource_ref] = await self._cluster_api.get_supervisor_refs(
+                [GlobalResourceManagerActor.default_uid()]
+            )
+        except mo.ActorNotExist:
+            self._global_resource_ref = None
         return self._global_resource_ref
 
     def get_slot_address(self, slot_id: int):
@@ -241,10 +242,21 @@ class BandSlotManagerActor(mo.Actor):
         self._restarting = False
         self._restart_done_event.set()
 
+    def _upload_slot_usage_with_delay(self, delay: int = 1):
+        self._usage_upload_task = self.ref().upload_slot_usages.tell_delay(
+            periodical=True, delay=delay
+        )
+
     async def upload_slot_usages(self, periodical: bool = False):
         delays = []
         slot_infos = []
         global_resource_ref = await self._get_global_resource_ref()
+
+        if global_resource_ref is None:  # pragma: no cover
+            if periodical:
+                self._upload_slot_usage_with_delay()
+            return
+
         for slot_id, proc in self._slot_to_proc.items():
             if slot_id not in self._slot_to_session_stid:
                 continue
@@ -291,9 +303,7 @@ class BandSlotManagerActor(mo.Actor):
             await self._cluster_api.set_band_slot_infos(self._band_name, slot_infos)
 
         if periodical:
-            self._usage_upload_task = self.ref().upload_slot_usages.tell_delay(
-                periodical=True, delay=1
-            )
+            self._upload_slot_usage_with_delay()
 
     def dump_data(self):
         """

--- a/mars/services/session/tests/test_service.py
+++ b/mars/services/session/tests/test_service.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import threading
+import time
 
 import pytest
 import numpy as np
@@ -99,7 +100,10 @@ async def test_get_last_idle_time():
             NodeRole.WORKER, config, address=worker_pool.external_address
         )
 
+        start_time = time.time()
         session_api = await SessionAPI.create(sv_pool.external_address)
+        assert await session_api.get_last_idle_time() < start_time
+
         session_id = "test_session"
         await session_api.create_session(session_id)
         # check last idle time is not None


### PR DESCRIPTION
## What do these changes do?

When no supervisors available, the API `ClusterAPI.get_supervisor_refs` should return None instead of raising ValueError.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2858

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
