### PR TITLE
[Ray] Ray execution state

### DIFF
--- a/mars/dataframe/datasource/core.py
+++ b/mars/dataframe/datasource/core.py
@@ -58,9 +58,7 @@ class HeadOptimizedDataSource(DataFrameOperand, DataFrameOperandMixin):
         # execute first chunk
         yield chunks[:1]
 
-        ctx = get_context()
-        chunk_shape = ctx.get_chunks_meta([chunks[0].key], fields=["shape"])[0]["shape"]
-
+        chunk_shape = chunks[0].shape
         if chunk_shape[0] == op.nrows:
             # the first chunk has enough data
             tileds[0]._nsplits = tuple((s,) for s in chunk_shape)

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -490,7 +490,7 @@ async def test_web_session(create_cluster, config):
             )
 
 
-@pytest.mark.parametrize("config", [{"backend": "mars", "incremental_index": True}])
+@pytest.mark.parametrize("config", [{"backend": "mars"}])
 def test_sync_execute(config):
     session = new_session(
         backend=config["backend"], n_cpu=2, web=False, use_uvloop=False
@@ -518,25 +518,31 @@ def test_sync_execute(config):
         assert d is c
         assert abs(session.fetch(d) - raw.sum()) < 0.001
 
-        # TODO(fyrestone): Remove this when the Ray backend support incremental index.
-        if config["incremental_index"]:
-            with tempfile.TemporaryDirectory() as tempdir:
-                file_path = os.path.join(tempdir, "test.csv")
-                pdf = pd.DataFrame(
-                    np.random.RandomState(0).rand(100, 10),
-                    columns=[f"col{i}" for i in range(10)],
-                )
-                pdf.to_csv(file_path, index=False)
+        with tempfile.TemporaryDirectory() as tempdir:
+            file_path = os.path.join(tempdir, "test.csv")
+            pdf = pd.DataFrame(
+                np.random.RandomState(0).rand(100, 10),
+                columns=[f"col{i}" for i in range(10)],
+            )
+            pdf.to_csv(file_path, index=False)
 
-                df = md.read_csv(file_path, chunk_bytes=os.stat(file_path).st_size / 5)
-                result = df.sum(axis=1).execute().fetch()
-                expected = pd.read_csv(file_path).sum(axis=1)
-                pd.testing.assert_series_equal(result, expected)
+            df = md.read_csv(
+                file_path,
+                chunk_bytes=os.stat(file_path).st_size / 5,
+                incremental_index=True,
+            )
+            result = df.sum(axis=1).execute().fetch()
+            expected = pd.read_csv(file_path).sum(axis=1)
+            pd.testing.assert_series_equal(result, expected)
 
-                df = md.read_csv(file_path, chunk_bytes=os.stat(file_path).st_size / 5)
-                result = df.head(10).execute().fetch()
-                expected = pd.read_csv(file_path).head(10)
-                pd.testing.assert_frame_equal(result, expected)
+            df = md.read_csv(
+                file_path,
+                chunk_bytes=os.stat(file_path).st_size / 5,
+                incremental_index=True,
+            )
+            result = df.head(10).execute().fetch()
+            expected = pd.read_csv(file_path).head(10)
+            pd.testing.assert_frame_equal(result, expected)
 
     for worker_pool in session._session.client._cluster._worker_pools:
         _assert_storage_cleaned(

--- a/mars/deploy/oscar/tests/test_ray_dag.py
+++ b/mars/deploy/oscar/tests/test_ray_dag.py
@@ -112,8 +112,7 @@ async def test_iterative_tiling(ray_start_regular_shared2, create_cluster):
     await test_local.test_iterative_tiling(create_cluster)
 
 
-# TODO(fyrestone): Support incremental index in ray backend.
 @require_ray
-@pytest.mark.parametrize("config", [{"backend": "ray", "incremental_index": False}])
+@pytest.mark.parametrize("config", [{"backend": "ray"}])
 def test_sync_execute(config):
     test_local.test_sync_execute(config)

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -456,7 +456,9 @@ class AbstractActorPool(ABC):
     async def stop(self):
         try:
             # clean global router
-            Router.get_instance().remove_router(self._router)
+            router = Router.get_instance()
+            if router is not None:
+                router.remove_router(self._router)
             stop_tasks = []
             # stop all servers
             stop_tasks.extend([server.stop() for server in self._servers])

--- a/mars/services/task/execution/mars/executor.py
+++ b/mars/services/task/execution/mars/executor.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional, Set
 
 from ..... import oscar as mo
 from .....core import ChunkGraph, TileContext
+from .....core.context import set_context
 from .....core.operand import (
     Fetch,
     MapReduceOperand,
@@ -33,6 +34,7 @@ from .....oscar.profiling import (
 from .....resource import Resource
 from .....typing import TileableType, BandType
 from .....utils import Timer
+from ....context import ThreadedServiceContext
 from ....cluster.api import ClusterAPI
 from ....lifecycle.api import LifecycleAPI
 from ....meta.api import MetaAPI
@@ -111,6 +113,7 @@ class MarsTaskExecutor(TaskExecutor):
         cluster_api, lifecycle_api, scheduling_api, meta_api = await cls._get_apis(
             session_id, address
         )
+        await cls._init_context(session_id, address)
         return cls(
             config,
             task,
@@ -130,6 +133,15 @@ class MarsTaskExecutor(TaskExecutor):
             SchedulingAPI.create(session_id, address),
             MetaAPI.create(session_id, address),
         )
+
+    @classmethod
+    async def _init_context(cls, session_id: str, address: str):
+        loop = asyncio.get_running_loop()
+        context = ThreadedServiceContext(
+            session_id, address, address, address, loop=loop
+        )
+        await context.init()
+        set_context(context)
 
     async def __aenter__(self):
         profiling = ProfilingData[self._task.task_id, "general"]

--- a/mars/services/task/execution/ray/context.py
+++ b/mars/services/task/execution/ray/context.py
@@ -12,9 +12,95 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+import inspect
 
-# TODO(fyrestone): Should implement the mars.core.context.Context.
-class RayExecutionContext(dict):
+from .....core.context import Context
+from .....utils import implements, lazy_import
+from ....context import ThreadedServiceContext
+
+ray = lazy_import("ray")
+
+
+class RayRemoteObjectManager:
+    """The remote object manager in task state actor."""
+
+    def __init__(self):
+        self._named_remote_objects = {}
+
+    def create_remote_object(self, name: str, object_cls, *args, **kwargs):
+        remote_object = object_cls(*args, **kwargs)
+        self._named_remote_objects[name] = remote_object
+
+    def destroy_remote_object(self, name: str):
+        self._named_remote_objects.pop(name, None)
+
+    async def call_remote_object(self, name: str, attr: str, *args, **kwargs):
+        remote_object = self._named_remote_objects[name]
+        meth = getattr(remote_object, attr)
+        async_meth = self._sync_to_async(meth)
+        return await async_meth(*args, **kwargs)
+
+    @staticmethod
+    @functools.lru_cache
+    def _sync_to_async(func):
+        if inspect.iscoroutinefunction(func):
+            return func
+        else:
+
+            async def async_wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return async_wrapper
+
+
+class _RayRemoteObjectWrapper:
+    def __init__(self, task_state_actor: "ray.actor.ActorHandle", name: str):
+        self._task_state_actor = task_state_actor
+        self._name = name
+
+    def __getattr__(self, attr):
+        def wrap(*args, **kwargs):
+            r = self._task_state_actor.call_remote_object.remote(
+                self._name, attr, *args, **kwargs
+            )
+            return ray.get(r)
+
+        return wrap
+
+
+class _RayRemoteObjectContext:
+    def __init__(self, task_state_actor: "ray.actor.ActorHandle", *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._task_state_actor = task_state_actor
+
+    @implements(Context.create_remote_object)
+    def create_remote_object(self, name: str, object_cls, *args, **kwargs):
+        self._task_state_actor.create_remote_object.remote(
+            name, object_cls, *args, **kwargs
+        )
+        return _RayRemoteObjectWrapper(self._task_state_actor, name)
+
+    @implements(Context.get_remote_object)
+    def get_remote_object(self, name: str):
+        return _RayRemoteObjectWrapper(self._task_state_actor, name)
+
+    @implements(Context.destroy_remote_object)
+    def destroy_remote_object(self, name: str):
+        self._task_state_actor.destroy_remote_object.remote(name)
+
+
+# TODO(fyrestone): Implement more APIs for Ray.
+class RayExecutionContext(_RayRemoteObjectContext, ThreadedServiceContext):
+    """The context for tiling."""
+
+    pass
+
+
+# TODO(fyrestone): Implement more APIs for Ray.
+class RayExecutionWorkerContext(_RayRemoteObjectContext, dict):
+    """The context for executing operands."""
+
     @staticmethod
     def new_custom_log_dir():
         return None

--- a/mars/services/task/execution/ray/context.py
+++ b/mars/services/task/execution/ray/context.py
@@ -42,7 +42,7 @@ class RayRemoteObjectManager:
         return await async_meth(*args, **kwargs)
 
     @staticmethod
-    @functools.lru_cache
+    @functools.lru_cache(100)
     def _sync_to_async(func):
         if inspect.iscoroutinefunction(func):
             return func

--- a/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
+++ b/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
@@ -23,11 +23,7 @@ from ......serialization import serialize
 from ......tests.core import require_ray
 from ......utils import lazy_import, get_chunk_params
 from ....core import new_task_id
-from ..context import (
-    RayRemoteObjectManager,
-    _RayRemoteObjectContext,
-    _RayRemoteObjectWrapper,
-)
+from ..context import RayRemoteObjectManager, _RayRemoteObjectContext
 from ..executor import execute_subtask
 from ..fetcher import RayFetcher
 

--- a/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
+++ b/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
@@ -43,11 +43,11 @@ def test_ray_execute_subtask_basic():
 
     subtask_id = new_task_id()
     subtask_chunk_graph = _gen_subtask_chunk_graph(b)
-    r = execute_subtask(subtask_id, serialize(subtask_chunk_graph), set(), [])
+    r = execute_subtask(None, subtask_id, serialize(subtask_chunk_graph), set(), [])
     np.testing.assert_array_equal(r, raw_expect)
     test_get_meta_chunk = subtask_chunk_graph.result_chunks[0]
     r = execute_subtask(
-        subtask_id, serialize(subtask_chunk_graph), {test_get_meta_chunk.key}, []
+        None, subtask_id, serialize(subtask_chunk_graph), {test_get_meta_chunk.key}, []
     )
     assert len(r) == 2
     meta_dict, r = r

--- a/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
+++ b/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
@@ -43,11 +43,11 @@ def test_ray_execute_subtask_basic():
 
     subtask_id = new_task_id()
     subtask_chunk_graph = _gen_subtask_chunk_graph(b)
-    r = execute_subtask(None, subtask_id, serialize(subtask_chunk_graph), set(), [])
+    r = execute_subtask("", subtask_id, serialize(subtask_chunk_graph), set(), [])
     np.testing.assert_array_equal(r, raw_expect)
     test_get_meta_chunk = subtask_chunk_graph.result_chunks[0]
     r = execute_subtask(
-        None, subtask_id, serialize(subtask_chunk_graph), {test_get_meta_chunk.key}, []
+        "", subtask_id, serialize(subtask_chunk_graph), {test_get_meta_chunk.key}, []
     )
     assert len(r) == 2
     meta_dict, r = r

--- a/mars/services/task/supervisor/manager.py
+++ b/mars/services/task/supervisor/manager.py
@@ -22,9 +22,7 @@ from typing import Any, Dict, List, Type, Union
 
 from .... import oscar as mo
 from ....core import TileableGraph, TileableType, enter_mode, TileContext
-from ....core.context import set_context
 from ....core.operand import Fetch
-from ...context import ThreadedServiceContext
 from ...subtask import SubtaskResult, SubtaskGraph
 from ..config import task_options
 from ..core import Task, new_task_id, TaskStatus
@@ -106,20 +104,9 @@ class TaskManagerActor(mo.Actor):
         )
         self._task_preprocessor_cls = self._get_task_preprocessor_cls()
 
-        # init context
-        await self._init_context()
-
     async def __pre_destroy__(self):
         for processor_ref in self._task_id_to_processor_ref.values():
             await processor_ref.destroy()
-
-    async def _init_context(self):
-        loop = asyncio.get_running_loop()
-        context = ThreadedServiceContext(
-            self._session_id, self.address, self.address, self.address, loop=loop
-        )
-        await context.init()
-        set_context(context)
 
     @staticmethod
     def gen_uid(session_id):

--- a/mars/services/task/supervisor/tests/test_task_manager.py
+++ b/mars/services/task/supervisor/tests/test_task_manager.py
@@ -550,9 +550,8 @@ async def test_numexpr(actor_pool):
     ) == [1] * len(result_tileable.chunks)
 
 
-@pytest.mark.parametrize("config", [{"incremental_index": True}])
 @pytest.mark.asyncio
-async def test_optimization(actor_pool, config):
+async def test_optimization(actor_pool):
     (
         execution_backend,
         pool,
@@ -576,7 +575,7 @@ async def test_optimization(actor_pool, config):
         )
         pdf.to_csv(file_path, index=False)
 
-        df = md.read_csv(file_path, incremental_index=config["incremental_index"])
+        df = md.read_csv(file_path, incremental_index=True)
         df2 = df.groupby("c").agg({"a": "sum"})
         df3 = df[["b", "a"]]
 

--- a/mars/services/task/supervisor/tests/test_task_manager_on_ray_dag.py
+++ b/mars/services/task/supervisor/tests/test_task_manager_on_ray_dag.py
@@ -57,10 +57,8 @@ async def test_numexpr(ray_start_regular_shared2, actor_pool):
     await test_task_manager.test_numexpr(actor_pool)
 
 
-# TODO(fyrestone): Support incremental index in ray backend.
 @require_ray
-@pytest.mark.parametrize("config", [{"incremental_index": False}])
 @pytest.mark.parametrize("actor_pool", [{"backend": "ray"}], indirect=True)
 @pytest.mark.asyncio
-async def test_optimization(ray_start_regular_shared2, actor_pool, config):
-    await test_task_manager.test_optimization(actor_pool, config)
+async def test_optimization(ray_start_regular_shared2, actor_pool):
+    await test_task_manager.test_optimization(actor_pool)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Mars execution context provides remote object to sync states between multiple running operands. Ray execution backends use a task state actor for this feature.

With this PR, ray backend supports incremental index.

- [x] Move the logic of initializing context _(the ThreadedServiceContext used in the supervisor)_ to the execution backend.
- [x] Add a task state actor to Ray execution backend.
- [x] Ray execution context supports remote object.
- [x] Not to fetch the chunk meta when tiling `HeadOptimizedDataSource`.

The drawback is that,

- Poor performance to sync states among operands, maybe we can avoid using remote object when executing operands in the future.
- Hard to fault tolerance because the remote object makes the operands stateful.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/mars-project/mars/issues/2893

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
