### PR TITLE
Fix `msg_to_simple_str` in Ray backend and add tests

### DIFF
--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -20,7 +20,7 @@ import time
 from abc import ABC
 from collections import namedtuple
 from dataclasses import dataclass
-from typing import Any, Callable, Coroutine, Dict, List, Tuple, Type
+from typing import Any, Callable, Coroutine, Dict, List, Set, Tuple, Type
 from urllib.parse import urlparse
 
 from ....oscar.profiling import ProfilingData
@@ -52,16 +52,19 @@ def msg_to_simple_str(msg):  # pragma: no cover
     if type(msg) == _ArgWrapper:
         msg = msg.message
     if isinstance(msg, SendMessage):
-        return f"{str(type(msg))}(actor_ref={msg.actor_ref}, content={msg_to_simple_str(msg.content)})"
+        return f"{str(type(msg).__name__)}(actor_ref={msg.actor_ref}, content={msg_to_simple_str(msg.content)})"
     if isinstance(msg, _MessageBase):
         return str(msg)
-    if msg and isinstance(msg, List):
+    if isinstance(msg, List):
         part_str = ", ".join([msg_to_simple_str(item) for item in msg[:5]])
         return f"List<{part_str}...{len(msg)}>"
-    if msg and isinstance(msg, Tuple):
+    if isinstance(msg, Set):
+        part_str = ", ".join([msg_to_simple_str(item) for item in list(msg)[:5]])
+        return f"Set<{part_str}...{len(msg)}>"
+    if isinstance(msg, Tuple):
         part_str = ", ".join([msg_to_simple_str(item) for item in msg[:5]])
         return f"Tuple<{part_str}...{len(msg)}>"
-    if msg and isinstance(msg, Dict):
+    if isinstance(msg, Dict):
         part_str = []
         it = iter(msg.items())
         try:
@@ -73,8 +76,8 @@ def msg_to_simple_str(msg):  # pragma: no cover
         except StopIteration:
             pass
         part_str = ", ".join(part_str)
-        return f"Dict<k={part_str}...{len(msg)}>"
-    if isinstance(msg, (str, float, int)):
+        return f"Dict<{part_str}...{len(msg)}>"
+    if isinstance(msg, (str, float, int, bool)):
         return "{!s:.50}".format(msg)
     return str(type(msg))
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR fix `msg_to_simple_str` error introduced in #2936 when truth value for some object is ambiguous.
![image](https://user-images.githubusercontent.com/12445254/167092789-05ba325b-b4f6-4c52-818d-39ca7b0187cd.png)

<!-- Please give a short brief about these changes. -->

## Related issue number
#2936
<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
