### PR TITLE
Call immutable web API only once when previous call blocks

### DIFF
--- a/mars/services/cluster/api/web.py
+++ b/mars/services/cluster/api/web.py
@@ -44,7 +44,7 @@ class ClusterWebAPIHandler(MarsServiceWebAPIHandler):
             res[node_addr] = res_dict
         return res
 
-    @web_api("nodes", method=["get", "post"])
+    @web_api("nodes", method=["get", "post"], cache_blocking=True)
     async def get_nodes_info(self):
         watch = bool(int(self.get_argument("watch", "0")))
         env = bool(int(self.get_argument("env", "0")))
@@ -104,7 +104,7 @@ class ClusterWebAPIHandler(MarsServiceWebAPIHandler):
             result["nodes"] = self._convert_node_dict(nodes)
         self.write(json.dumps(result))
 
-    @web_api("bands", method="get")
+    @web_api("bands", method="get", cache_blocking=True)
     async def get_all_bands(self):
         role_arg = self.get_argument("role", None)
         role = NodeRole(int(role_arg)) if role_arg is not None else None
@@ -135,19 +135,19 @@ class ClusterWebAPIHandler(MarsServiceWebAPIHandler):
                 )
             )
 
-    @web_api("versions", method="get")
+    @web_api("versions", method="get", cache_blocking=True)
     async def get_mars_versions(self):
         cluster_api = await self._get_cluster_api()
         self.write(json.dumps(list(await cluster_api.get_mars_versions())))
 
-    @web_api("pools", method="get")
+    @web_api("pools", method="get", cache_blocking=True)
     async def get_node_pool_configs(self):
         cluster_api = await self._get_cluster_api()
         address = self.get_argument("address", "") or None
         pools = list(await cluster_api.get_node_pool_configs(address))
         self.write(json.dumps({"pools": pools}))
 
-    @web_api("stacks", method="get")
+    @web_api("stacks", method="get", cache_blocking=True)
     async def get_node_thread_stacks(self):
         cluster_api = await self._get_cluster_api()
         address = self.get_argument("address", "") or None

--- a/mars/services/task/api/web.py
+++ b/mars/services/task/api/web.py
@@ -91,7 +91,7 @@ class TaskWebAPIHandler(MarsServiceWebAPIHandler):
         )
         self.write(task_id)
 
-    @web_api("", method="get")
+    @web_api("", method="get", cache_blocking=True)
     async def get_task_results(self, session_id: str):
         progress = bool(int(self.get_argument("progress", "0")))
         oscar_api = await self._get_oscar_task_api(session_id)
@@ -99,14 +99,17 @@ class TaskWebAPIHandler(MarsServiceWebAPIHandler):
         self.write(json.dumps({"tasks": [_json_serial_task_result(r) for r in res]}))
 
     @web_api(
-        "(?P<task_id>[^/]+)", method="get", arg_filter={"action": "fetch_tileables"}
+        "(?P<task_id>[^/]+)",
+        method="get",
+        arg_filter={"action": "fetch_tileables"},
+        cache_blocking=True,
     )
     async def get_fetch_tileables(self, session_id: str, task_id: str):
         oscar_api = await self._get_oscar_task_api(session_id)
         res = await oscar_api.get_fetch_tileables(task_id)
         self.write(serialize_serializable(res))
 
-    @web_api("(?P<task_id>[^/]+)", method="get")
+    @web_api("(?P<task_id>[^/]+)", method="get", cache_blocking=True)
     async def get_task_result(self, session_id: str, task_id: str):
         oscar_api = await self._get_oscar_task_api(session_id)
         res = await oscar_api.get_task_result(task_id)
@@ -116,19 +119,24 @@ class TaskWebAPIHandler(MarsServiceWebAPIHandler):
         "(?P<task_id>[^/]+)/tileable_graph",
         method="get",
         arg_filter={"action": "get_tileable_graph_as_json"},
+        cache_blocking=True,
     )
     async def get_tileable_graph_as_json(self, session_id: str, task_id: str):
         oscar_api = await self._get_oscar_task_api(session_id)
         res = await oscar_api.get_tileable_graph_as_json(task_id)
         self.write(json.dumps(res))
 
-    @web_api("(?P<task_id>[^/]+)/tileable_detail", method="get")
+    @web_api("(?P<task_id>[^/]+)/tileable_detail", method="get", cache_blocking=True)
     async def get_tileable_details(self, session_id: str, task_id: str):
         oscar_api = await self._get_oscar_task_api(session_id)
         res = await oscar_api.get_tileable_details(task_id)
         self.write(json.dumps(res))
 
-    @web_api("(?P<task_id>[^/]+)/(?P<tileable_id>[^/]+)/subtask", method="get")
+    @web_api(
+        "(?P<task_id>[^/]+)/(?P<tileable_id>[^/]+)/subtask",
+        method="get",
+        cache_blocking=True,
+    )
     async def get_tileable_subtasks(
         self, session_id: str, task_id: str, tileable_id: str
     ):
@@ -139,7 +147,12 @@ class TaskWebAPIHandler(MarsServiceWebAPIHandler):
         )
         self.write(json.dumps(res))
 
-    @web_api("(?P<task_id>[^/]+)", method="get", arg_filter={"action": "progress"})
+    @web_api(
+        "(?P<task_id>[^/]+)",
+        method="get",
+        arg_filter={"action": "progress"},
+        cache_blocking=True,
+    )
     async def get_task_progress(self, session_id: str, task_id: str):
         oscar_api = await self._get_oscar_task_api(session_id)
         res = await oscar_api.get_task_progress(task_id)

--- a/mars/services/web/core.py
+++ b/mars/services/web/core.py
@@ -71,6 +71,8 @@ def web_api(
                         func, self, *args, **kwargs
                     )
                 return res
+            except GeneratorExit:
+                raise
             except:  # noqa: E722  # nosec  # pylint: disable=bare-except
                 exc_type, exc, tb = sys.exc_info()
                 err_msg = (

--- a/mars/services/web/core.py
+++ b/mars/services/web/core.py
@@ -64,7 +64,7 @@ def web_api(
             try:
                 if not inspect.iscoroutinefunction(func):
                     return func(self, *args, **kwargs)
-                elif not cache_blocking:
+                elif not cache_blocking or self.request.method.lower() != "get":
                     res = await func(self, *args, **kwargs)
                 else:
                     res = await self._create_or_get_url_future(

--- a/mars/services/web/core.py
+++ b/mars/services/web/core.py
@@ -49,7 +49,10 @@ class _WebApiDef(NamedTuple):
 
 
 def web_api(
-    sub_pattern: str, method: Union[str, List[str]], arg_filter: Optional[Dict] = None
+    sub_pattern: str,
+    method: Union[str, List[str]],
+    arg_filter: Optional[Dict] = None,
+    cache_blocking: bool = False,
 ):
     if not sub_pattern.endswith("$"):  # pragma: no branch
         sub_pattern += "$"
@@ -57,11 +60,16 @@ def web_api(
 
     def wrapper(func):
         @functools.wraps(func)
-        async def wrapped(self, *args, **kwargs):
+        async def wrapped(self: "MarsServiceWebAPIHandler", *args, **kwargs):
             try:
-                res = func(self, *args, **kwargs)
-                if inspect.isawaitable(res):
-                    res = await res
+                if not inspect.iscoroutinefunction(func):
+                    return func(self, *args, **kwargs)
+                elif not cache_blocking:
+                    res = await func(self, *args, **kwargs)
+                else:
+                    res = await self._create_or_get_url_future(
+                        func, self, *args, **kwargs
+                    )
                 return res
             except:  # noqa: E722  # nosec  # pylint: disable=bare-except
                 exc_type, exc, tb = sys.exc_info()
@@ -102,8 +110,9 @@ async def _get_api_by_key(
 
 
 class MarsServiceWebAPIHandler(MarsRequestHandler):
-    _root_pattern = None
-    _method_to_handlers = None
+    _root_pattern: str = None
+    _method_to_handlers: Dict[str, Dict[Callable, _WebApiDef]] = None
+    _uri_to_futures: Dict[str, asyncio.Task] = None
 
     def __init__(self, *args, **kwargs):
         self._collect_services()
@@ -118,6 +127,21 @@ class MarsServiceWebAPIHandler(MarsRequestHandler):
             address=self._supervisor_addr,
             with_key_arg=with_key_arg,
         )
+
+    def _create_or_get_url_future(self, func, *args, **kw):
+        if self._uri_to_futures is None:
+            type(self)._uri_to_futures = dict()
+
+        uri = self.request.uri
+        if uri in self._uri_to_futures:
+            return self._uri_to_futures[uri]
+
+        def _future_remover(_fut):
+            self._uri_to_futures.pop(uri, None)
+
+        task = self._uri_to_futures[uri] = asyncio.create_task(func(*args, **kw))
+        task.add_done_callback(_future_remover)
+        return task
 
     @classmethod
     def _collect_services(cls):
@@ -144,9 +168,7 @@ class MarsServiceWebAPIHandler(MarsRequestHandler):
 
     @functools.lru_cache(100)
     def _route_sub_path(self, http_method: str, sub_path: str):
-        handlers = self._method_to_handlers[
-            http_method.lower()
-        ]  # type: Dict[Callable, _WebApiDef]
+        handlers = self._method_to_handlers[http_method.lower()]
         method, kwargs = None, None
         for handler_method, web_api_def in handlers.items():
             match = web_api_def.sub_pattern_compiled.match(sub_path)


### PR DESCRIPTION
## What do these changes do?

Call immutable web API only once when previous call does not return. This reduces potential call flood for services.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
