### PR TITLE
Ensure key is a valid Python identifier

### DIFF
--- a/mars/core/operand/tests/test_core.py
+++ b/mars/core/operand/tests/test_core.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from ....dataframe import core  # noqa: F401  # pylint: disable=unused-variable
 from ... import OutputType
 from .. import Operand, TileableOperandMixin, execute, estimate_size, ShuffleProxy
 

--- a/mars/deploy/oscar/tests/session.py
+++ b/mars/deploy/oscar/tests/session.py
@@ -17,6 +17,7 @@ import inspect
 import os
 import uuid
 
+from ....conftest import MARS_CI_BACKEND
 from ....core import OBJECT_TYPE
 from ....deploy.oscar.local import LocalCluster, LocalClient
 from ....tests.core import _check_args, ObjectCheckMixin
@@ -72,7 +73,7 @@ class CheckedSession(ObjectCheckMixin, _IsolatedSession):
 async def _new_test_session(
     address: str,
     session_id: str = None,
-    backend: str = "mars",
+    backend: str = MARS_CI_BACKEND,
     default: bool = False,
     new: bool = True,
     timeout: float = None,
@@ -129,7 +130,7 @@ async def _new_test_session(
 def new_test_session(
     address: str = None,
     session_id: str = None,
-    backend: str = "mars",
+    backend: str = MARS_CI_BACKEND,
     default: bool = False,
     new: bool = True,
     **kwargs,

--- a/mars/lib/mmh3_src/mmh3module.cpp
+++ b/mars/lib/mmh3_src/mmh3module.cpp
@@ -291,12 +291,9 @@ mmh3_hash_bytes(PyObject *self, PyObject *args, PyObject *keywds)
         Py_DECREF(target_mview);
     }
 
-    unsigned char bytes[16];
+    char bytes[16];
     memcpy(bytes, result, 16);
-    // Make the first char of hex be a letter, then the Mars chunk key can be a valid Python identifier:
-    // https://docs.python.org/3/reference/lexical_analysis.html#identifiers
-    bytes[0] |= 0xC0;
-    return PyBytes_FromStringAndSize((char*)bytes, 16);
+    return PyBytes_FromStringAndSize(bytes, 16);
 }
 
 struct module_state {

--- a/mars/lib/mmh3_src/mmh3module.cpp
+++ b/mars/lib/mmh3_src/mmh3module.cpp
@@ -291,9 +291,12 @@ mmh3_hash_bytes(PyObject *self, PyObject *args, PyObject *keywds)
         Py_DECREF(target_mview);
     }
 
-    char bytes[16];
+    unsigned char bytes[16];
     memcpy(bytes, result, 16);
-    return PyBytes_FromStringAndSize(bytes, 16);
+    // Make the first char of hex be a letter, then the Mars chunk key can be a valid Python identifier:
+    // https://docs.python.org/3/reference/lexical_analysis.html#identifiers
+    bytes[0] |= 0xC0;
+    return PyBytes_FromStringAndSize((char*)bytes, 16);
 }
 
 struct module_state {

--- a/mars/services/subtask/worker/tests/subtask_processor.py
+++ b/mars/services/subtask/worker/tests/subtask_processor.py
@@ -74,6 +74,8 @@ class CheckedSubtaskProcessor(ObjectCheckMixin, SubtaskProcessor):
                     continue
                 if self._check_keys and out.key not in self._check_keys:
                     continue
+                # The first char of key is a letter.
+                assert out.key[0] in {"c", "d", "e", "f"}, out.key
                 if out.key not in ctx and any(
                     k[0] == out.key for k in ctx if isinstance(k, tuple)
                 ):

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -548,11 +548,16 @@ class RayTaskExecutor(TaskExecutor):
         output_object_refs = set()
         for chunk in chunk_graph.result_chunks:
             chunk_key = chunk.key
-            object_ref = task_context[chunk_key]
-            output_object_refs.add(object_ref)
-            chunk_params = key_to_meta.get(chunk_key)
-            if chunk_params is not None:
-                chunk_to_meta[chunk] = ExecutionChunkResult(chunk_params, object_ref)
+            # The result chunk may be in previous stage result,
+            # then the chunk does not have to be processed.
+            if chunk_key in task_context:
+                object_ref = task_context[chunk_key]
+                output_object_refs.add(object_ref)
+                chunk_params = key_to_meta.get(chunk_key)
+                if chunk_params is not None:
+                    chunk_to_meta[chunk] = ExecutionChunkResult(
+                        chunk_params, object_ref
+                    )
 
         logger.info("Waiting for stage %s complete.", stage_id)
         # Patched the asyncio.to_thread for Python < 3.9 at mars/lib/aio/__init__.py

--- a/mars/services/task/execution/ray/fetcher.py
+++ b/mars/services/task/execution/ray/fetcher.py
@@ -64,6 +64,6 @@ class RayFetcher(Fetcher):
                 refs[index] = fetch_info.object_ref
             else:
                 refs[index] = self._remote_query_object_with_condition().remote(
-                    fetch_info.object_ref, fetch_info.conditions
+                    fetch_info.object_ref, tuple(fetch_info.conditions)
                 )
         return await asyncio.gather(*refs)

--- a/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
+++ b/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
@@ -275,13 +275,13 @@ async def test_ray_fetcher(ray_start_regular_shared2):
     fetcher = RayFetcher()
     await fetcher.append("pd_key", {"object_refs": [pd_object_ref]})
     await fetcher.append("np_key", {"object_refs": [np_object_ref]})
-    await fetcher.append("pd_key", {"object_refs": [pd_object_ref]}, [1, 3])
-    await fetcher.append("np_key", {"object_refs": [np_object_ref]}, [1, 3])
+    await fetcher.append("pd_key", {"object_refs": [pd_object_ref]}, [slice(1, 3, 1)])
+    await fetcher.append("np_key", {"object_refs": [np_object_ref]}, [slice(1, 3, 1)])
     results = await fetcher.get()
     pd.testing.assert_frame_equal(results[0], pd_value)
     np.testing.assert_array_equal(results[1], np_value)
-    pd.testing.assert_frame_equal(results[2], pd_value.iloc[[1, 3]])
-    np.testing.assert_array_equal(results[3], np_value[[1, 3]])
+    pd.testing.assert_frame_equal(results[2], pd_value.iloc[1:3])
+    np.testing.assert_array_equal(results[3], np_value[1:3])
 
 
 @require_ray

--- a/mars/tensor/datastore/tests/test_datastore_execution.py
+++ b/mars/tensor/datastore/tests/test_datastore_execution.py
@@ -109,6 +109,7 @@ def test_store_tiledb_execution(setup):
 
 
 @pytest.mark.skipif(h5py is None, reason="h5py not installed")
+@pytest.mark.ray_dag
 def test_store_hdf5_execution(setup):
     raw = np.random.RandomState(0).rand(10, 20)
 

--- a/mars/tests/test_eager_mode.py
+++ b/mars/tests/test_eager_mode.py
@@ -98,6 +98,7 @@ def test_mixed_config(setup):
     np.testing.assert_array_equal(r.execute(), np.ones((10, 10)) * 10)
 
 
+@pytest.mark.ray_dag
 def test_index(setup):
     with option_context({"eager_mode": True}):
         a = mt.random.rand(10, 5, chunk_size=5)

--- a/mars/tests/test_session.py
+++ b/mars/tests/test_session.py
@@ -210,6 +210,7 @@ def test_without_fuse(setup):
     np.testing.assert_array_equal(r1, r2)
 
 
+@pytest.mark.ray_dag
 def test_fetch_slices(setup):
     arr1 = mt.random.rand(10, 8, chunk_size=3)
     r1 = arr1.execute().fetch()

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1726,11 +1726,10 @@ def sync_to_async(func):
     if inspect.iscoroutinefunction(func):
         return func
     else:
-
-        async def async_wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        return async_wrapper
+        # Wrap the sync call to thread to avoid blocking the
+        # asyncio event loop. e.g. acquiring a threading.Lock()
+        # in the sync call.
+        return functools.partial(asyncio.to_thread, func)
 
 
 def retry_callable(

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import fnmatch
 import os
 import platform
 import shutil
@@ -82,6 +83,12 @@ else:
     cy_extension_kw["extra_compile_args"] = extra_compile_args
 
 
+# The pyx with C sources.
+ext_include_source_map = {
+    "mars/_utils.pyx": [["mars/lib/mmh3_src"], ["mars/lib/mmh3_src/MurmurHash3.cpp"]],
+}
+
+
 def _discover_pyx():
     exts = dict()
     for root, _, files in os.walk(os.path.join(repo_root, "mars")):
@@ -89,12 +96,17 @@ def _discover_pyx():
             if not fn.endswith(".pyx"):
                 continue
             full_fn = os.path.relpath(os.path.join(root, fn), repo_root)
+            include_dirs, source = ext_include_source_map.get(full_fn, [[], []])
             mod_name = full_fn.replace(".pyx", "").replace(os.path.sep, ".")
-            exts[mod_name] = Extension(mod_name, [full_fn], **cy_extension_kw)
+            exts[mod_name] = Extension(
+                mod_name,
+                [full_fn] + source,
+                include_dirs=[np.get_include()] + include_dirs,
+                **cy_extension_kw,
+            )
     return exts
 
 
-cy_extension_kw["include_dirs"] = [np.get_include()]
 extensions_dict = _discover_pyx()
 cy_extensions = list(extensions_dict.values())
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import fnmatch
 import os
 import platform
 import shutil

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,9 @@ def _discover_pyx():
             if not fn.endswith(".pyx"):
                 continue
             full_fn = os.path.relpath(os.path.join(root, fn), repo_root)
-            include_dirs, source = ext_include_source_map.get(full_fn, [[], []])
+            include_dirs, source = ext_include_source_map.get(
+                full_fn.replace(os.path.sep, "/"), [[], []]
+            )
             mod_name = full_fn.replace(".pyx", "").replace(os.path.sep, ".")
             exts[mod_name] = Extension(
                 mod_name,


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This PR masks the first two bits of mumur hash result to ensure the result hex string has a letter prefix. So, all the keys will be valid Python identifiers.

BTW, it fixes some minor bugs of Ray executor.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #3189 
Fixes #3188 
Fixes #3182 
Fixes #3187 
Fixes #3191

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
