### PR TITLE
Use OS-designated ports instead of random ports to create sub pools

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,3 +13,4 @@ include mars/services/web/static/*
 global-exclude .DS_Store
 include versioneer.py
 include mars/_version.py
+exclude mars/conftest.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,4 +13,3 @@ include mars/services/web/static/*
 global-exclude .DS_Store
 include versioneer.py
 include mars/_version.py
-exclude mars/conftest.py

--- a/mars/conftest.py
+++ b/mars/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import concurrent.futures
+import logging
 import os
 import subprocess
 
@@ -29,6 +30,7 @@ from mars.utils import lazy_import
 
 ray = lazy_import("ray")
 MARS_CI_BACKEND = os.environ.get("MARS_CI_BACKEND", "mars")
+logging.basicConfig(level=logging.DEBUG)
 
 
 @pytest.fixture(scope="module")

--- a/mars/conftest.py
+++ b/mars/conftest.py
@@ -18,7 +18,6 @@ import subprocess
 
 import psutil
 import pytest
-import pytest_asyncio
 
 from mars.config import option_context
 from mars.core.mode import is_kernel_mode, is_build_mode
@@ -136,7 +135,7 @@ def stop_ray(request):  # pragma: no cover
         ray.shutdown()
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def ray_create_mars_cluster(request):
     from mars.deploy.oscar.ray import new_cluster, _load_config
 

--- a/mars/conftest.py
+++ b/mars/conftest.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import concurrent.futures
-import logging
 import os
 import subprocess
 
@@ -30,7 +29,6 @@ from mars.utils import lazy_import
 
 ray = lazy_import("ray")
 MARS_CI_BACKEND = os.environ.get("MARS_CI_BACKEND", "mars")
-logging.basicConfig(level=logging.DEBUG)
 
 
 @pytest.fixture(scope="module")

--- a/mars/conftest.py
+++ b/mars/conftest.py
@@ -183,6 +183,7 @@ def _new_test_session():
             yield sess
         finally:
             sess.stop_server(isolation=False)
+            Router.set_instance(None)
 
 
 @pytest.fixture(scope="module")
@@ -204,6 +205,7 @@ def _new_integrated_test_session():
             try:
                 sess.stop_server(isolation=False)
             except concurrent.futures.TimeoutError:
+                Router.set_instance(None)
                 subprocesses = psutil.Process().children(recursive=True)
                 for proc in subprocesses:
                     proc.terminate()
@@ -240,6 +242,7 @@ def _new_gpu_test_session():  # pragma: no cover
             yield sess
         finally:
             sess.stop_server(isolation=False)
+            Router.set_instance(None)
 
 
 @pytest.fixture

--- a/mars/conftest.py
+++ b/mars/conftest.py
@@ -21,6 +21,7 @@ import pytest
 
 from mars.config import option_context
 from mars.core.mode import is_kernel_mode, is_build_mode
+from mars.lib.aio.lru import clear_all_alru_caches
 from mars.oscar.backends.router import Router
 from mars.oscar.backends.ray.communication import RayServer
 from mars.serialization.ray import register_ray_serializers, unregister_ray_serializers
@@ -28,6 +29,11 @@ from mars.utils import lazy_import
 
 ray = lazy_import("ray")
 MARS_CI_BACKEND = os.environ.get("MARS_CI_BACKEND", "mars")
+
+
+@pytest.fixture(autouse=True)
+def auto_cleanup(request):
+    request.addfinalizer(clear_all_alru_caches)
 
 
 @pytest.fixture(scope="module")
@@ -49,6 +55,7 @@ def ray_start_regular_shared2(request):  # pragma: no cover
         yield ray.init(num_cpus=num_cpus, job_config=job_config)
     finally:
         ray.shutdown()
+        Router.set_instance(None)
         os.environ.pop("RAY_kill_idle_workers_interval_ms", None)
 
 
@@ -133,6 +140,7 @@ def stop_ray(request):  # pragma: no cover
     yield
     if ray.is_initialized():
         ray.shutdown()
+    Router.set_instance(None)
 
 
 @pytest.fixture
@@ -154,16 +162,22 @@ async def ray_create_mars_cluster(request):
         worker_mem=worker_mem,
         config=ray_config,
     )
-    async with client:
-        yield client
+    try:
+        async with client:
+            yield client
+    finally:
+        Router.set_instance(None)
 
 
 @pytest.fixture
 def stop_mars():
-    yield
-    import mars
+    try:
+        yield
+    finally:
+        import mars
 
-    mars.stop_server()
+        mars.stop_server()
+        Router.set_instance(None)
 
 
 @pytest.fixture(scope="module")

--- a/mars/dataframe/contrib/raydataset/tests/test_mldataset.py
+++ b/mars/dataframe/contrib/raydataset/tests/test_mldataset.py
@@ -20,6 +20,7 @@ import pytest
 from ..... import dataframe as md
 from .....deploy.oscar.ray import new_cluster
 from .....deploy.oscar.session import new_session
+from .....oscar.backends.router import Router
 from .....tests.core import require_ray
 from .....utils import lazy_import
 from ....contrib import raydataset as mdd
@@ -46,8 +47,11 @@ async def create_cluster(request):
         worker_cpu=1,
         worker_mem=256 * 1024**2,
     )
-    async with client:
-        yield client
+    try:
+        async with client:
+            yield client
+    finally:
+        Router.set_instance(None)
 
 
 @require_ray

--- a/mars/dataframe/contrib/raydataset/tests/test_raydataset.py
+++ b/mars/dataframe/contrib/raydataset/tests/test_raydataset.py
@@ -16,7 +16,6 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
-import pytest_asyncio
 
 from ..... import dataframe as md
 from .....deploy.oscar.ray import new_cluster
@@ -37,7 +36,7 @@ except ImportError:  # pragma: no cover
     sklearn = None
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def create_cluster(request):
     client = await new_cluster(
         supervisor_mem=256 * 1024**2,

--- a/mars/dataframe/contrib/raydataset/tests/test_raydataset.py
+++ b/mars/dataframe/contrib/raydataset/tests/test_raydataset.py
@@ -20,6 +20,7 @@ import pytest
 from ..... import dataframe as md
 from .....deploy.oscar.ray import new_cluster
 from .....deploy.oscar.session import new_session
+from .....oscar.backends.router import Router
 from .....tests.core import require_ray
 from .....utils import lazy_import
 from ....contrib import raydataset as mdd
@@ -44,8 +45,11 @@ async def create_cluster(request):
         worker_cpu=1,
         worker_mem=256 * 1024**2,
     )
-    async with client:
-        yield client
+    try:
+        async with client:
+            yield client
+    finally:
+        Router.set_instance(None)
 
 
 @require_ray

--- a/mars/deploy/oscar/local.py
+++ b/mars/deploy/oscar/local.py
@@ -232,7 +232,6 @@ class LocalCluster:
             metrics=self._config.get("metrics", {}),
         )
         self.supervisor_address = self._supervisor_pool.external_address
-        logger.warning(f"TMP: START SV-POOL WITH ADDR {self.supervisor_address}")
 
     async def _start_worker_pools(self):
         worker_modules = get_third_party_modules_from_config(
@@ -247,10 +246,8 @@ class LocalCluster:
                 metrics=self._config.get("metrics", {}),
             )
             self._worker_pools.append(worker_pool)
-        logger.warning(f"TMP: START W-POOLS WITH ADDR {[pool.external_address for pool in self._worker_pools]}")
 
     async def _start_service(self):
-        logger.warning(f"TMP: TO START SV WITH ADDR {self.supervisor_address}")
         self._web = await start_supervisor(
             self.supervisor_address, config=self._config, web=self._web
         )

--- a/mars/deploy/oscar/local.py
+++ b/mars/deploy/oscar/local.py
@@ -232,6 +232,7 @@ class LocalCluster:
             metrics=self._config.get("metrics", {}),
         )
         self.supervisor_address = self._supervisor_pool.external_address
+        logger.warning(f"TMP: START SV-POOL WITH ADDR {self.supervisor_address}")
 
     async def _start_worker_pools(self):
         worker_modules = get_third_party_modules_from_config(
@@ -246,8 +247,10 @@ class LocalCluster:
                 metrics=self._config.get("metrics", {}),
             )
             self._worker_pools.append(worker_pool)
+        logger.warning(f"TMP: START W-POOLS WITH ADDR {[pool.external_address for pool in self._worker_pools]}")
 
     async def _start_service(self):
+        logger.warning(f"TMP: TO START SV WITH ADDR {self.supervisor_address}")
         self._web = await start_supervisor(
             self.supervisor_address, config=self._config, web=self._web
         )

--- a/mars/deploy/oscar/tests/test_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_fault_injection.py
@@ -14,7 +14,6 @@
 
 import os
 import pytest
-import pytest_asyncio
 import traceback
 import numpy as np
 import pandas as pd
@@ -41,7 +40,7 @@ RERUN_SUBTASK_CONFIG_FILE = os.path.join(
 )
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def fault_cluster(request):
     param = getattr(request, "param", {})
     start_method = os.environ.get("POOL_START_METHOD", None)

--- a/mars/deploy/oscar/tests/test_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_fault_injection.py
@@ -20,6 +20,7 @@ import pandas as pd
 
 from .... import dataframe as md
 from .... import tensor as mt
+from ....oscar.backends.router import Router
 from ....oscar.errors import ServerClosed
 from ....remote import spawn
 from ....services.tests.fault_injection_manager import (
@@ -50,8 +51,11 @@ async def fault_cluster(request):
         n_worker=2,
         n_cpu=2,
     )
-    async with client:
-        yield client
+    try:
+        async with client:
+            yield client
+    finally:
+        Router.set_instance(None)
 
 
 async def create_fault_injection_manager(

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -23,7 +23,6 @@ import uuid
 import numpy as np
 import pandas as pd
 import pytest
-import pytest_asyncio
 
 try:
     import vineyard
@@ -104,7 +103,7 @@ if vineyard is not None:
 
 
 @pytest.mark.parametrize(indirect=True)
-@pytest_asyncio.fixture(params=params)
+@pytest.fixture(params=params)
 async def create_cluster(request):
     if request.param == "default":
         config = CONFIG_TEST_FILE
@@ -858,7 +857,7 @@ def test_show_progress_raise_exception(m_log):
 min_task_runtime = 2
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def speculative_cluster():
     config = _load_config()
     config["scheduling"]["speculation"]["enabled"] = True

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -35,6 +35,7 @@ from .... import remote as mr
 from ....config import option_context
 from ....core.context import get_context
 from ....lib.aio import new_isolation
+from ....oscar.backends.router import Router
 from ....storage import StorageLevel
 from ....services.storage import StorageAPI
 from ....tensor.arithmetic.add import TensorAdd
@@ -119,10 +120,13 @@ async def create_cluster(request):
         n_cpu=2,
         use_uvloop=False,
     )
-    async with client:
-        if request.param == "default":
-            assert client.session.client is not None
-        yield client, request.param
+    try:
+        async with client:
+            if request.param == "default":
+                assert client.session.client is not None
+            yield client, request.param
+    finally:
+        Router.set_instance(None)
 
 
 def _assert_storage_cleaned(session_id: str, addr: str, level: StorageLevel):
@@ -636,11 +640,12 @@ def setup_session():
     session = new_session(n_cpu=2, use_uvloop=False)
     assert session.get_web_endpoint() is not None
 
-    with session:
-        with option_context({"show_progress": False}):
+    try:
+        with session, option_context({"show_progress": False}):
             yield session
-
-    session.stop_server()
+    finally:
+        session.stop_server()
+        Router.set_instance(None)
 
 
 def test_decref(setup_session):
@@ -876,8 +881,11 @@ async def speculative_cluster():
         n_cpu=10,
         use_uvloop=False,
     )
-    async with client:
-        yield client
+    try:
+        async with client:
+            yield client
+    finally:
+        Router.set_instance(None)
 
 
 @pytest.mark.timeout(timeout=500)

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -26,7 +26,6 @@ from functools import reduce
 import numpy as np
 import pandas as pd
 import pytest
-import pytest_asyncio
 
 import mars
 from .... import oscar as mo
@@ -93,7 +92,7 @@ EXPECT_PROFILING_STRUCTURE_NO_SLOW["supervisor"]["slow_calls"] = {}
 EXPECT_PROFILING_STRUCTURE_NO_SLOW["supervisor"]["slow_subtasks"] = {}
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def create_cluster(request):
     param = getattr(request, "param", {})
     ray_config = _load_config(CONFIG_FILE)

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -36,6 +36,7 @@ from ....oscar.backends.ray.utils import (
     process_placement_to_address,
     kill_and_wait,
 )
+from ....oscar.backends.router import Router
 from ....oscar.errors import ReconstructWorkerError
 from ....serialization.ray import register_ray_serializers
 from ....services.cluster import ClusterAPI
@@ -105,8 +106,11 @@ async def create_cluster(request):
         worker_mem=1 * 1024**3,
         config=ray_config,
     )
-    async with client:
-        yield client, param
+    try:
+        async with client:
+            yield client, param
+    finally:
+        Router.set_instance(None)
 
 
 @require_ray

--- a/mars/deploy/oscar/tests/test_ray_dag.py
+++ b/mars/deploy/oscar/tests/test_ray_dag.py
@@ -17,6 +17,7 @@ import os
 
 import pytest
 
+from ....oscar.backends.router import Router
 from ....tests.core import DICT_NOT_EMPTY, require_ray
 from ....utils import lazy_import
 from ..local import new_cluster
@@ -64,9 +65,12 @@ async def create_cluster(request):
         n_cpu=2,
         use_uvloop=False,
     )
-    async with client:
-        assert client.session.client is not None
-        yield client, {}
+    try:
+        async with client:
+            assert client.session.client is not None
+            yield client, {}
+    finally:
+        Router.set_instance(None)
 
 
 @require_ray

--- a/mars/deploy/oscar/tests/test_ray_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_ray_fault_injection.py
@@ -15,7 +15,6 @@
 import os
 
 import pytest
-import pytest_asyncio
 
 from ....oscar.errors import ServerClosed
 from ....services.tests.fault_injection_manager import (
@@ -46,7 +45,7 @@ SUBTASK_RERUN_CONFIG = {
 }
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def fault_cluster(request):
     param = getattr(request, "param", {})
     ray_config = _load_config(RAY_CONFIG_FILE)

--- a/mars/deploy/oscar/tests/test_ray_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_ray_fault_injection.py
@@ -16,6 +16,7 @@ import os
 
 import pytest
 
+from ....oscar.backends.router import Router
 from ....oscar.errors import ServerClosed
 from ....services.tests.fault_injection_manager import (
     FaultInjectionError,
@@ -58,8 +59,11 @@ async def fault_cluster(request):
         worker_mem=1 * 1024**3,
         config=ray_config,
     )
-    async with client:
-        yield client
+    try:
+        async with client:
+            yield client
+    finally:
+        Router.set_instance(None)
 
 
 @require_ray

--- a/mars/deploy/oscar/tests/test_ray_scheduling.py
+++ b/mars/deploy/oscar/tests/test_ray_scheduling.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import pytest
-import pytest_asyncio
 
 from ....tests.core import require_ray
 from ....utils import lazy_import
@@ -27,7 +26,7 @@ from .modules.utils import (  # noqa: F401; pylint: disable=unused-variable
 ray = lazy_import("ray")
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def speculative_cluster():
     client = await new_cluster(
         "test_cluster",

--- a/mars/deploy/oscar/tests/test_ray_scheduling.py
+++ b/mars/deploy/oscar/tests/test_ray_scheduling.py
@@ -14,6 +14,7 @@
 
 import pytest
 
+from ....oscar.backends.router import Router
 from ....tests.core import require_ray
 from ....utils import lazy_import
 from ..ray import new_cluster
@@ -48,8 +49,11 @@ async def speculative_cluster():
             },
         },
     )
-    async with client:
-        yield client
+    try:
+        async with client:
+            yield client
+    finally:
+        Router.set_instance(None)
 
 
 @pytest.mark.parametrize("ray_large_cluster", [{"num_nodes": 2}], indirect=True)

--- a/mars/lib/aio/__init__.py
+++ b/mars/lib/aio/__init__.py
@@ -26,17 +26,3 @@ if sys.version_info[:2] < (3, 9):
     from ._threads import to_thread
 
     asyncio.to_thread = to_thread
-
-
-if sys.version_info[:2] < (3, 7):
-    # patch run and get_running_loop etc for python 3.6
-    from ._runners import get_running_loop, run
-
-    asyncio.run = run
-    asyncio.get_running_loop = get_running_loop
-    asyncio.create_task = asyncio.ensure_future
-
-    # patch async generator
-    from async_generator import asynccontextmanager
-
-    contextlib.asynccontextmanager = asynccontextmanager

--- a/mars/oscar/__init__.py
+++ b/mars/oscar/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TypeVar, Union
+
 # import aio to ensure patch enabled for Python 3.6
 from ..lib import aio
 
@@ -49,3 +51,6 @@ from .utils import create_actor_ref
 from .backends import mars, ray, test
 
 del mars, ray, test
+
+_T = TypeVar("_T")
+ActorRefType = Union[ActorRef, _T]

--- a/mars/oscar/backends/communication/dummy.py
+++ b/mars/oscar/backends/communication/dummy.py
@@ -206,10 +206,10 @@ class DummyClient(Client):
         server = DummyServer.get_instance(dest_address)
         if server is None:  # pragma: no cover
             raise RuntimeError(
-                "DummyServer needs to be created first before DummyClient"
+                f"DummyServer {dest_address} needs to be created first before DummyClient"
             )
         if server.stopped:  # pragma: no cover
-            raise ConnectionError("Dummy server closed")
+            raise ConnectionError(f"Dummy server {dest_address} closed")
 
         q1, q2 = asyncio.Queue(), asyncio.Queue()
         closed = asyncio.Event()

--- a/mars/oscar/backends/communication/socket.py
+++ b/mars/oscar/backends/communication/socket.py
@@ -215,9 +215,14 @@ class SocketServer(_BaseSocketServer):
                 reader, writer, local_address=server.address
             )
 
+        port = port if port != 0 else None
         aio_server = await asyncio.start_server(
             handle_connection, host=host, port=port, **config
         )
+
+        # get port of the socket if not specified
+        if not port:
+            port = aio_server.sockets[0].getsockname()[1]
 
         if _is_windows:
             for sock in aio_server.sockets:

--- a/mars/oscar/backends/communication/socket.py
+++ b/mars/oscar/backends/communication/socket.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import concurrent.futures as futures
+import logging
 import os
 import socket
 import sys
@@ -245,7 +246,11 @@ class SocketClient(Client):
     ) -> "Client":
         host, port = dest_address.split(":", 1)
         port = int(port)
-        (reader, writer) = await asyncio.open_connection(host=host, port=port, **kwargs)
+        try:
+            (reader, writer) = await asyncio.open_connection(host=host, port=port, **kwargs)
+        except ConnectionRefusedError:
+            logging.exception(f"TMP: CONNECT REFUSED FOR {host}:{port}")
+            raise
         channel = SocketChannel(
             reader, writer, local_address=local_address, dest_address=dest_address
         )

--- a/mars/oscar/backends/communication/socket.py
+++ b/mars/oscar/backends/communication/socket.py
@@ -14,7 +14,6 @@
 
 import asyncio
 import concurrent.futures as futures
-import logging
 import os
 import socket
 import sys
@@ -246,11 +245,7 @@ class SocketClient(Client):
     ) -> "Client":
         host, port = dest_address.split(":", 1)
         port = int(port)
-        try:
-            (reader, writer) = await asyncio.open_connection(host=host, port=port, **kwargs)
-        except ConnectionRefusedError:
-            logging.exception(f"TMP: CONNECT REFUSED FOR {host}:{port}")
-            raise
+        (reader, writer) = await asyncio.open_connection(host=host, port=port, **kwargs)
         channel = SocketChannel(
             reader, writer, local_address=local_address, dest_address=dest_address
         )

--- a/mars/oscar/backends/config.py
+++ b/mars/oscar/backends/config.py
@@ -90,12 +90,15 @@ class ActorPoolConfig:
         if not isinstance(external_address, list):
             external_address = [external_address]
         cur_pool_config = self._conf["pools"][process_index]
+        internal_address = cur_pool_config["internal_address"]
 
         mapping: Dict = self._conf["mapping"]
         for addr in cur_pool_config["external_address"]:
+            if internal_address == addr:
+                # internal address may be the same as external address in Windows
+                internal_address = external_address[0]
             mapping.pop(addr, None)
 
-        internal_address = cur_pool_config["internal_address"]
         cur_pool_config["external_address"] = external_address
         for addr in external_address:
             mapping[addr] = internal_address

--- a/mars/oscar/backends/config.py
+++ b/mars/oscar/backends/config.py
@@ -60,8 +60,9 @@ class ActorPoolConfig:
             "logging_conf": logging_conf,
             "kwargs": kwargs or {},
         }
+
+        mapping: Dict = self._conf["mapping"]
         for addr in external_address:
-            mapping: Dict = self._conf["mapping"]
             mapping[addr] = internal_address
 
     def get_pool_config(self, process_index: int):
@@ -80,6 +81,24 @@ class ActorPoolConfig:
         raise ValueError(
             f"Cannot get process_index for {external_address}"
         )  # pragma: no cover
+
+    def reset_pool_external_address(
+        self,
+        process_index: int,
+        external_address: Union[str, List[str]],
+    ):
+        if not isinstance(external_address, list):
+            external_address = [external_address]
+        cur_pool_config = self._conf["pools"][process_index]
+
+        mapping: Dict = self._conf["mapping"]
+        for addr in cur_pool_config["external_address"]:
+            mapping.pop(addr, None)
+
+        internal_address = cur_pool_config["internal_address"]
+        cur_pool_config["external_address"] = external_address
+        for addr in external_address:
+            mapping[addr] = internal_address
 
     def get_external_addresses(self, label=None) -> List[str]:
         result = []

--- a/mars/oscar/backends/mars/tests/test_debug.py
+++ b/mars/oscar/backends/mars/tests/test_debug.py
@@ -21,7 +21,6 @@ from io import StringIO
 from typing import List
 
 import pytest
-import pytest_asyncio
 
 from ..... import oscar as mo
 from ....debug import reload_debug_opts_from_env, get_debug_options
@@ -63,7 +62,7 @@ class DebugActor(mo.Actor):
         await self.ref().wait(1)
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     start_method = (
         os.environ.get("POOL_START_METHOD", "forkserver")

--- a/mars/oscar/backends/mars/tests/test_mars_actor_context.py
+++ b/mars/oscar/backends/mars/tests/test_mars_actor_context.py
@@ -22,7 +22,6 @@ from collections import deque
 
 import pandas as pd
 import pytest
-import pytest_asyncio
 
 from ..... import oscar as mo
 from .....oscar.core import ActorRef, LocalActorRef
@@ -242,7 +241,7 @@ class PromiseTestActor(mo.Actor):
 
 
 @pytest.mark.parametrize(indirect=True)
-@pytest_asyncio.fixture(params=[False, True])
+@pytest.fixture(params=[False, True])
 async def actor_pool(request):
     start_method = (
         os.environ.get("POOL_START_METHOD", "forkserver")

--- a/mars/oscar/backends/message.pyi
+++ b/mars/oscar/backends/message.pyi
@@ -70,6 +70,7 @@ class ControlMessage(_MessageBase):
         control_message_type: ControlMessageType = None,
         content: Any = None,
         protocol: int = DEFAULT_PROTOCOL,
+        message_trace: list = None,
     ): ...
 
 class ResultMessage(_MessageBase):

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -665,10 +665,17 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
                 process_index, external_addresses
             )
             external_addresses = curr_pool_config["external_address"]
+
+            logger.debug(
+                "External address of process index %s updated to %s",
+                process_index,
+                external_addresses[0],
+            )
             if kw["internal_address"] == kw["external_address"]:
                 # internal address may be the same as external address in Windows
                 kw["internal_address"] = external_addresses[0]
             kw["external_address"] = external_addresses[0]
+
             kw["router"] = Router(
                 external_addresses,
                 gen_local_address(process_index),

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -646,28 +646,25 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
         kw = dict()
         cls._parse_config(config, kw)
         process_index: int = kw["process_index"]
-        actor_pool_config = kw["config"]
-        external_addresses = actor_pool_config.get_pool_config(process_index)[
-            "external_address"
-        ]
+        actor_pool_config = kw["config"]  # type: ActorPoolConfig
+        cur_pool_config = actor_pool_config.get_pool_config(process_index)
+        external_addresses = cur_pool_config["external_address"]
         internal_address = kw["internal_address"]
 
         # import predefined modules
-        modules = actor_pool_config.get_pool_config(process_index)["modules"] or []
+        modules = cur_pool_config["modules"] or []
         for mod in modules:
             __import__(mod, globals(), locals(), [])
         # make sure all lazy imports loaded
         TypeDispatcher.reload_all_lazy_handlers()
 
-        # set default router
-        # actor context would be able to use exact client
-        cls._set_global_router(kw["router"])
-
         def handle_channel(channel):
             return pool.on_new_channel(channel)
 
         # create servers
+        external_address_set = set(external_addresses)
         create_server_tasks = []
+        is_external_server = []
         for addr in set(
             external_addresses + [internal_address, gen_local_address(process_index)]
         ):
@@ -676,8 +673,31 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
                 server_type.create(dict(address=addr, handle_channel=handle_channel))
             )
             create_server_tasks.append(task)
+            is_external_server.append(addr in external_address_set)
+
         await asyncio.gather(*create_server_tasks)
-        kw["servers"] = [f.result() for f in create_server_tasks]
+        kw["servers"] = servers = [f.result() for f in create_server_tasks]
+        new_external_addresses = [
+            server.address
+            for server, is_ext in zip(servers, is_external_server)
+            if is_ext
+        ]
+
+        if set(external_addresses) != set(new_external_addresses):
+            external_addresses = new_external_addresses
+            actor_pool_config.reset_pool_external_address(
+                process_index, external_addresses
+            )
+            kw["external_address"] = external_addresses[0]
+            kw["router"] = Router(
+                external_addresses,
+                gen_local_address(process_index),
+                actor_pool_config.external_to_internal_address_map,
+            )
+
+        # set default router
+        # actor context would be able to use exact client
+        cls._set_global_router(kw["router"])
 
         # create pool
         pool = cls(**kw)
@@ -758,6 +778,14 @@ class SubActorPoolBase(ActorPoolBase):
             # sync back to main actor pool
             await self.notify_main_pool_to_destroy(message)
         return result
+
+    @implements(AbstractActorPool.handle_control_command)
+    async def handle_control_command(
+        self, message: ControlMessage
+    ) -> ResultMessageType:
+        if message.control_message_type == ControlMessageType.sync_config:
+            self._main_address = message.address
+        return await super().handle_control_command(message)
 
     @staticmethod
     def _parse_config(config: Dict, kw: Dict) -> Dict:
@@ -1009,12 +1037,13 @@ class MainActorPoolBase(ActorPoolBase):
         ) as processor:
             if message.address == self.external_address:
                 if message.control_message_type == ControlMessageType.sync_config:
+                    await super().handle_control_command(message)
                     # sync config, need to notify all sub pools
                     tasks = []
                     for addr in self.sub_processes:
                         control_message = ControlMessage(
                             new_message_id(),
-                            addr,
+                            message.address,
                             message.control_message_type,
                             message.content,
                             protocol=message.protocol,
@@ -1086,8 +1115,10 @@ class MainActorPoolBase(ActorPoolBase):
         if "process_index" not in config:
             config["process_index"] = actor_pool_config.get_process_indexes()[0]
         curr_process_index = config.get("process_index")
+        old_config_addresses = set(actor_pool_config.get_external_addresses())
 
         tasks = []
+        subpool_process_idxes = []
         # create sub actor pools
         n_sub_pool = actor_pool_config.n_pool - 1
         if n_sub_pool > 0:
@@ -1101,8 +1132,15 @@ class MainActorPoolBase(ActorPoolBase):
                 await asyncio.sleep(0)
                 # await create_pool_task
                 tasks.append(create_pool_task)
+                subpool_process_idxes.append(process_index)
 
-        processes = await cls.wait_sub_pools_ready(tasks)
+        processes, ext_addresses = await cls.wait_sub_pools_ready(tasks)
+        if ext_addresses:
+            for process_index, ext_address in zip(subpool_process_idxes, ext_addresses):
+                actor_pool_config.reset_pool_external_address(
+                    process_index, ext_address
+                )
+
         # create main actor pool
         pool: MainActorPoolType = await super().create(config)
         addresses = actor_pool_config.get_external_addresses()[1:]
@@ -1112,6 +1150,17 @@ class MainActorPoolBase(ActorPoolBase):
         ), f"addresses {addresses}, processes {processes}"
         for addr, proc in zip(addresses, processes):
             pool.attach_sub_process(addr, proc)
+
+        new_config_addresses = set(actor_pool_config.get_external_addresses())
+        if old_config_addresses != new_config_addresses:
+            control_message = ControlMessage(
+                message_id=new_message_id(),
+                address=pool.external_address,
+                control_message_type=ControlMessageType.sync_config,
+                content=actor_pool_config,
+            )
+            await pool.handle_control_command(control_message)
+
         return pool
 
     async def start_monitor(self):

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -1048,7 +1048,6 @@ class MainActorPoolBase(ActorPoolBase):
         ) as processor:
             if message.address == self.external_address:
                 if message.control_message_type == ControlMessageType.sync_config:
-                    await super().handle_control_command(message)
                     # sync config, need to notify all sub pools
                     tasks = []
                     for addr in self.sub_processes:

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -290,14 +290,12 @@ class AbstractActorPool(ABC):
         global_router = Router.get_instance()
         global_router.remove_router(self._router)
         # update router
-        self._router.set_mapping(
-            actor_pool_config.external_to_internal_address_map
-        )
+        self._router.set_mapping(actor_pool_config.external_to_internal_address_map)
         # update global router
         global_router.add_router(self._router)
 
     async def handle_control_command(
-            self, message: ControlMessage
+        self, message: ControlMessage
     ) -> ResultMessageType:
         """
         Handle control command.
@@ -650,13 +648,6 @@ class ActorPoolBase(AbstractActorPool, metaclass=ABCMeta):
         if kw["internal_address"] == kw["external_address"]:
             # internal address may be the same as external address in Windows
             kw["internal_address"] = external_addresses[0]
-
-        logger.warning(
-            "TMP: EXTERNAL address updated from %s to %s",
-            kw["external_address"],
-            external_addresses[0],
-        )
-
         kw["external_address"] = external_addresses[0]
         kw["router"] = Router(
             external_addresses,

--- a/mars/oscar/backends/ray/pool.py
+++ b/mars/oscar/backends/ray/pool.py
@@ -149,7 +149,7 @@ class RayMainActorPool(MainActorPoolBase):
 
     @classmethod
     async def wait_sub_pools_ready(cls, create_pool_tasks: List[asyncio.Task]):
-        return [await t for t in create_pool_tasks]
+        return [await t for t in create_pool_tasks], None
 
     async def recover_sub_pool(self, address: str):
         process = self.sub_processes[address]

--- a/mars/oscar/backends/ray/tests/test_ray_actor_context.py
+++ b/mars/oscar/backends/ray/tests/test_ray_actor_context.py
@@ -16,7 +16,6 @@ import inspect
 import time
 
 import pytest
-import pytest_asyncio
 
 from .....utils import lazy_import
 from .....tests.core import require_ray
@@ -30,7 +29,7 @@ from ..utils import process_placement_to_address
 ray = lazy_import("ray")
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool_context():
     pg_name, n_process = f"ray_cluster_{time.time_ns()}", 2
     from .....serialization.ray import (

--- a/mars/oscar/backends/ray/tests/test_ray_actor_driver.py
+++ b/mars/oscar/backends/ray/tests/test_ray_actor_driver.py
@@ -16,7 +16,6 @@ import collections
 import os
 
 import pytest
-import pytest_asyncio
 
 from ..... import oscar as mo
 from .....tests.core import require_ray
@@ -53,7 +52,7 @@ class DummyActor(mo.Actor):
         return self._index
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def mars_cluster():
     mo.setup_cluster(address_to_resources=TEST_ADDRESS_TO_RESOURCES)
     main_pool_handles = []  # Hold actor_handle to avoid actor being freed.

--- a/mars/oscar/backends/router.py
+++ b/mars/oscar/backends/router.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
-import logging
 import threading
 from typing import Dict, List, Tuple, Type, Any, Optional
 
@@ -115,15 +113,7 @@ class Router:
         local_address = (
             self._curr_external_addresses[0] if self._curr_external_addresses else None
         )
-        logging.warning(f"TMP: GET ADDR {address} FOR EXT_ADDR {external_address}")
-        try:
-            client = await asyncio.wait_for(
-                client_type.connect(address, local_address=local_address, **kw),
-                timeout=60
-            )
-        except asyncio.TimeoutError:
-            logging.exception("TMP: CONNECT TIMED OUT FOR ADDRESS %s", address)
-            raise
+        client = await client_type.connect(address, local_address=local_address, **kw)
         if cached:
             self._cache[external_address, from_who] = client
         return client

--- a/mars/oscar/backends/router.py
+++ b/mars/oscar/backends/router.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import logging
 import threading
 from typing import Dict, List, Tuple, Type, Any, Optional
 
@@ -113,7 +115,15 @@ class Router:
         local_address = (
             self._curr_external_addresses[0] if self._curr_external_addresses else None
         )
-        client = await client_type.connect(address, local_address=local_address, **kw)
+        logging.warning(f"TMP: GET ADDR {address} FOR EXT_ADDR {external_address}")
+        try:
+            client = await asyncio.wait_for(
+                client_type.connect(address, local_address=local_address, **kw),
+                timeout=60
+            )
+        except asyncio.TimeoutError:
+            logging.exception("TMP: CONNECT TIMED OUT FOR ADDRESS %s", address)
+            raise
         if cached:
             self._cache[external_address, from_who] = client
         return client

--- a/mars/oscar/backends/router.py
+++ b/mars/oscar/backends/router.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import logging
 import threading
 from typing import Dict, List, Tuple, Type, Any, Optional
 
@@ -113,7 +113,11 @@ class Router:
         local_address = (
             self._curr_external_addresses[0] if self._curr_external_addresses else None
         )
-        client = await client_type.connect(address, local_address=local_address, **kw)
+        try:
+            client = await client_type.connect(address, local_address=local_address, **kw)
+        except ConnectionRefusedError:
+            logging.exception(f"TMP: CONNECT REFUSED: {address}, EXT: {external_address} FROM_WHO: {from_who} LOCAL_ADDR: {local_address}")
+            raise
         if cached:
             self._cache[external_address, from_who] = client
         return client

--- a/mars/oscar/backends/router.py
+++ b/mars/oscar/backends/router.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
+
 import threading
 from typing import Dict, List, Tuple, Type, Any, Optional
 
@@ -113,11 +113,7 @@ class Router:
         local_address = (
             self._curr_external_addresses[0] if self._curr_external_addresses else None
         )
-        try:
-            client = await client_type.connect(address, local_address=local_address, **kw)
-        except ConnectionRefusedError:
-            logging.exception(f"TMP: CONNECT REFUSED: {address}, EXT: {external_address} FROM_WHO: {from_who} LOCAL_ADDR: {local_address}")
-            raise
+        client = await client_type.connect(address, local_address=local_address, **kw)
         if cached:
             self._cache[external_address, from_who] = client
         return client

--- a/mars/oscar/backends/test/pool.py
+++ b/mars/oscar/backends/test/pool.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-import logging
 import multiprocessing
 from typing import List, Dict
 
@@ -21,8 +20,6 @@ from ..config import ActorPoolConfig
 from ..communication import gen_local_address, get_server_type, DummyServer
 from ..mars.pool import MainActorPool, SubActorPool, SubpoolStatus
 from ..pool import ActorPoolType
-
-logger = logging.getLogger(__name__)
 
 
 class TestMainActorPool(MainActorPool):
@@ -48,7 +45,6 @@ class TestMainActorPool(MainActorPool):
         start_method: str = None,
     ):
         status_queue = multiprocessing.Queue()
-        logger.warning("TMP: START SUB POOL %s", process_index)
         return (
             asyncio.create_task(
                 cls._create_sub_pool(actor_pool_config, process_index, status_queue)
@@ -64,7 +60,6 @@ class TestMainActorPool(MainActorPool):
             pool_task, queue = await t
             tasks.append(pool_task)
             status = await asyncio.to_thread(queue.get)
-            logger.warning("TMP: ADDRESS %s ADDED", status.external_addresses)
             addresses.append(status.external_addresses)
         return tasks, addresses
 
@@ -82,13 +77,11 @@ class TestMainActorPool(MainActorPool):
         status_queue.put(
             SubpoolStatus(status=0, external_addresses=[pool.external_address])
         )
-        logger.warning(
-            "TMP: SUBPOOL %s STARTED WITH ADDR %s", process_index, pool.external_address
-        )
         actor_config.reset_pool_external_address(process_index, [pool.external_address])
         await pool.join()
 
     def _sync_pool_config(self, actor_pool_config: ActorPoolConfig):
+        # test pool does not create routers, thus can skip this step
         pass
 
     async def kill_sub_pool(
@@ -101,6 +94,10 @@ class TestMainActorPool(MainActorPool):
 
 
 class TestSubActorPool(SubActorPool):
+    def _sync_pool_config(self, actor_pool_config: ActorPoolConfig):
+        # test pool does not create routers, thus can skip this step
+        pass
+
     @classmethod
     async def create(cls, config: Dict) -> ActorPoolType:
         kw = dict()
@@ -152,6 +149,3 @@ class TestSubActorPool(SubActorPool):
             s for s in self._servers[:-1] if not isinstance(s, DummyServer)
         ]
         await super().stop()
-
-    def _sync_pool_config(self, actor_pool_config: ActorPoolConfig):
-        pass

--- a/mars/oscar/backends/test/pool.py
+++ b/mars/oscar/backends/test/pool.py
@@ -131,10 +131,6 @@ class TestSubActorPool(SubActorPool):
             )
             cls._update_kw_addresses(actor_pool_config, process_index, kw)
 
-        # set default router
-        # actor context would be able to use exact client
-        cls._set_global_router(kw["router"])
-
         # create pool
         pool = cls(**kw)
         return pool

--- a/mars/oscar/backends/test/pool.py
+++ b/mars/oscar/backends/test/pool.py
@@ -20,6 +20,7 @@ from ..config import ActorPoolConfig
 from ..communication import gen_local_address, get_server_type, DummyServer
 from ..mars.pool import MainActorPool, SubActorPool, SubpoolStatus
 from ..pool import ActorPoolType
+from ..router import Router
 
 
 class TestMainActorPool(MainActorPool):
@@ -45,13 +46,23 @@ class TestMainActorPool(MainActorPool):
         start_method: str = None,
     ):
         status_queue = multiprocessing.Queue()
-        return asyncio.create_task(
-            cls._create_sub_pool(actor_pool_config, process_index, status_queue)
+        return (
+            asyncio.create_task(
+                cls._create_sub_pool(actor_pool_config, process_index, status_queue)
+            ),
+            status_queue,
         )
 
     @classmethod
     async def wait_sub_pools_ready(cls, create_pool_tasks: List[asyncio.Task]):
-        return [await t for t in create_pool_tasks]
+        addresses = []
+        tasks = []
+        for t in create_pool_tasks:
+            pool_task, queue = await t
+            tasks.append(pool_task)
+            status = await asyncio.to_thread(queue.get)
+            addresses.append(status.external_addresses)
+        return tasks, addresses
 
     @classmethod
     async def _create_sub_pool(
@@ -64,7 +75,10 @@ class TestMainActorPool(MainActorPool):
             {"actor_pool_config": actor_config, "process_index": process_index}
         )
         await pool.start()
-        status_queue.put(SubpoolStatus(0))
+        status_queue.put(
+            SubpoolStatus(status=0, external_addresses=[pool.external_address])
+        )
+        actor_config.reset_pool_external_address(process_index, [pool.external_address])
         await pool.join()
 
     async def kill_sub_pool(
@@ -82,7 +96,7 @@ class TestSubActorPool(SubActorPool):
         kw = dict()
         cls._parse_config(config, kw)
         process_index: int = kw["process_index"]
-        actor_pool_config = kw["config"]
+        actor_pool_config = kw["config"]  # type: ActorPoolConfig
         external_addresses = actor_pool_config.get_pool_config(process_index)[
             "external_address"
         ]
@@ -91,15 +105,37 @@ class TestSubActorPool(SubActorPool):
             return pool.on_new_channel(channel)
 
         # create servers
+        external_address_set = set(external_addresses)
         create_server_tasks = []
+        is_external_server = []
         for addr in set(external_addresses + [gen_local_address(process_index)]):
             server_type = get_server_type(addr)
             task = asyncio.create_task(
                 server_type.create(dict(address=addr, handle_channel=handle_channel))
             )
             create_server_tasks.append(task)
+            is_external_server.append(addr in external_address_set)
+
         await asyncio.gather(*create_server_tasks)
-        kw["servers"] = [f.result() for f in create_server_tasks]
+        kw["servers"] = servers = [f.result() for f in create_server_tasks]
+
+        new_external_addresses = [
+            server.address
+            for server, is_ext in zip(servers, is_external_server)
+            if is_ext
+        ]
+
+        if set(external_addresses) != set(new_external_addresses):
+            external_addresses = new_external_addresses
+            actor_pool_config.reset_pool_external_address(
+                process_index, external_addresses
+            )
+            kw["external_address"] = external_addresses[0]
+            kw["router"] = Router(
+                external_addresses,
+                gen_local_address(process_index),
+                actor_pool_config.external_to_internal_address_map,
+            )
 
         # create pool
         pool = cls(**kw)

--- a/mars/oscar/backends/test/pool.py
+++ b/mars/oscar/backends/test/pool.py
@@ -20,7 +20,6 @@ from ..config import ActorPoolConfig
 from ..communication import gen_local_address, get_server_type, DummyServer
 from ..mars.pool import MainActorPool, SubActorPool, SubpoolStatus
 from ..pool import ActorPoolType
-from ..router import Router
 
 
 class TestMainActorPool(MainActorPool):
@@ -130,12 +129,11 @@ class TestSubActorPool(SubActorPool):
             actor_pool_config.reset_pool_external_address(
                 process_index, external_addresses
             )
-            kw["external_address"] = external_addresses[0]
-            kw["router"] = Router(
-                external_addresses,
-                gen_local_address(process_index),
-                actor_pool_config.external_to_internal_address_map,
-            )
+            cls._update_kw_addresses(actor_pool_config, process_index, kw)
+
+        # set default router
+        # actor context would be able to use exact client
+        cls._set_global_router(kw["router"])
 
         # create pool
         pool = cls(**kw)

--- a/mars/oscar/backends/test/tests/test_actor_context.py
+++ b/mars/oscar/backends/test/tests/test_actor_context.py
@@ -18,6 +18,7 @@ import sys
 import pytest
 
 from ..... import oscar as mo
+from ...router import Router
 
 
 class DummyActor(mo.Actor):
@@ -46,8 +47,11 @@ async def actor_pool_context():
         "test://127.0.0.1", n_process=2, subprocess_start_method=start_method
     )
     await pool.start()
-    yield pool
-    await pool.stop()
+    try:
+        yield pool
+    finally:
+        await pool.stop()
+        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/cluster/tests/test_api.py
+++ b/mars/services/cluster/tests/test_api.py
@@ -17,6 +17,7 @@ import asyncio
 import pytest
 
 from .... import oscar as mo
+from ....oscar.backends.router import Router
 from ....utils import get_next_port
 from ... import NodeRole
 from ...web.supervisor import WebSupervisorService
@@ -29,8 +30,11 @@ from ..core import NodeStatus
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
     await pool.start()
-    yield pool
-    await pool.stop()
+    try:
+        yield pool
+    finally:
+        await pool.stop()
+        Router.set_instance(None)
 
 
 class TestActor(mo.Actor):

--- a/mars/services/cluster/tests/test_api.py
+++ b/mars/services/cluster/tests/test_api.py
@@ -15,7 +15,6 @@
 import asyncio
 
 import pytest
-import pytest_asyncio
 
 from .... import oscar as mo
 from ....utils import get_next_port
@@ -26,7 +25,7 @@ from ..api.web import web_handlers
 from ..core import NodeStatus
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
     await pool.start()

--- a/mars/services/cluster/tests/test_locator.py
+++ b/mars/services/cluster/tests/test_locator.py
@@ -20,6 +20,7 @@ from typing import List
 import pytest
 
 from .... import oscar as mo
+from ....oscar.backends.router import Router
 from ....utils import Timer
 from ....tests.core import flaky
 from ..core import NodeRole, NodeStatus
@@ -63,8 +64,11 @@ async def actor_pool():
         address=pool.external_address,
     )
 
-    yield pool
-    await pool.stop()
+    try:
+        yield pool
+    finally:
+        await pool.stop()
+        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/cluster/tests/test_locator.py
+++ b/mars/services/cluster/tests/test_locator.py
@@ -18,7 +18,6 @@ import tempfile
 from typing import List
 
 import pytest
-import pytest_asyncio
 
 from .... import oscar as mo
 from ....utils import Timer
@@ -53,7 +52,7 @@ class MockNodeInfoCollectorActor(mo.Actor):
             self._node_infos[node] = NodeStatus.STARTING
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
     await pool.start()

--- a/mars/services/cluster/tests/test_procinfo.py
+++ b/mars/services/cluster/tests/test_procinfo.py
@@ -15,6 +15,7 @@
 import pytest
 
 from .... import oscar as mo
+from ....oscar.backends.router import Router
 from ..procinfo import ProcessInfoManagerActor
 
 
@@ -24,8 +25,11 @@ async def actor_pool():
         "127.0.0.1", n_process=2, labels=["main", "numa-0", "gpu-0"]
     )
     await pool.start()
-    yield pool
-    await pool.stop()
+    try:
+        yield pool
+    finally:
+        await pool.stop()
+        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/cluster/tests/test_procinfo.py
+++ b/mars/services/cluster/tests/test_procinfo.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 import pytest
-import pytest_asyncio
 
 from .... import oscar as mo
 from ..procinfo import ProcessInfoManagerActor
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool(
         "127.0.0.1", n_process=2, labels=["main", "numa-0", "gpu-0"]

--- a/mars/services/cluster/tests/test_service.py
+++ b/mars/services/cluster/tests/test_service.py
@@ -16,7 +16,6 @@ import asyncio
 import os
 
 import pytest
-import pytest_asyncio
 
 from .... import oscar as mo
 from ....storage import StorageLevel
@@ -24,7 +23,7 @@ from ... import start_services, stop_services, NodeRole
 from .. import ClusterAPI, WorkerSlotInfo, QuotaInfo, StorageInfo, DiskInfo
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pools():
     async def start_pool():
         pool = await mo.create_actor_pool("127.0.0.1", n_process=0)

--- a/mars/services/cluster/tests/test_service.py
+++ b/mars/services/cluster/tests/test_service.py
@@ -18,6 +18,7 @@ import os
 import pytest
 
 from .... import oscar as mo
+from ....oscar.backends.router import Router
 from ....storage import StorageLevel
 from ... import start_services, stop_services, NodeRole
 from .. import ClusterAPI, WorkerSlotInfo, QuotaInfo, StorageInfo, DiskInfo
@@ -31,8 +32,11 @@ async def actor_pools():
         return pool
 
     sv_pool, worker_pool = await asyncio.gather(start_pool(), start_pool())
-    yield sv_pool, worker_pool
-    await asyncio.gather(sv_pool.stop(), worker_pool.stop())
+    try:
+        yield sv_pool, worker_pool
+    finally:
+        await asyncio.gather(sv_pool.stop(), worker_pool.stop())
+        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/cluster/tests/test_uploader.py
+++ b/mars/services/cluster/tests/test_uploader.py
@@ -15,7 +15,6 @@
 import asyncio
 
 import pytest
-import pytest_asyncio
 
 from .... import oscar as mo
 from ... import NodeRole
@@ -24,7 +23,7 @@ from ..supervisor.node_info import NodeInfoCollectorActor
 from ..uploader import NodeInfoUploaderActor
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
     await pool.start()

--- a/mars/services/cluster/tests/test_uploader.py
+++ b/mars/services/cluster/tests/test_uploader.py
@@ -17,6 +17,7 @@ import asyncio
 import pytest
 
 from .... import oscar as mo
+from ....oscar.backends.router import Router
 from ... import NodeRole
 from ..supervisor.locator import SupervisorPeerLocatorActor
 from ..supervisor.node_info import NodeInfoCollectorActor
@@ -27,8 +28,11 @@ from ..uploader import NodeInfoUploaderActor
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
     await pool.start()
-    yield pool
-    await pool.stop()
+    try:
+        yield pool
+    finally:
+        await pool.stop()
+        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/cluster/uploader.py
+++ b/mars/services/cluster/uploader.py
@@ -98,6 +98,8 @@ class NodeInfoUploaderActor(mo.Actor):
                 break
 
     async def mark_node_ready(self):
+        self._upload_enabled = True
+
         while True:
             try:
                 # upload info in time to reduce latency
@@ -106,7 +108,6 @@ class NodeInfoUploaderActor(mo.Actor):
             except (mo.ActorNotExist, ConnectionError):  # pragma: no cover
                 await asyncio.sleep(1)
 
-        self._upload_enabled = True
         self._node_ready_event.set()
 
     def is_node_ready(self):

--- a/mars/services/cluster/uploader.py
+++ b/mars/services/cluster/uploader.py
@@ -98,9 +98,15 @@ class NodeInfoUploaderActor(mo.Actor):
                 break
 
     async def mark_node_ready(self):
+        while True:
+            try:
+                # upload info in time to reduce latency
+                await self.upload_node_info(status=NodeStatus.READY)
+                break
+            except (mo.ActorNotExist, ConnectionError):  # pragma: no cover
+                await asyncio.sleep(1)
+
         self._upload_enabled = True
-        # upload info in time to reduce latency
-        await self.upload_node_info(status=NodeStatus.READY)
         self._node_ready_event.set()
 
     def is_node_ready(self):

--- a/mars/services/core.py
+++ b/mars/services/core.py
@@ -17,7 +17,6 @@ import asyncio
 import enum
 import importlib
 import inspect
-import logging
 import warnings
 from typing import Dict, Iterable, List, Union
 
@@ -177,7 +176,6 @@ async def start_services(
     if mark_ready and "cluster" in service_names:
         from .cluster import ClusterAPI
 
-        logging.warning(f"TMP: MARK_NODE_READY FOR {address}")
         cluster_api = await ClusterAPI.create(address)
         await cluster_api.mark_node_ready()
 

--- a/mars/services/core.py
+++ b/mars/services/core.py
@@ -17,6 +17,7 @@ import asyncio
 import enum
 import importlib
 import inspect
+import logging
 import warnings
 from typing import Dict, Iterable, List, Union
 
@@ -176,6 +177,7 @@ async def start_services(
     if mark_ready and "cluster" in service_names:
         from .cluster import ClusterAPI
 
+        logging.warning(f"TMP: MARK_NODE_READY FOR {address}")
         cluster_api = await ClusterAPI.create(address)
         await cluster_api.mark_node_ready()
 

--- a/mars/services/core.py
+++ b/mars/services/core.py
@@ -17,7 +17,6 @@ import asyncio
 import enum
 import importlib
 import inspect
-import logging
 import warnings
 from typing import Dict, Iterable, List, Union
 
@@ -170,21 +169,14 @@ async def start_services(
 
         web_config["web_handlers"] = web_handlers
 
-    async def start_instance(inst):
-        logging.warning(f"TMP: before starting {inst!r}")
-        await inst.start()
-        logging.warning(f"TMP: after starting {inst!r}")
-
     for entries in svc_entries_list:
         instances = [svc_entry.get_instance(address, config) for svc_entry in entries]
-        await asyncio.gather(*[start_instance(inst) for inst in instances])
+        await asyncio.gather(*[inst.start() for inst in instances])
 
     if mark_ready and "cluster" in service_names:
         from .cluster import ClusterAPI
 
-        logging.warning(f"TMP: await ClusterAPI.create({address})")
         cluster_api = await ClusterAPI.create(address)
-        logging.warning("await cluster_api.mark_node_ready()")
         await cluster_api.mark_node_ready()
 
 

--- a/mars/services/core.py
+++ b/mars/services/core.py
@@ -17,6 +17,7 @@ import asyncio
 import enum
 import importlib
 import inspect
+import logging
 import warnings
 from typing import Dict, Iterable, List, Union
 
@@ -169,14 +170,21 @@ async def start_services(
 
         web_config["web_handlers"] = web_handlers
 
+    async def start_instance(inst):
+        logging.warning(f"TMP: before starting {inst!r}")
+        await inst.start()
+        logging.warning(f"TMP: after starting {inst!r}")
+
     for entries in svc_entries_list:
         instances = [svc_entry.get_instance(address, config) for svc_entry in entries]
-        await asyncio.gather(*[inst.start() for inst in instances])
+        await asyncio.gather(*[start_instance(inst) for inst in instances])
 
     if mark_ready and "cluster" in service_names:
         from .cluster import ClusterAPI
 
+        logging.warning(f"TMP: await ClusterAPI.create({address})")
         cluster_api = await ClusterAPI.create(address)
+        logging.warning("await cluster_api.mark_node_ready()")
         await cluster_api.mark_node_ready()
 
 

--- a/mars/services/lifecycle/api/oscar.py
+++ b/mars/services/lifecycle/api/oscar.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union
+from typing import Dict, List
 
 from .... import oscar as mo
 from ....lib.aio import alru_cache
@@ -24,7 +24,7 @@ class LifecycleAPI(AbstractLifecycleAPI):
     def __init__(
         self,
         session_id: str,
-        lifecycle_tracker_ref: Union[LifecycleTrackerActor, mo.ActorRef],
+        lifecycle_tracker_ref: mo.ActorRefType[LifecycleTrackerActor],
     ):
         self._session_id = session_id
         self._lifecycle_tracker_ref = lifecycle_tracker_ref

--- a/mars/services/meta/api/oscar.py
+++ b/mars/services/meta/api/oscar.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Dict, List, Any, Union
+from typing import Dict, List, Any
 
 from .... import oscar as mo
 from ....core import ChunkType
@@ -29,9 +29,7 @@ from .core import AbstractMetaAPI
 
 
 class BaseMetaAPI(AbstractMetaAPI):
-    def __init__(
-        self, session_id: str, meta_store: Union[AbstractMetaStore, mo.ActorRef]
-    ):
+    def __init__(self, session_id: str, meta_store: mo.ActorRefType[AbstractMetaStore]):
         # make sure all meta types registered
         from .. import metas
 

--- a/mars/services/mutable/api/oscar.py
+++ b/mars/services/mutable/api/oscar.py
@@ -30,7 +30,7 @@ class MutableAPI(AbstractMutableAPI):
     def __init__(
         self,
         address: str,
-        mutable_mananger: Union[MutableObjectManagerActor, mo.ActorRef],
+        mutable_mananger: mo.ActorRefType[MutableObjectManagerActor],
     ):
         self._address = address
         self._mutable_manager_ref = mutable_mananger
@@ -46,7 +46,7 @@ class MutableAPI(AbstractMutableAPI):
     @alru_cache(cache_exceptions=False)
     async def _get_mutable_tensor_ref(
         self, name: str
-    ) -> Union[MutableTensorActor, mo.ActorRef]:
+    ) -> mo.ActorRefType[MutableTensorActor]:
         return await self._mutable_manager_ref.get_mutable_tensor(name)
 
     async def create_mutable_tensor(

--- a/mars/services/mutable/supervisor/core.py
+++ b/mars/services/mutable/supervisor/core.py
@@ -115,7 +115,7 @@ class MutableTensorActor(mo.Actor):
         self._chunk_actors = []
         # chunk to actor: {chunk index -> actor uid}
         self._chunk_to_actor: Dict[
-            Tuple, Union[MutableTensorChunkActor, mo.ActorRef]
+            Tuple, mo.ActorRefType[MutableTensorChunkActor]
         ] = dict()
 
     async def __post_create__(self):

--- a/mars/services/mutable/tests/test_mutable.py
+++ b/mars/services/mutable/tests/test_mutable.py
@@ -17,7 +17,6 @@ import uuid
 import sys
 
 import pytest
-import pytest_asyncio
 import numpy as np
 
 from ....deploy.oscar.local import new_cluster
@@ -29,7 +28,7 @@ from ..utils import normalize_timestamp
 _is_windows = sys.platform.lower().startswith("win")
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def create_cluster():
     client = await new_cluster(n_worker=2, n_cpu=2, web=True)
     async with client:

--- a/mars/services/mutable/tests/test_mutable.py
+++ b/mars/services/mutable/tests/test_mutable.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from ....deploy.oscar.local import new_cluster
 from ....deploy.oscar.session import AsyncSession, SyncSession
+from ....oscar.backends.router import Router
 from ..core import MutableTensor
 from ..utils import normalize_timestamp
 
@@ -31,8 +32,11 @@ _is_windows = sys.platform.lower().startswith("win")
 @pytest.fixture
 async def create_cluster():
     client = await new_cluster(n_worker=2, n_cpu=2, web=True)
-    async with client:
-        yield client
+    try:
+        async with client:
+            yield client
+    finally:
+        Router.set_instance(None)
 
 
 @pytest.mark.skipif(_is_windows, reason="FIXME")

--- a/mars/services/scheduling/supervisor/tests/test_assigner.py
+++ b/mars/services/scheduling/supervisor/tests/test_assigner.py
@@ -15,7 +15,6 @@
 import numpy as np
 import asyncio
 import pytest
-import pytest_asyncio
 
 from ..... import oscar as mo
 from .....core import ChunkGraph
@@ -101,7 +100,7 @@ class FakeClusterAPI(ClusterAPI):
         return api
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool(request):
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
     with_gpu = request.param

--- a/mars/services/scheduling/supervisor/tests/test_assigner.py
+++ b/mars/services/scheduling/supervisor/tests/test_assigner.py
@@ -18,6 +18,7 @@ import pytest
 
 from ..... import oscar as mo
 from .....core import ChunkGraph
+from .....oscar.backends.router import Router
 from .....tensor.fetch import TensorFetch
 from .....tensor.arithmetic import TensorTreeAdd
 from ....cluster import ClusterAPI
@@ -119,9 +120,11 @@ async def actor_pool(request):
             address=pool.external_address,
         )
 
-        yield pool, session_id, assigner_ref, cluster_api, meta_api
-
-        await mo.destroy_actor(assigner_ref)
+        try:
+            yield pool, session_id, assigner_ref, cluster_api, meta_api
+        finally:
+            await mo.destroy_actor(assigner_ref)
+            Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/supervisor/tests/test_globalresource.py
+++ b/mars/services/scheduling/supervisor/tests/test_globalresource.py
@@ -17,6 +17,7 @@ import asyncio
 import pytest
 
 from ..... import oscar as mo
+from .....oscar.backends.router import Router
 from .....resource import Resource
 from ....cluster import ClusterAPI, MockClusterAPI
 from ....session import MockSessionAPI
@@ -43,6 +44,7 @@ async def actor_pool():
         finally:
             await mo.destroy_actor(global_resource_ref)
             await MockClusterAPI.cleanup(pool.external_address)
+            Router.set_instance(None)
 
 
 @pytest.mark.asyncio
@@ -54,7 +56,6 @@ async def test_global_resource(actor_pool):
     band = (pool.external_address, "numa-0")
     band_resource = bands[band]
 
-    print(await global_resource_ref.get_idle_bands(0))
     assert band in await global_resource_ref.get_idle_bands(0)
     assert ["subtask0"] == await global_resource_ref.apply_subtask_resources(
         band, session_id, ["subtask0"], [Resource(num_cpus=1)]

--- a/mars/services/scheduling/supervisor/tests/test_globalresource.py
+++ b/mars/services/scheduling/supervisor/tests/test_globalresource.py
@@ -15,7 +15,6 @@
 import asyncio
 
 import pytest
-import pytest_asyncio
 
 from ..... import oscar as mo
 from .....resource import Resource
@@ -24,7 +23,7 @@ from ....session import MockSessionAPI
 from ...supervisor import GlobalResourceManagerActor
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
 

--- a/mars/services/scheduling/supervisor/tests/test_manager.py
+++ b/mars/services/scheduling/supervisor/tests/test_manager.py
@@ -19,6 +19,7 @@ from typing import List, Tuple, Set
 import pytest
 
 from ..... import oscar as mo
+from .....oscar.backends.router import Router
 from .....typing import BandType
 from ....cluster import MockClusterAPI
 from ....subtask import Subtask, SubtaskResult, SubtaskStatus
@@ -132,10 +133,12 @@ async def actor_pool():
             address=pool.external_address,
         )
 
-        yield pool, session_id, execution_ref, submitter_ref, queue_ref, task_manager_ref
-
-        await mo.destroy_actor(slots_ref)
-        await MockClusterAPI.cleanup(pool.external_address)
+        try:
+            yield pool, session_id, execution_ref, submitter_ref, queue_ref, task_manager_ref
+        finally:
+            await mo.destroy_actor(slots_ref)
+            await MockClusterAPI.cleanup(pool.external_address)
+            Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/supervisor/tests/test_manager.py
+++ b/mars/services/scheduling/supervisor/tests/test_manager.py
@@ -17,7 +17,6 @@ from collections import defaultdict
 from typing import List, Tuple, Set
 
 import pytest
-import pytest_asyncio
 
 from ..... import oscar as mo
 from .....typing import BandType
@@ -99,7 +98,7 @@ class MockSubtaskExecutionActor(mo.StatelessActor):
             pass
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
 

--- a/mars/services/scheduling/supervisor/tests/test_queue_balance.py
+++ b/mars/services/scheduling/supervisor/tests/test_queue_balance.py
@@ -14,7 +14,6 @@
 
 import asyncio
 import pytest
-import pytest_asyncio
 from collections import defaultdict
 from typing import Tuple, List
 from ..... import oscar as mo
@@ -148,7 +147,7 @@ class MockSubtaskManagerActor(mo.Actor):
         return self._submitted_subtask_ids
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
 

--- a/mars/services/scheduling/supervisor/tests/test_queue_balance.py
+++ b/mars/services/scheduling/supervisor/tests/test_queue_balance.py
@@ -17,6 +17,7 @@ import pytest
 from collections import defaultdict
 from typing import Tuple, List
 from ..... import oscar as mo
+from .....oscar.backends.router import Router
 from .....resource import Resource
 from ....cluster import ClusterAPI
 from ....cluster.core import NodeRole, NodeStatus
@@ -182,9 +183,11 @@ async def actor_pool():
             address=pool.external_address,
         )
 
-        yield pool, session_id, cluster_api, queueing_ref, slots_ref, manager_ref
-
-        await mo.destroy_actor(queueing_ref)
+        try:
+            yield pool, session_id, cluster_api, queueing_ref, slots_ref, manager_ref
+        finally:
+            await mo.destroy_actor(queueing_ref)
+            Router.set_instance(None)
 
 
 async def _queue_subtasks(num_subtasks, expect_bands, queueing_ref):

--- a/mars/services/scheduling/supervisor/tests/test_queueing.py
+++ b/mars/services/scheduling/supervisor/tests/test_queueing.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import pytest
-import pytest_asyncio
 from typing import Tuple, List
 
 from ..... import oscar as mo
@@ -71,7 +70,7 @@ class MockSubtaskManagerActor(mo.Actor):
         return self._subtask_ids, self._bands
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
 

--- a/mars/services/scheduling/supervisor/tests/test_queueing.py
+++ b/mars/services/scheduling/supervisor/tests/test_queueing.py
@@ -16,6 +16,7 @@ import pytest
 from typing import Tuple, List
 
 from ..... import oscar as mo
+from .....oscar.backends.router import Router
 from .....resource import Resource
 from ....cluster import MockClusterAPI
 from ....subtask import Subtask
@@ -108,6 +109,7 @@ async def actor_pool():
         finally:
             await mo.destroy_actor(queueing_ref)
             await MockClusterAPI.cleanup(pool.external_address)
+            Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/supervisor/tests/test_speculation.py
+++ b/mars/services/scheduling/supervisor/tests/test_speculation.py
@@ -16,7 +16,6 @@ import asyncio
 from typing import List, Tuple, Set
 
 import pytest
-import pytest_asyncio
 
 from ..... import oscar as mo
 from ....cluster import MockClusterAPI
@@ -55,7 +54,7 @@ class MockSubtaskQueueingActor(mo.Actor):
         return self._exceptions
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
 

--- a/mars/services/scheduling/supervisor/tests/test_speculation.py
+++ b/mars/services/scheduling/supervisor/tests/test_speculation.py
@@ -24,6 +24,7 @@ from ...errors import NoAvailableBand
 from ...supervisor import GlobalResourceManagerActor
 from ..manager import SubtaskScheduleInfo
 from ..speculation import SpeculativeScheduler
+from .....oscar.backends.router import Router
 
 
 class MockSubtaskQueueingActor(mo.Actor):
@@ -70,9 +71,12 @@ async def actor_pool():
             MockSubtaskQueueingActor,
             address=pool.external_address,
         )
-        yield pool, cluster_api, session_id, slots_ref, queue_ref
-        await mo.destroy_actor(queue_ref)
-        await MockClusterAPI.cleanup(pool.external_address)
+        try:
+            yield pool, cluster_api, session_id, slots_ref, queue_ref
+        finally:
+            await mo.destroy_actor(queue_ref)
+            await MockClusterAPI.cleanup(pool.external_address)
+            Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/tests/test_service.py
+++ b/mars/services/scheduling/tests/test_service.py
@@ -18,7 +18,6 @@ from collections import defaultdict
 
 import numpy as np
 import pytest
-import pytest_asyncio
 
 from ..api.web import WebSchedulingAPI
 from .... import oscar as mo
@@ -90,7 +89,7 @@ def _approx_resource(actual, expect):
     )
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pools():
     async def start_pool(is_worker: bool):
         if is_worker:

--- a/mars/services/scheduling/tests/test_service.py
+++ b/mars/services/scheduling/tests/test_service.py
@@ -24,6 +24,7 @@ from .... import oscar as mo
 from .... import remote as mr
 from .... import tensor as mt
 from ....core.graph import TileableGraph, TileableGraphBuilder, ChunkGraphBuilder
+from ....oscar.backends.router import Router
 from ....resource import Resource
 from ... import start_services, stop_services, NodeRole
 from ...session import SessionAPI
@@ -158,6 +159,7 @@ async def actor_pools():
         )
 
         await asyncio.gather(sv_pool.stop(), worker_pool.stop())
+        Router.set_instance(None)
 
 
 async def _get_subtask_summaries_by_web(sv_pool_address, session_id, task_id=None):

--- a/mars/services/scheduling/worker/execution.py
+++ b/mars/services/scheduling/worker/execution.py
@@ -20,7 +20,7 @@ import pprint
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from .... import oscar as mo
 from ....core import ExecutionError
@@ -171,13 +171,13 @@ class SubtaskExecutionActor(mo.StatelessActor):
     @alru_cache(cache_exceptions=False)
     async def _get_slot_manager_ref(
         self, band: str
-    ) -> Union[mo.ActorRef, BandSlotManagerActor]:
+    ) -> mo.ActorRefType[BandSlotManagerActor]:
         return await mo.actor_ref(
             BandSlotManagerActor.gen_uid(band), address=self.address
         )
 
     @alru_cache(cache_exceptions=False)
-    async def _get_band_quota_ref(self, band: str) -> Union[mo.ActorRef, QuotaActor]:
+    async def _get_band_quota_ref(self, band: str) -> mo.ActorRefType[QuotaActor]:
         return await mo.actor_ref(QuotaActor.gen_uid(band), address=self.address)
 
     async def _prepare_input_data(self, subtask: Subtask, band_name: str):

--- a/mars/services/scheduling/worker/tests/test_execution.py
+++ b/mars/services/scheduling/worker/tests/test_execution.py
@@ -23,7 +23,6 @@ from typing import Tuple
 import numpy as np
 import pandas as pd
 import pytest
-import pytest_asyncio
 
 from ..... import oscar as mo
 from ..... import remote as mr
@@ -146,7 +145,7 @@ class MockTaskManager(mo.Actor):
         return self._results
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool(request):
     n_slots, enable_kill = request.param
     pool = await mo.create_actor_pool(

--- a/mars/services/scheduling/worker/tests/test_execution.py
+++ b/mars/services/scheduling/worker/tests/test_execution.py
@@ -33,6 +33,7 @@ from .....core import (
     TileableGraphBuilder,
     OutputType,
 )
+from .....oscar.backends.router import Router
 from .....remote.core import RemoteFunction
 from .....resource import Resource
 from .....tensor.fetch import TensorFetch
@@ -223,6 +224,7 @@ async def actor_pool(request):
             await MockSubtaskAPI.cleanup(pool.external_address)
             await MockClusterAPI.cleanup(pool.external_address)
             await MockMutableAPI.cleanup(session_id, pool.external_address)
+            Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/worker/tests/test_quota.py
+++ b/mars/services/scheduling/worker/tests/test_quota.py
@@ -20,6 +20,7 @@ import time
 import pytest
 
 from ..... import oscar as mo
+from .....oscar.backends.router import Router
 from .....tests.core import mock
 from .....utils import get_next_port
 from ...worker import QuotaActor, MemQuotaActor, BandSlotManagerActor
@@ -44,8 +45,11 @@ async def actor_pool():
         subprocess_start_method=start_method,
     )
     await pool.start()
-    yield pool
-    await pool.stop()
+    try:
+        yield pool
+    finally:
+        await pool.stop()
+        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/worker/tests/test_quota.py
+++ b/mars/services/scheduling/worker/tests/test_quota.py
@@ -16,7 +16,6 @@ import asyncio
 import os
 import sys
 import time
-from typing import Union
 
 import pytest
 import pytest_asyncio
@@ -25,8 +24,6 @@ from ..... import oscar as mo
 from .....tests.core import mock
 from .....utils import get_next_port
 from ...worker import QuotaActor, MemQuotaActor, BandSlotManagerActor
-
-QuotaActorRef = Union[QuotaActor, mo.ActorRef]
 
 
 class MockBandSlotManagerActor(mo.Actor):
@@ -60,7 +57,7 @@ async def test_quota(actor_pool):
         300,
         uid=QuotaActor.gen_uid("cpu-0"),
         address=actor_pool.external_address,
-    )  # type: QuotaActorRef
+    )  # type: mo.ActorRefType[QuotaActor]
 
     # test quota options with non-existing keys
     await quota_ref.hold_quotas(["non_exist"])
@@ -119,7 +116,7 @@ async def test_batch_quota_allocation(actor_pool):
         300,
         uid=QuotaActor.gen_uid("cpu-0"),
         address=actor_pool.external_address,
-    )  # type: QuotaActorRef
+    )  # type: mo.ActorRefType[QuotaActor]
 
     end_time = []
 
@@ -161,7 +158,7 @@ async def test_mem_quota_allocation(actor_pool, enable_kill_slot):
         enable_kill_slot=enable_kill_slot,
         uid=MemQuotaActor.gen_uid("cpu-0"),
         address=actor_pool.external_address,
-    )  # type: Union[QuotaActorRef, mo.ActorRef]
+    )  # type: mo.ActorRefType[QuotaActor]
 
     with mock.patch("mars.resource.virtual_memory", new=lambda: mock_mem_stat):
         time_recs = [time.time()]

--- a/mars/services/scheduling/worker/tests/test_quota.py
+++ b/mars/services/scheduling/worker/tests/test_quota.py
@@ -18,7 +18,6 @@ import sys
 import time
 
 import pytest
-import pytest_asyncio
 
 from ..... import oscar as mo
 from .....tests.core import mock
@@ -34,7 +33,7 @@ class MockBandSlotManagerActor(mo.Actor):
         self._restart_record = True
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     start_method = (
         os.environ.get("POOL_START_METHOD", "fork") if sys.platform != "win32" else None

--- a/mars/services/scheduling/worker/tests/test_workerslot.py
+++ b/mars/services/scheduling/worker/tests/test_workerslot.py
@@ -16,7 +16,7 @@ import asyncio
 import os
 import sys
 import time
-from typing import Tuple, Union
+from typing import Tuple
 
 import psutil
 import pytest
@@ -83,7 +83,7 @@ async def actor_pool(request):
             await slot_manager_ref.destroy()
 
 
-ActorPoolType = Tuple[mo.MainActorPoolType, Union[BandSlotManagerActor, mo.ActorRef]]
+ActorPoolType = Tuple[mo.MainActorPoolType, mo.ActorRefType[BandSlotManagerActor]]
 
 
 class TaskActor(mo.Actor):

--- a/mars/services/scheduling/worker/tests/test_workerslot.py
+++ b/mars/services/scheduling/worker/tests/test_workerslot.py
@@ -20,7 +20,6 @@ from typing import Tuple
 
 import psutil
 import pytest
-import pytest_asyncio
 import pandas as pd
 
 from ..... import oscar as mo
@@ -48,7 +47,7 @@ class MockGlobalResourceManagerActor(mo.Actor):
         return self._result
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool(request):
     start_method = (
         os.environ.get("POOL_START_METHOD", "forkserver")

--- a/mars/services/scheduling/worker/tests/test_workerslot.py
+++ b/mars/services/scheduling/worker/tests/test_workerslot.py
@@ -24,6 +24,7 @@ import pandas as pd
 
 from ..... import oscar as mo
 from .....oscar import ServerClosed
+from .....oscar.backends.router import Router
 from .....oscar.errors import NoFreeSlot, SlotStateError
 from .....oscar.backends.allocate_strategy import IdleLabel
 from .....resource import Resource
@@ -80,6 +81,7 @@ async def actor_pool(request):
             yield pool, slot_manager_ref
         finally:
             await slot_manager_ref.destroy()
+            Router.set_instance(None)
 
 
 ActorPoolType = Tuple[mo.MainActorPoolType, mo.ActorRefType[BandSlotManagerActor]]

--- a/mars/services/session/api/oscar.py
+++ b/mars/services/session/api/oscar.py
@@ -25,7 +25,7 @@ from .core import AbstractSessionAPI
 
 class SessionAPI(AbstractSessionAPI):
     def __init__(
-        self, address: str, session_manager: Union[SessionManagerActor, mo.ActorRef]
+        self, address: str, session_manager: mo.ActorRefType[SessionManagerActor]
     ):
         self._address = address
         self._session_manager_ref = session_manager
@@ -89,9 +89,7 @@ class SessionAPI(AbstractSessionAPI):
         return await self._session_manager_ref.get_last_idle_time(session_id)
 
     @alru_cache(cache_exceptions=False)
-    async def _get_session_ref(
-        self, session_id: str
-    ) -> Union[SessionActor, mo.ActorRef]:
+    async def _get_session_ref(self, session_id: str) -> mo.ActorRefType[SessionActor]:
         return await self._session_manager_ref.get_session_ref(session_id)
 
     async def create_remote_object(
@@ -111,7 +109,7 @@ class SessionAPI(AbstractSessionAPI):
     @alru_cache(cache_exceptions=False)
     async def _get_custom_log_meta_ref(
         self, session_id: str
-    ) -> Union[CustomLogMetaActor, mo.ActorRef]:
+    ) -> mo.ActorRefType[CustomLogMetaActor]:
         session = await self._get_session_ref(session_id)
         return await mo.actor_ref(
             mo.ActorRef(session.address, CustomLogMetaActor.gen_uid(session_id))

--- a/mars/services/storage/api/oscar.py
+++ b/mars/services/storage/api/oscar.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import sys
-from typing import Any, List, Type, TypeVar, Union
+from typing import Any, List, Type, TypeVar
 
 from .... import oscar as mo
 from ....lib.aio import alru_cache
@@ -33,8 +33,8 @@ APIType = TypeVar("APIType", bound="StorageAPI")
 
 
 class StorageAPI(AbstractStorageAPI):
-    _storage_handler_ref: Union[StorageHandlerActor, mo.ActorRef]
-    _data_manager_ref: Union[DataManagerActor, mo.ActorRef]
+    _storage_handler_ref: mo.ActorRefType[StorageHandlerActor]
+    _data_manager_ref: mo.ActorRefType[DataManagerActor]
 
     def __init__(self, address: str, session_id: str, band_name: str):
         self._address = address

--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -20,7 +20,6 @@ from typing import Dict, List, Optional, Union, Tuple
 
 from ... import oscar as mo
 from ...lib.aio import AioFileObject
-from ...oscar import ActorRef
 from ...oscar.backends.allocate_strategy import IdleLabel, NoIdleSlot
 from ...resource import cuda_card_stats
 from ...storage import StorageLevel, get_storage_backend
@@ -57,7 +56,7 @@ class WrappedStorageFileObject(AioFileObject):
         size: int,
         session_id: str,
         data_key: str,
-        data_manager: Union[ActorRef, "DataManagerActor"],
+        data_manager: mo.ActorRefType["DataManagerActor"],
         storage_handler: StorageBackend,
     ):
         self._object_id = file.object_id
@@ -92,7 +91,7 @@ class WrappedStorageFileObject(AioFileObject):
 class StorageQuotaActor(mo.Actor):
     def __init__(
         self,
-        data_manager: Union[mo.ActorRef, "DataManagerActor"],
+        data_manager: mo.ActorRefType["DataManagerActor"],
         level: StorageLevel,
         total_size: Optional[Union[int, float]],
     ):
@@ -344,7 +343,7 @@ class StorageManagerActor(mo.StatelessActor):
     and create all the necessary actors for storage service.
     """
 
-    _data_manager: Union[mo.ActorRef, DataManagerActor]
+    _data_manager: mo.ActorRefType[DataManagerActor]
 
     def __init__(
         self, storage_configs: Dict, transfer_block_size: int = None, **kwargs

--- a/mars/services/storage/handler.py
+++ b/mars/services/storage/handler.py
@@ -48,9 +48,9 @@ class StorageHandlerActor(mo.Actor):
     def __init__(
         self,
         storage_init_params: Dict,
-        data_manager_ref: Union[DataManagerActor, mo.ActorRef],
+        data_manager_ref: mo.ActorRefType[DataManagerActor],
         spill_manager_refs,
-        quota_refs: Dict[StorageLevel, Union[StorageQuotaActor, mo.ActorRef]],
+        quota_refs: Dict[StorageLevel, mo.ActorRefType[StorageQuotaActor]],
         band_name: str = "numa-0",
     ):
         from .spill import SpillManagerActor
@@ -58,7 +58,7 @@ class StorageHandlerActor(mo.Actor):
         self._storage_init_params = storage_init_params
         self._data_manager_ref = data_manager_ref
         self._spill_manager_refs: Dict[
-            StorageLevel, Union[SpillManagerActor, mo.ActorRef]
+            StorageLevel, mo.ActorRefType[SpillManagerActor]
         ] = spill_manager_refs
         self._quota_refs = quota_refs
         self._band_name = band_name
@@ -413,7 +413,7 @@ class StorageHandlerActor(mo.Actor):
         remote_band: BandType,
         error: str,
     ):
-        remote_manager_ref: Union[mo.ActorRef, DataManagerActor] = await mo.actor_ref(
+        remote_manager_ref: mo.ActorRefType[DataManagerActor] = await mo.actor_ref(
             uid=DataManagerActor.default_uid(), address=remote_band[0]
         )
         get_data_infos = []
@@ -455,7 +455,7 @@ class StorageHandlerActor(mo.Actor):
         from .transfer import SenderManagerActor
 
         logger.debug("Begin to fetch %s from band %s", data_keys, remote_band)
-        sender_ref: Union[mo.ActorRef, SenderManagerActor] = await mo.actor_ref(
+        sender_ref: mo.ActorRefType[SenderManagerActor] = await mo.actor_ref(
             address=remote_band[0], uid=SenderManagerActor.gen_uid(remote_band[1])
         )
         await sender_ref.send_batch_data(

--- a/mars/services/storage/spill.py
+++ b/mars/services/storage/spill.py
@@ -16,7 +16,7 @@ import asyncio
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import List, Union, Tuple
+from typing import List, Tuple
 
 from ... import oscar as mo
 from ...storage import StorageLevel
@@ -165,8 +165,8 @@ async def spill(
     request_size: int,
     level: StorageLevel,
     band_name: str,
-    data_manager: Union[mo.ActorRef, DataManagerActor],
-    storage_handler: Union[mo.ActorRef, StorageHandlerActor],
+    data_manager: mo.ActorRefType[DataManagerActor],
+    storage_handler: mo.ActorRefType[StorageHandlerActor],
     block_size=None,
     multiplier=1.1,
 ):

--- a/mars/services/storage/tests/test_service.py
+++ b/mars/services/storage/tests/test_service.py
@@ -20,6 +20,7 @@ import pandas as pd
 import pytest
 
 from .... import oscar as mo
+from ....oscar.backends.router import Router
 from ....resource import Resource
 from ....serialization import AioDeserializer, AioSerializer
 from ....storage import StorageLevel
@@ -49,8 +50,11 @@ async def actor_pools():
         return pool
 
     worker_pool = await start_pool()
-    yield worker_pool
-    await worker_pool.stop()
+    try:
+        yield worker_pool
+    finally:
+        await worker_pool.stop()
+        Router.set_instance(None)
 
 
 @pytest.mark.asyncio
@@ -138,8 +142,11 @@ async def actor_pools_with_gpu():
         return pool
 
     worker_pool = await start_pool()
-    yield worker_pool
-    await worker_pool.stop()
+    try:
+        yield worker_pool
+    finally:
+        await worker_pool.stop()
+        Router.set_instance(None)
 
 
 @require_cupy

--- a/mars/services/storage/tests/test_service.py
+++ b/mars/services/storage/tests/test_service.py
@@ -18,7 +18,6 @@ import sys
 import numpy as np
 import pandas as pd
 import pytest
-import pytest_asyncio
 
 from .... import oscar as mo
 from ....resource import Resource
@@ -32,7 +31,7 @@ from .. import StorageAPI
 _is_windows = sys.platform.lower().startswith("win")
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pools():
     async def start_pool():
         start_method = (
@@ -121,7 +120,7 @@ async def test_storage_service(actor_pools):
     )
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pools_with_gpu():
     async def start_pool():
         start_method = (

--- a/mars/services/storage/tests/test_spill.py
+++ b/mars/services/storage/tests/test_spill.py
@@ -19,7 +19,6 @@ import tempfile
 
 import numpy as np
 import pytest
-import pytest_asyncio
 
 from .... import oscar as mo
 from ....storage import StorageLevel, PlasmaStorage
@@ -35,7 +34,7 @@ if sys.platform.lower().startswith("win"):
 MEMORY_SIZE = 100 * 1024
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     async def start_pool():
         start_method = (
@@ -72,7 +71,7 @@ def _build_storage_config():
     return storage_configs
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def create_actors(actor_pool):
     storage_configs = _build_storage_config()
     manager_ref = await mo.create_actor(
@@ -156,7 +155,7 @@ class DelayPutStorageHandler(StorageHandlerActor):
         return data_info
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def create_actors_with_delay(actor_pool):
     storage_configs = _build_storage_config()
     manager_ref = await mo.create_actor(

--- a/mars/services/storage/tests/test_spill.py
+++ b/mars/services/storage/tests/test_spill.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytest
 
 from .... import oscar as mo
+from ....oscar.backends.router import Router
 from ....storage import StorageLevel, PlasmaStorage
 from ....utils import calc_data_size
 from ..core import StorageManagerActor, StorageQuotaActor, build_data_info
@@ -53,8 +54,11 @@ async def actor_pool():
         return pool
 
     worker_pool = await start_pool()
-    yield worker_pool
-    await worker_pool.stop()
+    try:
+        yield worker_pool
+    finally:
+        await worker_pool.stop()
+        Router.set_instance(None)
 
 
 def _build_storage_config():

--- a/mars/services/storage/tests/test_transfer.py
+++ b/mars/services/storage/tests/test_transfer.py
@@ -22,6 +22,7 @@ import pytest
 
 from .... import oscar as mo
 from ....oscar.backends.allocate_strategy import IdleLabel
+from ....oscar.backends.router import Router
 from ....storage import StorageLevel
 from ..core import DataManagerActor, StorageManagerActor, StorageQuotaActor
 from ..errors import DataNotExist
@@ -51,9 +52,12 @@ async def actor_pools():
 
     worker_pool_1 = await start_pool()
     worker_pool_2 = await start_pool()
-    yield worker_pool_1, worker_pool_2
-    await worker_pool_1.stop()
-    await worker_pool_2.stop()
+    try:
+        yield worker_pool_1, worker_pool_2
+    finally:
+        await worker_pool_1.stop()
+        await worker_pool_2.stop()
+        Router.set_instance(None)
 
 
 @pytest.fixture

--- a/mars/services/storage/tests/test_transfer.py
+++ b/mars/services/storage/tests/test_transfer.py
@@ -19,7 +19,6 @@ import sys
 import numpy as np
 import pandas as pd
 import pytest
-import pytest_asyncio
 
 from .... import oscar as mo
 from ....oscar.backends.allocate_strategy import IdleLabel
@@ -32,7 +31,7 @@ from ..transfer import ReceiverManagerActor, SenderManagerActor
 _is_windows = sys.platform.lower().startswith("win")
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pools():
     async def start_pool():
         start_method = (
@@ -57,7 +56,7 @@ async def actor_pools():
     await worker_pool_2.stop()
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def create_actors(actor_pools):
     worker_pool_1, worker_pool_2 = actor_pools
 

--- a/mars/services/storage/transfer.py
+++ b/mars/services/storage/transfer.py
@@ -66,8 +66,8 @@ class SenderManagerActor(mo.StatelessActor):
         self,
         band_name: str = "numa-0",
         transfer_block_size: int = None,
-        data_manager_ref: Union[mo.ActorRef, DataManagerActor] = None,
-        storage_handler_ref: Union[mo.ActorRef, StorageHandlerActor] = None,
+        data_manager_ref: mo.ActorRefType[DataManagerActor] = None,
+        storage_handler_ref: mo.ActorRefType[StorageHandlerActor] = None,
     ):
         self._band_name = band_name
         self._data_manager_ref = data_manager_ref
@@ -93,7 +93,7 @@ class SenderManagerActor(mo.StatelessActor):
 
     async def _send_data(
         self,
-        receiver_ref: Union[mo.ActorRef],
+        receiver_ref: mo.ActorRefType["ReceiverManagerActor"],
         session_id: str,
         data_keys: List[str],
         level: StorageLevel,
@@ -167,8 +167,8 @@ class SenderManagerActor(mo.StatelessActor):
             "Begin to send data (%s, %s) to %s", session_id, data_keys, address
         )
         block_size = block_size or self._transfer_block_size
-        receiver_ref: Union[
-            ReceiverManagerActor, mo.ActorRef
+        receiver_ref: mo.ActorRefType[
+            ReceiverManagerActor
         ] = await self.get_receiver_ref(address, band_name)
         get_infos = []
         pin_tasks = []
@@ -246,7 +246,7 @@ class ReceiverManagerActor(mo.StatelessActor):
     def __init__(
         self,
         quota_refs: Dict,
-        storage_handler_ref: Union[mo.ActorRef, StorageHandlerActor] = None,
+        storage_handler_ref: mo.ActorRefType[StorageHandlerActor] = None,
     ):
         self._quota_refs = quota_refs
         self._storage_handler = storage_handler_ref

--- a/mars/services/subtask/tests/test_service.py
+++ b/mars/services/subtask/tests/test_service.py
@@ -17,7 +17,6 @@ import time
 
 import numpy as np
 import pytest
-import pytest_asyncio
 
 from .... import oscar as mo
 from .... import tensor as mt
@@ -50,7 +49,7 @@ def _gen_subtask(t, session_id):
     return subtask
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pools():
     async def start_pool(is_worker: bool):
         if is_worker:

--- a/mars/services/subtask/tests/test_service.py
+++ b/mars/services/subtask/tests/test_service.py
@@ -22,7 +22,7 @@ from .... import oscar as mo
 from .... import tensor as mt
 from .... import remote as mr
 from ....core.graph import TileableGraph, TileableGraphBuilder, ChunkGraphBuilder
-
+from ....oscar.backends.router import Router
 from ....resource import Resource
 from ....utils import Timer
 from ... import start_services, stop_services, NodeRole
@@ -64,9 +64,12 @@ async def actor_pools():
         await pool.start()
         return pool
 
-    sv_pool, worker_pool = await asyncio.gather(start_pool(False), start_pool(True))
-    yield sv_pool, worker_pool
-    await asyncio.gather(sv_pool.stop(), worker_pool.stop())
+    try:
+        sv_pool, worker_pool = await asyncio.gather(start_pool(False), start_pool(True))
+        yield sv_pool, worker_pool
+    finally:
+        Router.set_instance(None)
+        await asyncio.gather(sv_pool.stop(), worker_pool.stop())
 
 
 @pytest.mark.asyncio

--- a/mars/services/subtask/worker/runner.py
+++ b/mars/services/subtask/worker/runner.py
@@ -15,7 +15,7 @@
 import asyncio
 import importlib
 import logging
-from typing import Dict, Optional, Type, Union
+from typing import Dict, Optional, Type
 
 from .... import oscar as mo
 from ....lib.aio import alru_cache
@@ -28,13 +28,13 @@ from .processor import SubtaskProcessor, SubtaskProcessorActor
 logger = logging.getLogger(__name__)
 
 
-SubtaskRunnerRef = Union["SubtaskRunnerActor", mo.ActorRef]
+SubtaskRunnerRef = mo.ActorRefType["SubtaskRunnerActor"]
 
 
 class SubtaskRunnerActor(mo.Actor):
-    _session_id_to_processors: Dict[str, Union[mo.ActorRef, SubtaskProcessorActor]]
-    _running_processor: Optional[Union[mo.ActorRef, SubtaskProcessorActor]]
-    _last_processor: Optional[Union[mo.ActorRef, SubtaskProcessorActor]]
+    _session_id_to_processors: Dict[str, mo.ActorRefType[SubtaskProcessorActor]]
+    _running_processor: Optional[mo.ActorRefType[SubtaskProcessorActor]]
+    _last_processor: Optional[mo.ActorRefType[SubtaskProcessorActor]]
 
     @classmethod
     def gen_uid(cls, band_name: str, slot_id: int):

--- a/mars/services/subtask/worker/tests/test_subtask.py
+++ b/mars/services/subtask/worker/tests/test_subtask.py
@@ -19,7 +19,6 @@ import time
 
 import numpy as np
 import pytest
-import pytest_asyncio
 
 from ..... import oscar as mo
 from ..... import tensor as mt
@@ -49,7 +48,7 @@ class FakeTaskManager(TaskManagerActor):
         return
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     start_method = (
         os.environ.get("POOL_START_METHOD", "forkserver")

--- a/mars/services/subtask/worker/tests/test_subtask.py
+++ b/mars/services/subtask/worker/tests/test_subtask.py
@@ -26,7 +26,7 @@ from ..... import remote as mr
 from .....core import ExecutionError
 from .....core.context import get_context
 from .....core.graph import TileableGraph, TileableGraphBuilder, ChunkGraphBuilder
-
+from .....oscar.backends.router import Router
 from .....resource import Resource
 from .....utils import Timer
 from ....cluster import MockClusterAPI
@@ -103,6 +103,7 @@ async def actor_pool():
             await MockStorageAPI.cleanup(pool.external_address)
             await MockClusterAPI.cleanup(pool.external_address)
             await MockMutableAPI.cleanup(session_id, pool.external_address)
+            Router.set_instance(None)
 
 
 def _gen_subtask(t, session_id):

--- a/mars/services/task/api/oscar.py
+++ b/mars/services/task/api/oscar.py
@@ -25,7 +25,7 @@ from .core import AbstractTaskAPI
 
 class TaskAPI(AbstractTaskAPI):
     def __init__(
-        self, session_id: str, task_manager_ref: Union[TaskManagerActor, mo.ActorRef]
+        self, session_id: str, task_manager_ref: mo.ActorRefType[TaskManagerActor]
     ):
         self._session_id = session_id
         self._task_manager_ref = task_manager_ref

--- a/mars/services/task/supervisor/manager.py
+++ b/mars/services/task/supervisor/manager.py
@@ -18,7 +18,7 @@ import logging
 import time
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Dict, List, Type
 
 from .... import oscar as mo
 from ....core import TileableGraph, TileableType, enter_mode, TileContext
@@ -60,14 +60,14 @@ class TaskConfigurationActor(mo.Actor):
 @dataclass
 class ResultTileableInfo:
     tileable: TileableType
-    processor_ref: Union[TaskProcessorActor, mo.ActorRef]
+    processor_ref: mo.ActorRefType[TaskProcessorActor]
 
 
 class TaskManagerActor(mo.Actor):
     _task_name_to_parent_task_id: Dict[str, str]
     _task_name_to_task_ids: Dict[str, List[str]]
 
-    _task_id_to_processor_ref: Dict[str, Union[TaskProcessorActor, mo.ActorRef]]
+    _task_id_to_processor_ref: Dict[str, mo.ActorRefType[TaskProcessorActor]]
     _tileable_key_to_info: Dict[str, List[ResultTileableInfo]]
 
     def __init__(self, session_id: str):

--- a/mars/services/task/supervisor/tests/test_task_manager.py
+++ b/mars/services/task/supervisor/tests/test_task_manager.py
@@ -22,7 +22,6 @@ import time
 import numpy as np
 import pandas as pd
 import pytest
-import pytest_asyncio
 
 from ..... import dataframe as md
 from ..... import oscar as mo
@@ -47,7 +46,7 @@ from ...execution.api import Fetcher, ExecutionConfig
 from ..manager import TaskConfigurationActor, TaskManagerActor
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool(request):
     param = getattr(request, "param", {})
     backend = param.get("backend", "mars")

--- a/mars/services/task/supervisor/tests/test_task_manager.py
+++ b/mars/services/task/supervisor/tests/test_task_manager.py
@@ -30,6 +30,7 @@ from ..... import tensor as mt
 from .....core import Tileable, TileableGraph, TileableGraphBuilder
 from .....core.operand import Fetch
 from .....oscar.backends.allocate_strategy import MainPool
+from .....oscar.backends.router import Router
 from .....resource import Resource
 from .....storage import StorageLevel
 from .....utils import Timer, merge_chunks
@@ -100,6 +101,7 @@ async def actor_pool(request):
             await MockStorageAPI.cleanup(pool.external_address)
             await MockClusterAPI.cleanup(pool.external_address)
             await MockMutableAPI.cleanup(session_id, pool.external_address)
+            Router.set_instance(None)
 
 
 async def _merge_data(

--- a/mars/services/task/tests/test_service.py
+++ b/mars/services/task/tests/test_service.py
@@ -18,7 +18,6 @@ import time
 import numpy as np
 import pandas as pd
 import pytest
-import pytest_asyncio
 
 from .... import dataframe as md
 from .... import oscar as mo
@@ -41,7 +40,7 @@ from ..supervisor.processor import TaskProcessor
 from ..errors import TaskNotExist
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pools():
     async def start_pool(is_worker: bool):
         if is_worker:
@@ -117,7 +116,7 @@ async def _start_services(
 
 
 @pytest.mark.parametrize(indirect=True)
-@pytest_asyncio.fixture(params=[False, True])
+@pytest.fixture(params=[False, True])
 async def start_test_service(actor_pools, request):
     sv_pool, worker_pool = actor_pools
 
@@ -142,7 +141,7 @@ class MockTaskProcessor(TaskProcessor):
 
 
 @pytest.mark.parametrize(indirect=True)
-@pytest_asyncio.fixture(params=[True])
+@pytest.fixture(params=[True])
 async def start_test_service_with_mock(actor_pools, request):
     sv_pool, worker_pool = actor_pools
 

--- a/mars/services/task/tests/test_service.py
+++ b/mars/services/task/tests/test_service.py
@@ -25,6 +25,7 @@ from .... import remote as mr
 from .... import tensor as mt
 from ....core import TileableGraph, TileableGraphBuilder, TileStatus, recursive_tile
 from ....core.context import get_context
+from ....oscar.backends.router import Router
 from ....resource import Resource
 from ....tensor.core import TensorOrder
 from ....tensor.operands import TensorOperand, TensorOperandMixin
@@ -60,6 +61,7 @@ async def actor_pools():
         yield sv_pool, worker_pool
     finally:
         await asyncio.gather(sv_pool.stop(), worker_pool.stop())
+        Router.set_instance(None)
 
 
 async def _start_services(
@@ -128,6 +130,7 @@ async def start_test_service(actor_pools, request):
         await MockStorageAPI.cleanup(worker_pool.external_address)
         await stop_services(NodeRole.WORKER, config, worker_pool.external_address)
         await stop_services(NodeRole.SUPERVISOR, config, sv_pool.external_address)
+        Router.set_instance(None)
 
 
 class MockTaskProcessor(TaskProcessor):
@@ -158,6 +161,7 @@ async def start_test_service_with_mock(actor_pools, request):
         await MockStorageAPI.cleanup(worker_pool.external_address)
         await stop_services(NodeRole.WORKER, config, worker_pool.external_address)
         await stop_services(NodeRole.SUPERVISOR, config, sv_pool.external_address)
+        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/tests/fault_injection_patch.py
+++ b/mars/services/tests/fault_injection_patch.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any, Dict
+from typing import Any, Dict
 
 from ... import oscar as mo
 from ...core import OperandType
@@ -35,7 +35,7 @@ class FaultInjectedSubtaskExecutionActor(SubtaskExecutionActor):
     @alru_cache(cache_exceptions=False)
     async def _get_fault_injection_manager_ref(
         self, supervisor_address: str, session_id: str, name: str
-    ) -> Union[mo.ActorRef, AbstractFaultInjectionManager]:
+    ) -> mo.ActorRefType[AbstractFaultInjectionManager]:
         session_api = await self._get_session_api(supervisor_address)
         return await session_api.get_remote_object(session_id, name)
 
@@ -68,8 +68,8 @@ class FaultInjectedSubtaskExecutionActor(SubtaskExecutionActor):
 class FaultInjectionSubtaskProcessor(SubtaskProcessor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._fault_injection_manager_ref: Union[
-            mo.ActorRef, AbstractFaultInjectionManager
+        self._fault_injection_manager_ref: mo.ActorRefType[
+            AbstractFaultInjectionManager
         ] = None
 
     async def run(self):

--- a/mars/services/tests/test_core.py
+++ b/mars/services/tests/test_core.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import pytest
-import pytest_asyncio
 from tornado import httpclient
 
 from ... import oscar as mo
@@ -27,7 +26,7 @@ from .. import (
 )
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool_context():
     pool = await mo.create_actor_pool(f"127.0.0.1:{get_next_port()}", n_process=0)
     await pool.start()

--- a/mars/services/tests/test_core.py
+++ b/mars/services/tests/test_core.py
@@ -16,6 +16,7 @@ import pytest
 from tornado import httpclient
 
 from ... import oscar as mo
+from ...oscar.backends.router import Router
 from ...utils import get_next_port
 from .. import (
     NodeRole,
@@ -34,6 +35,7 @@ async def actor_pool_context():
         yield pool
     finally:
         await pool.stop()
+        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/web/tests/test_core.py
+++ b/mars/services/web/tests/test_core.py
@@ -20,6 +20,7 @@ import pytest
 from tornado import httpclient
 
 from .... import oscar as mo
+from ....oscar.backends.router import Router
 from ....utils import get_next_port
 from .. import WebActor, web_api, MarsServiceWebAPIHandler, MarsWebAPIClientMixin
 from ..api.web import MarsApiEntryHandler
@@ -69,18 +70,21 @@ async def actor_pool():
     pool = await mo.create_actor_pool(
         "127.0.0.1", n_process=0, subprocess_start_method=start_method
     )
-    async with pool:
-        web_config = {
-            "host": "127.0.0.1",
-            "port": get_next_port(),
-            "web_handlers": {
-                "/api": MarsApiEntryHandler,
-                TestAPIHandler.get_root_pattern(): TestAPIHandler,
-            },
-            "extra_discovery_modules": ["mars.services.web.tests.extra_handler"],
-        }
-        await mo.create_actor(WebActor, web_config, address=pool.external_address)
-        yield pool, web_config["port"]
+    try:
+        async with pool:
+            web_config = {
+                "host": "127.0.0.1",
+                "port": get_next_port(),
+                "web_handlers": {
+                    "/api": MarsApiEntryHandler,
+                    TestAPIHandler.get_root_pattern(): TestAPIHandler,
+                },
+                "extra_discovery_modules": ["mars.services.web.tests.extra_handler"],
+            }
+            await mo.create_actor(WebActor, web_config, address=pool.external_address)
+            yield pool, web_config["port"]
+    finally:
+        Router.set_instance(None)
 
 
 class SimpleWebClient(MarsWebAPIClientMixin):

--- a/mars/services/web/tests/test_core.py
+++ b/mars/services/web/tests/test_core.py
@@ -17,7 +17,6 @@ import os
 import sys
 
 import pytest
-import pytest_asyncio
 from tornado import httpclient
 
 from .... import oscar as mo
@@ -60,7 +59,7 @@ class TestAPIHandler(MarsServiceWebAPIHandler):
         raise ValueError(test_id)
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def actor_pool():
     start_method = (
         os.environ.get("POOL_START_METHOD", "forkserver")

--- a/mars/services/web/ui/package-lock.json
+++ b/mars/services/web/ui/package-lock.json
@@ -2621,14 +2621,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001242",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-      "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
+      "version": "1.0.30001342",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz",
+      "integrity": "sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -9475,9 +9481,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001242",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-      "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
+      "version": "1.0.30001342",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz",
+      "integrity": "sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA==",
       "dev": true
     },
     "chalk": {

--- a/mars/storage/tests/test_libs.py
+++ b/mars/storage/tests/test_libs.py
@@ -18,11 +18,10 @@ import os
 import sys
 import tempfile
 import pkgutil
-import pytest
-import pytest_asyncio
 
 import numpy as np
 import pandas as pd
+import pytest
 import scipy.sparse as sps
 
 from ...lib.filesystem import LocalFileSystem
@@ -66,7 +65,7 @@ if ray is not None:
 @pytest.mark.parametrize(
     "ray_start_regular", [{"enable": ray is not None}], indirect=True
 )
-@pytest_asyncio.fixture(params=params)
+@pytest.fixture(params=params)
 async def storage_context(ray_start_regular, request):
     if request.param == "filesystem":
         tempdir = tempfile.mkdtemp()

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -35,6 +35,7 @@ from .. import dataframe as md
 from .. import remote as mr
 from ..config import option_context
 from ..deploy.utils import load_service_config_file
+from ..oscar.backends.router import Router
 from ..session import execute, fetch, fetch_log
 
 
@@ -54,6 +55,7 @@ def setup():
             yield sess
         finally:
             sess.stop_server()
+            Router.set_instance(None)
 
 
 def test_session_async_execute(setup):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,11 @@ extend-exclude = '''
 '''
 
 [tool.pytest.ini_options]
+asyncio_mode = "auto"
 markers = [
-    "ray_dag: marks tests for ray backend",
+    "cuda: mark a test as a cuda case.",
+    "hadoop: mark test as a hadoop case.",
+    "ray: mark test as a ray case.",
+    "pd_compat: mark test as a pandas-compatibility test.",
+    "ray_dag: marks tests for ray backend.",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,15 +9,15 @@ maintainer = Qin Xuye
 maintainer_email = qin@qinxuye.me
 license = Apache License 2.0
 url = http://github.com/mars-project/mars
-python_requires = >=3.6
+python_requires = >=3.7
 classifier =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Libraries
 
@@ -27,8 +27,7 @@ include_package_data = True
 packages = find:
 install_requires =
     numpy>=1.14.0
-    pandas>=1.0.0,<1.2.0; python_version<"3.7"
-    pandas>=1.0.0; python_version>="3.7"
+    pandas>=1.0.0
     scipy>=1.0.0
     scikit-learn>=0.20
     numexpr>=2.6.4
@@ -36,15 +35,12 @@ install_requires =
     pyyaml>=5.1
     psutil>=4.0.0
     pickle5; python_version<"3.8"
-    async_generator; python_version<"3.7"
-    dataclasses; python_version<"3.7"
     shared-memory38>=0.1.1; python_version<"3.8"
-    asyncio37>=0.1.3; python_version<"3.7"
     tornado>=6.0
     sqlalchemy>=1.2.0
     defusedxml>=0.5.0
     tqdm>=4.1.0
-    uvloop>=0.14.0; sys.platform!="win32" and python_version>="3.7"
+    uvloop>=0.14.0; sys.platform!="win32"
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,13 +75,6 @@ ray =
 vineyard =
     vineyard>=0.3; sys.platform != "win32"
 
-[tool:pytest]
-markers =
-    cuda: mark a test as a cuda case.
-    hadoop: mark test as a hadoop case.
-    ray: mark test as a ray case.
-    pd_compat: mark test as a pandas-compatibility test
-
 [coverage:run]
 branch = True
 relative_files = True


### PR DESCRIPTION
## What do these changes do?

It is often hard to obtain free ports, esp. in containers with host ports. It is better to assign ports of sub-pools by OS itself.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
