### PR TITLE
[Ray] Configurable subtask num_cpus

### DIFF
--- a/mars/services/task/execution/mars/executor.py
+++ b/mars/services/task/execution/mars/executor.py
@@ -196,7 +196,7 @@ class MarsTaskExecutor(TaskExecutor):
         return await stage_processor.run()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        # clean ups
+        # clean-ups
         decrefs = []
         error_or_cancelled = False
         for stage_processor in self._stage_processors:

--- a/mars/services/task/execution/ray/config.py
+++ b/mars/services/task/execution/ray/config.py
@@ -50,6 +50,9 @@ class RayExecutionConfig(ExecutionConfig):
     def get_subtask_max_retries(self):
         return self._ray_execution_config["subtask_max_retries"]
 
+    def get_subtask_num_cpus(self):
+        return self._ray_execution_config.get("subtask_num_cpus", 1)
+
     def get_n_cpu(self):
         return self._ray_execution_config["n_cpu"]
 

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -478,6 +478,7 @@ class RayTaskExecutor(TaskExecutor):
         }
         shuffle_manager = ShuffleManager(subtask_graph)
         subtask_max_retries = self._config.get_subtask_max_retries()
+        subtask_num_cpus = self._config.get_subtask_num_cpus()
         for subtask in subtask_graph.topological_iter():
             if subtask.virtual:
                 continue
@@ -502,7 +503,9 @@ class RayTaskExecutor(TaskExecutor):
                 output_count = out_count + bool(subtask_output_meta_keys)
             subtask_max_retries = subtask_max_retries if subtask.retryable else 0
             output_object_refs = self._ray_executor.options(
-                num_returns=output_count, max_retries=subtask_max_retries
+                num_cpus=subtask_num_cpus,
+                num_returns=output_count,
+                max_retries=subtask_max_retries,
             ).remote(
                 subtask.task_id,
                 subtask.subtask_id,

--- a/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
+++ b/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
@@ -12,26 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import pandas as pd
 import pytest
 import numpy as np
 
 from collections import Counter
 
-from ..shuffle import ShuffleManager
 from ...... import tensor as mt
 from ......config import Config
-from ......core import TileContext, ChunkGraph
+from ......core import TileContext
 from ......core.context import get_context
 from ......core.graph import TileableGraph, TileableGraphBuilder, ChunkGraphBuilder
-from ......core.operand import Fetch
 from ......resource import Resource
 from ......serialization import serialize
 from ......tests.core import require_ray, mock
 from ......utils import lazy_import, get_chunk_params
 from .....context import ThreadedServiceContext
-from .....subtask import SubtaskGraph
 from ....analyzer import GraphAnalyzer
 from ....core import new_task_id, Task
 from ..config import RayExecutionConfig
@@ -45,7 +41,6 @@ from ..executor import (
     execute_subtask,
     RayTaskExecutor,
     RayTaskState,
-    _get_subtask_out_info,
 )
 from ..fetcher import RayFetcher
 
@@ -92,69 +87,6 @@ class MockRayTaskExecutor(RayTaskExecutor):
     def __setattr__(self, key, value):
         super().__setattr__(key, value)
         self._set_attrs[key] += 1
-
-    async def submit_subtask_graph(
-        self,
-        stage_id: str,
-        subtask_graph: SubtaskGraph,
-        chunk_graph: ChunkGraph,
-    ):
-        result_meta_keys = {
-            chunk.key
-            for chunk in chunk_graph.result_chunks
-            if not isinstance(chunk.op, Fetch)
-        }
-
-        monitor_task = asyncio.create_task(
-            self._update_progress_and_collect_garbage(
-                stage_id,
-                subtask_graph,
-                result_meta_keys,
-                self._config.get_subtask_monitor_interval(),
-            )
-        )
-        shuffle_manager = ShuffleManager(subtask_graph)
-        for subtask in subtask_graph.topological_iter():
-            subtask_chunk_graph = subtask.chunk_graph
-            task_context = self._task_context
-            input_object_refs = await self._load_subtask_inputs(
-                stage_id, subtask, task_context, shuffle_manager
-            )
-            is_mapper, n_reducers = shuffle_manager.is_mapper(subtask), None
-            if is_mapper:
-                n_reducers = shuffle_manager.get_n_reducers(subtask)
-            output_keys, out_count = _get_subtask_out_info(
-                subtask_chunk_graph, is_mapper, n_reducers
-            )
-
-            output_meta_keys = result_meta_keys & output_keys
-            if is_mapper:
-                # shuffle meta won't be recorded in meta service.
-                output_count = out_count
-            else:
-                output_count = out_count + bool(output_meta_keys)
-            output_object_refs = self._ray_executor.options(
-                num_returns=output_count
-            ).remote(
-                subtask.task_id,
-                subtask.subtask_id,
-                serialize(subtask_chunk_graph),
-                output_meta_keys,
-                is_mapper,
-                *input_object_refs,
-            )
-            if output_count == 0:
-                continue
-            elif output_count == 1:
-                output_object_refs = [output_object_refs]
-            self._cur_stage_first_output_object_ref_to_subtask[
-                output_object_refs[0]
-            ] = subtask
-            if output_meta_keys:
-                meta_object_ref, *output_object_refs = output_object_refs
-            task_context.update(zip(output_keys, output_object_refs))
-
-        return monitor_task
 
 
 class MockTileContext(TileContext):
@@ -377,6 +309,55 @@ def test_ray_execution_worker_context():
 
 @require_ray
 @pytest.mark.asyncio
+async def test_ray_execution_config(ray_start_regular_shared2):
+    t1 = mt.random.randint(10, size=(100, 10), chunk_size=100)
+    chunk_graph, subtask_graph = _gen_subtask_graph(t1)
+
+    real_executor = RayTaskExecutor._get_ray_executor()
+
+    class MockExecutor:
+        opt = {}
+
+        @classmethod
+        def options(cls, *args, **kwargs):
+            cls.opt = kwargs
+            return real_executor.options(*args, **kwargs)
+
+    task = Task("mock_task", "mock_session")
+    mock_config = RayExecutionConfig.from_execution_config(
+        {
+            "backend": "ray",
+            "ray": {
+                "subtask_monitor_interval": 0,
+                "subtask_max_retries": 4,
+                "subtask_num_cpus": 0.8,
+                "n_cpu": 1,
+                "n_worker": 1,
+                "subtask_cancel_timeout": 1,
+            },
+        }
+    )
+    tile_context = MockTileContext()
+    executor = MockRayTaskExecutor(
+        config=mock_config,
+        task=task,
+        tile_context=tile_context,
+        task_context={},
+        task_chunks_meta={},
+        lifecycle_api=None,
+        meta_api=None,
+    )
+    executor._ray_executor = MockExecutor
+    await executor.execute_subtask_graph(
+        "mock_stage", subtask_graph, chunk_graph, tile_context
+    )
+
+    assert MockExecutor.opt["num_cpus"] == 0.8
+    assert MockExecutor.opt["max_retries"] == 4
+
+
+@require_ray
+@pytest.mark.asyncio
 async def test_executor_context_gc(ray_start_regular_shared2):
     popped_seq = []
 
@@ -392,7 +373,16 @@ async def test_executor_context_gc(ray_start_regular_shared2):
     chunk_graph, subtask_graph = _gen_subtask_graph(t4)
     task = Task("mock_task", "mock_session", fuse_enabled=True)
     mock_config = RayExecutionConfig.from_execution_config(
-        {"backend": "ray", "ray": {"subtask_monitor_interval": 0}}
+        {
+            "backend": "ray",
+            "ray": {
+                "subtask_monitor_interval": 0,
+                "subtask_max_retries": 0,
+                "n_cpu": 1,
+                "n_worker": 1,
+                "subtask_cancel_timeout": 1,
+            },
+        }
     )
     tile_context = MockTileContext()
     task_context = MockTaskContext()
@@ -406,10 +396,9 @@ async def test_executor_context_gc(ray_start_regular_shared2):
         meta_api=None,
     )
     executor._ray_executor = RayTaskExecutor._get_ray_executor()
-    monitor_task = await executor.submit_subtask_graph(
-        "mock_stage", subtask_graph, chunk_graph
+    await executor.execute_subtask_graph(
+        "mock_stage", subtask_graph, chunk_graph, tile_context
     )
-    await monitor_task
 
     assert len(task_context) == 1
     assert len(popped_seq) == 6


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Mars does not set the `num_cpus` for subtask execution, so it uses the Ray cluster's default `num_cpus` of normal task. The `num_cpus` affects Ray scheduling, so we should provide an option to set the `num_cpus`.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
