### PR TITLE
Lifecycle gc task service

### DIFF
--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -50,6 +50,8 @@ jobs:
           source ./ci/reload-env.sh
           unset CI
           cd benchmarks/asv_bench
+          git config --global user.email "fyrestone@outlook.com"
+          git config --global user.name "fyrestone"
           asv check -E existing
           git remote add upstream https://github.com/mars-project/mars.git
           git fetch upstream

--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -50,8 +50,8 @@ jobs:
           source ./ci/reload-env.sh
           unset CI
           cd benchmarks/asv_bench
-          git config --global user.email "fyrestone@outlook.com"
-          git config --global user.name "fyrestone"
+          git config --global user.email "mars_asv_benchmark@outlook.com"
+          git config --global user.name "Mars ASV Benchmark"
           asv check -E existing
           git remote add upstream https://github.com/mars-project/mars.git
           git fetch upstream

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -965,7 +965,6 @@ class _IsolatedSession(AbstractAsyncSession):
         if self._closed:
             raise RuntimeError("Session closed already")
         fuse_enabled: bool = kwargs.pop("fuse_enabled", None)
-        task_name: str = kwargs.pop("task_name", None)
         extra_config: dict = kwargs.pop("extra_config", None)
         warn_duplicated_execution: bool = kwargs.pop("warn_duplicated_execution", False)
         if kwargs:  # pragma: no cover
@@ -995,7 +994,6 @@ class _IsolatedSession(AbstractAsyncSession):
         # submit task
         task_id = await self._task_api.submit_tileable_graph(
             tileable_graph,
-            task_name=task_name,
             fuse_enabled=fuse_enabled,
             extra_config=extra_config,
         )

--- a/mars/deploy/oscar/tests/check_enabled_config.yml
+++ b/mars/deploy/oscar/tests/check_enabled_config.yml
@@ -1,5 +1,7 @@
 "@inherits": '@default'
 task:
+  default_config:
+      reserved_finish_tasks: 0
   task_preprocessor_cls: mars.services.task.supervisor.tests.CheckedTaskPreprocessor
 subtask:
   subtask_processor_cls: mars.services.subtask.worker.tests.CheckedSubtaskProcessor

--- a/mars/serialization/serializables/core.py
+++ b/mars/serialization/serializables/core.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import operator
 import weakref
 from typing import Dict, List, Type, Tuple
@@ -40,8 +39,6 @@ _primitive_field_types = (
     TimedeltaType,
     TZInfoType,
 )
-
-_is_ci = (os.environ.get("CI") or "0").lower() in ("1", "true")
 
 
 def _is_field_primitive_compound(field: Field):

--- a/mars/serialization/serializables/field.py
+++ b/mars/serialization/serializables/field.py
@@ -15,11 +15,10 @@
 import itertools
 import importlib
 import inspect
-import os
 from abc import ABC, ABCMeta, abstractmethod
 from typing import Any, Callable, Optional, Type, Union
 
-from ...utils import no_default
+from ...utils import no_default, _is_ci
 from .field_type import (
     AbstractFieldType,
     FieldTypes,
@@ -28,8 +27,6 @@ from .field_type import (
     DictType,
     ReferenceType,
 )
-
-_is_ci = (os.environ.get("CI") or "0").lower() in ("1", "true")
 
 
 class Field(ABC):

--- a/mars/services/lifecycle/supervisor/tracker.py
+++ b/mars/services/lifecycle/supervisor/tracker.py
@@ -228,6 +228,17 @@ class LifecycleTrackerActor(mo.Actor):
         )
         return decref_chunk_keys
 
+    def _get_remove_tileable_keys(self, tileable_keys: List[str]) -> List[str]:
+        to_remove_tileable_keys = []
+        for tileable_key in tileable_keys:
+            if self._tileable_ref_counts[tileable_key] <= 0:
+                if all(
+                    self._chunk_ref_counts[chunk_key] <= 0
+                    for chunk_key in self._tileable_key_to_chunk_keys[tileable_key]
+                ):
+                    to_remove_tileable_keys.append(tileable_key)
+        return to_remove_tileable_keys
+
     async def decref_tileables(
         self, tileable_keys: List[str], counts: List[int] = None
     ):
@@ -241,7 +252,7 @@ class LifecycleTrackerActor(mo.Actor):
             counts=list(decref_chunk_key_to_counts.values()),
         )
         to_remove_tileable_keys = await asyncio.to_thread(
-            list, (key for key in tileable_keys if self._tileable_ref_counts[key] <= 0)
+            self._get_remove_tileable_keys, tileable_keys
         )
         coros = []
         if to_remove_chunk_keys:

--- a/mars/services/lifecycle/supervisor/tracker.py
+++ b/mars/services/lifecycle/supervisor/tracker.py
@@ -228,17 +228,6 @@ class LifecycleTrackerActor(mo.Actor):
         )
         return decref_chunk_keys
 
-    def _get_remove_tileable_keys(self, tileable_keys: List[str]) -> List[str]:
-        to_remove_tileable_keys = []
-        for tileable_key in tileable_keys:
-            if self._tileable_ref_counts[tileable_key] <= 0:
-                if all(
-                    self._chunk_ref_counts[chunk_key] <= 0
-                    for chunk_key in self._tileable_key_to_chunk_keys[tileable_key]
-                ):
-                    to_remove_tileable_keys.append(tileable_key)
-        return to_remove_tileable_keys
-
     async def decref_tileables(
         self, tileable_keys: List[str], counts: List[int] = None
     ):
@@ -252,7 +241,7 @@ class LifecycleTrackerActor(mo.Actor):
             counts=list(decref_chunk_key_to_counts.values()),
         )
         to_remove_tileable_keys = await asyncio.to_thread(
-            self._get_remove_tileable_keys, tileable_keys
+            list, (key for key in tileable_keys if self._tileable_ref_counts[key] <= 0)
         )
         coros = []
         if to_remove_chunk_keys:

--- a/mars/services/task/api/core.py
+++ b/mars/services/task/api/core.py
@@ -40,7 +40,6 @@ class AbstractTaskAPI(ABC):
     async def submit_tileable_graph(
         self,
         graph: TileableGraph,
-        task_name: str = None,
         fuse_enabled: bool = True,
         extra_config: dict = None,
     ) -> str:

--- a/mars/services/task/api/oscar.py
+++ b/mars/services/task/api/oscar.py
@@ -104,3 +104,6 @@ class TaskAPI(AbstractTaskAPI):
 
     async def get_last_idle_time(self) -> Union[float, None]:
         return await self._task_manager_ref.get_last_idle_time()
+
+    async def remove_tileables(self, tileable_keys: List[str]):
+        return await self._task_manager_ref.remove_tileables(tileable_keys)

--- a/mars/services/task/api/oscar.py
+++ b/mars/services/task/api/oscar.py
@@ -59,13 +59,12 @@ class TaskAPI(AbstractTaskAPI):
     async def submit_tileable_graph(
         self,
         graph: TileableGraph,
-        task_name: str = None,
         fuse_enabled: bool = None,
         extra_config: dict = None,
     ) -> str:
         try:
             return await self._task_manager_ref.submit_tileable_graph(
-                graph, task_name, fuse_enabled=fuse_enabled, extra_config=extra_config
+                graph, fuse_enabled=fuse_enabled, extra_config=extra_config
             )
         except mo.ActorNotExist:
             raise RuntimeError("Session closed already")

--- a/mars/services/task/api/web.py
+++ b/mars/services/task/api/web.py
@@ -74,7 +74,6 @@ class TaskWebAPIHandler(MarsServiceWebAPIHandler):
             deserialize_serializable(self.request.body) if self.request.body else None
         )
 
-        task_name = body_args.get("task_name", None) or None
         fuse_enabled = body_args.get("fuse")
 
         graph = body_args["graph"]
@@ -85,7 +84,6 @@ class TaskWebAPIHandler(MarsServiceWebAPIHandler):
         oscar_api = await self._get_oscar_task_api(session_id)
         task_id = await oscar_api.submit_tileable_graph(
             graph,
-            task_name=task_name,
             fuse_enabled=fuse_enabled,
             extra_config=extra_config,
         )
@@ -212,7 +210,6 @@ class WebTaskAPI(AbstractTaskAPI, MarsWebAPIClientMixin):
     async def submit_tileable_graph(
         self,
         graph: TileableGraph,
-        task_name: str = None,
         fuse_enabled: bool = True,
         extra_config: dict = None,
     ) -> str:
@@ -222,7 +219,6 @@ class WebTaskAPI(AbstractTaskAPI, MarsWebAPIClientMixin):
         )
         body = serialize_serializable(
             {
-                "task_name": task_name if task_name else "",
                 "fuse": fuse_enabled,
                 "graph": graph,
                 "extra_config": extra_config_ser,

--- a/mars/services/task/config.py
+++ b/mars/services/task/config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...config import Config, is_bool, is_list
+from ...config import Config, is_bool, is_list, is_integer
 
 
 task_options = Config()
@@ -21,6 +21,7 @@ task_options = Config()
 task_options.register_option("optimize_tileable_graph", True, validator=is_bool)
 task_options.register_option("optimize_chunk_graph", True, validator=is_bool)
 task_options.register_option("fuse_enabled", True, validator=is_bool)
+task_options.register_option("reserved_finish_tasks", 10, validator=is_integer)
 
 # worker
 task_options.register_option("runtime_engines", ["numexpr", "cupy"], validator=is_list)

--- a/mars/services/task/core.py
+++ b/mars/services/task/core.py
@@ -38,7 +38,6 @@ class TaskStatus(Enum):
 
 class Task(Serializable):
     task_id: str = StringField("task_id")
-    task_name: str = StringField("task_name")
     session_id: str = StringField("session_id")
     parent_task_id: str = StringField("parent_task_id")
     tileable_graph: TileableGraph = ReferenceField("tileable_graph", TileableGraph)
@@ -51,7 +50,6 @@ class Task(Serializable):
         task_id: str = None,
         session_id: str = None,
         tileable_graph: TileableGraph = None,
-        task_name: str = None,
         parent_task_id: str = None,
         fuse_enabled: bool = True,
         rerun_time: int = 0,
@@ -59,7 +57,6 @@ class Task(Serializable):
     ):
         super().__init__(
             task_id=task_id,
-            task_name=task_name,
             session_id=session_id,
             parent_task_id=parent_task_id,
             tileable_graph=tileable_graph,

--- a/mars/services/task/core.py
+++ b/mars/services/task/core.py
@@ -39,7 +39,6 @@ class TaskStatus(Enum):
 class Task(Serializable):
     task_id: str = StringField("task_id")
     session_id: str = StringField("session_id")
-    parent_task_id: str = StringField("parent_task_id")
     tileable_graph: TileableGraph = ReferenceField("tileable_graph", TileableGraph)
     fuse_enabled: bool = BoolField("fuse_enabled")
     rerun_time: int = Int32Field("rerun_time")
@@ -50,7 +49,6 @@ class Task(Serializable):
         task_id: str = None,
         session_id: str = None,
         tileable_graph: TileableGraph = None,
-        parent_task_id: str = None,
         fuse_enabled: bool = True,
         rerun_time: int = 0,
         extra_config: dict = None,
@@ -58,7 +56,6 @@ class Task(Serializable):
         super().__init__(
             task_id=task_id,
             session_id=session_id,
-            parent_task_id=parent_task_id,
             tileable_graph=tileable_graph,
             fuse_enabled=fuse_enabled,
             rerun_time=rerun_time,

--- a/mars/services/task/supervisor/manager.py
+++ b/mars/services/task/supervisor/manager.py
@@ -326,3 +326,6 @@ class TaskManagerActor(mo.Actor):
             else:
                 self._last_idle_time = time.time()
         return self._last_idle_time
+
+    async def remove_tileables(self, tileable_keys: List[str]):
+        yield asyncio.to_thread(map, self._tileable_key_to_info.pop, tileable_keys)

--- a/mars/services/task/supervisor/manager.py
+++ b/mars/services/task/supervisor/manager.py
@@ -347,6 +347,6 @@ class TaskManagerActor(mo.Actor):
         return self._last_idle_time
 
     async def remove_tileables(self, tileable_keys: List[str]):
-        # TODO(fyrestone) yield
+        # TODO(fyrestone) yield if needed.
         for key in tileable_keys:
             self._result_tileable_key_to_info.pop(key, None)

--- a/mars/services/task/supervisor/service.py
+++ b/mars/services/task/supervisor/service.py
@@ -28,7 +28,8 @@ class TaskSupervisorService(AbstractService):
             "default_config": {
                 "optimize_tileable_graph": True,
                 "optimize_chunk_graph": True,
-                "fuse_enabled": True
+                "fuse_enabled": True,
+                "reserved_finish_tasks": 10
             },
             "execution_config": {
                 "backend": "mars",

--- a/mars/services/task/supervisor/task.py
+++ b/mars/services/task/supervisor/task.py
@@ -327,6 +327,8 @@ class TaskProcessorActor(mo.Actor, _TaskInfoProcessorMixin):
     @classmethod
     def _get_task_processor_cls(cls, task_processor_cls):
         if task_processor_cls is not None:  # pragma: no cover
+            if isinstance(task_processor_cls, type):
+                return task_processor_cls
             assert isinstance(task_processor_cls, str)
             module, name = task_processor_cls.rsplit(".", 1)
             return getattr(importlib.import_module(module), name)

--- a/mars/services/task/supervisor/task.py
+++ b/mars/services/task/supervisor/task.py
@@ -283,12 +283,10 @@ class TaskProcessorActor(mo.Actor, _TaskInfoProcessorMixin):
         self,
         session_id: str,
         task_id: str,
-        task_name: str = None,
         task_processor_cls: Type[TaskPreprocessor] = None,
     ):
         self.session_id = session_id
         self.task_id = task_id
-        self.task_name = task_name
 
         self._task_processor_cls = self._get_task_processor_cls(task_processor_cls)
         self._task_id_to_processor = dict()

--- a/mars/services/task/supervisor/tests/test_task_manager.py
+++ b/mars/services/task/supervisor/tests/test_task_manager.py
@@ -199,9 +199,7 @@ async def test_run_tasks_with_same_name(actor_pool):
         graph = TileableGraph([t.data])
         next(TileableGraphBuilder(graph).build())
 
-        task_id = await manager.submit_tileable_graph(
-            graph, task_name="my_task", fuse_enabled=False
-        )
+        task_id = await manager.submit_tileable_graph(graph, fuse_enabled=False)
         assert isinstance(task_id, str)
 
         await manager.wait_task(task_id)
@@ -661,7 +659,6 @@ async def test_dump_subtask_graph(actor_pool):
 
     task_id = await manager.submit_tileable_graph(
         graph,
-        task_name="my_task",
         fuse_enabled=True,
         extra_config={"dump_subtask_graph": True},
     )

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1796,20 +1796,3 @@ def retry_callable(
             raise ex  # pylint: disable-msg=E0702
 
     return retry_call
-
-
-def add_aiotask_done_check_callback(
-    aiotask: asyncio.Task, exception_formatter: str, *args
-):
-    def _on_mars_aiotask_done(fut):
-        # Print the error of task.
-        try:
-            fut.result()
-        except asyncio.CancelledError:  # pragma: no cover
-            pass
-        except Exception:  # pragma: no cover
-            logger.exception(exception_formatter, *args)
-            if _is_ci:
-                sys.exit(-1)
-
-    aiotask.add_done_callback(_on_mars_aiotask_done)

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -1776,7 +1776,7 @@ def add_aiotask_done_check_callback(
         # Print the error of task.
         try:
             fut.result()
-        except asyncio.CancelledError:
+        except asyncio.CancelledError:  # pragma: no cover
             pass
         except Exception:  # pragma: no cover
             logger.exception(exception_formatter, *args)

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     numexpr>=2.6.4
     cloudpickle>=1.5.0
     pyyaml>=5.1
-    psutil>=4.0.0
+    psutil>=5.9.0
     pickle5; python_version<"3.8"
     shared-memory38>=0.1.1; python_version<"3.8"
     tornado>=6.0


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

All the TaskProcessorActors, TaskProcessors and related contexts, graphs are not GC.  This PR is to GC the task services by lifecycle.

- [x] Destroy the `TaskProcessorActor` only if all the result tileables have no refs and the task is finish.
  - New config `task.default_config.reserved_finish_tasks`, default value is 10.
- [x] Remove task name feature to simplify the task manager. 

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/mars-project/mars/issues/3192
https://github.com/mars-project/mars/issues/3236

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
