### PR TITLE
Skip adding band in meta when fetch shuffle data

### DIFF
--- a/mars/services/scheduling/worker/execution.py
+++ b/mars/services/scheduling/worker/execution.py
@@ -189,7 +189,11 @@ class SubtaskExecutionActor(mo.StatelessActor):
         if shuffle_queries:
             # TODO(hks): The batch method doesn't accept different error arguments,
             #  combine them when it can.
-            await storage_api.fetch.batch(*shuffle_queries)
+
+            # shuffle data fetch from remote won't be recorded in meta,
+            # thus they are not tracked by lifecycle service,
+            # here return remote mapper keys to remove them later.
+            return await storage_api.fetch.batch(*shuffle_queries)
 
     async def _collect_input_sizes(
         self, subtask: Subtask, supervisor_address: str, band_name: str
@@ -336,7 +340,7 @@ class SubtaskExecutionActor(mo.StatelessActor):
                     subtask, subtask_info, self._prepare_input_data, subtask, band_name
                 )
             )
-            await asyncio.wait_for(
+            remote_mapper_keys = await asyncio.wait_for(
                 prepare_data_task, timeout=self._data_prepare_timeout
             )
 
@@ -353,6 +357,16 @@ class SubtaskExecutionActor(mo.StatelessActor):
             subtask_info.result = await self._retry_run_subtask(
                 subtask, band_name, subtask_api, batch_quota_req
             )
+            if remote_mapper_keys:
+                storage_api = await StorageAPI.create(
+                    subtask.session_id, address=self.address, band_name=band_name
+                )
+                await storage_api.delete.batch(
+                    *[
+                        storage_api.delete.delay(key, error="ignore")
+                        for key in remote_mapper_keys
+                    ]
+                )
         except:  # noqa: E722  # pylint: disable=bare-except
             _fill_subtask_result_with_exception(subtask, subtask_info)
         finally:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Skip adding band in meta when fetch shuffle data as shuffle produce fragmented data.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
