### PR TITLE
[Metrics] Optimize metric configs

### DIFF
--- a/mars/deploy/oscar/base_config.yml
+++ b/mars/deploy/oscar/base_config.yml
@@ -57,4 +57,6 @@ scheduling:
   subtask_cancel_timeout: 5
 metrics:
   backend: console
-  port: 0  # Need to assign a port argument when using prometheus
+  # If backend is prometheus, then we can add prometheus config as follows:
+  # prometheus:
+  #   port: 8988

--- a/mars/deploy/oscar/ray.py
+++ b/mars/deploy/oscar/ray.py
@@ -427,7 +427,8 @@ class RayCluster:
         logger.info("Start cluster with config %s", self._config)
         # init metrics to guarantee metrics use in driver
         metric_configs = self._config.get("metrics", {})
-        init_metrics(metric_configs.get("backend"), port=metric_configs.get("port"))
+        metric_backend = metric_configs.get("backend")
+        init_metrics(metric_backend, config=metric_configs.get(metric_backend))
         address_to_resources = dict()
         supervisor_standalone = (
             self._config.get("cluster", {})

--- a/mars/metrics/api.py
+++ b/mars/metrics/api.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import logging
+import time
 
 from contextlib import contextmanager
 from enum import Enum
 from queue import PriorityQueue
-import time
-from typing import Optional, Tuple, NamedTuple, Callable, List
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple
 
 from .backends.console import console_metric
 from .backends.prometheus import prometheus_metric
@@ -34,7 +34,7 @@ _backends_cls = {
 }
 
 
-def init_metrics(backend="console", port=0):
+def init_metrics(backend="console", config: Dict[str, Any] = None):
     backend = backend or "console"
     if backend not in _backends_cls:
         raise NotImplementedError(f"Do not support metric backend {backend}")
@@ -44,6 +44,7 @@ def init_metrics(backend="console", port=0):
         try:
             from prometheus_client import start_http_server
 
+            port = config.get("port", 0) if config else 0
             start_http_server(port)
             logger.info("Finished startup prometheus http server and port is %d", port)
         except ImportError:

--- a/mars/metrics/tests/test_metric_api.py
+++ b/mars/metrics/tests/test_metric_api.py
@@ -39,7 +39,7 @@ def test_init_metrics():
     assert api._metric_backend == "console"
     init_metrics("prometheus")
     assert api._metric_backend == "prometheus"
-    init_metrics(backend="prometheus", port=0)
+    init_metrics(backend="prometheus", config={"port": 0})
     assert api._metric_backend == "prometheus"
     init_metrics("ray")
     assert api._metric_backend == "ray"

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -163,7 +163,8 @@ class AbstractActorPool(ABC):
         init_extension_entrypoints()
         # init metrics
         metric_configs = self._config.get_metric_configs()
-        init_metrics(metric_configs.get("backend"), port=metric_configs.get("port"))
+        metric_backend = metric_configs.get("backend")
+        init_metrics(metric_backend, config=metric_configs.get(metric_backend))
 
     @property
     def router(self):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
The arguments  of `init_metrics(backend, port)` method are inappropriate. Because port is a configuration of prometheus. It is not necessary for `console` and `ray`. It's better to change it to `config` and in this way we could easily add new metric backend.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
