### PR TITLE
Ignore fetch operands when assign initial nodes

### DIFF
--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -52,6 +52,7 @@ jobs:
           asv check -E existing
           git remote add upstream https://github.com/mars-project/mars.git
           git fetch upstream
+          git merge upstream/master
           asv machine --yes
           asv continuous -f 1.1 --strict upstream/master HEAD
         if: ${{ steps.build.outcome == 'success' }}

--- a/docs/source/reference/tensor/special.rst
+++ b/docs/source/reference/tensor/special.rst
@@ -45,6 +45,18 @@ Error function
    mars.tensor.special.erf
 
 
+Ellipsoidal harmonics
+---------------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   mars.tensor.special.ellip_harm
+   mars.tensor.special.ellip_harm_2
+   mars.tensor.special.ellip_normal
+
+
 Gamma and related functions
 ---------------------------
 

--- a/mars/services/task/analyzer/analyzer.py
+++ b/mars/services/task/analyzer/analyzer.py
@@ -144,8 +144,6 @@ class GraphAnalyzer:
         bands_specified = None
         processed = set()
         for chunk in chunks:
-            if isinstance(chunk.op, Fetch):
-                continue
             if chunk in processed:
                 continue
             if expect_worker is None:

--- a/mars/services/task/analyzer/tests/test_assigner.py
+++ b/mars/services/task/analyzer/tests/test_assigner.py
@@ -1,0 +1,73 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from .....config import Config
+from .....core import ChunkGraph
+from .....tensor.random import TensorRand
+from .....tensor.arithmetic import TensorAdd
+from .....tensor.fetch import TensorFetch
+from .....resource import Resource
+from ...core import Task
+from ..analyzer import GraphAnalyzer
+from ..assigner import GraphAssigner
+
+
+def test_assigner_with_fetch_inputs():
+    band_num = 8
+    all_bands = [(f"address_{i}", "numa-0") for i in range(band_num)]
+    inputs = [
+        TensorFetch(key=str(i), source_key=str(i), dtype=np.dtype(int)).new_chunk([])
+        for i in range(band_num)
+    ]
+    no_fetch_inputs = [TensorRand(i).new_chunk([]) for i in range(4)]
+    results = [TensorAdd(lhs=inp, rhs=1).new_chunk([inp]) for inp in inputs]
+    cur_assigns = dict(
+        (fetch_chunk.op.key, band[0][0])
+        for fetch_chunk, band in zip(reversed(inputs), all_bands)
+    )
+
+    chunk_graph = ChunkGraph()
+    for fetch_chunk, add_chunk in zip(inputs, results):
+        chunk_graph.add_node(fetch_chunk)
+        chunk_graph.add_node(add_chunk)
+        chunk_graph.add_edge(fetch_chunk, add_chunk)
+    for inp in no_fetch_inputs:
+        results.append(inp)
+        chunk_graph.add_node(inp)
+    chunk_graph.results = results
+
+    band_resource = dict((band, Resource(num_cpus=1)) for band in all_bands)
+
+    task = Task("mock_task", "mock_session")
+    analyzer = GraphAnalyzer(chunk_graph, band_resource, task, Config())
+    subtask_graph = analyzer.gen_subtask_graph(cur_assigns)
+
+    assigner = GraphAssigner(
+        chunk_graph, list(GraphAnalyzer._iter_start_ops(chunk_graph)), band_resource
+    )
+    assigns = assigner.assign(cur_assigns)
+    key_to_assign = dict((c.key, band) for c, band in assigns.items())
+    for subtask in subtask_graph:
+        input_chunks = list(subtask.chunk_graph.iter_indep())
+        if all(isinstance(inp.op, TensorFetch) for inp in input_chunks):
+            # all inputs are fetch, expect band should be None
+            assert subtask.expect_band is None
+        else:
+            # if subtask has truly initial chunks, expect band should be
+            # same as assign results
+            for inp in input_chunks:
+                if not isinstance(inp.op, TensorFetch):
+                    assert subtask.expect_band == key_to_assign[inp.key]

--- a/mars/services/task/api/web.py
+++ b/mars/services/task/api/web.py
@@ -248,8 +248,8 @@ class WebTaskAPI(AbstractTaskAPI, MarsWebAPIClientMixin):
     async def wait_task(self, task_id: str, timeout: float = None):
         path = f"{self._address}/api/session/{self._session_id}/task/{task_id}"
         # increase client timeout to handle network overhead during entire request
-        client_timeout = timeout + 5 if timeout else 0
-        params = {"action": "wait", "timeout": timeout}
+        client_timeout = timeout + 3 if timeout else 0
+        params = {"action": "wait", "timeout": "" if timeout is None else str(timeout)}
         res = await self._request_url(
             "GET", path, params=params, request_timeout=client_timeout
         )

--- a/mars/services/task/api/web.py
+++ b/mars/services/task/api/web.py
@@ -247,11 +247,11 @@ class WebTaskAPI(AbstractTaskAPI, MarsWebAPIClientMixin):
 
     async def wait_task(self, task_id: str, timeout: float = None):
         path = f"{self._address}/api/session/{self._session_id}/task/{task_id}"
-        # client timeout should be longer than server timeout.
-        server_timeout = "" if timeout is None else str(max(timeout / 2.0, timeout - 1))
-        params = {"action": "wait", "timeout": server_timeout}
+        # increase client timeout to handle network overhead during entire request
+        client_timeout = timeout + 5 if timeout else 0
+        params = {"action": "wait", "timeout": timeout}
         res = await self._request_url(
-            "GET", path, params=params, request_timeout=timeout or 0
+            "GET", path, params=params, request_timeout=client_timeout
         )
         return _json_deserial_task_result(json.loads(res.body.decode()))
 

--- a/mars/services/task/execution/api.py
+++ b/mars/services/task/execution/api.py
@@ -68,10 +68,6 @@ class TaskExecutor(ABC):
         """Get available band slots."""
 
     @abstractmethod
-    async def get_chunk_bands(self, chunk_keys: List[str]) -> Dict[str, BandType]:
-        """Get bands that store these chunks"""
-
-    @abstractmethod
     async def get_progress(self) -> float:
         """Get the execution progress."""
 

--- a/mars/services/task/execution/api.py
+++ b/mars/services/task/execution/api.py
@@ -16,14 +16,14 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Dict, Any, Type
 
-from ....core import ChunkGraph
+from ....core import ChunkGraph, Chunk
 from ....typing import BandType
 from ...subtask import SubtaskGraph, SubtaskResult
 
 
 @dataclass
 class ExecutionChunkResult:
-    key: str  # The chunk key for fetching the result.
+    chunk: Chunk  # The chunk key for fetching the result.
     meta: Dict  # The chunk meta for iterative tiling.
     context: Any  # The context info, e.g. ray.ObjectRef.
 

--- a/mars/services/task/execution/api.py
+++ b/mars/services/task/execution/api.py
@@ -68,6 +68,10 @@ class TaskExecutor(ABC):
         """Get available band slots."""
 
     @abstractmethod
+    async def get_chunk_bands(self, chunk_keys: List[str]) -> Dict[str, BandType]:
+        """Get bands that store these chunks"""
+
+    @abstractmethod
     async def get_progress(self) -> float:
         """Get the execution progress."""
 

--- a/mars/services/task/execution/mars/executor.py
+++ b/mars/services/task/execution/mars/executor.py
@@ -174,16 +174,6 @@ class MarsTaskExecutor(TaskExecutor):
             if bands:
                 return bands
 
-    async def get_chunk_bands(self, chunk_keys: List[str]) -> Dict[str, BandType]:
-        tasks = [
-            self._meta_api.get_chunk_meta.delay(key, fields=["bands"])
-            for key in chunk_keys
-        ]
-        key_to_bands = await self._meta_api.get_chunk_meta.batch(*tasks)
-        return dict(
-            (key, meta["bands"][0]) for key, meta in zip(chunk_keys, key_to_bands)
-        )
-
     async def get_progress(self) -> float:
         # get progress of stages
         subtask_progress = 0.0

--- a/mars/services/task/execution/mars/stage.py
+++ b/mars/services/task/execution/mars/stage.py
@@ -118,7 +118,7 @@ class TaskStageProcessor:
         metas = await self._meta_api.get_chunk_meta.batch(*get_meta)
         for chunk, meta in zip(chunks, metas):
             execution_chunk_results.append(
-                ExecutionChunkResult(key=chunk.key, meta=meta, context=None)
+                ExecutionChunkResult(chunk=chunk, meta=meta, context=None)
             )
         return execution_chunk_results
 

--- a/mars/services/task/supervisor/preprocessor.py
+++ b/mars/services/task/supervisor/preprocessor.py
@@ -206,13 +206,14 @@ class TaskPreprocessor:
         chunk_graph: ChunkGraph,
         available_bands: Dict[BandType, Resource],
         stage_id: str = None,
+        op_to_bands: Dict[str, BandType] = None,
     ) -> SubtaskGraph:
         logger.debug("Start to gen subtask graph for task %s", self._task.task_id)
         task = self._task
         analyzer = GraphAnalyzer(
             chunk_graph, available_bands, task, self._config, stage_id=stage_id
         )
-        graph = analyzer.gen_subtask_graph()
+        graph = analyzer.gen_subtask_graph(op_to_bands)
         logger.debug(
             "Generated subtask graph of %s subtasks for task %s",
             len(graph),

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -253,8 +253,8 @@ class TaskProcessor:
     ):
         result_chunks = [c for c in chunk_graph.results if not isinstance(c.op, Fetch)]
         chunk_to_band = {
-            c: r.meta["bands"][0][0]
-            for c, r in zip(result_chunks, execution_chunk_results)
+            result.chunk: result.meta["bands"][0][0]
+            for result in execution_chunk_results
         }
         update_meta_chunks = set(result_chunks)
         update_meta_tileables = dict()

--- a/mars/services/task/supervisor/tests/task_preprocessor.py
+++ b/mars/services/task/supervisor/tests/task_preprocessor.py
@@ -142,6 +142,7 @@ class CheckedTaskPreprocessor(ObjectCheckMixin, TaskPreprocessor):
         chunk_graph: ChunkGraph,
         available_bands: Dict[BandType, Resource],
         stage_id: str,
+        op_to_bands: Dict[str, BandType] = None,
     ) -> SubtaskGraph:
         # record shapes generated in tile
         for n in chunk_graph:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
When trigger iterative tiling, subtask's graph may has fetch operand, and we treat them as initial nodes and assign them in `GraphAnalyzer`, it will result in losing locality and bad performance. This PR try to solve this issue by ignoring fetch chunks when assign chunk graph.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
