### PR TITLE
Optimize serialization of serializable

### DIFF
--- a/asv_bench/benchmarks/serialize.py
+++ b/asv_bench/benchmarks/serialize.py
@@ -30,6 +30,8 @@ from mars.serialization.serializables import (
 
 
 class SerializableChild(Serializable):
+    _cache_serialize = False
+
     str_field = StringField("str_field")
     int_field = Int64Field("int_field")
     float_field = Float64Field("float_field")
@@ -42,6 +44,8 @@ class SerializableChild(Serializable):
 
 
 class SerializableParent(Serializable):
+    _cache_serialize = False
+
     children = ListField("children", field_type=FieldTypes.reference)
 
 

--- a/mars/core/entity/core.py
+++ b/mars/core/entity/core.py
@@ -23,7 +23,7 @@ from ..base import Base
 
 
 class EntityData(Base):
-    __slots__ = "__weakref__", "_siblings"
+    __slots__ = ("_siblings",)
     type_name = None
 
     # required fields

--- a/mars/core/entity/tileables.py
+++ b/mars/core/entity/tileables.py
@@ -345,7 +345,7 @@ class TileableData(EntityData, _ExecutableMixin):
 
 
 class Tileable(Entity):
-    __slots__ = ("__weakref__",)
+    __slots__ = ()
 
     def __init__(self, data: TileableType = None, **kw):
         super().__init__(data=data, **kw)

--- a/mars/core/operand/base.py
+++ b/mars/core/operand/base.py
@@ -161,7 +161,7 @@ class Operand(Base, OperatorLogicKeyGeneratorMixin, metaclass=OperandMetaclass):
     which should be the :class:`mars.tensor.core.TensorData`, :class:`mars.tensor.core.ChunkData` etc.
     """
 
-    __slots__ = ("__weakref__",)
+    __slots__ = ()
     attr_tag = "attr"
     _init_update_key_ = False
     _output_type_ = None
@@ -328,10 +328,11 @@ class OperandSerializer(SerializableSerializer):
     serializer_name = "operand"
 
     @classmethod
-    def _get_tag_to_values(cls, obj: Operand):
-        tag_to_values = super()._get_tag_to_values(obj)
+    def _get_tag_to_field_values(cls, obj: Operand):
+        tag_to_values = super()._get_tag_to_field_values(obj)
         # outputs are weak-refs which are not pickle-able
-        tag_to_values["outputs"] = [out_ref() for out_ref in tag_to_values["outputs"]]
+        field, outputs = tag_to_values["outputs"]
+        tag_to_values["outputs"] = field, [out_ref() for out_ref in outputs]
         return tag_to_values
 
     def deserialize(self, header: Dict, buffers: List, context: Dict) -> Operand:

--- a/mars/serialization/serializables/core.py
+++ b/mars/serialization/serializables/core.py
@@ -158,9 +158,14 @@ class SerializableSerializer(Serializer):
         value_sizes = []
         value_buffers = []
         pickle_obj = cached_pickle_obj = None
+        need_cache = type(obj)._cache_serialize
         try:
             cached_pickle_obj = SerializableSerializer._cached[obj]
             is_cached = True
+        except TypeError:
+            pickle_obj = _PickleObj()
+            is_cached = False
+            need_cache = False
         except KeyError:
             pickle_obj = _PickleObj()
             is_cached = False
@@ -177,7 +182,7 @@ class SerializableSerializer(Serializer):
                 value_buffers.extend(val_buf)
         if not is_cached:
             pickled_header, pickled = yield pickle_obj
-            if type(obj)._cache_serialize:
+            if need_cache:
                 SerializableSerializer._cached[obj] = (pickled_header, pickled)
         else:
             pickled_header, pickled = cached_pickle_obj

--- a/mars/serialization/serializables/field_type.py
+++ b/mars/serialization/serializables/field_type.py
@@ -194,7 +194,7 @@ class KeyType(SingletonFieldType):
 
     @property
     def type_name(self) -> str:
-        return "dtype"
+        return "key"
 
     @property
     def valid_types(self) -> Tuple[Type, ...]:
@@ -353,6 +353,10 @@ class _CollectionType(AbstractFieldType, metaclass=ABCMeta):
         self._field_types = field_types
         if len(field_types) == 0:
             self._field_types = (AnyType(), Ellipsis)
+
+    @property
+    def element_types(self):
+        return self._field_types
 
     @property
     def name(self) -> str:

--- a/mars/services/subtask/core.py
+++ b/mars/services/subtask/core.py
@@ -154,6 +154,8 @@ class Subtask(Serializable):
 
 
 class SubtaskResult(Serializable):
+    _cache_serialize = False
+
     subtask_id: str = StringField("subtask_id")
     session_id: str = StringField("session_id")
     task_id: str = StringField("task_id")

--- a/mars/services/task/core.py
+++ b/mars/services/task/core.py
@@ -70,6 +70,8 @@ class Task(Serializable):
 
 
 class TaskResult(Serializable):
+    _cache_serialize = False
+
     task_id: str = StringField("task_id")
     session_id: str = StringField("session_id")
     stage_id: str = StringField("stage_id")


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR tried to optimize serialization of serializable via

1. Use cloudpickle to pickle values of primitive types of collections full of primitive types.
2. Try to cache above pickled data.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
