### PR TITLE
Stop including `dtypes` etc in chunk graph of subtasks to reduce serialization

### DIFF
--- a/mars/services/subtask/worker/tests/subtask_processor.py
+++ b/mars/services/subtask/worker/tests/subtask_processor.py
@@ -64,6 +64,7 @@ class CheckedSubtaskProcessor(ObjectCheckMixin, SubtaskProcessor):
             check_options[key] = kwargs.get(key, True)
         self._check_options = check_options
         self._check_keys = kwargs.get("check_keys")
+        self._chunk_to_params = self.subtask.extra_config["chunk_params"]
         self._storage_api = CheckStorageAPI(self._storage_api)
 
     def _execute_operand(self, ctx: Dict[str, Any], op: OperandType):
@@ -79,6 +80,8 @@ class CheckedSubtaskProcessor(ObjectCheckMixin, SubtaskProcessor):
                 ):
                     # both shuffle mapper and reducer
                     continue
+                # set back params for test
+                out.params = self._chunk_to_params[out]
                 self.assert_object_consistent(out, ctx[out.key])
 
     async def done(self):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR tries to skip including `dtypes` etc in chunk graph of subtasks to reduce serialization.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#2791 .

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
