### PR TITLE
[BACKPORT] Shuffle both sides at the same time for `md.merge` (#3041)

### DIFF
--- a/mars/dataframe/merge/tests/test_merge.py
+++ b/mars/dataframe/merge/tests/test_merge.py
@@ -54,16 +54,16 @@ def test_merge():
             assert left.op.stage == OperandStage.reduce
             assert isinstance(right.op, DataFrameMergeAlign)
             assert right.op.stage == OperandStage.reduce
-            assert len(left.inputs[0].inputs) == 2
-            assert len(right.inputs[0].inputs) == 2
-            for lchunk in left.inputs[0].inputs:
+            assert len(left.inputs[0].inputs) == 4
+            assert len(right.inputs[0].inputs) == 4
+            for lchunk in left.inputs[0].inputs[:2]:
                 assert isinstance(lchunk.op, DataFrameMergeAlign)
                 assert lchunk.op.stage == OperandStage.map
                 assert lchunk.op.index_shuffle_size == 2
                 assert lchunk.op.shuffle_on == kw.get("on", None) or kw.get(
                     "left_on", None
                 )
-            for rchunk in right.inputs[0].inputs:
+            for rchunk in right.inputs[0].inputs[2:]:
                 assert isinstance(rchunk.op, DataFrameMergeAlign)
                 assert rchunk.op.stage == OperandStage.map
                 assert rchunk.op.index_shuffle_size == 2
@@ -104,8 +104,8 @@ def test_join():
             assert left.op.stage == OperandStage.reduce
             assert isinstance(right.op, DataFrameMergeAlign)
             assert right.op.stage == OperandStage.reduce
-            assert len(left.inputs[0].inputs) == 2
-            assert len(right.inputs[0].inputs) == 3
+            assert len(left.inputs[0].inputs) == 5
+            assert len(right.inputs[0].inputs) == 5
             for lchunk in left.inputs[0].inputs:
                 assert isinstance(lchunk.op, DataFrameMergeAlign)
                 assert lchunk.op.stage == OperandStage.map
@@ -152,14 +152,14 @@ def test_join_on():
             assert left.op.stage == OperandStage.reduce
             assert isinstance(right.op, DataFrameMergeAlign)
             assert right.op.stage == OperandStage.reduce
-            assert len(left.inputs[0].inputs) == 2
-            assert len(right.inputs[0].inputs) == 3
-            for lchunk in left.inputs[0].inputs:
+            assert len(left.inputs[0].inputs) == 5
+            assert len(right.inputs[0].inputs) == 5
+            for lchunk in left.inputs[0].inputs[:2]:
                 assert isinstance(lchunk.op, DataFrameMergeAlign)
                 assert lchunk.op.stage == OperandStage.map
                 assert lchunk.op.index_shuffle_size == 3
                 assert lchunk.op.shuffle_on == kw.get("on", None)
-            for rchunk in right.inputs[0].inputs:
+            for rchunk in right.inputs[0].inputs[2:]:
                 assert isinstance(rchunk.op, DataFrameMergeAlign)
                 assert rchunk.op.stage == OperandStage.map
                 assert rchunk.op.index_shuffle_size == 3


### PR DESCRIPTION
Backport of #3041 