### PR TITLE
Support return graph independent nodes sorted

### DIFF
--- a/mars/core/graph/core.pyx
+++ b/mars/core/graph/core.pyx
@@ -16,6 +16,7 @@
 import logging
 from collections import deque
 from io import StringIO
+from typing import Callable
 
 
 logger = logging.getLogger(__name__)
@@ -169,6 +170,13 @@ cdef class DirectedGraph:
         for n, p in preds.items():
             if len(p) == 0:
                 yield n
+
+    def sorted_indep(self, bint reverse=False, key: Callable = None, sort_reverse=False):
+        cdef dict preds
+        preds = self._predecessors if not reverse else self._successors
+        nodes = [n for n, p in preds.items() if len(p) == 0]
+        nodes.sort(key=key, reverse=sort_reverse)
+        return nodes
 
     cpdef int count_indep(self, reverse=False):
         cdef:

--- a/mars/core/graph/tests/test_graph.py
+++ b/mars/core/graph/tests/test_graph.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import random
 
 import pytest
 
@@ -97,6 +98,27 @@ def test_dag():
             all(dag_copy.has_successor(pred, n) for pred in dag_copy.predecessors(n))
             is True
         )
+
+
+def test_indep():
+    dag = DAG()
+    for i in range(1, 101):
+        dag.add_node(i)
+        dag.add_node(-i)
+    for i in range(101, 201):
+        dag.add_node(i)
+        dag.add_node(-i)
+        dag.add_edge(i - 100, i)
+        dag.add_edge(-(i - 100), -i)
+    assert len(list(dag.iter_indep())) == 200
+    assert list(dag.sorted_indep()) == sorted(list(dag.iter_indep()))
+    assert list(dag.sorted_indep(key=lambda x: -x)) == sorted(
+        dag.iter_indep(), key=lambda x: -x
+    )
+    assert list(dag.sorted_indep(reverse=True)) == sorted(dag.iter_indep(reverse=True))
+    assert list(
+        dag.sorted_indep(reverse=True, key=lambda x: -x, sort_reverse=True)
+    ) == sorted(dag.iter_indep(reverse=True), key=lambda x: -x, reverse=True)
 
 
 @flaky(max_runs=3)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
In ray task-based shuffle, we need the `iter_indep` has deterministic order when calling it on same chunk graph in different process. But python dict didn't provide an deterministic order when serialization. And the order is an implicit assumption. This PR add an explicit `sorted_indep` API to mars to support deterministic order.

Since every subtask chunk graph independent nodes is pretty small, mostly less than 5, the sort cost is ignorable.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
