### PR TITLE
Fix missing extra_params when constructing operands

### DIFF
--- a/mars/core/operand/base.py
+++ b/mars/core/operand/base.py
@@ -195,7 +195,8 @@ class Operand(Base, OperatorLogicKeyGeneratorMixin, metaclass=OperandMetaclass):
 
     @classmethod
     def _parse_kwargs(cls, kwargs: Dict[str, Any]):
-        kwargs["extra_params"] = extras = AttributeDict()
+        extra_params = kwargs.pop("extra_params", {})
+        kwargs["extra_params"] = extras = AttributeDict(extra_params)
         kwargs["scheduling_hint"] = scheduling_hint = kwargs.get(
             "scheduling_hint", SchedulingHint()
         )

--- a/mars/core/operand/tests/test_core.py
+++ b/mars/core/operand/tests/test_core.py
@@ -73,6 +73,8 @@ class MyOperand5(MyOperand4):
 
 
 def test_execute():
+    op = MyOperand(extra_params={"my_extra_params": 1})
+    assert op.extra_params["my_extra_params"] == 1
     MyOperand.register_executor(lambda *_: 2)
     assert execute(dict(), MyOperand(_key="1")) == 2
     assert execute(dict(), MyOperand2(_key="1")) == 2


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Fix missing extra_params when constructing operands
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes https://github.com/mars-project/mars/issues/2998

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
