### PR TITLE
[shuffle] Make shuffle mapper outputs deterministic

### DIFF
--- a/mars/tensor/reshape/reshape.py
+++ b/mars/tensor/reshape/reshape.py
@@ -485,7 +485,7 @@ class TensorReshape(TensorMapReduceOperand, TensorOperandMixin):
                 chunk.shape, dtype=chunk.dtype, order=chunk.order.value
             )
         for data_tuple in op.iter_mapper_data(ctx, skip_none=True):
-            if data_tuple is None:
+            if data_tuple is None:  # pragma: no cover
                 # skip missing partition data
                 continue
             result_array[data_tuple[:-1]] = data_tuple[-1]

--- a/mars/tensor/reshape/reshape.py
+++ b/mars/tensor/reshape/reshape.py
@@ -449,6 +449,7 @@ class TensorReshape(TensorMapReduceOperand, TensorOperandMixin):
 
         logger.debug("Reshape mapper: splitting for %s", chunk.key)
 
+        mapper_outputs = {}
         for t in np.unique(target):
             data_slice = slice(
                 np.searchsorted(target, t), np.searchsorted(target, t, "right")
@@ -463,7 +464,16 @@ class TensorReshape(TensorMapReduceOperand, TensorOperandMixin):
                 t, target_chunk_idx[idx] = divmod(t, dim_chunk_count)
             target_chunk_idx.reverse()
 
-            ctx[chunk.key, tuple(target_chunk_idx)] = group_indices + (group_data,)
+            mapper_outputs[chunk.key, tuple(target_chunk_idx)] = group_indices + (
+                group_data,
+            )
+
+        # ensure all mapper data are inserted context in order and fill missing partition with None
+        for target_chunk_idx in itertools.product(
+            *[range(dim_chunk_cnt) for dim_chunk_cnt in dim_chunk_counts]
+        ):
+            data_key = chunk.key, tuple(target_chunk_idx)
+            ctx[data_key] = mapper_outputs.get(data_key)
 
     @classmethod
     def _execute_reduce(cls, ctx, op: "TensorReshape"):
@@ -475,6 +485,9 @@ class TensorReshape(TensorMapReduceOperand, TensorOperandMixin):
                 chunk.shape, dtype=chunk.dtype, order=chunk.order.value
             )
         for data_tuple in op.iter_mapper_data(ctx, skip_none=True):
+            if data_tuple is None:
+                # skip missing partition data
+                continue
             result_array[data_tuple[:-1]] = data_tuple[-1]
         ctx[chunk.key] = result_array
 

--- a/mars/tensor/statistics/bincount.py
+++ b/mars/tensor/statistics/bincount.py
@@ -181,6 +181,9 @@ class TensorBinCount(TensorMapReduceOperand, TensorOperandMixin):
             sliced = res.iloc[left_bound:right_bound]
             if len(sliced) > 0:
                 ctx[op.outputs[0].key, (target_idx,)] = sliced
+            else:
+                # ensure all mapper data are inserted context
+                ctx[op.outputs[0].key, (target_idx,)] = None
             left_bound = right_bound
 
     @classmethod


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR make shuffle mapper outputs and order deterministic, so that we can read shuffle data by index instead of data keys in future, which will reduce shuffle meta overhead.

## Related issue number
https://github.com/mars-project/meps/pull/2
https://github.com/mars-project/mars/issues/3054
https://github.com/mars-project/mars/pull/3040
https://github.com/mars-project/mars/issues/2916

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
