### PR TITLE
Enable ```TensorTupleOp``` to support functions with scalar inputs

### DIFF
--- a/docs/source/reference/tensor/special.rst
+++ b/docs/source/reference/tensor/special.rst
@@ -49,6 +49,7 @@ Error functions and fresnel integrals
    mars.tensor.special.erfinv
    mars.tensor.special.erfcinv
    mars.tensor.special.fresnel
+   mars.tensor.special.fresnel_zeros
 
 
 Ellipsoidal harmonics

--- a/mars/tensor/arithmetic/core.py
+++ b/mars/tensor/arithmetic/core.py
@@ -344,14 +344,21 @@ class TensorUnaryOpMixin(TensorElementWiseWithInputs):
 
     @classmethod
     def _execute_gpu(cls, op, xp, inp, **kw):
-        r = cls._get_func(xp)(inp, **kw)
+        if inp.ndim == 0: # scalar input
+            r = cls._get_func(xp)(np.ndarray.item(inp), **kw)
+        else:
+            r = cls._get_func(xp)(inp, **kw)
         return convert_order(r, op.outputs[0].order.value)
 
     @classmethod
     def _execute_cpu(cls, op, xp, inp, **kw):
         if op.order != "K":
             kw["order"] = op.order
-        return cls._get_func(xp)(inp, **kw)
+
+        if inp.ndim == 0: # scalar input
+            return cls._get_func(xp)(np.ndarray.item(inp), **kw)
+        else:
+            return cls._get_func(xp)(inp, **kw)
 
     @classmethod
     def execute(cls, ctx, op):

--- a/mars/tensor/arithmetic/core.py
+++ b/mars/tensor/arithmetic/core.py
@@ -344,21 +344,15 @@ class TensorUnaryOpMixin(TensorElementWiseWithInputs):
 
     @classmethod
     def _execute_gpu(cls, op, xp, inp, **kw):
-        if inp.ndim == 0: # scalar input
-            r = cls._get_func(xp)(np.ndarray.item(inp), **kw)
-        else:
-            r = cls._get_func(xp)(inp, **kw)
+        r = cls._get_func(xp)(inp, **kw)
         return convert_order(r, op.outputs[0].order.value)
 
     @classmethod
     def _execute_cpu(cls, op, xp, inp, **kw):
         if op.order != "K":
             kw["order"] = op.order
+        return cls._get_func(xp)(inp, **kw)
 
-        if inp.ndim == 0: # scalar input
-            return cls._get_func(xp)(np.ndarray.item(inp), **kw)
-        else:
-            return cls._get_func(xp)(inp, **kw)
 
     @classmethod
     def execute(cls, ctx, op):

--- a/mars/tensor/arithmetic/core.py
+++ b/mars/tensor/arithmetic/core.py
@@ -353,7 +353,6 @@ class TensorUnaryOpMixin(TensorElementWiseWithInputs):
             kw["order"] = op.order
         return cls._get_func(xp)(inp, **kw)
 
-
     @classmethod
     def execute(cls, ctx, op):
         inputs, device_id, xp = as_same_device(

--- a/mars/tensor/special/__init__.py
+++ b/mars/tensor/special/__init__.py
@@ -30,6 +30,8 @@ try:
         TensorErfcinv,
         fresnel,
         TensorFresnel,
+        fresnel_zeros,
+        TensorFresnelZeros,
     )
     from .gamma_funcs import (
         gamma,

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -17,7 +17,7 @@ import scipy.special as spspecial
 from ...core import ExecutableTuple
 from ... import opcodes
 from ..datasource import tensor as astensor
-from ..arithmetic.core import TensorUnaryOp, TensorBinOp, TensorMultiOp
+from ..arithmetic.core import TensorElementWise, TensorUnaryOp, TensorBinOp, TensorMultiOp
 from ..array_utils import (
     np,
     cp,
@@ -166,7 +166,7 @@ class TensorTupleOp(TensorSpecialUnaryOp):
         in_tensor = op.input
 
         if in_tensor.ndim != 0:
-            return (yield from super().tile(op))
+            return (yield from TensorElementWise.tile(op))
         else:
             in_chunk = in_tensor.chunks[0]
             chunk_op = op.copy().reset_key()

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -212,7 +212,7 @@ class TensorTupleOp(TensorSpecialUnaryOp):
             return cls._get_func(xp)(inp, **kw)
 
     @classmethod
-    def _execute_gpu(cls, op, xp, inp, **kw): # pragma: no cover
+    def _execute_gpu(cls, op, xp, inp, **kw):  # pragma: no cover
         if inp.ndim == 0:  # scalar input
             r = cls._get_func(xp)(np.ndarray.item(inp), **kw)
         else:

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -18,7 +18,6 @@ from ...core import ExecutableTuple
 from ... import opcodes
 from ..datasource import tensor as astensor
 from ..arithmetic.core import (
-    TensorElementWise,
     TensorUnaryOp,
     TensorBinOp,
     TensorMultiOp,
@@ -142,7 +141,7 @@ class TensorTupleOp(TensorSpecialUnaryOp):
 
         func = getattr(spspecial, self._func_name)
 
-        if isinstance(x, np.ScalarType):
+        if np.isscalar(x):
             res = func(x)
         else:
             res = func(np.ones(x_t.shape, dtype=x_t.dtype))
@@ -171,7 +170,7 @@ class TensorTupleOp(TensorSpecialUnaryOp):
         in_tensor = op.input
 
         if in_tensor.ndim != 0:
-            return (yield from TensorElementWise.tile(op))
+            return (yield from super().tile(op))
         else:
             in_chunk = in_tensor.chunks[0]
             chunk_op = op.copy().reset_key()

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -166,14 +166,14 @@ class TensorTupleOp(TensorSpecialUnaryOp):
         if op.order != "K":
             kw["order"] = op.order
 
-        if inp.ndim == 0: # scalar input
+        if inp.ndim == 0:  # scalar input
             return cls._get_func(xp)(np.ndarray.item(inp), **kw)
         else:
             return cls._get_func(xp)(inp, **kw)
 
     @classmethod
     def _execute_gpu(cls, op, xp, inp, **kw):
-        if inp.ndim == 0: # scalar input
+        if inp.ndim == 0:  # scalar input
             r = cls._get_func(xp)(np.ndarray.item(inp), **kw)
         else:
             r = cls._get_func(xp)(inp, **kw)

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -123,7 +123,7 @@ class TensorTupleOp(TensorSpecialUnaryOp):
         return self._n_outputs
 
     def __call__(self, x, out=None):
-        x = astensor(x)
+        x_t = astensor(x)
 
         if out is not None:
             if not isinstance(out, ExecutableTuple):
@@ -136,9 +136,14 @@ class TensorTupleOp(TensorSpecialUnaryOp):
                 )
 
         func = getattr(spspecial, self._func_name)
-        res = func(np.ones(x.shape, dtype=x.dtype))
+
+        if isinstance(x, np.ScalarType):
+            res = func(x)
+        else:
+            res = func(np.ones(x_t.shape, dtype=x_t.dtype))
+
         res_tensors = self.new_tensors(
-            [x],
+            [x_t],
             kws=[
                 {
                     "side": f"{self._func_name}[{i}]",

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -162,6 +162,24 @@ class TensorTupleOp(TensorSpecialUnaryOp):
         return out
 
     @classmethod
+    def _execute_cpu(cls, op, xp, inp, **kw):
+        if op.order != "K":
+            kw["order"] = op.order
+
+        if inp.ndim == 0: # scalar input
+            return cls._get_func(xp)(np.ndarray.item(inp), **kw)
+        else:
+            return cls._get_func(xp)(inp, **kw)
+
+    @classmethod
+    def _execute_gpu(cls, op, xp, inp, **kw):
+        if inp.ndim == 0: # scalar input
+            r = cls._get_func(xp)(np.ndarray.item(inp), **kw)
+        else:
+            r = cls._get_func(xp)(inp, **kw)
+        return convert_order(r, op.outputs[0].order.value)
+
+    @classmethod
     def execute(cls, ctx, op):
         inputs, device_id, xp = as_same_device(
             [ctx[c.key] for c in op.inputs], device=op.device, ret_extra=True

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -204,7 +204,7 @@ class TensorTupleOp(TensorSpecialUnaryOp):
     @classmethod
     def _execute_cpu(cls, op, xp, inp, **kw):
         if op.order != "K":
-            kw["order"] = op.order
+            kw["order"] = op.order  # pragma: no cover
 
         if inp.ndim == 0:  # scalar input
             return cls._get_func(xp)(np.ndarray.item(inp), **kw)

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -212,7 +212,7 @@ class TensorTupleOp(TensorSpecialUnaryOp):
             return cls._get_func(xp)(inp, **kw)
 
     @classmethod
-    def _execute_gpu(cls, op, xp, inp, **kw):
+    def _execute_gpu(cls, op, xp, inp, **kw): # pragma: no cover
         if inp.ndim == 0:  # scalar input
             r = cls._get_func(xp)(np.ndarray.item(inp), **kw)
         else:

--- a/mars/tensor/special/core.py
+++ b/mars/tensor/special/core.py
@@ -17,7 +17,12 @@ import scipy.special as spspecial
 from ...core import ExecutableTuple
 from ... import opcodes
 from ..datasource import tensor as astensor
-from ..arithmetic.core import TensorElementWise, TensorUnaryOp, TensorBinOp, TensorMultiOp
+from ..arithmetic.core import (
+    TensorElementWise,
+    TensorUnaryOp,
+    TensorBinOp,
+    TensorMultiOp,
+)
 from ..array_utils import (
     np,
     cp,

--- a/mars/tensor/special/err_fresnel.py
+++ b/mars/tensor/special/err_fresnel.py
@@ -65,6 +65,12 @@ class TensorFresnel(TensorTupleOp):
     _n_outputs = 2
 
 
+@_register_special_op
+class TensorFresnelZeros(TensorTupleOp):
+    _func_name = "fresnel_zeros"
+    _n_outputs = 2
+
+
 @implement_scipy(spspecial.erf)
 @infer_dtype(spspecial.erf)
 def erf(x, out=None, where=None, **kwargs):
@@ -156,4 +162,11 @@ def erfcinv(x, out=None, where=None, **kwargs):
 @infer_dtype(spspecial.fresnel, multi_outputs=True)
 def fresnel(x, out=None, **kwargs):
     op = TensorFresnel(**kwargs)
+    return op(x, out=out)
+
+
+@implement_scipy(spspecial.fresnel_zeros)
+@infer_dtype(spspecial.fresnel_zeros, multi_outputs=True)
+def fresnel_zeros(x, out=None, **kwargs):
+    op = TensorFresnelZeros(**kwargs)
     return op(x, out=out)

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -325,7 +325,7 @@ def test_fresnel():
 
 
 def test_fresnel_zeros():
-    raw = np.random.randint(10, size=1)[0]
+    raw = np.random.randint(1, 10, size=1)[0]
 
     r = fresnel_zeros(raw)
     expect = scipy_fresnel_zeros(raw)

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -29,6 +29,7 @@ from scipy.special import (
     ellipe as scipy_ellipe,
     ellipeinc as scipy_ellipeinc,
     fresnel as scipy_fresnel,
+    fresnel_zeros as scipy_fresnel_zeros,
     betainc as scipy_betainc,
 )
 
@@ -50,6 +51,8 @@ from ..err_fresnel import (
     TensorErfcinv,
     fresnel,
     TensorFresnel,
+    fresnel_zeros,
+    TensorFresnelZeros,
 )
 from ..gamma_funcs import (
     gammaln,
@@ -289,10 +292,10 @@ def test_fresnel():
     assert isinstance(r, ExecutableTuple)
     assert len(r) == 2
 
-    for i in range(len(r)):
-        assert r[i].shape == expect[i].shape
-        assert r[i].dtype == expect[i].dtype
-        assert isinstance(r[i].op, TensorFresnel)
+    for r_i, expect_i in zip(r, expect):
+        assert r_i.shape == expect_i.shape
+        assert r_i.dtype == expect_i.dtype
+        assert isinstance(r_i.op, TensorFresnel)
 
     non_tuple_out = tensor(raw, chunk_size=3)
     with pytest.raises(TypeError):
@@ -319,6 +322,21 @@ def test_fresnel():
         assert out_output.shape == expected_output.shape
         assert out_output.dtype == expected_output.dtype
         assert isinstance(out_output.op, TensorFresnel)
+
+
+def test_fresnel_zeros():
+    raw = np.random.randint(10, size=1)[0]
+
+    r = fresnel_zeros(raw)
+    expect = scipy_fresnel_zeros(raw)
+
+    assert isinstance(r, ExecutableTuple)
+    assert len(r) == 2
+
+    for r_i, expect_i in zip(r, expect):
+        assert r_i.shape == expect_i.shape
+        assert r_i.dtype == expect_i.dtype
+        assert isinstance(r_i.op, TensorFresnel)
 
 
 def test_beta_inc():

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -336,7 +336,7 @@ def test_fresnel_zeros():
     for r_i, expect_i in zip(r, expect):
         assert r_i.shape == expect_i.shape
         assert r_i.dtype == expect_i.dtype
-        assert isinstance(r_i.op, TensorFresnel)
+        assert isinstance(r_i.op, TensorFresnelZeros)
 
 
 def test_beta_inc():

--- a/mars/tensor/special/tests/test_special_execution.py
+++ b/mars/tensor/special/tests/test_special_execution.py
@@ -307,7 +307,7 @@ def test_quintuple_execution(setup, func):
         "fresnel",
     ],
 )
-def test_unary_tuple_execution(setup, func):
+def test_unary_array_input_tuple_execution(setup, func):
     sp_func = getattr(spspecial, func)
     mt_func = getattr(mt_special, func)
 
@@ -315,6 +315,27 @@ def test_unary_tuple_execution(setup, func):
     a = tensor(raw, chunk_size=3)
 
     r = mt_func(a)
+
+    result = r.execute().fetch()
+    expected = sp_func(raw)
+
+    for actual_output, expected_output in zip(result, expected):
+        np.testing.assert_array_equal(actual_output, expected_output)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        "fresnel_zeros",
+    ],
+)
+def test_unary_scalar_input_tuple_execution(setup, func):
+    sp_func = getattr(spspecial, func)
+    mt_func = getattr(mt_special, func)
+
+    raw = np.random.randint(10, size=1)[0]
+
+    r = mt_func(raw)
 
     result = r.execute().fetch()
     expected = sp_func(raw)

--- a/mars/tensor/special/tests/test_special_execution.py
+++ b/mars/tensor/special/tests/test_special_execution.py
@@ -333,7 +333,7 @@ def test_unary_scalar_input_tuple_execution(setup, func):
     sp_func = getattr(spspecial, func)
     mt_func = getattr(mt_special, func)
 
-    raw = np.random.randint(10, size=1)[0]
+    raw = np.random.randint(1, 10, size=1)[0]
 
     r = mt_func(raw)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Functions such as ```special.fresnel_zeros``` take in scalar inputs, but currently, TensorTupleOp will convert the input to be a tensor and feed to the original scipy special function. This change allows scalar inputs to be stored and used when needed. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
