### PR TITLE
Fix potential KeyError in actor_ref calls when running with multiple processes

### DIFF
--- a/mars/core/graph/tests/test_graph.py
+++ b/mars/core/graph/tests/test_graph.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import pytest
 
 from .... import tensor as mt
 from ....tests.core import flaky
+from ....utils import to_str
 from .. import DAG, GraphContainsCycleError
 
 
@@ -103,22 +103,5 @@ def test_to_dot():
     arr2 = arr + arr_add
     graph = arr2.build_graph(fuse_enabled=False, tile=True)
 
-    dot = str(graph.to_dot(trunc_key=5))
-    try:
-        assert all(str(n.key)[5] in dot for n in graph) is True
-    except AssertionError:
-        graph_reprs = []
-        for n in graph:
-            graph_reprs.append(
-                f"{n.op.key} -> {[succ.key for succ in graph.successors(n)]}"
-            )
-        logging.error(
-            "Unexpected error in test_to_dot.\ndot = %r\ngraph_repr = %r",
-            dot,
-            "\n".join(graph_reprs),
-        )
-        missing_prefix = next(n.key for n in graph if str(n.key)[5] not in dot)
-        logging.error(
-            "Missing prefix %r (type: %s)", missing_prefix, type(missing_prefix)
-        )
-        raise
+    dot = to_str(graph.to_dot(trunc_key=5))
+    assert all(to_str(n.key)[:5] in dot for n in graph) is True

--- a/mars/deploy/kubernetes/config.py
+++ b/mars/deploy/kubernetes/config.py
@@ -15,6 +15,7 @@
 
 import abc
 import functools
+import math
 import re
 
 from ... import __version__ as mars_version
@@ -605,6 +606,8 @@ class MarsSupervisorsConfig(MarsReplicationConfig):
             cmd += ["-p", str(self._service_port)]
         if self._web_port:
             cmd += ["-w", str(self._web_port)]
+        if self._cpu:
+            cmd += ["--n-process", str(int(math.ceil(self._cpu)))]
         return cmd
 
 

--- a/mars/deploy/oscar/supervisor.py
+++ b/mars/deploy/oscar/supervisor.py
@@ -38,7 +38,7 @@ class SupervisorCommandRunner(OscarCommandRunner):
         super().config_args(parser)
         parser.add_argument("-w", "--web-port", help="web port of the service")
         parser.add_argument(
-            "--n-process", help="number of supervisor processes", default="0"
+            "--n-process", help="number of supervisor processes", default="1"
         )
 
     def parse_args(self, parser, argv, environ=None):

--- a/mars/oscar/backends/context.py
+++ b/mars/oscar/backends/context.py
@@ -50,12 +50,12 @@ class ProfilingContext:
 
 
 class MarsActorContext(BaseActorContext):
-    __slots__ = "_address", "_caller"
+    __slots__ = ("_caller",)
 
     support_allocate_strategy = True
 
     def __init__(self, address: str = None):
-        self._address = address
+        BaseActorContext.__init__(self, address)
         self._caller = ActorCaller()
 
     def __del__(self):

--- a/mars/oscar/backends/mars/pool.py
+++ b/mars/oscar/backends/mars/pool.py
@@ -17,8 +17,10 @@ import concurrent.futures as futures
 import logging.config
 import multiprocessing
 import os
+import random
 import signal
 import sys
+import uuid
 from dataclasses import dataclass
 from types import TracebackType
 from typing import List
@@ -163,6 +165,9 @@ class MainActorPool(MainActorPoolBase):
         status_queue: multiprocessing.Queue,
     ):
         ensure_coverage()
+
+        # make sure enough randomness for every sub pool
+        random.seed(uuid.uuid1().bytes)
 
         conf = actor_config.get_pool_config(process_index)
         suspend_sigint = conf["suspend_sigint"]

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -724,8 +724,14 @@ class SubActorPoolBase(ActorPoolBase):
     async def actor_ref(self, message: ActorRefMessage) -> ResultMessageType:
         result = await super().actor_ref(message)
         if isinstance(result, ErrorMessage):
-            message.actor_ref.address = self._main_address
-            result = await self.call(self._main_address, message)
+            # need a new message id to call main actor
+            main_message = ActorRefMessage(
+                new_message_id(),
+                create_actor_ref(self._main_address, message.actor_ref.uid),
+            )
+            result = await self.call(self._main_address, main_message)
+            # rewrite to message_id of the original request
+            result.message_id = message.message_id
         return result
 
     @implements(AbstractActorPool.destroy_actor)

--- a/mars/oscar/context.pxd
+++ b/mars/oscar/context.pxd
@@ -14,7 +14,7 @@
 
 
 cdef class BaseActorContext:
-    pass
+    cdef public str _address
 
 
 cpdef get_context()

--- a/mars/oscar/context.pyx
+++ b/mars/oscar/context.pyx
@@ -31,6 +31,10 @@ cdef class BaseActorContext:
     Base class for actor context. Every backend need to implement
     actor context for their own.
     """
+
+    def __init__(self, address: str = None):
+        self._address = address
+
     async def create_actor(self, object actor_cls, *args, object uid=None, object address=None, **kwargs):
         """
         Stub method for creating an actor in current context.
@@ -169,7 +173,8 @@ cdef class ClientActorContext(BaseActorContext):
     """
     cdef dict _backend_contexts
 
-    def __init__(self):
+    def __init__(self, address: str = None):
+        BaseActorContext.__init__(self, address)
         self._backend_contexts = dict()
 
     cdef inline object _get_backend_context(self, object address):
@@ -183,7 +188,7 @@ cdef class ClientActorContext(BaseActorContext):
             return self._backend_contexts[scheme]
         except KeyError:
             context = self._backend_contexts[scheme] = \
-                _backend_context_cls[scheme]()
+                _backend_context_cls[scheme](address)
             return context
 
     def create_actor(self, object actor_cls, *args, object uid=None, object address=None, **kwargs):

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import fnmatch
 import functools
 import inspect

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -36,6 +36,7 @@ import sys
 import threading
 import time
 import types
+import uuid
 import warnings
 import zlib
 from abc import ABC
@@ -293,8 +294,7 @@ def get_next_port(typ: int = None, occupy: bool = True) -> int:
             occupied = _get_ports_from_netstat()
 
     occupied.update(_local_occupied_ports)
-    randn = struct.unpack("<Q", os.urandom(8))[0]
-    random.seed(int(time.time() * 1000000) | randn)
+    random.seed(uuid.uuid1().bytes)
     randn = random.randint(0, 100000000)
 
     idx = int(randn % (1 + HIGH_PORT_BOUND - LOW_PORT_BOUND - len(occupied)))


### PR DESCRIPTION
## What do these changes do?

Config multiple processes for supervisors by default.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
