### PR TITLE
[Ray] Use main pool as owner when autoscale disabled

### DIFF
--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -550,17 +550,6 @@ class StorageManagerActor(mo.StatelessActor):
     ):
         backend = get_storage_backend(storage_backend)
         storage_config = storage_config or dict()
-
-        from ..cluster import ClusterAPI
-
-        if backend.name == "ray":
-            try:
-                cluster_api = await ClusterAPI.create(self.address)
-                supervisor_address = (await cluster_api.get_supervisors())[0]
-                # ray storage backend need to set supervisor as owner to avoid data lost when worker dies.
-                storage_config["owner"] = supervisor_address
-            except mo.ActorNotExist:
-                pass
         init_params, teardown_params = await backend.setup(**storage_config)
         client = backend(**init_params)
         self._init_params[band_name][storage_backend] = init_params


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Use worker main pool as owner when autoscale disabled to avoid too much assign rpc.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#2877 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
