### PR TITLE
Fix default config to ensure storage backends configured

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -269,6 +269,7 @@ MIT License
 - dagre-d3:0.6.4
 - cytoscape:3.19.1
 - cytoscape-dagre:2.3.2
+- tqdm:4.60.0
 
 
 ISC License

--- a/mars/config.yml
+++ b/mars/config.yml
@@ -1,1 +1,1 @@
-"@inherits": "@mars/deploy/oscar/base_config.yml"
+"@inherits": "@mars/deploy/oscar/config.yml"

--- a/mars/deploy/oscar/cmdline.py
+++ b/mars/deploy/oscar/cmdline.py
@@ -26,20 +26,12 @@ from typing import List
 
 import psutil
 
+from ...utils import ensure_coverage
 from ..utils import load_service_config_file, get_third_party_modules_from_config
 
 logger = logging.getLogger(__name__)
-
 _is_windows: bool = sys.platform.startswith("win")
-
-# make sure coverage is handled when starting with subprocess.Popen
-if not _is_windows and "COV_CORE_SOURCE" in os.environ:  # pragma: no cover
-    try:
-        from pytest_cov.embed import cleanup_on_sigterm
-    except ImportError:
-        pass
-    else:
-        cleanup_on_sigterm()
+ensure_coverage()
 
 
 class OscarCommandRunner:

--- a/mars/deploy/oscar/supervisor.py
+++ b/mars/deploy/oscar/supervisor.py
@@ -12,13 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 
+from ... import oscar as mo
 from ...services import NodeRole
 from ...utils import get_next_port
 from .cmdline import OscarCommandRunner
 from .local import start_supervisor, stop_supervisor
 from .pool import create_supervisor_actor_pool
+
+
+logger = logging.getLogger(__name__)
 
 
 class SupervisorCommandRunner(OscarCommandRunner):
@@ -47,6 +52,7 @@ class SupervisorCommandRunner(OscarCommandRunner):
 
         web_config = self.config.get("web", {})
         if args.web_port is not None:
+            web_config["host"] = args.endpoint.split(":", 1)[0]
             web_config["port"] = int(args.web_port)
         self.config["web"] = web_config
 
@@ -64,11 +70,25 @@ class SupervisorCommandRunner(OscarCommandRunner):
         )
 
     async def start_services(self):
-        return await start_supervisor(
+        start_web = await start_supervisor(
             self.pool.external_address,
             self.args.supervisors,
             self.args.load_modules,
             self.config,
+        )
+        if start_web:
+            from ...services.web.supervisor import WebActor
+
+            web_actor = await mo.actor_ref(
+                WebActor.default_uid(), address=self.pool.external_address
+            )
+            web_address = await web_actor.get_web_address()
+        else:  # pragma: no cover
+            web_address = "<web not started>"
+        logger.warning(
+            "Supervisor started at %s, web address: %s",
+            self.pool.external_address,
+            web_address,
         )
 
     async def stop_services(self):

--- a/mars/oscar/backends/mars/pool.py
+++ b/mars/oscar/backends/mars/pool.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from types import TracebackType
 from typing import List
 
-from ....utils import get_next_port, dataslots
+from ....utils import get_next_port, dataslots, ensure_coverage
 from ..config import ActorPoolConfig
 from ..message import CreateActorMessage
 from ..pool import MainActorPoolBase, SubActorPoolBase, _register_message_handler
@@ -162,15 +162,7 @@ class MainActorPool(MainActorPoolBase):
         process_index: int,
         status_queue: multiprocessing.Queue,
     ):
-        if not _is_windows:
-            try:
-                # register coverage hooks on SIGTERM
-                from pytest_cov.embed import cleanup_on_sigterm
-
-                if "COV_CORE_SOURCE" in os.environ:  # pragma: no branch
-                    cleanup_on_sigterm()
-            except ImportError:  # pragma: no cover
-                pass
+        ensure_coverage()
 
         conf = actor_config.get_pool_config(process_index)
         suspend_sigint = conf["suspend_sigint"]

--- a/mars/oscar/backends/ray/tests/test_communication.py
+++ b/mars/oscar/backends/ray/tests/test_communication.py
@@ -14,32 +14,21 @@
 
 import asyncio
 import inspect
-import os
-import sys
 
 import pytest
 
 from .....tests.core import require_ray
-from .....utils import lazy_import
+from .....utils import ensure_coverage, lazy_import
 from ....errors import ServerClosed
 from ...communication.base import ChannelType
 from ..communication import ChannelID, Channel, RayServer, RayClient
 
 ray = lazy_import("ray")
-_is_windows: bool = sys.platform.startswith("win")
 
 
 class ServerActor:
     def __new__(cls, *args, **kwargs):
-        if not _is_windows:
-            try:
-                if "COV_CORE_SOURCE" in os.environ:  # pragma: no branch
-                    # register coverage hooks on SIGTERM
-                    from pytest_cov.embed import cleanup_on_sigterm
-
-                    cleanup_on_sigterm()
-            except ImportError:  # pragma: no cover
-                pass
+        ensure_coverage()
         return super().__new__(cls, *args, **kwargs)
 
     def __init__(self, address):

--- a/mars/serialization/aio.py
+++ b/mars/serialization/aio.py
@@ -80,6 +80,12 @@ class AioSerializer:
         return self._get_buffers()
 
 
+MALFORMED_MSG = """\
+Received malformed data, please check Mars version on both side,
+if error occurs when using `mars.new_session('http://web_ip:web_port'),
+please check if web port is right."""
+
+
 class AioDeserializer:
     def __init__(self, file):
         self._file = file
@@ -103,7 +109,7 @@ class AioDeserializer:
             raise EOFError("Received empty bytes")
         version = struct.unpack("B", header_bytes[:1])[0]
         # now we only have default version
-        assert version == DEFAULT_SERIALIZATION_VERSION
+        assert version == DEFAULT_SERIALIZATION_VERSION, MALFORMED_MSG
         # header length
         header_length = struct.unpack("<Q", header_bytes[1:9])[0]
         # compress

--- a/mars/services/web/core.py
+++ b/mars/services/web/core.py
@@ -211,10 +211,6 @@ class MarsWebAPIClientMixin:
     def request_rewriter(self, value: Callable):
         self._request_rewriter = value
 
-    def __del__(self):
-        if hasattr(self, "_client_obj"):
-            self._client_obj.close()
-
     async def _request_url(self, method, path, **kwargs):
         self._running_loop = asyncio.get_running_loop()
 

--- a/mars/supervisor.py
+++ b/mars/supervisor.py
@@ -1,0 +1,22 @@
+# Copyright 1999-2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shortcut to support
+# python -m mars.supervisor
+
+from .deploy.oscar.supervisor import main
+
+
+if __name__ == "__main__":
+    main()

--- a/mars/supervisor.py
+++ b/mars/supervisor.py
@@ -16,7 +16,9 @@
 # python -m mars.supervisor
 
 from .deploy.oscar.supervisor import main
+from .utils import ensure_coverage
 
 
 if __name__ == "__main__":
+    ensure_coverage()
     main()

--- a/mars/tests/test_cluster.py
+++ b/mars/tests/test_cluster.py
@@ -85,8 +85,8 @@ async def test_cluster():
         sess2 = new_session(web_addr, session_id=sess.session_id)
         sess2.close()
     finally:
-        r.kill()
-        w.kill()
+        r.terminate()
+        w.terminate()
 
     # test stderr
     out = r.communicate()[1].decode()

--- a/mars/tests/test_cluster.py
+++ b/mars/tests/test_cluster.py
@@ -1,0 +1,93 @@
+# Copyright 1999-2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import os
+import sys
+import subprocess
+import tempfile
+
+import pytest
+
+from .. import new_session
+from .. import tensor as mt
+from ..services.cluster import NodeRole, WebClusterAPI
+from ..utils import get_next_port
+
+
+CONFIG_CONTENT = """\
+"@inherits": "@mars/config.yml"
+scheduling:
+  mem_hard_limit: null"""
+
+
+@pytest.mark.asyncio
+async def test_cluster():
+    port = get_next_port()
+    web_port = get_next_port()
+    supervisor_addr = f"127.0.0.1:{port}"
+    web_addr = f"http://127.0.0.1:{web_port}"
+
+    # gen config file
+    fd, path = tempfile.mkstemp()
+    with os.fdopen(fd, mode="w") as f:
+        f.write(CONFIG_CONTENT)
+
+    r = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mars.supervisor",
+            "-H",
+            "127.0.0.1",
+            "-p",
+            str(port),
+            "-w",
+            str(web_port),
+            "-f",
+            path,
+        ],
+        stderr=subprocess.PIPE,
+    )
+    w = subprocess.Popen(
+        [sys.executable, "-m", "mars.worker", "-s", supervisor_addr, "-f", path]
+    )
+
+    try:
+        cluster_api = WebClusterAPI(web_addr)
+        while True:
+            try:
+                jsn = await cluster_api.get_nodes_info(role=NodeRole.WORKER)
+            except ConnectionError:
+                await asyncio.sleep(0.5)
+                continue
+            if not jsn:
+                await asyncio.sleep(0.5)
+                continue
+            if len(jsn) > 0:
+                break
+
+        sess = new_session(web_addr, default=True)
+        a = mt.arange(10)
+        assert a.sum().to_numpy(show_progress=False) == 45
+
+        sess2 = new_session(web_addr, session_id=sess.session_id)
+        sess2.close()
+    finally:
+        r.kill()
+        w.kill()
+
+    # test stderr
+    out = r.communicate()[1].decode()
+    assert f"Supervisor started at {supervisor_addr}, web address: {web_addr}" in out

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1654,3 +1654,17 @@ class TreeReductionBuilder:
         if len(inputs) == 1:
             return inputs[0]
         return self._build_reduction(inputs, final=True)
+
+
+_is_windows: bool = sys.platform.startswith("win")
+
+
+def ensure_coverage():
+    # make sure coverage is handled when starting with subprocess.Popen
+    if not _is_windows and "COV_CORE_SOURCE" in os.environ:  # pragma: no cover
+        try:
+            from pytest_cov.embed import cleanup_on_sigterm
+        except ImportError:
+            pass
+        else:
+            cleanup_on_sigterm()

--- a/mars/worker.py
+++ b/mars/worker.py
@@ -1,0 +1,22 @@
+# Copyright 1999-2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shortcut to support
+# python -m mars.worker
+
+from .deploy.oscar.worker import main
+
+
+if __name__ == "__main__":
+    main()

--- a/mars/worker.py
+++ b/mars/worker.py
@@ -16,7 +16,9 @@
 # python -m mars.worker
 
 from .deploy.oscar.worker import main
+from .utils import ensure_coverage
 
 
 if __name__ == "__main__":
+    ensure_coverage()
     main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     tornado>=6.0
     sqlalchemy>=1.2.0
     defusedxml>=0.5.0
+    tqdm>=4.1.0
     uvloop>=0.14.0; sys.platform!="win32" and python_version>="3.7"
 
 [options.packages.find]


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR did a few things:

1. Fix default config to ensure storage backends configured.
2. Add shortcuts of supervisor and worker, like starting supervisor with `python -m mars.supervisor`.
3. Optimize assertion error's message to tell that maybe wrong web port is provided.
4. Do not close http client if web client is gc because http client will close when itself gc collected.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2931 
Fixes #2933

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
