### PR TITLE
Stop importing main module when starting Mars local cluster

### DIFF
--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -62,5 +62,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Benchmarks log
-          path: benchmarks/asv_bench/benchmarks.log
+          path: benchmarks/asv_bench/results
         if: failure()

--- a/benchmarks/asv_bench/benchmarks/storage.py
+++ b/benchmarks/asv_bench/benchmarks/storage.py
@@ -102,3 +102,4 @@ if __name__ == "__main__":
     suite = TransferPackageSuite()
     suite.setup()
     print(suite.time_1_to_1())
+    suite.teardown()

--- a/benchmarks/asv_bench/benchmarks/storage.py
+++ b/benchmarks/asv_bench/benchmarks/storage.py
@@ -91,6 +91,9 @@ class TransferPackageSuite:
     def setup(self):
         mars.new_session(n_worker=2, n_cpu=8)
 
+    def teardown(self):
+        mars.stop_server()
+
     def time_1_to_1(self):
         return mr.spawn(send_1_to_1).execute().fetch()
 

--- a/benchmarks/asv_bench/benchmarks/storage.py
+++ b/benchmarks/asv_bench/benchmarks/storage.py
@@ -14,6 +14,7 @@
 
 import itertools
 
+import cloudpickle
 import numpy as np
 import pandas as pd
 
@@ -89,10 +90,19 @@ class TransferPackageSuite:
     """
 
     def setup(self):
+        try:
+            # make sure all submodules will serial functions instead of refs
+            cloudpickle.register_pickle_by_value(__import__("benchmarks.storage"))
+        except (AttributeError, ImportError):
+            pass
         mars.new_session(n_worker=2, n_cpu=8)
 
     def teardown(self):
         mars.stop_server()
+        try:
+            cloudpickle.unregister_pickle_by_value(__import__("benchmarks.storage"))
+        except (AttributeError, ImportError):
+            pass
 
     def time_1_to_1(self):
         return mr.spawn(send_1_to_1).execute().fetch()

--- a/mars/deploy/oscar/tests/test_local.py
+++ b/mars/deploy/oscar/tests/test_local.py
@@ -15,7 +15,6 @@
 import asyncio
 import copy
 import os
-import shutil
 import subprocess
 import sys
 import threading
@@ -950,9 +949,7 @@ def test_naive_code_file():
             env = os.environ.copy()
             env["PYTHONPATH"] = os.path.pathsep.join(sys.path)
             env["RESULTPATH"] = result_path
-            proc = subprocess.Popen(
-                [sys.executable, script_path], env=env, stdout=subprocess.PIPE
-            )
+            proc = subprocess.Popen([sys.executable, script_path], env=env)
             pid = proc.pid
             proc.wait(120)
 

--- a/mars/oscar/debug.py
+++ b/mars/oscar/debug.py
@@ -79,7 +79,7 @@ async def _log_timeout(timeout, msg, *args, **kwargs):
         await asyncio.sleep(timeout * rnd)
         rnd += 1
         logger.warning(
-            msg + "(timeout for %.4f seconds).",
+            msg + " (timeout for %.4f seconds).",
             *args,
             time.time() - start_time,
             **kwargs,

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -407,6 +407,7 @@ def test_quiet_stdio():
         print("LINE 2", file=sys.stderr, end="\n")
     finally:
         sys.stdout, sys.stderr = old_stdout, old_stderr
+        executor.shutdown(False)
 
     assert stdout_w.content == "LINE T\nLINE 1\n"
     assert stderr_w.content == "LINE 2\n"


### PR DESCRIPTION
## What do these changes do?

`multiprocessing` module fixes importing `__main__` when starting subprocesses with `forkserver` or `spawn`. This stops running Mars local clusters without wrapping code with `if __name__ == "__main__"` block. This can be fixed by suspending this import behavior when starting subprocesses with Mars actor pools.

Also fixes benchmark errors for storage mod.

## Related issue number

Fixes #3108

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
