### PR TITLE
Add stack display page on Mars Web

### DIFF
--- a/mars/oscar/__init__.py
+++ b/mars/oscar/__init__.py
@@ -29,6 +29,7 @@ from .api import (
     create_actor_pool,
     setup_cluster,
     wait_actor_pool_recovered,
+    get_pool_config,
 )
 from .backends import allocate_strategy
 from .backends.pool import MainActorPoolType

--- a/mars/oscar/api.py
+++ b/mars/oscar/api.py
@@ -65,6 +65,11 @@ async def wait_actor_pool_recovered(address: str, main_pool_address: str = None)
     return await ctx.wait_actor_pool_recovered(address, main_pool_address)
 
 
+async def get_pool_config(address: str):
+    ctx = get_context()
+    return await ctx.get_pool_config(address)
+
+
 def setup_cluster(address_to_resources: Dict[str, Dict[str, Number]]):
     scheme_to_address_resources = defaultdict(dict)
     for address, resources in address_to_resources.items():

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -223,3 +223,13 @@ class MarsActorContext(BaseActorContext):
             protocol=DEFAULT_PROTOCOL,
         )
         self._process_result_message(await self._call(main_address, control_message))
+
+    async def get_pool_config(self, address: str):
+        control_message = ControlMessage(
+            new_message_id(),
+            address,
+            ControlMessageType.get_config,
+            None,
+            protocol=DEFAULT_PROTOCOL,
+        )
+        return self._process_result_message(await self._call(address, control_message))

--- a/mars/oscar/backends/core.py
+++ b/mars/oscar/backends/core.py
@@ -24,7 +24,7 @@ from ...oscar.profiling import ProfilingData
 from ...utils import Timer
 
 
-result_message_type = Union[ResultMessage, ErrorMessage]
+ResultMessageType = Union[ResultMessage, ErrorMessage]
 
 
 class ActorCaller:

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -35,7 +35,7 @@ from .allocate_strategy import allocated_type, AddressSpecified
 from .communication import Channel, Server, get_server_type, gen_local_address
 from .communication.errors import ChannelClosed
 from .config import ActorPoolConfig
-from .core import result_message_type, ActorCaller
+from .core import ResultMessageType, ActorCaller
 from .message import (
     _MessageBase,
     new_message_id,
@@ -163,7 +163,7 @@ class AbstractActorPool(ABC):
         return self._router
 
     @abstractmethod
-    async def create_actor(self, message: CreateActorMessage) -> result_message_type:
+    async def create_actor(self, message: CreateActorMessage) -> ResultMessageType:
         """
         Create an actor.
 
@@ -195,7 +195,7 @@ class AbstractActorPool(ABC):
         """
 
     @abstractmethod
-    async def destroy_actor(self, message: DestroyActorMessage) -> result_message_type:
+    async def destroy_actor(self, message: DestroyActorMessage) -> ResultMessageType:
         """
         Destroy an actor.
 
@@ -211,7 +211,7 @@ class AbstractActorPool(ABC):
         """
 
     @abstractmethod
-    async def actor_ref(self, message: ActorRefMessage) -> result_message_type:
+    async def actor_ref(self, message: ActorRefMessage) -> ResultMessageType:
         """
         Get an actor's ref.
 
@@ -227,7 +227,7 @@ class AbstractActorPool(ABC):
         """
 
     @abstractmethod
-    async def send(self, message: SendMessage) -> result_message_type:
+    async def send(self, message: SendMessage) -> ResultMessageType:
         """
         Send a message to some actor.
 
@@ -243,7 +243,7 @@ class AbstractActorPool(ABC):
         """
 
     @abstractmethod
-    async def tell(self, message: TellMessage) -> result_message_type:
+    async def tell(self, message: TellMessage) -> ResultMessageType:
         """
         Tell message to some actor.
 
@@ -259,7 +259,7 @@ class AbstractActorPool(ABC):
         """
 
     @abstractmethod
-    async def cancel(self, message: CancelMessage) -> result_message_type:
+    async def cancel(self, message: CancelMessage) -> ResultMessageType:
         """
         Cancel message that sent
 
@@ -276,7 +276,7 @@ class AbstractActorPool(ABC):
 
     async def handle_control_command(
         self, message: ControlMessage
-    ) -> result_message_type:
+    ) -> ResultMessageType:
         """
         Handle control command.
 
@@ -354,9 +354,7 @@ class AbstractActorPool(ABC):
             if not self._stopped.is_set():
                 raise
 
-    async def call(
-        self, dest_address: str, message: _MessageBase
-    ) -> result_message_type:
+    async def call(self, dest_address: str, message: _MessageBase) -> ResultMessageType:
         return await self._caller.call(self._router, dest_address, message)
 
     @staticmethod
@@ -464,7 +462,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
     __slots__ = ()
 
     @implements(AbstractActorPool.create_actor)
-    async def create_actor(self, message: CreateActorMessage) -> result_message_type:
+    async def create_actor(self, message: CreateActorMessage) -> ResultMessageType:
         with _ErrorProcessor(
             self.external_address, message.message_id, message.protocol
         ) as processor:
@@ -497,7 +495,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
         return result
 
     @implements(AbstractActorPool.destroy_actor)
-    async def destroy_actor(self, message: DestroyActorMessage) -> result_message_type:
+    async def destroy_actor(self, message: DestroyActorMessage) -> ResultMessageType:
         with _ErrorProcessor(
             self.external_address, message.message_id, message.protocol
         ) as processor:
@@ -515,7 +513,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
         return processor.result
 
     @implements(AbstractActorPool.actor_ref)
-    async def actor_ref(self, message: ActorRefMessage) -> result_message_type:
+    async def actor_ref(self, message: ActorRefMessage) -> ResultMessageType:
         with _ErrorProcessor(
             self.external_address, message.message_id, message.protocol
         ) as processor:
@@ -531,7 +529,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
         return processor.result
 
     @implements(AbstractActorPool.send)
-    async def send(self, message: SendMessage) -> result_message_type:
+    async def send(self, message: SendMessage) -> ResultMessageType:
         with _ErrorProcessor(
             self.external_address, message.message_id, message.protocol
         ) as processor, record_message_trace(message):
@@ -549,7 +547,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
         return processor.result
 
     @implements(AbstractActorPool.tell)
-    async def tell(self, message: TellMessage) -> result_message_type:
+    async def tell(self, message: TellMessage) -> ResultMessageType:
         with _ErrorProcessor(
             self.external_address, message.message_id, message.protocol
         ) as processor:
@@ -569,7 +567,7 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
         return processor.result
 
     @implements(AbstractActorPool.cancel)
-    async def cancel(self, message: CancelMessage) -> result_message_type:
+    async def cancel(self, message: CancelMessage) -> ResultMessageType:
         with _ErrorProcessor(
             self.external_address, message.message_id, message.protocol
         ) as processor:
@@ -685,14 +683,14 @@ class SubActorPoolBase(ActorPoolBase):
         await self.call(self._main_address, reg_message)
 
     @implements(AbstractActorPool.create_actor)
-    async def create_actor(self, message: CreateActorMessage) -> result_message_type:
+    async def create_actor(self, message: CreateActorMessage) -> ResultMessageType:
         result = await super().create_actor(message)
         if not message.from_main:
             await self.notify_main_pool_to_create(message)
         return result
 
     @implements(AbstractActorPool.actor_ref)
-    async def actor_ref(self, message: ActorRefMessage) -> result_message_type:
+    async def actor_ref(self, message: ActorRefMessage) -> ResultMessageType:
         result = await super().actor_ref(message)
         if isinstance(result, ErrorMessage):
             message.actor_ref.address = self._main_address
@@ -700,7 +698,7 @@ class SubActorPoolBase(ActorPoolBase):
         return result
 
     @implements(AbstractActorPool.destroy_actor)
-    async def destroy_actor(self, message: DestroyActorMessage) -> result_message_type:
+    async def destroy_actor(self, message: DestroyActorMessage) -> ResultMessageType:
         result = await super().destroy_actor(message)
         if isinstance(result, ResultMessage) and not message.from_main:
             # sync back to main actor pool
@@ -785,7 +783,7 @@ class MainActorPoolBase(ActorPoolBase):
         return self.sub_processes
 
     @implements(AbstractActorPool.create_actor)
-    async def create_actor(self, message: CreateActorMessage) -> result_message_type:
+    async def create_actor(self, message: CreateActorMessage) -> ResultMessageType:
         with _ErrorProcessor(
             address=self.external_address,
             message_id=message.message_id,
@@ -850,7 +848,7 @@ class MainActorPoolBase(ActorPoolBase):
         return ResultMessage(message.message_id, False, protocol=message.protocol)
 
     @implements(AbstractActorPool.destroy_actor)
-    async def destroy_actor(self, message: DestroyActorMessage) -> result_message_type:
+    async def destroy_actor(self, message: DestroyActorMessage) -> ResultMessageType:
         actor_ref_message = ActorRefMessage(
             message.message_id, message.actor_ref, protocol=message.protocol
         )
@@ -875,7 +873,7 @@ class MainActorPoolBase(ActorPoolBase):
         return await self.call(real_actor_ref.address, new_destroy_message)
 
     @implements(AbstractActorPool.send)
-    async def send(self, message: SendMessage) -> result_message_type:
+    async def send(self, message: SendMessage) -> ResultMessageType:
         if message.actor_ref.uid in self._actors:
             return await super().send(message)
         actor_ref_message = ActorRefMessage(
@@ -895,7 +893,7 @@ class MainActorPoolBase(ActorPoolBase):
         return await self.call(actor_ref.address, new_send_message)
 
     @implements(AbstractActorPool.tell)
-    async def tell(self, message: TellMessage) -> result_message_type:
+    async def tell(self, message: TellMessage) -> ResultMessageType:
         if message.actor_ref.uid in self._actors:
             return await super().tell(message)
         actor_ref_message = ActorRefMessage(
@@ -915,7 +913,7 @@ class MainActorPoolBase(ActorPoolBase):
         return await self.call(actor_ref.address, new_tell_message)
 
     @implements(AbstractActorPool.actor_ref)
-    async def actor_ref(self, message: ActorRefMessage) -> result_message_type:
+    async def actor_ref(self, message: ActorRefMessage) -> ResultMessageType:
         actor_ref = message.actor_ref
         actor_ref.uid = to_binary(actor_ref.uid)
         if actor_ref.address == self.external_address and actor_ref.uid in self._actors:
@@ -939,7 +937,7 @@ class MainActorPoolBase(ActorPoolBase):
         return processor.result
 
     @implements(AbstractActorPool.cancel)
-    async def cancel(self, message: CancelMessage) -> result_message_type:
+    async def cancel(self, message: CancelMessage) -> ResultMessageType:
         if message.address == self.external_address:
             # local message
             return await super().cancel(message)
@@ -949,7 +947,7 @@ class MainActorPoolBase(ActorPoolBase):
     @implements(AbstractActorPool.handle_control_command)
     async def handle_control_command(
         self, message: ControlMessage
-    ) -> result_message_type:
+    ) -> ResultMessageType:
         with _ErrorProcessor(
             self.external_address, message.message_id, message.protocol
         ) as processor:

--- a/mars/oscar/context.pyx
+++ b/mars/oscar/context.pyx
@@ -146,6 +146,21 @@ cdef class BaseActorContext:
         """
         raise NotImplementedError
 
+    async def get_pool_config(self, str address):
+        """
+        Get config of actor pool with given address
+
+        Parameters
+        ----------
+        address
+            address of the actor pool
+
+        Returns
+        -------
+
+        """
+        raise NotImplementedError
+
 
 cdef class ClientActorContext(BaseActorContext):
     """
@@ -200,6 +215,10 @@ cdef class ClientActorContext(BaseActorContext):
     def wait_actor_pool_recovered(self, str address, str main_address = None):
         context = self._get_backend_context(address)
         return context.wait_actor_pool_recovered(address, main_address)
+
+    def get_pool_config(self, str address):
+        context = self._get_backend_context(address)
+        return context.get_pool_config(address)
 
 
 def register_backend_context(scheme, cls):

--- a/mars/services/cluster/api/core.py
+++ b/mars/services/cluster/api/core.py
@@ -148,3 +148,27 @@ class AbstractClusterAPI:
         version_list : list
             List of versions
         """
+
+    @abstractmethod
+    async def get_node_pool_configs(self, address: str) -> List[Dict]:
+        """
+        Get pool configs of a Mars node
+
+        Returns
+        -------
+        config_list : List[Dict]
+            List of configs for all pool processes
+        """
+
+    async def get_node_thread_stacks(self, address: str) -> List[Dict[int, List[str]]]:
+        """
+        Get current thread pool stacks of a Mars node
+
+        Parameters
+        ----------
+        address
+
+        Returns
+        -------
+
+        """

--- a/mars/services/cluster/api/oscar.py
+++ b/mars/services/cluster/api/oscar.py
@@ -289,14 +289,32 @@ class ClusterAPI(AbstractClusterAPI):
         )
         return node_allocator_ref
 
+    async def _get_process_info_manager_ref(self, address: str = None):
+        from ..procinfo import ProcessInfoManagerActor
+
+        return await mo.actor_ref(
+            ProcessInfoManagerActor.default_uid(), address=address or self._address
+        )
+
+    async def get_node_pool_configs(self, address: str = None) -> List[Dict]:
+        ref = await self._get_process_info_manager_ref(address)
+        return await ref.get_pool_configs()
+
+    async def get_node_thread_stacks(
+        self, address: str = None
+    ) -> List[Dict[int, List[str]]]:
+        ref = await self._get_process_info_manager_ref(address)
+        return await ref.get_thread_stacks()
+
 
 class MockClusterAPI(ClusterAPI):
     @classmethod
     async def create(cls: Type[APIType], address: str, **kw) -> APIType:
+        from ..procinfo import ProcessInfoManagerActor
         from ..supervisor.locator import SupervisorPeerLocatorActor
-        from ..uploader import NodeInfoUploaderActor
         from ..supervisor.node_allocator import NodeAllocatorActor
         from ..supervisor.node_info import NodeInfoCollectorActor
+        from ..uploader import NodeInfoUploaderActor
 
         dones, _ = await asyncio.wait(
             [
@@ -326,6 +344,11 @@ class MockClusterAPI(ClusterAPI):
                     band_to_slots=kw.get("band_to_slots"),
                     use_gpu=kw.get("use_gpu", False),
                     uid=NodeInfoUploaderActor.default_uid(),
+                    address=address,
+                ),
+                mo.create_actor(
+                    ProcessInfoManagerActor,
+                    uid=ProcessInfoManagerActor.default_uid(),
                     address=address,
                 ),
             ]

--- a/mars/services/cluster/api/web.py
+++ b/mars/services/cluster/api/web.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import time
 from typing import Callable, Dict, List, Optional, Set
 
 from ....lib.aio import alru_cache
@@ -137,6 +138,27 @@ class ClusterWebAPIHandler(MarsServiceWebAPIHandler):
     async def get_mars_versions(self):
         cluster_api = await self._get_cluster_api()
         self.write(json.dumps(list(await cluster_api.get_mars_versions())))
+
+    @web_api("pools", method="get")
+    async def get_node_pool_configs(self):
+        cluster_api = await self._get_cluster_api()
+        address = self.get_argument("address", "") or None
+        pools = list(await cluster_api.get_node_pool_configs(address))
+        self.write(json.dumps({"pools": pools}))
+
+    @web_api("stacks", method="get")
+    async def get_node_thread_stacks(self):
+        cluster_api = await self._get_cluster_api()
+        address = self.get_argument("address", "") or None
+        stacks = list(await cluster_api.get_node_thread_stacks(address))
+        self.write(
+            json.dumps(
+                {
+                    "generate_time": time.time(),
+                    "stacks": stacks,
+                }
+            )
+        )
 
 
 web_handlers = {ClusterWebAPIHandler.get_root_pattern(): ClusterWebAPIHandler}
@@ -300,3 +322,13 @@ class WebClusterAPI(AbstractClusterAPI, MarsWebAPIClientMixin):
         path = f"{self._address}/api/cluster/versions"
         res = await self._request_url("GET", path)
         return list(json.loads(res.body))
+
+    async def get_node_pool_configs(self, address: str) -> List[Dict]:
+        path = f"{self._address}/api/cluster/pools?address={address}"
+        res = await self._request_url("GET", path)
+        return list(json.loads(res.body)["pools"])
+
+    async def get_node_thread_stacks(self, address: str) -> List[Dict]:
+        path = f"{self._address}/api/cluster/stacks?address={address}"
+        res = await self._request_url("GET", path)
+        return list(json.loads(res.body)["stacks"])

--- a/mars/services/cluster/procinfo.py
+++ b/mars/services/cluster/procinfo.py
@@ -1,0 +1,95 @@
+# Copyright 1999-2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import sys
+import threading
+import traceback
+from typing import Dict, List
+
+from ... import oscar as mo
+from ...oscar.backends.allocate_strategy import ProcessIndex
+
+
+class ProcessInfoManagerActor(mo.StatelessActor):
+    _process_refs: List[mo.ActorRef]
+
+    def __init__(self):
+        self._process_refs = []
+        self._pool_configs = []
+
+    async def __post_create__(self):
+        index = 0
+        while True:
+            try:
+                ref = await mo.create_actor(
+                    ProcessInfoActor,
+                    process_index=index,
+                    uid=ProcessInfoActor.gen_uid(index),
+                    address=self.address,
+                    allocate_strategy=ProcessIndex(index),
+                )
+            except IndexError:
+                break
+
+            index += 1
+            self._process_refs.append(ref)
+
+        self._pool_configs = await asyncio.gather(
+            *[ref.get_pool_config() for ref in self._process_refs]
+        )
+
+    async def get_pool_configs(self) -> List[Dict]:
+        return self._pool_configs
+
+    async def get_thread_stacks(self) -> List[Dict[int, List[str]]]:
+        stack_tasks = [
+            asyncio.create_task(ref.get_thread_stacks()) for ref in self._process_refs
+        ]
+        await asyncio.wait(stack_tasks, return_when=asyncio.ALL_COMPLETED)
+
+        results = []
+        for fut in stack_tasks:
+            try:
+                results.append(fut.result())
+            except (mo.ActorNotExist, mo.ServerClosed):
+                results.append(None)
+        return results
+
+
+class ProcessInfoActor(mo.StatelessActor):
+    def __init__(self, process_index: int = 0):
+        self._process_index = process_index
+        self._pool_config = None
+
+    async def __post_create__(self):
+        self._pool_config = await mo.get_pool_config(self.address)
+
+    @classmethod
+    def gen_uid(cls, process_index: int):
+        return f"process_info_{process_index}"
+
+    def get_pool_config(self) -> dict:
+        idx = self._pool_config.get_process_index(self.address)
+        return self._pool_config.get_pool_config(idx)
+
+    @classmethod
+    def get_thread_stacks(cls) -> Dict[str, List[str]]:
+        frames = sys._current_frames()
+        stacks = dict()
+        for th in threading.enumerate():
+            tid = getattr(th, "native_id", th.ident)
+            stack_key = f"{tid}:{th.name}"
+            stacks[stack_key] = traceback.format_stack(frames[th.ident])
+        return stacks

--- a/mars/services/cluster/supervisor/service.py
+++ b/mars/services/cluster/supervisor/service.py
@@ -14,6 +14,7 @@
 
 from .... import oscar as mo
 from ...core import NodeRole, AbstractService
+from ..procinfo import ProcessInfoManagerActor
 from ..uploader import NodeInfoUploaderActor
 from .locator import SupervisorPeerLocatorActor
 from .node_allocator import NodeAllocatorActor
@@ -70,6 +71,11 @@ class ClusterSupervisorService(AbstractService):
             backend_name=backend,
             lookup_address=lookup_address,
             uid=NodeAllocatorActor.default_uid(),
+            address=address,
+        )
+        await mo.create_actor(
+            ProcessInfoManagerActor,
+            uid=ProcessInfoManagerActor.default_uid(),
             address=address,
         )
 

--- a/mars/services/cluster/tests/test_api.py
+++ b/mars/services/cluster/tests/test_api.py
@@ -114,14 +114,10 @@ async def test_web_api(actor_pool):
     assert await web_api.get_supervisors() == [pool_addr]
 
     assert len(await web_api.get_all_bands(statuses={NodeStatus.READY})) > 0
-    assert (
-        len(
-            await web_api.get_nodes_info(
-                role=NodeRole.WORKER, statuses={NodeStatus.READY}
-            )
-        )
-        > 0
+    nodes = await web_api.get_nodes_info(
+        role=NodeRole.WORKER, statuses={NodeStatus.READY}
     )
+    assert len(nodes) > 0
 
     from .... import __version__ as mars_version
 
@@ -135,6 +131,11 @@ async def test_web_api(actor_pool):
         )
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(wait_async_gen(web_api.watch_all_bands()), timeout=0.1)
+
+    proc_info = await web_api.get_node_pool_configs(pool_addr)
+    assert len(proc_info) > 0
+    stacks = await web_api.get_node_thread_stacks(pool_addr)
+    assert len(stacks) > 0
 
     await MockClusterAPI.cleanup(pool_addr)
 

--- a/mars/services/cluster/tests/test_procinfo.py
+++ b/mars/services/cluster/tests/test_procinfo.py
@@ -1,0 +1,43 @@
+# Copyright 1999-2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from .... import oscar as mo
+from ..procinfo import ProcessInfoManagerActor
+
+
+@pytest.fixture
+async def actor_pool():
+    pool = await mo.create_actor_pool(
+        "127.0.0.1", n_process=2, labels=["main", "numa-0", "gpu-0"]
+    )
+    await pool.start()
+    yield pool
+    await pool.stop()
+
+
+@pytest.mark.asyncio
+async def test_proc_info(actor_pool):
+    address = actor_pool.external_address
+    manager_ref = await mo.create_actor(
+        ProcessInfoManagerActor,
+        uid=ProcessInfoManagerActor.default_uid(),
+        address=address,
+    )  # type: ProcessInfoManagerActor | mo.ActorRef
+    pool_cfgs = await manager_ref.get_pool_configs()
+    for cfg, expect_label in zip(pool_cfgs, ["main", "numa-0", "gpu-0"]):
+        assert cfg["label"] == expect_label
+    stacks = await manager_ref.get_thread_stacks()
+    assert len(stacks) == len(pool_cfgs)

--- a/mars/services/cluster/worker/service.py
+++ b/mars/services/cluster/worker/service.py
@@ -14,6 +14,7 @@
 
 from .... import oscar as mo
 from ...core import NodeRole, AbstractService
+from ..procinfo import ProcessInfoManagerActor
 from ..uploader import NodeInfoUploaderActor
 from .locator import WorkerSupervisorLocatorActor
 
@@ -59,6 +60,11 @@ class ClusterWorkerService(AbstractService):
             interval=svc_config.get("node_check_interval"),
             band_to_slots=svc_config.get("resource"),
             uid=NodeInfoUploaderActor.default_uid(),
+            address=address,
+        )
+        await mo.create_actor(
+            ProcessInfoManagerActor,
+            uid=ProcessInfoManagerActor.default_uid(),
             address=address,
         )
 

--- a/mars/services/web/ui/package-lock.json
+++ b/mars/services/web/ui/package-lock.json
@@ -5619,7 +5619,8 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -11815,7 +11816,8 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",

--- a/mars/services/web/ui/src/node_info/NodeResourceTab.js
+++ b/mars/services/web/ui/src/node_info/NodeResourceTab.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2021 Alibaba Group Holding Ltd.
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,11 +161,6 @@ export default class NodeResourceTab extends React.Component {
   }
 
   render() {
-    if (!this.state.loaded) {
-      return (
-        <div>Loading</div>
-      );
-    }
     if (!this.state.loaded) {
       return (
         <div>Loading</div>

--- a/mars/services/web/ui/src/node_info/NodeStackTab.js
+++ b/mars/services/web/ui/src/node_info/NodeStackTab.js
@@ -1,0 +1,179 @@
+/*
+ * Copyright 1999-2021 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import join from 'lodash/join';
+import React from 'react';
+import MenuItem from '@material-ui/core/MenuItem';
+import InputLabel from '@material-ui/core/InputLabel';
+import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Select from '@material-ui/core/Select';
+import Switch from '@material-ui/core/Switch';
+import Typography from '@material-ui/core/Typography';
+import Paper from '@material-ui/core/Paper';
+import PropTypes from 'prop-types';
+import Title from '../Title';
+import {formatTime} from '../Utils';
+
+
+export default class NodeStackTab extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loaded: false,
+    };
+    this.interval = undefined;
+  }
+
+  componentDidMount() {
+    this.loadProcesses();
+    this.refreshStack();
+  }
+
+  loadProcesses() {
+    fetch(`api/cluster/pools?address=${this.props.endpoint}`)
+      .then((res) => res.json())
+      .then((res) => {
+        const pools = res.pools;
+        const {state} = this;
+        let poolToName = [];
+
+        for (let i = 0; i < pools.length; i++) {
+          let label = pools[i].label;
+          if (label)
+            poolToName.push(`${i}: ${pools[i].label}`);
+          else
+            poolToName.push(`${i}`);
+        }
+        state.loaded = true;
+        state.selectedIndex = 0;
+        state.pools = poolToName;
+        this.setState(state);
+      });
+  }
+
+  refreshStack() {
+    fetch(`api/cluster/stacks?address=${this.props.endpoint}`)
+      .then((res) => res.json())
+      .then((res) => {
+        const stacks = res.stacks;
+        const {state} = this;
+        let resultStacks = [];
+
+        for (let i = 0; i < stacks.length; i++) {
+          const inStacks = stacks[i];
+          let stackObj = {};
+          if (!inStacks) {
+            resultStacks.push(undefined);
+            continue;
+          }
+          Object.keys(inStacks).forEach((threadKey) => {
+            stackObj[threadKey] = join(inStacks[threadKey], '');
+          });
+          resultStacks.push(stackObj);
+        }
+        state.loaded = true;
+        state.generateTime = res.generate_time;
+        state.stacks = resultStacks;
+        this.setState(state);
+      });
+  }
+
+  renderStack() {
+    if (!this.state.stacks || !this.state.stacks[this.state.selectedIndex])
+      return <React.Fragment />;
+    const stacksObj = this.state.stacks[this.state.selectedIndex];
+    return (
+      <div>
+        <Title component="h3">Generate Time: {formatTime(this.state.generateTime)}</Title>
+        {Object.keys(stacksObj).map((threadKey) => (
+          <div key={`block-${threadKey}`}>
+            <Title component="h3">{threadKey}</Title>
+            <Paper style={{width: '100%', overflow: 'auto'}}>
+              <pre style={{fontSize: 'smaller'}}>{stacksObj[threadKey]}</pre>
+            </Paper>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  render() {
+    if (!this.state.loaded) {
+      return (
+        <div>Loading</div>
+      );
+    }
+
+    const onSelectProcess = (event) => {
+      const {state} = this;
+      console.log(event);
+      state.selectedIndex = parseInt(event.target.value);
+      this.setState(state);
+    };
+
+    const onRefreshChange = (event) => {
+      if (event.target.checked) {
+        this.interval = setInterval(() => this.refreshStack(), 5000);
+        this.refreshStack();
+      } else {
+        clearInterval(this.interval);
+      }
+    };
+
+    return (
+      <div>
+        <div style={{display: 'flex'}}>
+          <FormControl fullWidth>
+            <InputLabel id="process-index-select-label">Process</InputLabel>
+            <Select
+              labelId="process-index-select-label"
+              id="process-index-select"
+              label="Process"
+              style={{width: '100%'}}
+              value={`${this.state.selectedIndex}`}
+              onChange={onSelectProcess}
+            >
+              {this.state.pools.map((s, idx) => (
+                <MenuItem key={`item-${idx}`} value={idx}>{s}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl>
+            <FormControlLabel
+              style={{display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'flex-end',
+              }}
+              control={
+                <Switch onChange={onRefreshChange} />
+              }
+              label={<Typography style={{fontSize: 'smaller'}}>Refresh</Typography>}
+              labelPlacement="top"
+            />
+          </FormControl>
+        </div>
+        <div>
+          {this.renderStack()}
+        </div>
+      </div>
+    );
+  }
+}
+
+NodeStackTab.propTypes = {
+  endpoint: PropTypes.string,
+};

--- a/mars/services/web/ui/src/node_info/SupervisorDetailPage.js
+++ b/mars/services/web/ui/src/node_info/SupervisorDetailPage.js
@@ -25,6 +25,7 @@ import Title from '../Title';
 import { useStyles } from '../Style';
 import NodeEnvTab from './NodeEnvTab';
 import NodeResourceTab from './NodeResourceTab';
+import NodeStackTab from './NodeStackTab';
 
 
 export default function SupervisorDetailPage(props) {
@@ -46,12 +47,16 @@ export default function SupervisorDetailPage(props) {
           <Tabs value={value} onChange={handleChange}>
             <Tab label="Environment" />
             <Tab label="Resources" />
+            <Tab label="Stacks" />
           </Tabs>
           <TabPanel value={value} index={0}>
             <NodeEnvTab endpoint={props.endpoint} />
           </TabPanel>
           <TabPanel value={value} index={1}>
             <NodeResourceTab endpoint={props.endpoint} />
+          </TabPanel>
+          <TabPanel value={value} index={2}>
+            <NodeStackTab endpoint={props.endpoint} />
           </TabPanel>
         </Paper>
       </Grid>

--- a/mars/services/web/ui/src/node_info/WorkerDetailPage.js
+++ b/mars/services/web/ui/src/node_info/WorkerDetailPage.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2021 Alibaba Group Holding Ltd.
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import Title from '../Title';
 import { useStyles } from '../Style';
 import NodeEnvTab from './NodeEnvTab';
 import NodeResourceTab from './NodeResourceTab';
+import NodeStackTab from './NodeStackTab';
 
 
 export default function WorkerDetailPage(props) {
@@ -46,12 +47,16 @@ export default function WorkerDetailPage(props) {
           <Tabs value={value} onChange={handleChange}>
             <Tab label="Environment" />
             <Tab label="Resources" />
+            <Tab label="Stacks" />
           </Tabs>
           <TabPanel value={value} index={0}>
             <NodeEnvTab endpoint={props.endpoint} />
           </TabPanel>
           <TabPanel value={value} index={1}>
             <NodeResourceTab endpoint={props.endpoint} />
+          </TabPanel>
+          <TabPanel value={value} index={2}>
+            <NodeStackTab endpoint={props.endpoint} />
           </TabPanel>
         </Paper>
       </Grid>


### PR DESCRIPTION
## What do these changes do?

Add a web page to display stack for each process of Mars services. Also add required APIs. The page will look like

![未命名](https://user-images.githubusercontent.com/8284922/160225981-d432a6ae-e270-4f2c-9e19-d36dad52c220.jpg)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2875

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
