### PR TITLE
Fix dataframe sort_values with multiple ascendings bug in pandas < 1.4

### DIFF
--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -592,7 +592,6 @@ class DataFramePSRSShuffle(MapReduceOperand, DataFrameOperandMixin):
     @classmethod
     def _execute_dataframe_map(cls, ctx, op):
         a, pivots = [ctx[c.key] for c in op.inputs]
-        print("_execute_dataframe_map", pivots)
         out = op.outputs[0]
 
         if len(a) == 0:

--- a/mars/dataframe/sort/psrs.py
+++ b/mars/dataframe/sort/psrs.py
@@ -550,6 +550,17 @@ class DataFramePSRSShuffle(MapReduceOperand, DataFrameOperandMixin):
 
     @staticmethod
     def _calc_poses(src_cols, pivots, ascending=True):
+        # The pivots are immutable if it is got from shared memory, e.g. Ray object store.
+        # Pandas < 1.4 has item setting bug and pandas >= 1.4 has fixed it.
+        #
+        # Here, almost all the cases that the pivots are got from shared memory.
+        #
+        # `pivots[col] = -pivots[col]` will automatically replace the col with a new copy
+        # `-pivots[col]` in pandas >= 1.4, but it will try to inplace set col in pandas < 1.4
+        #
+        # So, we use assign here to walk around incorrect inplace set item bug in pandas < 1.4.
+        # Please refer to: https://github.com/mars-project/mars/issues/3215
+        # related issue: https://github.com/pandas-dev/pandas/pull/43406
         copy_cols = {}
         if isinstance(ascending, list):
             for asc, col in zip(ascending, pivots.columns):
@@ -557,20 +568,11 @@ class DataFramePSRSShuffle(MapReduceOperand, DataFrameOperandMixin):
                 if not asc:
                     if pd.api.types.is_numeric_dtype(pivots.dtypes[col]):
                         # for numeric dtypes, convert to negative is more efficient
-                        try:
-                            pivots[col] = -pivots[col]
-                        except ValueError:
-                            # When using ray backend, the numpy array of the pivots is immutable
-                            # if it is got from the object store. Pandas 1.3.x has item setting
-                            # bug. Pandas >= 1.4 has fixed the bug.
-                            #
-                            # Please refer to: https://github.com/mars-project/mars/issues/3215
-                            # related issue: https://github.com/pandas-dev/pandas/pull/43406
-                            copy_cols[col] = -pivots[col]
+                        copy_cols[col] = -pivots[col]
                         src_cols[col] = -src_cols[col]
                     else:
                         # for other types, convert to ReversedValue
-                        pivots[col] = pivots[col].map(
+                        copy_cols[col] = pivots[col].map(
                             lambda x: x
                             if type(x) is _ReversedValue
                             else _ReversedValue(x)

--- a/mars/dataframe/sort/tests/test_sort_execution.py
+++ b/mars/dataframe/sort/tests/test_sort_execution.py
@@ -19,17 +19,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ....lib.version import parse as parse_version
 from ....tests.core import require_cudf
 from ... import DataFrame, Series, ArrowStringDtype
 
 
 @pytest.mark.parametrize(
     "distinct_opt", ["0"] if sys.platform.lower().startswith("win") else ["0", "1"]
-)
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < parse_version("1.4.0"),
-    reason="sort_values requires pandas >= 1.4.0",
 )
 def test_sort_values_execution(setup, distinct_opt):
     ns = np.random.RandomState(0)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

The numpy array is immutable if it is got from shared memory. But, pandas < 1.4 has item setting bugs: https://github.com/pandas-dev/pandas/pull/43406.

pandas >= 1.4.x has fixed this bug. So, this PR is to make the Ray backend works with pandas < 1.4

``` python
import pandas as pd
import numpy as np

a = np.arange(2)
a.setflags(write=False)

df = pd.DataFrame(a, columns=["a"])
df["a"] = -df["a"]

assert a[1] > 0  # The original array is immutable.
assert df.iloc[1]["a"] < 0  # The df column is a copy one.
```

This code raises a ValueError in pandas < 1.4, but works in pandas >= 1.4
``` python
Traceback (most recent call last):
  File "/home/admin/Work/mars/t2.py", line 9, in <module>
    df["a"] = -df["a"]
  File "/home/admin/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pandas/core/frame.py", line 3612, in __setitem__
    self._set_item(key, value)
  File "/home/admin/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pandas/core/frame.py", line 3797, in _set_item
    self._set_item_mgr(key, value)
  File "/home/admin/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pandas/core/frame.py", line 3756, in _set_item_mgr
    self._iset_item_mgr(loc, value)
  File "/home/admin/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pandas/core/frame.py", line 3746, in _iset_item_mgr
    self._mgr.iset(loc, value)
  File "/home/admin/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pandas/core/internals/managers.py", line 1078, in iset
    blk.set_inplace(blk_locs, value_getitem(val_locs))
  File "/home/admin/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pandas/core/internals/blocks.py", line 360, in set_inplace
    self.values[locs] = values
ValueError: assignment destination is read-only
```

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes https://github.com/mars-project/mars/issues/3215

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
