### PR TITLE
Support scipy special function with tuple output

### DIFF
--- a/docs/source/reference/tensor/special.rst
+++ b/docs/source/reference/tensor/special.rst
@@ -35,7 +35,7 @@ Bessel functions
    mars.tensor.special.hankel2e
 
 
-Error function
+Error functions and fresnel integrals
 --------------
 
 .. autosummary::
@@ -48,6 +48,7 @@ Error function
    mars.tensor.special.erfi
    mars.tensor.special.erfinv
    mars.tensor.special.erfcinv
+   mars.tensor.special.fresnel
 
 
 Ellipsoidal harmonics

--- a/mars/tensor/array_utils.py
+++ b/mars/tensor/array_utils.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 
 import numpy as np
+from scipy import special as spspecial
 
 from ..lib import sparse
 from ..lib.sparse.core import issparse, get_dense_module

--- a/mars/tensor/array_utils.py
+++ b/mars/tensor/array_utils.py
@@ -16,7 +16,6 @@ from collections import defaultdict
 from contextlib import contextmanager
 
 import numpy as np
-from scipy import special as spspecial
 
 from ..lib import sparse
 from ..lib.sparse.core import issparse, get_dense_module

--- a/mars/tensor/special/__init__.py
+++ b/mars/tensor/special/__init__.py
@@ -29,8 +29,7 @@ try:
         erfcinv,
         TensorErfcinv,
         fresnel,
-        TensorFresnelS,
-        TensorFresnelC,
+        TensorFresnel,
     )
     from .gamma_funcs import (
         gamma,

--- a/mars/tensor/special/__init__.py
+++ b/mars/tensor/special/__init__.py
@@ -28,6 +28,9 @@ try:
         TensorErfinv,
         erfcinv,
         TensorErfcinv,
+        fresnel,
+        TensorFresnelS,
+        TensorFresnelC,
     )
     from .gamma_funcs import (
         gamma,

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -27,11 +27,19 @@ from ..array_utils import (
 
 
 _func_name_to_special_cls = {}
+_tuple_func_to_res = {}
 
 
 def _register_special_op(cls):
     if cls._func_name is not None:
-        _func_name_to_special_cls[cls._func_name] = cls
+        if getattr(cls, "_output_index", None) is None:
+            _func_name_to_special_cls[cls._func_name] = cls
+        else:
+            if cls._func_name not in _func_name_to_special_cls:
+                _func_name_to_special_cls[cls._func_name] = [
+                    None for _ in range(cls._func_outputs)
+                ]
+            _func_name_to_special_cls[cls._func_name][cls._output_index] = cls
     return cls
 
 
@@ -41,7 +49,13 @@ class TensorSpecialOperandMixin:
 
     def __new__(cls, *args, **kwargs):
         if cls._func_name is not None:
-            return object.__new__(_func_name_to_special_cls[cls._func_name])
+            if getattr(cls, "_output_index", None) is None:
+                return object.__new__(_func_name_to_special_cls[cls._func_name])
+            else:
+                return object.__new__(
+                    _func_name_to_special_cls[cls._func_name][cls._output_index]
+                )
+
         return super().__new__(cls, *args, **kwargs)
 
     @classmethod
@@ -109,6 +123,58 @@ class TensorSpecialMultiOp(TensorSpecialOperandMixin, TensorMultiOp):
                 else:
                     ret = cls._execute_cpu(op, xp, *args, **kw)
 
+                if ret.dtype != op.dtype:
+                    ret = ret.astype(op.dtype)
+                ctx[op.outputs[0].key] = ret
+
+
+class TensorTupleElementOp(TensorSpecialUnaryOp):
+    @classmethod
+    def execute(cls, ctx, op):
+        input_keys = [c.key for c in op.inputs]
+        inputs, device_id, xp = as_same_device(
+            [ctx[c.key] for c in op.inputs], device=op.device, ret_extra=True
+        )
+
+        with device(device_id):
+            kw = {"casting": op.casting} if op.out else {}
+
+            if op.out and op.where:
+                input_keys = input_keys[:-2]
+                inputs, kw["out"], kw["where"] = (
+                    inputs[:-2],
+                    inputs[-2].copy(),
+                    inputs[-1],
+                )
+            elif op.out:
+                input_keys = input_keys[:-1]
+                inputs, kw["out"] = inputs[:-1], inputs[-1].copy()
+            elif op.where:
+                input_keys = input_keys[:-1]
+                inputs, kw["where"] = inputs[:-1], inputs[-1]
+
+            with np.errstate(**op.err):
+                is_func_ret_cached = False
+                if (
+                    cls._func_name in _tuple_func_to_res
+                    and input_keys[0] in _tuple_func_to_res[cls._func_name]
+                ):
+                    is_func_ret_cached = True
+                    ret = _tuple_func_to_res[cls._func_name][input_keys[0]]
+                elif op.is_gpu():
+                    ret = cls._execute_gpu(op, xp, inputs[0], **kw)
+                else:
+                    ret = cls._execute_cpu(op, xp, inputs[0], **kw)
+
+                # during a single execution, if we use multiple components of the same
+                # scipy calculation, we can store the overall result after the first computation.
+                if not is_func_ret_cached:
+                    if cls._func_name not in _tuple_func_to_res:
+                        _tuple_func_to_res[cls._func_name] = {}
+                    if input_keys[0] not in _tuple_func_to_res[cls._func_name]:
+                        _tuple_func_to_res[cls._func_name][input_keys[0]] = ret
+
+                ret = ret[cls._output_index]
                 if ret.dtype != op.dtype:
                     ret = ret.astype(op.dtype)
                 ctx[op.outputs[0].key] = ret

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import scipy.special as spspecial
 
 from ...core import ExecutableTuple
 from ... import opcodes
@@ -19,7 +20,6 @@ from ..datasource import tensor as astensor
 from ..arithmetic.core import TensorUnaryOp, TensorBinOp, TensorMultiOp
 from ..array_utils import (
     np,
-    spspecial,
     cp,
     issparse,
     sparse,

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -140,18 +140,24 @@ class TensorTupleElementOp(TensorSpecialUnaryOp):
             kw = {"casting": op.casting} if op.out else {}
 
             if op.out and op.where:
-                input_keys = input_keys[:-2]
-                inputs, kw["out"], kw["where"] = (
+                input_keys, inputs, kw["out"], kw["where"] = (
+                    input_keys[:-2],
                     inputs[:-2],
                     inputs[-2].copy(),
                     inputs[-1],
                 )
             elif op.out:
-                input_keys = input_keys[:-1]
-                inputs, kw["out"] = inputs[:-1], inputs[-1].copy()
+                input_keys, inputs, kw["out"] = (
+                    input_keys[:-1],
+                    inputs[:-1],
+                    inputs[-1].copy(),
+                )
             elif op.where:
-                input_keys = input_keys[:-1]
-                inputs, kw["where"] = inputs[:-1], inputs[-1]
+                input_keys, inputs, kw["where"] = (
+                    input_keys[:-1],
+                    inputs[:-1],
+                    inputs[-1],
+                )
 
             with np.errstate(**op.err):
                 is_func_ret_cached = False

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -132,7 +132,7 @@ class TensorTupleOp(TensorSpecialUnaryOp):
                 )
             if len(out) != self._n_outputs:
                 raise TypeError(
-                    f"out shoud be an ExecutableTuple object with {self._n_outputs} elements, got {len(out)} instead"
+                    f"out should be an ExecutableTuple object with {self._n_outputs} elements, got {len(out)} instead"
                 )
 
         func = getattr(spspecial, self._func_name)

--- a/mars/tensor/special/err_fresnel.py
+++ b/mars/tensor/special/err_fresnel.py
@@ -159,7 +159,6 @@ def erfcinv(x, out=None, where=None, **kwargs):
     return op(x, out=out, where=where)
 
 
-# TODO: try to reduce implementation code
 @implement_scipy(spspecial.fresnel)
 @infer_dtype(spspecial.fresnel, multi_outputs=True)
 def fresnel(x, out=None, where=None, **kwargs):

--- a/mars/tensor/special/err_fresnel.py
+++ b/mars/tensor/special/err_fresnel.py
@@ -14,10 +14,13 @@
 
 import scipy.special as spspecial
 
-from ...core import ExecutableTuple
 from ..arithmetic.utils import arithmetic_operand
 from ..utils import infer_dtype, implement_scipy
-from .core import TensorSpecialUnaryOp, TensorTupleElementOp, _register_special_op
+from .core import (
+    TensorSpecialUnaryOp,
+    TensorTupleOp,
+    _register_special_op,
+)
 
 
 @_register_special_op
@@ -57,19 +60,9 @@ class TensorErfcinv(TensorSpecialUnaryOp):
 
 
 @_register_special_op
-@arithmetic_operand(sparse_mode="unary")
-class TensorFresnelS(TensorTupleElementOp):
+class TensorFresnel(TensorTupleOp):
     _func_name = "fresnel"
     _func_outputs = 2
-    _output_index = 0
-
-
-@_register_special_op
-@arithmetic_operand(sparse_mode="unary")
-class TensorFresnelC(TensorTupleElementOp):
-    _func_name = "fresnel"
-    _func_outputs = 2
-    _output_index = 1
 
 
 @implement_scipy(spspecial.erf)
@@ -161,10 +154,6 @@ def erfcinv(x, out=None, where=None, **kwargs):
 
 @implement_scipy(spspecial.fresnel)
 @infer_dtype(spspecial.fresnel, multi_outputs=True)
-def fresnel(x, out=None, where=None, **kwargs):
-    op_s = TensorFresnelS(**kwargs)
-    op_c = TensorFresnelC(**kwargs)
-
-    return ExecutableTuple(
-        [op_s(x, out=out, where=where), op_c(x, out=out, where=where)]
-    )
+def fresnel(x, out=None, **kwargs):
+    op = TensorFresnel(**kwargs)
+    return op(x, out=out)

--- a/mars/tensor/special/err_fresnel.py
+++ b/mars/tensor/special/err_fresnel.py
@@ -62,7 +62,7 @@ class TensorErfcinv(TensorSpecialUnaryOp):
 @_register_special_op
 class TensorFresnel(TensorTupleOp):
     _func_name = "fresnel"
-    _func_outputs = 2
+    _n_outputs = 2
 
 
 @implement_scipy(spspecial.erf)

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -310,11 +310,11 @@ def test_fresnel():
     for i in range(len(r_out)):
         assert r_out[i].shape == expect[i].shape
         assert r_out[i].dtype == expect[i].dtype
-        assert isinstance(r_out[i], TensorFresnel)
+        assert isinstance(r_out[i].op, TensorFresnel)
 
         assert out[i].shape == expect[i].shape
         assert out[i].dtype == expect[i].dtype
-        assert isinstance(out[i], TensorFresnel)
+        assert isinstance(out[i].op, TensorFresnel)
 
 
 def test_beta_inc():

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -298,6 +298,10 @@ def test_fresnel():
     with pytest.raises(TypeError):
         r = fresnel(t, non_tuple_out)
 
+    mismatch_size_tuple = ExecutableTuple([t])
+    with pytest.raises(TypeError):
+        r = fresnel(t, mismatch_size_tuple)
+
     out = ExecutableTuple([t, t])
     r_out = fresnel(t, out=out)
 
@@ -307,14 +311,14 @@ def test_fresnel():
     assert len(out) == 2
     assert len(r_out) == 2
 
-    for i in range(len(r_out)):
-        assert r_out[i].shape == expect[i].shape
-        assert r_out[i].dtype == expect[i].dtype
-        assert isinstance(r_out[i].op, TensorFresnel)
+    for r_output, expected_output, out_output in zip(r, expect, out):
+        assert r_output.shape == expected_output.shape
+        assert r_output.dtype == expected_output.dtype
+        assert isinstance(r_output.op, TensorFresnel)
 
-        assert out[i].shape == expect[i].shape
-        assert out[i].dtype == expect[i].dtype
-        assert isinstance(out[i].op, TensorFresnel)
+        assert out_output.shape == expected_output.shape
+        assert out_output.dtype == expected_output.dtype
+        assert isinstance(out_output.op, TensorFresnel)
 
 
 def test_beta_inc():

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -295,9 +295,9 @@ def test_fresnel():
         assert r[i].dtype == expect[i].dtype
 
         if i == 0:
-            assert isinstance(r[i], TensorFresnelS)
+            assert isinstance(r[i].op, TensorFresnelS)
         if i == 1:
-            assert isinstance(r[i], TensorFresnelC)
+            assert isinstance(r[i].op, TensorFresnelC)
 
 
 def test_beta_inc():

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -294,16 +294,10 @@ def test_fresnel():
         assert r[i].shape == expect[i].shape
         assert r[i].dtype == expect[i].dtype
 
-        t, r_i = tile(t, r[i])
-
-        assert r_i.nsplits == t.nsplits
-        for c in r_i.chunks:
-            if i == 0:
-                assert isinstance(c.op, TensorFresnelS)
-            else:
-                assert isinstance(c.op, TensorFresnelC)
-            assert c.index == c.inputs[0].index
-            assert c.shape == c.inputs[0].shape
+        if i == 0:
+            assert isinstance(r[i], TensorFresnelS)
+        if i == 1:
+            assert isinstance(r[i], TensorFresnelC)
 
 
 def test_beta_inc():

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -28,11 +28,12 @@ from scipy.special import (
     ellipkinc as scipy_ellipkinc,
     ellipe as scipy_ellipe,
     ellipeinc as scipy_ellipeinc,
+    fresnel as scipy_fresnel,
     betainc as scipy_betainc,
 )
 
 from ....lib.version import parse as parse_version
-from ....core import tile
+from ....core import tile, ExecutableTuple
 from ... import tensor
 from ..err_fresnel import (
     erf,
@@ -47,6 +48,9 @@ from ..err_fresnel import (
     TensorErfinv,
     erfcinv,
     TensorErfcinv,
+    fresnel,
+    TensorFresnelS,
+    TensorFresnelC,
 )
 from ..gamma_funcs import (
     gammaln,
@@ -274,6 +278,32 @@ def test_erfcinv():
         assert isinstance(c.op, TensorErfcinv)
         assert c.index == c.inputs[0].index
         assert c.shape == c.inputs[0].shape
+
+
+def test_fresnel():
+    raw = np.random.rand(10, 8, 5)
+    t = tensor(raw, chunk_size=3)
+
+    r = fresnel(t)
+    expect = scipy_fresnel(raw)
+
+    assert isinstance(r, ExecutableTuple)
+    assert len(r) == 2
+
+    for i in range(len(r)):
+        assert r[i].shape == expect[i].shape
+        assert r[i].dtype == expect[i].dtype
+
+        t, r_i = tile(t, r[i])
+
+        assert r_i.nsplits == t.nsplits
+        for c in r_i.chunks:
+            if i == 0:
+                assert isinstance(c.op, TensorFresnelS)
+            else:
+                assert isinstance(c.op, TensorFresnelC)
+            assert c.index == c.inputs[0].index
+            assert c.shape == c.inputs[0].shape
 
 
 def test_beta_inc():

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -49,8 +49,7 @@ from ..err_fresnel import (
     erfcinv,
     TensorErfcinv,
     fresnel,
-    TensorFresnelS,
-    TensorFresnelC,
+    TensorFresnel,
 )
 from ..gamma_funcs import (
     gammaln,
@@ -293,11 +292,29 @@ def test_fresnel():
     for i in range(len(r)):
         assert r[i].shape == expect[i].shape
         assert r[i].dtype == expect[i].dtype
+        assert isinstance(r[i], TensorFresnel)
 
-        if i == 0:
-            assert isinstance(r[i].op, TensorFresnelS)
-        if i == 1:
-            assert isinstance(r[i].op, TensorFresnelC)
+    non_tuple_out = tensor(raw, chunk_size=3)
+    with pytest.raises(TypeError):
+        r = fresnel(t, non_tuple_out)
+
+    out = ExecutableTuple([t, t])
+    r_out = fresnel(t, out=out)
+
+    assert isinstance(out, ExecutableTuple)
+    assert isinstance(r_out, ExecutableTuple)
+
+    assert len(out) == 2
+    assert len(r_out) == 2
+
+    for i in range(len(r_out)):
+        assert r_out[i].shape == expect[i].shape
+        assert r_out[i].dtype == expect[i].dtype
+        assert isinstance(r_out[i], TensorFresnel)
+
+        assert out[i].shape == expect[i].shape
+        assert out[i].dtype == expect[i].dtype
+        assert isinstance(out[i], TensorFresnel)
 
 
 def test_beta_inc():

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -292,7 +292,7 @@ def test_fresnel():
     for i in range(len(r)):
         assert r[i].shape == expect[i].shape
         assert r[i].dtype == expect[i].dtype
-        assert isinstance(r[i], TensorFresnel)
+        assert isinstance(r[i].op, TensorFresnel)
 
     non_tuple_out = tensor(raw, chunk_size=3)
     with pytest.raises(TypeError):

--- a/mars/tensor/special/tests/test_special_execution.py
+++ b/mars/tensor/special/tests/test_special_execution.py
@@ -319,5 +319,5 @@ def test_unary_tuple_execution(setup, func):
     result = r.execute().fetch()
     expected = sp_func(raw)
 
-    for i in range(len(result)):
-        np.testing.assert_array_equal(result[i], expected[i])
+    for actual_output, expected_output in zip(result, expected):
+        np.testing.assert_array_equal(actual_output, expected_output)

--- a/mars/tensor/special/tests/test_special_execution.py
+++ b/mars/tensor/special/tests/test_special_execution.py
@@ -299,3 +299,25 @@ def test_quintuple_execution(setup, func):
 
     expected = sp_func(raw1.toarray(), raw2, raw3, raw4, raw5)
     np.testing.assert_array_equal(result.toarray(), expected)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        "fresnel",
+    ],
+)
+def test_unary_tuple_execution(setup, func):
+    sp_func = getattr(spspecial, func)
+    mt_func = getattr(mt_special, func)
+
+    raw = np.random.rand(10, 8, 6)
+    a = tensor(raw, chunk_size=3)
+
+    r = mt_func(a)
+
+    result = r.execute().fetch()
+    expected = sp_func(raw)
+
+    for i in range(len(result)):
+        np.testing.assert_array_equal(result[i], expected[i])

--- a/mars/tensor/utils.py
+++ b/mars/tensor/utils.py
@@ -229,7 +229,7 @@ def inject_dtype(dtype):
     return inner
 
 
-def infer_dtype(np_func, empty=True, reverse=False, check=True):
+def infer_dtype(np_func, multi_outputs=False, empty=True, reverse=False, check=True):
     def make_arg(arg):
         if empty:
             return np.empty((1,) * max(1, arg.ndim), dtype=arg.dtype)
@@ -267,7 +267,10 @@ def infer_dtype(np_func, empty=True, reverse=False, check=True):
                 # that implements __tensor_ufunc__
                 try:
                     with np.errstate(all="ignore"):
-                        dtype = np_func(*args, **np_kw).dtype
+                        if multi_outputs:
+                            dtype = np_func(*args, **np_kw)[0].dtype
+                        else:
+                            dtype = np_func(*args, **np_kw).dtype
                 except:  # noqa: E722
                     dtype = None
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

We can use ExecutableTuple and TensorTupleElementOp to support mars execution of scipy special functions with tuple returns. Specifically, the following syntaxes can be supported:

```python
from mars.tensor import special
import mars.tensor as mt
x = mt.linspace(-3, 3)

S, C = special.fresnel(x)
S.execute()
C.execute()
special.fresnel(x).execute()
(S + C).execute()
```

Also since we invoke scipy.special.fresnel during tensor executions, a cache is added in core.py so if we execute multiple elements of the same function during one execute() call, we don't need to do the scipy computation for each element. Later executes can just use the cached scipy outputs.


## Related issue number

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
