### PR TITLE
Remove `should_be_monotonic` property

### DIFF
--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -493,21 +493,17 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
                     index=x1.dtypes.index,
                 )
                 columns = copy.copy(x1.columns_value)
-                columns.value.should_be_monotonic = False
                 column_shape = len(dtypes)
             elif x1.dtypes is not None and x2.dtypes is not None:
                 dtypes = infer_dtypes(x1.dtypes, x2.dtypes, cls._operator)
                 columns = parse_index(dtypes.index, store_data=True)
-                columns.value.should_be_monotonic = True
                 column_shape = len(dtypes)
             if x1.index_value is not None and x2.index_value is not None:
                 if x1.index_value.key == x2.index_value.key:
                     index = copy.copy(x1.index_value)
-                    index.value.should_be_monotonic = False
                     index_shape = x1.shape[0]
                 else:
                     index = infer_index_value(x1.index_value, x2.index_value)
-                    index.value.should_be_monotonic = True
                     if index.key == x1.index_value.key == x2.index_value.key and (
                         not np.isnan(x1.shape[0]) or not np.isnan(x2.shape[0])
                     ):
@@ -539,12 +535,10 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
                             index=x1.dtypes.index,
                         )
                         columns = copy.copy(x1.columns_value)
-                        columns.value.should_be_monotonic = False
                         column_shape = len(dtypes)
                     else:  # pragma: no cover
                         dtypes = x1.dtypes  # FIXME
                         columns = infer_index_value(x1.columns_value, x2.index_value)
-                        columns.value.should_be_monotonic = True
                         column_shape = np.nan
             else:
                 assert axis == "index" or axis == 0
@@ -562,7 +556,6 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
                             index=x1.dtypes.index,
                         )
                         index = copy.copy(x1.index_value)
-                        index.value.should_be_monotonic = False
                         index_shape = x1.shape[0]
                     else:
                         if x1.dtypes is not None:
@@ -574,7 +567,6 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
                                 index=x1.dtypes.index,
                             )
                         index = infer_index_value(x1.index_value, x2.index_value)
-                        index.value.should_be_monotonic = True
                         index_shape = np.nan
             return {
                 "shape": (index_shape, column_shape),
@@ -592,11 +584,9 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
             if x1.index_value is not None and x2.index_value is not None:
                 if x1.index_value.key == x2.index_value.key:
                     index = copy.copy(x1.index_value)
-                    index.value.should_be_monotonic = False
                     index_shape = x1.shape[0]
                 else:
                     index = infer_index_value(x1.index_value, x2.index_value)
-                    index.value.should_be_monotonic = True
                     if index.key == x1.index_value.key == x2.index_value.key and (
                         not np.isnan(x1.shape[0]) or not np.isnan(x2.shape[0])
                     ):

--- a/mars/dataframe/arithmetic/tests/test_arithmetic.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic.py
@@ -176,9 +176,7 @@ def test_without_shuffle(func_name, func_opts):
     pd.testing.assert_index_equal(
         df3.columns_value.to_pandas(), func_opts.func(data1, data2).columns
     )
-    assert df3.columns_value.should_be_monotonic is True
     assert isinstance(df3.index_value.value, IndexValue.Int64Index)
-    assert df3.index_value.should_be_monotonic is True
     pd.testing.assert_index_equal(
         df3.index_value.to_pandas(), pd.Index([], dtype=np.int64)
     )
@@ -192,9 +190,7 @@ def test_without_shuffle(func_name, func_opts):
     pd.testing.assert_index_equal(
         df3.columns_value.to_pandas(), func_opts.func(data1, data2).columns
     )
-    assert df3.columns_value.should_be_monotonic is True
     assert isinstance(df3.index_value.value, IndexValue.Int64Index)
-    assert df3.index_value.should_be_monotonic is True
     pd.testing.assert_index_equal(
         df3.index_value.to_pandas(), pd.Index([], dtype=np.int64)
     )
@@ -419,7 +415,6 @@ def test_dataframe_and_series_with_shuffle(func_name, func_opts):
         df2.columns_value.to_pandas(), pd.Index([], dtype=np.int64)
     )
     assert df2.columns_value.key != df1.columns_value.key
-    assert df2.columns_value.should_be_monotonic is True
 
     df1, df2, s1 = tile(df1, df2, s1)
 
@@ -614,7 +609,6 @@ def test_series_and_series_with_shuffle(func_name, func_opts):
     pd.testing.assert_index_equal(
         s3.index_value.to_pandas(), pd.Index([], dtype=np.int64)
     )
-    assert s3.index_value.should_be_monotonic is True
 
     s1, s2, s3 = tile(s1, s2, s3)
 
@@ -673,9 +667,7 @@ def test_identical_index_and_columns(func_name, func_opts):
     pd.testing.assert_index_equal(
         df3.columns_value.to_pandas(), func_opts.func(data1, data2).columns
     )
-    assert df3.columns_value.should_be_monotonic is False
     assert isinstance(df3.index_value.value, IndexValue.RangeIndex)
-    assert df3.index_value.should_be_monotonic is False
     pd.testing.assert_index_equal(df3.index_value.to_pandas(), pd.RangeIndex(0, 10))
     assert df3.index_value.key == df1.index_value.key
     assert df3.index_value.key == df2.index_value.key
@@ -734,9 +726,7 @@ def test_with_one_shuffle(func_name, func_opts):
     pd.testing.assert_index_equal(
         df3.columns_value.to_pandas(), func_opts.func(data1, data2).columns
     )
-    assert df3.columns_value.should_be_monotonic is True
     assert isinstance(df3.index_value.value, IndexValue.Int64Index)
-    assert df3.index_value.should_be_monotonic is True
     pd.testing.assert_index_equal(
         df3.index_value.to_pandas(), pd.Index([], dtype=np.int64)
     )
@@ -868,9 +858,7 @@ def test_with_all_shuffle(func_name, func_opts):
     pd.testing.assert_index_equal(
         df3.columns_value.to_pandas(), func_opts.func(data1, data2).columns
     )
-    assert df3.columns_value.should_be_monotonic is True
     assert isinstance(df3.index_value.value, IndexValue.Int64Index)
-    assert df3.index_value.should_be_monotonic is True
     pd.testing.assert_index_equal(
         df3.index_value.to_pandas(), pd.Index([], dtype=np.int64)
     )
@@ -970,9 +958,7 @@ def test_with_all_shuffle(func_name, func_opts):
     pd.testing.assert_index_equal(
         df6.columns_value.to_pandas(), func_opts.func(data4, data5).columns
     )
-    assert df6.columns_value.should_be_monotonic is True
     assert isinstance(df6.index_value.value, IndexValue.Int64Index)
-    assert df6.index_value.should_be_monotonic is True
     pd.testing.assert_index_equal(
         df6.index_value.to_pandas(), pd.Index([], dtype=np.int64)
     )
@@ -1077,9 +1063,7 @@ def test_without_shuffle_and_with_one_chunk(func_name, func_opts):
     pd.testing.assert_index_equal(
         df3.columns_value.to_pandas(), func_opts.func(data1, data2).columns
     )
-    assert df3.columns_value.should_be_monotonic is True
     assert isinstance(df3.index_value.value, IndexValue.Int64Index)
-    assert df3.index_value.should_be_monotonic is True
     pd.testing.assert_index_equal(
         df3.index_value.to_pandas(), pd.Index([], dtype=np.int64)
     )
@@ -1191,9 +1175,7 @@ def test_both_one_chunk(func_name, func_opts):
     pd.testing.assert_index_equal(
         df3.columns_value.to_pandas(), func_opts.func(data1, data2).columns
     )
-    assert df3.columns_value.should_be_monotonic is True
     assert isinstance(df3.index_value.value, IndexValue.Int64Index)
-    assert df3.index_value.should_be_monotonic is True
     pd.testing.assert_index_equal(
         df3.index_value.to_pandas(), pd.Index([], dtype=np.int64)
     )
@@ -1237,9 +1219,7 @@ def test_with_shuffle_and_one_chunk(func_name, func_opts):
     pd.testing.assert_index_equal(
         df3.columns_value.to_pandas(), func_opts.func(data1, data2).columns
     )
-    assert df3.columns_value.should_be_monotonic is True
     assert isinstance(df3.index_value.value, IndexValue.Int64Index)
-    assert df3.index_value.should_be_monotonic is True
     pd.testing.assert_index_equal(
         df3.index_value.to_pandas(), pd.Index([], dtype=np.int64)
     )
@@ -1332,9 +1312,7 @@ def test_on_same_dataframe(func_name, func_opts):
     pd.testing.assert_index_equal(
         df2.columns_value.to_pandas(), func_opts.func(data, data).columns
     )
-    assert df2.columns_value.should_be_monotonic is False
     assert isinstance(df2.index_value.value, IndexValue.Int64Index)
-    assert df2.index_value.should_be_monotonic is False
     pd.testing.assert_index_equal(
         df2.index_value.to_pandas(), pd.Index([], dtype=np.int64)
     )

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -79,7 +79,6 @@ class IndexValue(Serializable):
         _is_monotonic_increasing = BoolField("is_monotonic_increasing")
         _is_monotonic_decreasing = BoolField("is_monotonic_decreasing")
         _is_unique = BoolField("is_unique")
-        _should_be_monotonic = BoolField("should_be_monotonic")
         _max_val = AnyField("max_val", on_serialize=on_serialize_numpy_type)
         _max_val_close = BoolField("max_val_close")
         _min_val = AnyField("min_val", on_serialize=on_serialize_numpy_type)
@@ -96,14 +95,6 @@ class IndexValue(Serializable):
         @property
         def is_unique(self):
             return self._is_unique
-
-        @property
-        def should_be_monotonic(self):
-            return self._should_be_monotonic
-
-        @should_be_monotonic.setter
-        def should_be_monotonic(self, val):
-            self._should_be_monotonic = val
 
         @property
         def min_val(self):
@@ -344,10 +335,6 @@ class IndexValue(Serializable):
         return self.is_monotonic_increasing or self.is_monotonic_decreasing
 
     @property
-    def should_be_monotonic(self):
-        return self._index_value.should_be_monotonic
-
-    @property
     def is_unique(self):
         return self._index_value.is_unique
 
@@ -430,9 +417,6 @@ def refresh_index_value(tileable: ENTITY_TYPE):
         elif chunk.index[1] == 0:
             index_to_index_values[chunk.index] = chunk.index_value
     index_value = merge_index_value(index_to_index_values, store_data=False)
-    index_value._index_value.should_be_monotonic = getattr(
-        tileable.index_value, "should_be_monotonic", None
-    )
     # keep key as original index_value's
     index_value._index_value._key = tileable.index_value.key
     tileable._index_value = index_value
@@ -443,9 +427,6 @@ def refresh_dtypes(tileable: ENTITY_TYPE):
     dtypes = pd.concat(all_dtypes)
     tileable._dtypes = dtypes
     columns_values = parse_index(dtypes.index, store_data=True)
-    columns_values._index_value.should_be_monotonic = getattr(
-        tileable.columns_value, "should_be_monotonic", None
-    )
     tileable._columns_value = columns_values
     tileable._dtypes_value = DtypesValue(key=tokenize(dtypes), value=dtypes)
 

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -220,7 +220,6 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
 
         shape = (np.nan, agg_df.shape[1])
         index_value = parse_index(agg_df.index, groupby.key, groupby.index_value.key)
-        index_value.value.should_be_monotonic = True
 
         # make sure if as_index=False takes effect
         self._fix_as_index(agg_df.index)
@@ -248,7 +247,6 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
         index_value = parse_index(
             agg_result.index, groupby.key, groupby.index_value.key
         )
-        index_value.value.should_be_monotonic = True
 
         inputs = self._get_inputs([in_series])
 

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -297,7 +297,7 @@ def test_groupby_getitem(setup):
         {"c1": "max", "c4": "mean"}, method="shuffle"
     )
     pd.testing.assert_frame_equal(
-        r.execute().fetch(),
+        r.execute().fetch().sort_index(),
         raw.groupby(["c2"])[["c1", "c4"]].agg({"c1": "max", "c4": "mean"}),
     )
 

--- a/mars/dataframe/merge/concat.py
+++ b/mars/dataframe/merge/concat.py
@@ -356,10 +356,6 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
                     # cuDF will lost index name when concat two seriess.
                     ret.index.name = concats[0].index.name
 
-            if getattr(chunk.index_value, "should_be_monotonic", False):
-                ret.sort_index(inplace=True)
-            if getattr(chunk.columns_value, "should_be_monotonic", False):
-                ret.sort_index(axis=1, inplace=True)
             return ret
 
         def _auto_concat_series_chunks(chunk, inputs):
@@ -372,8 +368,6 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
                     concat = xdf.concat(inputs, axis=chunk.op.axis)
                 else:
                     concat = xdf.concat(inputs)
-            if getattr(chunk.index_value, "should_be_monotonic", False):
-                concat.sort_index(inplace=True)
             return concat
 
         def _auto_concat_index_chunks(chunk, inputs):
@@ -384,8 +378,6 @@ class DataFrameConcat(DataFrameOperand, DataFrameOperandMixin):
                 xdf = pd if isinstance(inputs[0], pd.Index) or cudf is None else cudf
                 empty_dfs = [xdf.DataFrame(index=inp) for inp in inputs]
                 concat_df = xdf.concat(empty_dfs, axis=0)
-            if getattr(chunk.index_value, "should_be_monotonic", False):
-                concat_df.sort_index(inplace=True)
             return concat_df.index
 
         def _auto_concat_categorical_chunks(_, inputs):

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -60,7 +60,6 @@ from ...typing import ClientType, BandType
 from ...utils import (
     implements,
     merge_chunks,
-    sort_dataframe_result,
     register_asyncio_task_timeout_detector,
     classproperty,
     copy_tileables,
@@ -1063,7 +1062,7 @@ class _IsolatedSession(AbstractAsyncSession):
         return result
 
     def _process_result(self, tileable, result):  # pylint: disable=no-self-use
-        return sort_dataframe_result(tileable, result)
+        return result
 
     @alru_cache(cache_exceptions=False)
     async def _get_storage_api(self, band: BandType):

--- a/mars/services/task/supervisor/tests/test_task_manager.py
+++ b/mars/services/task/supervisor/tests/test_task_manager.py
@@ -222,7 +222,7 @@ async def test_cancel_task(actor_pool):
         result = await manager.get_task_result(task_id)
         assert result.status == TaskStatus.terminated
 
-    assert timer.duration < 20
+    assert timer.duration < 25
 
     keys = [r.key for r in rs]
     del rs

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -715,25 +715,6 @@ def calc_nsplits(chunk_idx_to_shape: Dict[Tuple[int], Tuple[int]]) -> Tuple[Tupl
     return tuple(tileable_nsplits)
 
 
-def sort_dataframe_result(df, result: pd.DataFrame) -> pd.DataFrame:
-    """sort DataFrame on client according to `should_be_monotonic` attribute"""
-    if hasattr(df, "index_value"):
-        if getattr(df.index_value, "should_be_monotonic", False):
-            try:
-                result.sort_index(inplace=True)
-            except TypeError:  # pragma: no cover
-                # cudf doesn't support inplace
-                result = result.sort_index()
-        if hasattr(df, "columns_value"):
-            if getattr(df.columns_value, "should_be_monotonic", False):
-                try:
-                    result.sort_index(axis=1, inplace=True)
-                except TypeError:  # pragma: no cover
-                    # cudf doesn't support inplace
-                    result = result.sort_index(axis=1)
-    return result
-
-
 def has_unknown_shape(*tiled_tileables: TileableType) -> bool:
     for tileable in tiled_tileables:
         if getattr(tileable, "shape", None) is None:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Remove `should_be_monotonic` property in `IndexValue`, it may cause incompatible results for some operands.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2939 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
