### PR TITLE
Do not aggressively choose tree method in tile of groupby for distributed setting

### DIFF
--- a/benchmarks/tpch/run_queries.py
+++ b/benchmarks/tpch/run_queries.py
@@ -17,12 +17,12 @@
 import argparse
 import functools
 import time
-from typing import Callable
+from typing import Callable, List, Optional, Set, Union
 
 import mars
 import mars.dataframe as md
 
-queries = None
+queries: Optional[Union[Set[str], List[str]]] = None
 
 
 def load_lineitem(data_folder: str) -> md.DataFrame:
@@ -976,7 +976,11 @@ def q22(customer, orders):
     print(total.execute())
 
 
-def run_queries(data_folder: str):
+def run_queries(data_folder: str, select: List[str] = None):
+    if select:
+        global queries
+        queries = select
+
     # Load the data
     t1 = time.time()
     lineitem = load_lineitem(data_folder)

--- a/mars/dataframe/groupby/sort.py
+++ b/mars/dataframe/groupby/sort.py
@@ -18,17 +18,12 @@ import pandas as pd
 from ... import opcodes as OperandDef
 from ...core import OutputType
 from ...core.operand import MapReduceOperand, OperandStage
-from ...serialization.serializables import (
-    Int32Field,
-    ListField,
-)
-from ...utils import (
-    lazy_import,
-)
+from ...serialization.serializables import Int32Field, ListField
+from ...utils import lazy_import
 from ..operands import DataFrameOperandMixin
 from ..sort.psrs import DataFramePSRSChunkOperand
 
-cudf = lazy_import("cudf", globals=globals())
+cudf = lazy_import("cudf")
 
 
 def _series_to_df(in_series, xdf):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR optimized tile of groupby to stop aggressively choosing tree method for distributed setting.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
