### PR TITLE
[Shuffle] isolate mappers in different subtasks for fetch_by_index mode

### DIFF
--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -1625,8 +1625,7 @@ def test_add_prefix_suffix(setup):
     pd.testing.assert_series_equal(r.execute().fetch(), raw.add_suffix("_item"))
 
 
-# TODO https://github.com/mars-project/mars/issues/3221
-# @pytest.mark.ray_dag
+@pytest.mark.ray_dag
 @pytest.mark.parametrize("join", ["outer", "left"])
 def test_align_execution(setup, join):
     rs = np.random.RandomState(0)

--- a/mars/services/task/analyzer/analyzer.py
+++ b/mars/services/task/analyzer/analyzer.py
@@ -439,6 +439,26 @@ class GraphAnalyzer:
         # states
         visited = set()
         logic_key_to_subtasks = defaultdict(list)
+        if self._shuffle_fetch_type == ShuffleFetchType.FETCH_BY_INDEX:
+            for chunk in self._chunk_graph.topological_iter():
+                if not isinstance(chunk.op, ShuffleProxy):
+                    continue
+                # Can't use `OperandStage.map` to find mappers directly, since `stage` of some operand
+                # such as `DataFrameIndexAlign` are `OperandStage.map` but not a shuffle mapper sometimes.
+                mapper_chunks = self._chunk_graph.predecessors(chunk)
+                for mapper_chunk in mapper_chunks:
+                    chunk_color = chunk_to_colors[mapper_chunk]
+                    same_color_chunks = color_to_chunks[chunk_color]
+                    mappers = [
+                        c for c in same_color_chunks if c.op.stage == OperandStage.map
+                    ]
+                    if len(mappers) > 1:
+                        # ensure every subtask contains only at most one mapper
+                        for mapper in mappers:
+                            same_color_chunks.remove(mapper)
+                            mapper_color = coloring.next_color()
+                            chunk_to_colors[mapper] = mapper_color
+                            color_to_chunks[mapper_color] = [mapper]
         for chunk in self._chunk_graph.topological_iter():
             if chunk in visited or isinstance(chunk.op, Fetch):
                 # skip fetch chunk
@@ -449,17 +469,6 @@ class GraphAnalyzer:
             if all(isinstance(c.op, Fetch) for c in same_color_chunks):
                 # all fetch ops, no need to gen subtask
                 continue
-            if self._shuffle_fetch_type == ShuffleFetchType.FETCH_BY_INDEX:
-                mappers = [
-                    c for c in same_color_chunks if c.op.stage == OperandStage.map
-                ]
-                if len(mappers) > 1:
-                    # ensure every subtask contains only at most one mapper
-                    for mapper in mappers:
-                        same_color_chunks.remove(mapper)
-                        mapper_color = coloring.next_color()
-                        chunk_to_colors[mapper] = mapper_color
-                        color_to_chunks[mapper_color] = [mapper]
             subtask, inp_subtasks = self._gen_subtask_info(
                 same_color_chunks,
                 chunk_to_subtask,

--- a/mars/services/task/analyzer/fusion.py
+++ b/mars/services/task/analyzer/fusion.py
@@ -48,7 +48,7 @@ class Coloring:
 
         self._coloring_iter = itertools.count()
 
-    def _next_color(self) -> int:
+    def next_color(self) -> int:
         return next(self._coloring_iter)
 
     @classmethod
@@ -82,7 +82,7 @@ class Coloring:
         for chunk, band in self.chunk_to_bands.items():
             band_priority = (band, chunk.op.priority)
             if band_priority not in band_priority_to_colors:
-                band_priority_to_colors[band_priority] = self._next_color()
+                band_priority_to_colors[band_priority] = self.next_color()
 
         band_priority_to_color_list = defaultdict(list)
         for (band, priority), color in band_priority_to_colors.items():
@@ -94,7 +94,7 @@ class Coloring:
             color = band_priority_to_color_list[band, priority][-1]
             size = color_to_size[color]
             if size >= self.initial_same_color_num:
-                color = self._next_color()
+                color = self.next_color()
                 band_priority_to_color_list[band, priority].append(color)
             color_to_size[color] += 1
             op_to_colors[chunk.op] = color
@@ -125,17 +125,17 @@ class Coloring:
             if len(predecessors) == 1 and predecessors[0] in broadcaster_chunk_set:
                 # TODO: handle situation that chunks which specify reassign_workers
                 # predecessor is broadcaster, just allocate a new color
-                color = self._next_color()
+                color = self.next_color()
             elif len(pred_colors) == 1:
                 if self._can_color_same(chunk, predecessors):
                     # predecessors have only 1 color, will color with same one
                     color = next(iter(pred_colors))
                 else:
-                    color = self._next_color()
+                    color = self.next_color()
             else:
                 # has more than 1 color, color a new one
                 assert len(pred_colors) > 1
-                color = self._next_color()
+                color = self.next_color()
 
             op_to_colors[chunk.op] = chunk_to_colors[chunk] = color
 
@@ -155,7 +155,7 @@ class Coloring:
                 stack = []
                 for succ in self.chunk_graph.iter_successors(chunk):
                     if chunk_to_colors[succ] == chunk_color:
-                        new_color = op_to_colors[succ.op] = self._next_color()
+                        new_color = op_to_colors[succ.op] = self.next_color()
                         for c in succ.op.outputs:
                             if c not in self.chunk_graph:  # pragma: no cover
                                 continue
@@ -178,7 +178,7 @@ class Coloring:
                         if node_input_same_color:
                             node_new_color = node_pred_colors[0]
                         else:
-                            node_new_color = self._next_color()
+                            node_new_color = self.next_color()
                         op_to_colors[node.op] = node_new_color
                         for c in node.op.outputs:
                             if c not in self.chunk_graph:  # pragma: no cover


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Mars coloring-based fusion algorithm may fuse multiple mapper subtasks of different shuffles into one subtask, which conflict with `ShuffleFetchType.FETCH_BY_INDEX` shuffle block resolution mode.  In `ShuffleFetchType.FETCH_BY_INDEX` shuffle block resolution mode, shuffle data is resolved by index. If one subtask contains shuffle mapper of different shuffle, current resolution mode won't work.

One solution is adding second-level index to `ShuffleManager` to work around this. It's complicated and not compatible with push-based shuffle and other shuffle system such as [CloudShuffleService](https://github.com/bytedance/CloudShuffleService)、[alibaba/RemoteShuffleService](https://github.com/alibaba/RemoteShuffleService)、[Firestorm](https://github.com/Tencent/Firestorm). 

Considering very little shuffle operands will be fused into the same subtask(currently only `DataFrameIndexAlign` mappers of different shuffle are fused into one subtask). We can just change the fuse algorithm to make those mappers isolated with each other into different subtasks. 
![image](https://user-images.githubusercontent.com/12445254/188384951-2d2b2e11-133f-4140-8845-3e6fafd2a2fa.png)

For other shuffle operands, there won’t be any change in the generated subtask graph.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #3226
#2719
#2916
## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
