### PR TITLE
[Metrics] Add metrics for scheduling

### DIFF
--- a/mars/core/operand/core.py
+++ b/mars/core/operand/core.py
@@ -22,6 +22,7 @@ try:
 except ImportError:  # pragma: no cover
     UFuncTypeError = None
 
+from ...metrics import Metrics
 from ...typing import TileableType, ChunkType, OperandType
 from ...utils import calc_data_size
 from ..context import Context
@@ -37,6 +38,11 @@ from ..entity import (
 
 _op_type_to_executor: Dict[Type[OperandType], Callable] = dict()
 _op_type_to_size_estimator: Dict[Type[OperandType], Callable] = dict()
+
+
+op_executed_number = Metrics.counter(
+    "mars.operand.executed_number", "The number of executed operands.", ("op",)
+)
 
 
 class TileableOperandMixin:
@@ -484,6 +490,7 @@ def execute(results: Dict[str, Any], op: OperandType):
             try:
                 result = executor(results, op)
                 succeeded = True
+                op_executed_number.record(1, {"op": op.__class__.__name__})
                 return result
             except UFuncTypeError as e:  # pragma: no cover
                 raise TypeError(str(e)).with_traceback(sys.exc_info()[2]) from None

--- a/mars/metrics/backends/metric.py
+++ b/mars/metrics/backends/metric.py
@@ -29,9 +29,15 @@ class AbstractMetric(ABC):
     def __init__(
         self, name: str, description: str = "", tag_keys: Optional[Tuple[str]] = None
     ):
+        assert isinstance(name, str), "Argument name should be a str"
+        assert isinstance(description, str), "Argument description should be a str"
+        if tag_keys is not None:
+            assert isinstance(tag_keys, tuple) and all(
+                isinstance(tag, str) for tag in tag_keys
+            ), "Argument tag_keys should be a tuple and its elements should be str"
         self._name = name
         self._description = description
-        self._tag_keys = tuple(tag_keys) if tag_keys else tuple()
+        self._tag_keys = tag_keys or tuple()
         self._init()
 
     @property

--- a/mars/metrics/backends/tests/test_metric.py
+++ b/mars/metrics/backends/tests/test_metric.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from ..metric import (
     AbstractMetric,
     AbstractCounter,
@@ -19,6 +21,24 @@ from ..metric import (
     AbstractMeter,
     AbstractHistogram,
 )
+
+
+def test_illegal_arguments():
+    class DummyMetric(AbstractMetric):
+        pass
+
+    DummyMetric.__abstractmethods__ = set()
+    with pytest.raises(AssertionError):
+        DummyMetric(1)
+
+    with pytest.raises(AssertionError):
+        DummyMetric("dummy_metric", 1)
+
+    with pytest.raises(AssertionError):
+        DummyMetric("dummy_metric", "A test metric", "service")
+
+    with pytest.raises(AssertionError):
+        DummyMetric("dummy_metric", "A test metric", ("service", 1))
 
 
 def test_dummy_metric():


### PR DESCRIPTION
## What do these changes do?
* Add scheduling, band and op metrics
```
    mars.scheduling.submitted_subtask_count: The count of submitted subtasks to all bands.
    mars.scheduling.finished_subtask_count: The count of finished subtasks of all bands.
    mars.scheduling.canceled_subtask_count: The count of canceled subtasks of all bands.
    mars.band.submitted_subtask_number: The number of submitted subtask to a band.
    mars.band.unsubmitted_subtask_number: The number of unsubmitted subtask to a band.
    mars.operand.executed_number: The number of executed operands.
```
* Optimize metrics arguments check

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
