### PR TITLE
Ignore broadcaster's locality when assign subtasks

### DIFF
--- a/mars/core/entity/chunks.py
+++ b/mars/core/entity/chunks.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...serialization.serializables import FieldTypes, TupleField
+from ...serialization.serializables import BoolField, FieldTypes, TupleField
 from ...utils import tokenize
 from .core import EntityData, Entity
 
@@ -20,8 +20,12 @@ from .core import EntityData, Entity
 class ChunkData(EntityData):
     __slots__ = ()
 
+    _is_broadcaster = BoolField("is_broadcaster", default=False)
     # optional fields
     _index = TupleField("index", FieldTypes.uint32)
+
+    def __init__(self, is_broadcaster=None, **kw):
+        super().__init__(_is_broadcaster=is_broadcaster, **kw)
 
     def __repr__(self):
         if self.op.stage is None:
@@ -35,6 +39,14 @@ class ChunkData(EntityData):
     @property
     def index(self):
         return getattr(self, "_index", None)
+
+    @property
+    def is_broadcaster(self):
+        return self._is_broadcaster
+
+    @is_broadcaster.setter
+    def is_broadcaster(self, is_broadcaster: bool):
+        self._is_broadcaster = is_broadcaster
 
     @property
     def device(self):

--- a/mars/core/entity/chunks.py
+++ b/mars/core/entity/chunks.py
@@ -20,12 +20,9 @@ from .core import EntityData, Entity
 class ChunkData(EntityData):
     __slots__ = ()
 
-    _is_broadcaster = BoolField("is_broadcaster", default=False)
+    is_broadcaster = BoolField("is_broadcaster", default=False)
     # optional fields
     _index = TupleField("index", FieldTypes.uint32)
-
-    def __init__(self, is_broadcaster=None, **kw):
-        super().__init__(_is_broadcaster=is_broadcaster, **kw)
 
     def __repr__(self):
         if self.op.stage is None:
@@ -39,14 +36,6 @@ class ChunkData(EntityData):
     @property
     def index(self):
         return getattr(self, "_index", None)
-
-    @property
-    def is_broadcaster(self):
-        return self._is_broadcaster
-
-    @is_broadcaster.setter
-    def is_broadcaster(self, is_broadcaster: bool):
-        self._is_broadcaster = is_broadcaster
 
     @property
     def device(self):

--- a/mars/dataframe/base/bloom_filter.py
+++ b/mars/dataframe/base/bloom_filter.py
@@ -91,6 +91,7 @@ class DataFrameBloomFilter(DataFrameOperand, DataFrameOperandMixin):
         else:
             filter_chunk = chunks[0]
 
+        filter_chunk.is_broadcaster = True
         # filter df1
         out_chunks = []
         for chunk in df1.chunks:

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -112,7 +112,7 @@ class DataFrameMergeAlign(MapReduceOperand, DataFrameOperandMixin):
     @classmethod
     def execute_reduce(cls, ctx, op: "DataFrameMergeAlign"):
         chunk = op.outputs[0]
-        input_idx_to_df = dict(op.iter_mapper_data_with_index(ctx))
+        input_idx_to_df = dict(op.iter_mapper_data_with_index(ctx, skip_none=True))
         row_idxes = sorted({idx[0] for idx in input_idx_to_df})
 
         res = []

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -311,6 +311,7 @@ class DataFrameMerge(DataFrameOperand, DataFrameOperandMixin):
         elif len(left.chunks) == 1:
             out_chunks = []
             left_chunk = left.chunks[0]
+            left_chunk.is_broadcaster = True
             for c in right.chunks:
                 merge_op = op.copy().reset_key()
                 out_chunk = merge_op.new_chunk(
@@ -328,6 +329,8 @@ class DataFrameMerge(DataFrameOperand, DataFrameOperandMixin):
         else:
             out_chunks = []
             right_chunk = right.chunks[0]
+            # set `is_broadcaster` as True
+            right_chunk.is_broadcaster = True
             for c in left.chunks:
                 merge_op = op.copy().reset_key()
                 out_chunk = merge_op.new_chunk(
@@ -422,6 +425,9 @@ class DataFrameMerge(DataFrameOperand, DataFrameOperandMixin):
                 left_on = _prepare_shuffle_on(op.left_index, op.left_on, op.on)
                 left_chunks = cls._gen_shuffle_chunks(left.chunk_shape, left_on, left)
                 need_split = True
+            # set is_broadcast property
+            for c in left_chunks:
+                c.is_broadcaster = True
             right_chunks = right.chunks
             for right_chunk in right_chunks:
                 merged_chunks = []
@@ -465,6 +471,9 @@ class DataFrameMerge(DataFrameOperand, DataFrameOperandMixin):
                 right_chunks = cls._gen_shuffle_chunks(
                     right.chunk_shape, right_on, right
                 )
+            # set is_broadcast property
+            for c in right_chunks:
+                c.is_broadcaster = True
             left_chunks = left.chunks
             for left_chunk in left_chunks:
                 merged_chunks = []

--- a/mars/services/scheduling/supervisor/assigner.py
+++ b/mars/services/scheduling/supervisor/assigner.py
@@ -110,6 +110,7 @@ class AssignerActor(mo.Actor):
     ):
         exclude_bands = exclude_bands or set()
         inp_keys = set()
+        broadcaster_keys = set()
         selected_bands = dict()
 
         if not self._bands:
@@ -137,6 +138,8 @@ class AssignerActor(mo.Actor):
                 continue
             for indep_chunk in subtask.chunk_graph.iter_indep():
                 if isinstance(indep_chunk.op, Fetch):
+                    if indep_chunk.is_broadcaster:
+                        broadcaster_keys.add(indep_chunk.key)
                     inp_keys.add(indep_chunk.key)
                 elif isinstance(indep_chunk.op, FetchShuffle):
                     selected_bands[subtask.subtask_id] = [
@@ -153,6 +156,10 @@ class AssignerActor(mo.Actor):
         )
 
         inp_metas = dict(zip(inp_keys, metas))
+        if broadcaster_keys:
+            # set broadcaster's size as 0 to avoid assigning all successors to same band.
+            for key in broadcaster_keys:
+                inp_metas[key]["store_size"] = 0
         assigns = []
         for subtask in subtasks:
             is_gpu = any(c.op.gpu for c in subtask.chunk_graph)

--- a/mars/services/scheduling/supervisor/tests/test_assigner.py
+++ b/mars/services/scheduling/supervisor/tests/test_assigner.py
@@ -206,6 +206,40 @@ async def test_assign_cpu_tasks(actor_pool):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("actor_pool", [False], indirect=True)
+async def test_assign_broadcaster(actor_pool):
+    pool, session_id, assigner_ref, cluster_api, meta_api = actor_pool
+
+    broadcaster = TensorFetch(key="x", source_key="x", dtype=np.dtype(int)).new_chunk(
+        [], is_broadcaster=True
+    )
+    input_chunk = TensorFetch(key="a", source_key="a", dtype=np.dtype(int)).new_chunk(
+        []
+    )
+    result_chunk = TensorTreeAdd(args=[broadcaster, input_chunk]).new_chunk(
+        [broadcaster, input_chunk]
+    )
+
+    chunk_graph = ChunkGraph([result_chunk])
+    chunk_graph.add_node(broadcaster)
+    chunk_graph.add_node(input_chunk)
+    chunk_graph.add_node(result_chunk)
+    chunk_graph.add_edge(broadcaster, result_chunk)
+    chunk_graph.add_edge(input_chunk, result_chunk)
+
+    await meta_api.set_chunk_meta(
+        broadcaster, memory_size=1000, store_size=200, bands=[("address0", "numa-0")]
+    )
+    await meta_api.set_chunk_meta(
+        input_chunk, memory_size=200, store_size=200, bands=[("address1", "numa-0")]
+    )
+
+    subtask = Subtask("test_task", session_id, chunk_graph=chunk_graph)
+    [result] = await assigner_ref.assign_subtasks([subtask])
+    assert result == ("address1", "numa-0")
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("actor_pool", [True], indirect=True)
 async def test_assign_gpu_tasks(actor_pool):
     pool, session_id, assigner_ref, cluster_api, meta_api = actor_pool

--- a/mars/services/scheduling/worker/execution.py
+++ b/mars/services/scheduling/worker/execution.py
@@ -361,6 +361,7 @@ class SubtaskExecutionActor(mo.StatelessActor):
                 storage_api = await StorageAPI.create(
                     subtask.session_id, address=self.address, band_name=band_name
                 )
+                logger.debug("Delete mapper data %s", remote_mapper_keys)
                 await storage_api.delete.batch(
                     *[
                         storage_api.delete.delay(key, error="ignore")

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -519,7 +519,14 @@ def build_fetch_chunk(
         # for non-shuffle nodes, we build Fetch chunks
         # to replace original chunk
         op = chunk_op.get_fetch_op_cls(chunk)(sparse=chunk.op.sparse, gpu=chunk.op.gpu)
-    return op.new_chunk(None, kws=[params], _key=chunk.key, _id=chunk.id, **kwargs)
+    return op.new_chunk(
+        None,
+        is_broadcaster=chunk.is_broadcaster,
+        kws=[params],
+        _key=chunk.key,
+        _id=chunk.id,
+        **kwargs,
+    )
 
 
 def build_fetch_tileable(tileable: TileableType) -> TileableType:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Add `is_broadcaster` property in ChunkData and avoid scheduling all broadcaster's downstream nodes to one worker. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2941 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
