### PR TITLE
Refine apply key generation

### DIFF
--- a/mars/dataframe/base/apply.py
+++ b/mars/dataframe/base/apply.py
@@ -30,7 +30,7 @@ from ...serialization.serializables import (
     DictField,
     FunctionField,
 )
-from ...utils import enter_current_session, quiet_stdio, get_func_token
+from ...utils import enter_current_session, quiet_stdio, get_func_token, tokenize
 from ..arrays import ArrowArray
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..utils import (
@@ -101,6 +101,13 @@ class ApplyOperand(
             _elementwise=elementwise,
             **kw,
         )
+
+    def _update_key(self):
+        values = [v for v in self._values_ if v is not self.func] + [
+            get_func_token(self.func)
+        ]
+        self._obj_set("_key", tokenize(type(self).__name__, *values))
+        return self
 
     @property
     def func(self):

--- a/mars/dataframe/base/apply.py
+++ b/mars/dataframe/base/apply.py
@@ -30,7 +30,7 @@ from ...serialization.serializables import (
     DictField,
     FunctionField,
 )
-from ...utils import enter_current_session, quiet_stdio, get_func_token_values
+from ...utils import enter_current_session, quiet_stdio, get_func_token
 from ..arrays import ArrowArray
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..utils import (
@@ -56,7 +56,7 @@ class ApplyOperandLogicKeyGeneratorMixin(OperatorLogicKeyGeneratorMixin):
             self._elementwise,
         ]
         if self.func:
-            return token_values + get_func_token_values(self.func)
+            return token_values + [get_func_token(self.func)]
         else:  # pragma: no cover
             return token_values
 

--- a/mars/dataframe/groupby/apply.py
+++ b/mars/dataframe/groupby/apply.py
@@ -26,7 +26,7 @@ from ...serialization.serializables import (
     FunctionField,
 )
 from ...core.operand import OperatorLogicKeyGeneratorMixin
-from ...utils import enter_current_session, quiet_stdio, get_func_token_values
+from ...utils import enter_current_session, quiet_stdio, get_func_token
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..utils import (
     auto_merge_chunks,
@@ -43,7 +43,7 @@ class GroupByApplyLogicKeyGeneratorMixin(OperatorLogicKeyGeneratorMixin):
     def _get_logic_key_token_values(self):
         token_values = super()._get_logic_key_token_values()
         if self.func:
-            return token_values + get_func_token_values(self.func)
+            return token_values + [get_func_token(self.func)]
         else:  # pragma: no cover
             return token_values
 

--- a/mars/dataframe/groupby/apply.py
+++ b/mars/dataframe/groupby/apply.py
@@ -26,7 +26,7 @@ from ...serialization.serializables import (
     FunctionField,
 )
 from ...core.operand import OperatorLogicKeyGeneratorMixin
-from ...utils import enter_current_session, quiet_stdio, get_func_token
+from ...utils import enter_current_session, quiet_stdio, get_func_token, tokenize
 from ..operands import DataFrameOperandMixin, DataFrameOperand
 from ..utils import (
     auto_merge_chunks,
@@ -61,6 +61,13 @@ class GroupByApply(
 
     def __init__(self, output_types=None, **kw):
         super().__init__(_output_types=output_types, **kw)
+
+    def _update_key(self):
+        values = [v for v in self._values_ if v is not self.func] + [
+            get_func_token(self.func)
+        ]
+        self._obj_set("_key", tokenize(type(self).__name__, *values))
+        return self
 
     @classmethod
     @redirect_custom_log

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -160,7 +160,7 @@ def execute_subtask(
         # https://user-images.githubusercontent.com/12445254/168569524-f09e42a7-653a-4102-bdf0-cc1631b3168d.png
         reducer_chunks = subtask_chunk_graph.successors(start_chunks[0])
         reducer_operands = set(c.op for c in reducer_chunks)
-        if len(reducer_operands) != 1:
+        if len(reducer_operands) != 1:  # pragma: no cover
             raise ValueError(
                 f"Subtask {subtask_id} has more than 1 reduce operands: {subtask_chunk_graph.to_dot()}"
             )

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -587,9 +587,9 @@ def test_web_serialize_lambda():
 
 
 def test_get_func_token_values():
-    from ..utils import get_func_token_values
+    from ..utils import _get_func_token_values
 
-    assert get_func_token_values(test_get_func_token_values) == [
+    assert _get_func_token_values(test_get_func_token_values) == [
         test_get_func_token_values.__code__.co_code
     ]
     captured_vars = [1, 2, 3]
@@ -597,20 +597,20 @@ def test_get_func_token_values():
     def closure_func(a, b):
         return captured_vars
 
-    assert get_func_token_values(closure_func)[1][0] == captured_vars
-    assert get_func_token_values(partial(closure_func, 1))[0][0] == 1
-    assert get_func_token_values(partial(closure_func, 1))[-1][0] == captured_vars
+    assert _get_func_token_values(closure_func)[1][0] == captured_vars
+    assert _get_func_token_values(partial(closure_func, 1))[0][0] == 1
+    assert _get_func_token_values(partial(closure_func, 1))[-1][0] == captured_vars
 
     from .._utils import ceildiv
 
-    assert get_func_token_values(ceildiv) == [ceildiv.__module__, ceildiv.__name__]
+    assert _get_func_token_values(ceildiv) == [ceildiv.__module__, ceildiv.__name__]
 
     class Func:
         def __call__(self, *args, **kwargs):
             pass
 
     func = Func()
-    assert get_func_token_values(func) == [func]
+    assert _get_func_token_values(func) == [func]
 
 
 @pytest.mark.parametrize("id_length", [0, 5, 32, 63])

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1623,12 +1623,15 @@ _func_token_cache = weakref.WeakKeyDictionary()
 
 
 def get_func_token(func):
-    token = _func_token_cache.get(func)
-    if token is None:
-        fields = get_func_token_values(func)
-        token = tokenize(*fields)
-        _func_token_cache[func] = token
-    return token
+    try:
+        token = _func_token_cache.get(func)
+        if token is None:
+            fields = get_func_token_values(func)
+            token = tokenize(*fields)
+            _func_token_cache[func] = token
+        return token
+    except TypeError:  # cannot create weak reference to func like 'numpy.ufunc'
+        return tokenize(*get_func_token_values(func))
 
 
 def get_func_token_values(func):

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -27,6 +27,8 @@ import logging
 import numbers
 import operator
 import os
+import weakref
+
 import cloudpickle as pickle
 import pkgutil
 import random
@@ -1615,6 +1617,18 @@ def wrap_exception(
     )
     new_exc_type = type(type(exc).__name__, bases + (type(exc),), attr_dict)
     return new_exc_type().with_traceback(traceback)
+
+
+_func_token_cache = weakref.WeakKeyDictionary()
+
+
+def get_func_token(func):
+    token = _func_token_cache.get(func)
+    if token is None:
+        fields = get_func_token_values(func)
+        token = tokenize(*fields)
+        _func_token_cache[func] = token
+    return token
 
 
 def get_func_token_values(func):

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1626,15 +1626,15 @@ def get_func_token(func):
     try:
         token = _func_token_cache.get(func)
         if token is None:
-            fields = get_func_token_values(func)
+            fields = _get_func_token_values(func)
             token = tokenize(*fields)
             _func_token_cache[func] = token
         return token
     except TypeError:  # cannot create weak reference to func like 'numpy.ufunc'
-        return tokenize(*get_func_token_values(func))
+        return tokenize(*_get_func_token_values(func))
 
 
-def get_func_token_values(func):
+def _get_func_token_values(func):
     if hasattr(func, "__code__"):
         tokens = [func.__code__.co_code]
         if func.__closure__ is not None:
@@ -1647,7 +1647,7 @@ def get_func_token_values(func):
             tokens.extend([func.args, func.keywords])
             func = func.func
         if hasattr(func, "__code__"):
-            tokens.extend(get_func_token_values(func))
+            tokens.extend(_get_func_token_values(func))
         elif isinstance(func, types.BuiltinFunctionType):
             tokens.extend([func.__module__, func.__name__])
         else:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR add func key cache to avoid duplicate func serialization when generate apply key which will be costly when func capture some big objects 
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
