### PR TITLE
Disable version updates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,6 @@ updates:
       - "type: enhancement"
       - "mod: web"
       - "to be backported"
+    # Disable version updates for npm dependencies
+    open-pull-requests-limit: 0
 


### PR DESCRIPTION
## What do these changes do?

Disable version updates for dependabot, given docs at https://docs.github.com/cn/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates .

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx
