### PR TITLE
[Ray] Fix ray memory leak

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,7 +150,7 @@ jobs:
         flake8 mars --config=flake8_init.ini
 
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 mars --config="default" --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 mars --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       displayName: 'Lint with flake8'
 
     - bash: |

--- a/mars/deploy/oscar/ray.py
+++ b/mars/deploy/oscar/ray.py
@@ -425,9 +425,15 @@ class RayCluster:
         self.web_address = None
 
     async def start(self):
-        logging.basicConfig(
-            format=ray.ray_constants.LOGGER_FORMAT, level=logging.INFO, force=True
-        )
+        try:
+            # Python 3.8 support force argument.
+            logging.basicConfig(
+                format=ray.ray_constants.LOGGER_FORMAT, level=logging.INFO, force=True
+            )
+        except ValueError:
+            logging.basicConfig(
+                format=ray.ray_constants.LOGGER_FORMAT, level=logging.INFO
+            )
         logger.info("Start cluster with config %s", self._config)
         # init metrics to guarantee metrics use in driver
         metric_configs = self._config.get("metrics", {})
@@ -498,6 +504,9 @@ class RayCluster:
         supervisor_modules = get_third_party_modules_from_config(
             self._config, NodeRole.SUPERVISOR
         )
+
+        # set global router an empty one.
+        Router.set_instance(Router(list(), None))
 
         # create supervisor actor pool
         supervisor_pool_coro = asyncio.create_task(

--- a/mars/deploy/oscar/ray.py
+++ b/mars/deploy/oscar/ray.py
@@ -430,7 +430,7 @@ class RayCluster:
             logging.basicConfig(
                 format=ray.ray_constants.LOGGER_FORMAT, level=logging.INFO, force=True
             )
-        except ValueError:
+        except ValueError:  # pragma: no cover
             logging.basicConfig(
                 format=ray.ray_constants.LOGGER_FORMAT, level=logging.INFO
             )

--- a/mars/oscar/backends/core.py
+++ b/mars/oscar/backends/core.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import copy
+import logging
 from typing import Dict, Union
 
 from ...oscar.profiling import ProfilingData
@@ -25,6 +26,7 @@ from .router import Router
 
 
 ResultMessageType = Union[ResultMessage, ErrorMessage]
+logger = logging.getLogger(__name__)
 
 
 class ActorCaller:
@@ -41,6 +43,14 @@ class ActorCaller:
         if client not in self._clients:
             self._clients[client] = asyncio.create_task(self._listen(client))
             self._client_to_message_futures[client] = dict()
+            client_count = len(self._clients)
+            if client_count >= 100:  # pragma: no cover
+                if (client_count - 100) % 10 == 0:  # pragma: no cover
+                    logger.warning(
+                        "Actor caller has created too many clients (%s >= 100), "
+                        "the global router may not be set.",
+                        client_count,
+                    )
         return client
 
     async def _listen(self, client: Client):

--- a/mars/oscar/backends/core.py
+++ b/mars/oscar/backends/core.py
@@ -55,8 +55,6 @@ class ActorCaller:
 
     async def _listen(self, client: Client):
         while not client.closed:
-            message: Union[_MessageBase, None] = None
-            future = None
             try:
                 try:
                     message: _MessageBase = await client.recv()
@@ -84,8 +82,14 @@ class ActorCaller:
             finally:
                 # message may have Ray ObjectRef, delete it early in case next loop doesn't run
                 # as soon as expected.
-                del message
-                del future
+                try:
+                    del message
+                except NameError:
+                    pass
+                try:
+                    del future
+                except NameError:
+                    pass
                 await asyncio.sleep(0)
 
         message_futures = self._client_to_message_futures.get(client)

--- a/mars/oscar/backends/ray/backend.py
+++ b/mars/oscar/backends/ray/backend.py
@@ -17,6 +17,7 @@ from typing import Dict
 from ....utils import lazy_import, Timer
 from ...backend import BaseActorBackend, register_backend
 from ..context import MarsActorContext
+from ..router import Router
 from .driver import RayActorDriver
 from .pool import RayMainPool
 from .utils import process_address_to_placement, get_placement_group
@@ -48,6 +49,10 @@ class RayActorBackend(BaseActorBackend):
         kwargs.pop("n_io_process", 0)
         pg_name, bundle_index, _ = process_address_to_placement(address)
         from .pool import RayMainActorPool
+
+        # get default router or create an empty one
+        default_router = Router.get_instance_or_empty()
+        Router.set_instance(default_router)
 
         pool_addresses = RayMainActorPool.get_external_addresses(address, n_process)
         assert pool_addresses[0] == address

--- a/mars/oscar/backends/ray/backend.py
+++ b/mars/oscar/backends/ray/backend.py
@@ -17,7 +17,6 @@ from typing import Dict
 from ....utils import lazy_import, Timer
 from ...backend import BaseActorBackend, register_backend
 from ..context import MarsActorContext
-from ..router import Router
 from .driver import RayActorDriver
 from .pool import RayMainPool
 from .utils import process_address_to_placement, get_placement_group
@@ -49,10 +48,6 @@ class RayActorBackend(BaseActorBackend):
         kwargs.pop("n_io_process", 0)
         pg_name, bundle_index, _ = process_address_to_placement(address)
         from .pool import RayMainActorPool
-
-        # get default router or create an empty one
-        default_router = Router.get_instance_or_empty()
-        Router.set_instance(default_router)
 
         pool_addresses = RayMainActorPool.get_external_addresses(address, n_process)
         assert pool_addresses[0] == address


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

The memory leak is because when starting session by the `new_ray_session`, the global router is not set. There is a `_set_global_router` in ActorPoolBase::create, but the `new_ray_session` calls the create method in Ray actor. So, driver still has empty global router.

The memory leak details:
1. `new_ray_session` has not called the `Router.set_instance`.
2. Each Mars actor call invokes `Router.get_instance_or_empty()`, a new Router instance will be created.
3. The Router instance is always a new one, then `router.get_client(...)` creates a new client instance in `ActorCaller`.
4. The `asyncio.create_task(self._listen(client))` creates a new coroutine `_listen`.
5. The `_listen` coroutine captures the returned `ResultMessage` in  frame.


Before
```
[ Top 10 differences ]
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/ray/serialization.py:160: size=63.6 MiB (+60.5 MiB), count=1678 (+1606), average=38.8 KiB
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/ray/serialization.py:162: size=880 KiB (+815 KiB), count=3727 (+3301), average=242 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/ray/actor.py:947: size=250 KiB (+201 KiB), count=2914 (+2340), average=88 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/ray/actor.py:955: size=244 KiB (+195 KiB), count=225 (+180), average=1109 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/ray/actor.py:101: size=216 KiB (+170 KiB), count=4195 (+3325), average=53 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/asyncio/locks.py:244: size=185 KiB (+153 KiB), count=1203 (+981), average=158 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/ray/actor.py:954: size=187 KiB (+150 KiB), count=2968 (+2386), average=64 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/asyncio/queues.py:51: size=136 KiB (+112 KiB), count=436 (+360), average=319 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/redis/connection.py:225: size=127 KiB (+102 KiB), count=223 (+179), average=584 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/ray/actor.py:949: size=126 KiB (+101 KiB), count=224 (+180), average=576 B
```

After
```
[ Top 10 differences ]
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/redis/connection.py:194: size=1000 B (-64.0 KiB), count=14 (+0), average=71 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/redis/connection.py:225: size=24.0 KiB (+8176 B), count=42 (+14), average=584 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/threading.py:552: size=2760 B (-2208 B), count=5 (-4), average=552 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/redis/client.py:1436: size=12.7 KiB (-2032 B), count=69 (-9), average=189 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/redis/client.py:1422: size=6336 B (-1200 B), count=12 (-3), average=528 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/json/decoder.py:353: size=2640 B (+1192 B), count=32 (+14), average=82 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/pandas/core/indexes/base.py:495: size=1752 B (+1168 B), count=3 (+2), average=584 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/threading.py:348: size=7392 B (+1056 B), count=14 (+2), average=528 B
/home/admin/.pyenv/versions/3.7.7/lib/python3.7/site-packages/redis/client.py:1421: size=2672 B (-1040 B), count=11 (-3), average=243 B
<unknown>:0: size=42.1 KiB (+1008 B), count=144 (+6), average=299 
```

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes https://github.com/mars-project/mars/issues/3183
Fixes https://github.com/mars-project/mars/issues/3173

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
