### PR TITLE
Optimize serializable memory

### DIFF
--- a/benchmarks/asv_bench/benchmarks/serialize.py
+++ b/benchmarks/asv_bench/benchmarks/serialize.py
@@ -40,6 +40,8 @@ from mars.serialization.serializables import (
     Timedelta64Field,
     TupleField,
     DictField,
+    Complex64Field,
+    Complex128Field,
 )
 from mars.services.subtask import Subtask, SubtaskResult, SubtaskStatus
 from mars.services.task import new_task_id
@@ -72,11 +74,13 @@ class MySerializable(Serializable):
     _int64_val = Int64Field("f3")
     _float32_val = Float32Field("f4")
     _float64_val = Float64Field("f5")
-    _string_val = StringField("f6")
-    _datetime64_val = Datetime64Field("f7")
-    _timedelta64_val = Timedelta64Field("f8")
-    _datatype_val = DataTypeField("f9")
-    _slice_val = SliceField("f10")
+    _complex64_val = Complex64Field("f6")
+    _complex128_val = Complex128Field("f7")
+    _string_val = StringField("f8")
+    _datetime64_val = Datetime64Field("f9")
+    _timedelta64_val = Timedelta64Field("f10")
+    _datatype_val = DataTypeField("f11")
+    _slice_val = SliceField("f12")
     _list_val = ListField("list_val", FieldTypes.int64)
     _tuple_val = TupleField("tuple_val", FieldTypes.string)
     _dict_val = DictField("dict_val", FieldTypes.string, FieldTypes.bytes)

--- a/mars/core/base.py
+++ b/mars/core/base.py
@@ -64,7 +64,13 @@ class Base(Serializable):
 
     @property
     def _values_(self):
-        return [self._FIELDS[k].get(self) for k in self._copy_tags_]
+        values = []
+        for k in self._copy_tags_:
+            try:
+                values.append(self._FIELDS[k].get(self))
+            except AttributeError:
+                values.append(None)
+        return values
 
     def __mars_tokenize__(self):
         try:

--- a/mars/core/base.py
+++ b/mars/core/base.py
@@ -55,9 +55,7 @@ class Base(Serializable):
             return getattr(cls, member)
         except AttributeError:
             slots = sorted(
-                f.attr_name
-                for k, f in self._FIELDS.items()
-                if k not in self._no_copy_attrs_
+                f.name for k, f in self._FIELDS.items() if k not in self._no_copy_attrs_
             )
             setattr(cls, member, slots)
             return slots
@@ -121,9 +119,9 @@ class Base(Serializable):
         fields = self._FIELDS
         kv = {}
         no_value = object()
-        for attr_name, field in fields.items():
-            if attr_name not in exclude_fields:
-                value = getattr(self, attr_name, no_value)
+        for name, field in fields.items():
+            if name not in exclude_fields:
+                value = getattr(self, name, no_value)
                 if value is not no_value and isinstance(value, accept_value_types):
                     kv[field.tag] = value
         return kv

--- a/mars/core/base.py
+++ b/mars/core/base.py
@@ -63,9 +63,10 @@ class Base(Serializable):
     @property
     def _values_(self):
         values = []
+        fields = self._FIELDS
         for k in self._copy_tags_:
             try:
-                values.append(self._FIELDS[k].get(self))
+                values.append(fields[k].get(self))
             except AttributeError:
                 values.append(None)
         return values
@@ -96,13 +97,17 @@ class Base(Serializable):
 
     def copy_to(self, target: "Base"):
         target_fields = target._FIELDS
-        for k in self._FIELDS:
-            if k in self._no_copy_attrs_:
+        no_copy_attrs = self._no_copy_attrs_
+        for k, field in self._FIELDS.items():
+            if k in no_copy_attrs:
                 continue
             try:
-                target_fields[k].set(target, getattr(self, k))
+                # Slightly faster than getattr.
+                value = field.__get__(self, k)
+                target_fields[k].set(target, value)
             except AttributeError:
                 continue
+
         return target
 
     def copy_from(self, obj):

--- a/mars/core/base.py
+++ b/mars/core/base.py
@@ -95,11 +95,12 @@ class Base(Serializable):
         return self.copy_to(type(self)(_key=self.key))
 
     def copy_to(self, target: "Base"):
+        target_fields = target._FIELDS
         for k in self._FIELDS:
             if k in self._no_copy_attrs_:
                 continue
             try:
-                setattr(target, k, getattr(self, k))
+                target_fields[k].set(target, getattr(self, k))
             except AttributeError:
                 continue
         return target

--- a/mars/dataframe/arithmetic/tests/test_arithmetic.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic.py
@@ -1523,12 +1523,15 @@ def test_arithmetic_lazy_chunk_meta():
     df2 = tile(df2)
 
     chunk = df2.chunks[0].data
-    assert chunk._FIELD_VALUES.get("_dtypes") is None
+    assert chunk._FIELDS["_dtypes"].get(chunk) is None
     pd.testing.assert_series_equal(chunk.dtypes, df.dtypes)
-    assert chunk._FIELD_VALUES.get("_index_value") is None
+    assert chunk._FIELDS["_dtypes"].get(chunk) is not None
+    assert chunk._FIELDS["_index_value"].get(chunk) is None
     pd.testing.assert_index_equal(chunk.index_value.to_pandas(), pd.RangeIndex(3))
-    assert chunk._FIELD_VALUES.get("_columns_value") is None
+    assert chunk._FIELDS["_index_value"].get(chunk) is not None
+    assert chunk._FIELDS["_columns_value"].get(chunk) is None
     pd.testing.assert_index_equal(chunk.columns_value.to_pandas(), pd.RangeIndex(3))
+    assert chunk._FIELDS["_columns_value"].get(chunk) is not None
 
 
 def test_datetime_arithmetic():

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -505,15 +505,16 @@ class ChunkDtypesField(SeriesField):
             cache[tileable_key, index] = dtypes
             return dtypes
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         if not issubclass(owner, LazyMetaChunkData):  # pragma: no cover
             return super().__get__(instance, owner)
 
-        values = instance._FIELD_VALUES
-        dtypes = values.get("_dtypes", None)
-        if dtypes is not None:
-            # been set before
-            return dtypes
+        try:
+            value = self._member_descriptor.__get__(instance, owner)
+            if value is not None:
+                return value
+        except AttributeError:
+            pass
 
         if instance.index is None:
             return super().__get__(instance, owner)
@@ -522,7 +523,7 @@ class ChunkDtypesField(SeriesField):
         index = instance.index[1]
         dtypes = self._gen_chunk_dtypes(instance, index)
         # cache dtypes
-        values["_dtypes"] = dtypes
+        self._member_descriptor.__set__(instance, dtypes)
         return dtypes
 
 
@@ -557,15 +558,16 @@ class ChunkIndexValueField(ReferenceField):
             cache[tileable_key, index] = index_value
             return index_value
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         if not issubclass(owner, LazyMetaChunkData):  # pragma: no cover
             return super().__get__(instance, owner)
 
-        values = instance._FIELD_VALUES
-        index_value = values.get("_index_value", None)
-        if index_value is not None:
-            # been set before
-            return index_value
+        try:
+            value = self._member_descriptor.__get__(instance, owner)
+            if value is not None:
+                return value
+        except AttributeError:
+            pass
 
         if instance.index is None:
             return super().__get__(instance, owner)
@@ -574,7 +576,7 @@ class ChunkIndexValueField(ReferenceField):
         index = instance.index[0]
         index_value = self._gen_chunk_index_value(instance, index)
         # cache index_value
-        values["_index_value"] = index_value
+        self._member_descriptor.__set__(instance, index_value)
         return index_value
 
 
@@ -605,15 +607,16 @@ class ChunkColumnsValueField(ReferenceField):
             cache[tileable_key, index] = columns_value
             return columns_value
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         if not issubclass(owner, LazyMetaChunkData):  # pragma: no cover
             return super().__get__(instance, owner)
 
-        values = instance._FIELD_VALUES
-        columns_value = values.get("_columns_value", None)
-        if columns_value is not None:
-            # been set before
-            return columns_value
+        try:
+            value = self._member_descriptor.__get__(instance, owner)
+            if value is not None:
+                return value
+        except AttributeError:
+            pass
 
         if instance.index is None:
             return super().__get__(instance, owner)
@@ -622,7 +625,7 @@ class ChunkColumnsValueField(ReferenceField):
         index = instance.index[1]
         columns_value = self._gen_chunk_columns_value(instance, index)
         # cache columns_value
-        values["_columns_value"] = columns_value
+        self._member_descriptor.__set__(instance, columns_value)
         return columns_value
 
 

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -513,7 +513,7 @@ class ChunkDtypesField(SeriesField):
             value = self.get(instance, owner)
             if value is not None:
                 return value
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             pass
 
         if instance.index is None:
@@ -566,7 +566,7 @@ class ChunkIndexValueField(ReferenceField):
             value = self.get(instance, owner)
             if value is not None:
                 return value
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             pass
 
         if instance.index is None:
@@ -615,7 +615,7 @@ class ChunkColumnsValueField(ReferenceField):
             value = self.get(instance, owner)
             if value is not None:
                 return value
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             pass
 
         if instance.index is None:

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -510,7 +510,7 @@ class ChunkDtypesField(SeriesField):
             return super().__get__(instance, owner)
 
         try:
-            value = self._member_descriptor.__get__(instance, owner)
+            value = self.get(instance, owner)
             if value is not None:
                 return value
         except AttributeError:
@@ -523,7 +523,7 @@ class ChunkDtypesField(SeriesField):
         index = instance.index[1]
         dtypes = self._gen_chunk_dtypes(instance, index)
         # cache dtypes
-        self._member_descriptor.__set__(instance, dtypes)
+        self.set(instance, dtypes)
         return dtypes
 
 
@@ -563,7 +563,7 @@ class ChunkIndexValueField(ReferenceField):
             return super().__get__(instance, owner)
 
         try:
-            value = self._member_descriptor.__get__(instance, owner)
+            value = self.get(instance, owner)
             if value is not None:
                 return value
         except AttributeError:
@@ -576,7 +576,7 @@ class ChunkIndexValueField(ReferenceField):
         index = instance.index[0]
         index_value = self._gen_chunk_index_value(instance, index)
         # cache index_value
-        self._member_descriptor.__set__(instance, index_value)
+        self.set(instance, index_value)
         return index_value
 
 
@@ -612,7 +612,7 @@ class ChunkColumnsValueField(ReferenceField):
             return super().__get__(instance, owner)
 
         try:
-            value = self._member_descriptor.__get__(instance, owner)
+            value = self.get(instance, owner)
             if value is not None:
                 return value
         except AttributeError:
@@ -625,7 +625,7 @@ class ChunkColumnsValueField(ReferenceField):
         index = instance.index[1]
         columns_value = self._gen_chunk_columns_value(instance, index)
         # cache columns_value
-        self._member_descriptor.__set__(instance, columns_value)
+        self.set(instance, columns_value)
         return columns_value
 
 

--- a/mars/dataframe/indexing/tests/test_indexing.py
+++ b/mars/dataframe/indexing/tests/test_indexing.py
@@ -940,16 +940,20 @@ def test_getitem_lazy_chunk_meta():
     df2 = tile(df2)
 
     chunk = df2.chunks[0].data
-    assert chunk._FIELD_VALUES.get("_dtypes") is None
+    assert chunk._FIELDS["_dtypes"].get(chunk) is None
     pd.testing.assert_series_equal(chunk.dtypes, df.dtypes[[0, 2]])
-    assert chunk._FIELD_VALUES.get("_index_value") is None
+    assert chunk._FIELDS["_dtypes"].get(chunk) is not None
+    assert chunk._FIELDS["_index_value"].get(chunk) is None
     pd.testing.assert_index_equal(chunk.index_value.to_pandas(), pd.RangeIndex(3))
-    assert chunk._FIELD_VALUES.get("_columns_value") is None
+    assert chunk._FIELDS["_index_value"].get(chunk) is not None
+    assert chunk._FIELDS["_columns_value"].get(chunk) is None
     pd.testing.assert_index_equal(chunk.columns_value.to_pandas(), pd.Index([0, 2]))
+    assert chunk._FIELDS["_columns_value"].get(chunk) is not None
 
     df2 = df[2]
     df2 = tile(df2)
 
     chunk = df2.chunks[0].data
-    assert chunk._FIELD_VALUES.get("_index_value") is None
+    assert chunk._FIELDS["_index_value"].get(chunk) is None
     pd.testing.assert_index_equal(chunk.index_value.to_pandas(), pd.RangeIndex(3))
+    assert chunk._FIELDS["_index_value"].get(chunk) is not None

--- a/mars/serialization/serializables/core.py
+++ b/mars/serialization/serializables/core.py
@@ -90,7 +90,7 @@ class SerializableMeta(type):
             if field is None:
                 properties_field_slot_names.append(k)
             else:
-                v.attr_name = field.attr_name
+                v.name = field.name
                 v.get = field.get
                 v.set = field.set
             all_fields[k] = v
@@ -115,11 +115,11 @@ class SerializableMeta(type):
         properties["__slots__"] = tuple(slots)
 
         clz = type.__new__(mcs, name, bases, properties)
-        # Replace slot member_descriptor with field.
+        # Bind slot member_descriptor with field.
         for name in properties_field_slot_names:
             member_descriptor = getattr(clz, name)
             field = all_fields[name]
-            field.attr_name = member_descriptor.__name__
+            field.name = member_descriptor.__name__
             field.get = member_descriptor.__get__
             field.set = member_descriptor.__set__
             setattr(clz, name, field)

--- a/mars/serialization/serializables/core.py
+++ b/mars/serialization/serializables/core.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import copy
 import os
 import operator
 import weakref
@@ -158,7 +157,16 @@ class Serializable(metaclass=SerializableMeta):
         return "{}({})".format(self.__class__.__name__, values)
 
     def copy(self) -> "Serializable":
-        copied = copy.copy(self)
+        copied = type(self)()
+        copied_fields = copied._FIELDS
+        for k, field in self._FIELDS.items():
+            try:
+                # Slightly faster than getattr.
+                value = field.get(self, k)
+                copied_fields[k].set(copied, value)
+            except AttributeError:
+                continue
+
         return copied
 
 

--- a/mars/serialization/serializables/core.py
+++ b/mars/serialization/serializables/core.py
@@ -198,15 +198,15 @@ class SerializableSerializer(Serializer):
         if type(value) is Placeholder:
             if field.on_deserialize:
                 value.callbacks.append(
-                    lambda v: field.__set__(obj, field.on_deserialize(v))
+                    lambda v: field.set(obj, field.on_deserialize(v))
                 )
             else:
-                value.callbacks.append(lambda v: field.__set__(obj, v))
+                value.callbacks.append(lambda v: field.set(obj, v))
         else:
             if field.on_deserialize:
-                field.__set__(obj, field.on_deserialize(value))
+                field.set(obj, field.on_deserialize(value))
             else:
-                field.__set__(obj, value)
+                field.set(obj, value)
 
     def deserial(self, serialized: Tuple, context: Dict, subs: List) -> Serializable:
         obj_class, primitives = serialized

--- a/mars/serialization/serializables/core.py
+++ b/mars/serialization/serializables/core.py
@@ -93,6 +93,7 @@ class SerializableMeta(type):
                 v.name = field.name
                 v.get = field.get
                 v.set = field.set
+                v.__delete__ = field.__delete__
             all_fields[k] = v
 
         # Make field order deterministic to serialize it as list instead of dict.
@@ -122,6 +123,7 @@ class SerializableMeta(type):
             field.name = member_descriptor.__name__
             field.get = member_descriptor.__get__
             field.set = member_descriptor.__set__
+            field.__delete__ = member_descriptor.__delete__
             setattr(clz, name, field)
 
         return clz

--- a/mars/serialization/serializables/core.py
+++ b/mars/serialization/serializables/core.py
@@ -15,16 +15,13 @@ import copy
 import os
 import operator
 import weakref
-from collections import OrderedDict
-from functools import partial
-from typing import Any, Dict, List, Type, Tuple
+from typing import Dict, List, Type, Tuple
 
 import cloudpickle
 
-from ...core.mode import is_kernel_mode, is_build_mode
 from ...utils import no_default
 from ..core import Serializer, Placeholder, buffered
-from .field import Field, OneOfField
+from .field import Field
 from .field_type import (
     PrimitiveFieldType,
     ListType,
@@ -207,7 +204,7 @@ class SerializableSerializer(Serializer):
                 value.callbacks.append(lambda v: field.__set__(obj, v))
         else:
             if field.on_deserialize:
-                field.__set__(obj, field.on_deserialize(v))
+                field.__set__(obj, field.on_deserialize(value))
             else:
                 field.__set__(obj, value)
 

--- a/mars/serialization/serializables/core.py
+++ b/mars/serialization/serializables/core.py
@@ -166,7 +166,6 @@ class Serializable(metaclass=SerializableMeta):
                 copied_fields[k].set(copied, value)
             except AttributeError:
                 continue
-
         return copied
 
 

--- a/mars/serialization/serializables/field.py
+++ b/mars/serialization/serializables/field.py
@@ -101,6 +101,10 @@ class Field(ABC):
         except AttributeError:
             return None
 
+    def set(self, instance, value):
+        """Set the value to instance without side effect in __set__."""
+        self._member_descriptor.__set__(instance, value)
+
     def __get__(self, instance, owner=None):
         try:
             return self._member_descriptor.__get__(instance, owner)

--- a/mars/serialization/serializables/field.py
+++ b/mars/serialization/serializables/field.py
@@ -39,9 +39,9 @@ class Field(ABC):
         "_default_factory",
         "_on_serialize",
         "_on_deserialize",
-        "attr_name",
-        "get",
-        "set",
+        "name",  # The __name__ of member_descriptor
+        "get",  # The __get__ of member_descriptor
+        "set",  # The __set__ of member_descriptor
     )
 
     _tag: str
@@ -119,7 +119,7 @@ class Field(ABC):
                     field_type.validate(to_check_value)
                 except (TypeError, ValueError) as e:
                     raise type(e)(
-                        f"Failed to set `{self.attr_name}` for {type(instance).__name__} "
+                        f"Failed to set `{self.name}` for {type(instance).__name__} "
                         f"when environ CI=true is set: {str(e)}"
                     )
         self.set(instance, value)
@@ -513,7 +513,7 @@ class ReferenceField(Field):
                     field_type.validate(to_check_value)
                 except (TypeError, ValueError) as e:
                     raise type(e)(
-                        f"Failed to set `{self.attr_name}` for {type(instance).__name__} "
+                        f"Failed to set `{self.name}` for {type(instance).__name__} "
                         f"when environ CI=true is set: {e}"
                     )
             self.set(instance, value)
@@ -576,7 +576,7 @@ class OneOfField(Field):
             )
         )
         raise TypeError(
-            f"Failed to set `{self.attr_name}` for {type(instance).__name__} "
+            f"Failed to set `{self.name}` for {type(instance).__name__} "
             f"when environ CI=true is set: type of instance cannot match any "
             f"of {valid_types}, got {type(value).__name__}"
         )

--- a/mars/serialization/serializables/field.py
+++ b/mars/serialization/serializables/field.py
@@ -42,6 +42,7 @@ class Field(ABC):
         "name",  # The __name__ of member_descriptor
         "get",  # The __get__ of member_descriptor
         "set",  # The __set__ of member_descriptor
+        "__delete__",  # The __delete__ of member_descriptor
     )
 
     _tag: str

--- a/mars/serialization/serializables/field.py
+++ b/mars/serialization/serializables/field.py
@@ -502,7 +502,7 @@ class ReferenceField(Field):
         return self._field_type
 
     def __set__(self, instance, value):
-        if _is_ci and self._field_type is None:
+        if _is_ci:
             from ...core import is_kernel_mode
 
             if not is_kernel_mode():
@@ -517,9 +517,7 @@ class ReferenceField(Field):
                         f"Failed to set `{self.name}` for {type(instance).__name__} "
                         f"when environ CI=true is set: {e}"
                     )
-            self.set(instance, value)
-        else:
-            super().__set__(instance, value)
+        self.set(instance, value)
 
 
 class OneOfField(Field):
@@ -556,7 +554,7 @@ class OneOfField(Field):
 
     def __set__(self, instance, value):
         if not _is_ci:  # pragma: no cover
-            return super().__set__(instance, value)
+            return self.set(instance, value)
 
         for reference_field in self._reference_fields:
             try:

--- a/mars/serialization/serializables/tests/test_serializable.py
+++ b/mars/serialization/serializables/tests/test_serializable.py
@@ -201,7 +201,7 @@ def test_serializable(set_environ):
 
 def _assert_serializable_eq(my_serializable, my_serializable2):
     for field_name, field in my_serializable._FIELDS.items():
-        if field.tag not in my_serializable._FIELD_VALUES:
+        if not hasattr(my_serializable, field.tag):
             continue
         expect_value = getattr(my_serializable, field_name)
         actual_value = getattr(my_serializable2, field_name)

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -245,8 +245,8 @@ class RayTaskExecutor(TaskExecutor):
         self._config = None
         self._task = None
         self._tile_context = None
-        self._task_context = None
-        self._task_chunks_meta = None
+        self._task_context = {}
+        self._task_chunks_meta = {}
         self._ray_executor = None
 
         # api


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This PR implements the serializable fields by slots instead of a value dict, 

- Reduces **~25%** memory usage / peaks of constructing graph (in the supervisor).
- Reduces **~40%** memory footprint of serializables (most of them are chunks). 
- About **~12%** faster when serialize / deserialize the serializables.

Test code 
``` python
import time
import tracemalloc
import mars.dataframe as md
import mars.tensor as mt
from mars.core.graph import TileableGraph, TileableGraphBuilder, ChunkGraphBuilder
from asv.extern import asizeof

tracemalloc.start()
start_time = time.time()

num_rows = 10000
df1 = md.DataFrame(
    mt.random.rand(num_rows, 4, chunk_size=10), columns=list("abcd")
)
df2 = md.DataFrame(
    mt.random.rand(num_rows, 4, chunk_size=10), columns=list("abcd")
)
merged_df = df1.merge(
    df2, left_on="a", right_on="a", auto_merge="none", bloom_filter=False
)
graph = TileableGraph([merged_df.data])
next(TileableGraphBuilder(graph).build())
chunk_graph = next(ChunkGraphBuilder(graph, fuse_enabled=False).build())
duration = time.time() - start_time
print(f"Chunk graph size: {len(chunk_graph)}")

size, peak = tracemalloc.get_traced_memory()
sizeof_chunk_graph = asizeof.asizeof(chunk_graph)
print(f"{sizeof_chunk_graph=}, {size=}, {peak=}, {duration=}")
```

Before this PR:
```
Chunk graph size: 9001
sizeof_chunk_graph=25969144, size=39536890, peak=41326016, duration=3.821443796157837
```

With this PR:
```
Chunk graph size: 9001
sizeof_chunk_graph=15783832, size=28084948, peak=29874137, duration=3.8508338928222656
```

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
