### PR TITLE
[Ray] Support reducer has inputs which isn't mapper

### DIFF
--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -160,7 +160,7 @@ def execute_subtask(
         # https://user-images.githubusercontent.com/12445254/168569524-f09e42a7-653a-4102-bdf0-cc1631b3168d.png
         reducer_chunks = subtask_chunk_graph.successors(shuffle_chunk)
         reducer_operands = set(c.op for c in reducer_chunks)
-        if len(reducer_operands) != 1:
+        if len(reducer_operands) != 1:  # pragma: no cover
             raise ValueError(
                 f"Subtask {subtask_id} has more than 1 reduce operands: {subtask_chunk_graph.to_dot()}"
             )

--- a/mars/tensor/indexing/tests/test_indexing_execution.py
+++ b/mars/tensor/indexing/tests/test_indexing_execution.py
@@ -307,6 +307,7 @@ def test_mixed_indexing_execution(setup):
     np.testing.assert_array_equal(res, expected)
 
 
+@pytest.mark.ray_dag
 def test_setitem_fancy_index_execution(setup):
     rs = np.random.RandomState(0)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR add ray shuffle support for operands whose reducers has inputs which are not mapper outputs such as `TensorIndexSetValue`:
![graphviz (2)](https://user-images.githubusercontent.com/12445254/182786156-0d825d1d-a49e-4119-bc02-eb6342965c09.svg)

<!-- Please give a short brief about these changes. -->

## Related issue number
Fixes #3185
<!-- Are there any issues opened that will be resolved by merging this change? -->
#2916
## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
