### PR TITLE
[Ray] Implements get_total_n_cpu for Ray execution context

### DIFF
--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -1928,6 +1928,7 @@ def test_cartesian_chunk_execution(setup):
     )
 
 
+@pytest.mark.ray_dag
 def test_rebalance_execution(setup):
     raw = pd.DataFrame(np.random.rand(10, 3), columns=list("abc"))
     df = from_pandas_df(raw)

--- a/mars/services/task/execution/api.py
+++ b/mars/services/task/execution/api.py
@@ -93,6 +93,7 @@ class ExecutionConfig:
         else:
             name = execution_config.setdefault("backend", "mars")
         config_cls = _name_to_config_cls[name]
+        execution_config.setdefault(name, {})
         return config_cls(execution_config)
 
     @classmethod

--- a/mars/services/task/execution/mars/config.py
+++ b/mars/services/task/execution/mars/config.py
@@ -22,5 +22,9 @@ from ..utils import get_band_resources_from_config
 class MarsExecutionConfig(ExecutionConfig):
     name = "mars"
 
+    def __init__(self, execution_config: Dict):
+        super().__init__(execution_config)
+        self._mars_execution_config = execution_config[self.backend]
+
     def get_deploy_band_resources(self) -> List[Dict[str, Resource]]:
-        return get_band_resources_from_config(self._execution_config)
+        return get_band_resources_from_config(self._mars_execution_config)

--- a/mars/services/task/execution/mars/executor.py
+++ b/mars/services/task/execution/mars/executor.py
@@ -41,7 +41,8 @@ from ....meta.api import MetaAPI
 from ....scheduling import SchedulingAPI
 from ....subtask import Subtask, SubtaskResult, SubtaskStatus, SubtaskGraph
 from ...core import Task
-from ..api import ExecutionConfig, TaskExecutor, register_executor_cls
+from ..api import TaskExecutor, register_executor_cls
+from .config import MarsExecutionConfig
 from .resource import ResourceEvaluator
 from .stage import TaskStageProcessor
 
@@ -68,7 +69,7 @@ class MarsTaskExecutor(TaskExecutor):
 
     def __init__(
         self,
-        config: ExecutionConfig,
+        config: MarsExecutionConfig,
         task: Task,
         tile_context: TileContext,
         cluster_api: ClusterAPI,
@@ -103,14 +104,14 @@ class MarsTaskExecutor(TaskExecutor):
     @classmethod
     async def create(
         cls,
-        config: ExecutionConfig,
+        config: MarsExecutionConfig,
         *,
         session_id: str,
         address: str,
         task: Task,
         tile_context: TileContext,
         **kwargs,
-    ) -> "TaskExecutor":
+    ) -> "MarsTaskExecutor":
         assert (
             len(kwargs) == 0
         ), f"Unexpected kwargs for {cls.__name__}.create: {kwargs}"

--- a/mars/services/task/execution/ray/config.py
+++ b/mars/services/task/execution/ray/config.py
@@ -28,9 +28,6 @@ class RayExecutionConfig(ExecutionConfig):
 
     def __init__(self, execution_config: Dict):
         super().__init__(execution_config)
-        self._subtask_max_retries = self._execution_config.get("ray", {}).get(
-            "subtask_max_retries", DEFAULT_SUBTASK_MAX_RETRIES
-        )
 
     def get_band_resources(self):
         """
@@ -42,6 +39,13 @@ class RayExecutionConfig(ExecutionConfig):
     def get_deploy_band_resources(self) -> List[Dict[str, Resource]]:
         return []
 
-    @property
-    def subtask_max_retries(self):
-        return self._subtask_max_retries
+    def get_subtask_max_retries(self):
+        return self._execution_config[self.backend].get(
+            "subtask_max_retries", DEFAULT_SUBTASK_MAX_RETRIES
+        )
+
+    def get_n_cpu(self):
+        return self._execution_config[self.backend]["n_cpu"]
+
+    def get_n_worker(self):
+        return self._execution_config[self.backend]["n_worker"]

--- a/mars/services/task/execution/ray/config.py
+++ b/mars/services/task/execution/ray/config.py
@@ -28,24 +28,25 @@ class RayExecutionConfig(ExecutionConfig):
 
     def __init__(self, execution_config: Dict):
         super().__init__(execution_config)
+        self._ray_execution_config = execution_config[self.backend]
 
     def get_band_resources(self):
         """
         Get the band resources from config for generating ray virtual
         resources.
         """
-        return get_band_resources_from_config(self._execution_config)
+        return get_band_resources_from_config(self._ray_execution_config)
 
     def get_deploy_band_resources(self) -> List[Dict[str, Resource]]:
         return []
 
     def get_subtask_max_retries(self):
-        return self._execution_config[self.backend].get(
+        return self._ray_execution_config.get(
             "subtask_max_retries", DEFAULT_SUBTASK_MAX_RETRIES
         )
 
     def get_n_cpu(self):
-        return self._execution_config[self.backend]["n_cpu"]
+        return self._ray_execution_config["n_cpu"]
 
     def get_n_worker(self):
-        return self._execution_config[self.backend]["n_worker"]
+        return self._ray_execution_config["n_worker"]

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -44,10 +44,10 @@ from ....subtask.utils import iter_input_data_keys, iter_output_data
 from ...core import Task
 from ..api import (
     TaskExecutor,
-    ExecutionConfig,
     ExecutionChunkResult,
     register_executor_cls,
 )
+from .config import RayExecutionConfig
 from .context import (
     RayExecutionContext,
     RayExecutionWorkerContext,
@@ -131,7 +131,7 @@ class RayTaskExecutor(TaskExecutor):
 
     def __init__(
         self,
-        config: ExecutionConfig,
+        config: RayExecutionConfig,
         task: Task,
         tile_context: TileContext,
         task_context: Dict[str, "ray.ObjectRef"],
@@ -163,14 +163,14 @@ class RayTaskExecutor(TaskExecutor):
     @classmethod
     async def create(
         cls,
-        config: ExecutionConfig,
+        config: RayExecutionConfig,
         *,
         session_id: str,
         address: str,
         task: Task,
         tile_context: TileContext,
         **kwargs,
-    ) -> "TaskExecutor":
+    ) -> "RayTaskExecutor":
         lifecycle_api, meta_api = await cls._get_apis(session_id, address)
         task_state_actor = (
             ray.remote(RayTaskState)
@@ -180,7 +180,12 @@ class RayTaskExecutor(TaskExecutor):
         task_context = {}
         task_chunks_meta = {}
         await cls._init_context(
-            task_context, task_chunks_meta, task_state_actor, session_id, address
+            config,
+            task_context,
+            task_chunks_meta,
+            task_state_actor,
+            session_id,
+            address,
         )
         return cls(
             config,
@@ -232,6 +237,7 @@ class RayTaskExecutor(TaskExecutor):
     @classmethod
     async def _init_context(
         cls,
+        config: RayExecutionConfig,
         task_context: Dict[str, "ray.ObjectRef"],
         task_chunks_meta: Dict[str, _RayChunkMeta],
         task_state_actor: "ray.actor.ActorHandle",
@@ -240,6 +246,7 @@ class RayTaskExecutor(TaskExecutor):
     ):
         loop = asyncio.get_running_loop()
         context = RayExecutionContext(
+            config,
             task_context,
             task_chunks_meta,
             task_state_actor,
@@ -275,6 +282,7 @@ class RayTaskExecutor(TaskExecutor):
             for chunk in chunk_graph.result_chunks
             if not isinstance(chunk.op, Fetch)
         }
+        subtask_max_retries = self._config.get_subtask_max_retries()
         for subtask in subtask_graph.topological_iter():
             subtask_chunk_graph = subtask.chunk_graph
             key_to_input = await self._load_subtask_inputs(
@@ -283,11 +291,9 @@ class RayTaskExecutor(TaskExecutor):
             output_keys = self._get_subtask_output_keys(subtask_chunk_graph)
             output_meta_keys = result_meta_keys & output_keys
             output_count = len(output_keys) + bool(output_meta_keys)
-            subtask_max_retries = (
-                self._config.subtask_max_retries if subtask.retryable else 0
-            )
+            max_retries = subtask_max_retries if subtask.retryable else 0
             output_object_refs = self._ray_executor.options(
-                num_returns=output_count, max_retries=subtask_max_retries
+                num_returns=output_count, max_retries=max_retries
             ).remote(
                 subtask.task_id,
                 subtask.subtask_id,

--- a/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
+++ b/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
@@ -195,7 +195,8 @@ def test_get_chunks_result(ray_start_regular_shared2):
         pass
 
     with mock.patch.object(ThreadedServiceContext, "__init__", new=fake_init):
-        context = RayExecutionContext(None, {"abc": o}, {}, None)
+        config = RayExecutionConfig.from_execution_config({"backend": "mars"})
+        context = RayExecutionContext(config, {"abc": o}, {}, None)
         r = context.get_chunks_result(["abc"])
         assert r == [value]
 

--- a/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
+++ b/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
@@ -195,7 +195,7 @@ def test_get_chunks_result(ray_start_regular_shared2):
         pass
 
     with mock.patch.object(ThreadedServiceContext, "__init__", new=fake_init):
-        context = RayExecutionContext({"abc": o}, {}, None)
+        context = RayExecutionContext(None, {"abc": o}, {}, None)
         r = context.get_chunks_result(["abc"])
         assert r == [value]
 

--- a/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
+++ b/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
@@ -66,9 +66,9 @@ class MockRayTaskExecutor(RayTaskExecutor):
 
 def test_ray_executor_destroy():
     task = Task("mock_task", "mock_session")
-    config = RayExecutionConfig.from_execution_config({"backend": "mars"})
+    mock_config = RayExecutionConfig.from_execution_config({"backend": "ray"})
     executor = MockRayTaskExecutor(
-        config=config,
+        config=mock_config,
         task=task,
         tile_context=TileContext(),
         task_context={},
@@ -195,8 +195,8 @@ def test_get_chunks_result(ray_start_regular_shared2):
         pass
 
     with mock.patch.object(ThreadedServiceContext, "__init__", new=fake_init):
-        config = RayExecutionConfig.from_execution_config({"backend": "mars"})
-        context = RayExecutionContext(config, {"abc": o}, {}, None)
+        mock_config = RayExecutionConfig.from_execution_config({"backend": "ray"})
+        context = RayExecutionContext(mock_config, {"abc": o}, {}, None)
         r = context.get_chunks_result(["abc"])
         assert r == [value]
 

--- a/mars/services/task/execution/utils.py
+++ b/mars/services/task/execution/utils.py
@@ -17,9 +17,10 @@ from typing import List, Dict
 from ....resource import Resource
 
 
-def get_band_resources_from_config(execution_config: Dict) -> List[Dict[str, Resource]]:
-    backend = execution_config["backend"]
-    config = execution_config[backend]
+def get_band_resources_from_config(
+    backend_execution_config: Dict,
+) -> List[Dict[str, Resource]]:
+    config = backend_execution_config
     n_worker: int = config["n_worker"]
     n_cpu: int = config["n_cpu"]
     mem_bytes: int = config["mem_bytes"]

--- a/mars/tensor/base/tests/test_base_execution.py
+++ b/mars/tensor/base/tests/test_base_execution.py
@@ -1780,6 +1780,7 @@ def test_shape(setup):
     assert result == expected
 
 
+@pytest.mark.ray_dag
 def test_rebalance_execution(setup):
     session = setup
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

- [x] Implements `get_total_n_cpu` for Ray execution context.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/mars-project/mars/issues/2893

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
