### PR TITLE
Add logic key for tileable graph

### DIFF
--- a/mars/core/graph/entity.py
+++ b/mars/core/graph/entity.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 from abc import ABCMeta, abstractmethod
 from typing import List, Dict, Tuple, Union, Iterable
 
@@ -23,8 +21,6 @@ from ...serialization.serializables import Serializable, DictField, ListField, B
 from ...serialization.serializables.core import SerializableSerializer
 from ...utils import tokenize
 from .core import DAG
-
-logger = logging.getLogger(__name__)
 
 
 class EntityGraph(DAG, metaclass=ABCMeta):
@@ -88,14 +84,13 @@ class TileableGraph(EntityGraph, Iterable[Tileable]):
     def logic_key(self):
         if not hasattr(self, "_logic_key") or self._logic_key is None:
             token_keys = []
-            for node in self.topological_iter():
+            for node in self.bfs():
                 token_keys.append(
                     tokenize(node.op.get_logic_key(), **node.extra_params)
+                    if node.extra_params
+                    else node.op.get_logic_key()
                 )
-            self._logic_key = tokenize(*sorted(token_keys))
-            logger.debug(
-                "Got logic key: %s, token_keys: %s", self._logic_key, token_keys
-            )
+            self._logic_key = tokenize(*token_keys)
         return self._logic_key
 
 

--- a/mars/core/graph/tests/test_graph.py
+++ b/mars/core/graph/tests/test_graph.py
@@ -115,11 +115,14 @@ def test_tileable_graph_logic_key():
     t1 = mt.random.randint(10, size=(10, 8), chunk_size=4)
     t2 = mt.random.randint(10, size=(10, 8), chunk_size=5)
     graph1 = (t1 + t2).build_graph(tile=False)
-    graph2 = (t1 + t2).build_graph(tile=False)
+    tt1 = mt.random.randint(10, size=(10, 8), chunk_size=4)
+    tt2 = mt.random.randint(10, size=(10, 8), chunk_size=5)
+    graph2 = (tt1 + tt2).build_graph(tile=False)
     assert graph1.logic_key == graph2.logic_key
     t3 = mt.random.randint(10, size=(10, 8), chunk_size=6)
+    tt3 = mt.random.randint(10, size=(10, 8), chunk_size=6)
     graph3 = (t1 + t3).build_graph(tile=False)
-    graph4 = (t1 + t3).build_graph(tile=False)
+    graph4 = (t1 + tt3).build_graph(tile=False)
     assert graph1.logic_key != graph3.logic_key
     assert graph3.logic_key == graph4.logic_key
     t4 = mt.random.randint(10, size=(10, 8))
@@ -130,11 +133,14 @@ def test_tileable_graph_logic_key():
     s1 = md.Series([1, 3, 5, mt.nan, 6, 8])
     s2 = md.Series(np.random.randn(1000), chunk_size=100)
     graph1 = (s1 + s2).build_graph(tile=False)
-    graph2 = (s1 + s2).build_graph(tile=False)
+    ss1 = md.Series([1, 3, 5, mt.nan, 6, 8])
+    ss2 = md.Series(np.random.randn(1000), chunk_size=100)
+    graph2 = (ss1 + ss2).build_graph(tile=False)
     assert graph1.logic_key == graph2.logic_key
     s3 = md.Series(np.random.randn(1000), chunk_size=200)
+    ss3 = md.Series(np.random.randn(1000), chunk_size=200)
     graph3 = (s1 + s3).build_graph(tile=False)
-    graph4 = (s1 + s3).build_graph(tile=False)
+    graph4 = (s1 + ss3).build_graph(tile=False)
     assert graph1.logic_key != graph3.logic_key
     assert graph3.logic_key == graph4.logic_key
     s4 = md.Series(np.random.randn(1000))
@@ -149,13 +155,22 @@ def test_tileable_graph_logic_key():
         np.random.randint(0, 100, size=(100_000, 4)), columns=list("ABCD"), chunk_size=4
     )
     graph1 = (df1 + df2).build_graph(tile=False)
-    graph2 = (df1 + df2).build_graph(tile=False)
+    ddf1 = md.DataFrame(
+        np.random.randint(0, 100, size=(100_000, 4)), columns=list("ABCD"), chunk_size=5
+    )
+    ddf2 = md.DataFrame(
+        np.random.randint(0, 100, size=(100_000, 4)), columns=list("ABCD"), chunk_size=4
+    )
+    graph2 = (ddf1 + ddf2).build_graph(tile=False)
     assert graph1.logic_key == graph2.logic_key
     df3 = md.DataFrame(
         np.random.randint(0, 100, size=(100_000, 4)), columns=list("ABCD"), chunk_size=3
     )
+    ddf3 = md.DataFrame(
+        np.random.randint(0, 100, size=(100_000, 4)), columns=list("ABCD"), chunk_size=3
+    )
     graph3 = (df1 + df3).build_graph(tile=False)
-    graph4 = (df1 + df3).build_graph(tile=False)
+    graph4 = (df1 + ddf3).build_graph(tile=False)
     assert graph1.logic_key != graph3.logic_key
     assert graph3.logic_key == graph4.logic_key
     df5 = md.DataFrame(

--- a/mars/core/graph/tests/test_graph.py
+++ b/mars/core/graph/tests/test_graph.py
@@ -115,27 +115,33 @@ def test_tileable_graph_logic_key():
     t1 = mt.random.randint(10, size=(10, 8), chunk_size=4)
     t2 = mt.random.randint(10, size=(10, 8), chunk_size=5)
     graph1 = (t1 + t2).build_graph(tile=False)
-    graph2 = (t2 + t1).build_graph(tile=False)
-    assert graph1.logic_key == "49a93c50414bbc14f308b0d662a74095"
+    graph2 = (t1 + t2).build_graph(tile=False)
+    assert graph1.logic_key == "33b1700157220552d27b5d4be63a4a8e"
     assert graph1.logic_key == graph2.logic_key
     t3 = mt.random.randint(10, size=(10, 8), chunk_size=6)
     graph3 = (t1 + t3).build_graph(tile=False)
-    graph4 = (t3 + t1).build_graph(tile=False)
+    graph4 = (t1 + t3).build_graph(tile=False)
     assert graph1.logic_key != graph3.logic_key
     assert graph3.logic_key == graph4.logic_key
+    t4 = mt.random.randint(10, size=(10, 8))
+    graph5 = (t1 + t4).build_graph(tile=False)
+    assert graph1.logic_key != graph5.logic_key
 
     # Series
     s1 = md.Series([1, 3, 5, mt.nan, 6, 8])
     s2 = md.Series(np.random.randn(1000), chunk_size=100)
     graph1 = (s1 + s2).build_graph(tile=False)
-    graph2 = (s2 + s1).build_graph(tile=False)
+    graph2 = (s1 + s2).build_graph(tile=False)
     assert graph1.logic_key == "922e93fe10764a5548efa3f06ca8252c"
     assert graph1.logic_key == graph2.logic_key
     s3 = md.Series(np.random.randn(1000), chunk_size=200)
     graph3 = (s1 + s3).build_graph(tile=False)
-    graph4 = (s3 + s1).build_graph(tile=False)
+    graph4 = (s1 + s3).build_graph(tile=False)
     assert graph1.logic_key != graph3.logic_key
     assert graph3.logic_key == graph4.logic_key
+    s4 = md.Series(np.random.randn(1000))
+    graph5 = (s1 + s4).build_graph(tile=False)
+    assert graph1.logic_key != graph5.logic_key
 
     # DataFrame
     df1 = md.DataFrame(
@@ -145,26 +151,31 @@ def test_tileable_graph_logic_key():
         np.random.randint(0, 100, size=(100_000, 4)), columns=list("ABCD"), chunk_size=4
     )
     graph1 = (df1 + df2).build_graph(tile=False)
-    graph2 = (df2 + df1).build_graph(tile=False)
-    assert graph1.logic_key == "9e8c90043f49060b112081aa8be5dbcb"
+    graph2 = (df1 + df2).build_graph(tile=False)
+    assert graph1.logic_key == "62379a3ddd8369623d04e3104ec098ef"
     assert graph1.logic_key == graph2.logic_key
     df3 = md.DataFrame(
         np.random.randint(0, 100, size=(100_000, 4)), columns=list("ABCD"), chunk_size=3
     )
     graph3 = (df1 + df3).build_graph(tile=False)
-    graph4 = (df3 + df1).build_graph(tile=False)
+    graph4 = (df1 + df3).build_graph(tile=False)
     assert graph1.logic_key != graph3.logic_key
     assert graph3.logic_key == graph4.logic_key
-    graph5 = df1.describe().build_graph(tile=False)
-    graph6 = df1.apply(lambda x: x.max() - x.min()).build_graph(tile=False)
-    assert graph5.logic_key == "ba74ee4ca9b725186a32d920f013093e"
-    assert graph6.logic_key == "64cd0afee708e8bf295733e55ea74cb3"
+    df5 = md.DataFrame(
+        np.random.randint(0, 100, size=(100_000, 4)), columns=list("ABCD")
+    )
+    graph5 = (df1 + df5).build_graph(tile=False)
+    assert graph1.logic_key != graph5.logic_key
+    graph6 = df1.describe().build_graph(tile=False)
+    graph7 = df1.apply(lambda x: x.max() - x.min()).build_graph(tile=False)
+    assert graph6.logic_key == "62957d11cf4892060626042c584c5dea"
+    assert graph7.logic_key == "64cd0afee708e8bf295733e55ea74cb3"
     pieces = [df1[:3], df1[3:7], df1[7:]]
-    graph7 = md.concat(pieces).build_graph()
-    assert graph7.logic_key == "309535447287fd566b3b383a21e26785"
-    graph8 = md.merge(df1, df2, on="A", how="left").build_graph()
-    assert graph8.logic_key == "aa047766e009bda5880e59c0129430bc"
-    graph9 = df2.groupby("A").sum().build_graph()
-    graph10 = df3.groupby("A").sum().build_graph()
-    assert graph9.logic_key == "1e4512b4bc3783b002ceccc1a0ed058f"
-    assert graph9.logic_key != graph10.logic_key
+    graph8 = md.concat(pieces).build_graph()
+    assert graph8.logic_key == "07cdf055e24496692edc9e8c7b20a39f"
+    graph9 = md.merge(df1, df2, on="A", how="left").build_graph()
+    assert graph9.logic_key == "9d4998e652b6d1bdfbdb65bbc83de69a"
+    graph10 = df2.groupby("A").sum().build_graph()
+    graph11 = df3.groupby("A").sum().build_graph()
+    assert graph10.logic_key == "1e4512b4bc3783b002ceccc1a0ed058f"
+    assert graph10.logic_key != graph11.logic_key

--- a/mars/core/graph/tests/test_graph.py
+++ b/mars/core/graph/tests/test_graph.py
@@ -116,7 +116,6 @@ def test_tileable_graph_logic_key():
     t2 = mt.random.randint(10, size=(10, 8), chunk_size=5)
     graph1 = (t1 + t2).build_graph(tile=False)
     graph2 = (t1 + t2).build_graph(tile=False)
-    assert graph1.logic_key == "33b1700157220552d27b5d4be63a4a8e"
     assert graph1.logic_key == graph2.logic_key
     t3 = mt.random.randint(10, size=(10, 8), chunk_size=6)
     graph3 = (t1 + t3).build_graph(tile=False)
@@ -132,7 +131,6 @@ def test_tileable_graph_logic_key():
     s2 = md.Series(np.random.randn(1000), chunk_size=100)
     graph1 = (s1 + s2).build_graph(tile=False)
     graph2 = (s1 + s2).build_graph(tile=False)
-    assert graph1.logic_key == "922e93fe10764a5548efa3f06ca8252c"
     assert graph1.logic_key == graph2.logic_key
     s3 = md.Series(np.random.randn(1000), chunk_size=200)
     graph3 = (s1 + s3).build_graph(tile=False)
@@ -152,7 +150,6 @@ def test_tileable_graph_logic_key():
     )
     graph1 = (df1 + df2).build_graph(tile=False)
     graph2 = (df1 + df2).build_graph(tile=False)
-    assert graph1.logic_key == "62379a3ddd8369623d04e3104ec098ef"
     assert graph1.logic_key == graph2.logic_key
     df3 = md.DataFrame(
         np.random.randint(0, 100, size=(100_000, 4)), columns=list("ABCD"), chunk_size=3
@@ -167,15 +164,19 @@ def test_tileable_graph_logic_key():
     graph5 = (df1 + df5).build_graph(tile=False)
     assert graph1.logic_key != graph5.logic_key
     graph6 = df1.describe().build_graph(tile=False)
-    graph7 = df1.apply(lambda x: x.max() - x.min()).build_graph(tile=False)
-    assert graph6.logic_key == "62957d11cf4892060626042c584c5dea"
-    assert graph7.logic_key == "64cd0afee708e8bf295733e55ea74cb3"
-    pieces = [df1[:3], df1[3:7], df1[7:]]
-    graph8 = md.concat(pieces).build_graph()
-    assert graph8.logic_key == "07cdf055e24496692edc9e8c7b20a39f"
-    graph9 = md.merge(df1, df2, on="A", how="left").build_graph()
-    assert graph9.logic_key == "9d4998e652b6d1bdfbdb65bbc83de69a"
-    graph10 = df2.groupby("A").sum().build_graph()
-    graph11 = df3.groupby("A").sum().build_graph()
-    assert graph10.logic_key == "1e4512b4bc3783b002ceccc1a0ed058f"
+    graph7 = df2.describe().build_graph(tile=False)
+    assert graph6.logic_key != graph7.logic_key
+    graph8 = df1.apply(lambda x: x.max() - x.min()).build_graph(tile=False)
+    graph9 = df2.apply(lambda x: x.max() - x.min()).build_graph(tile=False)
+    assert graph8.logic_key != graph9.logic_key
+    pieces1 = [df1[:3], df1[3:7], df1[7:]]
+    graph10 = md.concat(pieces1).build_graph(tile=False)
+    pieces2 = [df2[:3], df2[3:7], df2[7:]]
+    graph11 = md.concat(pieces2).build_graph(tile=False)
     assert graph10.logic_key != graph11.logic_key
+    graph12 = md.merge(df1, df2, on="A", how="left").build_graph(tile=False)
+    graph13 = md.merge(df1, df3, on="A", how="left").build_graph(tile=False)
+    assert graph12.logic_key != graph13.logic_key
+    graph14 = df2.groupby("A").sum().build_graph(tile=False)
+    graph15 = df3.groupby("A").sum().build_graph(tile=False)
+    assert graph14.logic_key != graph15.logic_key

--- a/mars/core/graph/tests/test_graph.py
+++ b/mars/core/graph/tests/test_graph.py
@@ -14,6 +14,9 @@
 
 import pytest
 
+import numpy as np
+
+from .... import dataframe as md
 from .... import tensor as mt
 from ....tests.core import flaky
 from ....utils import to_str
@@ -105,3 +108,63 @@ def test_to_dot():
 
     dot = to_str(graph.to_dot(trunc_key=5))
     assert all(to_str(n.key)[:5] in dot for n in graph) is True
+
+
+def test_tileable_graph_logic_key():
+    # Tensor
+    t1 = mt.random.randint(10, size=(10, 8), chunk_size=4)
+    t2 = mt.random.randint(10, size=(10, 8), chunk_size=5)
+    graph1 = (t1 + t2).build_graph(tile=False)
+    graph2 = (t2 + t1).build_graph(tile=False)
+    assert graph1.logic_key == "49a93c50414bbc14f308b0d662a74095"
+    assert graph1.logic_key == graph2.logic_key
+    t3 = mt.random.randint(10, size=(10, 8), chunk_size=6)
+    graph3 = (t1 + t3).build_graph(tile=False)
+    graph4 = (t3 + t1).build_graph(tile=False)
+    assert graph1.logic_key != graph3.logic_key
+    assert graph3.logic_key == graph4.logic_key
+
+    # Series
+    s1 = md.Series([1, 3, 5, mt.nan, 6, 8])
+    s2 = md.Series(np.random.randn(1000), chunk_size=100)
+    graph1 = (s1 + s2).build_graph(tile=False)
+    graph2 = (s2 + s1).build_graph(tile=False)
+    assert graph1.logic_key == "922e93fe10764a5548efa3f06ca8252c"
+    assert graph1.logic_key == graph2.logic_key
+    s3 = md.Series(np.random.randn(1000), chunk_size=200)
+    graph3 = (s1 + s3).build_graph(tile=False)
+    graph4 = (s3 + s1).build_graph(tile=False)
+    assert graph1.logic_key != graph3.logic_key
+    assert graph3.logic_key == graph4.logic_key
+
+    # DataFrame
+    df1 = md.DataFrame(
+        np.random.randint(0, 100, size=(100_000, 4)), columns=list("ABCD"), chunk_size=5
+    )
+    df2 = md.DataFrame(
+        np.random.randint(0, 100, size=(100_000, 4)), columns=list("ABCD"), chunk_size=4
+    )
+    graph1 = (df1 + df2).build_graph(tile=False)
+    graph2 = (df2 + df1).build_graph(tile=False)
+    assert graph1.logic_key == "9e8c90043f49060b112081aa8be5dbcb"
+    assert graph1.logic_key == graph2.logic_key
+    df3 = md.DataFrame(
+        np.random.randint(0, 100, size=(100_000, 4)), columns=list("ABCD"), chunk_size=3
+    )
+    graph3 = (df1 + df3).build_graph(tile=False)
+    graph4 = (df3 + df1).build_graph(tile=False)
+    assert graph1.logic_key != graph3.logic_key
+    assert graph3.logic_key == graph4.logic_key
+    graph5 = df1.describe().build_graph(tile=False)
+    graph6 = df1.apply(lambda x: x.max() - x.min()).build_graph(tile=False)
+    assert graph5.logic_key == "ba74ee4ca9b725186a32d920f013093e"
+    assert graph6.logic_key == "64cd0afee708e8bf295733e55ea74cb3"
+    pieces = [df1[:3], df1[3:7], df1[7:]]
+    graph7 = md.concat(pieces).build_graph()
+    assert graph7.logic_key == "309535447287fd566b3b383a21e26785"
+    graph8 = md.merge(df1, df2, on="A", how="left").build_graph()
+    assert graph8.logic_key == "aa047766e009bda5880e59c0129430bc"
+    graph9 = df2.groupby("A").sum().build_graph()
+    graph10 = df3.groupby("A").sum().build_graph()
+    assert graph9.logic_key == "1e4512b4bc3783b002ceccc1a0ed058f"
+    assert graph9.logic_key != graph10.logic_key


### PR DESCRIPTION
## What do these changes do?
 Logic key is a unique and deterministic key for `TileableGraph`. For multiple runs the logic key will remain same if the computational logic doesn't change. And it can be used to some optimization when running a same `execute`, like HBO.

## Related issue number
#2787 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
