### PR TITLE
Simplify router clean up when pools or clusters ends

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,3 +13,4 @@ include mars/services/web/static/*
 global-exclude .DS_Store
 include versioneer.py
 include mars/_version.py
+global-exclude conftest.py

--- a/benchmarks/tpch/gen_data.py
+++ b/benchmarks/tpch/gen_data.py
@@ -26,7 +26,6 @@ import argparse
 import shutil
 import subprocess
 from multiprocessing import Pool, set_start_method
-import pandas as pd
 import pyarrow.parquet as pq
 
 
@@ -43,6 +42,7 @@ from loader import (
 
 # Change location of tpch-dbgen if not in same place as this script
 tpch_dbgen_location = "./tpch-dbgen"
+
 
 # First element is the table single character short-hand understood by dbgen
 # Second element is the number of pieces we want the parquet dataset to have for that table

--- a/benchmarks/tpch/run_queries.py
+++ b/benchmarks/tpch/run_queries.py
@@ -301,7 +301,6 @@ def q03(lineitem, orders, customer):
 
 @tpc_query
 def q04(lineitem, orders):
-    t1 = time.time()
     date1 = md.Timestamp("1993-11-01")
     date2 = md.Timestamp("1993-08-01")
     lsel = lineitem.L_COMMITDATE < lineitem.L_RECEIPTDATE
@@ -617,7 +616,7 @@ def q12(lineitem, orders):
 def q13(customer, orders):
     customer_filtered = customer.loc[:, ["C_CUSTKEY"]]
     orders_filtered = orders[
-        ~orders["O_COMMENT"].str.contains("special[\S|\s]*requests")
+        ~orders["O_COMMENT"].str.contains(r"special[\S|\s]*requests")
     ]
     orders_filtered = orders_filtered.loc[:, ["O_ORDERKEY", "O_CUSTKEY"]]
     c_o_merged = customer_filtered.merge(
@@ -696,7 +695,7 @@ def q16(part, partsupp, supplier):
     )
     total = total.loc[:, ["P_BRAND", "P_TYPE", "P_SIZE", "PS_SUPPKEY"]]
     supplier_filtered = supplier[
-        supplier["S_COMMENT"].str.contains("Customer(\S|\s)*Complaints")
+        supplier["S_COMMENT"].str.contains(r"Customer(\S|\s)*Complaints")
     ]
     supplier_filtered = supplier_filtered.loc[:, ["S_SUPPKEY"]].drop_duplicates()
     # left merge to select only PS_SUPPKEY values not in supplier_filtered

--- a/mars/dataframe/contrib/raydataset/tests/test_mldataset.py
+++ b/mars/dataframe/contrib/raydataset/tests/test_mldataset.py
@@ -20,7 +20,6 @@ import pytest
 from ..... import dataframe as md
 from .....deploy.oscar.ray import new_cluster
 from .....deploy.oscar.session import new_session
-from .....oscar.backends.router import Router
 from .....tests.core import require_ray
 from .....utils import lazy_import
 from ....contrib import raydataset as mdd
@@ -47,11 +46,8 @@ async def create_cluster(request):
         worker_cpu=1,
         worker_mem=256 * 1024**2,
     )
-    try:
-        async with client:
-            yield client
-    finally:
-        Router.set_instance(None)
+    async with client:
+        yield client
 
 
 @require_ray

--- a/mars/dataframe/contrib/raydataset/tests/test_raydataset.py
+++ b/mars/dataframe/contrib/raydataset/tests/test_raydataset.py
@@ -20,7 +20,6 @@ import pytest
 from ..... import dataframe as md
 from .....deploy.oscar.ray import new_cluster
 from .....deploy.oscar.session import new_session
-from .....oscar.backends.router import Router
 from .....tests.core import require_ray
 from .....utils import lazy_import
 from ....contrib import raydataset as mdd
@@ -45,11 +44,8 @@ async def create_cluster(request):
         worker_cpu=1,
         worker_mem=256 * 1024**2,
     )
-    try:
-        async with client:
-            yield client
-    finally:
-        Router.set_instance(None)
+    async with client:
+        yield client
 
 
 @require_ray

--- a/mars/deploy/oscar/local.py
+++ b/mars/deploy/oscar/local.py
@@ -25,6 +25,7 @@ import numpy as np
 from ... import oscar as mo
 from ...core.entrypoints import init_extension_entrypoints
 from ...lib.aio import get_isolation, stop_isolation
+from ...oscar.backends.router import Router
 from ...resource import cpu_count, cuda_count, mem_total
 from ...services import NodeRole
 from ...services.task.execution.api import ExecutionConfig
@@ -128,6 +129,7 @@ async def stop_cluster(cluster: ClusterType):
     isolation = get_isolation()
     coro = cluster.stop()
     await asyncio.wrap_future(asyncio.run_coroutine_threadsafe(coro, isolation.loop))
+    Router.set_instance(None)
 
 
 class LocalCluster:
@@ -287,6 +289,7 @@ class LocalCluster:
         await self._supervisor_pool.stop()
         AbstractSession.reset_default()
         self._exiting_check_task.cancel()
+        Router.set_instance(None)
 
 
 class LocalClient:

--- a/mars/deploy/oscar/ray.py
+++ b/mars/deploy/oscar/ray.py
@@ -29,6 +29,7 @@ from ...oscar.backends.ray.utils import (
     process_address_to_placement,
 )
 from ...oscar.backends.ray.pool import RayPoolState
+from ...oscar.backends.router import Router
 from ...oscar.errors import ReconstructWorkerError
 from ...resource import Resource
 from ...services.cluster.backends.base import (
@@ -569,6 +570,7 @@ class RayCluster:
             finally:
                 AbstractSession.reset_default()
                 RayActorDriver.stop_cluster()
+                Router.set_instance(None)
             self._stopped = True
 
 

--- a/mars/deploy/oscar/tests/test_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_fault_injection.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from .... import dataframe as md
 from .... import tensor as mt
-from ....oscar.backends.router import Router
 from ....oscar.errors import ServerClosed
 from ....remote import spawn
 from ....services.tests.fault_injection_manager import (
@@ -51,11 +50,8 @@ async def fault_cluster(request):
         n_worker=2,
         n_cpu=2,
     )
-    try:
-        async with client:
-            yield client
-    finally:
-        Router.set_instance(None)
+    async with client:
+        yield client
 
 
 async def create_fault_injection_manager(

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -35,7 +35,6 @@ from .... import remote as mr
 from ....config import option_context
 from ....core.context import get_context
 from ....lib.aio import new_isolation
-from ....oscar.backends.router import Router
 from ....storage import StorageLevel
 from ....services.storage import StorageAPI
 from ....tensor.arithmetic.add import TensorAdd
@@ -120,13 +119,10 @@ async def create_cluster(request):
         n_cpu=2,
         use_uvloop=False,
     )
-    try:
-        async with client:
-            if request.param == "default":
-                assert client.session.client is not None
-            yield client, request.param
-    finally:
-        Router.set_instance(None)
+    async with client:
+        if request.param == "default":
+            assert client.session.client is not None
+        yield client, request.param
 
 
 def _assert_storage_cleaned(session_id: str, addr: str, level: StorageLevel):
@@ -649,7 +645,6 @@ def setup_session(request):
             yield session
     finally:
         session.stop_server()
-        Router.set_instance(None)
 
 
 def test_decref(setup_session):
@@ -892,11 +887,8 @@ async def speculative_cluster():
         n_cpu=10,
         use_uvloop=False,
     )
-    try:
-        async with client:
-            yield client
-    finally:
-        Router.set_instance(None)
+    async with client:
+        yield client
 
 
 @pytest.mark.timeout(timeout=500)

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -36,7 +36,6 @@ from ....oscar.backends.ray.utils import (
     process_placement_to_address,
     kill_and_wait,
 )
-from ....oscar.backends.router import Router
 from ....oscar.errors import ReconstructWorkerError
 from ....serialization.ray import register_ray_serializers
 from ....services.cluster import ClusterAPI
@@ -106,11 +105,8 @@ async def create_cluster(request):
         worker_mem=1 * 1024**3,
         config=ray_config,
     )
-    try:
-        async with client:
-            yield client, param
-    finally:
-        Router.set_instance(None)
+    async with client:
+        yield client, param
 
 
 @require_ray

--- a/mars/deploy/oscar/tests/test_ray_dag.py
+++ b/mars/deploy/oscar/tests/test_ray_dag.py
@@ -17,7 +17,6 @@ import os
 
 import pytest
 
-from ....oscar.backends.router import Router
 from ....tests.core import DICT_NOT_EMPTY, require_ray
 from ....utils import lazy_import
 from ..local import new_cluster
@@ -66,12 +65,9 @@ async def create_cluster(request):
         n_cpu=2,
         use_uvloop=False,
     )
-    try:
-        async with client:
-            assert client.session.client is not None
-            yield client, {}
-    finally:
-        Router.set_instance(None)
+    async with client:
+        assert client.session.client is not None
+        yield client, {}
 
 
 @require_ray

--- a/mars/deploy/oscar/tests/test_ray_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_ray_fault_injection.py
@@ -16,7 +16,6 @@ import os
 
 import pytest
 
-from ....oscar.backends.router import Router
 from ....oscar.errors import ServerClosed
 from ....services.tests.fault_injection_manager import (
     FaultInjectionError,
@@ -59,11 +58,8 @@ async def fault_cluster(request):
         worker_mem=1 * 1024**3,
         config=ray_config,
     )
-    try:
-        async with client:
-            yield client
-    finally:
-        Router.set_instance(None)
+    async with client:
+        yield client
 
 
 @require_ray

--- a/mars/deploy/oscar/tests/test_ray_scheduling.py
+++ b/mars/deploy/oscar/tests/test_ray_scheduling.py
@@ -14,7 +14,6 @@
 
 import pytest
 
-from ....oscar.backends.router import Router
 from ....tests.core import require_ray
 from ....utils import lazy_import
 from ..ray import new_cluster
@@ -49,11 +48,8 @@ async def speculative_cluster():
             },
         },
     )
-    try:
-        async with client:
-            yield client
-    finally:
-        Router.set_instance(None)
+    async with client:
+        yield client
 
 
 @pytest.mark.parametrize("ray_large_cluster", [{"num_nodes": 2}], indirect=True)

--- a/mars/oscar/backends/pool.py
+++ b/mars/oscar/backends/pool.py
@@ -1202,6 +1202,10 @@ class MainActorPoolBase(ActorPoolBase):
 
     @implements(AbstractActorPool.stop)
     async def stop(self):
+        global_router = Router.get_instance()
+        if global_router is not None:
+            global_router.remove_router(self._router)
+
         # turn off auto recover to avoid errors
         self._auto_recover = False
         self._stopped.set()

--- a/mars/oscar/backends/router.py
+++ b/mars/oscar/backends/router.py
@@ -65,11 +65,13 @@ class Router:
 
     def set_mapping(self, mapping: Dict[str, str]):
         self._mapping = mapping
+        self._cache_local = threading.local()
 
     def add_router(self, router: "Router"):
         self._curr_external_addresses.extend(router._curr_external_addresses)
         self._local_mapping.update(router._local_mapping)
         self._mapping.update(router._mapping)
+        self._cache_local = threading.local()
 
     def remove_router(self, router: "Router"):
         for external_address in router._curr_external_addresses:
@@ -81,6 +83,7 @@ class Router:
             self._local_mapping.pop(addr, None)
         for addr in router._mapping:
             self._mapping.pop(addr, None)
+        self._cache_local = threading.local()
 
     @property
     def external_address(self):

--- a/mars/oscar/backends/test/tests/test_actor_context.py
+++ b/mars/oscar/backends/test/tests/test_actor_context.py
@@ -18,7 +18,6 @@ import sys
 import pytest
 
 from ..... import oscar as mo
-from ...router import Router
 
 
 class DummyActor(mo.Actor):
@@ -46,12 +45,8 @@ async def actor_pool_context():
     pool = await mo.create_actor_pool(
         "test://127.0.0.1", n_process=2, subprocess_start_method=start_method
     )
-    await pool.start()
-    try:
+    async with pool:
         yield pool
-    finally:
-        await pool.stop()
-        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/cluster/tests/test_api.py
+++ b/mars/services/cluster/tests/test_api.py
@@ -17,7 +17,6 @@ import asyncio
 import pytest
 
 from .... import oscar as mo
-from ....oscar.backends.router import Router
 from ....utils import get_next_port
 from ... import NodeRole
 from ...web.supervisor import WebSupervisorService
@@ -29,12 +28,8 @@ from ..core import NodeStatus
 @pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
-    await pool.start()
-    try:
+    async with pool:
         yield pool
-    finally:
-        await pool.stop()
-        Router.set_instance(None)
 
 
 class TestActor(mo.Actor):

--- a/mars/services/cluster/tests/test_locator.py
+++ b/mars/services/cluster/tests/test_locator.py
@@ -20,7 +20,6 @@ from typing import List
 import pytest
 
 from .... import oscar as mo
-from ....oscar.backends.router import Router
 from ....utils import Timer
 from ....tests.core import flaky
 from ..core import NodeRole, NodeStatus
@@ -56,19 +55,13 @@ class MockNodeInfoCollectorActor(mo.Actor):
 @pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
-    await pool.start()
-
-    await mo.create_actor(
-        MockNodeInfoCollectorActor,
-        uid=NodeInfoCollectorActor.default_uid(),
-        address=pool.external_address,
-    )
-
-    try:
+    async with pool:
+        await mo.create_actor(
+            MockNodeInfoCollectorActor,
+            uid=NodeInfoCollectorActor.default_uid(),
+            address=pool.external_address,
+        )
         yield pool
-    finally:
-        await pool.stop()
-        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/cluster/tests/test_procinfo.py
+++ b/mars/services/cluster/tests/test_procinfo.py
@@ -15,7 +15,6 @@
 import pytest
 
 from .... import oscar as mo
-from ....oscar.backends.router import Router
 from ..procinfo import ProcessInfoManagerActor
 
 
@@ -24,12 +23,8 @@ async def actor_pool():
     pool = await mo.create_actor_pool(
         "127.0.0.1", n_process=2, labels=["main", "numa-0", "gpu-0"]
     )
-    await pool.start()
-    try:
+    async with pool:
         yield pool
-    finally:
-        await pool.stop()
-        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/cluster/tests/test_service.py
+++ b/mars/services/cluster/tests/test_service.py
@@ -18,7 +18,6 @@ import os
 import pytest
 
 from .... import oscar as mo
-from ....oscar.backends.router import Router
 from ....storage import StorageLevel
 from ... import start_services, stop_services, NodeRole
 from .. import ClusterAPI, WorkerSlotInfo, QuotaInfo, StorageInfo, DiskInfo
@@ -36,7 +35,6 @@ async def actor_pools():
         yield sv_pool, worker_pool
     finally:
         await asyncio.gather(sv_pool.stop(), worker_pool.stop())
-        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/cluster/tests/test_uploader.py
+++ b/mars/services/cluster/tests/test_uploader.py
@@ -17,7 +17,6 @@ import asyncio
 import pytest
 
 from .... import oscar as mo
-from ....oscar.backends.router import Router
 from ... import NodeRole
 from ..supervisor.locator import SupervisorPeerLocatorActor
 from ..supervisor.node_info import NodeInfoCollectorActor
@@ -27,12 +26,8 @@ from ..uploader import NodeInfoUploaderActor
 @pytest.fixture
 async def actor_pool():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
-    await pool.start()
-    try:
+    async with pool:
         yield pool
-    finally:
-        await pool.stop()
-        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/meta/tests/test_service.py
+++ b/mars/services/meta/tests/test_service.py
@@ -26,7 +26,7 @@ async def test_meta_service():
     pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
     worker_pool = await mo.create_actor_pool("127.0.0.1", n_process=0)
 
-    async with pool:
+    async with pool, worker_pool:
         config = {
             "services": ["cluster", "session", "meta"],
             "cluster": {

--- a/mars/services/mutable/tests/test_mutable.py
+++ b/mars/services/mutable/tests/test_mutable.py
@@ -21,7 +21,6 @@ import numpy as np
 
 from ....deploy.oscar.local import new_cluster
 from ....deploy.oscar.session import AsyncSession, SyncSession
-from ....oscar.backends.router import Router
 from ..core import MutableTensor
 from ..utils import normalize_timestamp
 
@@ -32,11 +31,8 @@ _is_windows = sys.platform.lower().startswith("win")
 @pytest.fixture
 async def create_cluster():
     client = await new_cluster(n_worker=2, n_cpu=2, web=True)
-    try:
-        async with client:
-            yield client
-    finally:
-        Router.set_instance(None)
+    async with client:
+        yield client
 
 
 @pytest.mark.skipif(_is_windows, reason="FIXME")

--- a/mars/services/scheduling/supervisor/tests/test_assigner.py
+++ b/mars/services/scheduling/supervisor/tests/test_assigner.py
@@ -18,7 +18,6 @@ import pytest
 
 from ..... import oscar as mo
 from .....core import ChunkGraph
-from .....oscar.backends.router import Router
 from .....tensor.fetch import TensorFetch
 from .....tensor.arithmetic import TensorTreeAdd
 from ....cluster import ClusterAPI
@@ -124,7 +123,6 @@ async def actor_pool(request):
             yield pool, session_id, assigner_ref, cluster_api, meta_api
         finally:
             await mo.destroy_actor(assigner_ref)
-            Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/supervisor/tests/test_globalresource.py
+++ b/mars/services/scheduling/supervisor/tests/test_globalresource.py
@@ -17,7 +17,6 @@ import asyncio
 import pytest
 
 from ..... import oscar as mo
-from .....oscar.backends.router import Router
 from .....resource import Resource
 from ....cluster import ClusterAPI, MockClusterAPI
 from ....session import MockSessionAPI
@@ -44,7 +43,6 @@ async def actor_pool():
         finally:
             await mo.destroy_actor(global_resource_ref)
             await MockClusterAPI.cleanup(pool.external_address)
-            Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/supervisor/tests/test_manager.py
+++ b/mars/services/scheduling/supervisor/tests/test_manager.py
@@ -19,7 +19,6 @@ from typing import List, Tuple, Set
 import pytest
 
 from ..... import oscar as mo
-from .....oscar.backends.router import Router
 from .....typing import BandType
 from ....cluster import MockClusterAPI
 from ....subtask import Subtask, SubtaskResult, SubtaskStatus
@@ -138,7 +137,6 @@ async def actor_pool():
         finally:
             await mo.destroy_actor(slots_ref)
             await MockClusterAPI.cleanup(pool.external_address)
-            Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/supervisor/tests/test_queue_balance.py
+++ b/mars/services/scheduling/supervisor/tests/test_queue_balance.py
@@ -17,7 +17,6 @@ import pytest
 from collections import defaultdict
 from typing import Tuple, List
 from ..... import oscar as mo
-from .....oscar.backends.router import Router
 from .....resource import Resource
 from ....cluster import ClusterAPI
 from ....cluster.core import NodeRole, NodeStatus
@@ -187,7 +186,6 @@ async def actor_pool():
             yield pool, session_id, cluster_api, queueing_ref, slots_ref, manager_ref
         finally:
             await mo.destroy_actor(queueing_ref)
-            Router.set_instance(None)
 
 
 async def _queue_subtasks(num_subtasks, expect_bands, queueing_ref):

--- a/mars/services/scheduling/supervisor/tests/test_queueing.py
+++ b/mars/services/scheduling/supervisor/tests/test_queueing.py
@@ -16,7 +16,6 @@ import pytest
 from typing import Tuple, List
 
 from ..... import oscar as mo
-from .....oscar.backends.router import Router
 from .....resource import Resource
 from ....cluster import MockClusterAPI
 from ....subtask import Subtask
@@ -109,7 +108,6 @@ async def actor_pool():
         finally:
             await mo.destroy_actor(queueing_ref)
             await MockClusterAPI.cleanup(pool.external_address)
-            Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/supervisor/tests/test_speculation.py
+++ b/mars/services/scheduling/supervisor/tests/test_speculation.py
@@ -24,7 +24,6 @@ from ...errors import NoAvailableBand
 from ...supervisor import GlobalResourceManagerActor
 from ..manager import SubtaskScheduleInfo
 from ..speculation import SpeculativeScheduler
-from .....oscar.backends.router import Router
 
 
 class MockSubtaskQueueingActor(mo.Actor):
@@ -76,7 +75,6 @@ async def actor_pool():
         finally:
             await mo.destroy_actor(queue_ref)
             await MockClusterAPI.cleanup(pool.external_address)
-            Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/tests/test_service.py
+++ b/mars/services/scheduling/tests/test_service.py
@@ -24,7 +24,6 @@ from .... import oscar as mo
 from .... import remote as mr
 from .... import tensor as mt
 from ....core.graph import TileableGraph, TileableGraphBuilder, ChunkGraphBuilder
-from ....oscar.backends.router import Router
 from ....resource import Resource
 from ... import start_services, stop_services, NodeRole
 from ...session import SessionAPI
@@ -159,7 +158,6 @@ async def actor_pools():
         )
 
         await asyncio.gather(sv_pool.stop(), worker_pool.stop())
-        Router.set_instance(None)
 
 
 async def _get_subtask_summaries_by_web(sv_pool_address, session_id, task_id=None):

--- a/mars/services/scheduling/worker/tests/test_execution.py
+++ b/mars/services/scheduling/worker/tests/test_execution.py
@@ -33,7 +33,6 @@ from .....core import (
     TileableGraphBuilder,
     OutputType,
 )
-from .....oscar.backends.router import Router
 from .....remote.core import RemoteFunction
 from .....resource import Resource
 from .....tensor.fetch import TensorFetch
@@ -224,7 +223,6 @@ async def actor_pool(request):
             await MockSubtaskAPI.cleanup(pool.external_address)
             await MockClusterAPI.cleanup(pool.external_address)
             await MockMutableAPI.cleanup(session_id, pool.external_address)
-            Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/worker/tests/test_quota.py
+++ b/mars/services/scheduling/worker/tests/test_quota.py
@@ -20,7 +20,6 @@ import time
 import pytest
 
 from ..... import oscar as mo
-from .....oscar.backends.router import Router
 from .....tests.core import mock
 from .....utils import get_next_port
 from ...worker import QuotaActor, MemQuotaActor, BandSlotManagerActor
@@ -49,7 +48,6 @@ async def actor_pool():
         yield pool
     finally:
         await pool.stop()
-        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/scheduling/worker/tests/test_workerslot.py
+++ b/mars/services/scheduling/worker/tests/test_workerslot.py
@@ -24,7 +24,6 @@ import pandas as pd
 
 from ..... import oscar as mo
 from .....oscar import ServerClosed
-from .....oscar.backends.router import Router
 from .....oscar.errors import NoFreeSlot, SlotStateError
 from .....oscar.backends.allocate_strategy import IdleLabel
 from .....resource import Resource
@@ -81,7 +80,6 @@ async def actor_pool(request):
             yield pool, slot_manager_ref
         finally:
             await slot_manager_ref.destroy()
-            Router.set_instance(None)
 
 
 ActorPoolType = Tuple[mo.MainActorPoolType, mo.ActorRefType[BandSlotManagerActor]]

--- a/mars/services/storage/tests/test_service.py
+++ b/mars/services/storage/tests/test_service.py
@@ -20,7 +20,6 @@ import pandas as pd
 import pytest
 
 from .... import oscar as mo
-from ....oscar.backends.router import Router
 from ....resource import Resource
 from ....serialization import AioDeserializer, AioSerializer
 from ....storage import StorageLevel
@@ -54,7 +53,6 @@ async def actor_pools():
         yield worker_pool
     finally:
         await worker_pool.stop()
-        Router.set_instance(None)
 
 
 @pytest.mark.asyncio
@@ -146,7 +144,6 @@ async def actor_pools_with_gpu():
         yield worker_pool
     finally:
         await worker_pool.stop()
-        Router.set_instance(None)
 
 
 @require_cupy

--- a/mars/services/storage/tests/test_spill.py
+++ b/mars/services/storage/tests/test_spill.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 
 from .... import oscar as mo
-from ....oscar.backends.router import Router
 from ....storage import StorageLevel, PlasmaStorage
 from ....utils import calc_data_size
 from ..core import StorageManagerActor, StorageQuotaActor, build_data_info
@@ -58,7 +57,6 @@ async def actor_pool():
         yield worker_pool
     finally:
         await worker_pool.stop()
-        Router.set_instance(None)
 
 
 def _build_storage_config():

--- a/mars/services/storage/tests/test_transfer.py
+++ b/mars/services/storage/tests/test_transfer.py
@@ -22,7 +22,6 @@ import pytest
 
 from .... import oscar as mo
 from ....oscar.backends.allocate_strategy import IdleLabel
-from ....oscar.backends.router import Router
 from ....storage import StorageLevel
 from ..core import DataManagerActor, StorageManagerActor, StorageQuotaActor
 from ..errors import DataNotExist
@@ -57,7 +56,6 @@ async def actor_pools():
     finally:
         await worker_pool_1.stop()
         await worker_pool_2.stop()
-        Router.set_instance(None)
 
 
 @pytest.fixture

--- a/mars/services/subtask/tests/test_service.py
+++ b/mars/services/subtask/tests/test_service.py
@@ -22,7 +22,6 @@ from .... import oscar as mo
 from .... import tensor as mt
 from .... import remote as mr
 from ....core.graph import TileableGraph, TileableGraphBuilder, ChunkGraphBuilder
-from ....oscar.backends.router import Router
 from ....resource import Resource
 from ....utils import Timer
 from ... import start_services, stop_services, NodeRole
@@ -68,7 +67,6 @@ async def actor_pools():
         sv_pool, worker_pool = await asyncio.gather(start_pool(False), start_pool(True))
         yield sv_pool, worker_pool
     finally:
-        Router.set_instance(None)
         await asyncio.gather(sv_pool.stop(), worker_pool.stop())
 
 

--- a/mars/services/subtask/worker/tests/test_subtask.py
+++ b/mars/services/subtask/worker/tests/test_subtask.py
@@ -26,7 +26,6 @@ from ..... import remote as mr
 from .....core import ExecutionError
 from .....core.context import get_context
 from .....core.graph import TileableGraph, TileableGraphBuilder, ChunkGraphBuilder
-from .....oscar.backends.router import Router
 from .....resource import Resource
 from .....utils import Timer
 from ....cluster import MockClusterAPI
@@ -103,7 +102,6 @@ async def actor_pool():
             await MockStorageAPI.cleanup(pool.external_address)
             await MockClusterAPI.cleanup(pool.external_address)
             await MockMutableAPI.cleanup(session_id, pool.external_address)
-            Router.set_instance(None)
 
 
 def _gen_subtask(t, session_id):

--- a/mars/services/task/supervisor/tests/test_task_manager.py
+++ b/mars/services/task/supervisor/tests/test_task_manager.py
@@ -30,7 +30,6 @@ from ..... import tensor as mt
 from .....core import Tileable, TileableGraph, TileableGraphBuilder
 from .....core.operand import Fetch
 from .....oscar.backends.allocate_strategy import MainPool
-from .....oscar.backends.router import Router
 from .....resource import Resource
 from .....storage import StorageLevel
 from .....utils import Timer, merge_chunks
@@ -101,7 +100,6 @@ async def actor_pool(request):
             await MockStorageAPI.cleanup(pool.external_address)
             await MockClusterAPI.cleanup(pool.external_address)
             await MockMutableAPI.cleanup(session_id, pool.external_address)
-            Router.set_instance(None)
 
 
 async def _merge_data(

--- a/mars/services/task/tests/test_service.py
+++ b/mars/services/task/tests/test_service.py
@@ -25,7 +25,6 @@ from .... import remote as mr
 from .... import tensor as mt
 from ....core import TileableGraph, TileableGraphBuilder, TileStatus, recursive_tile
 from ....core.context import get_context
-from ....oscar.backends.router import Router
 from ....resource import Resource
 from ....tensor.core import TensorOrder
 from ....tensor.operands import TensorOperand, TensorOperandMixin
@@ -61,7 +60,6 @@ async def actor_pools():
         yield sv_pool, worker_pool
     finally:
         await asyncio.gather(sv_pool.stop(), worker_pool.stop())
-        Router.set_instance(None)
 
 
 async def _start_services(
@@ -130,7 +128,6 @@ async def start_test_service(actor_pools, request):
         await MockStorageAPI.cleanup(worker_pool.external_address)
         await stop_services(NodeRole.WORKER, config, worker_pool.external_address)
         await stop_services(NodeRole.SUPERVISOR, config, sv_pool.external_address)
-        Router.set_instance(None)
 
 
 class MockTaskProcessor(TaskProcessor):
@@ -161,7 +158,6 @@ async def start_test_service_with_mock(actor_pools, request):
         await MockStorageAPI.cleanup(worker_pool.external_address)
         await stop_services(NodeRole.WORKER, config, worker_pool.external_address)
         await stop_services(NodeRole.SUPERVISOR, config, sv_pool.external_address)
-        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/tests/test_core.py
+++ b/mars/services/tests/test_core.py
@@ -16,7 +16,6 @@ import pytest
 from tornado import httpclient
 
 from ... import oscar as mo
-from ...oscar.backends.router import Router
 from ...utils import get_next_port
 from .. import (
     NodeRole,
@@ -35,7 +34,6 @@ async def actor_pool_context():
         yield pool
     finally:
         await pool.stop()
-        Router.set_instance(None)
 
 
 @pytest.mark.asyncio

--- a/mars/services/web/tests/test_core.py
+++ b/mars/services/web/tests/test_core.py
@@ -20,7 +20,6 @@ import pytest
 from tornado import httpclient
 
 from .... import oscar as mo
-from ....oscar.backends.router import Router
 from ....utils import get_next_port
 from .. import WebActor, web_api, MarsServiceWebAPIHandler, MarsWebAPIClientMixin
 from ..api.web import MarsApiEntryHandler
@@ -70,21 +69,18 @@ async def actor_pool():
     pool = await mo.create_actor_pool(
         "127.0.0.1", n_process=0, subprocess_start_method=start_method
     )
-    try:
-        async with pool:
-            web_config = {
-                "host": "127.0.0.1",
-                "port": get_next_port(),
-                "web_handlers": {
-                    "/api": MarsApiEntryHandler,
-                    TestAPIHandler.get_root_pattern(): TestAPIHandler,
-                },
-                "extra_discovery_modules": ["mars.services.web.tests.extra_handler"],
-            }
-            await mo.create_actor(WebActor, web_config, address=pool.external_address)
-            yield pool, web_config["port"]
-    finally:
-        Router.set_instance(None)
+    async with pool:
+        web_config = {
+            "host": "127.0.0.1",
+            "port": get_next_port(),
+            "web_handlers": {
+                "/api": MarsApiEntryHandler,
+                TestAPIHandler.get_root_pattern(): TestAPIHandler,
+            },
+            "extra_discovery_modules": ["mars.services.web.tests.extra_handler"],
+        }
+        await mo.create_actor(WebActor, web_config, address=pool.external_address)
+        yield pool, web_config["port"]
 
 
 class SimpleWebClient(MarsWebAPIClientMixin):

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -35,7 +35,6 @@ from .. import dataframe as md
 from .. import remote as mr
 from ..config import option_context
 from ..deploy.utils import load_service_config_file
-from ..oscar.backends.router import Router
 from ..session import execute, fetch, fetch_log
 
 
@@ -55,7 +54,6 @@ def setup():
             yield sess
         finally:
             sess.stop_server()
-            Router.set_instance(None)
 
 
 def test_session_async_execute(setup):

--- a/setup.cfg
+++ b/setup.cfg
@@ -180,6 +180,7 @@ exclude =
     __pycache__
     .git/
     .github/
+    benchmarks/asv_bench/env/
     build/
     ci/
     dist/

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
 [options.packages.find]
 exclude =
     benchmarks*
+    *.conftest*
     *.tests.*
     *.tests
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Simplify router clean up when pools or clusters ends.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
