### PR TITLE
Fix incorrect result for `df.sort_values` when specifying multiple ascending

### DIFF
--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -59,7 +59,7 @@ class _ReversedValue:
         self._value = value
 
     def __lt__(self, other):
-        if isinstance(other, _ReversedValue):
+        if type(other) is _ReversedValue:
             # may happen when call searchsorted
             return self._value >= other._value
         return self._value >= other
@@ -551,6 +551,7 @@ class DataFramePSRSShuffle(MapReduceOperand, DataFrameOperandMixin):
     def _calc_poses(src_cols, pivots, ascending=True):
         if isinstance(ascending, list):
             for asc, col in zip(ascending, pivots.columns):
+                # Make pivots available to use ascending order when mixed order specified
                 if not asc:
                     if pd.api.types.is_numeric_dtype(pivots.dtypes[col]):
                         # for numeric dtypes, convert to negative is more efficient
@@ -560,7 +561,7 @@ class DataFramePSRSShuffle(MapReduceOperand, DataFrameOperandMixin):
                         # for other types, convert to ReversedValue
                         pivots[col] = pivots[col].map(
                             lambda x: x
-                            if isinstance(x, _ReversedValue)
+                            if type(x) is _ReversedValue
                             else _ReversedValue(x)
                         )
             ascending = True

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -389,7 +389,7 @@ class DataFramePSRSChunkOperand(DataFrameOperand):
     sort_type = StringField("sort_type")
 
     axis = Int32Field("axis")
-    by = ListField("by")
+    by = ListField("by", default=None)
     ascending = AnyField("ascending")
     inplace = BoolField("inplace")
     kind = StringField("kind")

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -20,7 +20,13 @@ import pandas as pd
 from ... import opcodes as OperandDef
 from ...core.operand import OperandStage, MapReduceOperand
 from ...utils import lazy_import, calc_nsplits
-from ...serialization.serializables import Int32Field, ListField, StringField, BoolField
+from ...serialization.serializables import (
+    AnyField,
+    Int32Field,
+    ListField,
+    StringField,
+    BoolField,
+)
 from ...tensor.base.psrs import PSRSOperandMixin
 from ..core import IndexValue, OutputType
 from ..utils import standardize_range_index, parse_index, is_cudf
@@ -380,90 +386,23 @@ def execute_sort_index(data, op, inplace=None):
 
 class DataFramePSRSChunkOperand(DataFrameOperand):
     # sort type could be 'sort_values' or 'sort_index'
-    _sort_type = StringField("sort_type")
+    sort_type = StringField("sort_type")
 
-    _axis = Int32Field("axis")
-    _by = ListField("by")
-    _ascending = BoolField("ascending")
-    _inplace = BoolField("inplace")
-    _kind = StringField("kind")
-    _na_position = StringField("na_position")
+    axis = Int32Field("axis")
+    by = ListField("by")
+    ascending = AnyField("ascending")
+    inplace = BoolField("inplace")
+    kind = StringField("kind")
+    na_position = StringField("na_position")
 
     # for sort_index
-    _level = ListField("level")
-    _sort_remaining = BoolField("sort_remaining")
+    level = ListField("level")
+    sort_remaining = BoolField("sort_remaining")
 
-    _n_partition = Int32Field("n_partition")
+    n_partition = Int32Field("n_partition")
 
-    def __init__(
-        self,
-        sort_type=None,
-        by=None,
-        axis=None,
-        ascending=None,
-        inplace=None,
-        kind=None,
-        na_position=None,
-        level=None,
-        sort_remaining=None,
-        n_partition=None,
-        output_types=None,
-        **kw
-    ):
-        super().__init__(
-            _sort_type=sort_type,
-            _by=by,
-            _axis=axis,
-            _ascending=ascending,
-            _inplace=inplace,
-            _kind=kind,
-            _na_position=na_position,
-            _level=level,
-            _sort_remaining=sort_remaining,
-            _n_partition=n_partition,
-            _output_types=output_types,
-            **kw
-        )
-
-    @property
-    def sort_type(self):
-        return self._sort_type
-
-    @property
-    def axis(self):
-        return self._axis
-
-    @property
-    def by(self):
-        return self._by
-
-    @property
-    def ascending(self):
-        return self._ascending
-
-    @property
-    def inplace(self):
-        return self._inplace
-
-    @property
-    def kind(self):
-        return self._kind
-
-    @property
-    def na_position(self):
-        return self._na_position
-
-    @property
-    def level(self):
-        return self._level
-
-    @property
-    def sort_remaining(self):
-        return self._sort_remaining
-
-    @property
-    def n_partition(self):
-        return self._n_partition
+    def __init__(self, output_types=None, **kw):
+        super().__init__(_output_types=output_types, **kw)
 
 
 class DataFramePSRSSortRegularSample(DataFramePSRSChunkOperand, DataFrameOperandMixin):
@@ -567,92 +506,25 @@ class DataFramePSRSConcatPivot(DataFramePSRSChunkOperand, DataFrameOperandMixin)
 class DataFramePSRSShuffle(MapReduceOperand, DataFrameOperandMixin):
     _op_type_ = OperandDef.PSRS_SHUFFLE
 
-    _sort_type = StringField("sort_type")
+    sort_type = StringField("sort_type")
 
     # for shuffle map
-    _axis = Int32Field("axis")
-    _by = ListField("by")
-    _ascending = BoolField("ascending")
-    _inplace = BoolField("inplace")
-    _na_position = StringField("na_position")
-    _n_partition = Int32Field("n_partition")
+    axis = Int32Field("axis")
+    by = ListField("by")
+    ascending = AnyField("ascending")
+    inplace = BoolField("inplace")
+    na_position = StringField("na_position")
+    n_partition = Int32Field("n_partition")
 
     # for sort_index
-    _level = ListField("level")
-    _sort_remaining = BoolField("sort_remaining")
+    level = ListField("level")
+    sort_remaining = BoolField("sort_remaining")
 
     # for shuffle reduce
-    _kind = StringField("kind")
+    kind = StringField("kind")
 
-    def __init__(
-        self,
-        sort_type=None,
-        by=None,
-        axis=None,
-        ascending=None,
-        n_partition=None,
-        na_position=None,
-        inplace=None,
-        kind=None,
-        level=None,
-        sort_remaining=None,
-        output_types=None,
-        **kw
-    ):
-        super().__init__(
-            _sort_type=sort_type,
-            _by=by,
-            _axis=axis,
-            _ascending=ascending,
-            _n_partition=n_partition,
-            _na_position=na_position,
-            _inplace=inplace,
-            _kind=kind,
-            _level=level,
-            _sort_remaining=sort_remaining,
-            _output_types=output_types,
-            **kw
-        )
-
-    @property
-    def sort_type(self):
-        return self._sort_type
-
-    @property
-    def by(self):
-        return self._by
-
-    @property
-    def axis(self):
-        return self._axis
-
-    @property
-    def ascending(self):
-        return self._ascending
-
-    @property
-    def inplace(self):
-        return self._inplace
-
-    @property
-    def na_position(self):
-        return self._na_position
-
-    @property
-    def level(self):
-        return self._level
-
-    @property
-    def sort_remaining(self):
-        return self._sort_remaining
-
-    @property
-    def n_partition(self):
-        return self._n_partition
-
-    @property
-    def kind(self):
-        return self._kind
+    def __init__(self, output_types=None, **kw):
+        super().__init__(_output_types=output_types, **kw)
 
     @property
     def output_limit(self):
@@ -660,6 +532,31 @@ class DataFramePSRSShuffle(MapReduceOperand, DataFrameOperandMixin):
 
     @staticmethod
     def _calc_poses(src_cols, pivots, ascending=True):
+        class ReversedValue:
+            def __init__(self, value):
+                self._value = value
+
+            def __lt__(self, other):
+                if isinstance(other, ReversedValue):
+                    # may happen when call searchsorted
+                    return self._value >= other._value
+                return self._value >= other
+
+            def __gt__(self, other):
+                if isinstance(other, ReversedValue):
+                    # may happen when call searchsorted
+                    return self._value <= other._value
+                return self._value <= other
+
+            def __repr__(self):
+                return repr(self._value)
+
+        if isinstance(ascending, list):
+            for asc, col in zip(ascending, pivots.columns):
+                if not asc:
+                    pivots[col] = pivots[col].map(lambda x: ReversedValue(x))
+            ascending = True
+
         records = src_cols.to_records(index=False)
         p_records = pivots.to_records(index=False)
         if ascending:

--- a/mars/dataframe/sort/sort_values.py
+++ b/mars/dataframe/sort/sort_values.py
@@ -256,7 +256,7 @@ def dataframe_sort_values(
         if all(ascending):
             # all are True, convert to True
             ascending = True
-        if not any(ascending):
+        elif not any(ascending):
             # all are False, convert to False
             ascending = False
     op = DataFrameSortValues(

--- a/mars/dataframe/sort/sort_values.py
+++ b/mars/dataframe/sort/sort_values.py
@@ -252,6 +252,13 @@ def dataframe_sort_values(
         raise NotImplementedError("Only support sort on axis 0")
     psrs_kinds = _validate_sort_psrs_kinds(psrs_kinds)
     by = by if isinstance(by, (list, tuple)) else [by]
+    if isinstance(ascending, list):  # pragma: no cover
+        if all(ascending):
+            # all are True, convert to True
+            ascending = True
+        if not any(ascending):
+            # all are False, convert to False
+            ascending = False
     op = DataFrameSortValues(
         by=by,
         axis=axis,

--- a/mars/dataframe/sort/tests/test_sort_execution.py
+++ b/mars/dataframe/sort/tests/test_sort_execution.py
@@ -81,13 +81,18 @@ def test_sort_values_execution(setup, distinct_opt):
     int_df = pd.DataFrame(
         np.random.randint(0, 10, (100, 10)), columns=["a" + str(i) for i in range(10)]
     )
+    int_df["a10"] = np.random.choice([f"a{i}" for i in range(10)], size=(100,))
     mdf = DataFrame(int_df, chunk_size=10)
     result = (
-        mdf.sort_values(["a3", "a4", "a5"], ascending=[False, True, False])
+        mdf.sort_values(
+            ["a3", "a4", "a5", "a10"], ascending=[False, True, False, False]
+        )
         .execute()
         .fetch()
     )
-    expected = int_df.sort_values(["a3", "a4", "a5"], ascending=[False, True, False])
+    expected = int_df.sort_values(
+        ["a3", "a4", "a5", "a10"], ascending=[False, True, False, False]
+    )
     pd.testing.assert_frame_equal(result, expected)
 
     # test multiindex

--- a/mars/dataframe/sort/tests/test_sort_execution.py
+++ b/mars/dataframe/sort/tests/test_sort_execution.py
@@ -67,6 +67,29 @@ def test_sort_values_execution(setup, distinct_opt):
 
     pd.testing.assert_frame_equal(result, expected)
 
+    # test ascending is a list
+    result = (
+        mdf.sort_values(["a3", "a4", "a5", "a6"], ascending=[False, True, True, False])
+        .execute()
+        .fetch()
+    )
+    expected = df.sort_values(
+        ["a3", "a4", "a5", "a6"], ascending=[False, True, True, False]
+    )
+    pd.testing.assert_frame_equal(result, expected)
+
+    int_df = pd.DataFrame(
+        np.random.randint(0, 10, (100, 10)), columns=["a" + str(i) for i in range(10)]
+    )
+    mdf = DataFrame(int_df, chunk_size=10)
+    result = (
+        mdf.sort_values(["a3", "a4", "a5"], ascending=[False, True, False])
+        .execute()
+        .fetch()
+    )
+    expected = int_df.sort_values(["a3", "a4", "a5"], ascending=[False, True, False])
+    pd.testing.assert_frame_equal(result, expected)
+
     # test multiindex
     df2 = df.copy(deep=True)
     df2.columns = pd.MultiIndex.from_product([list("AB"), list("CDEFG")])


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Before we didn't consider the `ascending` parameter would be a list, the behavior in `DataFramePSRSShuffle._calc_poses` simply take it as a bool value and leads to incorrect result. This PR converts value as `ReversedValue` for those columns with `ascending=False` to work correctly with `np.searchsorted`.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #2980 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
