### PR TITLE
Build web code before CIBW when deploying to PyPI

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - name: Build web source
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          git reset --hard
+          pip install -r ci/requirements-wheel.txt
+          python setup.py build_web
+
       - name: Set up QEMU
         if: ${{ matrix.arch == 'aarch64' }}
         uses: docker/setup-qemu-action@v1
@@ -36,7 +43,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BEFORE_BUILD: git reset --hard && pip install -r ci/requirements-wheel.txt
-          CIBW_BEFORE_BUILD_LINUX: apt-get install -y npm
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: pp* *-musllinux* cp36-* cp310-win32 *i686 cp310-manylinux_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
@@ -47,12 +53,11 @@ jobs:
         uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BEFORE_BUILD: git reset --hard && pip install -r ci/requirements-wheel.txt
-          CIBW_BEFORE_BUILD_LINUX: apt-get install -y npm
           CIBW_BUILD: cp310-manylinux_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
       - name: Build source
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.arch == 'auto'}}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.arch == 'auto' }}
         run: |
           git reset --hard
           pip install -r ci/requirements-wheel.txt

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Build web source
+      - name: Build web for Linux
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           git reset --hard

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -36,6 +36,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BEFORE_BUILD: git reset --hard && pip install -r ci/requirements-wheel.txt
+          CIBW_BEFORE_BUILD_LINUX: apt-get install -y npm
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: pp* *-musllinux* cp36-* cp310-win32 *i686 cp310-manylinux_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
@@ -46,6 +47,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BEFORE_BUILD: git reset --hard && pip install -r ci/requirements-wheel.txt
+          CIBW_BEFORE_BUILD_LINUX: apt-get install -y npm
           CIBW_BUILD: cp310-manylinux_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
 
 [options.packages.find]
 exclude =
+    benchmarks*
     *.tests.*
     *.tests
 


### PR DESCRIPTION
## What do these changes do?

Build web code before CIBW when deploying to PyPI in Linux. Also remove benchmarks in wheels.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
