### PR TITLE
[Ray] Support basic subtask retry and lineage reconstruction

### DIFF
--- a/mars/conftest.py
+++ b/mars/conftest.py
@@ -156,6 +156,14 @@ async def ray_create_mars_cluster(request):
         yield client
 
 
+@pytest.fixture
+def stop_mars():
+    yield
+    import mars
+
+    mars.stop_server()
+
+
 @pytest.fixture(scope="module")
 def _stop_isolation():
     yield

--- a/mars/dataframe/contrib/raydataset/dataset.py
+++ b/mars/dataframe/contrib/raydataset/dataset.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import operator
+from functools import reduce
 
 from ....utils import lazy_import
 from .mldataset import _rechunk_if_needed
@@ -59,5 +61,6 @@ def to_ray_dataset(df, num_shards: int = None):
 
 
 def get_chunk_refs(df):
-    fetched_infos: Dict[str, List] = df.fetch_infos(fields=["object_id"])
-    return fetched_infos["object_id"]
+    fetched_infos: Dict[str, List] = df.fetch_infos(["object_refs"])
+    object_refs = reduce(operator.concat, fetched_infos["object_refs"])
+    return object_refs

--- a/mars/dataframe/contrib/raydataset/mldataset.py
+++ b/mars/dataframe/contrib/raydataset/mldataset.py
@@ -104,11 +104,14 @@ def to_ray_mldataset(df, num_shards: int = None):
     #       chunk1 for addr1,
     #       chunk2 & chunk3 for addr2,
     #       chunk4 for addr1
-    fetched_infos: Dict[str, List] = df.fetch_infos(fields=["band", "object_id"])
+    fetched_infos: Dict[str, List] = df.fetch_infos(fields=["band", "object_refs"])
     chunk_addr_refs: List[Tuple[Tuple, "ray.ObjectRef"]] = [
-        (band, object_id)
-        for band, object_id in zip(fetched_infos["band"], fetched_infos["object_id"])
+        (band, object_refs[0])
+        for band, object_refs in zip(
+            fetched_infos["band"], fetched_infos["object_refs"]
+        )
     ]
+    print(f"fetched_infos {fetched_infos} \n {chunk_addr_refs}")
     group_to_obj_refs: Dict[str, List[ray.ObjectRef]] = _group_chunk_refs(
         chunk_addr_refs, num_shards
     )

--- a/mars/dataframe/contrib/raydataset/mldataset.py
+++ b/mars/dataframe/contrib/raydataset/mldataset.py
@@ -104,11 +104,11 @@ def to_ray_mldataset(df, num_shards: int = None):
     #       chunk1 for addr1,
     #       chunk2 & chunk3 for addr2,
     #       chunk4 for addr1
-    fetched_infos: Dict[str, List] = df.fetch_infos(fields=["band", "object_refs"])
+    fetched_infos: Dict[str, List] = df.fetch_infos(fields=["bands", "object_refs"])
     chunk_addr_refs: List[Tuple[Tuple, "ray.ObjectRef"]] = [
-        (band, object_refs[0])
-        for band, object_refs in zip(
-            fetched_infos["band"], fetched_infos["object_refs"]
+        (bands[0], object_refs[0])
+        for bands, object_refs in zip(
+            fetched_infos["bands"], fetched_infos["object_refs"]
         )
     ]
     group_to_obj_refs: Dict[str, List[ray.ObjectRef]] = _group_chunk_refs(

--- a/mars/dataframe/contrib/raydataset/mldataset.py
+++ b/mars/dataframe/contrib/raydataset/mldataset.py
@@ -111,7 +111,6 @@ def to_ray_mldataset(df, num_shards: int = None):
             fetched_infos["band"], fetched_infos["object_refs"]
         )
     ]
-    print(f"fetched_infos {fetched_infos} \n {chunk_addr_refs}")
     group_to_obj_refs: Dict[str, List[ray.ObjectRef]] = _group_chunk_refs(
         chunk_addr_refs, num_shards
     )

--- a/mars/dataframe/contrib/raydataset/tests/test_raydataset.py
+++ b/mars/dataframe/contrib/raydataset/tests/test_raydataset.py
@@ -62,7 +62,12 @@ async def test_convert_to_ray_dataset(
     with session:
         value = np.random.rand(10, 10)
         chunk_size, num_shards = test_option
-        df: md.DataFrame = md.DataFrame(value, chunk_size=chunk_size)
+        # ray dataset needs str columns
+        df: md.DataFrame = md.DataFrame(
+            value,
+            chunk_size=chunk_size,
+            columns=[f"c{i}" for i in range(value.shape[1])],
+        )
         df.execute()
 
         ds = mdd.to_ray_dataset(df, num_shards=num_shards)
@@ -164,7 +169,8 @@ async def test_mars_with_xgboost_sklearn_reg(ray_start_regular_shared, create_cl
     session = new_session(address=create_cluster.address, default=True)
     with session:
         np_X, np_y = make_regression(n_samples=1_0000, n_features=10)
-        X, y = md.DataFrame(np_X), md.DataFrame({"target": np_y})
+        columns = [f"c{i}" for i in range(np_X.shape[1])]
+        X, y = md.DataFrame(np_X, columns=columns), md.DataFrame({"target": np_y})
         df: md.DataFrame = md.concat([md.DataFrame(X), md.DataFrame(y)], axis=1)
         df.execute()
 
@@ -174,10 +180,10 @@ async def test_mars_with_xgboost_sklearn_reg(ray_start_regular_shared, create_cl
 
         import gc
 
-        gc.collect()  # Ensure MLDataset does hold mars dataframe to avoid gc.
+        gc.collect()  # Ensure Dataset does hold mars dataframe to avoid gc.
         ray_params = RayParams(num_actors=2, cpus_per_actor=1)
         reg = RayXGBRegressor(ray_params=ray_params, random_state=42)
         # train
         reg.fit(RayDMatrix(ds, "target"), y=None, ray_params=ray_params)
         reg.predict(RayDMatrix(ds, "target"))
-        reg.predict(pd.DataFrame(np_X))
+        reg.predict(pd.DataFrame(np_X, columns=columns))

--- a/mars/deploy/oscar/rayconfig.yml
+++ b/mars/deploy/oscar/rayconfig.yml
@@ -9,9 +9,6 @@ session:
   custom_log_dir: null
 storage:
   backends: [ray]
-task:
-  task_executor_config:
-    subtask_max_retries: 3
 scheduling:
   autoscale:
     enabled: false

--- a/mars/deploy/oscar/rayconfig.yml
+++ b/mars/deploy/oscar/rayconfig.yml
@@ -9,6 +9,9 @@ session:
   custom_log_dir: null
 storage:
   backends: [ray]
+task:
+  task_executor_config:
+    subtask_max_retries: 3
 scheduling:
   autoscale:
     enabled: false

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -1216,8 +1216,9 @@ class _IsolatedSession(AbstractAsyncSession):
                         for f in fields:
                             if f == "band":
                                 bands = chunk_to_meta[fetch_info.chunk]["bands"]
-                                fetched[f] = bands[0] if bands else None
-                            fetched[f].append(chunk_to_meta[fetch_info.chunk][f])
+                                fetched[f].append(bands[0] if bands else None)
+                            else:
+                                fetched[f].append(chunk_to_meta[fetch_info.chunk][f])
                     result.append(fetched)
                 return result
             chunk_to_band = {

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -1181,10 +1181,11 @@ class _IsolatedSession(AbstractAsyncSession):
         if kwargs:  # pragma: no cover
             unexpected_keys = ", ".join(list(kwargs.keys()))
             raise TypeError(f"`fetch` got unexpected arguments: {unexpected_keys}")
-        need_fetch_fields = {"level", "memory_size", "store_size"}
-        need_fetch = bool(need_fetch_fields & fields)
+        # following fields needs to access storage API to get the meta.
+        _need_query_storage_fields = {"level", "memory_size", "store_size"}
+        _need_query_storage = bool(_need_query_storage_fields & fields)
         get_chunk_meta_fields = ["bands"]
-        if not need_fetch:
+        if not _need_query_storage:
             get_chunk_meta_fields = list(fields)
             if "band" in get_chunk_meta_fields:
                 get_chunk_meta_fields[get_chunk_meta_fields.index("band")] = "bands"
@@ -1207,7 +1208,7 @@ class _IsolatedSession(AbstractAsyncSession):
                     )
                 fetch_infos_list.append(fetch_infos)
             chunk_metas = await self._meta_api.get_chunk_meta.batch(*get_chunk_metas)
-            if not need_fetch:
+            if not _need_query_storage:
                 result = []
                 chunk_to_meta = dict(zip(chunks, chunk_metas))
                 for fetch_infos in fetch_infos_list:

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -1166,7 +1166,7 @@ class _IsolatedSession(AbstractAsyncSession):
             "level",
             "memory_size",
             "store_size",
-            "band",
+            "bands",
         }
         if fields is None:
             fields = available_fields
@@ -1184,54 +1184,19 @@ class _IsolatedSession(AbstractAsyncSession):
         # following fields needs to access storage API to get the meta.
         _need_query_storage_fields = {"level", "memory_size", "store_size"}
         _need_query_storage = bool(_need_query_storage_fields & fields)
-        get_chunk_meta_fields = ["bands"]
-        if not _need_query_storage:
-            get_chunk_meta_fields = list(fields)
-            if "band" in get_chunk_meta_fields:
-                get_chunk_meta_fields[get_chunk_meta_fields.index("band")] = "bands"
         with enter_mode(build=True):
-            chunks = []
-            get_chunk_metas = []
-            fetch_infos_list = []
-            for tileable in tileables:
-                fetch_tileable, _ = self._get_to_fetch_tileable(tileable)
-                fetch_infos = []
-                for chunk in fetch_tileable.chunks:
-                    chunks.append(chunk)
-                    get_chunk_metas.append(
-                        self._meta_api.get_chunk_meta.delay(
-                            chunk.key, fields=get_chunk_meta_fields
-                        )
-                    )
-                    fetch_infos.append(
-                        ChunkFetchInfo(tileable=tileable, chunk=chunk, indexes=None)
-                    )
-                fetch_infos_list.append(fetch_infos)
-            chunk_metas = await self._meta_api.get_chunk_meta.batch(*get_chunk_metas)
+            chunk_to_bands, fetch_infos_list, result = await self._query_meta_service(
+                tileables, fields, _need_query_storage
+            )
             if not _need_query_storage:
-                result = []
-                chunk_to_meta = dict(zip(chunks, chunk_metas))
-                for fetch_infos in fetch_infos_list:
-                    fetched = defaultdict(list)
-                    for fetch_info in fetch_infos:
-                        for f in fields:
-                            if f == "band":
-                                bands = chunk_to_meta[fetch_info.chunk]["bands"]
-                                fetched[f].append(bands[0] if bands else None)
-                            else:
-                                fetched[f].append(chunk_to_meta[fetch_info.chunk][f])
-                    result.append(fetched)
+                assert result is not None
                 return result
-            chunk_to_band = {
-                chunk: meta["bands"][0] for chunk, meta in zip(chunks, chunk_metas)
-            }
-
             storage_api_to_gets = defaultdict(list)
             storage_api_to_fetch_infos = defaultdict(list)
             for fetch_info in itertools.chain(*fetch_infos_list):
                 chunk = fetch_info.chunk
-                band = chunk_to_band[chunk]
-                storage_api = await self._get_storage_api(band)
+                bands = chunk_to_bands[chunk]
+                storage_api = await self._get_storage_api(bands[0])
                 storage_api_to_gets[storage_api].append(
                     storage_api.get_infos.delay(chunk.key)
                 )
@@ -1248,7 +1213,7 @@ class _IsolatedSession(AbstractAsyncSession):
             for fetch_infos in fetch_infos_list:
                 fetched = defaultdict(list)
                 for fetch_info in fetch_infos:
-                    band = chunk_to_band[fetch_info.chunk]
+                    bands = chunk_to_bands[fetch_info.chunk]
                     # Currently there's only one item in the returned List from storage_api.get_infos()
                     data = fetch_info.data[0]
                     if "object_id" in fields:
@@ -1261,11 +1226,46 @@ class _IsolatedSession(AbstractAsyncSession):
                         fetched["store_size"].append(data.store_size)
                     # data.band misses ip info, e.g. 'numa-0'
                     # while band doesn't, e.g. (address0, 'numa-0')
-                    if "band" in fields:
-                        fetched["band"].append(band)
+                    if "bands" in fields:
+                        fetched["bands"].append(bands)
                 result.append(fetched)
 
             return result
+
+    async def _query_meta_service(self, tileables, fields, query_storage):
+        chunks = []
+        get_chunk_metas = []
+        fetch_infos_list = []
+        for tileable in tileables:
+            fetch_tileable, _ = self._get_to_fetch_tileable(tileable)
+            fetch_infos = []
+            for chunk in fetch_tileable.chunks:
+                chunks.append(chunk)
+                get_chunk_metas.append(
+                    self._meta_api.get_chunk_meta.delay(
+                        chunk.key,
+                        fields=["bands"] if query_storage else fields,
+                    )
+                )
+                fetch_infos.append(
+                    ChunkFetchInfo(tileable=tileable, chunk=chunk, indexes=None)
+                )
+            fetch_infos_list.append(fetch_infos)
+        chunk_metas = await self._meta_api.get_chunk_meta.batch(*get_chunk_metas)
+        if not query_storage:
+            result = []
+            chunk_to_meta = dict(zip(chunks, chunk_metas))
+            for fetch_infos in fetch_infos_list:
+                fetched = defaultdict(list)
+                for fetch_info in fetch_infos:
+                    for field in fields:
+                        fetched[field].append(chunk_to_meta[fetch_info.chunk][field])
+                result.append(fetched)
+            return {}, fetch_infos_list, result
+        chunk_to_bands = {
+            chunk: meta["bands"] for chunk, meta in zip(chunks, chunk_metas)
+        }
+        return chunk_to_bands, fetch_infos_list, None
 
     async def decref(self, *tileable_keys):
         logger.debug("Decref tileables on client: %s", tileable_keys)

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -382,6 +382,14 @@ async def test_fetch_infos(create_cluster):
     assert "store_size" in fetched_infos
     assert "band" in fetched_infos
 
+    fetched_infos = df.fetch_infos(fields=["object_id", "band"])
+    assert "object_id" in fetched_infos
+    assert "band" in fetched_infos
+    assert "level" not in fetched_infos
+    assert "memory_size" not in fetched_infos
+    assert "store_size" not in fetched_infos
+    assert "object_refs" not in fetched_infos
+
     fetch_infos((df, df), fields=None)
     results_infos = mr.ExecutableTuple([df, df]).execute()._fetch_infos()
     assert len(results_infos) == 2

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -385,10 +385,7 @@ async def test_fetch_infos(create_cluster):
     fetched_infos = df.fetch_infos(fields=["object_id", "band"])
     assert "object_id" in fetched_infos
     assert "band" in fetched_infos
-    assert "level" not in fetched_infos
-    assert "memory_size" not in fetched_infos
-    assert "store_size" not in fetched_infos
-    assert "object_refs" not in fetched_infos
+    assert len(fetched_infos) == 2
 
     fetch_infos((df, df), fields=None)
     results_infos = mr.ExecutableTuple([df, df]).execute()._fetch_infos()

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -380,11 +380,11 @@ async def test_fetch_infos(create_cluster):
     assert "level" in fetched_infos
     assert "memory_size" in fetched_infos
     assert "store_size" in fetched_infos
-    assert "band" in fetched_infos
+    assert "bands" in fetched_infos
 
-    fetched_infos = df.fetch_infos(fields=["object_id", "band"])
+    fetched_infos = df.fetch_infos(fields=["object_id", "bands"])
     assert "object_id" in fetched_infos
-    assert "band" in fetched_infos
+    assert "bands" in fetched_infos
     assert len(fetched_infos) == 2
 
     fetch_infos((df, df), fields=None)
@@ -394,7 +394,7 @@ async def test_fetch_infos(create_cluster):
     assert "level" in results_infos[0]
     assert "memory_size" in results_infos[0]
     assert "store_size" in results_infos[0]
-    assert "band" in results_infos[0]
+    assert "bands" in results_infos[0]
 
 
 async def _run_web_session_test(web_address):

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -14,12 +14,14 @@
 
 import asyncio
 import copy
+import operator
 import os
 import subprocess
 import sys
 import tempfile
 import threading
 import time
+from functools import reduce
 
 import numpy as np
 import pandas as pd
@@ -726,3 +728,13 @@ def test_init_metrics_on_ray(ray_start_regular, create_cluster):
     assert api._metric_backend == "ray"
 
     client.session.stop_server()
+
+
+@pytest.mark.asyncio
+async def test_fetch_infos(create_cluster):
+    df = md.DataFrame(mt.random.RandomState(0).rand(5000, 1, chunk_size=1000))
+    df.execute()
+    fetched_infos = df.fetch_infos(fields=["object_refs"])
+    object_refs = reduce(operator.concat, fetched_infos["object_refs"])
+    assert len(fetched_infos) == 1
+    assert len(object_refs) == 5

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -155,6 +155,12 @@ async def test_execute_describe(ray_start_regular, create_cluster):
 @pytest.mark.asyncio
 async def test_fetch_infos(ray_start_regular, create_cluster):
     await test_local.test_fetch_infos(create_cluster)
+    df = md.DataFrame(mt.random.RandomState(0).rand(5000, 1, chunk_size=1000))
+    df.execute()
+    fetched_infos = df.fetch_infos(fields=["object_refs"])
+    object_refs = reduce(operator.concat, fetched_infos["object_refs"])
+    assert len(fetched_infos) == 1
+    assert len(object_refs) == 5
 
 
 @require_ray
@@ -728,13 +734,3 @@ def test_init_metrics_on_ray(ray_start_regular, create_cluster):
     assert api._metric_backend == "ray"
 
     client.session.stop_server()
-
-
-@pytest.mark.asyncio
-async def test_fetch_infos(create_cluster):
-    df = md.DataFrame(mt.random.RandomState(0).rand(5000, 1, chunk_size=1000))
-    df.execute()
-    fetched_infos = df.fetch_infos(fields=["object_refs"])
-    object_refs = reduce(operator.concat, fetched_infos["object_refs"])
-    assert len(fetched_infos) == 1
-    assert len(object_refs) == 5

--- a/mars/deploy/oscar/tests/test_ray_dag_failover.py
+++ b/mars/deploy/oscar/tests/test_ray_dag_failover.py
@@ -20,8 +20,8 @@ import pandas as pd
 import pytest
 
 import mars
-import mars.dataframe as md
-import mars.tensor as mt
+from .... import dataframe as md
+from .... import tensor as mt
 from ....tests.core import require_ray
 from ....utils import lazy_import
 
@@ -35,7 +35,9 @@ ray = lazy_import("ray")
     indirect=True,
 )
 @pytest.mark.parametrize("reconstruction_enabled", [True, False])
-def test_basic_object_reconstruction(ray_large_cluster, reconstruction_enabled):
+def test_basic_object_reconstruction(
+    ray_large_cluster, reconstruction_enabled, stop_mars
+):
     config = {
         "num_heartbeats_timeout": 10,
         "raylet_heartbeat_period_milliseconds": 200,

--- a/mars/deploy/oscar/tests/test_ray_dag_failover.py
+++ b/mars/deploy/oscar/tests/test_ray_dag_failover.py
@@ -1,0 +1,106 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import operator
+from functools import reduce
+
+import pandas as pd
+import pytest
+
+import mars
+import mars.dataframe as md
+import mars.tensor as mt
+from ....tests.core import require_ray
+from ....utils import lazy_import
+
+ray = lazy_import("ray")
+
+
+@require_ray
+@pytest.mark.parametrize(
+    "ray_large_cluster",
+    [{"num_nodes": 0, "use_ray_serialization": False}],
+    indirect=True,
+)
+@pytest.mark.parametrize("reconstruction_enabled", [True, False])
+def test_basic_object_reconstruction(ray_large_cluster, reconstruction_enabled):
+    config = {
+        "num_heartbeats_timeout": 10,
+        "raylet_heartbeat_period_milliseconds": 200,
+        "object_timeout_milliseconds": 200,
+    }
+    # Workaround to reset the config to the default value.
+    if not reconstruction_enabled:
+        config["lineage_pinning_enabled"] = False
+        subtask_max_retries = 0
+    else:
+        subtask_max_retries = 1
+
+    cluster = ray_large_cluster
+    # Head node with no resources.
+    cluster.add_node(
+        num_cpus=0,
+        _system_config=config,
+        enable_object_reconstruction=reconstruction_enabled,
+    )
+    ray.init(address=cluster.address)
+    # Node to place the initial object.
+    node_to_kill = cluster.add_node(num_cpus=1, object_store_memory=10**8)
+    mars.new_session(
+        backend="ray",
+        config={"scheduling.subtask_max_retries": subtask_max_retries},
+        default=True,
+    )
+    cluster.wait_for_nodes()
+
+    df = md.DataFrame(mt.random.RandomState(0).rand(2_000_000, 1, chunk_size=1_000_000))
+    df.execute()
+    # this will submit new ray tasks
+    df2 = df.map_chunk(lambda pdf: pdf * 2).execute()
+    executed_infos = df2.fetch_infos(fields=["object_refs"])
+    object_refs = reduce(operator.concat, executed_infos["object_refs"])
+    head5 = df2.head(5).to_pandas()
+
+    cluster.remove_node(node_to_kill, allow_graceful=False)
+    node_to_kill = cluster.add_node(num_cpus=1, object_store_memory=10**8)
+
+    # use a dependent_task to avoid fetch lost objects to local
+    @ray.remote
+    def dependent_task(x):
+        return x
+
+    if reconstruction_enabled:
+        ray.get([dependent_task.remote(ref) for ref in object_refs])
+        new_head5 = df2.head(5).to_pandas()
+        pd.testing.assert_frame_equal(head5, new_head5)
+    else:
+        with pytest.raises(ray.exceptions.RayTaskError):
+            df2.head(5).to_pandas()
+        with pytest.raises(ray.exceptions.ObjectLostError):
+            ray.get(object_refs)
+
+    # Losing the object a second time will cause reconstruction to fail because
+    # we have reached the max task retries.
+    cluster.remove_node(node_to_kill, allow_graceful=False)
+    cluster.add_node(num_cpus=1, object_store_memory=10**8)
+
+    if reconstruction_enabled:
+        with pytest.raises(
+            ray.exceptions.ObjectReconstructionFailedMaxAttemptsExceededError
+        ):
+            ray.get(object_refs)
+    else:
+        with pytest.raises(ray.exceptions.ObjectLostError):
+            ray.get(object_refs)

--- a/mars/deploy/utils.py
+++ b/mars/deploy/utils.py
@@ -163,6 +163,10 @@ def load_config(config: Union[str, Dict], default_config_file: str):
             "ensure enough homogeneous subtasks to calculate statistics."
         )
         config["task"]["default_config"]["initial_same_color_num"] = 1
+    ray_execution_config = config["task"]["execution_config"].setdefault("ray", {})
+    subtask_max_retries = config["scheduling"].get("subtask_max_retries")
+    if subtask_max_retries is not None:
+        ray_execution_config.setdefault("subtask_max_retries", subtask_max_retries)
     return config
 
 

--- a/mars/services/task/execution/ray/config.py
+++ b/mars/services/task/execution/ray/config.py
@@ -18,9 +18,21 @@ from ..api import ExecutionConfig, register_config_cls
 from ..utils import get_band_resources_from_config
 
 
+# the default times to retry subtask.
+DEFAULT_SUBTASK_MAX_RETRIES = 3
+
+
 @register_config_cls
 class RayExecutionConfig(ExecutionConfig):
     name = "ray"
+
+    def __init__(self, execution_config: Dict):
+        super().__init__(execution_config)
+        self._subtask_max_retries = (
+            self.get_execution_config()
+            .get("ray", {})
+            .get("subtask_max_retries", DEFAULT_SUBTASK_MAX_RETRIES)
+        )
 
     def get_band_resources(self):
         """
@@ -31,3 +43,7 @@ class RayExecutionConfig(ExecutionConfig):
 
     def get_deploy_band_resources(self) -> List[Dict[str, Resource]]:
         return []
+
+    @property
+    def subtask_max_retries(self):
+        return self._subtask_max_retries

--- a/mars/services/task/execution/ray/config.py
+++ b/mars/services/task/execution/ray/config.py
@@ -28,10 +28,8 @@ class RayExecutionConfig(ExecutionConfig):
 
     def __init__(self, execution_config: Dict):
         super().__init__(execution_config)
-        self._subtask_max_retries = (
-            self.get_execution_config()
-            .get("ray", {})
-            .get("subtask_max_retries", DEFAULT_SUBTASK_MAX_RETRIES)
+        self._subtask_max_retries = self._execution_config.get("ray", {}).get(
+            "subtask_max_retries", DEFAULT_SUBTASK_MAX_RETRIES
         )
 
     def get_band_resources(self):

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -123,7 +123,10 @@ class RayTaskExecutor(TaskExecutor):
         meta_api: MetaAPI,
     ):
         self._config = config
-        self._subtask_max_retries = self._config.get("subtask_max_retries", DEFAULT_SUBTASK_MAX_RETRIES)
+        self._ray_config = self._config.get_execution_config().get("ray", {})
+        self._subtask_max_retries = self._ray_config.get(
+            "subtask_max_retries", DEFAULT_SUBTASK_MAX_RETRIES
+        )
         self._task = task
         self._tile_context = tile_context
         self._ray_executor = ray_executor
@@ -212,8 +215,7 @@ class RayTaskExecutor(TaskExecutor):
             output_count = len(output_keys) + bool(output_meta_keys)
             subtask_max_retries = self._subtask_max_retries if subtask.retryable else 0
             output_object_refs = self._ray_executor.options(
-                num_returns=output_count,
-                max_retries=subtask_max_retries
+                num_returns=output_count, max_retries=subtask_max_retries
             ).remote(
                 subtask.task_id,
                 subtask.subtask_id,

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -119,7 +119,6 @@ class RayTaskExecutor(TaskExecutor):
         meta_api: MetaAPI,
     ):
         self._config = config
-        self._ray_config = self._config.get_execution_config().get("ray", {})
         self._task = task
         self._tile_context = tile_context
         self._ray_executor = ray_executor

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -104,6 +104,10 @@ def execute_subtask(
     return output_values[0] if len(output_values) == 1 else output_values
 
 
+# the default times to retry subtask.
+DEFAULT_SUBTASK_MAX_RETRIES = 3
+
+
 @register_executor_cls
 class RayTaskExecutor(TaskExecutor):
     name = "ray"
@@ -119,6 +123,7 @@ class RayTaskExecutor(TaskExecutor):
         meta_api: MetaAPI,
     ):
         self._config = config
+        self._subtask_max_retries = self._config.get("subtask_max_retries", DEFAULT_SUBTASK_MAX_RETRIES)
         self._task = task
         self._tile_context = tile_context
         self._ray_executor = ray_executor
@@ -205,8 +210,10 @@ class RayTaskExecutor(TaskExecutor):
             output_keys = self._get_subtask_output_keys(subtask_chunk_graph)
             output_meta_keys = result_meta_keys & output_keys
             output_count = len(output_keys) + bool(output_meta_keys)
+            subtask_max_retries = self._subtask_max_retries if subtask.retryable else 0
             output_object_refs = self._ray_executor.options(
-                num_returns=output_count
+                num_returns=output_count,
+                max_retries=subtask_max_retries
             ).remote(
                 subtask.task_id,
                 subtask.subtask_id,


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR implements basic subtask retry and reconstruction based on ray object lineage reconstruction.
- [x] reuse `subtask_retry_times` in scheduling config for ray task retry config.
- [x] Use `max_retries` in ray task to enable subtask retry and reconstruction.
- [x] Support fetch tileable chunks meta without accessing storage api.

With this PR, if task lineage are not evicted, the mars tasks will succeed even some ray nodes has failed.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #3029
#2972 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
