### PR TITLE
Fix error message when sparse data format not supported

### DIFF
--- a/mars/lib/sparse/array.py
+++ b/mars/lib/sparse/array.py
@@ -46,9 +46,13 @@ class SparseNDArray:
             return object.__new__(SparseMatrix)
 
         else:
-            from .coo import COONDArray
-
-            return object.__new__(COONDArray)
+            if cls is not SparseNDArray:
+                return object.__new__(cls)
+            else:
+                raise ValueError(
+                    f"The construct params of {cls.__name__} are invalid: "
+                    f"args={args}, kwargs={kwargs}"
+                )
 
     @property
     def raw(self):
@@ -228,6 +232,12 @@ class SparseArray(SparseNDArray):
             return lambda: SparseNDArray(self.spmatrix.get(), shape=self.shape)
 
         return super().__getattribute__(attr)
+
+    def __getstate__(self):
+        return self.spmatrix
+
+    def __setstate__(self, state):
+        self.spmatrix = state
 
     def astype(self, dtype, **_):
         dtype = np.dtype(dtype)

--- a/mars/lib/sparse/tests/test_sparse.py
+++ b/mars/lib/sparse/tests/test_sparse.py
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pickle
+
 import numpy as np
+import pytest
 import scipy.sparse as sps
 
 from ... import sparse as mls
@@ -47,11 +50,19 @@ def assert_array_equal(a, b, almost=False):
 
 
 def test_sparse_creation():
+    with pytest.raises(ValueError):
+        SparseNDArray()
+
     s = SparseNDArray(s1_data)
     assert s.ndim == 2
     assert isinstance(s, SparseMatrix)
     assert_array_equal(s.toarray(), s1_data.A)
     assert_array_equal(s.todense(), s1_data.A)
+
+    ss = pickle.loads(pickle.dumps(s))
+    assert s == ss
+    assert_array_equal(ss.toarray(), s1_data.A)
+    assert_array_equal(ss.todense(), s1_data.A)
 
     v = SparseNDArray(v1, shape=(3,))
     assert s.ndim
@@ -60,6 +71,12 @@ def test_sparse_creation():
     assert_array_equal(v.todense(), v1_data)
     assert_array_equal(v.toarray(), v1_data)
     assert_array_equal(v, v1_data)
+
+    vv = pickle.loads(pickle.dumps(v))
+    assert v == vv
+    assert_array_equal(vv.todense(), v1_data)
+    assert_array_equal(vv.toarray(), v1_data)
+    assert_array_equal(vv, v1_data)
 
 
 def test_sparse_add():

--- a/mars/tensor/base/tests/test_base_execution.py
+++ b/mars/tensor/base/tests/test_base_execution.py
@@ -101,6 +101,7 @@ def test_copyto_execution(setup):
     assert res.flags["C_CONTIGUOUS"] is False
 
 
+@pytest.mark.ray_dag
 def test_astype_execution(setup):
     raw = np.random.random((10, 5))
     arr = tensor(raw, chunk_size=3)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Makes `SparseNDArray` object pickleable.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes https://github.com/mars-project/mars/issues/3045

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
