### PR TITLE
[Ray] Fix flaky test `test_optional_supervisor_node`

### DIFF
--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -189,38 +189,6 @@ def _sync_web_session_test(web_address):
 
 @require_ray
 @pytest.mark.parametrize(
-    "test_option",
-    [
-        [True, 0, ["ray://test_cluster/1/0", "ray://test_cluster/2/0"]],
-        [False, 0, ["ray://test_cluster/0/1", "ray://test_cluster/1/0"]],
-        [True, 2, ["ray://test_cluster/1/0", "ray://test_cluster/2/0"]],
-        [False, 5, ["ray://test_cluster/0/6", "ray://test_cluster/1/0"]],
-    ],
-)
-@pytest.mark.asyncio
-async def test_optional_supervisor_node(ray_start_regular_shared, test_option):
-    import logging
-
-    logging.basicConfig(level=logging.INFO)
-    supervisor_standalone, supervisor_sub_pool_num, worker_addresses = test_option
-    config = _load_config()
-    config["cluster"]["ray"]["supervisor"]["standalone"] = supervisor_standalone
-    config["cluster"]["ray"]["supervisor"]["sub_pool_num"] = supervisor_sub_pool_num
-    client = await new_cluster(
-        "test_cluster",
-        supervisor_mem=1 * 1024**3,
-        worker_num=2,
-        worker_cpu=2,
-        worker_mem=1 * 1024**3,
-        config=config,
-    )
-    async with client:
-        assert client.address == "ray://test_cluster/0/0"
-        assert client._cluster._worker_addresses == worker_addresses
-
-
-@require_ray
-@pytest.mark.parametrize(
     "config",
     [
         [


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
`test_optional_supervisor_node` use same actor name for different run which is flaky because ray kill actor async. This PR fix it by using a standalone ray cluster
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
