### PR TITLE
Add `n_reducers` and `reducer_ordinal` to shuffle operands

### DIFF
--- a/mars/core/operand/shuffle.py
+++ b/mars/core/operand/shuffle.py
@@ -32,7 +32,7 @@ class MapReduceOperand(Operand):
     # for reducer
     reducer_index = TupleField("reducer_index", FieldTypes.uint64)
     # Total reducer nums, which also be shuffle blocks for single mapper.
-    n_reducers = TupleField("n_reducers", FieldTypes.uint64)
+    n_reducer = TupleField("n_reducer", FieldTypes.uint64)
     # The reducer ordinal in all reducers. It's different from reducer_index,
     # which might be a tuple.
     reducer_ordinal = TupleField("reducer_ordinal", FieldTypes.uint64)

--- a/mars/core/operand/shuffle.py
+++ b/mars/core/operand/shuffle.py
@@ -32,10 +32,10 @@ class MapReduceOperand(Operand):
     # for reducer
     reducer_index = TupleField("reducer_index", FieldTypes.uint64)
     # Total reducer nums, which also be shuffle blocks for single mapper.
-    n_reducers = TupleField("n_reducers", FieldTypes.int64)
+    n_reducers = Int32Field("n_reducers")
     # The reducer ordinal in all reducers. It's different from reducer_index,
     # which might be a tuple.
-    reducer_ordinal = TupleField("reducer_ordinal", FieldTypes.int64)
+    reducer_ordinal = Int32Field("reducer_ordinal")
     reducer_phase = StringField("reducer_phase", default=None)
 
     def _new_chunks(self, inputs, kws=None, **kw):

--- a/mars/core/operand/shuffle.py
+++ b/mars/core/operand/shuffle.py
@@ -32,10 +32,10 @@ class MapReduceOperand(Operand):
     # for reducer
     reducer_index = TupleField("reducer_index", FieldTypes.uint64)
     # Total reducer nums, which also be shuffle blocks for single mapper.
-    n_reducer = TupleField("n_reducer", FieldTypes.uint64)
+    n_reducers = TupleField("n_reducers", FieldTypes.int64)
     # The reducer ordinal in all reducers. It's different from reducer_index,
     # which might be a tuple.
-    reducer_ordinal = TupleField("reducer_ordinal", FieldTypes.uint64)
+    reducer_ordinal = TupleField("reducer_ordinal", FieldTypes.int64)
     reducer_phase = StringField("reducer_phase", default=None)
 
     def _new_chunks(self, inputs, kws=None, **kw):

--- a/mars/core/operand/shuffle.py
+++ b/mars/core/operand/shuffle.py
@@ -31,6 +31,11 @@ class MapReduceOperand(Operand):
     mapper_id = Int32Field("mapper_id", default=0)
     # for reducer
     reducer_index = TupleField("reducer_index", FieldTypes.uint64)
+    # Total reducer nums, which also be shuffle blocks for single mapper.
+    n_reducers = TupleField("n_reducers", FieldTypes.uint64)
+    # The reducer ordinal in all reducers. It's different from reducer_index,
+    # which might be a tuple.
+    reducer_ordinal = TupleField("reducer_ordinal", FieldTypes.uint64)
     reducer_phase = StringField("reducer_phase", default=None)
 
     def _new_chunks(self, inputs, kws=None, **kw):

--- a/mars/core/operand/tests/test_core.py
+++ b/mars/core/operand/tests/test_core.py
@@ -134,10 +134,10 @@ def test_post_execute(setup):
 
 
 def test_shuffle(setup):
-    import mars.dataframe as md
+    from ....dataframe import DataFrame
 
     chunk_size, n_rows = 10, 100
-    df = md.DataFrame(
+    df = DataFrame(
         pd.DataFrame(np.random.rand(n_rows, 3), columns=list("abc")),
         chunk_size=chunk_size,
     )

--- a/mars/dataframe/align.py
+++ b/mars/dataframe/align.py
@@ -683,7 +683,7 @@ def _gen_series_chunks(splits, out_shape, left_or_right, series):
         for out_idx in range(out_shape[0]):
             reduce_op = DataFrameIndexAlign(
                 stage=OperandStage.reduce,
-                n_reducers=len(out_shape[0]),
+                n_reducer=len(out_shape[0]),
                 reducer_ordinal=out_idx,
                 i=out_idx,
                 sparse=proxy_chunk.issparse(),
@@ -822,7 +822,7 @@ def _gen_dataframe_chunks(splits, out_shape, left_or_right, df):
                 )
                 reduce_op = DataFrameIndexAlign(
                     stage=OperandStage.reduce,
-                    n_reducers=len(out_shape[shuffle_axis]),
+                    n_reducer=len(out_shape[shuffle_axis]),
                     reducer_ordinal=j,
                     i=j,
                     sparse=proxy_chunk.issparse(),
@@ -861,7 +861,7 @@ def _gen_dataframe_chunks(splits, out_shape, left_or_right, df):
         for ordinal, out_idx in enumerate(out_indices):
             reduce_op = DataFrameIndexAlign(
                 stage=OperandStage.reduce,
-                n_reducers=len(out_indices),
+                n_reducer=len(out_indices),
                 reducer_ordinal=ordinal,
                 i=out_idx,
                 sparse=proxy_chunk.issparse(),

--- a/mars/dataframe/align.py
+++ b/mars/dataframe/align.py
@@ -683,6 +683,8 @@ def _gen_series_chunks(splits, out_shape, left_or_right, series):
         for out_idx in range(out_shape[0]):
             reduce_op = DataFrameIndexAlign(
                 stage=OperandStage.reduce,
+                n_reducers=len(out_shape[0]),
+                reducer_ordinal=out_idx,
                 i=out_idx,
                 sparse=proxy_chunk.issparse(),
                 output_types=[OutputType.series],
@@ -820,6 +822,8 @@ def _gen_dataframe_chunks(splits, out_shape, left_or_right, df):
                 )
                 reduce_op = DataFrameIndexAlign(
                     stage=OperandStage.reduce,
+                    n_reducers=len(out_shape[shuffle_axis]),
+                    reducer_ordinal=j,
                     i=j,
                     sparse=proxy_chunk.issparse(),
                     output_types=[OutputType.dataframe],
@@ -853,9 +857,12 @@ def _gen_dataframe_chunks(splits, out_shape, left_or_right, df):
         ).new_chunk(map_chunks, shape=())
 
         # gen reduce chunks
-        for out_idx in itertools.product(*(range(s) for s in out_shape)):
+        out_indices = list(itertools.product(*(range(s) for s in out_shape)))
+        for ordinal, out_idx in enumerate(out_indices):
             reduce_op = DataFrameIndexAlign(
                 stage=OperandStage.reduce,
+                n_reducers=len(out_indices),
+                reducer_ordinal=ordinal,
                 i=out_idx,
                 sparse=proxy_chunk.issparse(),
                 output_types=[OutputType.dataframe],

--- a/mars/dataframe/align.py
+++ b/mars/dataframe/align.py
@@ -683,7 +683,7 @@ def _gen_series_chunks(splits, out_shape, left_or_right, series):
         for out_idx in range(out_shape[0]):
             reduce_op = DataFrameIndexAlign(
                 stage=OperandStage.reduce,
-                n_reducer=out_shape[0],
+                n_reducers=out_shape[0],
                 reducer_ordinal=out_idx,
                 i=out_idx,
                 sparse=proxy_chunk.issparse(),
@@ -822,7 +822,7 @@ def _gen_dataframe_chunks(splits, out_shape, left_or_right, df):
                 )
                 reduce_op = DataFrameIndexAlign(
                     stage=OperandStage.reduce,
-                    n_reducer=out_shape[shuffle_axis],
+                    n_reducers=out_shape[shuffle_axis],
                     reducer_ordinal=j,
                     i=j,
                     sparse=proxy_chunk.issparse(),
@@ -861,7 +861,7 @@ def _gen_dataframe_chunks(splits, out_shape, left_or_right, df):
         for ordinal, out_idx in enumerate(out_indices):
             reduce_op = DataFrameIndexAlign(
                 stage=OperandStage.reduce,
-                n_reducer=len(out_indices),
+                n_reducers=len(out_indices),
                 reducer_ordinal=ordinal,
                 i=out_idx,
                 sparse=proxy_chunk.issparse(),

--- a/mars/dataframe/align.py
+++ b/mars/dataframe/align.py
@@ -683,7 +683,7 @@ def _gen_series_chunks(splits, out_shape, left_or_right, series):
         for out_idx in range(out_shape[0]):
             reduce_op = DataFrameIndexAlign(
                 stage=OperandStage.reduce,
-                n_reducer=len(out_shape[0]),
+                n_reducer=out_shape[0],
                 reducer_ordinal=out_idx,
                 i=out_idx,
                 sparse=proxy_chunk.issparse(),
@@ -822,7 +822,7 @@ def _gen_dataframe_chunks(splits, out_shape, left_or_right, df):
                 )
                 reduce_op = DataFrameIndexAlign(
                     stage=OperandStage.reduce,
-                    n_reducer=len(out_shape[shuffle_axis]),
+                    n_reducer=out_shape[shuffle_axis],
                     reducer_ordinal=j,
                     i=j,
                     sparse=proxy_chunk.issparse(),

--- a/mars/dataframe/base/_duplicate.py
+++ b/mars/dataframe/base/_duplicate.py
@@ -232,7 +232,7 @@ class DuplicateOperand(MapReduceOperand, DataFrameOperandMixin):
             reduce_op._method = "shuffle"
             reduce_op.stage = OperandStage.reduce
             reduce_op.reducer_phase = "drop_duplicates"
-            reduce_op.n_reducers = len(map_chunks)
+            reduce_op.n_reducer = len(map_chunks)
             reduce_op.reducer_ordinal = i
             reduce_op._shuffle_size = inp.chunk_shape[0]
             reduce_op._output_types = op.output_types
@@ -252,7 +252,7 @@ class DuplicateOperand(MapReduceOperand, DataFrameOperandMixin):
             put_back_op.stage = OperandStage.reduce
             put_back_op.reducer_phase = "put_back"
             put_back_op.reducer_index = (i,)
-            put_back_op.n_reducers = len(map_chunks)
+            put_back_op.n_reducer = len(map_chunks)
             put_back_op.reducer_ordinal = i
             if out.ndim == 2:
                 put_back_chunk_params = map_chunks[i].params

--- a/mars/dataframe/base/_duplicate.py
+++ b/mars/dataframe/base/_duplicate.py
@@ -232,7 +232,7 @@ class DuplicateOperand(MapReduceOperand, DataFrameOperandMixin):
             reduce_op._method = "shuffle"
             reduce_op.stage = OperandStage.reduce
             reduce_op.reducer_phase = "drop_duplicates"
-            reduce_op.n_reducer = len(map_chunks)
+            reduce_op.n_reducers = len(map_chunks)
             reduce_op.reducer_ordinal = i
             reduce_op._shuffle_size = inp.chunk_shape[0]
             reduce_op._output_types = op.output_types
@@ -252,7 +252,7 @@ class DuplicateOperand(MapReduceOperand, DataFrameOperandMixin):
             put_back_op.stage = OperandStage.reduce
             put_back_op.reducer_phase = "put_back"
             put_back_op.reducer_index = (i,)
-            put_back_op.n_reducer = len(map_chunks)
+            put_back_op.n_reducers = len(map_chunks)
             put_back_op.reducer_ordinal = i
             if out.ndim == 2:
                 put_back_chunk_params = map_chunks[i].params

--- a/mars/dataframe/base/_duplicate.py
+++ b/mars/dataframe/base/_duplicate.py
@@ -232,6 +232,8 @@ class DuplicateOperand(MapReduceOperand, DataFrameOperandMixin):
             reduce_op._method = "shuffle"
             reduce_op.stage = OperandStage.reduce
             reduce_op.reducer_phase = "drop_duplicates"
+            reduce_op.n_reducers = len(map_chunks)
+            reduce_op.reducer_ordinal = i
             reduce_op._shuffle_size = inp.chunk_shape[0]
             reduce_op._output_types = op.output_types
             reduce_chunk_params = map_chunks[0].params
@@ -250,6 +252,8 @@ class DuplicateOperand(MapReduceOperand, DataFrameOperandMixin):
             put_back_op.stage = OperandStage.reduce
             put_back_op.reducer_phase = "put_back"
             put_back_op.reducer_index = (i,)
+            put_back_op.n_reducers = len(map_chunks)
+            put_back_op.reducer_ordinal = i
             if out.ndim == 2:
                 put_back_chunk_params = map_chunks[i].params
             else:

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -319,7 +319,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
             partition_shuffle_reduce = DataFrameGroupbySortShuffle(
                 stage=OperandStage.reduce,
                 reducer_index=(i, 0),
-                n_reducers=len(partition_chunks),
+                n_reducer=len(partition_chunks),
                 reducer_ordinal=i,
                 output_types=output_types,
                 **properties,
@@ -444,7 +444,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
                 stage=OperandStage.reduce,
                 output_types=[OutputType.dataframe_groupby],
                 reduce_ordinal=ordinal,
-                n_reducers=len(out_indices),
+                n_reducer=len(out_indices),
             )
             reduce_chunks.append(
                 reduce_op.new_chunk(

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -443,7 +443,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
             reduce_op = DataFrameGroupByOperand(
                 stage=OperandStage.reduce,
                 output_types=[OutputType.dataframe_groupby],
-                reduce_ordinal=ordinal,
+                reducer_ordinal=ordinal,
                 n_reducer=len(out_indices),
             )
             reduce_chunks.append(

--- a/mars/dataframe/groupby/aggregation.py
+++ b/mars/dataframe/groupby/aggregation.py
@@ -319,7 +319,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
             partition_shuffle_reduce = DataFrameGroupbySortShuffle(
                 stage=OperandStage.reduce,
                 reducer_index=(i, 0),
-                n_reducer=len(partition_chunks),
+                n_reducers=len(partition_chunks),
                 reducer_ordinal=i,
                 output_types=output_types,
                 **properties,
@@ -444,7 +444,7 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
                 stage=OperandStage.reduce,
                 output_types=[OutputType.dataframe_groupby],
                 reducer_ordinal=ordinal,
-                n_reducer=len(out_indices),
+                n_reducers=len(out_indices),
             )
             reduce_chunks.append(
                 reduce_op.new_chunk(

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -294,11 +294,14 @@ class DataFrameGroupByOperand(MapReduceOperand, DataFrameOperandMixin):
 
         # generate reduce chunks
         reduce_chunks = []
-        for out_idx in itertools.product(*(range(s) for s in chunk_shape)):
+        out_indices = list(itertools.product(*(range(s) for s in chunk_shape)))
+        for ordinal, out_idx in enumerate(out_indices):
             reduce_op = op.copy().reset_key()
             reduce_op._by = None
             reduce_op._output_types = [output_type]
             reduce_op.stage = OperandStage.reduce
+            reduce_op.reduce_ordinal = ordinal
+            reduce_op.n_reducers = len(out_indices)
             reduce_chunks.append(
                 reduce_op.new_chunk(
                     [proxy_chunk], shape=(np.nan, np.nan), index=out_idx

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -301,7 +301,7 @@ class DataFrameGroupByOperand(MapReduceOperand, DataFrameOperandMixin):
             reduce_op._output_types = [output_type]
             reduce_op.stage = OperandStage.reduce
             reduce_op.reducer_ordinal = ordinal
-            reduce_op.n_reducer = len(out_indices)
+            reduce_op.n_reducers = len(out_indices)
             reduce_chunks.append(
                 reduce_op.new_chunk(
                     [proxy_chunk], shape=(np.nan, np.nan), index=out_idx

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -300,7 +300,7 @@ class DataFrameGroupByOperand(MapReduceOperand, DataFrameOperandMixin):
             reduce_op._by = None
             reduce_op._output_types = [output_type]
             reduce_op.stage = OperandStage.reduce
-            reduce_op.reduce_ordinal = ordinal
+            reduce_op.reducer_ordinal = ordinal
             reduce_op.n_reducer = len(out_indices)
             reduce_chunks.append(
                 reduce_op.new_chunk(

--- a/mars/dataframe/groupby/core.py
+++ b/mars/dataframe/groupby/core.py
@@ -301,7 +301,7 @@ class DataFrameGroupByOperand(MapReduceOperand, DataFrameOperandMixin):
             reduce_op._output_types = [output_type]
             reduce_op.stage = OperandStage.reduce
             reduce_op.reduce_ordinal = ordinal
-            reduce_op.n_reducers = len(out_indices)
+            reduce_op.n_reducer = len(out_indices)
             reduce_chunks.append(
                 reduce_op.new_chunk(
                     [proxy_chunk], shape=(np.nan, np.nan), index=out_idx

--- a/mars/dataframe/groupby/sample.py
+++ b/mars/dataframe/groupby/sample.py
@@ -503,7 +503,7 @@ class GroupBySample(MapReduceOperand, DataFrameOperandMixin):
             new_op.stage = OperandStage.reduce
             new_op.reducer_index = (src_chunk.index[0],)
             new_op.reducer_ordinal = ordinal
-            new_op.n_reducer = len(in_df.chunks)
+            new_op.n_reducers = len(in_df.chunks)
             new_op._input_nsplits = np.array(in_df.nsplits[0])
 
             reduce_chunks.append(

--- a/mars/dataframe/groupby/sample.py
+++ b/mars/dataframe/groupby/sample.py
@@ -496,12 +496,14 @@ class GroupBySample(MapReduceOperand, DataFrameOperandMixin):
         )
 
         reduce_chunks = []
-        for src_chunk in in_df.chunks:
+        for ordinal, src_chunk in enumerate(in_df.chunks):
             new_op = op.copy().reset_key()
             new_op._weights = None
             new_op._output_types = [OutputType.tensor]
             new_op.stage = OperandStage.reduce
             new_op.reducer_index = (src_chunk.index[0],)
+            new_op.reduce_ordinal = ordinal
+            new_op.n_reducers = len(in_df.chunks)
             new_op._input_nsplits = np.array(in_df.nsplits[0])
 
             reduce_chunks.append(

--- a/mars/dataframe/groupby/sample.py
+++ b/mars/dataframe/groupby/sample.py
@@ -502,7 +502,7 @@ class GroupBySample(MapReduceOperand, DataFrameOperandMixin):
             new_op._output_types = [OutputType.tensor]
             new_op.stage = OperandStage.reduce
             new_op.reducer_index = (src_chunk.index[0],)
-            new_op.reduce_ordinal = ordinal
+            new_op.reducer_ordinal = ordinal
             new_op.n_reducer = len(in_df.chunks)
             new_op._input_nsplits = np.array(in_df.nsplits[0])
 

--- a/mars/dataframe/groupby/sample.py
+++ b/mars/dataframe/groupby/sample.py
@@ -503,7 +503,7 @@ class GroupBySample(MapReduceOperand, DataFrameOperandMixin):
             new_op.stage = OperandStage.reduce
             new_op.reducer_index = (src_chunk.index[0],)
             new_op.reduce_ordinal = ordinal
-            new_op.n_reducers = len(in_df.chunks)
+            new_op.n_reducer = len(in_df.chunks)
             new_op._input_nsplits = np.array(in_df.nsplits[0])
 
             reduce_chunks.append(

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -263,7 +263,7 @@ class DataFrameMerge(DataFrameOperand, DataFrameOperandMixin):
         for ordinal, out_idx in enumerate(out_indices):
             reduce_op = DataFrameMergeAlign(
                 stage=OperandStage.reduce,
-                reduce_ordinal=ordinal,
+                reducer_ordinal=ordinal,
                 n_reducer=len(out_indices),
                 sparse=proxy_chunk.issparse(),
                 output_types=[OutputType.dataframe],
@@ -320,7 +320,7 @@ class DataFrameMerge(DataFrameOperand, DataFrameOperandMixin):
             reduce_op = DataFrameMergeAlign(
                 stage=OperandStage.reduce,
                 sparse=proxy_chunk.issparse(),
-                reduce_ordinal=ordinal,
+                reducer_ordinal=ordinal,
                 n_reducer=len(out_indices),
             )
             left_param = {

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -264,7 +264,7 @@ class DataFrameMerge(DataFrameOperand, DataFrameOperandMixin):
             reduce_op = DataFrameMergeAlign(
                 stage=OperandStage.reduce,
                 reducer_ordinal=ordinal,
-                n_reducer=len(out_indices),
+                n_reducers=len(out_indices),
                 sparse=proxy_chunk.issparse(),
                 output_types=[OutputType.dataframe],
             )
@@ -321,7 +321,7 @@ class DataFrameMerge(DataFrameOperand, DataFrameOperandMixin):
                 stage=OperandStage.reduce,
                 sparse=proxy_chunk.issparse(),
                 reducer_ordinal=ordinal,
-                n_reducer=len(out_indices),
+                n_reducers=len(out_indices),
             )
             left_param = {
                 "shape": (np.nan, np.nan),

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -264,7 +264,7 @@ class DataFrameMerge(DataFrameOperand, DataFrameOperandMixin):
             reduce_op = DataFrameMergeAlign(
                 stage=OperandStage.reduce,
                 reduce_ordinal=ordinal,
-                n_reducers=len(out_indices),
+                n_reducer=len(out_indices),
                 sparse=proxy_chunk.issparse(),
                 output_types=[OutputType.dataframe],
             )
@@ -321,7 +321,7 @@ class DataFrameMerge(DataFrameOperand, DataFrameOperandMixin):
                 stage=OperandStage.reduce,
                 sparse=proxy_chunk.issparse(),
                 reduce_ordinal=ordinal,
-                n_reducers=len(out_indices),
+                n_reducer=len(out_indices),
             )
             left_param = {
                 "shape": (np.nan, np.nan),

--- a/mars/dataframe/merge/merge.py
+++ b/mars/dataframe/merge/merge.py
@@ -259,9 +259,12 @@ class DataFrameMerge(DataFrameOperand, DataFrameOperandMixin):
 
         # gen reduce chunks
         reduce_chunks = []
-        for out_idx in itertools.product(*(range(s) for s in out_shape)):
+        out_indices = list(itertools.product(*(range(s) for s in out_shape)))
+        for ordinal, out_idx in enumerate(out_indices):
             reduce_op = DataFrameMergeAlign(
                 stage=OperandStage.reduce,
+                reduce_ordinal=ordinal,
+                n_reducers=len(out_indices),
                 sparse=proxy_chunk.issparse(),
                 output_types=[OutputType.dataframe],
             )
@@ -312,9 +315,13 @@ class DataFrameMerge(DataFrameOperand, DataFrameOperandMixin):
         # gen reduce chunks
         left_reduce_chunks = []
         right_reduce_chunks = []
-        for out_idx in itertools.product(*(range(s) for s in out_shape)):
+        out_indices = list(itertools.product(*(range(s) for s in out_shape)))
+        for ordinal, out_idx in enumerate(out_indices):
             reduce_op = DataFrameMergeAlign(
-                stage=OperandStage.reduce, sparse=proxy_chunk.issparse()
+                stage=OperandStage.reduce,
+                sparse=proxy_chunk.issparse(),
+                reduce_ordinal=ordinal,
+                n_reducers=len(out_indices),
             )
             left_param = {
                 "shape": (np.nan, np.nan),

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -239,7 +239,7 @@ class DataFramePSRSOperandMixin(DataFrameOperandMixin, PSRSOperandMixin):
                 kind=kind,
                 reducer_index=(i,),
                 reducer_ordinal=i,
-                n_reducer=len(partition_chunks),
+                n_reducers=len(partition_chunks),
                 output_types=op.output_types,
                 **cls._collect_op_properties(op)
             )

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -239,7 +239,7 @@ class DataFramePSRSOperandMixin(DataFrameOperandMixin, PSRSOperandMixin):
                 kind=kind,
                 reducer_index=(i,),
                 reducer_ordinal=i,
-                n_reducers=len(partition_chunks),
+                n_reducer=len(partition_chunks),
                 output_types=op.output_types,
                 **cls._collect_op_properties(op)
             )

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -238,6 +238,8 @@ class DataFramePSRSOperandMixin(DataFrameOperandMixin, PSRSOperandMixin):
                 stage=OperandStage.reduce,
                 kind=kind,
                 reducer_index=(i,),
+                reducer_ordinal=i,
+                n_reducers=len(partition_chunks),
                 output_types=op.output_types,
                 **cls._collect_op_properties(op)
             )

--- a/mars/learn/ensemble/_bagging.py
+++ b/mars/learn/ensemble/_bagging.py
@@ -294,7 +294,7 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
 
         n_reducers = (
             op.n_reducers
-            if op.n_reducers is not None
+            if getattr(op, "n_reducers", None)
             else max(1, int(in_sample.chunk_shape[0] * op.reducer_ratio))
         )
 

--- a/mars/learn/ensemble/_bagging.py
+++ b/mars/learn/ensemble/_bagging.py
@@ -357,6 +357,8 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
             new_op = op.copy().reset_key()
             new_op.random_state = None
             new_op.stage = OperandStage.reduce
+            new_op.reduce_ordinal = idx
+            new_op.n_reducers = n_reducers
             new_op.chunk_shape = in_sample.chunk_shape
             new_op.n_estimators = op.n_estimators // n_reducers
             if remain_reducers:

--- a/mars/learn/ensemble/_bagging.py
+++ b/mars/learn/ensemble/_bagging.py
@@ -357,7 +357,7 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
             new_op = op.copy().reset_key()
             new_op.random_state = None
             new_op.stage = OperandStage.reduce
-            new_op.reduce_ordinal = idx
+            new_op.reducer_ordinal = idx
             new_op.n_reducer = n_reducer
             new_op.chunk_shape = in_sample.chunk_shape
             new_op.n_estimators = op.n_estimators // n_reducer

--- a/mars/learn/ensemble/_bagging.py
+++ b/mars/learn/ensemble/_bagging.py
@@ -133,7 +133,6 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
     feature_random_state = RandomStateField("feature_random_state")
 
     reducer_ratio: float = Float32Field("reducer_ratio")
-    n_reducer: int = Int64Field("n_reducer", default=None)
     column_offset: int = Int64Field("column_offset", default=None)
 
     chunk_shape: Tuple[int] = TupleField("chunk_shape", FieldTypes.int64)
@@ -293,9 +292,9 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
             and not op.bootstrap_features,
         ]
 
-        n_reducer = (
-            op.n_reducer
-            if op.n_reducer is not None
+        n_reducers = (
+            op.n_reducers
+            if op.n_reducers is not None
             else max(1, int(in_sample.chunk_shape[0] * op.reducer_ratio))
         )
 
@@ -321,7 +320,7 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
             new_op.stage = OperandStage.map
             new_op.max_samples = max_samples_splits[:, chunk.index[0]]
             new_op.max_features = max_features_splits[:, chunk.index[1]]
-            new_op.n_reducer = n_reducer
+            new_op.n_reducers = n_reducers
             new_op.column_offset = int(column_cum_offset[chunk.index[1]])
 
             if chunk.index[0] != 0:
@@ -348,19 +347,19 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
             map_chunks, dtype=np.dtype(int), shape=()
         )
 
-        remain_reducers = op.n_estimators % n_reducer
+        remain_reducers = op.n_estimators % n_reducers
         reduce_data_chunks = []
         reduce_labels_chunks = []
         reduce_weights_chunks = []
         reduce_feature_chunks = []
-        for idx in range(n_reducer):
+        for idx in range(n_reducers):
             new_op = op.copy().reset_key()
             new_op.random_state = None
             new_op.stage = OperandStage.reduce
             new_op.reducer_ordinal = idx
-            new_op.n_reducer = n_reducer
+            new_op.n_reducers = n_reducers
             new_op.chunk_shape = in_sample.chunk_shape
-            new_op.n_estimators = op.n_estimators // n_reducer
+            new_op.n_estimators = op.n_estimators // n_reducers
             if remain_reducers:
                 remain_reducers -= 1
                 new_op.n_estimators += 1
@@ -472,14 +471,14 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
         in_weights_data = ctx[in_weights.key] if op.with_weights else None
         out_samples = op.outputs[0]
 
-        remains = op.n_estimators % op.n_reducer
+        remains = op.n_estimators % op.n_reducers
         reducer_iters = [
-            itertools.repeat(idx, 1 + op.n_estimators // op.n_reducer)
+            itertools.repeat(idx, 1 + op.n_estimators // op.n_reducers)
             for idx in range(remains)
         ]
         reducer_iters += [
-            itertools.repeat(idx, op.n_estimators // op.n_reducer)
-            for idx in range(remains, op.n_reducer)
+            itertools.repeat(idx, op.n_estimators // op.n_reducers)
+            for idx in range(remains, op.n_reducers)
         ]
         reducer_iter = itertools.chain(*reducer_iters)
 
@@ -765,7 +764,7 @@ class BaggingFitOperand(LearnOperand, LearnOperandMixin):
     random_state = RandomStateField("random_state", default=None)
 
     reducer_ratio: float = Float32Field("reducer_ratio")
-    n_reducer: int = Int64Field("n_reducer")
+    n_reducers: int = Int64Field("n_reducers")
 
     labels: TileableType = ReferenceField("labels", default=None)
     weights: TileableType = ReferenceField("weights", default=None)
@@ -804,7 +803,7 @@ class BaggingFitOperand(LearnOperand, LearnOperandMixin):
             bootstrap_features=self.bootstrap_features,
             random_state=self.random_state,
             reducer_ratio=self.reducer_ratio,
-            n_reducer=self.n_reducer,
+            n_reducers=self.n_reducers,
             with_weights=self.weights is not None,
             with_labels=self.labels is not None,
             with_feature_indices=self.with_feature_indices,
@@ -1283,7 +1282,7 @@ class BaseBagging:
             bootstrap_features=self.bootstrap_features,
             random_state=self.random_state,
             reducer_ratio=self.reducers if isinstance(self.reducers, float) else None,
-            n_reducer=self.reducers if isinstance(self.reducers, int) else None,
+            n_reducers=self.reducers if isinstance(self.reducers, int) else None,
         )
         tileables = fit_op(X, y, sample_weight, feature_indices)
         ret = execute(*tileables, session=session, **(run_kwargs or dict()))

--- a/mars/learn/ensemble/_bagging.py
+++ b/mars/learn/ensemble/_bagging.py
@@ -133,7 +133,7 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
     feature_random_state = RandomStateField("feature_random_state")
 
     reducer_ratio: float = Float32Field("reducer_ratio")
-    n_reducers: int = Int64Field("n_reducers", default=None)
+    n_reducer: int = Int64Field("n_reducer", default=None)
     column_offset: int = Int64Field("column_offset", default=None)
 
     chunk_shape: Tuple[int] = TupleField("chunk_shape", FieldTypes.int64)
@@ -293,9 +293,9 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
             and not op.bootstrap_features,
         ]
 
-        n_reducers = (
-            op.n_reducers
-            if op.n_reducers is not None
+        n_reducer = (
+            op.n_reducer
+            if op.n_reducer is not None
             else max(1, int(in_sample.chunk_shape[0] * op.reducer_ratio))
         )
 
@@ -321,7 +321,7 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
             new_op.stage = OperandStage.map
             new_op.max_samples = max_samples_splits[:, chunk.index[0]]
             new_op.max_features = max_features_splits[:, chunk.index[1]]
-            new_op.n_reducers = n_reducers
+            new_op.n_reducer = n_reducer
             new_op.column_offset = int(column_cum_offset[chunk.index[1]])
 
             if chunk.index[0] != 0:
@@ -348,19 +348,19 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
             map_chunks, dtype=np.dtype(int), shape=()
         )
 
-        remain_reducers = op.n_estimators % n_reducers
+        remain_reducers = op.n_estimators % n_reducer
         reduce_data_chunks = []
         reduce_labels_chunks = []
         reduce_weights_chunks = []
         reduce_feature_chunks = []
-        for idx in range(n_reducers):
+        for idx in range(n_reducer):
             new_op = op.copy().reset_key()
             new_op.random_state = None
             new_op.stage = OperandStage.reduce
             new_op.reduce_ordinal = idx
-            new_op.n_reducers = n_reducers
+            new_op.n_reducer = n_reducer
             new_op.chunk_shape = in_sample.chunk_shape
-            new_op.n_estimators = op.n_estimators // n_reducers
+            new_op.n_estimators = op.n_estimators // n_reducer
             if remain_reducers:
                 remain_reducers -= 1
                 new_op.n_estimators += 1
@@ -472,14 +472,14 @@ class BaggingSample(LearnShuffle, LearnOperandMixin):
         in_weights_data = ctx[in_weights.key] if op.with_weights else None
         out_samples = op.outputs[0]
 
-        remains = op.n_estimators % op.n_reducers
+        remains = op.n_estimators % op.n_reducer
         reducer_iters = [
-            itertools.repeat(idx, 1 + op.n_estimators // op.n_reducers)
+            itertools.repeat(idx, 1 + op.n_estimators // op.n_reducer)
             for idx in range(remains)
         ]
         reducer_iters += [
-            itertools.repeat(idx, op.n_estimators // op.n_reducers)
-            for idx in range(remains, op.n_reducers)
+            itertools.repeat(idx, op.n_estimators // op.n_reducer)
+            for idx in range(remains, op.n_reducer)
         ]
         reducer_iter = itertools.chain(*reducer_iters)
 
@@ -765,7 +765,7 @@ class BaggingFitOperand(LearnOperand, LearnOperandMixin):
     random_state = RandomStateField("random_state", default=None)
 
     reducer_ratio: float = Float32Field("reducer_ratio")
-    n_reducers: int = Int64Field("n_reducers")
+    n_reducer: int = Int64Field("n_reducer")
 
     labels: TileableType = ReferenceField("labels", default=None)
     weights: TileableType = ReferenceField("weights", default=None)
@@ -804,7 +804,7 @@ class BaggingFitOperand(LearnOperand, LearnOperandMixin):
             bootstrap_features=self.bootstrap_features,
             random_state=self.random_state,
             reducer_ratio=self.reducer_ratio,
-            n_reducers=self.n_reducers,
+            n_reducer=self.n_reducer,
             with_weights=self.weights is not None,
             with_labels=self.labels is not None,
             with_feature_indices=self.with_feature_indices,
@@ -1283,7 +1283,7 @@ class BaseBagging:
             bootstrap_features=self.bootstrap_features,
             random_state=self.random_state,
             reducer_ratio=self.reducers if isinstance(self.reducers, float) else None,
-            n_reducers=self.reducers if isinstance(self.reducers, int) else None,
+            n_reducer=self.reducers if isinstance(self.reducers, int) else None,
         )
         tileables = fit_op(X, y, sample_weight, feature_indices)
         ret = execute(*tileables, session=session, **(run_kwargs or dict()))

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -307,7 +307,7 @@ class LearnShuffle(MapReduceOperand, LearnOperandMixin):
                     ax for j, ax in enumerate(inp_axes) if reduce_sizes[j] > 1
                 )
                 reduce_sizes_ = tuple(rs for rs in reduce_sizes if rs > 1)
-                for c in map_chunks:
+                for ordinal, c in enumerate(map_chunks):
                     chunk_op = LearnShuffle(
                         stage=OperandStage.reduce,
                         output_types=output_types,
@@ -318,6 +318,8 @@ class LearnShuffle(MapReduceOperand, LearnOperandMixin):
                             if reduce_sizes[j] > 1
                         ),
                         reduce_sizes=reduce_sizes_,
+                        reduce_ordinal=ordinal,
+                        n_reducers=len(map_chunks),
                     )
                     params = cls._calc_chunk_params(
                         c, inp_axes, inp.chunk_shape, oup, output_type, chunk_op, False

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -319,7 +319,7 @@ class LearnShuffle(MapReduceOperand, LearnOperandMixin):
                         ),
                         reduce_sizes=reduce_sizes_,
                         reducer_ordinal=ordinal,
-                        n_reducer=len(map_chunks),
+                        n_reducers=len(map_chunks),
                     )
                     params = cls._calc_chunk_params(
                         c, inp_axes, inp.chunk_shape, oup, output_type, chunk_op, False

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -318,7 +318,7 @@ class LearnShuffle(MapReduceOperand, LearnOperandMixin):
                             if reduce_sizes[j] > 1
                         ),
                         reduce_sizes=reduce_sizes_,
-                        reduce_ordinal=ordinal,
+                        reducer_ordinal=ordinal,
                         n_reducer=len(map_chunks),
                     )
                     params = cls._calc_chunk_params(

--- a/mars/learn/utils/shuffle.py
+++ b/mars/learn/utils/shuffle.py
@@ -319,7 +319,7 @@ class LearnShuffle(MapReduceOperand, LearnOperandMixin):
                         ),
                         reduce_sizes=reduce_sizes_,
                         reduce_ordinal=ordinal,
-                        n_reducers=len(map_chunks),
+                        n_reducer=len(map_chunks),
                     )
                     params = cls._calc_chunk_params(
                         c, inp_axes, inp.chunk_shape, oup, output_type, chunk_op, False

--- a/mars/services/task/execution/mars/executor.py
+++ b/mars/services/task/execution/mars/executor.py
@@ -49,7 +49,7 @@ from .stage import TaskStageProcessor
 logger = logging.getLogger(__name__)
 
 
-def _get_n_reducer(subtask: Subtask) -> int:
+def _get_n_reducers(subtask: Subtask) -> int:
     return len(
         [
             r
@@ -377,9 +377,9 @@ class MarsTaskExecutor(TaskExecutor):
             for pre_graph in subtask_graph.iter_predecessors(subtask):
                 for chk in pre_graph.chunk_graph.results:
                     if isinstance(chk.op, ShuffleProxy):
-                        n_reducer = _get_n_reducer(subtask)
+                        n_reducers = _get_n_reducers(subtask)
                         for map_chunk in chk.inputs:
-                            incref_chunk_key_to_counts[map_chunk.key] += n_reducer
+                            incref_chunk_key_to_counts[map_chunk.key] += n_reducers
         result_chunks = stage_processor.chunk_graph.result_chunks
         for c in result_chunks:
             incref_chunk_key_to_counts[c.key] += 1
@@ -461,9 +461,9 @@ class MarsTaskExecutor(TaskExecutor):
             for result_chunk in in_subtask.chunk_graph.results:
                 # for reducer chunk, decref mapper chunks
                 if isinstance(result_chunk.op, ShuffleProxy):
-                    n_reducer = _get_n_reducer(subtask)
+                    n_reducers = _get_n_reducers(subtask)
                     for inp in result_chunk.inputs:
-                        decref_chunk_key_to_counts[inp.key] += n_reducer
+                        decref_chunk_key_to_counts[inp.key] += n_reducers
                 decref_chunk_key_to_counts[result_chunk.key] += 1
         logger.debug(
             "Decref chunks %s when subtask %s finish",

--- a/mars/services/task/supervisor/tests/task_preprocessor.py
+++ b/mars/services/task/supervisor/tests/task_preprocessor.py
@@ -26,7 +26,7 @@ from .....core import (
     register,
     unregister,
 )
-from .....core.operand import Fetch
+from .....core.operand import Fetch, ShuffleProxy
 from .....resource import Resource
 from .....tests.core import _check_args, ObjectCheckMixin
 from .....typing import BandType, ChunkType
@@ -177,4 +177,20 @@ class CheckedTaskPreprocessor(ObjectCheckMixin, TaskPreprocessor):
                 subtask.extra_config["check_keys"] = [
                     c.key for c in subtask.chunk_graph.results if c in results
                 ]
+            proxy_chunks = [
+                c for c in subtask.chunk_graph if isinstance(c.op, ShuffleProxy)
+            ]
+            if proxy_chunks:
+                assert len(proxy_chunks) == 1, proxy_chunks
+                proxy_chunk_key = proxy_chunks[0].key
+                [proxy_chunk] = [c for c in chunk_graph if c.key == proxy_chunk_key]
+                reducer_chunks = chunk_graph.successors(proxy_chunk)
+                n_reducers_list = [c.op.n_reducers for c in reducer_chunks]
+                n_reducers = n_reducers_list[0]
+                reducer_ordinals = [c.op.reducer_ordinal for c in reducer_chunks]
+                assert set(reducer_ordinals).issubset(list(range(n_reducers))), (
+                    reducer_ordinals,
+                    n_reducers,
+                )
+                assert len(set(n_reducers_list)) == 1, n_reducers_list
         return subtask_graph

--- a/mars/services/task/supervisor/tests/task_preprocessor.py
+++ b/mars/services/task/supervisor/tests/task_preprocessor.py
@@ -183,7 +183,7 @@ class CheckedTaskPreprocessor(ObjectCheckMixin, TaskPreprocessor):
             if proxy_chunks:
                 assert len(proxy_chunks) == 1, proxy_chunks
                 proxy_chunk_key = proxy_chunks[0].key
-                [proxy_chunk] = [c for c in chunk_graph if c.key == proxy_chunk_key]
+                proxy_chunk = next(c for c in chunk_graph if c.key == proxy_chunk_key)
                 reducer_chunks = chunk_graph.successors(proxy_chunk)
                 n_reducers_list = [c.op.n_reducers for c in reducer_chunks]
                 n_reducers = n_reducers_list[0]

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -277,7 +277,7 @@ class TensorPSRSOperandMixin(TensorOperandMixin, PSRSOperandMixin):
                 order=op.order,
                 kind=kind,
                 reducer_index=(i,),
-                n_reducers=len(partition_chunks),
+                n_reducer=len(partition_chunks),
                 reducer_ordinal=i,
                 dtype=partition_chunk.dtype,
                 gpu=partition_chunk.op.gpu,
@@ -378,7 +378,7 @@ class TensorPSRSOperandMixin(TensorOperandMixin, PSRSOperandMixin):
                 axis=op.axis,
                 reducer_index=(i,),
                 reducer_ordinal=i,
-                n_reducers=len(align_map_chunks),
+                n_reducer=len(align_map_chunks),
                 dtype=align_map_chunk.dtype,
                 gpu=align_map_chunk.op.gpu,
             )

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -277,6 +277,8 @@ class TensorPSRSOperandMixin(TensorOperandMixin, PSRSOperandMixin):
                 order=op.order,
                 kind=kind,
                 reducer_index=(i,),
+                n_reducers=len(partition_chunks),
+                reducer_ordinal=i,
                 dtype=partition_chunk.dtype,
                 gpu=partition_chunk.op.gpu,
                 need_align=need_align,
@@ -375,6 +377,8 @@ class TensorPSRSOperandMixin(TensorOperandMixin, PSRSOperandMixin):
                 stage=OperandStage.reduce,
                 axis=op.axis,
                 reducer_index=(i,),
+                reducer_ordinal=i,
+                n_reducers=len(align_map_chunks),
                 dtype=align_map_chunk.dtype,
                 gpu=align_map_chunk.op.gpu,
             )

--- a/mars/tensor/base/psrs.py
+++ b/mars/tensor/base/psrs.py
@@ -277,7 +277,7 @@ class TensorPSRSOperandMixin(TensorOperandMixin, PSRSOperandMixin):
                 order=op.order,
                 kind=kind,
                 reducer_index=(i,),
-                n_reducer=len(partition_chunks),
+                n_reducers=len(partition_chunks),
                 reducer_ordinal=i,
                 dtype=partition_chunk.dtype,
                 gpu=partition_chunk.op.gpu,
@@ -378,7 +378,7 @@ class TensorPSRSOperandMixin(TensorOperandMixin, PSRSOperandMixin):
                 axis=op.axis,
                 reducer_index=(i,),
                 reducer_ordinal=i,
-                n_reducer=len(align_map_chunks),
+                n_reducers=len(align_map_chunks),
                 dtype=align_map_chunk.dtype,
                 gpu=align_map_chunk.op.gpu,
             )

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -236,6 +236,8 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
                 axis=op.axis,
                 reducer_index=(i,),
                 reducer_phase="agg",
+                reducer_ordinal=i,
+                n_reducers=aggregate_size,
             )
             kws = cls._gen_kws(op, inp, chunk=True, chunk_index=i)
             chunks = reduce_op.new_chunks(
@@ -254,6 +256,8 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
             for j, cs in enumerate(unique_on_chunk_sizes):
                 chunk_op = TensorUnique(
                     stage=OperandStage.reduce,
+                    reducer_ordinal=j,
+                    n_reducers=len(unique_on_chunk_sizes),
                     dtype=map_inverse_chunks[0].dtype,
                     reducer_index=(j,),
                     reducer_phase="inverse",

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -237,7 +237,7 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
                 reducer_index=(i,),
                 reducer_phase="agg",
                 reducer_ordinal=i,
-                n_reducers=aggregate_size,
+                n_reducer=aggregate_size,
             )
             kws = cls._gen_kws(op, inp, chunk=True, chunk_index=i)
             chunks = reduce_op.new_chunks(
@@ -257,7 +257,7 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
                 chunk_op = TensorUnique(
                     stage=OperandStage.reduce,
                     reducer_ordinal=j,
-                    n_reducers=len(unique_on_chunk_sizes),
+                    n_reducer=len(unique_on_chunk_sizes),
                     dtype=map_inverse_chunks[0].dtype,
                     reducer_index=(j,),
                     reducer_phase="inverse",

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -237,7 +237,7 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
                 reducer_index=(i,),
                 reducer_phase="agg",
                 reducer_ordinal=i,
-                n_reducer=aggregate_size,
+                n_reducers=aggregate_size,
             )
             kws = cls._gen_kws(op, inp, chunk=True, chunk_index=i)
             chunks = reduce_op.new_chunks(
@@ -257,7 +257,7 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
                 chunk_op = TensorUnique(
                     stage=OperandStage.reduce,
                     reducer_ordinal=j,
-                    n_reducer=len(unique_on_chunk_sizes),
+                    n_reducers=len(unique_on_chunk_sizes),
                     dtype=map_inverse_chunks[0].dtype,
                     reducer_index=(j,),
                     reducer_phase="inverse",
@@ -299,7 +299,7 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
         (ar,), device_id, xp = as_same_device(
             [ctx[c.key] for c in op.inputs], device=op.device, ret_extra=True
         )
-        n_reducer = op.aggregate_size
+        n_reducers = op.aggregate_size
 
         with device(device_id):
             results = xp.unique(
@@ -327,13 +327,13 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
             )
             if unique_ar.size > 0:
                 unique_reducers = dense_xp.asarray(
-                    hash_on_axis(unique_ar, op.axis, n_reducer)
+                    hash_on_axis(unique_ar, op.axis, n_reducers)
                 )
             else:
                 unique_reducers = dense_xp.empty_like(unique_ar)
             ind_ar = dense_xp.arange(ar.shape[op.axis])
 
-            for reducer in range(n_reducer):
+            for reducer in range(n_reducers):
                 res = []
                 cond = unique_reducers == reducer
                 # unique

--- a/mars/tensor/indexing/index_lib.py
+++ b/mars/tensor/indexing/index_lib.py
@@ -787,7 +787,7 @@ class TensorFancyIndexHandler(_FancyIndexHandler):
                 axes=axes,
                 dtype=proxy_chunk.dtype,
                 reducer_ordinal=ordinal,
-                n_reducers=len(out_indices),
+                n_reducer=len(out_indices),
             )
             # chunks of fancy indexes on each axis
             kws = [
@@ -934,7 +934,7 @@ class TensorFancyIndexHandler(_FancyIndexHandler):
                     sparse=to_shuffle_chunks[0].issparse(),
                     reducer_index=(next(it),),
                     reducer_ordinal=ordinal,
-                    n_reducers=len(out_indices),
+                    n_reducer=len(out_indices),
                 )
                 reduce_chunk_shape = (
                     other_shape[:to_concat_axis]

--- a/mars/tensor/indexing/index_lib.py
+++ b/mars/tensor/indexing/index_lib.py
@@ -787,7 +787,7 @@ class TensorFancyIndexHandler(_FancyIndexHandler):
                 axes=axes,
                 dtype=proxy_chunk.dtype,
                 reducer_ordinal=ordinal,
-                n_reducer=len(out_indices),
+                n_reducers=len(out_indices),
             )
             # chunks of fancy indexes on each axis
             kws = [
@@ -934,7 +934,7 @@ class TensorFancyIndexHandler(_FancyIndexHandler):
                     sparse=to_shuffle_chunks[0].issparse(),
                     reducer_index=(next(it),),
                     reducer_ordinal=ordinal,
-                    n_reducer=len(out_indices),
+                    n_reducers=len(out_indices),
                 )
                 reduce_chunk_shape = (
                     other_shape[:to_concat_axis]

--- a/mars/tensor/indexing/setitem.py
+++ b/mars/tensor/indexing/setitem.py
@@ -162,7 +162,7 @@ class TensorIndexSetValue(TensorMapReduceOperand, TensorOperandMixin):
             )
             reducer_op = TensorIndexSetValue(
                 stage=OperandStage.reduce,
-                n_reducer=len(inp.chunks),
+                n_reducers=len(inp.chunks),
                 reducer_ordinal=ordinal,
                 dtype=input_chunk.dtype,
                 shuffle_axes=shuffle_axes,

--- a/mars/tensor/indexing/setitem.py
+++ b/mars/tensor/indexing/setitem.py
@@ -162,7 +162,7 @@ class TensorIndexSetValue(TensorMapReduceOperand, TensorOperandMixin):
             )
             reducer_op = TensorIndexSetValue(
                 stage=OperandStage.reduce,
-                n_reducers=len(inp.chunks),
+                n_reducer=len(inp.chunks),
                 reducer_ordinal=ordinal,
                 dtype=input_chunk.dtype,
                 shuffle_axes=shuffle_axes,

--- a/mars/tensor/indexing/setitem.py
+++ b/mars/tensor/indexing/setitem.py
@@ -155,13 +155,15 @@ class TensorIndexSetValue(TensorMapReduceOperand, TensorOperandMixin):
 
         reducer_chunks = []
         offsets_on_axis = [np.cumsum([0] + list(split)) for split in input_nsplits]
-        for input_chunk in inp.chunks:
+        for ordinal, input_chunk in enumerate(inp.chunks):
             chunk_offsets = tuple(
                 offsets_on_axis[axis][input_chunk.index[axis]]
                 for axis in range(len(inp.shape))
             )
             reducer_op = TensorIndexSetValue(
                 stage=OperandStage.reduce,
+                n_reducers=len(inp.chunks),
+                reducer_ordinal=ordinal,
                 dtype=input_chunk.dtype,
                 shuffle_axes=shuffle_axes,
                 chunk_offsets=chunk_offsets,

--- a/mars/tensor/random/permutation.py
+++ b/mars/tensor/random/permutation.py
@@ -109,9 +109,11 @@ class TensorPermutation(TensorRandomMapReduceOperand, TensorOperandMixin):
                 dtype=out_tensor.dtype, _tensor_keys=[in_tensor.key]
             ).new_chunk(map_chunks, shape=())
 
-            for c in map_chunks:
+            for ordinal, c in enumerate(map_chunks):
                 chunk_op = TensorPermutation(
                     stage=OperandStage.reduce,
+                    n_reducers=len(map_chunks),
+                    reducer_ordinal=ordinal,
                     seed=reduce_seeds[c.index[op.axis]],
                     axis=op.axis,
                 )

--- a/mars/tensor/random/permutation.py
+++ b/mars/tensor/random/permutation.py
@@ -112,7 +112,7 @@ class TensorPermutation(TensorRandomMapReduceOperand, TensorOperandMixin):
             for ordinal, c in enumerate(map_chunks):
                 chunk_op = TensorPermutation(
                     stage=OperandStage.reduce,
-                    n_reducers=len(map_chunks),
+                    n_reducer=len(map_chunks),
                     reducer_ordinal=ordinal,
                     seed=reduce_seeds[c.index[op.axis]],
                     axis=op.axis,

--- a/mars/tensor/random/permutation.py
+++ b/mars/tensor/random/permutation.py
@@ -112,7 +112,7 @@ class TensorPermutation(TensorRandomMapReduceOperand, TensorOperandMixin):
             for ordinal, c in enumerate(map_chunks):
                 chunk_op = TensorPermutation(
                     stage=OperandStage.reduce,
-                    n_reducer=len(map_chunks),
+                    n_reducers=len(map_chunks),
                     reducer_ordinal=ordinal,
                     seed=reduce_seeds[c.index[op.axis]],
                     axis=op.axis,

--- a/mars/tensor/reshape/reshape.py
+++ b/mars/tensor/reshape/reshape.py
@@ -255,15 +255,18 @@ class TensorReshape(TensorMapReduceOperand, TensorOperandMixin):
             zip(itertools.product(*out_nsplits), itertools.product(*chunk_size_idxes))
         )
         for ordinal, (chunk_shape, chunk_idx) in enumerate(out_indices):
-            chunk_op = TensorReshape(stage=OperandStage.reduce, dtype=tensor.dtype)
+            chunk_op = TensorReshape(
+                stage=OperandStage.reduce,
+                dtype=tensor.dtype,
+                reducer_ordinal=ordinal,
+                n_reducer=len(out_indices),
+            )
             shuffle_outputs.append(
                 chunk_op.new_chunk(
                     [proxy_chunk],
                     shape=chunk_shape,
                     order=tensor.order,
                     index=chunk_idx,
-                    reducer_ordinal=ordinal,
-                    n_reducers=len(out_indices),
                 )
             )
 

--- a/mars/tensor/reshape/reshape.py
+++ b/mars/tensor/reshape/reshape.py
@@ -259,7 +259,7 @@ class TensorReshape(TensorMapReduceOperand, TensorOperandMixin):
                 stage=OperandStage.reduce,
                 dtype=tensor.dtype,
                 reducer_ordinal=ordinal,
-                n_reducer=len(out_indices),
+                n_reducers=len(out_indices),
             )
             shuffle_outputs.append(
                 chunk_op.new_chunk(

--- a/mars/tensor/reshape/reshape.py
+++ b/mars/tensor/reshape/reshape.py
@@ -251,9 +251,10 @@ class TensorReshape(TensorMapReduceOperand, TensorOperandMixin):
             dtype=in_tensor.dtype, _tensor_keys=[in_tensor.op.key]
         ).new_chunk(shuffle_inputs, shape=())
 
-        for chunk_shape, chunk_idx in zip(
-            itertools.product(*out_nsplits), itertools.product(*chunk_size_idxes)
-        ):
+        out_indices = list(
+            zip(itertools.product(*out_nsplits), itertools.product(*chunk_size_idxes))
+        )
+        for ordinal, (chunk_shape, chunk_idx) in enumerate(out_indices):
             chunk_op = TensorReshape(stage=OperandStage.reduce, dtype=tensor.dtype)
             shuffle_outputs.append(
                 chunk_op.new_chunk(
@@ -261,6 +262,8 @@ class TensorReshape(TensorMapReduceOperand, TensorOperandMixin):
                     shape=chunk_shape,
                     order=tensor.order,
                     index=chunk_idx,
+                    reducer_ordinal=ordinal,
+                    n_reducers=len(out_indices),
                 )
             )
 

--- a/mars/tensor/spatial/distance/pdist.py
+++ b/mars/tensor/spatial/distance/pdist.py
@@ -265,7 +265,7 @@ class TensorPdist(TensorMapReduceOperand, TensorOperandMixin):
                 stage=OperandStage.reduce,
                 dtype=out_tensor.dtype,
                 reducer_ordinal=p,
-                n_reducer=aggregate_size,
+                n_reducers=aggregate_size,
             )
             reduce_chunk = reduce_chunk_op.new_chunk(
                 [proxy_chunk], shape=(out_sizes[p],), order=out_tensor.order, index=(p,)

--- a/mars/tensor/spatial/distance/pdist.py
+++ b/mars/tensor/spatial/distance/pdist.py
@@ -262,7 +262,10 @@ class TensorPdist(TensorMapReduceOperand, TensorOperandMixin):
         reduce_chunks = []
         for p in range(aggregate_size):
             reduce_chunk_op = TensorPdist(
-                stage=OperandStage.reduce, dtype=out_tensor.dtype
+                stage=OperandStage.reduce,
+                dtype=out_tensor.dtype,
+                reducer_ordinal=p,
+                n_reducers=aggregate_size,
             )
             reduce_chunk = reduce_chunk_op.new_chunk(
                 [proxy_chunk], shape=(out_sizes[p],), order=out_tensor.order, index=(p,)

--- a/mars/tensor/spatial/distance/pdist.py
+++ b/mars/tensor/spatial/distance/pdist.py
@@ -265,7 +265,7 @@ class TensorPdist(TensorMapReduceOperand, TensorOperandMixin):
                 stage=OperandStage.reduce,
                 dtype=out_tensor.dtype,
                 reducer_ordinal=p,
-                n_reducers=aggregate_size,
+                n_reducer=aggregate_size,
             )
             reduce_chunk = reduce_chunk_op.new_chunk(
                 [proxy_chunk], shape=(out_sizes[p],), order=out_tensor.order, index=(p,)

--- a/mars/tensor/spatial/distance/squareform.py
+++ b/mars/tensor/spatial/distance/squareform.py
@@ -233,7 +233,7 @@ class TensorSquareform(TensorMapReduceOperand, TensorOperandMixin):
                 stage=OperandStage.reduce,
                 dtype=out.dtype,
                 reducer_ordinal=ordinal,
-                n_reducer=len(out_indices),
+                n_reducers=len(out_indices),
             )
             reduce_chunk = reduce_chunk_op.new_chunk(
                 [proxy_chunk], shape=out_shape, index=out_idx, order=out.order

--- a/mars/tensor/spatial/distance/squareform.py
+++ b/mars/tensor/spatial/distance/squareform.py
@@ -225,10 +225,15 @@ class TensorSquareform(TensorMapReduceOperand, TensorOperandMixin):
 
         reduce_chunks = []
         out_shape_iter = itertools.product(*chunk_size)
-        out_idx_iter = itertools.product(*(range(len(cs)) for cs in chunk_size))
-        for out_idx, out_shape in zip(out_idx_iter, out_shape_iter):
+        out_indices = list(itertools.product(*(range(len(cs)) for cs in chunk_size)))
+        for ordinal, (out_idx, out_shape) in enumerate(
+            zip(out_indices, out_shape_iter)
+        ):
             reduce_chunk_op = TensorSquareform(
-                stage=OperandStage.reduce, dtype=out.dtype
+                stage=OperandStage.reduce,
+                dtype=out.dtype,
+                reducer_ordinal=ordinal,
+                n_reducers=len(out_indices),
             )
             reduce_chunk = reduce_chunk_op.new_chunk(
                 [proxy_chunk], shape=out_shape, index=out_idx, order=out.order

--- a/mars/tensor/spatial/distance/squareform.py
+++ b/mars/tensor/spatial/distance/squareform.py
@@ -233,7 +233,7 @@ class TensorSquareform(TensorMapReduceOperand, TensorOperandMixin):
                 stage=OperandStage.reduce,
                 dtype=out.dtype,
                 reducer_ordinal=ordinal,
-                n_reducers=len(out_indices),
+                n_reducer=len(out_indices),
             )
             reduce_chunk = reduce_chunk_op.new_chunk(
                 [proxy_chunk], shape=out_shape, index=out_idx, order=out.order

--- a/mars/tensor/statistics/bincount.py
+++ b/mars/tensor/statistics/bincount.py
@@ -135,7 +135,7 @@ class TensorBinCount(TensorMapReduceOperand, TensorOperandMixin):
             new_op = op.copy().reset_key()
             new_op.stage = OperandStage.reduce
             new_op.reducer_ordinal = chunk_idx
-            new_op.n_reducer = chunk_count
+            new_op.n_reducers = chunk_count
             new_op.chunk_count = chunk_count
             new_op.tileable_right_bound = tileable_right_bound
 

--- a/mars/tensor/statistics/bincount.py
+++ b/mars/tensor/statistics/bincount.py
@@ -135,7 +135,7 @@ class TensorBinCount(TensorMapReduceOperand, TensorOperandMixin):
             new_op = op.copy().reset_key()
             new_op.stage = OperandStage.reduce
             new_op.reducer_ordinal = chunk_idx
-            new_op.n_reducers = chunk_count
+            new_op.n_reducer = chunk_count
             new_op.chunk_count = chunk_count
             new_op.tileable_right_bound = tileable_right_bound
 

--- a/mars/tensor/statistics/bincount.py
+++ b/mars/tensor/statistics/bincount.py
@@ -134,6 +134,8 @@ class TensorBinCount(TensorMapReduceOperand, TensorOperandMixin):
 
             new_op = op.copy().reset_key()
             new_op.stage = OperandStage.reduce
+            new_op.reducer_ordinal = chunk_idx
+            new_op.n_reducers = chunk_count
             new_op.chunk_count = chunk_count
             new_op.tileable_right_bound = tileable_right_bound
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR add `n_reducers` and `reducer_ordinal` to all shuffle operands, which enable further meta and scheduling optimization for shuffle in future.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/mars-project/meps/pull/2
#3054 
#3040
#2916

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
