### PR TITLE
Fix task hang when error object cannot be pickled

### DIFF
--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -402,4 +402,4 @@ cdef class Timer:
 
 
 __all__ = ['to_str', 'to_binary', 'to_text', 'TypeDispatcher', 'tokenize', 'tokenize_int',
-           'register_tokenizer', 'insert_reversed_tuple', 'ceildiv', 'Timer']
+           'register_tokenizer', 'ceildiv', 'Timer']

--- a/mars/core/graph/tests/test_graph.py
+++ b/mars/core/graph/tests/test_graph.py
@@ -110,13 +110,15 @@ def test_to_dot():
         graph_reprs = []
         for n in graph:
             graph_reprs.append(
-                f"{n.op.key} -> {[succ.op.key for succ in graph.successors(n)]}"
+                f"{n.op.key} -> {[succ.key for succ in graph.successors(n)]}"
             )
         logging.error(
-            "Unexpected error in test_to_dot.\ndot = %r\ngraph_repr: %r",
+            "Unexpected error in test_to_dot.\ndot = %r\ngraph_repr = %r",
             dot,
             "\n".join(graph_reprs),
         )
-        missing_prefix = next(str(n.key)[5] not in dot for n in graph)
-        logging.error("Missing prefix %s", missing_prefix)
+        missing_prefix = next(n.key for n in graph if str(n.key)[5] not in dot)
+        logging.error(
+            "Missing prefix %r (type: %s)", missing_prefix, type(missing_prefix)
+        )
         raise

--- a/mars/oscar/__init__.py
+++ b/mars/oscar/__init__.py
@@ -36,7 +36,13 @@ from .backends.pool import MainActorPoolType
 from .batch import extensible
 from .core import ActorRef
 from .debug import set_debug_options, get_debug_options, DebugOptions
-from .errors import ActorNotExist, ActorAlreadyExist, ServerClosed, Return
+from .errors import (
+    ActorNotExist,
+    ActorAlreadyExist,
+    ServerClosed,
+    SendMessageFailed,
+    Return,
+)
 from .utils import create_actor_ref
 
 # make sure methods are registered

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -29,7 +29,13 @@ from ...utils import lazy_import, register_asyncio_task_timeout_detector
 from ..api import Actor
 from ..core import ActorRef, register_local_pool
 from ..debug import record_message_trace, debug_async_timeout
-from ..errors import ActorAlreadyExist, ActorNotExist, ServerClosed, CannotCancelTask
+from ..errors import (
+    ActorAlreadyExist,
+    ActorNotExist,
+    ServerClosed,
+    CannotCancelTask,
+    SendMessageFailed,
+)
 from ..utils import create_actor_ref
 from .allocate_strategy import allocated_type, AddressSpecified
 from .communication import Channel, Server, get_server_type, gen_local_address
@@ -334,6 +340,33 @@ class AbstractActorPool(ABC):
         finally:
             self._process_messages.pop(message_id, None)
 
+    async def _send_channel(
+        self, result: _MessageBase, channel: Channel, resend_failure: bool = True
+    ):
+        try:
+            await channel.send(result)
+        except (ChannelClosed, ConnectionResetError):
+            if not self._stopped.is_set():
+                raise
+        except Exception as ex:
+            logger.exception(
+                "Error when sending message %s from %s to %s",
+                result.message_id.hex(),
+                channel.local_address,
+                channel.dest_address,
+            )
+            if not resend_failure:  # pragma: no cover
+                raise
+
+            with _ErrorProcessor(
+                self.external_address, result.message_id, result.protocol
+            ) as processor:
+                raise SendMessageFailed(
+                    f"Error when sending message {result.message_id.hex()}. "
+                    f"Caused by {ex!r}. See server logs for more details"
+                ) from None
+            await self._send_channel(processor.result, channel, resend_failure=False)
+
     async def process_message(self, message: _MessageBase, channel: Channel):
         handler = self._message_handler[message.message_type]
         with _ErrorProcessor(
@@ -349,11 +382,8 @@ class AbstractActorPool(ABC):
                 processor.result = await self._run_coro(
                     message.message_id, handler(self, message)
                 )
-        try:
-            await channel.send(processor.result)
-        except (ChannelClosed, ConnectionResetError):
-            if not self._stopped.is_set():
-                raise
+
+        await self._send_channel(processor.result, channel)
 
     async def call(self, dest_address: str, message: _MessageBase) -> ResultMessageType:
         return await self._caller.call(self._router, dest_address, message)

--- a/mars/oscar/errors.py
+++ b/mars/oscar/errors.py
@@ -53,6 +53,10 @@ class CannotCancelTask(MarsError):
     pass
 
 
+class SendMessageFailed(MarsError):
+    pass
+
+
 class Return(MarsError):
     def __init__(self, value):
         self.value = value


### PR DESCRIPTION
## What do these changes do?

Fix task hang when error object cannot be pickled.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #1959

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
