### PR TITLE
Unify DataFrameGroupByAgg's tile logic for auto method

### DIFF
--- a/mars/dataframe/groupby/tests/test_groupby.py
+++ b/mars/dataframe/groupby/tests/test_groupby.py
@@ -186,7 +186,7 @@ def test_groupby_auto_on_cluster():
         tiled_mdf = tile(mdf)
         r = mdf.groupby("c2").sum()
         func_infos = DataFrameGroupByAgg._compile_funcs(r.op, mdf)
-        tiled = DataFrameGroupByAgg._tile_auto_on_distributed(
+        tiled = DataFrameGroupByAgg._build_tree_and_shuffle_chunks(
             r.op, tiled_mdf, r, func_infos, tiled_mdf.chunks[:4], [8] * 4
         )[0]
         assert len(tiled.chunks) == 5


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
In #3051, we introduce a new tile strategy for DataFrameGroupByAgg if method is "auto" , it only works for cluster mode. However, it also brings improvements when executing on local, so we remove branch for local and unify them in this PR.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
