### PR TITLE
Make `test_session_set_progress` more stable under Ray tests

### DIFF
--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -608,14 +608,15 @@ async def test_session_get_progress(create_cluster):
     assert session.session_id is not None
 
     raw = np.random.rand(100, 4)
-    t = mt.tensor(raw, chunk_size=5)
+    t = mt.tensor(raw, chunk_size=50)
 
     def f1(c):
         time.sleep(0.5)
         return c
 
     t1 = t.sum()
-    r = t1.map_chunk(f1)
+    t2 = t1.map_chunk(f1)
+    r = t2.map_chunk(f1)
     info = await session.execute(r)
 
     for _ in range(100):

--- a/mars/deploy/oscar/tests/test_ray_dag.py
+++ b/mars/deploy/oscar/tests/test_ray_dag.py
@@ -67,6 +67,7 @@ async def create_cluster(request):
         n_worker=2,
         n_cpu=2,
         use_uvloop=False,
+        config={"task.execution_config.ray.subtask_monitor_interval": 0},
     )
     async with client:
         assert client.session.client is not None

--- a/mars/deploy/oscar/tests/test_ray_dag.py
+++ b/mars/deploy/oscar/tests/test_ray_dag.py
@@ -60,6 +60,7 @@ EXPECT_PROFILING_STRUCTURE_NO_SLOW["supervisor"]["slow_calls"] = {}
 @pytest.mark.parametrize(indirect=True)
 @pytest.fixture
 async def create_cluster(request):
+    param = getattr(request, "param", {})
     start_method = os.environ.get("POOL_START_METHOD", None)
     client = await new_cluster(
         subprocess_start_method=start_method,
@@ -67,7 +68,7 @@ async def create_cluster(request):
         n_worker=2,
         n_cpu=2,
         use_uvloop=False,
-        config={"task.execution_config.ray.subtask_monitor_interval": 0},
+        config=param.get("config", None),
     )
     async with client:
         assert client.session.client is not None
@@ -124,6 +125,11 @@ def test_sync_execute(config):
 
 
 @require_ray
+@pytest.mark.parametrize(
+    "create_cluster",
+    [{"config": {"task.execution_config.ray.subtask_monitor_interval": 0}}],
+    indirect=True,
+)
 @pytest.mark.asyncio
 async def test_session_get_progress(ray_start_regular_shared2, create_cluster):
     await test_local.test_session_get_progress(create_cluster)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Fix `test_session_set_progress` when running on backend ray.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
