### PR TITLE
Improve numexpr fusion

### DIFF
--- a/benchmarks/asv_bench/benchmarks/execution.py
+++ b/benchmarks/asv_bench/benchmarks/execution.py
@@ -1,0 +1,93 @@
+# Copyright 1999-2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+
+import mars.tensor as mt
+from mars import new_session
+from mars.core.graph import (
+    TileableGraph,
+    TileableGraphBuilder,
+    ChunkGraphBuilder,
+    ChunkGraph,
+)
+from mars.serialization import serialize
+from mars.services.task import new_task_id
+from mars.services.task.execution.ray.executor import execute_subtask
+
+
+def _gen_subtask_chunk_graph(t):
+    graph = TileableGraph([t.data])
+    next(TileableGraphBuilder(graph).build())
+    return next(ChunkGraphBuilder(graph, fuse_enabled=False).build())
+
+
+@dataclasses.dataclass
+class _ASVSubtaskInfo:
+    subtask_id: str
+    serialized_subtask_chunk_graph: ChunkGraph
+
+
+class NumExprExecutionSuite:
+    """
+    Benchmark that times performance of numexpr execution.
+    """
+
+    def setup(self):
+        self.session = new_session(default=True)
+        self.asv_subtasks = []
+        for _ in range(100):
+            a = mt.arange(1e6)
+            b = mt.arange(1e6) * 0.1
+            c = mt.sin(a) + mt.arcsinh(a / b)
+            subtask_id = new_task_id()
+            subtask_chunk_graph = _gen_subtask_chunk_graph(c)
+            self.asv_subtasks.append(
+                _ASVSubtaskInfo(
+                    subtask_id=subtask_id,
+                    serialized_subtask_chunk_graph=serialize(subtask_chunk_graph),
+                )
+            )
+
+            c = a * b - 4.1 * a > 2.5 * b
+            subtask_id = new_task_id()
+            subtask_chunk_graph = _gen_subtask_chunk_graph(c)
+            self.asv_subtasks.append(
+                _ASVSubtaskInfo(
+                    subtask_id=subtask_id,
+                    serialized_subtask_chunk_graph=serialize(subtask_chunk_graph),
+                )
+            )
+
+    def teardown(self):
+        self.session.stop_server()
+
+    def time_numexpr_execution(self):
+        for _ in range(100):
+            a = mt.arange(1e6)
+            b = mt.arange(1e6) * 0.1
+            c = mt.sin(a) + mt.arcsinh(a / b)
+            c.execute(show_progress=False)
+            c = a * b - 4.1 * a > 2.5 * b
+            c.execute(show_progress=False)
+
+    def time_numexpr_subtask_execution(self):
+        for asv_subtask_info in self.asv_subtasks:
+            execute_subtask(
+                "",
+                asv_subtask_info.subtask_id,
+                asv_subtask_info.serialized_subtask_chunk_graph,
+                set(),
+                False,
+            )

--- a/mars/optimization/physical/numexpr.py
+++ b/mars/optimization/physical/numexpr.py
@@ -15,9 +15,9 @@
 import dataclasses
 import functools
 import logging
-import numpy as np
-
 from typing import List, Set
+
+import numpy as np
 
 from ...core import ChunkType, ChunkGraph
 from ...tensor import arithmetic

--- a/mars/optimization/physical/numexpr.py
+++ b/mars/optimization/physical/numexpr.py
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...core import ChunkType
+import dataclasses
+import functools
+import logging
+import numpy as np
+
+from typing import List
+
+from ...core import ChunkType, ChunkGraph
 from ...tensor import arithmetic
 from ...tensor import reduction
 from ...tensor.fuse import TensorNeFuseChunk
@@ -20,6 +27,10 @@ from ...tensor.fuse.numexpr import NUMEXPR_INSTALLED
 from .core import RuntimeOptimizer, register_optimizer
 
 
+logger = logging.getLogger(__name__)
+
+
+REDUCTION = object()
 REDUCTION_OP = {
     reduction.TensorSum,
     reduction.TensorProd,
@@ -64,6 +75,11 @@ SUPPORT_OP = {
     arithmetic.TensorRshift,
     arithmetic.TensorTreeAdd,
     arithmetic.TensorTreeMultiply,
+    arithmetic.TensorFloor,
+    arithmetic.TensorCeil,
+    arithmetic.TensorAnd,
+    arithmetic.TensorOr,
+    arithmetic.TensorNot,
     reduction.TensorSum,
     reduction.TensorProd,
     reduction.TensorMax,
@@ -71,22 +87,86 @@ SUPPORT_OP = {
 }
 
 
-def _check_reduction_axis(node: ChunkType):
-    return len(node.op.axis) == 1 or len(node.op.axis) == node.ndim
+@dataclasses.dataclass
+class _Fuse:
+    graph: ChunkGraph
+    heads: List[ChunkType]
+    tails: List[ChunkType]
 
 
-def _support(node: ChunkType):
-    op_type = type(node.op)
-    if op_type in REDUCTION_OP:
-        return _check_reduction_axis(node)
-    return op_type in SUPPORT_OP
-
-
-def _transfer_op(node: ChunkType):
+def _can_fuse(node: ChunkType):
     op = node.op
-    if type(op) in REDUCTION_OP and not _check_reduction_axis(node):
-        return op
-    return op
+    op_type = type(op)
+    if op_type in REDUCTION_OP:
+        if len(op.axis) == 1 or len(op.axis) == node.ndim:
+            return REDUCTION
+        else:
+            return False
+    # return op_type in SUPPORT_OP
+    if op_type not in SUPPORT_OP:
+        return False
+    if op_type in (arithmetic.TensorOr, arithmetic.TensorAnd):
+        # numexpr only support logical and or:
+        # https://numexpr.readthedocs.io/projects/NumExpr3/en/latest/user_guide.html#supported-operators
+        if np.isscalar(op.lhs) or np.isscalar(op.rhs):
+            return False
+    return True
+
+
+def _collect_fuse(
+    graph: ChunkGraph,
+    node: ChunkType,
+    cached_can_fuse,
+):
+    fuse_graph = ChunkGraph()
+    fuse_graph.add_node(node)
+    fuse_heads = []
+    fuse_tails = []
+    tail_reduction_node = None
+
+    stack = [node]
+    # Do a full search of sub graph even the fuse tails > 1
+    while len(stack) != 0:
+        node = stack.pop()
+        is_head = graph.count_predecessors(node) == 0
+        for n in graph.iter_predecessors(node):
+            can_fuse = cached_can_fuse(n)
+            if can_fuse is False or can_fuse is REDUCTION:
+                is_head = True
+            elif not fuse_graph.contains(n):
+                stack.append(n)
+                fuse_graph.add_node(n)
+            else:
+                fuse_graph.add_edge(n, node)
+        if is_head:
+            fuse_heads.append(node)
+        # Skip the successors of tail reduction node.
+        if node is tail_reduction_node:
+            continue
+        is_tail = graph.count_successors(node) == 0
+        for n in graph.iter_successors(node):
+            can_fuse = cached_can_fuse(n)
+            if can_fuse is False:
+                is_tail = True
+            elif can_fuse is REDUCTION:
+                if tail_reduction_node is None:
+                    tail_reduction_node = n
+                    fuse_tails.append(n)
+                    stack.append(n)
+                    fuse_graph.add_node(n)
+                elif n is tail_reduction_node:
+                    fuse_graph.add_edge(node, n)
+                else:
+                    is_tail = True
+            elif not fuse_graph.contains(n):
+                stack.append(n)
+                fuse_graph.add_node(n)
+            else:
+                fuse_graph.add_edge(node, n)
+        if is_tail:
+            fuse_tails.append(node)
+
+    return _Fuse(fuse_graph, fuse_heads, fuse_tails)
 
 
 @register_optimizer
@@ -100,35 +180,74 @@ class NumexprRuntimeOptimizer(RuntimeOptimizer):
     def optimize(self):
         fuses = []
         explored = set()
+        cached_can_fuse = functools.lru_cache(maxsize=None)(_can_fuse)
 
         graph = self._graph
+        graph_results = set(graph.results)
         for node in graph.topological_iter():
             if node.op.gpu or node.op.sparse:
                 # break
                 return [], []
-            if type(node.op) not in SUPPORT_OP or node in graph.results:
+            if node in explored or node in graph_results:
                 continue
-            if node in explored or type(node.op) in REDUCTION_OP:
-                # TODO: check logic here
-                continue
-            if graph.count_successors(node) != 1:
-                continue
-
-            selected = [node]
-            # add successors
-            cur_node = graph.successors(node)[0]
-            while graph.count_predecessors(cur_node) == 1 and _support(cur_node):
-                selected.append(cur_node)
-                if (
-                    graph.count_successors(cur_node) != 1
-                    or type(cur_node.op) in REDUCTION_OP
-                    or cur_node in graph.results
-                ):
-                    break
-                else:
-                    cur_node = graph.successors(cur_node)[0]
-            if len(selected) > 1:
-                explored.update(selected)
-                fuses.append(list(selected))
+            can_fuse = cached_can_fuse(node)
+            if can_fuse is True:
+                fuse = _collect_fuse(graph, node, cached_can_fuse)
+                if len(fuse.graph) > 1:
+                    explored.update(fuse.graph)
+                    if len(fuse.tails) == 1:
+                        fuses.append(fuse)
+                    else:
+                        logger.info(
+                            "Refused fusing for numexpr because the tail node count > 1."
+                        )
 
         return self._fuse_nodes(fuses, TensorNeFuseChunk)
+
+    def _fuse_nodes(self, fuses: List[_Fuse], fuse_cls):
+        graph = self._graph
+        fused_nodes = []
+
+        for fuse in fuses:
+            fuse_graph = fuse.graph
+            tail_nodes = fuse.tails
+            head_nodes = fuse.heads
+            inputs = [
+                inp for n in head_nodes for inp in n.inputs if inp not in fuse_graph
+            ]
+
+            tail_chunk = tail_nodes[0]
+            tail_chunk_op = tail_chunk.op
+            fuse_op = fuse_cls(
+                sparse=tail_chunk_op.sparse,
+                gpu=tail_chunk_op.gpu,
+                _key=tail_chunk_op.key,
+                fuse_graph=fuse_graph,
+                dtype=tail_chunk.dtype,
+            )
+            fused_chunk = fuse_op.new_chunk(
+                inputs,
+                kws=[tail_chunk.params],
+                _key=tail_chunk.key,
+                _chunk=tail_chunk,
+            ).data
+
+            graph.add_node(fused_chunk)
+            for node in graph.iter_successors(tail_chunk):
+                graph.add_edge(fused_chunk, node)
+            for head_chunk in head_nodes:
+                for node in graph.iter_predecessors(head_chunk):
+                    if not fuse_graph.contains(node):
+                        graph.add_edge(node, fused_chunk)
+            for node in fuse_graph:
+                graph.remove_node(node)
+            fused_nodes.append(fused_chunk)
+
+            try:
+                # check tail node if it's in results
+                i = graph.results.index(tail_chunk)
+                graph.results[i] = fused_chunk
+            except ValueError:
+                pass
+
+        return fuses, fused_nodes

--- a/mars/optimization/physical/tests/test_numexpr.py
+++ b/mars/optimization/physical/tests/test_numexpr.py
@@ -326,7 +326,7 @@ def test_numexpr():
         graph(@: node, R: Reduction Chunk, #: fused_node):
 
         @ --> @ --> R   ========>  #
-        
+
         fuse stopped at R, because reduction should be the last in the numexpr stack.
         """
     chunks = [
@@ -347,13 +347,13 @@ def test_numexpr():
     r"""
         graph(@: node, R: Reduction Chunk, #: fused_node):
 
-        @ 
+        @
           \                                        R
             R     R                               /
           /  \   /         =============>  # --> #     R
         @      R     R                            \   /
              /   \  /                               @ --> R
-            @     @ --> R       
+            @     @ --> R
 
         fuse stopped at R, because reduction should be the last in the numexpr stack.
         """

--- a/mars/optimization/physical/tests/test_numexpr.py
+++ b/mars/optimization/physical/tests/test_numexpr.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import operator
 
 from ....core import ChunkGraph
 from ....tensor.arithmetic import TensorTreeAdd
 from ....tensor.indexing import TensorSlice
+from ....tensor.reduction import TensorSum
 from ..numexpr import NumexprRuntimeOptimizer
 
 
@@ -22,11 +24,11 @@ def test_numexpr():
     r"""
         graph(@: node, S: Slice Chunk, #: fused_node):
 
-        @                   @              @             @
-          \               /                  \         /
-            @ --> @ --> S      ========>       # --> S
-          /               \                  /         \
-        @                   @              @             @
+        @                   @                          @
+          \               /                          /
+            @ --> @ --> S      ========>     # --> S
+          /               \                          \
+        @                   @                          @
 
         fuse stopped at S, because numexpr don't support Slice op
         """
@@ -34,6 +36,7 @@ def test_numexpr():
         TensorTreeAdd(args=[], _key=str(n)).new_chunk(None, None).data for n in range(6)
     ]
     chunk_slice = TensorSlice().new_chunk([None], None).data
+    chunk_reduction = TensorSum(axis=(1,)).new_chunk([None], None).data
     graph = ChunkGraph([chunks[4], chunks[5]])
     list(map(graph.add_node, chunks[:6]))
     graph.add_node(chunk_slice)
@@ -46,12 +49,191 @@ def test_numexpr():
 
     optimizer = NumexprRuntimeOptimizer(graph)
     _, fused_nodes = optimizer.optimize()
-    assert fused_nodes[0].composed == chunks[2:4]
+    assert fused_nodes[0].composed == chunks[:4]
+    assert len(graph) == 4
 
     r"""
-            graph(@: node, S: Slice Chunk, #: fused_node):
+        graph(@: node, S: Slice Chunk, #: fused_node):
 
-            @ --> @ --> S --> @  ========>  # --> S --> @
+        @                   @
+          \               /
+            @ --> @ --> @      ========>   Tail node count > 1, can't be fused.
+          /               \
+        @                   @
+
+        fuse stopped at S, because numexpr don't support Slice op
+        """
+    chunks = [
+        TensorTreeAdd(args=[], _key=str(n)).new_chunk(None, None).data for n in range(7)
+    ]
+    graph = ChunkGraph([chunks[5], chunks[6]])
+    list(map(graph.add_node, chunks[:7]))
+    graph.add_edge(chunks[0], chunks[2])
+    graph.add_edge(chunks[1], chunks[2])
+    graph.add_edge(chunks[2], chunks[3])
+    graph.add_edge(chunks[3], chunks[4])
+    graph.add_edge(chunks[4], chunks[5])
+    graph.add_edge(chunks[4], chunks[6])
+
+    optimizer = NumexprRuntimeOptimizer(graph)
+    _, fused_nodes = optimizer.optimize()
+    assert len(fused_nodes) == 0
+    assert len(graph) == 7
+
+    r"""
+        graph(@: node, S: Slice Chunk, #: fused_node):
+
+        @           S       S
+          \        /       /
+            @ --> @ --> @      ========>   Tail node count > 1, can't be fused.
+          /               \
+        @                   @
+
+        fuse stopped at S, because numexpr don't support Slice op
+        """
+    chunks = [
+        TensorTreeAdd(args=[], _key=str(n)).new_chunk(None, None).data for n in range(6)
+    ]
+    chunk_slices = [
+        TensorSlice(_key=str(n)).new_chunk([None], None).data for n in range(2)
+    ]
+    graph = ChunkGraph([chunks[5], chunk_slices[0], chunk_slices[1]])
+    list(map(graph.add_node, chunks[:6]))
+    list(map(graph.add_node, chunk_slices[:2]))
+    graph.add_edge(chunks[0], chunks[2])
+    graph.add_edge(chunks[1], chunks[2])
+    graph.add_edge(chunks[2], chunks[3])
+    graph.add_edge(chunks[3], chunk_slices[0])
+    graph.add_edge(chunks[3], chunks[4])
+    graph.add_edge(chunks[4], chunks[5])
+    graph.add_edge(chunks[4], chunk_slices[1])
+
+    optimizer = NumexprRuntimeOptimizer(graph)
+    _, fused_nodes = optimizer.optimize()
+    assert len(fused_nodes) == 0
+    assert len(graph) == 8
+
+    r"""
+        graph(@: node, S: Slice Chunk, #: fused_node):
+
+        @
+          \
+            @
+          /   \
+        @      \
+                 @   ========>   #
+        @      /
+          \   /
+            @
+          /
+        @
+
+        fuse stopped at S, because numexpr don't support Slice op
+        """
+    chunks = [
+        TensorTreeAdd(args=[], _key=str(n)).new_chunk(None, None).data for n in range(7)
+    ]
+    graph = ChunkGraph([chunks[6]])
+    list(map(graph.add_node, chunks[:7]))
+    graph.add_edge(chunks[0], chunks[2])
+    graph.add_edge(chunks[1], chunks[2])
+    graph.add_edge(chunks[3], chunks[5])
+    graph.add_edge(chunks[4], chunks[5])
+    graph.add_edge(chunks[2], chunks[6])
+    graph.add_edge(chunks[5], chunks[6])
+
+    optimizer = NumexprRuntimeOptimizer(graph)
+    _, fused_nodes = optimizer.optimize()
+    sorted_composed = sorted(fused_nodes[0].composed, key=operator.attrgetter("key"))
+    assert sorted_composed == chunks
+    assert len(graph) == 1
+
+    r"""
+        graph(@: node, S: Slice Chunk, #: fused_node):
+
+        @
+          \
+            @
+          /   \                            #
+        @      \                              \
+                 S --> @ --> @  ========>       S --> #
+        @      /                              /
+          \   /                            #
+            @
+          /
+        @
+
+        fuse stopped at S, because numexpr don't support Slice op
+        """
+    chunks = [
+        TensorTreeAdd(args=[], _key=str(n)).new_chunk(None, None).data for n in range(8)
+    ]
+    graph = ChunkGraph([chunks[7]])
+    list(map(graph.add_node, chunks[:8]))
+    graph.add_node(chunk_slice)
+    graph.add_edge(chunks[0], chunks[2])
+    graph.add_edge(chunks[1], chunks[2])
+    graph.add_edge(chunks[3], chunks[5])
+    graph.add_edge(chunks[4], chunks[5])
+    graph.add_edge(chunks[2], chunk_slice)
+    graph.add_edge(chunks[5], chunk_slice)
+    graph.add_edge(chunk_slice, chunks[6])
+    graph.add_edge(chunks[6], chunks[7])
+
+    optimizer = NumexprRuntimeOptimizer(graph)
+    _, fused_nodes = optimizer.optimize()
+    assert len(fused_nodes) == 3
+    assert sorted(len(n.composed) for n in fused_nodes) == [2, 3, 3]
+    assert len(graph) == 4
+    assert graph.contains(chunk_slice)
+
+    r"""
+        graph(@: node, S: Slice Chunk, #: fused_node):
+
+        S
+          \
+            @
+          /   \                         S
+        @      \                           \
+                 @ --- @   ========>    S --  #
+        @      /     /                     /
+          \   /     S                   S
+            @
+          /
+        S
+
+        fuse stopped at S, because numexpr don't support Slice op
+        """
+    chunks = [
+        TensorTreeAdd(args=[], _key=str(n)).new_chunk(None, None).data for n in range(6)
+    ]
+    chunk_slices = [
+        TensorSlice(_key=str(n)).new_chunk([None], None).data for n in range(3)
+    ]
+    graph = ChunkGraph([chunks[5]])
+    list(map(graph.add_node, chunks[:6]))
+    list(map(graph.add_node, chunk_slices[:3]))
+    graph.add_edge(chunk_slices[0], chunks[1])
+    graph.add_edge(chunks[0], chunks[1])
+    graph.add_edge(chunks[2], chunks[3])
+    graph.add_edge(chunk_slices[1], chunks[3])
+    graph.add_edge(chunks[1], chunks[4])
+    graph.add_edge(chunks[3], chunks[4])
+    graph.add_edge(chunks[4], chunks[5])
+    graph.add_edge(chunk_slices[2], chunks[5])
+
+    optimizer = NumexprRuntimeOptimizer(graph)
+    _, fused_nodes = optimizer.optimize()
+    assert len(fused_nodes) == 1
+    sorted_composed = sorted(fused_nodes[0].composed, key=operator.attrgetter("key"))
+    assert sorted_composed == chunks
+    assert len(graph) == 4
+    assert graph.count_predecessors(fused_nodes[0]) == 3
+
+    r"""
+        graph(@: node, S: Slice Chunk, #: fused_node):
+
+        @ --> @ --> S --> @  ========>  # --> S --> @
 
         fuse stopped at S, because numexpr don't support Slice op
         """
@@ -75,8 +257,8 @@ def test_numexpr():
 
         @ --> @ --> S --> @ --> @   ========>  # --> S --> #
 
-    fuse stopped at S, because numexpr don't support Slice op
-    """
+        fuse stopped at S, because numexpr don't support Slice op
+        """
     chunks = [
         TensorTreeAdd(args=[], _key=str(n)).new_chunk(None, None).data for n in range(4)
     ]
@@ -92,3 +274,110 @@ def test_numexpr():
     _, fused_nodes = optimizer.optimize()
     assert fused_nodes[0].composed == chunks[:2]
     assert fused_nodes[1].composed == chunks[2:4]
+
+    r"""
+        graph(@: node, R: Reduction Chunk, #: fused_node):
+
+        @ --> @ --> R --> @ --> @   ========>  # --> #
+
+        fuse stopped at R, because reduction should be the last in the numexpr stack.
+        """
+    chunks = [
+        TensorTreeAdd(args=[], _key=str(n)).new_chunk(None, None).data for n in range(4)
+    ]
+    graph = ChunkGraph([chunks[3]])
+    list(map(graph.add_node, chunks[:4]))
+    graph.add_node(chunk_reduction)
+    graph.add_edge(chunks[0], chunks[1])
+    graph.add_edge(chunks[1], chunk_reduction)
+    graph.add_edge(chunk_reduction, chunks[2])
+    graph.add_edge(chunks[2], chunks[3])
+
+    optimizer = NumexprRuntimeOptimizer(graph)
+    _, fused_nodes = optimizer.optimize()
+    assert len(fused_nodes) == 2
+    assert fused_nodes[0].composed == chunks[:2] + [chunk_reduction]
+    assert fused_nodes[1].composed == chunks[2:4]
+    assert len(graph) == 2
+
+    r"""
+        graph(@: node, R: Reduction Chunk, #: fused_node):
+
+        R --> @ --> @   ========>  R --> #
+
+        fuse stopped at R, because reduction should be the last in the numexpr stack.
+        """
+    chunks = [
+        TensorTreeAdd(args=[], _key=str(n)).new_chunk(None, None).data for n in range(2)
+    ]
+    graph = ChunkGraph([chunks[1]])
+    list(map(graph.add_node, chunks[:2]))
+    graph.add_node(chunk_reduction)
+    graph.add_edge(chunk_reduction, chunks[0])
+    graph.add_edge(chunks[0], chunks[1])
+
+    optimizer = NumexprRuntimeOptimizer(graph)
+    _, fused_nodes = optimizer.optimize()
+    assert len(fused_nodes) == 1
+    assert fused_nodes[0].composed == chunks[:2]
+    assert len(graph) == 2
+
+    r"""
+        graph(@: node, R: Reduction Chunk, #: fused_node):
+
+        @ --> @ --> R   ========>  #
+        
+        fuse stopped at R, because reduction should be the last in the numexpr stack.
+        """
+    chunks = [
+        TensorTreeAdd(args=[], _key=str(n)).new_chunk(None, None).data for n in range(2)
+    ]
+    graph = ChunkGraph([chunk_reduction])
+    list(map(graph.add_node, chunks[:2]))
+    graph.add_node(chunk_reduction)
+    graph.add_edge(chunks[0], chunks[1])
+    graph.add_edge(chunks[1], chunk_reduction)
+
+    optimizer = NumexprRuntimeOptimizer(graph)
+    _, fused_nodes = optimizer.optimize()
+    assert len(fused_nodes) == 1
+    assert fused_nodes[0].composed == chunks[:2] + [chunk_reduction]
+    assert len(graph) == 1
+
+    r"""
+        graph(@: node, R: Reduction Chunk, #: fused_node):
+
+        @ 
+          \                                        R
+            R     R                               /
+          /  \   /         =============>  # --> #     R
+        @      R     R                            \   /
+             /   \  /                               @ --> R
+            @     @ --> R       
+
+        fuse stopped at R, because reduction should be the last in the numexpr stack.
+        """
+    chunks = [
+        TensorTreeAdd(args=[], _key=str(n)).new_chunk(None, None).data for n in range(4)
+    ]
+    chunk_reductions = [
+        TensorSum(axis=(1,), _key=str(n)).new_chunk([None], None).data for n in range(5)
+    ]
+    graph = ChunkGraph([chunk_reductions[2], chunk_reductions[3], chunk_reductions[4]])
+    list(map(graph.add_node, chunks[:4]))
+    list(map(graph.add_node, chunk_reductions[:5]))
+    graph.add_edge(chunks[0], chunk_reductions[0])
+    graph.add_edge(chunks[1], chunk_reductions[0])
+    graph.add_edge(chunks[2], chunk_reductions[1])
+    graph.add_edge(chunk_reductions[0], chunk_reductions[1])
+    graph.add_edge(chunk_reductions[1], chunk_reductions[2])
+    graph.add_edge(chunk_reductions[1], chunks[3])
+    graph.add_edge(chunks[3], chunk_reductions[3])
+    graph.add_edge(chunks[3], chunk_reductions[4])
+
+    optimizer = NumexprRuntimeOptimizer(graph)
+    _, fused_nodes = optimizer.optimize()
+    assert len(fused_nodes) == 2
+    assert fused_nodes[0].composed == [chunks[2], chunk_reductions[1]]
+    assert set(fused_nodes[1].composed) == {chunks[0], chunks[1], chunk_reductions[0]}
+    assert len(graph) == 6

--- a/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
+++ b/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
@@ -244,11 +244,11 @@ def test_ray_execute_subtask_basic():
 
     subtask_id = new_task_id()
     subtask_chunk_graph = _gen_subtask_chunk_graph(b)
-    r = execute_subtask("", subtask_id, serialize(subtask_chunk_graph), set(), [])
+    r = execute_subtask("", subtask_id, serialize(subtask_chunk_graph), set(), False)
     np.testing.assert_array_equal(r, raw_expect)
     test_get_meta_chunk = subtask_chunk_graph.result_chunks[0]
     r = execute_subtask(
-        "", subtask_id, serialize(subtask_chunk_graph), {test_get_meta_chunk.key}, []
+        "", subtask_id, serialize(subtask_chunk_graph), {test_get_meta_chunk.key}, False
     )
     assert len(r) == 2
     meta_dict, r = r

--- a/mars/tensor/fuse/tests/test_numexpr_execution.py
+++ b/mars/tensor/fuse/tests/test_numexpr_execution.py
@@ -17,7 +17,9 @@
 import numpy as np
 
 from ....utils import ignore_warning
-from ...datasource import tensor
+from ...datasource import tensor, arange
+from ...reduction import sum as mt_sum
+from ...arithmetic import abs as mt_abs
 
 
 def test_base_execution(setup):
@@ -32,6 +34,23 @@ def test_base_execution(setup):
     res3 = arr3.execute().fetch()
     res3_cmp = arr4.execute().fetch()
     np.testing.assert_array_equal(res3, res3_cmp)
+
+    a = arange(10)
+    b = arange(10) * 0.1
+    raw_a = np.arange(10)
+    raw_b = np.arange(10) * 0.1
+    c = a * b - 4.1 * a > 2.5 * b
+    res4_cmp = raw_a * raw_b - 4.1 * raw_a > 2.5 * raw_b
+    res4 = c.execute().fetch()
+    np.testing.assert_array_equal(res4, res4_cmp)
+
+    c = mt_sum(1) * (-1)
+    r = c.execute().fetch()
+    assert r == -1
+
+    c = -mt_abs(mt_sum(mt_abs(-1)))
+    r = c.execute().fetch()
+    assert r == -1
 
 
 def _gen_pairs(seq):
@@ -85,9 +104,21 @@ def test_bin_execution(setup):
         lshift,
         rshift,
         ldexp,
+        logical_and,
+        logical_or,
     )
 
-    _sp_bin_ufunc = [mod, fmod, bitand, bitor, bitxor, lshift, rshift]
+    _sp_bin_ufunc = [
+        mod,
+        fmod,
+        bitand,
+        bitor,
+        bitxor,
+        lshift,
+        rshift,
+        logical_and,
+        logical_or,
+    ]
     _new_bin_ufunc = list(BIN_UFUNC - set(_sp_bin_ufunc) - {ldexp})
 
     tested = set()

--- a/mars/tensor/fuse/tests/test_numexpr_execution.py
+++ b/mars/tensor/fuse/tests/test_numexpr_execution.py
@@ -17,9 +17,9 @@
 import numpy as np
 
 from ....utils import ignore_warning
+from ...arithmetic import abs as mt_abs
 from ...datasource import tensor, arange
 from ...reduction import sum as mt_sum
-from ...arithmetic import abs as mt_abs
 
 
 def test_base_execution(setup):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

### Fuse a sub graph instead of a line
graph(@: node, S: Slice Chunk, #: fused_node): fuse stopped at S, because numexpr don't support Slice op

- before

```python
@                   @              @             @
  \               /                  \         /
    @ --> @ --> S      ========>       # --> S
  /               \                  /         \
@                   @              @             @
```

- after

```python
@                   @                          @
  \               /                          /
    @ --> @ --> S      ========>     # --> S
  /               \                          \
@                   @                          @
```

### New support operands

Update Mars fuse logic to support new operands:
- TensorFloor
- TensorCeil
- TensorAnd
- TensorOr
- TensorNot

### Better cache hit

- before

`((V_7db74de3f328b72d4e13457955bf5289_0+V_5b589bdfffe813d3d0414d0a7fe76c1e_0)+10)`

- after

`((V_0+V_1)+10)`

## Performance

The fused expr has the same performance boost according to the numexpr benchmark. My test environment,
- Quad-Core Intel Core i7 @ 2.2GHz
- Python 3.8.7
- numexpr 2.8.1 without MKL support
- numpy 1.22.4

The test code
```python
import time
import mars
import mars.tensor as mt

mars.new_session()


start_time = time.time()
for _ in range(100):
    a = mt.arange(1e6)
    b = mt.arange(1e6) * 0.1
    c = mt.sin(a) + mt.arcsinh(a / b)
    c.execute()
    c = a * b - 4.1 * a > 2.5 * b
    c.execute()
print(time.time() - start_time)
```
 Result
- The average cost of subtask `mt.sin(a) + mt.arcsinh(a / b)` is reduced from 0.07 to 0.02 (faster ~3x)
- The average cost of subtask `a * b - 4.1 * a > 2.5 * b` is reduced from 0.019 to 0.004 (faster ~5x)
- The cost of 100 loops of the test code  is reduced from 16.9 to 11 (faster ~30%)

For the complex expression, the performance of single subtask execution (including fusing cost) is faster about **3x~5x**, the end to end is faster about **25%~35%**.


In the future, we can try to move the numexpr fusion from physical to logical to get better performance.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
