### PR TITLE
Fix speculative execution compatibility with coloring

### DIFF
--- a/mars/deploy/oscar/base_config.yml
+++ b/mars/deploy/oscar/base_config.yml
@@ -39,7 +39,9 @@ scheduling:
     scheduler_backlog_timeout: 60
     worker_idle_timeout: 120
   speculation:
-    # Enables (yes) or disables (no) speculative execution of subtasks
+    # Enables (yes) or disables (no) speculative execution of subtasks.
+    # If enabled, `initial_same_color_num` will be set to 1 to ensure enough homogeneous subtasks to
+    # calculate statistics
     enabled: no
     # Don't submit subtasks actually for slow subtasks
     dry: no

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -772,9 +772,6 @@ min_task_runtime = 2
 @pytest.fixture
 async def speculative_cluster():
     config = _load_config()
-    # coloring based fusion will make subtask too heterogeneous such that the speculative scheduler can't
-    # get enough homogeneous subtasks to calculate statistics
-    config["task"]["default_config"]["fuse_enabled"] = False
     config["scheduling"]["speculation"]["enabled"] = True
     config["scheduling"]["speculation"]["interval"] = 0.5
     config["scheduling"]["speculation"]["threshold"] = 0.2

--- a/mars/deploy/oscar/tests/test_ray_scheduling.py
+++ b/mars/deploy/oscar/tests/test_ray_scheduling.py
@@ -35,9 +35,6 @@ async def speculative_cluster():
         worker_mem=512 * 1024**2,
         supervisor_mem=100 * 1024**2,
         config={
-            # coloring based fusion will make subtask too heterogeneous such that the speculative scheduler can't
-            # get enough homogeneous subtasks to calculate statistics
-            "task": {"default_config": {"fuse_enabled": False}},
             "scheduling": {
                 "speculation": {
                     "enabled": True,


### PR DESCRIPTION
This pr fixed speculative execution compatibility with coloring by set `initial_same_color_num` to 1 to ensure enough homogeneous subtasks. If `initial_same_color_num` > 1, coloring based fusion will make subtask too heterogeneous such that the speculative scheduler can't get enough homogeneous subtasks to calculate statistics

<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
