### PR TITLE
Combine tree and shuffle methods in `DataFrameGroupBy.agg` tile

### DIFF
--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -714,7 +714,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
             assert input_chunk_size is not None
             check_size = True
         concat_chunk_size = input_chunk_size
-        while (concat_chunk_size < chunk_store_limit if check_size else True) and (
+        while (not check_size or concat_chunk_size < chunk_store_limit) and (
             len(chunks) > combine_size
         ):
             new_chunks = []

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -376,6 +376,8 @@ class DataFrameGroupByOperand(MapReduceOperand, DataFrameOperandMixin):
             result = src.iloc[f]
             if src.index.names:
                 result.index.names = src.index.names
+            if isinstance(src.index, pd.MultiIndex):
+                result.index = result.index.remove_unused_levels()
             if is_cudf(result):  # pragma: no cover
                 result = result.copy()
             return result

--- a/mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -350,55 +350,62 @@ def test_dataframe_groupby_agg(setup):
     mdf = md.DataFrame(raw, chunk_size=13)
 
     for method in ["tree", "shuffle"]:
-        r = mdf.groupby("c2").agg("size", method=method)
-        pd.testing.assert_series_equal(
-            r.execute().fetch().sort_index(), raw.groupby("c2").agg("size").sort_index()
-        )
-
-        for agg_fun in agg_funs:
-            if agg_fun == "size":
-                continue
-            r = mdf.groupby("c2").agg(agg_fun, method=method)
-            pd.testing.assert_frame_equal(
+        for sort in [True, False]:
+            r = mdf.groupby("c2").agg("size", method=method)
+            pd.testing.assert_series_equal(
                 r.execute().fetch().sort_index(),
-                raw.groupby("c2").agg(agg_fun).sort_index(),
+                raw.groupby("c2").agg("size").sort_index(),
             )
 
-        r = mdf.groupby("c2").agg(agg_funs, method=method)
-        pd.testing.assert_frame_equal(
-            r.execute().fetch().sort_index(),
-            raw.groupby("c2").agg(agg_funs).sort_index(),
-        )
+            for agg_fun in agg_funs:
+                if agg_fun == "size":
+                    continue
+                r = mdf.groupby("c2", sort=sort).agg(agg_fun, method=method)
+                pd.testing.assert_frame_equal(
+                    r.execute().fetch().sort_index(),
+                    raw.groupby("c2").agg(agg_fun).sort_index(),
+                )
 
-        agg = OrderedDict([("c1", ["min", "mean"]), ("c3", "std")])
-        r = mdf.groupby("c2").agg(agg, method=method)
-        pd.testing.assert_frame_equal(
-            r.execute().fetch().sort_index(), raw.groupby("c2").agg(agg).sort_index()
-        )
+            r = mdf.groupby("c2", sort=sort).agg(agg_funs, method=method)
+            pd.testing.assert_frame_equal(
+                r.execute().fetch().sort_index(),
+                raw.groupby("c2").agg(agg_funs).sort_index(),
+            )
 
-        agg = OrderedDict([("c1", "min"), ("c3", "sum")])
-        r = mdf.groupby("c2").agg(agg, method=method)
-        pd.testing.assert_frame_equal(
-            r.execute().fetch().sort_index(), raw.groupby("c2").agg(agg).sort_index()
-        )
+            agg = OrderedDict([("c1", ["min", "mean"]), ("c3", "std")])
+            r = mdf.groupby("c2", sort=sort).agg(agg, method=method)
+            pd.testing.assert_frame_equal(
+                r.execute().fetch().sort_index(),
+                raw.groupby("c2").agg(agg).sort_index(),
+            )
 
-        r = mdf.groupby("c2").agg({"c1": "min", "c3": "min"}, method=method)
-        pd.testing.assert_frame_equal(
-            r.execute().fetch().sort_index(),
-            raw.groupby("c2").agg({"c1": "min", "c3": "min"}).sort_index(),
-        )
+            agg = OrderedDict([("c1", "min"), ("c3", "sum")])
+            r = mdf.groupby("c2", sort=sort).agg(agg, method=method)
+            pd.testing.assert_frame_equal(
+                r.execute().fetch().sort_index(),
+                raw.groupby("c2").agg(agg).sort_index(),
+            )
 
-        r = mdf.groupby("c2").agg({"c1": "min"}, method=method)
-        pd.testing.assert_frame_equal(
-            r.execute().fetch().sort_index(),
-            raw.groupby("c2").agg({"c1": "min"}).sort_index(),
-        )
+            r = mdf.groupby("c2", sort=sort).agg(
+                {"c1": "min", "c3": "min"}, method=method
+            )
+            pd.testing.assert_frame_equal(
+                r.execute().fetch().sort_index(),
+                raw.groupby("c2").agg({"c1": "min", "c3": "min"}).sort_index(),
+            )
 
-        # test groupby series
-        r = mdf.groupby(mdf["c2"]).sum(method=method)
-        pd.testing.assert_frame_equal(
-            r.execute().fetch().sort_index(), raw.groupby(raw["c2"]).sum().sort_index()
-        )
+            r = mdf.groupby("c2", sort=sort).agg({"c1": "min"}, method=method)
+            pd.testing.assert_frame_equal(
+                r.execute().fetch().sort_index(),
+                raw.groupby("c2").agg({"c1": "min"}).sort_index(),
+            )
+
+            # test groupby series
+            r = mdf.groupby(mdf["c2"], sort=sort).sum(method=method)
+            pd.testing.assert_frame_equal(
+                r.execute().fetch().sort_index(),
+                raw.groupby(raw["c2"]).sum().sort_index(),
+            )
 
     r = mdf.groupby("c2").size(method="tree")
     pd.testing.assert_series_equal(r.execute().fetch(), raw.groupby("c2").size())
@@ -732,6 +739,37 @@ def test_distributed_groupby_agg(setup_cluster):
     pd.testing.assert_frame_equal(result, raw.groupby(0).sum())
     # test use shuffle
     assert len(r._fetch_infos()["memory_size"]) > 1
+
+    rs = np.random.RandomState(0)
+    raw = pd.DataFrame(
+        {
+            "c1": rs.randint(20, size=100),
+            "c2": rs.choice(["a", "b", "c"], (100,)),
+            "c3": rs.rand(100),
+        }
+    )
+    mdf = md.DataFrame(raw, chunk_size=20)
+    r = mdf.groupby("c2").sum().execute()
+    pd.testing.assert_frame_equal(r.fetch(), raw.groupby("c2").sum())
+    # test use tree
+    assert len(r._fetch_infos()["memory_size"]) == 1
+
+    rs = np.random.RandomState(0)
+    raw = pd.DataFrame(
+        {
+            "c1": rs.randint(20, size=100),
+            "c2": rs.choice(["a", "b", "c"], (100,)),
+            "c3": rs.rand(100),
+        }
+    )
+    mdf = md.DataFrame(raw, chunk_size=10)
+    with option_context({"chunk_store_limit": 2048}):
+        r = mdf.groupby("c2", sort=False).sum().execute()
+    pd.testing.assert_frame_equal(
+        r.fetch().sort_index(), raw.groupby("c2", sort=False).sum().sort_index()
+    )
+    # use tree and shuffle
+    assert len(r._fetch_infos()["memory_size"]) == 3
 
 
 def test_groupby_agg_str_cat(setup):

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -599,7 +599,12 @@ class SubtaskProcessorActor(mo.Actor):
         set_context(context)
 
     async def run(self, subtask: Subtask):
-        logger.info("Start to run subtask: %r on %s.", subtask, self.address)
+        logger.info(
+            "Start to run subtask: %r on %s. chunk graph contains %s",
+            subtask,
+            self.address,
+            [c for c in subtask.chunk_graph],
+        )
 
         assert subtask.session_id == self._session_id
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This PR applies both tree and shuffle methods for `DataFrameGroupBy.agg`'s auto method. First, combine map chunks into larger chunks according to sample chunk's size, then shuffle those combined chunks. It brings improvements when executing groupby on cluster.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
