### PR TITLE
Wrap errors in operand execution to protect scheduling service

### DIFF
--- a/mars/core/__init__.py
+++ b/mars/core/__init__.py
@@ -14,6 +14,7 @@
 
 # noinspection PyUnresolvedReferences
 from ..typing import ChunkType, TileableType, EntityType, OperandType
+from .base import ExecutionError
 from .entity import (
     Entity,
     EntityData,

--- a/mars/core/base.py
+++ b/mars/core/base.py
@@ -142,3 +142,9 @@ BaseSerializer.register(Base)
 
 class MarsError(Exception):
     pass
+
+
+class UserFunctionError(MarsError):
+    def __init__(self, nested_error: BaseException):
+        super().__init__(nested_error)
+        self.nested_error = nested_error

--- a/mars/core/base.py
+++ b/mars/core/base.py
@@ -144,7 +144,7 @@ class MarsError(Exception):
     pass
 
 
-class UserFunctionError(MarsError):
+class ExecutionError(MarsError):
     def __init__(self, nested_error: BaseException):
         super().__init__(nested_error)
         self.nested_error = nested_error

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -15,9 +15,8 @@
 import functools
 import itertools
 import logging
-import typing
 import uuid
-from typing import List
+from typing import Callable, Dict, List
 
 import numpy as np
 import pandas as pd
@@ -129,8 +128,8 @@ del _patch_groupby_kurt
 
 def build_mock_agg_result(
     groupby: GROUPBY_TYPE,
-    groupby_params: typing.Dict,
-    raw_func: typing.Callable,
+    groupby_params: Dict,
+    raw_func: Callable,
     **raw_func_kw,
 ):
     try:

--- a/mars/lib/cython/__init__.py
+++ b/mars/lib/cython/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 1999-2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mars/lib/cython/libcpp.pxd
+++ b/mars/lib/cython/libcpp.pxd
@@ -1,0 +1,30 @@
+# Copyright 1999-2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# complementary header for C++ STL libs not included in Cython
+
+from libc.stdint cimport uint_fast64_t
+
+
+cdef extern from "<random>" namespace "std" nogil:
+    cdef cppclass mt19937_64:
+        ctypedef uint_fast64_t result_type
+
+        mt19937_64() except +
+        mt19937_64(result_type seed) except +
+        result_type operator()() except +
+        result_type min() except +
+        result_type max() except +
+        void discard(size_t z) except +
+        void seed(result_type seed) except +

--- a/mars/oscar/backends/mars/pool.py
+++ b/mars/oscar/backends/mars/pool.py
@@ -27,7 +27,7 @@ from typing import List
 
 from ....utils import get_next_port, dataslots, ensure_coverage
 from ..config import ActorPoolConfig
-from ..message import CreateActorMessage
+from ..message import CreateActorMessage, reset_random_seed as reset_message_seed
 from ..pool import MainActorPoolBase, SubActorPoolBase, _register_message_handler
 
 
@@ -168,6 +168,7 @@ class MainActorPool(MainActorPoolBase):
 
         # make sure enough randomness for every sub pool
         random.seed(uuid.uuid1().bytes)
+        reset_message_seed()
 
         conf = actor_config.get_pool_config(process_index)
         suspend_sigint = conf["suspend_sigint"]

--- a/mars/oscar/backends/message.pyi
+++ b/mars/oscar/backends/message.pyi
@@ -1,0 +1,214 @@
+# Copyright 1999-2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+from types import TracebackType
+from typing import Any, Type
+
+from ..core import ActorRef
+
+DEFAULT_PROTOCOL: int = 0
+
+class MessageType(Enum):
+    control = 0
+    result = 1
+    error = 2
+    create_actor = 3
+    destroy_actor = 4
+    has_actor = 5
+    actor_ref = 6
+    send = 7
+    tell = 8
+    cancel = 9
+
+class ControlMessageType(Enum):
+    stop = 0
+    restart = 1
+    sync_config = 2
+    get_config = 3
+    wait_pool_recovered = 4
+    add_sub_pool_actor = 5
+
+class _MessageBase:
+    message_type: MessageType
+    protocol: int
+    message_id: bytes
+    message_trace: list
+    profiling_context: Any
+
+    def __init__(
+        self,
+        message_id: bytes = None,
+        protocol: int = DEFAULT_PROTOCOL,
+        message_trace: list = None,
+        profiling_context: Any = None,
+    ): ...
+    def __repr__(self): ...
+
+class ControlMessage(_MessageBase):
+    message_type = MessageType.control
+
+    address: str
+    control_message_type: ControlMessageType
+    content: Any
+
+    def __init__(
+        self,
+        message_id: bytes = None,
+        address: str = None,
+        control_message_type: ControlMessageType = None,
+        content: Any = None,
+        protocol: int = DEFAULT_PROTOCOL,
+    ): ...
+
+class ResultMessage(_MessageBase):
+    message_type = MessageType.result
+
+    result: Any
+
+    def __init__(
+        self,
+        message_id: bytes = None,
+        result: Any = None,
+        protocol: int = DEFAULT_PROTOCOL,
+        message_trace: list = None,
+        profiling_context: Any = None,
+    ): ...
+
+class ErrorMessage(_MessageBase):
+    message_type = MessageType.error
+
+    address: str
+    pid: int
+    error_type: Type
+    error: BaseException
+    traceback: TracebackType
+
+    def __init__(
+        self,
+        message_id: bytes = None,
+        address: str = None,
+        pid: int = -1,
+        error_type: Type[BaseException] = None,
+        error: BaseException = None,
+        traceback: TracebackType = None,
+        protocol: int = DEFAULT_PROTOCOL,
+        message_trace: list = None,
+    ): ...
+    def as_instanceof_cause(self) -> BaseException: ...
+
+class CreateActorMessage(_MessageBase):
+    message_type = MessageType.create_actor
+
+    actor_cls: Type
+    actor_id: bytes
+    args: tuple
+    kwargs: dict
+    allocate_strategy: Any
+    from_main: bool
+
+    def __init__(
+        self,
+        message_id: bytes = None,
+        actor_cls: Type = None,
+        actor_id: bytes = None,
+        args: tuple = None,
+        kwargs: dict = None,
+        allocate_strategy: Any = None,
+        from_main: bool = False,
+        protocol: int = DEFAULT_PROTOCOL,
+        message_trace: list = None,
+    ): ...
+
+class DestroyActorMessage(_MessageBase):
+    message_type = MessageType.destroy_actor
+
+    actor_ref: ActorRef
+    from_main: bool
+
+    def __init__(
+        self,
+        message_id: bytes = None,
+        actor_ref: ActorRef = None,
+        from_main: bool = False,
+        protocol: int = DEFAULT_PROTOCOL,
+        message_trace: list = None,
+    ): ...
+
+class HasActorMessage(_MessageBase):
+    message_type = MessageType.has_actor
+
+    actor_ref: ActorRef
+
+    def __init__(
+        self,
+        message_id: bytes = None,
+        actor_ref: ActorRef = None,
+        protocol: int = DEFAULT_PROTOCOL,
+        message_trace: list = None,
+    ): ...
+
+class ActorRefMessage(_MessageBase):
+    message_type = MessageType.actor_ref
+
+    actor_ref: ActorRef
+
+    def __init__(
+        self,
+        message_id: bytes = None,
+        actor_ref: ActorRef = None,
+        protocol: int = DEFAULT_PROTOCOL,
+        message_trace: list = None,
+    ): ...
+
+class SendMessage(_MessageBase):
+    message_type = MessageType.send
+
+    actor_ref: ActorRef
+    content: Any
+
+    def __init__(
+        self,
+        message_id: bytes = None,
+        actor_ref: ActorRef = None,
+        content: object = None,
+        protocol: int = DEFAULT_PROTOCOL,
+        message_trace: list = None,
+        profiling_context: Any = None,
+    ): ...
+
+class TellMessage(SendMessage):
+    message_type = MessageType.tell
+
+class CancelMessage(_MessageBase):
+    message_type = MessageType.cancel
+
+    address: str
+    cancel_message_id: bytes
+
+    def __init__(
+        self,
+        message_id: bytes = None,
+        address: str = None,
+        cancel_message_id: bytes = None,
+        protocol: int = DEFAULT_PROTOCOL,
+        message_trace: list = None,
+    ): ...
+
+class DeserializeMessageFailed(RuntimeError):
+    def __init__(self, message_id: bytes): ...
+    def __str__(self): ...
+
+def reset_random_seed(): ...
+def new_message_id() -> bytes: ...

--- a/mars/oscar/backends/message.pyx
+++ b/mars/oscar/backends/message.pyx
@@ -1,4 +1,5 @@
-# Copyright 1999-2021 Alibaba Group Holding Ltd.
+# distutils: language = c++
+# Copyright 1999-2022 Alibaba Group Holding Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,28 +14,26 @@
 # limitations under the License.
 
 from enum import Enum
+from random import getrandbits
 from types import TracebackType
 from typing import Any, Type
 
+from libc.stdint cimport uint_fast64_t
+
+from ...lib.cython.libcpp cimport mt19937_64
 from ...lib.tblib import pickling_support
 from ...serialization.core cimport Serializer
 from ...utils import wrap_exception
 from ..core cimport ActorRef
-
-try:
-    from random import randbytes
-except ImportError:  # pragma: no cover
-    from random import getrandbits
-
-    def randbytes(long n) -> bytes:
-        return getrandbits(n * 8).to_bytes(n, "little")
-
 
 # make sure traceback can be pickled
 pickling_support.install()
 
 cdef int _DEFAULT_PROTOCOL = 0
 DEFAULT_PROTOCOL = _DEFAULT_PROTOCOL
+
+cdef mt19937_64 _rnd_gen
+cdef bint _rnd_is_seed_set = False
 
 
 class MessageType(Enum):
@@ -552,5 +551,23 @@ cdef class MessageSerializer(Serializer):
 MessageSerializer.register(_MessageBase)
 
 
+cpdef reset_random_seed():
+    cdef bytes seed_bytes
+    global _rnd_is_seed_set
+
+    seed_bytes = getrandbits(64).to_bytes(8, "little")
+    # memcpy(&seed, <char *>seed_bytes, 8)
+    _rnd_gen.seed((<uint_fast64_t *><char *>seed_bytes)[0])
+    _rnd_is_seed_set = True
+
+
 cpdef bytes new_message_id():
-    return randbytes(32)
+    cdef uint_fast64_t res_array[4]
+    cdef int i
+
+    if not _rnd_is_seed_set:
+        reset_random_seed()
+
+    for i in range(4):
+        res_array[i] = _rnd_gen()
+    return <bytes>((<char *>&(res_array[0]))[:32])

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -17,11 +17,10 @@ import concurrent.futures as futures
 import itertools
 import logging
 import time
-import typing
 from abc import ABC
 from collections import namedtuple
 from dataclasses import dataclass
-from typing import Any, Callable, Coroutine, Dict, Type
+from typing import Any, Callable, Coroutine, Dict, List, Tuple, Type
 from urllib.parse import urlparse
 
 from ....oscar.profiling import ProfilingData
@@ -56,13 +55,13 @@ def msg_to_simple_str(msg):  # pragma: no cover
         return f"{str(type(msg))}(actor_ref={msg.actor_ref}, content={msg_to_simple_str(msg.content)})"
     if isinstance(msg, _MessageBase):
         return str(msg)
-    if msg and isinstance(msg, typing.List):
+    if msg and isinstance(msg, List):
         part_str = ", ".join([msg_to_simple_str(item) for item in msg[:5]])
         return f"List<{part_str}...{len(msg)}>"
-    if msg and isinstance(msg, typing.Tuple):
+    if msg and isinstance(msg, Tuple):
         part_str = ", ".join([msg_to_simple_str(item) for item in msg[:5]])
         return f"Tuple<{part_str}...{len(msg)}>"
-    if msg and isinstance(msg, typing.Dict):
+    if msg and isinstance(msg, Dict):
         part_str = []
         it = iter(msg.items())
         try:

--- a/mars/oscar/context.pyx
+++ b/mars/oscar/context.pyx
@@ -35,7 +35,14 @@ cdef class BaseActorContext:
     def __init__(self, address: str = None):
         self._address = address
 
-    async def create_actor(self, object actor_cls, *args, object uid=None, object address=None, **kwargs):
+    async def create_actor(
+        self,
+        object actor_cls,
+        *args,
+        object uid=None,
+        object address=None,
+        **kwargs,
+    ):
         """
         Stub method for creating an actor in current context.
 
@@ -106,7 +113,13 @@ cdef class BaseActorContext:
         bool
         """
 
-    async def send(self, ActorRef actor_ref, object message, bint wait_response=True, object profiling_context=None):
+    async def send(
+        self,
+        ActorRef actor_ref,
+        object message,
+        bint wait_response=True,
+        object profiling_context=None,
+    ):
         """
         Send a message to given actor by its reference
 
@@ -191,7 +204,14 @@ cdef class ClientActorContext(BaseActorContext):
                 _backend_context_cls[scheme](address)
             return context
 
-    def create_actor(self, object actor_cls, *args, object uid=None, object address=None, **kwargs):
+    def create_actor(
+        self,
+        object actor_cls,
+        *args,
+        object uid=None,
+        object address=None,
+        **kwargs,
+    ):
         context = self._get_backend_context(address)
         uid = uid or new_actor_id()
         return context.create_actor(actor_cls, *args, uid=uid, address=address, **kwargs)
@@ -213,9 +233,20 @@ cdef class ClientActorContext(BaseActorContext):
         context = self._get_backend_context(actor_ref.address)
         return context.actor_ref(actor_ref)
 
-    def send(self, ActorRef actor_ref, object message, bint wait_response=True, object profiling_context=None):
+    def send(
+        self,
+        ActorRef actor_ref,
+        object message,
+        bint wait_response=True,
+        object profiling_context=None
+    ):
         context = self._get_backend_context(actor_ref.address)
-        return context.send(actor_ref, message, wait_response=wait_response, profiling_context=profiling_context)
+        return context.send(
+            actor_ref,
+            message,
+            wait_response=wait_response,
+            profiling_context=profiling_context,
+        )
 
     def wait_actor_pool_recovered(self, str address, str main_address = None):
         context = self._get_backend_context(address)
@@ -240,10 +271,3 @@ cpdef get_context():
     if _context is None:
         _context = ClientActorContext()
     return _context
-
-
-def set_context(context):
-    """
-    Set default actor context to use
-    """
-    _context = context

--- a/mars/oscar/utils.pyx
+++ b/mars/oscar/utils.pyx
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from random import getrandbits
 from typing import AsyncGenerator
-
-import numpy as np
 
 from .._utils cimport to_str
 from .core cimport ActorRef, LocalActorRef
 
 
 cpdef bytes new_actor_id():
-    return np.random.bytes(32)
+    return getrandbits(256).to_bytes(32, "little")
 
 
 def create_actor_ref(*args, **kwargs):

--- a/mars/serialization/core.pyx
+++ b/mars/serialization/core.pyx
@@ -15,17 +15,18 @@
 
 import asyncio
 import datetime
+import enum
 import hashlib
 import inspect
 import sys
-from cpython cimport PyObject
 from functools import partial, wraps
-from libc.stdint cimport int32_t, uint32_t, int64_t, uint64_t, uintptr_t
-from libcpp.unordered_map cimport unordered_map
 from typing import Any, Dict, List
 
 import numpy as np
 import pandas as pd
+from cpython cimport PyObject
+from libc.stdint cimport int32_t, uint32_t, int64_t, uint64_t, uintptr_t
+from libcpp.unordered_map cimport unordered_map
 
 from .._utils cimport TypeDispatcher
 
@@ -254,6 +255,7 @@ cdef set _primitive_types = {
     datetime.datetime,
     datetime.date,
     datetime.timedelta,
+    enum.Enum,
     type(max),  # builtin functions
     np.dtype,
     np.number,

--- a/mars/services/scheduling/tests/test_service.py
+++ b/mars/services/scheduling/tests/test_service.py
@@ -255,27 +255,19 @@ async def test_schedule_error(actor_pools):
     )
     scheduling_api = await SchedulingAPI.create(session_id, sv_pool.external_address)
 
-    def _remote_fun():
-        raise ValueError
+    exc_types = [ValueError, asyncio.CancelledError, GeneratorExit]
+    for exc_type in exc_types:
 
-    a = mr.spawn(_remote_fun)
-    subtask = _gen_subtask(a, session_id)
-    subtask.expect_bands = [(worker_pool.external_address, "numa-0")]
+        def _remote_fun():
+            raise exc_type
 
-    await scheduling_api.add_subtasks([subtask])
-    with pytest.raises(ValueError):
-        await task_manager_ref.wait_subtask_result(subtask.subtask_id)
+        a = mr.spawn(_remote_fun)
+        subtask = _gen_subtask(a, session_id)
+        subtask.expect_bands = [(worker_pool.external_address, "numa-0")]
 
-    def _remote_fun_gen_exit():
-        raise asyncio.CancelledError
-
-    a = mr.spawn(_remote_fun_gen_exit)
-    subtask = _gen_subtask(a, session_id)
-    subtask.expect_bands = [(worker_pool.external_address, "numa-0")]
-
-    await scheduling_api.add_subtasks([subtask])
-    with pytest.raises(asyncio.CancelledError):
-        await task_manager_ref.wait_subtask_result(subtask.subtask_id)
+        await scheduling_api.add_subtasks([subtask])
+        with pytest.raises(exc_type):
+            await task_manager_ref.wait_subtask_result(subtask.subtask_id)
 
     assert _approx_resource(
         (await global_resource_ref.get_used_resources()).get(

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 from typing import Any, Dict, List, Optional, Set, Type
 
 from .... import oscar as mo
-from ....core import ChunkGraph, OperandType, enter_mode
+from ....core import ChunkGraph, OperandType, enter_mode, ExecutionError
 from ....core.context import get_context, set_context
 from ....core.operand import (
     Fetch,
@@ -185,7 +185,11 @@ class SubtaskProcessor:
     def _execute_operand(
         self, ctx: Dict[str, Any], op: OperandType
     ):  # noqa: R0201  # pylint: disable=no-self-use
-        return execute(ctx, op)
+        try:
+            return execute(ctx, op)
+        except BaseException as ex:
+            # wrap exception in execution to avoid side effects
+            raise ExecutionError(ex).with_traceback(ex.__traceback__) from None
 
     async def _execute_graph(self, chunk_graph: ChunkGraph):
         loop = asyncio.get_running_loop()

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -480,10 +480,14 @@ class SubtaskProcessor:
             self.result.status = SubtaskStatus.cancelled
             self.result.progress = 1.0
             raise
-        except:  # noqa: E722  # nosec  # pylint: disable=bare-except
+        except BaseException as ex:  # noqa: E722  # nosec  # pylint: disable=bare-except
             self.result.status = SubtaskStatus.errored
             self.result.progress = 1.0
-            _, self.result.error, self.result.traceback = sys.exc_info()
+            if isinstance(ex, ExecutionError):
+                self.result.error = ex.nested_error
+                self.result.traceback = ex.nested_error.__traceback__
+            else:  # pragma: no cover
+                _, self.result.error, self.result.traceback = sys.exc_info()
             await self.done()
             raise
         finally:

--- a/mars/services/subtask/worker/tests/test_subtask.py
+++ b/mars/services/subtask/worker/tests/test_subtask.py
@@ -23,6 +23,7 @@ import pytest
 from ..... import oscar as mo
 from ..... import tensor as mt
 from ..... import remote as mr
+from .....core import ExecutionError
 from .....core.context import get_context
 from .....core.graph import TileableGraph, TileableGraphBuilder, ChunkGraphBuilder
 
@@ -155,8 +156,9 @@ async def test_subtask_failure(actor_pool):
     subtask_runner: SubtaskRunnerRef = await mo.actor_ref(
         SubtaskRunnerActor.gen_uid("numa-0", 0), address=pool.external_address
     )
-    with pytest.raises(FloatingPointError):
+    with pytest.raises(ExecutionError) as ex_info:
         await subtask_runner.run_subtask(subtask)
+    assert isinstance(ex_info.value.nested_error, FloatingPointError)
     result = await subtask_runner.get_subtask_result()
     assert result.status == SubtaskStatus.errored
     assert isinstance(result.error, FloatingPointError)

--- a/mars/tests/test_cluster.py
+++ b/mars/tests/test_cluster.py
@@ -24,6 +24,7 @@ import pytest
 from .. import new_session
 from .. import tensor as mt
 from ..services.cluster import NodeRole, WebClusterAPI
+from ..tests.core import flaky
 from ..utils import get_next_port
 
 
@@ -46,6 +47,7 @@ def _terminate(pid: int):
             continue
 
 
+@flaky(max_runs=3)
 @pytest.mark.asyncio
 async def test_cluster():
     port = get_next_port()

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1122,6 +1122,26 @@ def enter_current_session(func: Callable):
     return wrapped
 
 
+def wrap_user_function_error(ctx):
+    def wrapper(fun: Callable):
+        @functools.wraps(fun)
+        def wrapped(*args, **kw):
+            from .core.base import UserFunctionError
+            # skip in some test cases
+            if not hasattr(ctx, "get_current_session"):
+                return fun(*args, **kw)
+
+            try:
+                return fun(*args, **kw)
+            except BaseException as exc:
+                if not hasattr(ctx, "get_current_session"):
+                    raise
+                raise UserFunctionError(exc).with_traceback(exc.__traceback__) from None
+        return wrapped
+
+    return wrapper
+
+
 _io_quiet_local = threading.local()
 _io_quiet_lock = threading.Lock()
 

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -71,6 +71,7 @@ from ._utils import (  # noqa: F401 # pylint: disable=unused-import
     ceildiv,
     Timer,
 )
+from .core.base import MarsError
 from .lib.version import parse as parse_version
 from .typing import ChunkType, TileableType, EntityType, OperandType
 

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -122,7 +122,6 @@ except ImportError:  # pragma: no cover
         from pandas._libs import lib as _pd__libs_lib
 
         _pd__libs_lib.NoDefault = NoDefault
-        _pd__libs_lib.no_default = no_default
     except (ImportError, AttributeError):
         pass
 


### PR DESCRIPTION
## What do these changes do?

Wrap errors in operand execution to protect scheduling service with an `ExecutionError`. When building `ErrorMessage` real errors are extracted and stored in the message from the wrapper.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2963

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
