### PR TITLE
Fix dataframe loc with slice returns incorrect results

### DIFF
--- a/mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -293,6 +293,11 @@ def test_loc_getitem(setup):
     expected = raw2.loc[[]]
     pd.testing.assert_frame_equal(result, expected)
 
+    df = df2.loc[1:4]
+    result = df.execute().fetch()
+    expected = raw2.loc[1:4]
+    pd.testing.assert_frame_equal(result, expected)
+
     df = df2.loc[1:4, "b":"d"]
     result = df.execute().fetch()
     expected = raw2.loc[1:4, "b":"d"]


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Mars loc will use iloc for some slice inputs, but the loc and iloc bounds are different,
- loc[m:n], m and n are included
- iloc[m:n], m is included, n is excluded

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes https://github.com/mars-project/mars/issues/2584

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
