### PR TITLE
[Shuffle] Skip store shuffle object refs to reduce meta overhead

### DIFF
--- a/ci/reload-env.sh
+++ b/ci/reload-env.sh
@@ -91,5 +91,3 @@ function retry {
 alias pip="retry pip"
 shopt -s expand_aliases
 set -e
-# https://github.com/pypa/setuptools/issues/3504
-export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"

--- a/ci/reload-env.sh
+++ b/ci/reload-env.sh
@@ -91,3 +91,5 @@ function retry {
 alias pip="retry pip"
 shopt -s expand_aliases
 set -e
+# https://github.com/pypa/setuptools/issues/3504
+export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"

--- a/mars/deploy/oscar/tests/test_ray_scheduling.py
+++ b/mars/deploy/oscar/tests/test_ray_scheduling.py
@@ -293,7 +293,9 @@ async def test_ownership_when_scale_in(ray_large_cluster):
             await asyncio.sleep(1)
         # Test data on node of released worker can still be fetched
         pd_df = df.fetch()
-        groupby_sum_df = df.rechunk(chunk_size * 2).groupby("a").sum()
+        groupby_sum_df = (
+            df.rechunk(chunk_size * 2).groupby("a").apply(lambda pdf: pdf.sum())
+        )
         logger.info(groupby_sum_df.execute())
         while await autoscaler_ref.get_dynamic_worker_nums() > 1:
             dynamic_workers = await autoscaler_ref.get_dynamic_workers()
@@ -301,7 +303,8 @@ async def test_ownership_when_scale_in(ray_large_cluster):
             await asyncio.sleep(1)
         assert df.to_pandas().to_dict() == pd_df.to_dict()
         assert (
-            groupby_sum_df.to_pandas().to_dict() == pd_df.groupby("a").sum().to_dict()
+            groupby_sum_df.to_pandas().to_dict()
+            == pd_df.groupby("a").apply(lambda pdf: pdf.sum()).to_dict()
         )
 
 

--- a/mars/services/scheduling/api/oscar.py
+++ b/mars/services/scheduling/api/oscar.py
@@ -57,9 +57,8 @@ class SchedulingAPI(AbstractSchedulingAPI):
         from ..supervisor.autoscale import AutoscalerActor
 
         cluster_api = await ClusterAPI.create(address)
-        supervisor_address = (await cluster_api.get_supervisors())[0]
-        autoscaler = await mo.actor_ref(
-            AutoscalerActor.default_uid(), address=supervisor_address
+        [autoscaler] = await cluster_api.get_supervisor_refs(
+            [AutoscalerActor.default_uid()]
         )
         scheduling_api = SchedulingAPI(
             session_id, address, manager_ref, queueing_ref, autoscaler

--- a/mars/services/scheduling/supervisor/autoscale.py
+++ b/mars/services/scheduling/supervisor/autoscale.py
@@ -39,6 +39,10 @@ class AutoscalerActor(mo.Actor):
         self.queueing_refs = dict()
         self.global_resource_ref = None
         self._dynamic_workers: Set[str] = set()
+        self._released_worker_lock = asyncio.Lock()
+        self._autoscale_in_disable_counter = 0
+        self._autoscale_in_disable_event = asyncio.Event()
+        self._autoscale_in_disable_event.set()
 
     async def __post_create__(self):
         strategy = self._autoscale_conf.get("strategy")
@@ -95,47 +99,68 @@ class AutoscalerActor(mo.Actor):
                 time.time() - start_time,
             )
 
+    async def disable_autoscale_in(self):
+        try:
+            await self._released_worker_lock.acquire()
+            self._autoscale_in_disable_counter += 1
+            if self._autoscale_in_disable_event.is_set():
+                self._autoscale_in_disable_event.clear()
+        finally:
+            self._released_worker_lock.release()
+
+    async def try_enable_autoscale_in(self):
+        self._autoscale_in_disable_counter -= 1
+        if self._autoscale_in_disable_counter == 0:
+            self._autoscale_in_disable_event.set()
+
     async def release_workers(self, addresses: List[str]):
         """
         Release a group of worker nodes.
         Parameters
         ----------
         addresses : List[str]
-            The addresses of the specified noded.
+            The addresses of the specified node.
         """
-        workers_bands = {
-            address: await self.get_worker_bands(address) for address in addresses
-        }
-        logger.info(
-            "Start to release workers %s which have bands %s.", addresses, workers_bands
-        )
-        for address in addresses:
-            await self._cluster_api.set_node_status(
-                node=address, role=NodeRole.WORKER, status=NodeStatus.STOPPING
+        try:
+            await self._released_worker_lock.acquire()
+            await self._autoscale_in_disable_event.wait()
+            workers_bands = {
+                address: await self.get_worker_bands(address) for address in addresses
+            }
+            logger.info(
+                "Start to release workers %s which have bands %s.",
+                addresses,
+                workers_bands,
             )
-        # Ensure global_slot_manager get latest bands timely, so that we can invoke `wait_band_idle`
-        # to ensure there won't be new tasks scheduled to the stopping worker.
-        await self.global_resource_ref.refresh_bands()
-        excluded_bands = set(b for bands in workers_bands.values() for b in bands)
+            for address in addresses:
+                await self._cluster_api.set_node_status(
+                    node=address, role=NodeRole.WORKER, status=NodeStatus.STOPPING
+                )
+            # Ensure global_slot_manager get latest bands timely, so that we can invoke `wait_band_idle`
+            # to ensure there won't be new tasks scheduled to the stopping worker.
+            await self.global_resource_ref.refresh_bands()
+            excluded_bands = set(b for bands in workers_bands.values() for b in bands)
 
-        async def release_worker(address):
-            logger.info("Start to release worker %s.", address)
-            worker_bands = workers_bands[address]
-            await asyncio.gather(
-                *[
-                    self.global_resource_ref.wait_band_idle(band)
-                    for band in worker_bands
-                ]
-            )
-            await self._migrate_data_of_bands(worker_bands, excluded_bands)
-            await self._cluster_api.release_worker(address)
-            self._dynamic_workers.remove(address)
-            logger.info("Released worker %s.", address)
+            async def release_worker(address):
+                logger.info("Start to release worker %s.", address)
+                worker_bands = workers_bands[address]
+                await asyncio.gather(
+                    *[
+                        self.global_resource_ref.wait_band_idle(band)
+                        for band in worker_bands
+                    ]
+                )
+                await self._migrate_data_of_bands(worker_bands, excluded_bands)
+                await self._cluster_api.release_worker(address)
+                self._dynamic_workers.remove(address)
+                logger.info("Released worker %s.", address)
 
-        # Release workers one by one to ensure others workers which the current is moving data to
-        # is not being releasing.
-        for address in addresses:
-            await release_worker(address)
+            # Release workers one by one to ensure others workers which the current is moving data to
+            # is not being releasing.
+            for address in addresses:
+                await release_worker(address)
+        finally:
+            self._released_worker_lock.release()
 
     def get_dynamic_workers(self) -> Set[str]:
         return self._dynamic_workers

--- a/mars/services/scheduling/supervisor/autoscale.py
+++ b/mars/services/scheduling/supervisor/autoscale.py
@@ -40,8 +40,6 @@ class AutoscalerActor(mo.Actor):
         self.global_resource_ref = None
         self._dynamic_workers: Set[str] = set()
         self._autoscale_in_disable_counter = 0
-        self._autoscale_in_disable_event = asyncio.Event()
-        self._autoscale_in_disable_event.set()
 
     async def __post_create__(self):
         strategy = self._autoscale_conf.get("strategy")
@@ -100,7 +98,7 @@ class AutoscalerActor(mo.Actor):
 
     async def disable_autoscale_in(self):
         self._autoscale_in_disable_counter += 1
-        if self._autoscale_in_disable_event.is_set() and self._enabled:
+        if self._enabled:
             logger.info("Disabled autoscale_in")
 
     async def try_enable_autoscale_in(self):

--- a/mars/services/scheduling/supervisor/service.py
+++ b/mars/services/scheduling/supervisor/service.py
@@ -117,10 +117,12 @@ class SchedulingSupervisorService(AbstractService):
             uid=SubtaskManagerActor.gen_uid(session_id),
         )
 
+        from ...cluster import ClusterAPI
         from .autoscale import AutoscalerActor
 
-        autoscaler_ref = await mo.actor_ref(
-            AutoscalerActor.default_uid(), address=self._address
+        cluster_api = await ClusterAPI.create(self._address)
+        [autoscaler_ref] = await cluster_api.get_supervisor_refs(
+            [AutoscalerActor.default_uid()]
         )
         await autoscaler_ref.register_session(session_id, self._address)
 

--- a/mars/services/subtask/core.py
+++ b/mars/services/subtask/core.py
@@ -192,6 +192,10 @@ class SubtaskGraph(DAG, Iterable[Subtask]):
     Subtask graph.
     """
 
+    def __init__(self):
+        super().__init__()
+        self._proxy_subtasks = []
+
     @classmethod
     def _extract_operands(cls, node: Subtask):
         from ...core.operand import Fetch, FetchShuffle
@@ -200,3 +204,12 @@ class SubtaskGraph(DAG, Iterable[Subtask]):
             if isinstance(node.op, (Fetch, FetchShuffle)):
                 continue
             yield node.op
+
+    def add_proxy_subtask(self, proxy_subtask):
+        self._proxy_subtasks.append(proxy_subtask)
+
+    def num_shuffles(self) -> int:
+        return len(self._proxy_subtasks)
+
+    def get_proxy_subtasks(self):
+        return self._proxy_subtasks

--- a/mars/services/subtask/core.py
+++ b/mars/services/subtask/core.py
@@ -205,11 +205,11 @@ class SubtaskGraph(DAG, Iterable[Subtask]):
                 continue
             yield node.op
 
-    def add_proxy_subtask(self, proxy_subtask):
+    def add_shuffle_proxy_subtask(self, proxy_subtask):
         self._proxy_subtasks.append(proxy_subtask)
 
     def num_shuffles(self) -> int:
         return len(self._proxy_subtasks)
 
-    def get_proxy_subtasks(self):
+    def get_shuffle_proxy_subtasks(self):
         return self._proxy_subtasks

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -452,9 +452,6 @@ class SubtaskProcessor:
         unpinned = False
         try:
             raw_result_chunks = list(self._chunk_graph.result_chunks)
-            print(
-                f"self._chunk_graph, self._engines {self._chunk_graph, self._engines, task_options.runtime_engines}"
-            )
             chunk_graph = optimize(self._chunk_graph, self._engines)
             self._chunk_key_to_data_keys = get_chunk_key_to_data_keys(chunk_graph)
             report_progress = asyncio.create_task(self.report_progress_periodically())

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -373,7 +373,8 @@ class SubtaskProcessor:
                 mapper_keys = get_mapper_data_keys(chunk_key, data_key_to_store_size)
                 store_size = sum(data_key_to_store_size[k] for k in mapper_keys)
                 memory_size = sum(data_key_to_memory_size[k] for k in mapper_keys)
-                object_ref = [data_key_to_object_id[k] for k in mapper_keys]
+                # Skip meta for shuffle
+                object_ref = None
             # for worker, if chunk in update_meta_chunks
             # save meta including dtypes_value etc, otherwise,
             # save basic meta only
@@ -451,6 +452,9 @@ class SubtaskProcessor:
         unpinned = False
         try:
             raw_result_chunks = list(self._chunk_graph.result_chunks)
+            print(
+                f"self._chunk_graph, self._engines {self._chunk_graph, self._engines, task_options.runtime_engines}"
+            )
             chunk_graph = optimize(self._chunk_graph, self._engines)
             self._chunk_key_to_data_keys = get_chunk_key_to_data_keys(chunk_graph)
             report_progress = asyncio.create_task(self.report_progress_periodically())

--- a/mars/services/task/analyzer/analyzer.py
+++ b/mars/services/task/analyzer/analyzer.py
@@ -317,10 +317,13 @@ class GraphAnalyzer:
 
         is_shuffle_proxy = False
         if self._has_shuffle:
-            shuffle_chunks, proxy_chunks = [], []
+            mapper_chunks, proxy_chunks = [], []
             for c in result_chunks:
-                if isinstance(c.op, MapReduceOperand):
-                    shuffle_chunks.append(c)
+                if (
+                    isinstance(c.op, MapReduceOperand)
+                    and c.op.stage == OperandStage.map
+                ):
+                    mapper_chunks.append(c)
                 elif isinstance(c.op, ShuffleProxy):
                     proxy_chunks.append(c)
             if proxy_chunks:
@@ -329,7 +332,9 @@ class GraphAnalyzer:
             if self._shuffle_fetch_type == ShuffleFetchType.FETCH_BY_INDEX:
                 # ensure no shuffle mapper chunks fused into same subtask and subtask only produce mapper outputs
                 # which can be merged dynamically by the reducers.
-                assert len(shuffle_chunks) <= 1, shuffle_chunks
+                if len(mapper_chunks) > 1:
+                    print(mapper_chunks)
+                # assert len(shuffle_chunks) <= 1, shuffle_chunks
         return subtask, inp_subtasks, is_shuffle_proxy
 
     def _gen_logic_key(self, chunks: List[ChunkType]):

--- a/mars/services/task/analyzer/analyzer.py
+++ b/mars/services/task/analyzer/analyzer.py
@@ -317,19 +317,10 @@ class GraphAnalyzer:
 
         is_shuffle_proxy = False
         if self._has_shuffle:
-            mapper_chunks, proxy_chunks = [], []
-            for c in result_chunks:
-                if c.op is not None and c.op.stage == OperandStage.map:
-                    mapper_chunks.append(c)
-                elif isinstance(c.op, ShuffleProxy):
-                    proxy_chunks.append(c)
+            proxy_chunks = [c for c in result_chunks if isinstance(c.op, ShuffleProxy)]
             if proxy_chunks:
                 assert len(proxy_chunks) <= 1, proxy_chunks
                 is_shuffle_proxy = True
-            if self._shuffle_fetch_type == ShuffleFetchType.FETCH_BY_INDEX:
-                # ensure no shuffle mapper chunks fused into same subtask and subtask only produce mapper outputs
-                # which can be merged dynamically by the reducers.
-                assert len(mapper_chunks) <= 1, mapper_chunks
         return subtask, inp_subtasks, is_shuffle_proxy
 
     def _gen_logic_key(self, chunks: List[ChunkType]):

--- a/mars/services/task/analyzer/analyzer.py
+++ b/mars/services/task/analyzer/analyzer.py
@@ -316,20 +316,20 @@ class GraphAnalyzer:
         )
 
         is_shuffle_proxy = False
-        if (
-            self._has_shuffle
-            and self._shuffle_fetch_type == ShuffleFetchType.FETCH_BY_INDEX
-        ):
-            shuffle_chunks = [
-                c for c in result_chunks if isinstance(c, MapReduceOperand)
-            ]
-            # ensure no shuffle mapper chunks fused into same subtask and subtask only produce mapper outputs
-            # which can be merged dynamically by the reducers.
-            assert len(shuffle_chunks) <= 1, shuffle_chunks
-            proxy_chunks = [c for c in chunks if isinstance(c.op, ShuffleProxy)]
-            assert len(proxy_chunks) <= 1, proxy_chunks
+        if self._has_shuffle:
+            shuffle_chunks, proxy_chunks = [], []
+            for c in result_chunks:
+                if isinstance(c.op, MapReduceOperand):
+                    shuffle_chunks.append(c)
+                elif isinstance(c.op, ShuffleProxy):
+                    proxy_chunks.append(c)
             if proxy_chunks:
+                assert len(proxy_chunks) <= 1, proxy_chunks
                 is_shuffle_proxy = True
+            if self._shuffle_fetch_type == ShuffleFetchType.FETCH_BY_INDEX:
+                # ensure no shuffle mapper chunks fused into same subtask and subtask only produce mapper outputs
+                # which can be merged dynamically by the reducers.
+                assert len(shuffle_chunks) <= 1, shuffle_chunks
         return subtask, inp_subtasks, is_shuffle_proxy
 
     def _gen_logic_key(self, chunks: List[ChunkType]):

--- a/mars/services/task/analyzer/analyzer.py
+++ b/mars/services/task/analyzer/analyzer.py
@@ -319,10 +319,7 @@ class GraphAnalyzer:
         if self._has_shuffle:
             mapper_chunks, proxy_chunks = [], []
             for c in result_chunks:
-                if (
-                    isinstance(c.op, MapReduceOperand)
-                    and c.op.stage == OperandStage.map
-                ):
+                if c.op is not None and c.op.stage == OperandStage.map:
                     mapper_chunks.append(c)
                 elif isinstance(c.op, ShuffleProxy):
                     proxy_chunks.append(c)
@@ -332,9 +329,7 @@ class GraphAnalyzer:
             if self._shuffle_fetch_type == ShuffleFetchType.FETCH_BY_INDEX:
                 # ensure no shuffle mapper chunks fused into same subtask and subtask only produce mapper outputs
                 # which can be merged dynamically by the reducers.
-                if len(mapper_chunks) > 1:
-                    print(mapper_chunks)
-                # assert len(shuffle_chunks) <= 1, shuffle_chunks
+                assert len(mapper_chunks) <= 1, mapper_chunks
         return subtask, inp_subtasks, is_shuffle_proxy
 
     def _gen_logic_key(self, chunks: List[ChunkType]):
@@ -485,7 +480,7 @@ class GraphAnalyzer:
             )
             subtask_graph.add_node(subtask)
             if is_shuffle_proxy:
-                subtask_graph.add_proxy_subtask(subtask)
+                subtask_graph.add_shuffle_proxy_subtask(subtask)
             logic_key_to_subtasks[subtask.logic_key].append(subtask)
             for inp_subtask in inp_subtasks:
                 subtask_graph.add_edge(inp_subtask, subtask)

--- a/mars/services/task/analyzer/tests/test_analyzer.py
+++ b/mars/services/task/analyzer/tests/test_analyzer.py
@@ -27,9 +27,10 @@ t1 = mt.random.RandomState(0).rand(31, 27, chunk_size=10)
 t2 = t1.reshape(27, 31)
 t2.op.extra_params["_reshape_with_shuffle"] = True
 df1 = md.DataFrame(t1, columns=[f"c{i}" for i in range(t1.shape[1])])
+df2 = df1.groupby(["c1"]).apply(lambda pdf: pdf.sum())
 
 
-@pytest.mark.parametrize("tileable", [df1.describe(), t2])
+@pytest.mark.parametrize("tileable", [df1.describe(), df2, t2])
 @pytest.mark.parametrize("fuse", [True, False])
 def test_shuffle_graph(tileable, fuse):
     # can't test df.groupby and mt.bincount, those chunk graph build depend on ctx.get_chunks_meta/get_chunks_result
@@ -61,6 +62,7 @@ def test_shuffle_graph(tileable, fuse):
     ]
     assert len(proxy_subtasks) == len(proxy_chunks)
     assert len(proxy_subtasks) > 0
+    assert len(proxy_subtasks) == len(subtask_graph.get_proxy_subtasks())
     for proxy_chunk, proxy_subtask in zip(proxy_chunks, proxy_subtasks):
         reducer_subtasks = subtask_graph.successors(proxy_subtask)
         for reducer_subtask in reducer_subtasks:

--- a/mars/services/task/analyzer/tests/test_analyzer.py
+++ b/mars/services/task/analyzer/tests/test_analyzer.py
@@ -62,7 +62,7 @@ def test_shuffle_graph(tileable, fuse):
     ]
     assert len(proxy_subtasks) == len(proxy_chunks)
     assert len(proxy_subtasks) > 0
-    assert len(proxy_subtasks) == len(subtask_graph.get_proxy_subtasks())
+    assert len(proxy_subtasks) == len(subtask_graph.get_shuffle_proxy_subtasks())
     for proxy_chunk, proxy_subtask in zip(proxy_chunks, proxy_subtasks):
         reducer_subtasks = subtask_graph.successors(proxy_subtask)
         for reducer_subtask in reducer_subtasks:

--- a/mars/services/task/execution/ray/shuffle.py
+++ b/mars/services/task/execution/ray/shuffle.py
@@ -29,7 +29,7 @@ class ShuffleManager:
 
     def __init__(self, subtask_graph: SubtaskGraph):
         self.subtask_graph = subtask_graph
-        self._proxy_subtasks = subtask_graph.get_proxy_subtasks()
+        self._proxy_subtasks = subtask_graph.get_shuffle_proxy_subtasks()
         self.num_shuffles = subtask_graph.num_shuffles()
         self.mapper_output_refs = []
         self.mapper_indices = {}

--- a/mars/services/task/execution/ray/shuffle.py
+++ b/mars/services/task/execution/ray/shuffle.py
@@ -15,9 +15,9 @@
 import numpy as np
 from typing import List, Iterable
 
-from .....core.operand import ShuffleProxy, MapReduceOperand, OperandStage
+from .....core.operand import MapReduceOperand, OperandStage
 from .....utils import lazy_import
-from ....subtask import Subtask
+from ....subtask import Subtask, SubtaskGraph
 
 ray = lazy_import("ray")
 
@@ -27,14 +27,10 @@ class ShuffleManager:
     mapper and reducer index.
     """
 
-    def __init__(self, subtask_graph):
+    def __init__(self, subtask_graph: SubtaskGraph):
         self.subtask_graph = subtask_graph
-        self._proxy_subtasks = []
-        for subtask in subtask_graph:
-            chunk = subtask.chunk_graph.results[0]
-            if isinstance(chunk.op, ShuffleProxy):
-                self._proxy_subtasks.append(subtask)
-        self.num_shuffles = len(self._proxy_subtasks)
+        self._proxy_subtasks = subtask_graph.get_proxy_subtasks()
+        self.num_shuffles = subtask_graph.num_shuffles()
         self.mapper_output_refs = []
         self.mapper_indices = {}
         self.reducer_indices = {}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR skip store shuffle object refs to reduce meta overhead and supervisor serialization bottleneck by disable autoscale-in when shuffle is executing.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#2916

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
