### PR TITLE
Implement airy functions (except the `ai_zeros` and `bi_zeros` functions)

### DIFF
--- a/docs/source/reference/tensor/special.rst
+++ b/docs/source/reference/tensor/special.rst
@@ -1,6 +1,18 @@
 Special Functions
 =================
 
+Airy functions
+--------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   mars.tensor.special.airy
+   mars.tensor.special.airye
+   mars.tensor.special.itairy
+
+
 Information Theory functions
 ----------------------------
 

--- a/mars/lib/sparse/__init__.py
+++ b/mars/lib/sparse/__init__.py
@@ -309,6 +309,9 @@ elliprf = partial(call_sparse, "elliprf")
 elliprg = partial(call_sparse, "elliprg")
 elliprj = partial(call_sparse, "elliprj")
 
+airy = partial(_call_unary, "airy")
+airye = partial(_call_unary, "airye")
+itairy = partial(_call_unary, "itairy")
 
 def equal(a, b, **_):
     try:

--- a/mars/lib/sparse/__init__.py
+++ b/mars/lib/sparse/__init__.py
@@ -313,6 +313,7 @@ airy = partial(_call_unary, "airy")
 airye = partial(_call_unary, "airye")
 itairy = partial(_call_unary, "itairy")
 
+
 def equal(a, b, **_):
     try:
         return a == b

--- a/mars/lib/sparse/array.py
+++ b/mars/lib/sparse/array.py
@@ -768,6 +768,12 @@ class SparseArray(SparseNDArray):
 
     hyp0f1 = partialmethod(_scipy_binary, "hyp0f1")
 
+    airy = partialmethod(_scipy_unary, "airy")
+    airye = partialmethod(_scipy_unary, "airye")
+    ai_zeros = partialmethod(_scipy_unary, "ai_zeros")
+    bi_zeros = partialmethod(_scipy_unary, "bi_zeros")
+    itairy = partialmethod(_scipy_unary, "itairy")
+
     def __eq__(self, other):
         try:
             naked_other = naked(other)

--- a/mars/lib/sparse/array.py
+++ b/mars/lib/sparse/array.py
@@ -770,8 +770,6 @@ class SparseArray(SparseNDArray):
 
     airy = partialmethod(_scipy_unary, "airy")
     airye = partialmethod(_scipy_unary, "airye")
-    ai_zeros = partialmethod(_scipy_unary, "ai_zeros")
-    bi_zeros = partialmethod(_scipy_unary, "bi_zeros")
     itairy = partialmethod(_scipy_unary, "itairy")
 
     def __eq__(self, other):

--- a/mars/tensor/special/__init__.py
+++ b/mars/tensor/special/__init__.py
@@ -161,6 +161,18 @@ try:
         elliprj,
         TensorElliprj,
     )
+    from .airy import (
+        airy,
+        TensorAiry,
+        airye,
+        TensorAirye,
+        ai_zeros,
+        TensorAiZeros,
+        bi_zeros,
+        TensorBiZeros,
+        itairy,
+        TensorItairy,
+    )
 except ImportError:  # pragma: no cover
     pass
 

--- a/mars/tensor/special/__init__.py
+++ b/mars/tensor/special/__init__.py
@@ -166,10 +166,6 @@ try:
         TensorAiry,
         airye,
         TensorAirye,
-        ai_zeros,
-        TensorAiZeros,
-        bi_zeros,
-        TensorBiZeros,
         itairy,
         TensorItairy,
     )

--- a/mars/tensor/special/airy.py
+++ b/mars/tensor/special/airy.py
@@ -22,63 +22,37 @@ from .core import TensorSpecialUnaryOp, TensorTupleOp, _register_special_op
 @_register_special_op
 class TensorAiry(TensorTupleOp):
     _func_name = "airy"
-    _n_outputs = 4
+    _n_outputs = 2
 
 
 @implement_scipy(spspecial.airy)
 @infer_dtype(spspecial.airy, multi_outputs=True)
-def airy(z, out=None, **kwargs):
+def airy(z, out = None,  **kwargs):
     op = TensorAiry(**kwargs)
-    return op(z, out=out)
+    return op(z, out = out)
 
 
 @_register_special_op
-@arithmetic_operand(sparse_mode="unary")
-class TensorAirye(TensorSpecialUnaryOp):
+class TensorAirye(TensorTupleOp):
     _func_name = "airye"
+    _n_outputs = 2
 
 
 @implement_scipy(spspecial.airye)
 @infer_dtype(spspecial.airye, multi_outputs=True)
-def airye(z, **kwargs):
+def airye(z, out = None, **kwargs):
     op = TensorAirye(**kwargs)
-    return op(z)
+    return op(z, out = out)
 
 
 @_register_special_op
-@arithmetic_operand(sparse_mode="unary")
-class TensorAiZeros(TensorSpecialUnaryOp):
-    _func_name = "ai_zeros"
-
-
-@implement_scipy(spspecial.ai_zeros)
-@infer_dtype(spspecial.ai_zeros, multi_outputs=True)
-def ai_zeros(nt, **kwargs):
-    op = TensorAiZeros(**kwargs)
-    return op(nt)
-
-
-@_register_special_op
-@arithmetic_operand(sparse_mode="unary")
-class TensorBiZeros(TensorSpecialUnaryOp):
-    _func_name = "bi_zeros"
-
-
-@implement_scipy(spspecial.bi_zeros)
-@infer_dtype(spspecial.bi_zeros, multi_outputs=True)
-def bi_zeros(nt, **kwargs):
-    op = TensorBiZeros(**kwargs)
-    return op(nt)
-
-
-@_register_special_op
-@arithmetic_operand(sparse_mode="unary")
-class TensorItairy(TensorSpecialUnaryOp):
+class TensorItairy(TensorTupleOp):
     _func_name = "itairy"
+    _n_outputs = 2
 
 
 @implement_scipy(spspecial.itairy)
 @infer_dtype(spspecial.itairy, multi_outputs=True)
-def itairy(x, **kwargs):
+def itairy(x, out = None, **kwargs):
     op = TensorItairy(**kwargs)
-    return op(x)
+    return op(x, out = out)

--- a/mars/tensor/special/airy.py
+++ b/mars/tensor/special/airy.py
@@ -16,20 +16,20 @@ import scipy.special as spspecial
 
 from ..arithmetic.utils import arithmetic_operand
 from ..utils import infer_dtype, implement_scipy
-from .core import TensorSpecialUnaryOp, _register_special_op
+from .core import TensorSpecialUnaryOp, TensorTupleOp, _register_special_op
 
 
 @_register_special_op
-@arithmetic_operand(sparse_mode="unary")
-class TensorAiry(TensorSpecialUnaryOp):
+class TensorAiry(TensorTupleOp):
     _func_name = "airy"
+    _n_outputs = 4
 
 
 @implement_scipy(spspecial.airy)
 @infer_dtype(spspecial.airy, multi_outputs=True)
-def airy(z, **kwargs):
+def airy(z, out=None, **kwargs):
     op = TensorAiry(**kwargs)
-    return op(z)
+    return op(z, out=out)
 
 
 @_register_special_op

--- a/mars/tensor/special/airy.py
+++ b/mars/tensor/special/airy.py
@@ -1,0 +1,84 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import scipy.special as spspecial
+
+from ..arithmetic.utils import arithmetic_operand
+from ..utils import infer_dtype, implement_scipy
+from .core import TensorSpecialUnaryOp, _register_special_op
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="unary")
+class TensorAiry(TensorSpecialUnaryOp):
+    _func_name = "airy"
+
+
+@implement_scipy(spspecial.airy)
+@infer_dtype(spspecial.airy, multi_outputs=True)
+def airy(z, **kwargs):
+    op = TensorAiry(**kwargs)
+    return op(z)
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="unary")
+class TensorAirye(TensorSpecialUnaryOp):
+    _func_name = "airye"
+
+
+@implement_scipy(spspecial.airye)
+@infer_dtype(spspecial.airye, multi_outputs=True)
+def airye(z, **kwargs):
+    op = TensorAirye(**kwargs)
+    return op(z)
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="unary")
+class TensorAiZeros(TensorSpecialUnaryOp):
+    _func_name = "ai_zeros"
+
+
+@implement_scipy(spspecial.ai_zeros)
+@infer_dtype(spspecial.ai_zeros, multi_outputs=True)
+def ai_zeros(nt, **kwargs):
+    op = TensorAiZeros(**kwargs)
+    return op(nt)
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="unary")
+class TensorBiZeros(TensorSpecialUnaryOp):
+    _func_name = "bi_zeros"
+
+
+@implement_scipy(spspecial.bi_zeros)
+@infer_dtype(spspecial.bi_zeros, multi_outputs=True)
+def bi_zeros(nt, **kwargs):
+    op = TensorBiZeros(**kwargs)
+    return op(nt)
+
+
+@_register_special_op
+@arithmetic_operand(sparse_mode="unary")
+class TensorItairy(TensorSpecialUnaryOp):
+    _func_name = "itairy"
+
+
+@implement_scipy(spspecial.itairy)
+@infer_dtype(spspecial.itairy, multi_outputs=True)
+def itairy(x, **kwargs):
+    op = TensorItairy(**kwargs)
+    return op(x)

--- a/mars/tensor/special/airy.py
+++ b/mars/tensor/special/airy.py
@@ -21,7 +21,7 @@ from .core import TensorTupleOp, _register_special_op
 @_register_special_op
 class TensorAiry(TensorTupleOp):
     _func_name = "airy"
-    _n_outputs = 2
+    _n_outputs = 4
 
 
 @implement_scipy(spspecial.airy)
@@ -34,7 +34,7 @@ def airy(z, out=None, **kwargs):
 @_register_special_op
 class TensorAirye(TensorTupleOp):
     _func_name = "airye"
-    _n_outputs = 2
+    _n_outputs = 4
 
 
 @implement_scipy(spspecial.airye)
@@ -47,7 +47,7 @@ def airye(z, out=None, **kwargs):
 @_register_special_op
 class TensorItairy(TensorTupleOp):
     _func_name = "itairy"
-    _n_outputs = 2
+    _n_outputs = 4
 
 
 @implement_scipy(spspecial.itairy)

--- a/mars/tensor/special/airy.py
+++ b/mars/tensor/special/airy.py
@@ -27,9 +27,9 @@ class TensorAiry(TensorTupleOp):
 
 @implement_scipy(spspecial.airy)
 @infer_dtype(spspecial.airy, multi_outputs=True)
-def airy(z, out = None,  **kwargs):
+def airy(z, out=None, **kwargs):
     op = TensorAiry(**kwargs)
-    return op(z, out = out)
+    return op(z, out=out)
 
 
 @_register_special_op
@@ -40,9 +40,9 @@ class TensorAirye(TensorTupleOp):
 
 @implement_scipy(spspecial.airye)
 @infer_dtype(spspecial.airye, multi_outputs=True)
-def airye(z, out = None, **kwargs):
+def airye(z, out=None, **kwargs):
     op = TensorAirye(**kwargs)
-    return op(z, out = out)
+    return op(z, out=out)
 
 
 @_register_special_op
@@ -53,6 +53,6 @@ class TensorItairy(TensorTupleOp):
 
 @implement_scipy(spspecial.itairy)
 @infer_dtype(spspecial.itairy, multi_outputs=True)
-def itairy(x, out = None, **kwargs):
+def itairy(x, out=None, **kwargs):
     op = TensorItairy(**kwargs)
-    return op(x, out = out)
+    return op(x, out=out)

--- a/mars/tensor/special/airy.py
+++ b/mars/tensor/special/airy.py
@@ -14,9 +14,8 @@
 
 import scipy.special as spspecial
 
-from ..arithmetic.utils import arithmetic_operand
 from ..utils import infer_dtype, implement_scipy
-from .core import TensorSpecialUnaryOp, TensorTupleOp, _register_special_op
+from .core import TensorTupleOp, _register_special_op
 
 
 @_register_special_op

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -51,7 +51,13 @@ from ..ellip_func_integrals import (
     TensorEllipe,
     TensorEllipeinc,
 )
-
+from ..airy import (
+    TensorAiry,
+    TensorAirye,
+    TensorAiZeros,
+    TensorBiZeros,
+    TensorItairy,
+)
 
 @pytest.mark.parametrize(
     "func,tensor_cls",

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -54,11 +54,8 @@ from ..ellip_func_integrals import (
 from ..airy import (
     TensorAiry,
     TensorAirye,
-    TensorAiZeros,
-    TensorBiZeros,
     TensorItairy,
 )
-
 @pytest.mark.parametrize(
     "func,tensor_cls",
     [
@@ -146,6 +143,9 @@ def test_unary_operand_out(func, tensor_cls):
         ("fresnel", TensorFresnel),
         ("modfresnelp", TensorModFresnelP),
         ("modfresnelm", TensorModFresnelM),
+        ("airy", TensorAiry),
+        ("airye", TensorAirye),
+        ("itairy", TensorItairy),
     ],
 )
 def test_unary_tuple_operand(func, tensor_cls):

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -140,17 +140,17 @@ def test_unary_operand_out(func, tensor_cls):
 
 
 @pytest.mark.parametrize(
-    "func,tensor_cls",
+    "func,tensor_cls,n_outputs",
     [
-        ("fresnel", TensorFresnel),
-        ("modfresnelp", TensorModFresnelP),
-        ("modfresnelm", TensorModFresnelM),
-        ("airy", TensorAiry),
-        ("airye", TensorAirye),
-        ("itairy", TensorItairy),
+        ("fresnel", TensorFresnel, 2),
+        ("modfresnelp", TensorModFresnelP, 2),
+        ("modfresnelm", TensorModFresnelM, 2),
+        ("airy", TensorAiry, 4),
+        ("airye", TensorAirye, 4),
+        ("itairy", TensorItairy, 4),
     ],
 )
-def test_unary_tuple_operand(func, tensor_cls):
+def test_unary_tuple_operand(func, tensor_cls, n_outputs):
     sp_func = getattr(spsecial, func)
     mt_func = getattr(mt_special, func)
 
@@ -175,7 +175,7 @@ def test_unary_tuple_operand(func, tensor_cls):
     with pytest.raises(TypeError):
         r = mt_func(t, mismatch_size_tuple)
 
-    out = ExecutableTuple([t, t])
+    out = ExecutableTuple([t] * n_outputs)
     r_out = mt_func(t, out=out)
 
     assert isinstance(out, ExecutableTuple)

--- a/mars/tensor/special/tests/test_special.py
+++ b/mars/tensor/special/tests/test_special.py
@@ -56,6 +56,8 @@ from ..airy import (
     TensorAirye,
     TensorItairy,
 )
+
+
 @pytest.mark.parametrize(
     "func,tensor_cls",
     [

--- a/mars/tensor/special/tests/test_special_execution.py
+++ b/mars/tensor/special/tests/test_special_execution.py
@@ -45,6 +45,11 @@ from ... import special as mt_special
         "ellipk",
         "ellipkm1",
         "ellipe",
+        "airy",
+        "airye",
+        "ai_zeros",
+        "bi_zeros",
+        "itairy"
     ],
 )
 def test_unary_execution(setup, func):

--- a/mars/tensor/special/tests/test_special_execution.py
+++ b/mars/tensor/special/tests/test_special_execution.py
@@ -307,14 +307,7 @@ def test_quintuple_execution(setup, func):
 
 @pytest.mark.parametrize(
     "func",
-    [
-        "fresnel",
-        "modfresnelp",
-        "modfresnelm",
-        "airy",
-        "airye",
-        "itairy"
-    ],
+    ["fresnel", "modfresnelp", "modfresnelm", "airy", "airye", "itairy"],
 )
 def test_unary_tuple_execution(setup, func):
     sp_func = getattr(spspecial, func)

--- a/mars/tensor/special/tests/test_special_execution.py
+++ b/mars/tensor/special/tests/test_special_execution.py
@@ -45,10 +45,6 @@ from ... import special as mt_special
         "ellipk",
         "ellipkm1",
         "ellipe",
-        # "airye",
-        # "ai_zeros",
-        # "bi_zeros",
-        # "itairy"
     ],
 )
 def test_unary_execution(setup, func):
@@ -316,6 +312,8 @@ def test_quintuple_execution(setup, func):
         "modfresnelp",
         "modfresnelm",
         "airy",
+        "airye",
+        "itairy"
     ],
 )
 def test_unary_tuple_execution(setup, func):

--- a/mars/tensor/special/tests/test_special_execution.py
+++ b/mars/tensor/special/tests/test_special_execution.py
@@ -45,11 +45,10 @@ from ... import special as mt_special
         "ellipk",
         "ellipkm1",
         "ellipe",
-        "airy",
-        "airye",
-        "ai_zeros",
-        "bi_zeros",
-        "itairy"
+        # "airye",
+        # "ai_zeros",
+        # "bi_zeros",
+        # "itairy"
     ],
 )
 def test_unary_execution(setup, func):
@@ -316,6 +315,7 @@ def test_quintuple_execution(setup, func):
         "fresnel",
         "modfresnelp",
         "modfresnelm",
+        "airy",
     ],
 )
 def test_unary_tuple_execution(setup, func):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. --> The PR is implements all airy functions except for ai_zeros and bi_zeros.
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Attempts to fixes #750

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
