### PR TITLE
[Ray] Basic shuffle support for Ray backend

### DIFF
--- a/mars/core/operand/shuffle.py
+++ b/mars/core/operand/shuffle.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union, List
+
 from ... import opcodes
 from ...serialization.serializables import (
     Int32Field,
@@ -40,8 +42,12 @@ class MapReduceOperand(Operand):
 
         return super()._new_chunks(inputs, kws, **kw)
 
-    def get_output_data_keys(self):
-        return None
+    def get_output_data_keys(self) -> Union[List, None]:
+        """
+        Get the output data keys before execute.
+        If the stage != OperandStage.map, returns None.
+        """
+        raise NotImplementedError
 
     def get_dependent_data_keys(self):
         from .fetch import FetchShuffle

--- a/mars/core/operand/shuffle.py
+++ b/mars/core/operand/shuffle.py
@@ -26,7 +26,7 @@ from .base import Operand, VirtualOperand, OperandStage
 
 class ExactlyMapDataKeys(list):
     """
-    The type for the shuffle output data keys which
+    The type for the shuffle output data keys which are
     exactly the same with map execution results keys.
     """
 
@@ -54,7 +54,7 @@ class MapReduceOperand(Operand):
 
     def get_output_data_keys(self) -> Union[ExactlyMapDataKeys, None]:
         """
-        Get the output data keys before execute.
+        Get the output data keys before execution.
         If the stage != OperandStage.map, returns None.
         """
         raise NotImplementedError

--- a/mars/core/operand/shuffle.py
+++ b/mars/core/operand/shuffle.py
@@ -24,6 +24,13 @@ from ...serialization.serializables import (
 from .base import Operand, VirtualOperand, OperandStage
 
 
+class ExactlyMapDataKeys(list):
+    """
+    The type for the shuffle output data keys which
+    exactly the same with map execution results keys.
+    """
+
+
 class ShuffleProxy(VirtualOperand):
     _op_type_ = opcodes.SHUFFLE_PROXY
 
@@ -42,7 +49,7 @@ class MapReduceOperand(Operand):
 
         return super()._new_chunks(inputs, kws, **kw)
 
-    def get_output_data_keys(self) -> Union[List, None]:
+    def get_output_data_keys(self) -> Union[ExactlyMapDataKeys, None]:
         """
         Get the output data keys before execute.
         If the stage != OperandStage.map, returns None.

--- a/mars/core/operand/shuffle.py
+++ b/mars/core/operand/shuffle.py
@@ -40,6 +40,9 @@ class MapReduceOperand(Operand):
 
         return super()._new_chunks(inputs, kws, **kw)
 
+    def get_output_data_keys(self):
+        return None
+
     def get_dependent_data_keys(self):
         from .fetch import FetchShuffle
 

--- a/mars/core/operand/shuffle.py
+++ b/mars/core/operand/shuffle.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, List
+from typing import Union
 
 from ... import opcodes
 from ...serialization.serializables import (

--- a/mars/core/operand/shuffle.py
+++ b/mars/core/operand/shuffle.py
@@ -30,6 +30,9 @@ class ExactlyMapDataKeys(list):
     exactly the same with map execution results keys.
     """
 
+    def __repr__(self):
+        return f"{type(self).__name__}({super().__repr__()})"
+
 
 class ShuffleProxy(VirtualOperand):
     _op_type_ = opcodes.SHUFFLE_PROXY

--- a/mars/dataframe/align.py
+++ b/mars/dataframe/align.py
@@ -298,7 +298,7 @@ class DataFrameIndexAlign(MapReduceOperand, DataFrameOperandMixin):
         if out.ndim == 1:
             if filters[0] == 1:
                 # no shuffle
-                return ExactlyMapDataKeys(out.key)
+                return ExactlyMapDataKeys([out.key])
             else:
                 return ExactlyMapDataKeys(
                     (out.key, (index_idx,)) for index_idx in range(filters[0])
@@ -316,7 +316,7 @@ class DataFrameIndexAlign(MapReduceOperand, DataFrameOperandMixin):
 
         if all(it == 1 for it in filters):
             # no shuffle
-            return ExactlyMapDataKeys(out.key)
+            return ExactlyMapDataKeys([out.key])
         elif filters[0] == 1:
             # shuffle on columns
             return ExactlyMapDataKeys(

--- a/mars/dataframe/base/_duplicate.py
+++ b/mars/dataframe/base/_duplicate.py
@@ -397,9 +397,9 @@ class DuplicateOperand(MapReduceOperand, DataFrameOperandMixin):
         if method is not None:
             if self.stage == OperandStage.map:
                 if method == "tree":
-                    return ExactlyMapDataKeys(self.outputs[0].key)
+                    return ExactlyMapDataKeys([self.outputs[0].key])
                 elif method == "subset_tree":
-                    return ExactlyMapDataKeys(self.outputs[0].key)
+                    return ExactlyMapDataKeys([self.outputs[0].key])
                 else:
                     assert method == "shuffle"
                     out = self.outputs[0]

--- a/mars/dataframe/base/_duplicate.py
+++ b/mars/dataframe/base/_duplicate.py
@@ -21,6 +21,7 @@ from pandas.api.types import is_list_like
 from ...config import options
 from ...core import OutputType, recursive_tile
 from ...core.operand import OperandStage, MapReduceOperand
+from ...core.operand.shuffle import ExactlyMapDataKeys
 from ...serialization.serializables import AnyField, Int32Field, StringField, KeyField
 from ...utils import ceildiv, has_unknown_shape, lazy_import
 from ..initializer import DataFrame as asdataframe

--- a/mars/dataframe/base/_duplicate.py
+++ b/mars/dataframe/base/_duplicate.py
@@ -391,6 +391,23 @@ class DuplicateOperand(MapReduceOperand, DataFrameOperandMixin):
         ret.reset_index(drop=True, inplace=True)
         ctx[op.outputs[0].key] = ret
 
+    def get_output_data_keys(self):
+        method = self.method
+        if method is not None:
+            if self.stage == OperandStage.map:
+                if method == "tree":
+                    return [self.outputs[0].key]
+                elif method == "subset_tree":
+                    return [self.outputs[0].key]
+                else:
+                    assert method == "shuffle"
+                    out = self.outputs[0]
+                    shuffle_size = self.shuffle_size
+                    return [
+                        (out.key, (i,) + out.index[1:]) for i in range(shuffle_size)
+                    ]
+        return super().get_output_data_keys()
+
 
 def validate_subset(df, subset):
     if subset is None:

--- a/mars/dataframe/base/_duplicate.py
+++ b/mars/dataframe/base/_duplicate.py
@@ -396,16 +396,16 @@ class DuplicateOperand(MapReduceOperand, DataFrameOperandMixin):
         if method is not None:
             if self.stage == OperandStage.map:
                 if method == "tree":
-                    return [self.outputs[0].key]
+                    return ExactlyMapDataKeys(self.outputs[0].key)
                 elif method == "subset_tree":
-                    return [self.outputs[0].key]
+                    return ExactlyMapDataKeys(self.outputs[0].key)
                 else:
                     assert method == "shuffle"
                     out = self.outputs[0]
                     shuffle_size = self.shuffle_size
-                    return [
+                    return ExactlyMapDataKeys(
                         (out.key, (i,) + out.index[1:]) for i in range(shuffle_size)
-                    ]
+                    )
         return None
 
 

--- a/mars/dataframe/base/_duplicate.py
+++ b/mars/dataframe/base/_duplicate.py
@@ -406,7 +406,7 @@ class DuplicateOperand(MapReduceOperand, DataFrameOperandMixin):
                     return [
                         (out.key, (i,) + out.index[1:]) for i in range(shuffle_size)
                     ]
-        return super().get_output_data_keys()
+        return None
 
 
 def validate_subset(df, subset):

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -344,6 +344,21 @@ class DataFrameGroupByOperand(MapReduceOperand, DataFrameOperandMixin):
         params["chunks"] = out_chunks
         return new_op.new_tileables(new_inputs, **params)
 
+    def get_output_data_keys(self):
+        if self.stage == OperandStage.map:
+            is_dataframe_obj = self.is_dataframe_obj
+            chunk = self.outputs[0]
+            output = []
+            for index_idx in range(self.shuffle_size):
+                if is_dataframe_obj:
+                    reducer_index = (index_idx, chunk.index[1])
+                else:
+                    reducer_index = (index_idx,)
+                output.append((chunk.key, reducer_index))
+            return output
+        else:
+            return super().get_output_data_keys()
+
     @classmethod
     def execute_map(cls, ctx, op):
         is_dataframe_obj = op.is_dataframe_obj

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -357,7 +357,7 @@ class DataFrameGroupByOperand(MapReduceOperand, DataFrameOperandMixin):
                 output.append((chunk.key, reducer_index))
             return output
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def execute_map(cls, ctx, op):

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -21,6 +21,7 @@ import pandas as pd
 from ... import opcodes as OperandDef
 from ...core import ENTITY_TYPE, Entity, OutputType
 from ...core.operand import OperandStage, MapReduceOperand
+from ...core.operand.shuffle import ExactlyMapDataKeys
 from ...lib.groupby_wrapper import wrapped_groupby
 from ...serialization.serializables import BoolField, Int32Field, AnyField
 from ...utils import lazy_import
@@ -348,7 +349,7 @@ class DataFrameGroupByOperand(MapReduceOperand, DataFrameOperandMixin):
         if self.stage == OperandStage.map:
             is_dataframe_obj = self.is_dataframe_obj
             chunk = self.outputs[0]
-            output = []
+            output = ExactlyMapDataKeys()
             for index_idx in range(self.shuffle_size):
                 if is_dataframe_obj:
                     reducer_index = (index_idx, chunk.index[1])

--- a/mars/dataframe/groupby/sample.py
+++ b/mars/dataframe/groupby/sample.py
@@ -23,6 +23,7 @@ import pandas as pd
 from ... import opcodes
 from ...core import ENTITY_TYPE, OutputType, get_output_types, recursive_tile
 from ...core.operand import OperandStage, MapReduceOperand
+from ...core.operand.shuffle import ExactlyMapDataKeys
 from ...serialization.serializables import (
     BoolField,
     DictField,
@@ -566,7 +567,9 @@ class GroupBySample(MapReduceOperand, DataFrameOperandMixin):
     def get_output_data_keys(self):
         if self.stage == OperandStage.map:
             key = self.outputs[0].key
-            return [(key, (idx,)) for idx in range(len(self.input_nsplits))]
+            return ExactlyMapDataKeys(
+                (key, (idx,)) for idx in range(len(self.input_nsplits))
+            )
         else:
             return None
 

--- a/mars/dataframe/groupby/sample.py
+++ b/mars/dataframe/groupby/sample.py
@@ -568,7 +568,7 @@ class GroupBySample(MapReduceOperand, DataFrameOperandMixin):
             key = self.outputs[0].key
             return [(key, (idx,)) for idx in range(len(self.input_nsplits))]
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def execute(cls, ctx, op: "GroupBySample"):

--- a/mars/dataframe/groupby/sample.py
+++ b/mars/dataframe/groupby/sample.py
@@ -563,6 +563,13 @@ class GroupBySample(MapReduceOperand, DataFrameOperandMixin):
             return cls._tile_one_chunk(op, in_df, weights)
         return (yield from cls._tile_distributed(op, in_df, weights))
 
+    def get_output_data_keys(self):
+        if self.stage == OperandStage.map:
+            key = self.outputs[0].key
+            return [(key, (idx,)) for idx in range(len(self.input_nsplits))]
+        else:
+            return super().get_output_data_keys()
+
     @classmethod
     def execute(cls, ctx, op: "GroupBySample"):
         out_df = op.outputs[0]

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -24,6 +24,7 @@ from ... import opcodes as OperandDef
 from ...core import OutputType, recursive_tile, TileStatus
 from ...core.context import get_context
 from ...core.operand import OperandStage, MapReduceOperand
+from ...core.operand.shuffle import ExactlyMapDataKeys
 from ...serialization.serializables import (
     AnyField,
     BoolField,
@@ -85,10 +86,10 @@ class DataFrameMergeAlign(MapReduceOperand, DataFrameOperandMixin):
             chunk = self.outputs[0]
             chunk_index = chunk.index[1]
             chunk_key = chunk.key
-            return [
+            return ExactlyMapDataKeys(
                 (chunk_key, (index_idx, chunk_index))
                 for index_idx in range(self.index_shuffle_size)
-            ]
+            )
         else:
             return None
 

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -80,6 +80,18 @@ class DataFrameMergeAlign(MapReduceOperand, DataFrameOperandMixin):
         super()._set_inputs(inputs)
         self._input = self._inputs[0]
 
+    def get_output_data_keys(self):
+        if self.stage == OperandStage.map:
+            chunk = self.outputs[0]
+            chunk_index = chunk.index[1]
+            chunk_key = chunk.key
+            return [
+                (chunk_key, (index_idx, chunk_index))
+                for index_idx in range(self.index_shuffle_size)
+            ]
+        else:
+            return super().get_output_data_keys()
+
     @classmethod
     def execute_map(cls, ctx, op):
         chunk = op.outputs[0]

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -90,7 +90,7 @@ class DataFrameMergeAlign(MapReduceOperand, DataFrameOperandMixin):
                 for index_idx in range(self.index_shuffle_size)
             ]
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def execute_map(cls, ctx, op):

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -658,6 +658,13 @@ class DataFramePSRSShuffle(MapReduceOperand, DataFrameOperandMixin):
             values = a.iloc[poses[i] : poses[i + 1]]
             ctx[out.key, (i,)] = values
 
+    def get_output_data_keys(self):
+        if self.stage == OperandStage.map:
+            out = self.outputs[0]
+            return [(out.key, (i,)) for i in range(self.n_partition)]
+        else:
+            return super().get_output_data_keys()
+
     @classmethod
     def _execute_map(cls, ctx, op):
         a = [ctx[c.key] for c in op.inputs][0]

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -19,6 +19,7 @@ import pandas as pd
 
 from ... import opcodes as OperandDef
 from ...core.operand import OperandStage, MapReduceOperand
+from ...core.operand.shuffle import ExactlyMapDataKeys
 from ...utils import lazy_import, calc_nsplits
 from ...serialization.serializables import (
     AnyField,
@@ -661,7 +662,7 @@ class DataFramePSRSShuffle(MapReduceOperand, DataFrameOperandMixin):
     def get_output_data_keys(self):
         if self.stage == OperandStage.map:
             key = self.outputs[0].key
-            return [(key, (i,)) for i in range(self.n_partition)]
+            return ExactlyMapDataKeys((key, (i,)) for i in range(self.n_partition))
         else:
             return None
 

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -660,8 +660,8 @@ class DataFramePSRSShuffle(MapReduceOperand, DataFrameOperandMixin):
 
     def get_output_data_keys(self):
         if self.stage == OperandStage.map:
-            out = self.outputs[0]
-            return [(out.key, (i,)) for i in range(self.n_partition)]
+            key = self.outputs[0].key
+            return [(key, (i,)) for i in range(self.n_partition)]
         else:
             return None
 

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -663,7 +663,7 @@ class DataFramePSRSShuffle(MapReduceOperand, DataFrameOperandMixin):
             out = self.outputs[0]
             return [(out.key, (i,)) for i in range(self.n_partition)]
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def _execute_map(cls, ctx, op):

--- a/mars/deploy/oscar/tests/test_ray_dag.py
+++ b/mars/deploy/oscar/tests/test_ray_dag.py
@@ -112,7 +112,6 @@ async def test_iterative_tiling(ray_start_regular_shared2, create_cluster):
     await test_local.test_iterative_tiling(create_cluster)
 
 
-
 @require_ray
 @pytest.mark.asyncio
 async def test_execute_describe(ray_start_regular_shared2, create_cluster):

--- a/mars/deploy/oscar/tests/test_ray_dag.py
+++ b/mars/deploy/oscar/tests/test_ray_dag.py
@@ -112,6 +112,13 @@ async def test_iterative_tiling(ray_start_regular_shared2, create_cluster):
     await test_local.test_iterative_tiling(create_cluster)
 
 
+
+@require_ray
+@pytest.mark.asyncio
+async def test_execute_describe(ray_start_regular_shared2, create_cluster):
+    await test_local.test_execute_describe(create_cluster)
+
+
 # TODO(fyrestone): Support incremental index in ray backend.
 @require_ray
 @pytest.mark.parametrize("config", [{"backend": "ray", "incremental_index": False}])

--- a/mars/learn/ensemble/_bagging.py
+++ b/mars/learn/ensemble/_bagging.py
@@ -475,9 +475,16 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
 
     def get_output_data_keys(self):
         if self.stage == OperandStage.map:
-            out_samples = self.outputs[0]
+            key = self.outputs[0].key
             reducer_iter = self._get_reducer_iter(self)
-            return [(out_samples.key, (reducer_id, 0)) for reducer_id in reducer_iter]
+            seen = set()
+            output = []
+            for reducer_id in reducer_iter:
+                out_key = (key, (reducer_id, 0))
+                if out_key not in seen:
+                    seen.add(out_key)
+                    output.append(out_key)
+            return output
         else:
             return None
 

--- a/mars/learn/ensemble/_bagging.py
+++ b/mars/learn/ensemble/_bagging.py
@@ -479,7 +479,7 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
             reducer_iter = self._get_reducer_iter(self)
             return [(out_samples.key, (reducer_id, 0)) for reducer_id in reducer_iter]
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def _execute_map(cls, ctx, op: "BaggingSample"):

--- a/mars/learn/ensemble/_bagging.py
+++ b/mars/learn/ensemble/_bagging.py
@@ -35,6 +35,7 @@ from ... import opcodes, tensor as mt
 from ...core import OutputType, get_output_types, recursive_tile
 from ...core.context import Context
 from ...core.operand import OperandStage
+from ...core.operand.shuffle import ExactlyMapDataKeys
 from ...dataframe.core import DATAFRAME_TYPE
 from ...dataframe.utils import parse_index
 from ...deploy.oscar.session import execute
@@ -478,7 +479,7 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
             key = self.outputs[0].key
             reducer_iter = self._get_reducer_iter(self)
             seen = set()
-            output = []
+            output = ExactlyMapDataKeys()
             for reducer_id in reducer_iter:
                 out_key = (key, (reducer_id, 0))
                 if out_key not in seen:

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -385,7 +385,7 @@ class LearnShuffle(MapReduceOperand, LearnOperandMixin):
                 keys.append((out.key, tuple(index)))
             return keys
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def execute_map(cls, ctx, op):

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -378,13 +378,13 @@ class LearnShuffle(MapReduceOperand, LearnOperandMixin):
                 extra_reduce_sizes.append(reduce_size)
             axes, reduce_sizes = extra_axes, extra_reduce_sizes
 
-            keys = ExactlyMapDataKeys()
+            output = ExactlyMapDataKeys()
             for reduce_index in itertools.product(*(range(rs) for rs in reduce_sizes)):
                 index = list(out.index)
                 for ax, ind in zip(axes, reduce_index):
                     index[ax] = ind
-                keys.append((out.key, tuple(index)))
-            return keys
+                output.append((out.key, tuple(index)))
+            return output
         else:
             return None
 

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -23,6 +23,7 @@ import pandas as pd
 from ... import opcodes as OperandDef
 from ...core import get_output_types, recursive_tile
 from ...core.operand import OperandStage, MapReduceOperand
+from ...core.operand.shuffle import ExactlyMapDataKeys
 from ...dataframe.utils import parse_index
 from ...lib import sparse
 from ...serialization.serializables import FieldTypes, TupleField, KeyField
@@ -377,7 +378,7 @@ class LearnShuffle(MapReduceOperand, LearnOperandMixin):
                 extra_reduce_sizes.append(reduce_size)
             axes, reduce_sizes = extra_axes, extra_reduce_sizes
 
-            keys = []
+            keys = ExactlyMapDataKeys()
             for reduce_index in itertools.product(*(range(rs) for rs in reduce_sizes)):
                 index = list(out.index)
                 for ax, ind in zip(axes, reduce_index):

--- a/mars/services/subtask/worker/tests/subtask_processor.py
+++ b/mars/services/subtask/worker/tests/subtask_processor.py
@@ -15,7 +15,7 @@
 from typing import Any, Dict
 
 from .....core import OperandType
-from .....core.operand.shuffle import MapReduceOperand
+from .....core.operand.shuffle import MapReduceOperand, ExactlyMapDataKeys
 from .....tests.core import _check_args, ObjectCheckMixin
 from ...worker.processor import SubtaskProcessor
 
@@ -73,7 +73,7 @@ class CheckedSubtaskProcessor(ObjectCheckMixin, SubtaskProcessor):
         )
         super()._execute_operand(ctx, op)
         # Check the get_output_data_keys is correct.
-        if output_data_keys is not None:
+        if isinstance(output_data_keys, ExactlyMapDataKeys):
             # The same operand may be executed multiple times.
             first_key = output_data_keys[0]
             ctx_keys = list(ctx.keys())
@@ -82,6 +82,8 @@ class CheckedSubtaskProcessor(ObjectCheckMixin, SubtaskProcessor):
             assert (
                 new_keys == output_data_keys
             ), f"\nexpect data keys: {new_keys}\noutput data keys: {output_data_keys}"
+        else:
+            assert output_data_keys is None
         if self._check_options.get("check_all", True):
             for out in op.outputs:
                 if out not in self._chunk_graph.result_chunks:

--- a/mars/services/subtask/worker/tests/subtask_processor.py
+++ b/mars/services/subtask/worker/tests/subtask_processor.py
@@ -74,7 +74,11 @@ class CheckedSubtaskProcessor(ObjectCheckMixin, SubtaskProcessor):
         super()._execute_operand(ctx, op)
         # Check the get_output_data_keys is correct.
         if output_data_keys is not None:
-            new_keys = list(ctx.keys())[-len(output_data_keys) :]
+            # The same operand may be executed multiple times.
+            first_key = output_data_keys[0]
+            ctx_keys = list(ctx.keys())
+            pos = ctx_keys.index(first_key)
+            new_keys = ctx_keys[pos : pos + len(output_data_keys)]
             assert (
                 new_keys == output_data_keys
             ), f"\nexpect data keys: {new_keys}\noutput data keys: {output_data_keys}"

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -689,6 +689,12 @@ class PSRSShuffle(TensorMapReduceOperand, TensorOperandMixin):
                 limit += 1
             return limit
 
+    def get_output_data_keys(self):
+        if self.stage == OperandStage.map:
+            return [(self.outputs[0].key, (i,)) for i in range(self.n_partition)]
+        else:
+            return super().get_output_data_keys()
+
     @classmethod
     def _execute_map(cls, ctx, op):
         return_value = op.return_value
@@ -870,6 +876,14 @@ class PSRSAlign(TensorMapReduceOperand, TensorOperandMixin):
             return 1
         else:
             return int(bool(self._return_value)) + int(bool(self._return_indices))
+
+    def get_output_data_keys(self):
+        if self.stage == OperandStage.map:
+            return [
+                (self.outputs[0].key, (idx,)) for idx in range(len(self.output_sizes))
+            ]
+        else:
+            return super().get_output_data_keys()
 
     @classmethod
     def _execute_map(cls, ctx, op):

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -20,6 +20,7 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...core import recursive_tile
 from ...core.operand import OperandStage
+from ...core.operand.shuffle import ExactlyMapDataKeys
 from ...serialization.serializables import (
     FieldTypes,
     Int32Field,
@@ -692,7 +693,7 @@ class PSRSShuffle(TensorMapReduceOperand, TensorOperandMixin):
     def get_output_data_keys(self):
         if self.stage == OperandStage.map:
             key = self.outputs[0].key
-            return [(key, (i,)) for i in range(self.n_partition)]
+            return ExactlyMapDataKeys((key, (i,)) for i in range(self.n_partition))
         else:
             return None
 

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -882,7 +882,9 @@ class PSRSAlign(TensorMapReduceOperand, TensorOperandMixin):
     def get_output_data_keys(self):
         if self.stage == OperandStage.map:
             key = self.outputs[0].key
-            return [(key, (idx,)) for idx in range(len(self.output_sizes))]
+            return ExactlyMapDataKeys(
+                (key, (idx,)) for idx in range(len(self.output_sizes))
+            )
         else:
             return None
 

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -691,7 +691,8 @@ class PSRSShuffle(TensorMapReduceOperand, TensorOperandMixin):
 
     def get_output_data_keys(self):
         if self.stage == OperandStage.map:
-            return [(self.outputs[0].key, (i,)) for i in range(self.n_partition)]
+            key = self.outputs[0].key
+            return [(key, (i,)) for i in range(self.n_partition)]
         else:
             return None
 
@@ -879,9 +880,8 @@ class PSRSAlign(TensorMapReduceOperand, TensorOperandMixin):
 
     def get_output_data_keys(self):
         if self.stage == OperandStage.map:
-            return [
-                (self.outputs[0].key, (idx,)) for idx in range(len(self.output_sizes))
-            ]
+            key = self.outputs[0].key
+            return [(key, (idx,)) for idx in range(len(self.output_sizes))]
         else:
             return None
 

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -693,7 +693,7 @@ class PSRSShuffle(TensorMapReduceOperand, TensorOperandMixin):
         if self.stage == OperandStage.map:
             return [(self.outputs[0].key, (i,)) for i in range(self.n_partition)]
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def _execute_map(cls, ctx, op):
@@ -883,7 +883,7 @@ class PSRSAlign(TensorMapReduceOperand, TensorOperandMixin):
                 (self.outputs[0].key, (idx,)) for idx in range(len(self.output_sizes))
             ]
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def _execute_map(cls, ctx, op):

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -290,6 +290,15 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
         else:
             return (yield from cls._tile_via_shuffle(op))
 
+    def get_output_data_keys(self):
+        if self.stage == OperandStage.map:
+            return [
+                (self.outputs[0].key, (reducer,))
+                for reducer in range(op.aggregate_size)
+            ]
+        else:
+            return super().get_output_data_keys()
+
     @classmethod
     def _execute_map(cls, ctx, op: "TensorUnique"):
         (ar,), device_id, xp = as_same_device(

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -294,7 +294,7 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
         if self.stage == OperandStage.map:
             return [
                 (self.outputs[0].key, (reducer,))
-                for reducer in range(op.aggregate_size)
+                for reducer in range(self.aggregate_size)
             ]
         else:
             return None

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -292,10 +292,8 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
 
     def get_output_data_keys(self):
         if self.stage == OperandStage.map:
-            return [
-                (self.outputs[0].key, (reducer,))
-                for reducer in range(self.aggregate_size)
-            ]
+            key = self.outputs[0].key
+            return [(key, (reducer,)) for reducer in range(self.aggregate_size)]
         else:
             return None
 

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -297,7 +297,7 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
                 for reducer in range(op.aggregate_size)
             ]
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def _execute_map(cls, ctx, op: "TensorUnique"):

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -20,6 +20,7 @@ from ... import opcodes as OperandDef
 from ...config import options
 from ...core import recursive_tile
 from ...core.operand import OperandStage
+from ...core.operand.shuffle import ExactlyMapDataKeys
 from ...lib import sparse
 from ...lib.sparse.core import get_array_module as get_sparse_array_module
 from ...serialization.serializables import BoolField, Int32Field, Int64Field
@@ -293,7 +294,9 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
     def get_output_data_keys(self):
         if self.stage == OperandStage.map:
             key = self.outputs[0].key
-            return [(key, (reducer,)) for reducer in range(self.aggregate_size)]
+            return ExactlyMapDataKeys(
+                (key, (reducer,)) for reducer in range(self.aggregate_size)
+            )
         else:
             return None
 

--- a/mars/tensor/indexing/getitem.py
+++ b/mars/tensor/indexing/getitem.py
@@ -189,7 +189,7 @@ class FancyIndexingDistribute(TensorMapReduceOperand, TensorOperandMixin):
                 for idx in itertools.product(*(range(len(nsplits[ax])) for ax in axes))
             ]
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def _execute_map(cls, ctx, op):
@@ -287,7 +287,7 @@ class FancyIndexingConcat(TensorMapReduceOperand, TensorOperandMixin):
             key = self.outputs[0].key
             return [(key, (i,)) for i in range(self._fancy_shuffle_size)]
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def _execute_map(cls, ctx, op):

--- a/mars/tensor/indexing/getitem.py
+++ b/mars/tensor/indexing/getitem.py
@@ -286,7 +286,9 @@ class FancyIndexingConcat(TensorMapReduceOperand, TensorOperandMixin):
     def get_output_data_keys(self):
         if self.stage == OperandStage.map:
             key = self.outputs[0].key
-            return [(key, (i,)) for i in range(self._fancy_shuffle_size)]
+            return ExactlyMapDataKeys(
+                (key, (i,)) for i in range(self._fancy_shuffle_size)
+            )
         else:
             return None
 

--- a/mars/tensor/indexing/getitem.py
+++ b/mars/tensor/indexing/getitem.py
@@ -20,6 +20,7 @@ import numpy as np
 from ... import opcodes as OperandDef
 from ...core import ENTITY_TYPE
 from ...core.operand import OperandStage
+from ...core.operand.shuffle import ExactlyMapDataKeys
 from ...serialization.serializables import (
     FieldTypes,
     KeyField,
@@ -184,10 +185,10 @@ class FancyIndexingDistribute(TensorMapReduceOperand, TensorOperandMixin):
             nsplits = self.dest_nsplits
             axes = self.axes
             output_key = self.outputs[0].key
-            return [
+            return ExactlyMapDataKeys(
                 (output_key, idx)
                 for idx in itertools.product(*(range(len(nsplits[ax])) for ax in axes))
-            ]
+            )
         else:
             return None
 

--- a/mars/tensor/indexing/index_lib.py
+++ b/mars/tensor/indexing/index_lib.py
@@ -861,7 +861,10 @@ class TensorFancyIndexHandler(_FancyIndexHandler):
             tileable.chunk_shape[info.input_axis] for info in fancy_index_infos
         )
         fancy_indexes = [info.shape_unified_index for info in fancy_index_infos]
-        fancy_shuffle_size = np.prod(fancy_indexes[0].chunk_shape)
+        fancy_indexes_chunk_shape = fancy_indexes[0].chunk_shape
+        fancy_shuffle_size = (
+            np.prod(fancy_indexes_chunk_shape) if fancy_indexes_chunk_shape else 1
+        )
 
         concat_index_to_chunks = dict()
         for chunk in chunks:

--- a/mars/tensor/indexing/index_lib.py
+++ b/mars/tensor/indexing/index_lib.py
@@ -861,6 +861,7 @@ class TensorFancyIndexHandler(_FancyIndexHandler):
             tileable.chunk_shape[info.input_axis] for info in fancy_index_infos
         )
         fancy_indexes = [info.shape_unified_index for info in fancy_index_infos]
+        fancy_shuffle_size = np.prod(fancy_indexes[0].chunk_shape)
 
         concat_index_to_chunks = dict()
         for chunk in chunks:
@@ -873,6 +874,7 @@ class TensorFancyIndexHandler(_FancyIndexHandler):
             concat_map_op = FancyIndexingConcat(
                 stage=OperandStage.map,
                 fancy_index_axis=to_concat_axis,
+                fancy_shuffle_size=fancy_shuffle_size,
                 sparse=chunk.issparse(),
                 dtype=chunk.dtype,
             )

--- a/mars/tensor/indexing/setitem.py
+++ b/mars/tensor/indexing/setitem.py
@@ -276,6 +276,19 @@ class TensorIndexSetValue(TensorMapReduceOperand, TensorOperandMixin):
         input_[tuple(indexes)] = value
         ctx[op.outputs[0].key] = input_
 
+    def get_output_data_keys(self):
+        if self.stage == OperandStage.map:
+            nsplits = self.input_nsplits
+            output_key = self.outputs[0].key
+            return [
+                (output_key, reducer_index)
+                for reducer_index in itertools.product(
+                    *(map(range, [len(s) for s in nsplits]))
+                )
+            ]
+        else:
+            return super().get_output_data_keys()
+
     @classmethod
     def _execute_map(cls, ctx, op):
         nsplits = op.input_nsplits

--- a/mars/tensor/indexing/setitem.py
+++ b/mars/tensor/indexing/setitem.py
@@ -24,6 +24,7 @@ from ... import opcodes as OperandDef
 from ...core import ENTITY_TYPE, recursive_tile
 from ...core.context import Context
 from ...core.operand import OperandStage
+from ...core.operand.shuffle import ExactlyMapDataKeys
 from ...serialization.serializables import KeyField, TupleField, AnyField, BoolField
 from ...tensor import tensor as astensor
 from ...utils import has_unknown_shape
@@ -280,12 +281,12 @@ class TensorIndexSetValue(TensorMapReduceOperand, TensorOperandMixin):
         if self.stage == OperandStage.map:
             nsplits = self.input_nsplits
             output_key = self.outputs[0].key
-            return [
+            return ExactlyMapDataKeys(
                 (output_key, reducer_index)
                 for reducer_index in itertools.product(
                     *(map(range, [len(s) for s in nsplits]))
                 )
-            ]
+            )
         else:
             return None
 

--- a/mars/tensor/indexing/setitem.py
+++ b/mars/tensor/indexing/setitem.py
@@ -287,7 +287,7 @@ class TensorIndexSetValue(TensorMapReduceOperand, TensorOperandMixin):
                 )
             ]
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def _execute_map(cls, ctx, op):

--- a/mars/tensor/random/permutation.py
+++ b/mars/tensor/random/permutation.py
@@ -159,15 +159,15 @@ class TensorPermutation(TensorRandomMapReduceOperand, TensorOperandMixin):
         if self.stage == OperandStage.map:
             out_chunk = self.outputs[0]
             reduce_size = self.reduce_size
-            keys = ExactlyMapDataKeys()
+            output = ExactlyMapDataKeys()
             for to_reduce_idx in range(reduce_size):
                 reduce_idx = (
                     out_chunk.index[: self.axis]
                     + (to_reduce_idx,)
                     + out_chunk.index[self.axis + 1 :]
                 )
-                keys.append((out_chunk.key, reduce_idx))
-            return keys
+                output.append((out_chunk.key, reduce_idx))
+            return output
         else:
             return None
 

--- a/mars/tensor/random/permutation.py
+++ b/mars/tensor/random/permutation.py
@@ -168,7 +168,7 @@ class TensorPermutation(TensorRandomMapReduceOperand, TensorOperandMixin):
                 keys.append((out_chunk.key, reduce_idx))
             return keys
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def _execute_map(cls, ctx, op):

--- a/mars/tensor/random/permutation.py
+++ b/mars/tensor/random/permutation.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from ... import opcodes as OperandDef
 from ...core.operand import OperandStage
+from ...core.operand.shuffle import ExactlyMapDataKeys
 from ...serialization.serializables import KeyField, Int32Field
 from ..operands import TensorOperandMixin, TensorShuffleProxy
 from ..utils import gen_random_seeds, validate_axis
@@ -158,7 +159,7 @@ class TensorPermutation(TensorRandomMapReduceOperand, TensorOperandMixin):
         if self.stage == OperandStage.map:
             out_chunk = self.outputs[0]
             reduce_size = self.reduce_size
-            keys = []
+            keys = ExactlyMapDataKeys()
             for to_reduce_idx in range(reduce_size):
                 reduce_idx = (
                     out_chunk.index[: self.axis]

--- a/mars/tensor/random/permutation.py
+++ b/mars/tensor/random/permutation.py
@@ -154,6 +154,22 @@ class TensorPermutation(TensorRandomMapReduceOperand, TensorOperandMixin):
             nsplits=nsplits,
         )
 
+    def get_output_data_keys(self):
+        if self.stage == OperandStage.map:
+            out_chunk = self.outputs[0]
+            reduce_size = self.reduce_size
+            keys = []
+            for to_reduce_idx in range(reduce_size):
+                reduce_idx = (
+                    out_chunk.index[: self.axis]
+                    + (to_reduce_idx,)
+                    + out_chunk.index[self.axis + 1 :]
+                )
+                keys.append((out_chunk.key, reduce_idx))
+            return keys
+        else:
+            return super().get_output_data_keys()
+
     @classmethod
     def _execute_map(cls, ctx, op):
         (x,), device_id, xp = as_same_device(

--- a/mars/tensor/reshape/reshape.py
+++ b/mars/tensor/reshape/reshape.py
@@ -379,6 +379,10 @@ class TensorReshape(TensorMapReduceOperand, TensorOperandMixin):
         else:
             super().estimate_size(ctx, op)
 
+    def get_output_data_keys(self):
+        # TODO(fyrestone): To be implemented.
+        return None
+
     @classmethod
     def _execute_map(cls, ctx, op):
         chunk = op.outputs[0]

--- a/mars/tensor/spatial/distance/pdist.py
+++ b/mars/tensor/spatial/distance/pdist.py
@@ -305,7 +305,7 @@ class TensorPdist(TensorMapReduceOperand, TensorOperandMixin):
             out = self.outputs[0]
             return [(out.key, (i,)) for i in range(len(self.out_sizes))]
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def _execute_map(cls, ctx, op):

--- a/mars/tensor/spatial/distance/pdist.py
+++ b/mars/tensor/spatial/distance/pdist.py
@@ -19,6 +19,7 @@ import numpy as np
 from .... import opcodes as OperandDef
 from ....core import recursive_tile
 from ....core.operand import OperandStage
+from ....core.operand.shuffle import ExactlyMapDataKeys
 from ....serialization.serializables import (
     FieldTypes,
     KeyField,
@@ -302,8 +303,8 @@ class TensorPdist(TensorMapReduceOperand, TensorOperandMixin):
 
     def get_output_data_keys(self):
         if self.stage == OperandStage.map:
-            out = self.outputs[0]
-            return [(out.key, (i,)) for i in range(len(self.out_sizes))]
+            key = self.outputs[0].key
+            return ExactlyMapDataKeys((key, (i,)) for i in range(len(self.out_sizes)))
         else:
             return None
 

--- a/mars/tensor/spatial/distance/pdist.py
+++ b/mars/tensor/spatial/distance/pdist.py
@@ -300,6 +300,13 @@ class TensorPdist(TensorMapReduceOperand, TensorOperandMixin):
         else:
             return cls._tile_chunks(op, in_tensor, w, v, vi)
 
+    def get_output_data_keys(self):
+        if self.stage == OperandStage.map:
+            out = self.outputs[0]
+            return [(out.key, (i,)) for i in range(len(self.out_sizes))]
+        else:
+            return super().get_output_data_keys()
+
     @classmethod
     def _execute_map(cls, ctx, op):
         from scipy.spatial.distance import pdist, cdist

--- a/mars/tensor/spatial/distance/squareform.py
+++ b/mars/tensor/spatial/distance/squareform.py
@@ -346,7 +346,7 @@ class TensorSquareform(TensorMapReduceOperand, TensorOperandMixin):
             else:
                 return [(output_key, (i,)) for i in range(len(out_chunk_size[0]))]
         else:
-            return super().get_output_data_keys()
+            return None
 
     @classmethod
     def _execute_map(cls, ctx, op):

--- a/mars/tensor/spatial/distance/squareform.py
+++ b/mars/tensor/spatial/distance/squareform.py
@@ -19,6 +19,7 @@ import numpy as np
 from .... import opcodes as OperandDef
 from ....core import recursive_tile
 from ....core.operand import OperandStage
+from ....core.operand.shuffle import ExactlyMapDataKeys
 from ....serialization.serializables import FieldTypes, KeyField, BoolField, TupleField
 from ....config import options
 from ....utils import has_unknown_shape, require_module
@@ -337,12 +338,12 @@ class TensorSquareform(TensorMapReduceOperand, TensorOperandMixin):
             out_chunk_size = self.reduce_sizes
             output_key = self.outputs[0].key
             if x.ndim == 1:
-                return [
+                return ExactlyMapDataKeys(
                     (output_key, idx)
                     for idx in itertools.product(
                         *(range(len(ns)) for ns in out_chunk_size)
                     )
-                ]
+                )
             else:
                 return [(output_key, (i,)) for i in range(len(out_chunk_size[0]))]
         else:

--- a/mars/tensor/spatial/distance/squareform.py
+++ b/mars/tensor/spatial/distance/squareform.py
@@ -345,7 +345,9 @@ class TensorSquareform(TensorMapReduceOperand, TensorOperandMixin):
                     )
                 )
             else:
-                return [(output_key, (i,)) for i in range(len(out_chunk_size[0]))]
+                return ExactlyMapDataKeys(
+                    (output_key, (i,)) for i in range(len(out_chunk_size[0]))
+                )
         else:
             return None
 

--- a/mars/tensor/statistics/bincount.py
+++ b/mars/tensor/statistics/bincount.py
@@ -158,6 +158,10 @@ class TensorBinCount(TensorMapReduceOperand, TensorOperandMixin):
             **params,
         )
 
+    def get_output_data_keys(self):
+        # TODO(fyrestone): To be implemented.
+        return None
+
     @classmethod
     def _execute_map(cls, ctx, op: "TensorBinCount"):
         input_val = ctx[op.inputs[0].key]


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Most of the shuffle operands can provide the output data keys before execute, so it's possible to construct the Ray DAG for the shuffle operands.

This PR is the basic shuffle support for Ray backend, it based on the current shuffle operands and graph optimization. The push based shuffle will be the next gen: https://github.com/mars-project/mars/issues/2916

All the shuffle operands are list here, there are only two shuffle operands that generate the output data keys at runtime _(depend on the input data)_. This PR marks them as `To be implemented`. We can support these two operands in this inefficient way,

1. Generate the full output data key set before execute.
2. Construct the Ray DAG by `#1` keys.
3. Fill `None` value for the missing data keys before returning from `execute_subtask`.

<div class="lake-content" typography="classic">

Shuffle class | Can get the output data keys before execute
-- | --
mars.dataframe.align.DataFrameIndexAlign | True
mars.dataframe.base._duplicate.DuplicateOperand | True
mars.dataframe.base.drop_duplicates.DataFrameDropDuplicates | True
mars.dataframe.base.duplicated.DataFrameDuplicated | True
mars.dataframe.groupby.core.DataFrameGroupByOperand | True
mars.dataframe.groupby.sample.GroupBySample | True
mars.dataframe.merge.merge.DataFrameMergeAlign | True
mars.dataframe.sort.psrs.DataFramePSRSShuffle | True
mars.learn.ensemble._bagging.BaggingSample | True
mars.learn.utils.shuffle.LearnShuffle | True
mars.tensor.base.psrs.PSRSAlign | True
mars.tensor.base.psrs.PSRSShuffle | True
mars.tensor.base.unique.TensorUnique | True
mars.tensor.indexing.getitem.FancyIndexingConcat | True
mars.tensor.indexing.getitem.FancyIndexingDistribute | True
mars.tensor.indexing.setitem.TensorIndexSetValue | True
mars.tensor.random.permutation.TensorPermutation | True
mars.tensor.reshape.reshape.TensorReshape | False
mars.tensor.spatial.distance.pdist.TensorPdist | True
mars.tensor.spatial.distance.squareform.TensorSquareform | True
mars.tensor.statistics.bincount.TensorBinCount | False

</div>

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/mars-project/mars/issues/2893

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
