### PR TITLE
release actor lock when set_subtask_result

### DIFF
--- a/mars/services/task/supervisor/task.py
+++ b/mars/services/task/supervisor/task.py
@@ -415,7 +415,7 @@ class TaskProcessorActor(mo.Actor, _TaskInfoProcessorMixin):
             "Set subtask %s with result %s.", subtask_result.subtask_id, subtask_result
         )
         if self._cur_processor is not None:
-            await self._cur_processor.set_subtask_result(subtask_result)
+            yield self._cur_processor.set_subtask_result(subtask_result)
 
     def is_done(self) -> bool:
         for processor in self._task_id_to_processor.values():


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR make `set_subtask_result` concurrent by releasing actor lock when `set_subtask_result`
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
