### PR TITLE
Integrate part of scipy elliptic functions and integrals

### DIFF
--- a/docs/source/reference/tensor/special.rst
+++ b/docs/source/reference/tensor/special.rst
@@ -62,6 +62,24 @@ Ellipsoidal harmonics
    mars.tensor.special.ellip_normal
 
 
+Elliptic functions and integrals
+---------------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   mars.tensor.special.ellipk
+   mars.tensor.special.ellipkm1
+   mars.tensor.special.ellipkinc
+   mars.tensor.special.ellipe
+   mars.tensor.special.ellipeinc
+   mars.tensor.special.elliprc
+   mars.tensor.special.elliprf
+   mars.tensor.special.elliprg
+   mars.tensor.special.elliprj
+
+
 Gamma and related functions
 ---------------------------
 

--- a/mars/lib/sparse/__init__.py
+++ b/mars/lib/sparse/__init__.py
@@ -295,6 +295,17 @@ ellip_harm = partial(call_sparse, "ellip_harm")
 ellip_harm_2 = partial(call_sparse, "ellip_harm_2")
 ellip_normal = partial(call_sparse, "ellip_normal")
 
+ellipk = partial(_call_unary, "ellipk")
+ellipkm1 = partial(_call_unary, "ellipkm1")
+ellipkinc = partial(_call_bin, "ellipkinc")
+ellipe = partial(_call_unary, "ellipe")
+ellipeinc = partial(_call_bin, "ellipeinc")
+elliprc = partial(_call_bin, "elliprc")
+elliprd = partial(call_sparse, "elliprd")
+elliprf = partial(call_sparse, "elliprf")
+elliprg = partial(call_sparse, "elliprg")
+elliprj = partial(call_sparse, "elliprj")
+
 
 def equal(a, b, **_):
     try:

--- a/mars/lib/sparse/array.py
+++ b/mars/lib/sparse/array.py
@@ -738,6 +738,13 @@ class SparseArray(SparseNDArray):
     erfcinv = partialmethod(_scipy_unary, "erfcinv")
     entr = partialmethod(_scipy_unary, "entr")
 
+    ellipk = partialmethod(_scipy_unary, "ellipk")
+    ellipkm1 = partialmethod(_scipy_unary, "ellipkm1")
+    ellipkinc = partialmethod(_scipy_binary, "ellipkinc")
+    ellipe = partialmethod(_scipy_unary, "ellipe")
+    ellipeinc = partialmethod(_scipy_binary, "ellipeinc")
+    elliprc = partialmethod(_scipy_binary, "elliprc")
+
     rel_entr = partialmethod(_scipy_binary, "rel_entr")
     kl_div = partialmethod(_scipy_binary, "kl_div")
     xlogy = partialmethod(_scipy_binary, "xlogy")

--- a/mars/tensor/special/__init__.py
+++ b/mars/tensor/special/__init__.py
@@ -127,5 +127,27 @@ try:
         ellip_normal,
         TensorEllipNormal,
     )
+    from .ellip_func_integrals import (
+        ellipk,
+        TensorEllipk,
+        ellipkm1,
+        TensorEllipkm1,
+        ellipkinc,
+        TensorEllipkinc,
+        ellipe,
+        TensorEllipe,
+        ellipeinc,
+        TensorEllipeinc,
+        elliprc,
+        TensorElliprc,
+        elliprd,
+        TensorElliprd,
+        elliprf,
+        TensorElliprf,
+        elliprg,
+        TensorElliprg,
+        elliprj,
+        TensorElliprj,
+    )
 except ImportError:  # pragma: no cover
     pass

--- a/mars/tensor/special/ellip_func_integrals.py
+++ b/mars/tensor/special/ellip_func_integrals.py
@@ -1,0 +1,163 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import scipy.special as spspecial
+
+from ..arithmetic.utils import arithmetic_operand
+from ..utils import infer_dtype, implement_scipy
+from .core import (
+    _register_special_op,
+    TensorSpecialBinOp,
+    TensorSpecialUnaryOp,
+    TensorSpecialMultiOp,
+)
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="unary")
+class TensorEllipk(TensorSpecialUnaryOp):
+    _func_name = "ellipk"
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="unary")
+class TensorEllipkm1(TensorSpecialUnaryOp):
+    _func_name = "ellipkm1"
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="binary_and")
+class TensorEllipkinc(TensorSpecialBinOp):
+    _func_name = "ellipkinc"
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="unary")
+class TensorEllipkm1(TensorSpecialUnaryOp):
+    _func_name = "ellipkm1"
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="unary")
+class TensorEllipe(TensorSpecialUnaryOp):
+    _func_name = "ellipe"
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="binary_and")
+class TensorEllipeinc(TensorSpecialBinOp):
+    _func_name = "ellipeinc"
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="binary_and")
+class TensorElliprc(TensorSpecialBinOp):
+    _func_name = "elliprc"
+
+
+@_register_special_op
+class TensorElliprd(TensorSpecialMultiOp):
+    _ARG_COUNT = 3
+    _func_name = "elliprd"
+
+
+@_register_special_op
+class TensorElliprf(TensorSpecialMultiOp):
+    _ARG_COUNT = 3
+    _func_name = "elliprf"
+
+
+@_register_special_op
+class TensorElliprg(TensorSpecialMultiOp):
+    _ARG_COUNT = 3
+    _func_name = "elliprg"
+
+
+@_register_special_op
+class TensorElliprj(TensorSpecialMultiOp):
+    _ARG_COUNT = 4
+    _func_name = "elliprj"
+
+
+@implement_scipy(spspecial.ellipk)
+@infer_dtype(spspecial.ellipk)
+def ellipk(x, **kwargs):
+    op = TensorEllipk(**kwargs)
+    return op(x)
+
+
+@implement_scipy(spspecial.ellipkm1)
+@infer_dtype(spspecial.ellipkm1)
+def ellipkm1(x, **kwargs):
+    op = TensorEllipkm1(**kwargs)
+    return op(x)
+
+
+@implement_scipy(spspecial.ellipkinc)
+@infer_dtype(spspecial.ellipkinc)
+def ellipkinc(phi, m, **kwargs):
+    op = TensorEllipkinc(**kwargs)
+    return op(phi, m)
+
+
+@implement_scipy(spspecial.ellipe)
+@infer_dtype(spspecial.ellipe)
+def ellipe(x, **kwargs):
+    op = TensorEllipe(**kwargs)
+    return op(x)
+
+
+@implement_scipy(spspecial.ellipeinc)
+@infer_dtype(spspecial.ellipeinc)
+def ellipeinc(phi, m, **kwargs):
+    op = TensorEllipeinc(**kwargs)
+    return op(phi, m)
+
+
+try:
+
+    @implement_scipy(spspecial.elliprc)
+    @infer_dtype(spspecial.elliprc)
+    def elliprc(x, y, **kwargs):
+        op = TensorElliprc(**kwargs)
+        return op(x, y)
+
+    @implement_scipy(spspecial.elliprd)
+    @infer_dtype(spspecial.elliprd)
+    def elliprd(x, y, z, **kwargs):
+        op = TensorElliprd(**kwargs)
+        return op(x, y, z)
+
+    @implement_scipy(spspecial.elliprf)
+    @infer_dtype(spspecial.elliprf)
+    def elliprf(x, y, z, **kwargs):
+        op = TensorElliprf(**kwargs)
+        return op(x, y, z)
+
+    @implement_scipy(spspecial.elliprg)
+    @infer_dtype(spspecial.elliprg)
+    def elliprg(x, y, z, **kwargs):
+        op = TensorElliprg(**kwargs)
+        return op(x, y, z)
+
+    @implement_scipy(spspecial.elliprj)
+    @infer_dtype(spspecial.elliprj)
+    def elliprj(x, y, z, p, **kwargs):
+        op = TensorElliprj(**kwargs)
+        return op(x, y, z, p)
+
+except AttributeError:
+    # These functions are not implemented before scipy v1.8 so
+    # spsecial.func may cause AttributeError
+    pass

--- a/mars/tensor/special/ellip_func_integrals.py
+++ b/mars/tensor/special/ellip_func_integrals.py
@@ -44,12 +44,6 @@ class TensorEllipkinc(TensorSpecialBinOp):
 
 @_register_special_op
 @arithmetic_operand(sparse_mode="unary")
-class TensorEllipkm1(TensorSpecialUnaryOp):
-    _func_name = "ellipkm1"
-
-
-@_register_special_op
-@arithmetic_operand(sparse_mode="unary")
 class TensorEllipe(TensorSpecialUnaryOp):
     _func_name = "ellipe"
 

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import numpy as np
+import scipy
+import pytest
 from scipy.special import (
     gammaln as scipy_gammaln,
     erf as scipy_erf,
@@ -21,6 +23,16 @@ from scipy.special import (
     erfi as scipy_erfi,
     erfinv as scipy_erfinv,
     erfcinv as scipy_erfcinv,
+    ellipk as scipy_ellipk,
+    ellipkm1 as scipy_ellipkm1,
+    ellipkinc as scipy_ellipkinc,
+    ellipe as scipy_ellipe,
+    ellipeinc as scipy_ellipeinc,
+    elliprc as scipy_elliprc,
+    elliprd as scipy_elliprd,
+    elliprf as scipy_elliprf,
+    elliprg as scipy_elliprg,
+    elliprj as scipy_elliprj,
     betainc as scipy_betainc,
 )
 
@@ -45,6 +57,28 @@ from ..gamma_funcs import (
     TensorGammaln,
     betainc,
     TensorBetaInc,
+)
+from ..ellip_func_integrals import (
+    ellipk,
+    TensorEllipk,
+    ellipkm1,
+    TensorEllipkm1,
+    ellipkinc,
+    TensorEllipkinc,
+    ellipe,
+    TensorEllipe,
+    ellipeinc,
+    TensorEllipeinc,
+    elliprc,
+    TensorElliprc,
+    elliprd,
+    TensorElliprd,
+    elliprf,
+    TensorElliprf,
+    elliprg,
+    TensorElliprg,
+    elliprj,
+    TensorElliprj,
 )
 
 
@@ -291,3 +325,232 @@ def test_beta_inc():
         assert isinstance(c.op, TensorBetaInc)
         assert c.index == c.inputs[0].index
         assert c.shape == c.inputs[0].shape
+
+
+def test_ellipk():
+    raw = np.random.rand(10, 8, 5)
+    t = tensor(raw, chunk_size=3)
+
+    r = ellipk(t)
+    expect = scipy_ellipk(raw)
+
+    assert r.shape == raw.shape
+    assert r.dtype == expect.dtype
+
+    t, r = tile(t, r)
+
+    assert r.nsplits == t.nsplits
+    for c in r.chunks:
+        assert isinstance(c.op, TensorEllipk)
+        assert c.index == c.inputs[0].index
+        assert c.shape == c.inputs[0].shape
+
+
+def test_ellipkm1():
+    raw = np.random.rand(10, 8, 5)
+    t = tensor(raw, chunk_size=3)
+
+    r = ellipkm1(t)
+    expect = scipy_ellipkm1(raw)
+
+    assert r.shape == raw.shape
+    assert r.dtype == expect.dtype
+
+    t, r = tile(t, r)
+
+    assert r.nsplits == t.nsplits
+    for c in r.chunks:
+        assert isinstance(c.op, TensorEllipkm1)
+        assert c.index == c.inputs[0].index
+        assert c.shape == c.inputs[0].shape
+
+
+def test_ellipkinc():
+    raw1 = np.random.rand(4, 3, 2)
+    raw2 = np.random.rand(4, 3, 2)
+    a = tensor(raw1, chunk_size=3)
+    b = tensor(raw2, chunk_size=3)
+
+    r = ellipkinc(a, b)
+    expect = scipy_ellipkinc(raw1, raw2)
+
+    assert r.shape == raw1.shape
+    assert r.dtype == expect.dtype
+
+    tiled_a, r = tile(a, r)
+
+    assert r.nsplits == tiled_a.nsplits
+    for chunk in r.chunks:
+        assert isinstance(chunk.op, TensorEllipkinc)
+        assert chunk.index == chunk.inputs[0].index
+        assert chunk.shape == chunk.inputs[0].shape
+
+
+def test_ellipe():
+    raw = np.random.rand(10, 8, 5)
+    t = tensor(raw, chunk_size=3)
+
+    r = ellipe(t)
+    expect = scipy_ellipe(raw)
+
+    assert r.shape == raw.shape
+    assert r.dtype == expect.dtype
+
+    t, r = tile(t, r)
+
+    assert r.nsplits == t.nsplits
+    for c in r.chunks:
+        assert isinstance(c.op, TensorEllipe)
+        assert c.index == c.inputs[0].index
+        assert c.shape == c.inputs[0].shape
+
+
+def test_ellipeinc():
+    raw1 = np.random.rand(4, 3, 2)
+    raw2 = np.random.rand(4, 3, 2)
+    a = tensor(raw1, chunk_size=3)
+    b = tensor(raw2, chunk_size=3)
+
+    r = ellipeinc(a, b)
+    expect = scipy_ellipeinc(raw1, raw2)
+
+    assert r.shape == raw1.shape
+    assert r.dtype == expect.dtype
+
+    tiled_a, r = tile(a, r)
+
+    assert r.nsplits == tiled_a.nsplits
+    for chunk in r.chunks:
+        assert isinstance(chunk.op, TensorEllipeinc)
+        assert chunk.index == chunk.inputs[0].index
+        assert chunk.shape == chunk.inputs[0].shape
+
+
+@pytest.mark.skipif(
+    scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+)
+def test_elliprc():
+    raw1 = np.random.rand(4, 3, 2)
+    raw2 = np.random.rand(4, 3, 2)
+    a = tensor(raw1, chunk_size=3)
+    b = tensor(raw2, chunk_size=3)
+
+    r = elliprc(a, b)
+    expect = scipy_elliprc(raw1, raw2)
+
+    assert r.shape == raw1.shape
+    assert r.dtype == expect.dtype
+
+    tiled_a, r = tile(a, r)
+
+    assert r.nsplits == tiled_a.nsplits
+    for chunk in r.chunks:
+        assert isinstance(chunk.op, TensorElliprc)
+        assert chunk.index == chunk.inputs[0].index
+        assert chunk.shape == chunk.inputs[0].shape
+
+
+@pytest.mark.skipif(
+    scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+)
+def test_elliprd():
+    raw1 = np.random.rand(4, 3, 2)
+    raw2 = np.random.rand(4, 3, 2)
+    raw3 = np.random.rand(4, 3, 2)
+    a = tensor(raw1, chunk_size=3)
+    b = tensor(raw2, chunk_size=3)
+    c = tensor(raw3, chunk_size=3)
+
+    r = elliprd(a, b, c)
+    expect = scipy_elliprd(raw1, raw2, raw3)
+
+    assert r.shape == raw1.shape
+    assert r.dtype == expect.dtype
+
+    tiled_a, r = tile(a, r)
+
+    assert r.nsplits == tiled_a.nsplits
+    for chunk in r.chunks:
+        assert isinstance(chunk.op, TensorElliprd)
+        assert chunk.index == chunk.inputs[0].index
+        assert chunk.shape == chunk.inputs[0].shape
+
+
+@pytest.mark.skipif(
+    scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+)
+def test_elliprf():
+    raw1 = np.random.rand(4, 3, 2)
+    raw2 = np.random.rand(4, 3, 2)
+    raw3 = np.random.rand(4, 3, 2)
+    a = tensor(raw1, chunk_size=3)
+    b = tensor(raw2, chunk_size=3)
+    c = tensor(raw3, chunk_size=3)
+
+    r = elliprf(a, b, c)
+    expect = scipy_elliprf(raw1, raw2, raw3)
+
+    assert r.shape == raw1.shape
+    assert r.dtype == expect.dtype
+
+    tiled_a, r = tile(a, r)
+
+    assert r.nsplits == tiled_a.nsplits
+    for chunk in r.chunks:
+        assert isinstance(chunk.op, TensorElliprf)
+        assert chunk.index == chunk.inputs[0].index
+        assert chunk.shape == chunk.inputs[0].shape
+
+
+@pytest.mark.skipif(
+    scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+)
+def test_elliprg():
+    raw1 = np.random.rand(4, 3, 2)
+    raw2 = np.random.rand(4, 3, 2)
+    raw3 = np.random.rand(4, 3, 2)
+    a = tensor(raw1, chunk_size=3)
+    b = tensor(raw2, chunk_size=3)
+    c = tensor(raw3, chunk_size=3)
+
+    r = elliprg(a, b, c)
+    expect = scipy_elliprg(raw1, raw2, raw3)
+
+    assert r.shape == raw1.shape
+    assert r.dtype == expect.dtype
+
+    tiled_a, r = tile(a, r)
+
+    assert r.nsplits == tiled_a.nsplits
+    for chunk in r.chunks:
+        assert isinstance(chunk.op, TensorElliprg)
+        assert chunk.index == chunk.inputs[0].index
+        assert chunk.shape == chunk.inputs[0].shape
+
+
+@pytest.mark.skipif(
+    scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+)
+def test_elliprj():
+    raw1 = np.random.rand(4, 3, 2)
+    raw2 = np.random.rand(4, 3, 2)
+    raw3 = np.random.rand(4, 3, 2)
+    raw4 = np.random.rand(4, 3, 2)
+    a = tensor(raw1, chunk_size=3)
+    b = tensor(raw2, chunk_size=3)
+    c = tensor(raw3, chunk_size=3)
+    d = tensor(raw4, chunk_size=3)
+
+    r = elliprj(a, b, c, d)
+    expect = scipy_elliprj(raw1, raw2, raw3, raw4)
+
+    assert r.shape == raw1.shape
+    assert r.dtype == expect.dtype
+
+    tiled_a, r = tile(a, r)
+
+    assert r.nsplits == tiled_a.nsplits
+    for chunk in r.chunks:
+        assert isinstance(chunk.op, TensorElliprj)
+        assert chunk.index == chunk.inputs[0].index
+        assert chunk.shape == chunk.inputs[0].shape

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ....lib.version import parse as parse_version
 import numpy as np
 import scipy
 import pytest
@@ -427,7 +428,7 @@ def test_ellipeinc():
 
 
 @pytest.mark.skipif(
-    scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+    parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
 )
 def test_elliprc():
     raw1 = np.random.rand(4, 3, 2)
@@ -451,7 +452,7 @@ def test_elliprc():
 
 
 @pytest.mark.skipif(
-    scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+    parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
 )
 def test_elliprd():
     raw1 = np.random.rand(4, 3, 2)
@@ -477,7 +478,7 @@ def test_elliprd():
 
 
 @pytest.mark.skipif(
-    scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+    parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
 )
 def test_elliprf():
     raw1 = np.random.rand(4, 3, 2)
@@ -503,7 +504,7 @@ def test_elliprf():
 
 
 @pytest.mark.skipif(
-    scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+    parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
 )
 def test_elliprg():
     raw1 = np.random.rand(4, 3, 2)
@@ -529,7 +530,7 @@ def test_elliprg():
 
 
 @pytest.mark.skipif(
-    scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+    parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
 )
 def test_elliprj():
     raw1 = np.random.rand(4, 3, 2)

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -428,7 +428,8 @@ def test_ellipeinc():
 
 
 @pytest.mark.skipif(
-    parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
+    parse_version(scipy.__version__) < parse_version("1.8.0"),
+    reason="function not implemented in scipy.",
 )
 def test_elliprc():
     raw1 = np.random.rand(4, 3, 2)
@@ -452,7 +453,8 @@ def test_elliprc():
 
 
 @pytest.mark.skipif(
-    parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
+    parse_version(scipy.__version__) < parse_version("1.8.0"),
+    reason="function not implemented in scipy.",
 )
 def test_elliprd():
     raw1 = np.random.rand(4, 3, 2)
@@ -478,7 +480,8 @@ def test_elliprd():
 
 
 @pytest.mark.skipif(
-    parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
+    parse_version(scipy.__version__) < parse_version("1.8.0"),
+    reason="function not implemented in scipy.",
 )
 def test_elliprf():
     raw1 = np.random.rand(4, 3, 2)
@@ -504,7 +507,8 @@ def test_elliprf():
 
 
 @pytest.mark.skipif(
-    parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
+    parse_version(scipy.__version__) < parse_version("1.8.0"),
+    reason="function not implemented in scipy.",
 )
 def test_elliprg():
     raw1 = np.random.rand(4, 3, 2)
@@ -530,7 +534,8 @@ def test_elliprg():
 
 
 @pytest.mark.skipif(
-    parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
+    parse_version(scipy.__version__) < parse_version("1.8.0"),
+    reason="function not implemented in scipy.",
 )
 def test_elliprj():
     raw1 = np.random.rand(4, 3, 2)

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ....lib.version import parse as parse_version
 import numpy as np
 import scipy
 import pytest
@@ -37,6 +36,7 @@ from scipy.special import (
     betainc as scipy_betainc,
 )
 
+from ....lib.version import parse as parse_version
 from ....core import tile
 from ... import tensor
 from ..err_fresnel import (

--- a/mars/tensor/special/tests/test_special_execution.py
+++ b/mars/tensor/special/tests/test_special_execution.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ....lib.version import parse as parse_version
 import numpy as np
 import pytest
 import scipy
@@ -105,7 +106,7 @@ def test_unary_execution(setup, func):
         pytest.param(
             "elliprc",
             marks=pytest.mark.skipif(
-                scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+                parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
             ),
         ),
     ],
@@ -150,19 +151,19 @@ def test_binary_execution(setup, func):
         pytest.param(
             "elliprd",
             marks=pytest.mark.skipif(
-                scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+                parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
             ),
         ),
         pytest.param(
             "elliprf",
             marks=pytest.mark.skipif(
-                scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+                parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
             ),
         ),
         pytest.param(
             "elliprg",
             marks=pytest.mark.skipif(
-                scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+                parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
             ),
         ),
     ],
@@ -209,7 +210,7 @@ def test_triple_execution(setup, func):
         pytest.param(
             "elliprj",
             marks=pytest.mark.skipif(
-                scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+                parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
             ),
         ),
     ],

--- a/mars/tensor/special/tests/test_special_execution.py
+++ b/mars/tensor/special/tests/test_special_execution.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ....lib.version import parse as parse_version
 import numpy as np
 import pytest
 import scipy
 import scipy.sparse as sps
 import scipy.special as spspecial
 
+from ....lib.version import parse as parse_version
 from ... import tensor
 from ... import special as mt_special
 

--- a/mars/tensor/special/tests/test_special_execution.py
+++ b/mars/tensor/special/tests/test_special_execution.py
@@ -14,6 +14,7 @@
 
 import numpy as np
 import pytest
+import scipy
 import scipy.sparse as sps
 import scipy.special as spspecial
 
@@ -37,6 +38,9 @@ from ... import special as mt_special
         "erfi",
         "erfinv",
         "entr",
+        "ellipk",
+        "ellipkm1",
+        "ellipe",
     ],
 )
 def test_unary_execution(setup, func):
@@ -96,6 +100,14 @@ def test_unary_execution(setup, func):
         "hankel2",
         "hankel2e",
         "hyp0f1",
+        "ellipkinc",
+        "ellipeinc",
+        pytest.param(
+            "elliprc",
+            marks=pytest.mark.skipif(
+                scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+            ),
+        ),
     ],
 )
 def test_binary_execution(setup, func):
@@ -128,7 +140,33 @@ def test_binary_execution(setup, func):
     np.testing.assert_array_equal(result.toarray(), expected)
 
 
-@pytest.mark.parametrize("func", ["betainc", "betaincinv", "hyp1f1", "hyperu"])
+@pytest.mark.parametrize(
+    "func",
+    [
+        "betainc",
+        "betaincinv",
+        "hyp1f1",
+        "hyperu",
+        pytest.param(
+            "elliprd",
+            marks=pytest.mark.skipif(
+                scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+            ),
+        ),
+        pytest.param(
+            "elliprf",
+            marks=pytest.mark.skipif(
+                scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+            ),
+        ),
+        pytest.param(
+            "elliprg",
+            marks=pytest.mark.skipif(
+                scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+            ),
+        ),
+    ],
+)
 def test_triple_execution(setup, func):
     sp_func = getattr(spspecial, func)
     mt_func = getattr(mt_special, func)
@@ -163,7 +201,19 @@ def test_triple_execution(setup, func):
     np.testing.assert_array_equal(result.toarray(), expected)
 
 
-@pytest.mark.parametrize("func", ["hyp2f1", "ellip_normal"])
+@pytest.mark.parametrize(
+    "func",
+    [
+        "hyp2f1",
+        "ellip_normal",
+        pytest.param(
+            "elliprj",
+            marks=pytest.mark.skipif(
+                scipy.__version__ < "1.8.0", reason="function not implemented in scipy."
+            ),
+        ),
+    ],
+)
 def test_quadruple_execution(setup, func):
     sp_func = getattr(spspecial, func)
     mt_func = getattr(mt_special, func)

--- a/mars/tensor/special/tests/test_special_execution.py
+++ b/mars/tensor/special/tests/test_special_execution.py
@@ -106,7 +106,8 @@ def test_unary_execution(setup, func):
         pytest.param(
             "elliprc",
             marks=pytest.mark.skipif(
-                parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
+                parse_version(scipy.__version__) < parse_version("1.8.0"),
+                reason="function not implemented in scipy.",
             ),
         ),
     ],
@@ -151,19 +152,22 @@ def test_binary_execution(setup, func):
         pytest.param(
             "elliprd",
             marks=pytest.mark.skipif(
-                parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
+                parse_version(scipy.__version__) < parse_version("1.8.0"),
+                reason="function not implemented in scipy.",
             ),
         ),
         pytest.param(
             "elliprf",
             marks=pytest.mark.skipif(
-                parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
+                parse_version(scipy.__version__) < parse_version("1.8.0"),
+                reason="function not implemented in scipy.",
             ),
         ),
         pytest.param(
             "elliprg",
             marks=pytest.mark.skipif(
-                parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
+                parse_version(scipy.__version__) < parse_version("1.8.0"),
+                reason="function not implemented in scipy.",
             ),
         ),
     ],
@@ -210,7 +214,8 @@ def test_triple_execution(setup, func):
         pytest.param(
             "elliprj",
             marks=pytest.mark.skipif(
-                parse_version(scipy.__version__) < parse_version("1.8.0"), reason="function not implemented in scipy."
+                parse_version(scipy.__version__) < parse_version("1.8.0"),
+                reason="function not implemented in scipy.",
             ),
         ),
     ],


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Integrate scipy elliptic functions and integrals except ellipj which returns multiple outputs. Some functions are within a try except block because they were not implemented in scipy v1.7, so spspecial.func may throw an AttributeError if the scipy version is low.

## Related issue number

#751 (except ellipj)

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
