### PR TITLE
Optimize tile of DataFrame.__setitem__ by reducing time of generating chunk meta

### DIFF
--- a/benchmarks/asv_bench/benchmarks/graph_builder.py
+++ b/benchmarks/asv_bench/benchmarks/graph_builder.py
@@ -30,3 +30,10 @@ class ChunkGraphBuilderSuite:
     def time_filter(self):
         df = self.df[self.df["a"] < 0.8]
         build_graph([df], tile=True)
+
+    def time_setitem(self):
+        df2 = self.df.copy()
+        df2["k"] = df2["c"]
+        df2["l"] = df2["a"] * (1 - df2["d"])
+        df2["m"] = df2["e"] * (1 + df2["d"]) * (1 - df2["h"])
+        build_graph([df2], tile=True)

--- a/benchmarks/tpch/run_queries.py
+++ b/benchmarks/tpch/run_queries.py
@@ -1051,8 +1051,12 @@ def main():
     queries = (
         set(x.lower().strip() for x in args.query.split(",")) if args.query else None
     )
-    mars.new_session(endpoint)
-    run_queries(folder, use_arrow_dtype=use_arrow_dtype)
+    sess = mars.new_session(endpoint)
+    try:
+        run_queries(folder, use_arrow_dtype=use_arrow_dtype)
+    finally:
+        if endpoint is None:
+            sess.stop_server()
 
 
 if __name__ == "__main__":

--- a/mars/dataframe/align.py
+++ b/mars/dataframe/align.py
@@ -39,6 +39,7 @@ from .utils import (
     build_split_idx_to_origin_idx,
     filter_index_value,
     hash_index,
+    is_index_value_identical,
 )
 
 
@@ -974,6 +975,10 @@ def align_dataframe_series(left, right, axis="columns"):
 
 
 def align_series_series(left, right):
+    if is_index_value_identical(left, right):
+        # index identical, skip align
+        return left.nsplits, left.chunk_shape, left.chunks, right.chunks
+
     left_index_chunks = [c.index_value for c in left.chunks]
     right_index_chunks = [c.index_value for c in right.chunks]
 
@@ -988,9 +993,6 @@ def align_series_series(left, right):
 
     left_chunks = _gen_series_chunks(splits, out_chunk_shape, 0, left)
     right_chunks = _gen_series_chunks(splits, out_chunk_shape, 1, right)
-    if _is_index_identical(left_index_chunks, right_index_chunks):
-        index_nsplits = left.nsplits[0]
-    else:
-        index_nsplits = [np.nan for _ in range(out_chunk_shape[0])]
+    index_nsplits = [np.nan for _ in range(out_chunk_shape[0])]
     nsplits = [index_nsplits]
     return nsplits, out_chunk_shape, left_chunks, right_chunks

--- a/mars/dataframe/indexing/setitem.py
+++ b/mars/dataframe/indexing/setitem.py
@@ -270,7 +270,10 @@ class DataFrameSetitem(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def execute(cls, ctx, op: "DataFrameSetitem"):
-        target = ctx[op.target.key].copy()
+        target = ctx[op.target.key]
+        # only deep copy when updating
+        deep = bool(set(op.indexes) & set(target.columns))
+        target = ctx[op.target.key].copy(deep=deep)
         value = ctx[op.value.key] if not np.isscalar(op.value) else op.value
         try:
 

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -742,7 +742,7 @@ def is_index_value_identical(left: TileableType, right: TileableType) -> bool:
         is_identical = True
     else:
         target_chunk_index_values = [
-            c.index_value for c in left.chunks if c.index[1] == 0
+            c.index_value for c in left.chunks if len(c.index) <= 1 or c.index[1] == 0
         ]
         value_chunk_index_values = [v.index_value for v in right.chunks]
         is_identical = len(target_chunk_index_values) == len(

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -732,6 +732,28 @@ def build_concatenated_rows_frame(df):
     )
 
 
+def is_index_value_identical(left: TileableType, right: TileableType) -> bool:
+    if (
+        left.index_value.key == right.index_value.key
+        and not np.isnan(sum(left.nsplits[0]))
+        and not np.isnan(sum(right.nsplits[0]))
+        and left.nsplits[0] == right.nsplits[0]
+    ):
+        is_identical = True
+    else:
+        target_chunk_index_values = [
+            c.index_value for c in left.chunks if c.index[1] == 0
+        ]
+        value_chunk_index_values = [v.index_value for v in right.chunks]
+        is_identical = len(target_chunk_index_values) == len(
+            value_chunk_index_values
+        ) and all(
+            c.key == v.key
+            for c, v in zip(target_chunk_index_values, value_chunk_index_values)
+        )
+    return is_identical
+
+
 def _filter_range_index(pd_range_index, min_val, min_val_close, max_val, max_val_close):
     if is_pd_range_empty(pd_range_index):
         return pd_range_index


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR optimized tile of DataFrame.__setitem__ by reducing time of generating chunk meta.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
