### PR TITLE
[Ray] Optimize Ray CI execution time and stability

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8-kubernetes, 3.8-hadoop, 3.8-ray, 3.8-ray-dag, 3.8-vineyard, 3.8-dask]
+        python-version: [3.8-kubernetes, 3.8-hadoop, 3.8-ray, 3.8-ray-deploy, 3.8-ray-dag, 3.8-vineyard, 3.8-dask]
         include:
           - { os: ubuntu-latest, python-version: 3.8-kubernetes, no-common-tests: 1,
               no-deploy: 1, with-kubernetes: "with Kubernetes" }
@@ -28,6 +28,8 @@ jobs:
               no-deploy: 1, with-vineyard: "with vineyard" }
           - { os: ubuntu-latest, python-version: 3.8-ray, no-common-tests: 1,
               no-deploy: 1, with-ray: "with ray" }
+          - { os: ubuntu-latest, python-version: 3.8-ray-deploy, no-common-tests: 1,
+              no-deploy: 1, with-ray-deploy: "with ray deploy" }
           - { os: ubuntu-latest, python-version: 3.8-ray-dag, no-common-tests: 1,
               no-deploy: 1, with-ray-dag: "with ray dag" }
           - { os: ubuntu-latest, python-version: 3.8-dask, no-common-tests: 1,
@@ -53,6 +55,7 @@ jobs:
           WITH_KUBERNETES: ${{ matrix.with-kubernetes }}
           WITH_VINEYARD: ${{ matrix.with-vineyard }}
           WITH_RAY: ${{ matrix.with-ray }}
+          WITH_RAY_DEPLOY: ${{ matrix.with-ray-deploy }}
           WITH_RAY_DAG: ${{ matrix.with-ray-dag }}
           RUN_DASK: ${{ matrix.run-dask }}
           NO_COMMON_TESTS: ${{ matrix.no-common-tests }}
@@ -93,7 +96,7 @@ jobs:
               sudo mv /tmp/etcd-download-test/etcdctl /usr/local/bin/
               rm -fr /tmp/etcd-$ETCD_VER-linux-amd64.tar.gz /tmp/etcd-download-test
             fi
-            if [ -n "$WITH_RAY" ] || [ -n "$WITH_RAY_DAG" ]; then
+            if [ -n "$WITH_RAY" ] || [ -n "$WITH_RAY_DAG" ] || [ -n "$WITH_RAY_DEPLOY" ]; then
               pip install ray[default]==1.9.2 "protobuf<4"
               pip install "xgboost_ray==0.1.5" "xgboost<1.6.0"
             fi
@@ -110,6 +113,7 @@ jobs:
           WITH_CYTHON: ${{ matrix.with-cython }}
           WITH_VINEYARD: ${{ matrix.with-vineyard }}
           WITH_RAY: ${{ matrix.with-ray }}
+          WITH_RAY_DEPLOY: ${{ matrix.with-ray-deploy }}
           WITH_RAY_DAG: ${{ matrix.with-ray-dag }}
           RUN_DASK: ${{ matrix.run-dask }}
           NO_COMMON_TESTS: ${{ matrix.no-common-tests }}
@@ -144,7 +148,11 @@ jobs:
             coverage combine build/ && coverage report
           fi
           if [ -n "$WITH_RAY" ]; then
-            pytest $PYTEST_CONFIG --durations=0 --timeout=200 -v -s -m ray
+            pytest $PYTEST_CONFIG --durations=0 --timeout=200 -v -s --ignore=mars/deploy/oscar/ -m ray 
+            coverage report
+          fi
+          if [ -n "$WITH_RAY_DEPLOY" ]; then
+            pytest $PYTEST_CONFIG --durations=0 --timeout=200 -v -s mars/deploy/oscar/ -m ray
             coverage report
           fi
           if [ -n "$WITH_RAY_DAG" ]; then

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -152,13 +152,27 @@ jobs:
             coverage report
           fi
           if [ -n "$WITH_RAY_DEPLOY" ]; then
-            pytest $PYTEST_CONFIG --durations=0 --timeout=200 -v -s mars/deploy/oscar/ -m ray
-            coverage report
+            pytest $PYTEST_CONFIG --durations=0 --timeout=200 -v -s mars/deploy/oscar/tests/test_ray.py -m ray
+            mv .coverage build/.coverage.test_ray.file
+            pytest $PYTEST_CONFIG --durations=0 --timeout=200 -v -s mars/deploy/oscar/tests/test_ray_client.py -m ray
+            mv .coverage build/.coverage.test_ray_client.file
+            pytest $PYTEST_CONFIG --durations=0 --timeout=200 -v -s mars/deploy/oscar/tests/test_ray_fault_injection.py -m ray
+            mv .coverage build/.coverage.test_ray_fault_injection.file
+            pytest $PYTEST_CONFIG --durations=0 --timeout=200 -v -s mars/deploy/oscar/tests/test_ray_scheduling.py -m ray
+            mv .coverage build/.coverage.test_ray_scheduling.file
+          
+            coverage combine build/ && coverage report
           fi
           if [ -n "$WITH_RAY_DAG" ]; then
             export MARS_CI_BACKEND=ray
-            pytest $PYTEST_CONFIG --durations=0 --timeout=600 -v -s -m ray_dag
-            coverage report
+            pytest $PYTEST_CONFIG --durations=0 --timeout=200 -v -s -m ray_dag
+            mv .coverage build/.coverage.ray_dag.file
+            pytest $PYTEST_CONFIG --durations=0 --timeout=200 -v -s mars/deploy/oscar/tests/test_ray_dag.py
+            mv .coverage build/.coverage.test_ray_dag.file
+            pytest $PYTEST_CONFIG --durations=0 --timeout=200 -v -s mars/deploy/oscar/tests/test_ray_dag_failover.py
+            mv .coverage build/.coverage.test_ray_dag_failover.file
+            
+            coverage combine build/ && coverage report
           fi
           if [ -n "$RUN_DASK" ]; then
             pytest $PYTEST_CONFIG mars/contrib/dask/tests/test_dask.py

--- a/mars/conftest.py
+++ b/mars/conftest.py
@@ -165,7 +165,6 @@ async def ray_create_mars_cluster(request, check_router_cleaned):
     worker_mem = param.get("worker_mem", 256 * 1024**2)
     ray_config.update(param.get("config", {}))
     client = await new_cluster(
-        "test_cluster",
         supervisor_mem=supervisor_mem,
         worker_num=worker_num,
         worker_cpu=worker_cpu,

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -20,26 +20,16 @@ import subprocess
 import sys
 import tempfile
 import threading
-import time
 from functools import reduce
 
 import numpy as np
-import pandas as pd
 import pytest
 
 import mars
-from .... import oscar as mo
 from .... import tensor as mt
 from .... import dataframe as md
-from ....oscar.backends.ray.utils import (
-    process_address_to_placement,
-    process_placement_to_address,
-    kill_and_wait,
-)
 from ....oscar.errors import ReconstructWorkerError
 from ....serialization.ray import register_ray_serializers
-from ....services.cluster import ClusterAPI
-from ....services.scheduling.supervisor.autoscale import AutoscalerActor
 from ....tests.core import require_ray, mock, DICT_NOT_EMPTY
 from ....utils import lazy_import
 from ..ray import (
@@ -135,25 +125,25 @@ async def create_cluster(request):
     ],
 )
 @pytest.mark.asyncio
-async def test_execute(ray_start_regular, create_cluster, config):
+async def test_execute(ray_start_regular_shared, create_cluster, config):
     await test_local.test_execute(create_cluster, config)
 
 
 @require_ray
 @pytest.mark.asyncio
-async def test_iterative_tiling(ray_start_regular, create_cluster):
+async def test_iterative_tiling(ray_start_regular_shared, create_cluster):
     await test_local.test_iterative_tiling(create_cluster)
 
 
 @require_ray
 @pytest.mark.asyncio
-async def test_execute_describe(ray_start_regular, create_cluster):
+async def test_execute_describe(ray_start_regular_shared, create_cluster):
     await test_local.test_execute_describe(create_cluster)
 
 
 @require_ray
 @pytest.mark.asyncio
-async def test_fetch_infos(ray_start_regular, create_cluster):
+async def test_fetch_infos(ray_start_regular_shared, create_cluster):
     await test_local.test_fetch_infos(create_cluster)
     df = md.DataFrame(mt.random.RandomState(0).rand(5000, 1, chunk_size=1000))
     df.execute()
@@ -165,7 +155,7 @@ async def test_fetch_infos(ray_start_regular, create_cluster):
 
 @require_ray
 @pytest.mark.asyncio
-def test_sync_execute(ray_start_regular, create_cluster):
+def test_sync_execute(ray_start_regular_shared, create_cluster):
     client = create_cluster[0]
     assert client.session
     session = new_session(address=client.address)
@@ -247,7 +237,7 @@ def new_ray_session_test():
 
 
 @require_ray
-def test_ray_client(ray_start_regular):
+def test_ray_client():
     server_code = """import time
 import ray.util.client.server.server as ray_client_server
 
@@ -310,7 +300,7 @@ while True:
     ],
 )
 @pytest.mark.asyncio
-async def test_optional_supervisor_node(ray_start_regular, test_option):
+async def test_optional_supervisor_node(ray_start_regular_shared, test_option):
     import logging
 
     logging.basicConfig(level=logging.INFO)
@@ -357,7 +347,7 @@ async def test_optional_supervisor_node(ray_start_regular, test_option):
     ],
 )
 @pytest.mark.asyncio
-async def test_web_session(ray_start_regular, create_cluster, config):
+async def test_web_session(ray_start_regular_shared, create_cluster, config):
     client = create_cluster[0]
     await test_local.test_web_session(create_cluster, config)
     web_address = client.web_address
@@ -381,7 +371,7 @@ async def test_web_session(ray_start_regular, create_cluster, config):
     ],
 )
 @pytest.mark.asyncio
-async def test_load_third_party_modules(ray_start_regular, config_exception):
+async def test_load_third_party_modules(ray_start_regular_shared, config_exception):
     third_party_modules_config, expected_exception = config_exception
     config = _load_config()
 
@@ -410,7 +400,7 @@ async def test_load_third_party_modules(ray_start_regular, config_exception):
     indirect=True,
 )
 @pytest.mark.asyncio
-def test_load_third_party_modules2(ray_start_regular, create_cluster):
+def test_load_third_party_modules2(ray_start_regular_shared, create_cluster):
     client = create_cluster[0]
     assert client.session
     session = new_session(address=client.address)
@@ -429,7 +419,7 @@ def test_load_third_party_modules2(ray_start_regular, create_cluster):
 @require_ray
 @pytest.mark.asyncio
 async def test_load_third_party_modules_from_config(
-    ray_start_regular, cleanup_third_party_modules_output  # noqa: F811
+    ray_start_regular_shared, cleanup_third_party_modules_output  # noqa: F811
 ):
     client = await new_cluster(
         supervisor_mem=1 * 1024**3,
@@ -460,84 +450,6 @@ def test_load_config():
     with pytest.raises(ValueError):
         _load_config({"scheduling.autoscale.enabled": True, "scheduling.autoscale": {}})
     assert _load_config(CONFIG_FILE)["session"]["custom_log_dir"] == "auto"
-
-
-@pytest.mark.parametrize(
-    "ray_large_cluster", [{"num_nodes": 1, "num_cpus": 3}], indirect=True
-)
-@require_ray
-@pytest.mark.asyncio
-async def test_request_worker(ray_large_cluster):
-    worker_cpu, worker_mem = 1, 100 * 1024**2
-    client = await new_cluster(
-        worker_num=0, worker_cpu=worker_cpu, worker_mem=worker_mem
-    )
-    async with client:
-        cluster_state_ref = client._cluster._cluster_backend.get_cluster_state_ref()
-        # Note that supervisor took one node
-        workers = await asyncio.gather(
-            *[cluster_state_ref.request_worker(timeout=5) for _ in range(2)]
-        )
-        assert all(worker is not None for worker in workers)
-        assert not await cluster_state_ref.request_worker(timeout=5)
-        release_workers = [
-            cluster_state_ref.release_worker(worker) for worker in workers
-        ]
-        # Duplicate release workers requests should be handled.
-        release_workers.extend(
-            [cluster_state_ref.release_worker(worker) for worker in workers]
-        )
-        await asyncio.gather(*release_workers)
-        assert await cluster_state_ref.request_worker(timeout=5)
-        cluster_state_ref.reconstruct_worker()
-
-
-@pytest.mark.parametrize(
-    "ray_large_cluster", [{"num_nodes": 1, "num_cpus": 3}], indirect=True
-)
-@require_ray
-@pytest.mark.asyncio
-async def test_reconstruct_worker(ray_large_cluster):
-    worker_cpu, worker_mem = 1, 100 * 1024**2
-    client = await new_cluster(
-        worker_num=0, worker_cpu=worker_cpu, worker_mem=worker_mem
-    )
-    async with client:
-        cluster_api = await ClusterAPI.create(client._cluster.supervisor_address)
-        worker = await cluster_api.request_worker(timeout=5)
-        pg_name, bundle_index, process_index = process_address_to_placement(worker)
-        worker_sub_pool = process_placement_to_address(
-            pg_name, bundle_index, process_index + 1
-        )
-
-        worker_actor = ray.get_actor(worker)
-        worker_pid = await worker_actor.getpid.remote()
-        # the worker pool actor should be destroyed even we get actor.
-        worker_sub_pool_actor = ray.get_actor(worker_sub_pool)
-        worker_sub_pool_pid = await worker_sub_pool_actor.getpid.remote()
-
-        # kill worker main pool
-        await kill_and_wait(ray.get_actor(worker))
-
-        # duplicated reconstruct worker request can be handled.
-        await asyncio.gather(
-            cluster_api.reconstruct_worker(worker),
-            cluster_api.reconstruct_worker(worker),
-        )
-        worker_actor = ray.get_actor(worker)
-        new_worker_pid = await worker_actor.getpid.remote()
-        worker_sub_pool_actor = ray.get_actor(worker_sub_pool)
-        new_worker_sub_pool_pid = await worker_sub_pool_actor.getpid.remote()
-        assert new_worker_pid != worker_pid
-        assert new_worker_sub_pool_pid != worker_sub_pool_pid
-
-        # the compute should be ok after the worker is reconstructed.
-        raw = np.random.RandomState(0).rand(10, 5)
-        a = mt.tensor(raw, chunk_size=5).sum(axis=1)
-        b = a.execute(show_progress=False)
-        assert b is a
-        result = a.fetch()
-        np.testing.assert_array_equal(result, raw.sum(axis=1))
 
 
 @require_ray
@@ -595,138 +507,9 @@ async def test_release_worker_during_reconstructing_worker(
     release_task.cancel()
 
 
-@pytest.mark.parametrize(
-    "ray_large_cluster", [{"num_nodes": 2, "num_cpus": 4}], indirect=True
-)
-@pytest.mark.parametrize("init_workers", [0, 1])
 @require_ray
 @pytest.mark.asyncio
-async def test_auto_scale_out(ray_large_cluster, init_workers: int):
-    client = await new_cluster(
-        worker_num=init_workers,
-        worker_cpu=2,
-        worker_mem=200 * 1024**2,
-        supervisor_mem=1 * 1024**3,
-        config={
-            "scheduling.autoscale.enabled": True,
-            "scheduling.autoscale.scheduler_backlog_timeout": 1,
-            "scheduling.autoscale.worker_idle_timeout": 10000000,
-            "scheduling.autoscale.max_workers": 10,
-        },
-    )
-    async with client:
-
-        def time_consuming(x):
-            time.sleep(1)
-            return x * x
-
-        series_size = 100
-        assert (
-            md.Series(list(range(series_size)), chunk_size=1)
-            .apply(time_consuming)
-            .sum()
-            .execute()
-            .fetch()
-            == pd.Series(list(range(series_size))).apply(lambda x: x * x).sum()
-        )
-        autoscaler_ref = mo.create_actor_ref(
-            uid=AutoscalerActor.default_uid(),
-            address=client._cluster.supervisor_address,
-        )
-        assert await autoscaler_ref.get_dynamic_worker_nums() > 0
-
-
-@pytest.mark.timeout(timeout=600)
-@pytest.mark.parametrize(
-    "ray_large_cluster", [{"num_nodes": 2, "num_cpus": 4}], indirect=True
-)
-@require_ray
-@pytest.mark.asyncio
-async def test_auto_scale_in(ray_large_cluster):
-    config = _load_config()
-    config["scheduling"]["autoscale"]["enabled"] = True
-    config["scheduling"]["autoscale"]["worker_idle_timeout"] = 1
-    config["scheduling"]["autoscale"]["max_workers"] = 4
-    config["scheduling"]["autoscale"]["min_workers"] = 2
-    client = await new_cluster(
-        worker_num=0,
-        worker_cpu=2,
-        worker_mem=200 * 102**2,
-        supervisor_mem=1 * 1024**3,
-        config=config,
-    )
-    async with client:
-        autoscaler_ref = mo.create_actor_ref(
-            uid=AutoscalerActor.default_uid(),
-            address=client._cluster.supervisor_address,
-        )
-        new_worker_nums = 3
-        await asyncio.gather(
-            *[autoscaler_ref.request_worker() for _ in range(new_worker_nums)]
-        )
-        series_size = 100
-        assert (
-            md.Series(list(range(series_size)), chunk_size=20).sum().execute().fetch()
-            == pd.Series(list(range(series_size))).sum()
-        )
-        while await autoscaler_ref.get_dynamic_worker_nums() > 2:
-            dynamic_workers = await autoscaler_ref.get_dynamic_workers()
-            print(f"Waiting workers {dynamic_workers} to be released.")
-            await asyncio.sleep(1)
-        await asyncio.sleep(1)
-        assert await autoscaler_ref.get_dynamic_worker_nums() == 2
-
-
-@pytest.mark.skip("Enable it when ray ownership bug is fixed")
-@pytest.mark.timeout(timeout=200)
-@pytest.mark.parametrize("ray_large_cluster", [{"num_nodes": 4}], indirect=True)
-@require_ray
-@pytest.mark.asyncio
-async def test_ownership_when_scale_in(ray_large_cluster):
-    client = await new_cluster(
-        worker_num=0,
-        worker_cpu=2,
-        worker_mem=200 * 1024**2,
-        supervisor_mem=200 * 1024**2,
-        config={
-            "scheduling.autoscale.enabled": True,
-            "scheduling.autoscale.scheduler_check_interval": 1,
-            "scheduling.autoscale.scheduler_backlog_timeout": 1,
-            "scheduling.autoscale.worker_idle_timeout": 10,
-            "scheduling.autoscale.min_workers": 1,
-            "scheduling.autoscale.max_workers": 4,
-        },
-    )
-    async with client:
-        autoscaler_ref = mo.create_actor_ref(
-            uid=AutoscalerActor.default_uid(),
-            address=client._cluster.supervisor_address,
-        )
-        await asyncio.gather(*[autoscaler_ref.request_worker() for _ in range(2)])
-        df = md.DataFrame(mt.random.rand(100, 4, chunk_size=2), columns=list("abcd"))
-        print(df.execute())
-        assert await autoscaler_ref.get_dynamic_worker_nums() > 1
-        while await autoscaler_ref.get_dynamic_worker_nums() > 1:
-            dynamic_workers = await autoscaler_ref.get_dynamic_workers()
-            print(f"Waiting workers {dynamic_workers} to be released.")
-            await asyncio.sleep(1)
-        # Test data on node of released worker can still be fetched
-        pd_df = df.to_pandas()
-        groupby_sum_df = df.rechunk(40).groupby("a").sum()
-        print(groupby_sum_df.execute())
-        while await autoscaler_ref.get_dynamic_worker_nums() > 1:
-            dynamic_workers = await autoscaler_ref.get_dynamic_workers()
-            print(f"Waiting workers {dynamic_workers} to be released.")
-            await asyncio.sleep(1)
-        assert df.to_pandas().to_dict() == pd_df.to_dict()
-        assert (
-            groupby_sum_df.to_pandas().to_dict() == pd_df.groupby("a").sum().to_dict()
-        )
-
-
-@require_ray
-@pytest.mark.asyncio
-def test_init_metrics_on_ray(ray_start_regular, create_cluster):
+def test_init_metrics_on_ray(ray_start_regular_shared, create_cluster):
     client = create_cluster[0]
     assert client.session
     from ....metrics import api

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -16,11 +16,6 @@ import asyncio
 import copy
 import operator
 import os
-import subprocess
-import sys
-import tempfile
-import threading
-import time
 from functools import reduce
 
 import numpy as np
@@ -237,59 +232,6 @@ def new_ray_session_test():
 
 
 @require_ray
-def test_ray_client():
-    server_code = """import time
-import ray.util.client.server.server as ray_client_server
-
-server = ray_client_server.init_and_serve("{address}", num_cpus=20)
-print("OK", flush=True)
-while True:
-    time.sleep(1)
-"""
-
-    address = "127.0.0.1:50051"
-
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".py") as f:
-        f.write(server_code.format(address=address))
-        f.flush()
-
-        proc = subprocess.Popen([sys.executable, "-u", f.name], stdout=subprocess.PIPE)
-
-        try:
-
-            def _check_ready(expect_exit=False):
-                while True:
-                    line = proc.stdout.readline()
-                    if proc.returncode is not None:
-                        if expect_exit:
-                            break
-                        raise Exception(
-                            f"Failed to start ray server at {address}, "
-                            f"the return code is {proc.returncode}."
-                        )
-                    if b"OK" in line:
-                        break
-
-            # Avoid ray.init timeout.
-            _check_ready()
-
-            # Avoid blocking the subprocess when the stdout pipe is full.
-            t = threading.Thread(target=_check_ready, args=(True,))
-            t.start()
-
-            ray.init(f"ray://{address}")
-            ray._inside_client_test = True
-            try:
-                new_ray_session_test()
-            finally:
-                ray._inside_client_test = False
-                ray.shutdown()
-        finally:
-            proc.kill()
-            proc.wait()
-
-
-@require_ray
 @pytest.mark.parametrize(
     "test_option",
     [
@@ -429,8 +371,8 @@ async def test_load_third_party_modules_from_config(
         config=CONFIG_THIRD_PARTY_MODULES_TEST_FILE,
     )
     async with client:
-        # 1 supervisor, 2 worker main pools, 4 worker sub pools.
-        assert len(get_output_filenames()) == 7
+        # 1 supervisor, 1 worker main pools, 1 worker sub pools.
+        assert len(get_output_filenames()) == 3
 
 
 @require_ray

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import time
 from functools import reduce
 
 import numpy as np
@@ -88,7 +89,6 @@ async def create_cluster(request):
     ray_config = _load_config(CONFIG_FILE)
     ray_config.update(param.get("config", {}))
     client = await new_cluster(
-        "test_cluster",
         supervisor_mem=1 * 1024**3,
         worker_num=2,
         worker_cpu=2,
@@ -378,8 +378,8 @@ async def test_load_third_party_modules(ray_start_regular_shared, config_excepti
     config["third_party_modules"] = third_party_modules_config
     with expected_exception:
         await new_cluster(
-            worker_num=2,
-            worker_cpu=2,
+            worker_num=1,
+            worker_cpu=1,
             worker_mem=1 * 1024**3,
             config=config,
         )
@@ -423,8 +423,8 @@ async def test_load_third_party_modules_from_config(
 ):
     client = await new_cluster(
         supervisor_mem=1 * 1024**3,
-        worker_num=2,
-        worker_cpu=2,
+        worker_num=1,
+        worker_cpu=1,
         worker_mem=1 * 1024**3,
         config=CONFIG_THIRD_PARTY_MODULES_TEST_FILE,
     )

--- a/mars/deploy/oscar/tests/test_ray_client.py
+++ b/mars/deploy/oscar/tests/test_ray_client.py
@@ -25,7 +25,7 @@ ray = lazy_import("ray")
 
 
 @require_ray
-def test_ray_client(ray_start_regular):
+def test_ray_client():
     server_code = """import time
 import ray.util.client.server.server as ray_client_server
 
@@ -62,7 +62,7 @@ while True:
             _check_ready()
 
             # Avoid blocking the subprocess when the stdout pipe is full.
-            t = threading.Thread(target=_check_ready, args=(True,))
+            t = threading.Thread(target=_check_ready, args=(True,), daemon=True)
             t.start()
 
             ray.init(f"ray://{address}")

--- a/mars/deploy/oscar/tests/test_ray_client.py
+++ b/mars/deploy/oscar/tests/test_ray_client.py
@@ -1,0 +1,77 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import sys
+import tempfile
+import threading
+
+from .test_ray import new_ray_session_test
+from ....tests.core import require_ray
+from ....utils import lazy_import
+
+ray = lazy_import("ray")
+
+
+@require_ray
+def test_ray_client(ray_start_regular):
+    server_code = """import time
+import ray.util.client.server.server as ray_client_server
+
+server = ray_client_server.init_and_serve("{address}", num_cpus=20)
+print("OK", flush=True)
+while True:
+    time.sleep(1)
+"""
+
+    address = "127.0.0.1:50051"
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py") as f:
+        f.write(server_code.format(address=address))
+        f.flush()
+
+        proc = subprocess.Popen([sys.executable, "-u", f.name], stdout=subprocess.PIPE)
+
+        try:
+
+            def _check_ready(expect_exit=False):
+                while True:
+                    line = proc.stdout.readline()
+                    if proc.returncode is not None:
+                        if expect_exit:
+                            break
+                        raise Exception(
+                            f"Failed to start ray server at {address}, "
+                            f"the return code is {proc.returncode}."
+                        )
+                    if b"OK" in line:
+                        break
+
+            # Avoid ray.init timeout.
+            _check_ready()
+
+            # Avoid blocking the subprocess when the stdout pipe is full.
+            t = threading.Thread(target=_check_ready, args=(True,))
+            t.start()
+
+            ray.init(f"ray://{address}")
+            ray._inside_client_test = True
+            try:
+                new_ray_session_test()
+            finally:
+                ray._inside_client_test = False
+                ray.shutdown()
+        finally:
+            proc.kill()
+            proc.wait()

--- a/mars/deploy/oscar/tests/test_ray_dag.py
+++ b/mars/deploy/oscar/tests/test_ray_dag.py
@@ -20,7 +20,7 @@ import pytest
 
 from .... import get_context
 from .... import tensor as mt
-from ....tests.core import DICT_NOT_EMPTY
+from ....tests.core import DICT_NOT_EMPTY, require_ray
 from ....utils import lazy_import
 from ..local import new_cluster
 from ..session import new_session, get_default_async_session
@@ -73,14 +73,14 @@ async def create_cluster(request):
         yield client, {}
 
 
-@pytest.mark.ray_dag
+@require_ray
 @pytest.mark.parametrize("backend", ["ray"])
 @pytest.mark.parametrize("_new_session", [new_session, new_test_session])
-def test_new_session_backend(_new_session, backend):
+def test_new_session_backend(ray_start_regular_shared2, _new_session, backend):
     test_local.test_new_session_backend(_new_session, backend)
 
 
-@pytest.mark.ray_dag
+@require_ray
 @pytest.mark.parametrize(
     "config",
     [
@@ -106,38 +106,38 @@ def test_new_session_backend(_new_session, backend):
     ],
 )
 @pytest.mark.asyncio
-async def test_execute(create_cluster, config):
+async def test_execute(ray_start_regular_shared2, create_cluster, config):
     await test_local.test_execute(create_cluster, config)
 
 
-@pytest.mark.ray_dag
+@require_ray
 @pytest.mark.asyncio
-async def test_iterative_tiling(create_cluster):
+async def test_iterative_tiling(ray_start_regular_shared2, create_cluster):
     await test_local.test_iterative_tiling(create_cluster)
 
 
-@pytest.mark.ray_dag
+@require_ray
 @pytest.mark.parametrize("config", [{"backend": "ray"}])
-def test_sync_execute(config):
+def test_sync_execute(ray_start_regular_shared2, config):
     test_local.test_sync_execute(config)
 
 
+@require_ray
 @pytest.mark.skip("Enable when ray progress got fixed")
-@pytest.mark.ray_dag
 @pytest.mark.asyncio
-async def test_session_get_progress(create_cluster):
+async def test_session_get_progress(ray_start_regular_shared2, create_cluster):
     await test_local.test_session_get_progress(create_cluster)
 
 
-@pytest.mark.ray_dag
+@require_ray
 @pytest.mark.parametrize("test_func", [_cancel_when_execute, _cancel_when_tile])
-def test_cancel(create_cluster, test_func):
+def test_cancel(ray_start_regular_shared2, create_cluster, test_func):
     test_local.test_cancel(create_cluster, test_func)
 
 
-@pytest.mark.ray_dag
+@require_ray
 @pytest.mark.parametrize("config", [{"backend": "ray"}])
-def test_executor_context_gc(config):
+def test_executor_context_gc(ray_start_regular_shared2, config):
     session = new_session(
         backend=config["backend"],
         n_cpu=2,

--- a/mars/deploy/oscar/tests/test_ray_dag.py
+++ b/mars/deploy/oscar/tests/test_ray_dag.py
@@ -20,7 +20,7 @@ import pytest
 
 from .... import get_context
 from .... import tensor as mt
-from ....tests.core import DICT_NOT_EMPTY, require_ray
+from ....tests.core import DICT_NOT_EMPTY
 from ....utils import lazy_import
 from ..local import new_cluster
 from ..session import new_session, get_default_async_session
@@ -73,14 +73,14 @@ async def create_cluster(request):
         yield client, {}
 
 
-@require_ray
+@pytest.mark.ray_dag
 @pytest.mark.parametrize("backend", ["ray"])
 @pytest.mark.parametrize("_new_session", [new_session, new_test_session])
 def test_new_session_backend(ray_start_regular_shared2, _new_session, backend):
     test_local.test_new_session_backend(_new_session, backend)
 
 
-@require_ray
+@pytest.mark.ray_dag
 @pytest.mark.parametrize(
     "config",
     [
@@ -110,31 +110,31 @@ async def test_execute(ray_start_regular_shared2, create_cluster, config):
     await test_local.test_execute(create_cluster, config)
 
 
-@require_ray
+@pytest.mark.ray_dag
 @pytest.mark.asyncio
 async def test_iterative_tiling(ray_start_regular_shared2, create_cluster):
     await test_local.test_iterative_tiling(create_cluster)
 
 
-@require_ray
+@pytest.mark.ray_dag
 @pytest.mark.parametrize("config", [{"backend": "ray"}])
 def test_sync_execute(config):
     test_local.test_sync_execute(config)
 
 
-@require_ray
+@pytest.mark.ray_dag
 @pytest.mark.asyncio
 async def test_session_get_progress(ray_start_regular_shared2, create_cluster):
     await test_local.test_session_get_progress(create_cluster)
 
 
-@require_ray
+@pytest.mark.ray_dag
 @pytest.mark.parametrize("test_func", [_cancel_when_execute, _cancel_when_tile])
 def test_cancel(ray_start_regular_shared2, create_cluster, test_func):
     test_local.test_cancel(create_cluster, test_func)
 
 
-@require_ray
+@pytest.mark.ray_dag
 @pytest.mark.parametrize("config", [{"backend": "ray"}])
 def test_executor_context_gc(config):
     session = new_session(

--- a/mars/deploy/oscar/tests/test_ray_dag.py
+++ b/mars/deploy/oscar/tests/test_ray_dag.py
@@ -76,7 +76,7 @@ async def create_cluster(request):
 @pytest.mark.ray_dag
 @pytest.mark.parametrize("backend", ["ray"])
 @pytest.mark.parametrize("_new_session", [new_session, new_test_session])
-def test_new_session_backend(ray_start_regular_shared2, _new_session, backend):
+def test_new_session_backend(_new_session, backend):
     test_local.test_new_session_backend(_new_session, backend)
 
 
@@ -106,13 +106,13 @@ def test_new_session_backend(ray_start_regular_shared2, _new_session, backend):
     ],
 )
 @pytest.mark.asyncio
-async def test_execute(ray_start_regular_shared2, create_cluster, config):
+async def test_execute(create_cluster, config):
     await test_local.test_execute(create_cluster, config)
 
 
 @pytest.mark.ray_dag
 @pytest.mark.asyncio
-async def test_iterative_tiling(ray_start_regular_shared2, create_cluster):
+async def test_iterative_tiling(create_cluster):
     await test_local.test_iterative_tiling(create_cluster)
 
 
@@ -125,13 +125,13 @@ def test_sync_execute(config):
 @pytest.mark.skip("Enable when ray progress got fixed")
 @pytest.mark.ray_dag
 @pytest.mark.asyncio
-async def test_session_get_progress(ray_start_regular_shared2, create_cluster):
+async def test_session_get_progress(create_cluster):
     await test_local.test_session_get_progress(create_cluster)
 
 
 @pytest.mark.ray_dag
 @pytest.mark.parametrize("test_func", [_cancel_when_execute, _cancel_when_tile])
-def test_cancel(ray_start_regular_shared2, create_cluster, test_func):
+def test_cancel(create_cluster, test_func):
     test_local.test_cancel(create_cluster, test_func)
 
 

--- a/mars/deploy/oscar/tests/test_ray_dag.py
+++ b/mars/deploy/oscar/tests/test_ray_dag.py
@@ -122,6 +122,7 @@ def test_sync_execute(config):
     test_local.test_sync_execute(config)
 
 
+@pytest.mark.skip("Enable when ray progress got fixed")
 @pytest.mark.ray_dag
 @pytest.mark.asyncio
 async def test_session_get_progress(ray_start_regular_shared2, create_cluster):

--- a/mars/deploy/oscar/tests/test_ray_dag_failover.py
+++ b/mars/deploy/oscar/tests/test_ray_dag_failover.py
@@ -22,13 +22,12 @@ import pytest
 import mars
 from .... import dataframe as md
 from .... import tensor as mt
-from ....tests.core import require_ray
 from ....utils import lazy_import
 
 ray = lazy_import("ray")
 
 
-@require_ray
+@pytest.mark.ray_dag
 @pytest.mark.parametrize(
     "ray_large_cluster",
     [{"num_nodes": 0, "use_ray_serialization": False}],

--- a/mars/deploy/oscar/tests/test_ray_dag_failover.py
+++ b/mars/deploy/oscar/tests/test_ray_dag_failover.py
@@ -22,12 +22,13 @@ import pytest
 import mars
 from .... import dataframe as md
 from .... import tensor as mt
+from ....tests.core import require_ray
 from ....utils import lazy_import
 
 ray = lazy_import("ray")
 
 
-@pytest.mark.ray_dag
+@require_ray
 @pytest.mark.parametrize(
     "ray_large_cluster",
     [{"num_nodes": 0, "use_ray_serialization": False}],

--- a/mars/deploy/oscar/tests/test_ray_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_ray_fault_injection.py
@@ -96,7 +96,7 @@ async def fault_cluster(request):
 )
 @pytest.mark.asyncio
 async def test_fault_inject_subtask_processor(
-    ray_start_regular, fault_cluster, fault_and_exception
+    ray_start_regular_shared, fault_cluster, fault_and_exception
 ):
     await test_fault_injection.test_fault_inject_subtask_processor(
         fault_cluster, fault_and_exception
@@ -128,7 +128,7 @@ async def test_fault_inject_subtask_processor(
     ],
 )
 @pytest.mark.asyncio
-async def test_rerun_subtask(ray_start_regular, fault_cluster, fault_config):
+async def test_rerun_subtask(ray_start_regular_shared, fault_cluster, fault_config):
     await test_fault_injection.test_rerun_subtask(fault_cluster, fault_config)
 
 
@@ -148,7 +148,9 @@ async def test_rerun_subtask(ray_start_regular, fault_cluster, fault_config):
     ],
 )
 @pytest.mark.asyncio
-async def test_rerun_subtask_describe(ray_start_regular, fault_cluster, fault_config):
+async def test_rerun_subtask_describe(
+    ray_start_regular_shared, fault_cluster, fault_config
+):
     await test_fault_injection.test_rerun_subtask_describe(fault_cluster, fault_config)
 
 
@@ -174,7 +176,9 @@ async def test_rerun_subtask_describe(ray_start_regular, fault_cluster, fault_co
     ],
 )
 @pytest.mark.asyncio
-async def test_rerun_subtask_fail(ray_start_regular, fault_cluster, fault_config):
+async def test_rerun_subtask_fail(
+    ray_start_regular_shared, fault_cluster, fault_config
+):
     await test_fault_injection.test_rerun_subtask_fail(fault_cluster, fault_config)
 
 
@@ -200,5 +204,5 @@ async def test_rerun_subtask_fail(ray_start_regular, fault_cluster, fault_config
     ],
 )
 @pytest.mark.asyncio
-async def test_retryable(ray_start_regular, fault_cluster, fault_config):
+async def test_retryable(ray_start_regular_shared, fault_cluster, fault_config):
     await test_fault_injection.test_retryable(fault_cluster, fault_config)

--- a/mars/deploy/oscar/tests/test_ray_fault_injection.py
+++ b/mars/deploy/oscar/tests/test_ray_fault_injection.py
@@ -52,7 +52,6 @@ async def fault_cluster(request):
     ray_config.update(FAULT_INJECTION_CONFIG)
     ray_config.update(param.get("config", {}))
     client = await new_cluster(
-        "test_cluster",
         worker_num=2,
         worker_cpu=2,
         worker_mem=1 * 1024**3,

--- a/mars/deploy/oscar/tests/test_ray_scheduling.py
+++ b/mars/deploy/oscar/tests/test_ray_scheduling.py
@@ -11,12 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 
+import numpy as np
 import pytest
+import pandas as pd
+import time
 
+from .... import dataframe as md
+from .... import oscar as mo
+from .... import tensor as mt
+from ....oscar.backends.ray.utils import (
+    process_address_to_placement,
+    process_placement_to_address,
+    kill_and_wait,
+)
+from ....services.cluster import ClusterAPI
+from ....services.scheduling.supervisor.autoscale import AutoscalerActor
 from ....tests.core import require_ray
 from ....utils import lazy_import
-from ..ray import new_cluster
+from ..ray import new_cluster, _load_config
 from ..tests import test_local
 from .modules.utils import (  # noqa: F401; pylint: disable=unused-variable
     cleanup_third_party_modules_output,
@@ -58,3 +72,210 @@ async def speculative_cluster():
 @pytest.mark.asyncio
 async def test_task_speculation_execution(ray_large_cluster, speculative_cluster):
     await test_local.test_task_speculation_execution(speculative_cluster)
+
+
+@pytest.mark.parametrize(
+    "ray_large_cluster", [{"num_nodes": 1, "num_cpus": 3}], indirect=True
+)
+@require_ray
+@pytest.mark.asyncio
+async def test_request_worker(ray_large_cluster):
+    worker_cpu, worker_mem = 1, 100 * 1024**2
+    client = await new_cluster(
+        worker_num=0, worker_cpu=worker_cpu, worker_mem=worker_mem
+    )
+    async with client:
+        cluster_state_ref = client._cluster._cluster_backend.get_cluster_state_ref()
+        # Note that supervisor took one node
+        workers = await asyncio.gather(
+            *[cluster_state_ref.request_worker(timeout=5) for _ in range(2)]
+        )
+        assert all(worker is not None for worker in workers)
+        assert not await cluster_state_ref.request_worker(timeout=5)
+        release_workers = [
+            cluster_state_ref.release_worker(worker) for worker in workers
+        ]
+        # Duplicate release workers requests should be handled.
+        release_workers.extend(
+            [cluster_state_ref.release_worker(worker) for worker in workers]
+        )
+        await asyncio.gather(*release_workers)
+        assert await cluster_state_ref.request_worker(timeout=5)
+        cluster_state_ref.reconstruct_worker()
+
+
+@pytest.mark.parametrize(
+    "ray_large_cluster", [{"num_nodes": 1, "num_cpus": 3}], indirect=True
+)
+@require_ray
+@pytest.mark.asyncio
+async def test_reconstruct_worker(ray_large_cluster):
+    worker_cpu, worker_mem = 1, 100 * 1024**2
+    client = await new_cluster(
+        worker_num=0, worker_cpu=worker_cpu, worker_mem=worker_mem
+    )
+    async with client:
+        cluster_api = await ClusterAPI.create(client._cluster.supervisor_address)
+        worker = await cluster_api.request_worker(timeout=5)
+        pg_name, bundle_index, process_index = process_address_to_placement(worker)
+        worker_sub_pool = process_placement_to_address(
+            pg_name, bundle_index, process_index + 1
+        )
+
+        worker_actor = ray.get_actor(worker)
+        worker_pid = await worker_actor.getpid.remote()
+        # the worker pool actor should be destroyed even we get actor.
+        worker_sub_pool_actor = ray.get_actor(worker_sub_pool)
+        worker_sub_pool_pid = await worker_sub_pool_actor.getpid.remote()
+
+        # kill worker main pool
+        await kill_and_wait(ray.get_actor(worker))
+
+        # duplicated reconstruct worker request can be handled.
+        await asyncio.gather(
+            cluster_api.reconstruct_worker(worker),
+            cluster_api.reconstruct_worker(worker),
+        )
+        worker_actor = ray.get_actor(worker)
+        new_worker_pid = await worker_actor.getpid.remote()
+        worker_sub_pool_actor = ray.get_actor(worker_sub_pool)
+        new_worker_sub_pool_pid = await worker_sub_pool_actor.getpid.remote()
+        assert new_worker_pid != worker_pid
+        assert new_worker_sub_pool_pid != worker_sub_pool_pid
+
+        # the compute should be ok after the worker is reconstructed.
+        raw = np.random.RandomState(0).rand(10, 5)
+        a = mt.tensor(raw, chunk_size=5).sum(axis=1)
+        b = a.execute(show_progress=False)
+        assert b is a
+        result = a.fetch()
+        np.testing.assert_array_equal(result, raw.sum(axis=1))
+
+
+@pytest.mark.parametrize(
+    "ray_large_cluster", [{"num_nodes": 2, "num_cpus": 4}], indirect=True
+)
+@pytest.mark.parametrize("init_workers", [0, 1])
+@require_ray
+@pytest.mark.asyncio
+async def test_auto_scale_out(ray_large_cluster, init_workers: int):
+    client = await new_cluster(
+        worker_num=init_workers,
+        worker_cpu=2,
+        worker_mem=200 * 1024**2,
+        supervisor_mem=1 * 1024**3,
+        config={
+            "scheduling.autoscale.enabled": True,
+            "scheduling.autoscale.scheduler_backlog_timeout": 1,
+            "scheduling.autoscale.worker_idle_timeout": 10000000,
+            "scheduling.autoscale.max_workers": 10,
+        },
+    )
+    async with client:
+
+        def time_consuming(x):
+            time.sleep(1)
+            return x * x
+
+        series_size = 100
+        assert (
+            md.Series(list(range(series_size)), chunk_size=1)
+            .apply(time_consuming)
+            .sum()
+            .execute()
+            .fetch()
+            == pd.Series(list(range(series_size))).apply(lambda x: x * x).sum()
+        )
+        autoscaler_ref = mo.create_actor_ref(
+            uid=AutoscalerActor.default_uid(),
+            address=client._cluster.supervisor_address,
+        )
+        assert await autoscaler_ref.get_dynamic_worker_nums() > 0
+
+
+@pytest.mark.timeout(timeout=600)
+@pytest.mark.parametrize(
+    "ray_large_cluster", [{"num_nodes": 2, "num_cpus": 4}], indirect=True
+)
+@require_ray
+@pytest.mark.asyncio
+async def test_auto_scale_in(ray_large_cluster):
+    config = _load_config()
+    config["scheduling"]["autoscale"]["enabled"] = True
+    config["scheduling"]["autoscale"]["worker_idle_timeout"] = 1
+    config["scheduling"]["autoscale"]["max_workers"] = 4
+    config["scheduling"]["autoscale"]["min_workers"] = 2
+    client = await new_cluster(
+        worker_num=0,
+        worker_cpu=2,
+        worker_mem=200 * 102**2,
+        supervisor_mem=1 * 1024**3,
+        config=config,
+    )
+    async with client:
+        autoscaler_ref = mo.create_actor_ref(
+            uid=AutoscalerActor.default_uid(),
+            address=client._cluster.supervisor_address,
+        )
+        new_worker_nums = 3
+        await asyncio.gather(
+            *[autoscaler_ref.request_worker() for _ in range(new_worker_nums)]
+        )
+        series_size = 100
+        assert (
+            md.Series(list(range(series_size)), chunk_size=20).sum().execute().fetch()
+            == pd.Series(list(range(series_size))).sum()
+        )
+        while await autoscaler_ref.get_dynamic_worker_nums() > 2:
+            dynamic_workers = await autoscaler_ref.get_dynamic_workers()
+            print(f"Waiting workers {dynamic_workers} to be released.")
+            await asyncio.sleep(1)
+        await asyncio.sleep(1)
+        assert await autoscaler_ref.get_dynamic_worker_nums() == 2
+
+
+@pytest.mark.skip("Enable it when ray ownership bug is fixed")
+@pytest.mark.timeout(timeout=200)
+@pytest.mark.parametrize("ray_large_cluster", [{"num_nodes": 4}], indirect=True)
+@require_ray
+@pytest.mark.asyncio
+async def test_ownership_when_scale_in(ray_large_cluster):
+    client = await new_cluster(
+        worker_num=0,
+        worker_cpu=2,
+        worker_mem=200 * 1024**2,
+        supervisor_mem=200 * 1024**2,
+        config={
+            "scheduling.autoscale.enabled": True,
+            "scheduling.autoscale.scheduler_check_interval": 1,
+            "scheduling.autoscale.scheduler_backlog_timeout": 1,
+            "scheduling.autoscale.worker_idle_timeout": 10,
+            "scheduling.autoscale.min_workers": 1,
+            "scheduling.autoscale.max_workers": 4,
+        },
+    )
+    async with client:
+        autoscaler_ref = mo.create_actor_ref(
+            uid=AutoscalerActor.default_uid(),
+            address=client._cluster.supervisor_address,
+        )
+        await asyncio.gather(*[autoscaler_ref.request_worker() for _ in range(2)])
+        df = md.DataFrame(mt.random.rand(100, 4, chunk_size=2), columns=list("abcd"))
+        print(df.execute())
+        assert await autoscaler_ref.get_dynamic_worker_nums() > 1
+        while await autoscaler_ref.get_dynamic_worker_nums() > 1:
+            dynamic_workers = await autoscaler_ref.get_dynamic_workers()
+            print(f"Waiting workers {dynamic_workers} to be released.")
+            await asyncio.sleep(1)
+        # Test data on node of released worker can still be fetched
+        pd_df = df.to_pandas()
+        groupby_sum_df = df.rechunk(40).groupby("a").sum()
+        print(groupby_sum_df.execute())
+        while await autoscaler_ref.get_dynamic_worker_nums() > 1:
+            dynamic_workers = await autoscaler_ref.get_dynamic_workers()
+            print(f"Waiting workers {dynamic_workers} to be released.")
+            await asyncio.sleep(1)
+        assert df.to_pandas().to_dict() == pd_df.to_dict()
+        assert (
+            groupby_sum_df.to_pandas().to_dict() == pd_df.groupby("a").sum().to_dict()
+        )

--- a/mars/deploy/oscar/tests/test_ray_scheduling.py
+++ b/mars/deploy/oscar/tests/test_ray_scheduling.py
@@ -32,10 +32,6 @@ from ....tests.core import require_ray
 from ....utils import lazy_import
 from ..ray import new_cluster, _load_config
 from ..tests import test_local
-from .modules.utils import (  # noqa: F401; pylint: disable=unused-variable
-    cleanup_third_party_modules_output,
-    get_output_filenames,
-)
 
 ray = lazy_import("ray")
 

--- a/mars/oscar/backends/ray/driver.py
+++ b/mars/oscar/backends/ray/driver.py
@@ -64,7 +64,9 @@ class RayActorDriver(BaseActorDriver):
         pg_name = cls._cluster_info["pg_name"]
         pg = cls._cluster_info["pg_group"]
         for index, bundle_spec in enumerate(pg.bundle_specs):
-            n_process = int(bundle_spec["CPU"]) + 1
+            # Main pool took a process.
+            # If supervisor is created in the same node with worker, it will take a process too.
+            n_process = int(bundle_spec["CPU"]) + 2
             for process_index in reversed(range(n_process)):
                 address = process_placement_to_address(
                     pg_name, index, process_index=process_index


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR optimizes Ray CI execution time and stability by :
- Making ray/deploy as a separate CI pipeline. The `ray/deploy` tests cases took at least 20~40 minutes to finish, which is long enough for a separate CI pipeline. A faster and small CI is more friendly to retry and more stable
- Move all scheduling tests from `test_ray.py` into `test_ray_scheduling.py`
- Using shared ray cluster for `test_ray.py` and `test_ray_fault_injection.py`
- Reduce created workers for some tests
- Split pytest into multiple pytest cases

With this PR, the longest Ray Deploy CI only took 19 minutes, which speed up development efficiency notably:
![image](https://user-images.githubusercontent.com/12445254/171323350-51a7c414-5676-4639-9dc4-3bfa1626debd.png)

Ray CI took 17 minutes:
![image](https://user-images.githubusercontent.com/12445254/171323398-ce340094-03e1-4e50-833f-eae7a1edf3da.png)

Ray DAG CI took 3 minutes:
![image](https://user-images.githubusercontent.com/12445254/171323501-a5707705-b373-4ead-84c8-cfee3f29881e.png)

And Ray CI is more stable. Timeout doesn't happen again.

<!-- Please give a short brief about these changes. -->

## Related issue number
Closes #3101 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
