### PR TITLE
Fix paramter issue of worker actor pool

### DIFF
--- a/mars/deploy/oscar/ray.py
+++ b/mars/deploy/oscar/ray.py
@@ -528,6 +528,7 @@ class RayCluster:
                     modules=get_third_party_modules_from_config(
                         self._config, NodeRole.WORKER
                     ),
+                    metrics=self._config.get("metrics", {}),
                 )
             )
             for addr in worker_addresses

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -674,6 +674,7 @@ def test_init_metrics_on_ray(ray_start_regular, create_cluster):
     assert client.session
     from ....metrics import api
 
+    assert client._cluster._config.get("metrics", {}).get("backend") == "ray"
     assert api._metric_backend == "ray"
 
     client.session.stop_server()


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
There is  no `metrics` parameter passed in `create_worker_actor_pool` of `mars/deploy/oscar/ray.py` which leads to metrics backend not work in worker pool.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
