### PR TITLE
[Shuffle] Support shuffle operands mapper whose outputs aren't mapper blocks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -127,7 +127,7 @@ Copyright 1999-2021 Alibaba Group Holding Ltd.
       may provide additional or different license terms and conditions
       for use, reproduction, or distribution of Your modifications, or
       for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
+      reproduction, and distribution of the Work otherwise compiles with
       the conditions stated in this License.
 
    5. Submission of Contributions. Unless You explicitly state otherwise,

--- a/benchmarks/asv_bench/benchmarks/serialize.py
+++ b/benchmarks/asv_bench/benchmarks/serialize.py
@@ -47,7 +47,7 @@ from mars.services.subtask import Subtask, SubtaskResult, SubtaskStatus
 from mars.services.task import new_task_id
 from mars.utils import tokenize
 
-# do warmup
+# do warm up
 serialize(None)
 
 

--- a/docs/source/locale/zh_CN/LC_MESSAGES/reference/tensor/generated/mars.tensor.array.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/reference/tensor/generated/mars.tensor.array.po
@@ -135,7 +135,7 @@ msgstr ""
 #: mars.tensor.array:34 of
 msgid ""
 "Specifies the minimum number of dimensions that the resulting array "
-"should have.  Ones will be pre-pended to the shape as needed to meet this"
+"should have.  Ones will be prepended to the shape as needed to meet this"
 " requirement."
 msgstr ""
 

--- a/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/tensor/generated/mars.tensor.array.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/tensor/generated/mars.tensor.array.po
@@ -135,7 +135,7 @@ msgstr ""
 #: mars.tensor.array:34 of
 msgid ""
 "Specifies the minimum number of dimensions that the resulting array "
-"should have.  Ones will be pre-pended to the shape as needed to meet this"
+"should have.  Ones will be prepended to the shape as needed to meet this"
 " requirement."
 msgstr ""
 

--- a/mars/core/entity/chunks.py
+++ b/mars/core/entity/chunks.py
@@ -21,6 +21,9 @@ class ChunkData(EntityData):
     __slots__ = ()
 
     is_broadcaster = BoolField("is_broadcaster", default=False)
+    # If the operand is a shuffle mapper, this flag indicates whether the current chunk is mapper chunk when
+    # the operand produce multiple chunks such as TensorUnique.
+    is_mapper = BoolField("is_mapper", default=False)
     # optional fields
     _index = TupleField("index", FieldTypes.uint32)
 

--- a/mars/learn/linear_model/tests/test_base.py
+++ b/mars/learn/linear_model/tests/test_base.py
@@ -68,7 +68,7 @@ def test_linear_regression(setup):
     assert_array_almost_equal(reg.intercept_, model.intercept_)
     assert_array_almost_equal(reg.predict(X), model.predict(X))
 
-    # Extra case #1: singluar matrix, degenerate input
+    # Extra case #1: singular matrix, degenerate input
     error_msg = re.escape("Does not support sigular matrix!")
 
     X = [[1]]
@@ -78,7 +78,7 @@ def test_linear_regression(setup):
     with pytest.raises(NotImplementedError, match=error_msg):
         reg.fit(X, Y)
 
-    # # Extra case #2: algebrically singluar matrix but algorithmically not
+    # # Extra case #2: algebrically singular matrix but algorithmically not
     # # Works locally but not work in github checks
     # # May be because the inverse is super large
     # X = [[1, 1.5], [1.8, 2]]

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -227,11 +227,6 @@ def execute_subtask(
         output_values.append(output_meta)
     output_values.extend(normal_output.values())
     output_values.extend(mapper_output.values())
-
-    if not is_mapper:
-        expect_output_keys, _ = _get_subtask_out_info(subtask_chunk_graph, False)
-        output_keys = normal_output.keys()
-        assert expect_output_keys == output_keys, (expect_output_keys, output_keys)
     logger.info("Finish executing subtask %s.", subtask_id)
     return output_values[0] if len(output_values) == 1 else output_values
 
@@ -553,9 +548,9 @@ class RayTaskExecutor(TaskExecutor):
                 output_meta_object_refs.append(meta_object_ref)
             if is_mapper:
                 shuffle_manager.add_mapper_output_refs(
-                    subtask, output_object_refs[len(subtask_output_meta_keys) :]
+                    subtask, output_object_refs[-n_reducers:]
                 )
-                output_object_refs = output_object_refs[: len(subtask_output_meta_keys)]
+                output_object_refs = output_object_refs[:-n_reducers]
             subtask_outputs = zip(output_keys, output_object_refs)
             task_context.update(subtask_outputs)
         logger.info("Submitted %s subtasks of stage %s.", len(subtask_graph), stage_id)

--- a/mars/tensor/base/tests/test_base_execution.py
+++ b/mars/tensor/base/tests/test_base_execution.py
@@ -985,8 +985,7 @@ def test_searchsorted_execution(setup):
             np.testing.assert_array_equal(res, expected)
 
 
-# TODO https://github.com/mars-project/mars/issues/3221
-# @pytest.mark.ray_dag
+@pytest.mark.ray_dag
 def test_unique_execution(setup):
     rs = np.random.RandomState(0)
     raw = rs.randint(10, size=(10,))

--- a/mars/tensor/base/unique.py
+++ b/mars/tensor/base/unique.py
@@ -242,6 +242,8 @@ class TensorUnique(TensorMapReduceOperand, TensorOperandMixin):
             chunks = reduce_op.new_chunks(
                 [shuffle_chunk], kws=kws, order=op.outputs[0].order
             )
+            if op.return_inverse:
+                chunks[0].is_mapper, chunks[1].is_mapper = False, True
             for j, c in enumerate(chunks):
                 reduce_chunks[j].append(c)
 

--- a/mars/tensor/datasource/array.py
+++ b/mars/tensor/datasource/array.py
@@ -233,7 +233,7 @@ def array(x, dtype=None, copy=True, order="K", ndmin=None, chunk_size=None):
         Notes section. The default order is 'K'.
     ndmin : int, optional
         Specifies the minimum number of dimensions that the resulting
-        array should have.  Ones will be pre-pended to the shape as
+        array should have.  Ones will be prepended to the shape as
         needed to meet this requirement.
     chunk_size: int, tuple, optional
         Specifies chunk size for each dimension.


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR add shuffle support for operands whose mapper produce outputs which isn't shuffle blocks. In traditional map-reduce paradigm, all outputs of a mapper operand will be shuffle blocks, and used by downstream reducers. But in mars , operands such as `TensorUnique` will produce final results such as `unique index` in mapper stage too, those results are not mapper blocks, which need special handling in ray-task based shuffle.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #3221

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
