### PR TITLE
Patch pandas magic functions to allow reverse operands

### DIFF
--- a/mars/dataframe/arithmetic/core.py
+++ b/mars/dataframe/arithmetic/core.py
@@ -22,7 +22,6 @@ import pandas as pd
 from ...core import ENTITY_TYPE, CHUNK_TYPE, recursive_tile
 from ...serialization.serializables import AnyField
 from ...tensor.core import TENSOR_TYPE, TENSOR_CHUNK_TYPE, ChunkData, Chunk
-from ...tensor.datasource import tensor as astensor
 from ...utils import classproperty, get_dtype
 from ..align import (
     align_series_series,
@@ -36,7 +35,6 @@ from ..core import (
     SERIES_CHUNK_TYPE,
     is_chunk_meta_lazy,
 )
-from ..initializer import Series, DataFrame
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..ufunc.tensor import TensorUfuncMixin
 from ..utils import (
@@ -638,18 +636,6 @@ class DataFrameBinOpMixin(DataFrameOperandMixin):
                 kw[prop] = value
 
         return super()._new_chunks(inputs, shape=shape, kws=kws, **kw)
-
-    @staticmethod
-    def _process_input(x):
-        if isinstance(x, (DATAFRAME_TYPE, SERIES_TYPE)) or pd.api.types.is_scalar(x):
-            return x
-        elif isinstance(x, pd.Series):
-            return Series(x)
-        elif isinstance(x, pd.DataFrame):
-            return DataFrame(x)
-        elif isinstance(x, (list, tuple, np.ndarray, TENSOR_TYPE)):
-            return astensor(x)
-        raise NotImplementedError
 
     def _check_inputs(self, x1, x2):
         if isinstance(x1, TENSOR_TYPE) or isinstance(x2, TENSOR_TYPE):

--- a/mars/dataframe/arithmetic/dot.py
+++ b/mars/dataframe/arithmetic/dot.py
@@ -29,26 +29,20 @@ from ..utils import parse_index
 class DataFrameDot(DataFrameOperand, DataFrameOperandMixin):
     _op_type_ = OperandDef.DOT
 
-    _lhs = KeyField("lhs")
-    _rhs = AnyField("rhs")
+    lhs = KeyField("lhs")
+    rhs = AnyField("rhs")
 
-    def __init__(self, output_types=None, lhs=None, rhs=None, **kw):
-        super().__init__(_output_types=output_types, _lhs=lhs, _rhs=rhs, **kw)
-
-    @property
-    def lhs(self):
-        return self._lhs
-
-    @property
-    def rhs(self):
-        return self._rhs
+    def __init__(self, output_types=None, **kw):
+        super().__init__(_output_types=output_types, **kw)
 
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
-        self._lhs = self._inputs[0]
-        self._rhs = self._inputs[1]
+        self.lhs = self._inputs[0]
+        self.rhs = self._inputs[1]
 
     def __call__(self, lhs, rhs):
+        lhs = self._process_input(lhs)
+        rhs = self._process_input(rhs)
         if not isinstance(rhs, (DATAFRAME_TYPE, SERIES_TYPE)):
             rhs = astensor(rhs)
             test_rhs = rhs
@@ -171,9 +165,14 @@ class DataFrameDot(DataFrameOperand, DataFrameOperandMixin):
         return [tiled]
 
 
-def dot(df_or_seris, other):
-    op = DataFrameDot(lhs=df_or_seris, rhs=other)
-    return op(df_or_seris, other)
+def dot(df_or_series, other):
+    op = DataFrameDot(lhs=df_or_series, rhs=other)
+    return op(df_or_series, other)
+
+
+def rdot(df_or_series, other):
+    op = DataFrameDot(lhs=other, rhs=df_or_series)
+    return op(other, df_or_series)
 
 
 dot.__frame_doc__ = """

--- a/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
+++ b/mars/dataframe/arithmetic/tests/test_arithmetic_execution.py
@@ -479,6 +479,12 @@ def test_dataframe_and_scalar(setup, func_name, func_opts):
     result6 = getattr(df, func_opts.rfunc_name)(1).execute().fetch()
     pd.testing.assert_frame_equal(expected2, result6)
 
+    # test pandas series and dataframe
+    pdf2 = pd.DataFrame(np.random.rand(10, 10))
+    expected = func_opts.func(pdf2, pdf)
+    result = func_opts.func(pdf2, df).execute().fetch()
+    pd.testing.assert_frame_equal(expected, result)
+
 
 @pytest.mark.parametrize("func_name, func_opts", binary_functions.items())
 def test_with_shuffle_on_string_index(setup, func_name, func_opts):

--- a/mars/dataframe/arithmetic/tests/test_comparison.py
+++ b/mars/dataframe/arithmetic/tests/test_comparison.py
@@ -24,8 +24,10 @@ from ...initializer import DataFrame, Series
 
 
 def test_comp(setup):
-    df1 = DataFrame(pd.DataFrame(np.random.rand(4, 3)))
-    df2 = DataFrame(pd.DataFrame(np.random.rand(4, 3)))
+    raw_df1 = pd.DataFrame(np.random.rand(4, 3))
+    raw_df2 = pd.DataFrame(np.random.rand(4, 3))
+    df1 = DataFrame(raw_df1)
+    df2 = DataFrame(raw_df2)
 
     with enter_mode(build=True):
         assert not df1.data == df2.data
@@ -40,6 +42,10 @@ def test_comp(setup):
         operator.ge,
     ]:
         eq_df = op(df1, df2)
+        pd.testing.assert_index_equal(
+            eq_df.index_value.to_pandas(), df1.index_value.to_pandas()
+        )
+        eq_df = op(raw_df1, df2)
         pd.testing.assert_index_equal(
             eq_df.index_value.to_pandas(), df1.index_value.to_pandas()
         )

--- a/mars/dataframe/arithmetic/tests/test_dot.py
+++ b/mars/dataframe/arithmetic/tests/test_dot.py
@@ -40,6 +40,12 @@ def test_dot_execution(setup):
     expected = df1_raw @ df2_raw
     pd.testing.assert_frame_equal(result, expected)
 
+    # test reversed @
+    r = df1_raw @ df2
+    result = r.execute().fetch()
+    expected = df1_raw @ df2_raw
+    pd.testing.assert_frame_equal(result, expected)
+
     series1 = Series(s1_raw, chunk_size=5)
 
     # df.dot(series)

--- a/mars/dataframe/base/accessor.py
+++ b/mars/dataframe/base/accessor.py
@@ -16,6 +16,12 @@ from functools import wraps
 from typing import Iterable
 
 import pandas as pd
+from pandas.api.types import (
+    is_datetime64_dtype,
+    is_datetime64tz_dtype,
+    is_timedelta64_dtype,
+    is_period_dtype,
+)
 
 from ...utils import adapt_mars_docstring
 from .string_ import _string_method_to_handlers, SeriesStringMethod
@@ -218,6 +224,13 @@ class StringAccessor:
 
 class DatetimeAccessor:
     def __init__(self, series):
+        if (
+            not is_datetime64_dtype(series.dtype)
+            and not is_datetime64tz_dtype(series.dtype)
+            and not is_timedelta64_dtype(series.dtype)
+            and not is_period_dtype(series.dtype)
+        ):
+            raise AttributeError("Can only use .dt accessor with datetimelike values")
         self._series = series
 
     @classmethod

--- a/mars/dataframe/base/tests/test_base.py
+++ b/mars/dataframe/base/tests/test_base.py
@@ -674,6 +674,8 @@ def test_datetime_method():
         assert c.shape == (2,) if i == 0 else (1,)
 
     with pytest.raises(AttributeError):
+        _ = from_pandas_series(pd.Series([1])).dt
+    with pytest.raises(AttributeError):
         _ = series.dt.non_exist
 
     assert "ceil" in dir(series.dt)

--- a/mars/dataframe/operands.py
+++ b/mars/dataframe/operands.py
@@ -15,6 +15,7 @@
 from collections import OrderedDict
 from functools import reduce
 
+import numpy as np
 import pandas as pd
 
 from ..core import FuseChunkData, FuseChunk, ENTITY_TYPE, OutputType
@@ -26,6 +27,7 @@ from ..core.operand import (
     FuseChunkMixin,
 )
 from ..tensor.core import TENSOR_TYPE
+from ..tensor.datasource import tensor as astensor
 from ..tensor.operands import TensorOperandMixin
 from ..utils import calc_nsplits
 from .core import (
@@ -433,6 +435,20 @@ class DataFrameOperandMixin(TileableOperandMixin):
 
     def get_fuse_op_cls(self, _):
         return DataFrameFuseChunk
+
+    @staticmethod
+    def _process_input(x):
+        from .initializer import DataFrame, Series
+
+        if isinstance(x, (DATAFRAME_TYPE, SERIES_TYPE)) or pd.api.types.is_scalar(x):
+            return x
+        elif isinstance(x, pd.Series):
+            return Series(x)
+        elif isinstance(x, pd.DataFrame):
+            return DataFrame(x)
+        elif isinstance(x, (list, tuple, np.ndarray, TENSOR_TYPE)):
+            return astensor(x)
+        raise NotImplementedError
 
 
 DataFrameOperand = Operand

--- a/mars/dataframe/tseries/to_datetime.py
+++ b/mars/dataframe/tseries/to_datetime.py
@@ -34,91 +34,23 @@ class DataFrameToDatetime(DataFrameOperand, DataFrameOperandMixin):
     _op_type_ = opcodes.TO_DATETIME
 
     arg = KeyField("arg")
-    _errors = StringField("errors")
-    _dayfirst = BoolField("dayfirst")
-    _yearfirst = BoolField("yearfirst")
-    _utc = BoolField("utc")
-    _format = StringField("format")
-    _exact = BoolField("exact")
-    _unit = StringField("unit")
-    _infer_datetime_format = BoolField("infer_datetime_format")
-    _origin = AnyField("origin")
-    _cache = BoolField("cache")
-
-    def __init__(
-        self,
-        errors=None,
-        dayfirst=None,
-        yearfirst=None,
-        utc=None,
-        format=None,
-        exact=None,
-        unit=None,
-        infer_datetime_format=None,
-        origin=None,
-        cache=None,
-        **kw,
-    ):
-        super().__init__(
-            _errors=errors,
-            _dayfirst=dayfirst,
-            _yearfirst=yearfirst,
-            _utc=utc,
-            _format=format,
-            _exact=exact,
-            _unit=unit,
-            _infer_datetime_format=infer_datetime_format,
-            _origin=origin,
-            _cache=cache,
-            **kw,
-        )
-
-    @property
-    def errors(self):
-        return self._errors
-
-    @property
-    def dayfirst(self):
-        return self._dayfirst
-
-    @property
-    def yearfirst(self):
-        return self._yearfirst
-
-    @property
-    def utc(self):
-        return self._utc
-
-    @property
-    def format(self):
-        return self._format
-
-    @property
-    def exact(self):
-        return self._exact
-
-    @property
-    def unit(self):
-        return self._unit
-
-    @property
-    def infer_datetime_format(self):
-        return self._infer_datetime_format
-
-    @property
-    def origin(self):
-        return self._origin
-
-    @property
-    def cache(self):
-        return self._cache
+    errors = StringField("errors", default=None)
+    dayfirst = BoolField("dayfirst", default=None)
+    yearfirst = BoolField("yearfirst", default=None)
+    utc = BoolField("utc", default=None)
+    format = StringField("format", default=None)
+    exact = BoolField("exact", default=None)
+    unit = StringField("unit", default=None)
+    infer_datetime_format = BoolField("infer_datetime_format", default=None)
+    origin = AnyField("origin", default=None)
+    cache = BoolField("cache", default=None)
 
     @property
     def _params(self):
         return tuple(
             getattr(self, k)
             for k in self._keys_
-            if k not in self._no_copy_attrs_ and k != "_arg" and hasattr(self, k)
+            if k not in self._no_copy_attrs_ and k != "arg" and hasattr(self, k)
         )
 
     def _set_inputs(self, inputs):
@@ -129,16 +61,16 @@ class DataFrameToDatetime(DataFrameOperand, DataFrameOperandMixin):
         if is_scalar(arg):
             ret = pd.to_datetime(
                 arg,
-                errors=self._errors,
-                dayfirst=self._dayfirst,
-                yearfirst=self._yearfirst,
-                utc=self._utc,
-                format=self._format,
-                exact=self._exact,
-                unit=self._unit,
-                infer_datetime_format=self._infer_datetime_format,
-                origin=self._origin,
-                cache=self._cache,
+                errors=self.errors,
+                dayfirst=self.dayfirst,
+                yearfirst=self.yearfirst,
+                utc=self.utc,
+                format=self.format,
+                exact=self.exact,
+                unit=self.unit,
+                infer_datetime_format=self.infer_datetime_format,
+                origin=self.origin,
+                cache=self.cache,
             )
             return astensor(ret)
 

--- a/mars/dataframe/tseries/to_datetime.py
+++ b/mars/dataframe/tseries/to_datetime.py
@@ -33,7 +33,7 @@ from ..utils import parse_index
 class DataFrameToDatetime(DataFrameOperand, DataFrameOperandMixin):
     _op_type_ = opcodes.TO_DATETIME
 
-    _arg = KeyField("arg")
+    arg = KeyField("arg")
     _errors = StringField("errors")
     _dayfirst = BoolField("dayfirst")
     _yearfirst = BoolField("yearfirst")
@@ -72,10 +72,6 @@ class DataFrameToDatetime(DataFrameOperand, DataFrameOperandMixin):
             _cache=cache,
             **kw,
         )
-
-    @property
-    def arg(self):
-        return self._arg
 
     @property
     def errors(self):
@@ -127,7 +123,7 @@ class DataFrameToDatetime(DataFrameOperand, DataFrameOperandMixin):
 
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
-        self._arg = self._inputs[0]
+        self.arg = self._inputs[0]
 
     def __call__(self, arg):
         if is_scalar(arg):

--- a/mars/typing.py
+++ b/mars/typing.py
@@ -12,7 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, TypeVar
+try:
+    from typing import Tuple, TypeVar
+except ImportError:  # pragma: no cover
+    # in some scenario (for instance, pycharm debug), `mars.typing`
+    # could be mistakenly imported as builtin typing. Code below
+    # resolves this issue.
+    import os
+    import sys
+
+    _orig_sys_path = list(sys.path)
+    _mars_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    try:
+        sys.path = [p for p in sys.path if not p.startswith(_mars_path)]
+        sys.modules.pop("typing", None)
+        from typing import Tuple, TypeVar
+    finally:
+        sys.path = _orig_sys_path
+        del _orig_sys_path, _mars_path
 
 OperandType = TypeVar("OperandType")
 TileableType = TypeVar("TileableType")


### PR DESCRIPTION
## What do these changes do?

Patch pandas magic functions to allow handling Mars objects.

## Related issue number

Fixes #3154

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
