### PR TITLE
Optimize gen subtask graph

### DIFF
--- a/mars/services/task/analyzer/analyzer.py
+++ b/mars/services/task/analyzer/analyzer.py
@@ -327,8 +327,9 @@ class GraphAnalyzer:
         )
         # assign expect workers for those specified with `expect_worker`
         # skip `start_ops`, which have been assigned before
+        start_ops_set = set(start_ops)
         for chunk in self._chunk_graph:
-            if chunk not in start_ops and chunk.op.expect_worker is not None:
+            if chunk not in start_ops_set and chunk.op.expect_worker is not None:
                 chunk_to_bands[chunk] = self._to_band(chunk.op.expect_worker)
 
         # color nodes


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
If `start ops` is huge, `chunk not in start_ops` will take `O(n)` complexties, which will be very time comsuing. This PR optimize gen subtask graph by using `set` instead of `list` for `start ops`
![image](https://user-images.githubusercontent.com/12445254/167149705-7bb91d7d-963a-4d5d-ae68-49506c5e8d34.png)

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
