### PR TITLE
TypeDispatcher support one type multiple serializers

### DIFF
--- a/mars/_utils.pxd
+++ b/mars/_utils.pxd
@@ -23,7 +23,6 @@ cdef class TypeDispatcher:
     cpdef void unregister(self, object type_)
     cdef _reload_lazy_handlers(self)
     cpdef get_handler(self, object type_)
-    cdef _get_handler(self, object type_)
 
 
 cpdef str to_str(s, encoding=*)

--- a/mars/_utils.pxd
+++ b/mars/_utils.pxd
@@ -23,6 +23,7 @@ cdef class TypeDispatcher:
     cpdef void unregister(self, object type_)
     cdef _reload_lazy_handlers(self)
     cpdef get_handler(self, object type_)
+    cdef _get_handler(self, object type_)
 
 
 cpdef str to_str(s, encoding=*)

--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -167,7 +167,8 @@ cdef class TypeDispatcher:
             else:
                 mro = type_.__mro__
             for clz in mro:
-                handler = self._handlers.get(clz) or self._inherit_handlers.get(clz)
+                # only lookup self._handlers for mro clz
+                handler = self._handlers.get(clz)
                 if handler is not None:
                     return handler
             return None

--- a/mars/_utils.pyx
+++ b/mars/_utils.pyx
@@ -124,7 +124,7 @@ cdef class TypeDispatcher:
             self._handlers[type_] = handler
 
     cpdef void unregister(self, object type_):
-        if isinstance(type_, tuple):
+        if type(type_) is not NamedType and isinstance(type_, tuple):
             for t in type_:
                 self.unregister(t)
         else:

--- a/mars/deploy/oscar/tests/test_ray.py
+++ b/mars/deploy/oscar/tests/test_ray.py
@@ -24,7 +24,6 @@ import pytest
 from .... import tensor as mt
 from .... import dataframe as md
 from ....oscar.errors import ReconstructWorkerError
-from ....serialization.ray import register_ray_serializers
 from ....tests.core import require_ray, mock, DICT_NOT_EMPTY
 from ....utils import lazy_import
 from ..ray import (
@@ -165,7 +164,6 @@ def test_sync_execute(ray_start_regular_shared, create_cluster):
 
 
 def _run_web_session(web_address):
-    register_ray_serializers()
     import asyncio
 
     asyncio.new_event_loop().run_until_complete(
@@ -175,7 +173,6 @@ def _run_web_session(web_address):
 
 
 def _sync_web_session_test(web_address):
-    register_ray_serializers()
     new_session(web_address)
     raw = np.random.RandomState(0).rand(10, 5)
     a = mt.tensor(raw, chunk_size=5).sum(axis=1)

--- a/mars/deploy/oscar/tests/test_ray_dag_failover.py
+++ b/mars/deploy/oscar/tests/test_ray_dag_failover.py
@@ -35,7 +35,7 @@ except ImportError:  # pragma: no cover
 @require_ray
 @pytest.mark.parametrize(
     "ray_large_cluster",
-    [{"num_nodes": 0, "use_ray_serialization": False}],
+    [{"num_nodes": 0}],
     indirect=True,
 )
 @pytest.mark.parametrize("reconstruction_enabled", [True, False])

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -101,7 +101,7 @@ class _ArgWrapper:
 
     def __reduce__(self):
         _register_ray_serializers_once()
-        return _argwrapper_unpickler, (serialize(self.message),)
+        return _argwrapper_unpickler, (serialize(self.message, context={"name": "ray"}),)
 
 
 @lazy_import_on_load(ray)

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -96,7 +96,7 @@ class _ArgWrapper:
 
     def __reduce__(self):
         return _argwrapper_unpickler, (
-            serialize(self.message, context={"name": "ray"}),
+            serialize(self.message, context={"serializer": "ray"}),
         )
 
 

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -14,7 +14,6 @@
 
 import asyncio
 import concurrent.futures as futures
-import functools
 import itertools
 import logging
 import time

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -26,7 +26,6 @@ from urllib.parse import urlparse
 
 from ....oscar.profiling import ProfilingData
 from ....serialization import serialize, deserialize
-from ....serialization.ray import register_ray_serializers
 from ....metrics import Metrics
 from ....utils import lazy_import, lazy_import_on_load, implements, classproperty, Timer
 from ...debug import debug_async_timeout
@@ -84,11 +83,7 @@ def msg_to_simple_str(msg):  # pragma: no cover
     return str(type(msg))
 
 
-_register_ray_serializers_once = functools.lru_cache(1)(register_ray_serializers)
-
-
 def _argwrapper_unpickler(serialized_message):
-    _register_ray_serializers_once()
     return _ArgWrapper(deserialize(*serialized_message))
 
 
@@ -100,8 +95,9 @@ class _ArgWrapper:
         self.message = message
 
     def __reduce__(self):
-        _register_ray_serializers_once()
-        return _argwrapper_unpickler, (serialize(self.message, context={"name": "ray"}),)
+        return _argwrapper_unpickler, (
+            serialize(self.message, context={"name": "ray"}),
+        )
 
 
 @lazy_import_on_load(ray)

--- a/mars/oscar/backends/ray/driver.py
+++ b/mars/oscar/backends/ray/driver.py
@@ -17,7 +17,6 @@ import os
 from numbers import Number
 from typing import Dict
 
-from ....serialization.ray import register_ray_serializers, unregister_ray_serializers
 from ....utils import lazy_import
 from ...driver import BaseActorDriver
 from .utils import process_placement_to_address, addresses_to_placement_group_info
@@ -54,7 +53,6 @@ class RayActorDriver(BaseActorDriver):
         }
         logger.info("Create placement group success.")
         cls._cluster_info = cluster_info
-        register_ray_serializers()
 
     @classmethod
     def stop_cluster(cls):
@@ -91,5 +89,4 @@ class RayActorDriver(BaseActorDriver):
                     pass
         ray.util.remove_placement_group(pg)
         cls._cluster_info = dict()
-        unregister_ray_serializers()
         logger.info("Stopped cluster %s.", pg_name)

--- a/mars/oscar/backends/ray/pool.py
+++ b/mars/oscar/backends/ray/pool.py
@@ -27,7 +27,6 @@ from enum import Enum
 from typing import List, Optional
 
 from ... import ServerClosed
-from ....serialization.ray import register_ray_serializers
 from ....utils import lazy_import, ensure_coverage, retry_callable
 from ..config import ActorPoolConfig
 from ..message import CreateActorMessage
@@ -228,7 +227,6 @@ class RayPoolBase(ABC):
     def __init__(self):
         self._actor_pool = None
         self._ray_server = None
-        register_ray_serializers()
         RayServer.set_ray_actor_started()
 
     @abstractmethod

--- a/mars/oscar/backends/ray/tests/test_ray_actor_context.py
+++ b/mars/oscar/backends/ray/tests/test_ray_actor_context.py
@@ -32,12 +32,6 @@ ray = lazy_import("ray")
 @pytest.fixture
 async def actor_pool_context():
     pg_name, n_process = f"ray_cluster_{time.time_ns()}", 2
-    from .....serialization.ray import (
-        register_ray_serializers,
-        unregister_ray_serializers,
-    )
-
-    register_ray_serializers()
     address = process_placement_to_address(pg_name, 0, process_index=0)
     # Hold actor_handle to avoid actor being freed.
     pg = ray.util.placement_group(
@@ -80,7 +74,6 @@ async def actor_pool_context():
             pass
     ray.util.remove_placement_group(pg)
     Router.set_instance(None)
-    unregister_ray_serializers()
     RayServer.clear()
 
 

--- a/mars/serialization/ray.py
+++ b/mars/serialization/ray.py
@@ -15,8 +15,7 @@
 from typing import Any, Dict, List, Tuple
 
 from ..utils import lazy_import
-from .core import Serializer, buffered, PickleSerializer
-from .exception import ExceptionSerializer
+from .core import Serializer, buffered
 
 ray = lazy_import("ray")
 
@@ -33,17 +32,6 @@ class RaySerializer(Serializer):
         return serialized[0]
 
 
-def register_ray_serializers():
-    PickleSerializer.unregister(object)
-    ExceptionSerializer.unregister(Exception)
-    RaySerializer.register(object)
-    RaySerializer.register(ray.ObjectRef)
-    RaySerializer.register(ray.actor.ActorHandle)
-
-
-def unregister_ray_serializers():
-    RaySerializer.unregister(ray.actor.ActorHandle)
-    RaySerializer.unregister(ray.ObjectRef)
-    RaySerializer.unregister(object)
-    PickleSerializer.register(object)
-    ExceptionSerializer.register(Exception)
+RaySerializer.register(object, "ray")
+RaySerializer.register(ray.ObjectRef, "ray")
+RaySerializer.register(ray.actor.ActorHandle, "ray")

--- a/mars/serialization/ray.py
+++ b/mars/serialization/ray.py
@@ -32,6 +32,7 @@ class RaySerializer(Serializer):
         return serialized[0]
 
 
-RaySerializer.register(object, "ray")
-RaySerializer.register(ray.ObjectRef, "ray")
-RaySerializer.register(ray.actor.ActorHandle, "ray")
+if ray:
+    RaySerializer.register(object, "ray")
+    RaySerializer.register(ray.ObjectRef, "ray")
+    RaySerializer.register(ray.actor.ActorHandle, "ray")

--- a/mars/serialization/tests/test_serial.py
+++ b/mars/serialization/tests/test_serial.py
@@ -258,6 +258,7 @@ def test_deserial_errors():
     try:
         MockSerializerForErrors.raises = False
         MockSerializerForErrors.register(CustomList)
+        ListSerializer.register(CustomList, name="test_name")
 
         # error of leaf object is raised
         obj = [1, [[3, UnpickleWithError()]]]
@@ -276,14 +277,17 @@ def test_deserial_errors():
         obj = [CustomList([[1], [[2]]])]
         with pytest.raises(TypeError):
             deserialize(*serialize(obj))
+        deserialize(*serialize(obj, {"serializer": "test_name"}))
 
         # error of non-leaf CustomList is rewritten in parent object
         obj = CustomList([[1], CustomList([[1], [[2]]]), [2]])
         with pytest.raises(SystemError) as exc_info:
             deserialize(*serialize(obj))
         assert isinstance(exc_info.value.__cause__, TypeError)
+        deserialize(*serialize(obj, {"serializer": "test_name"}))
     finally:
         MockSerializerForErrors.unregister(CustomList)
+        ListSerializer.unregister(CustomList, name="test_name")
 
 
 class MockSerializerForSpawn(ListSerializer):

--- a/mars/serialization/tests/test_serial.py
+++ b/mars/serialization/tests/test_serial.py
@@ -288,6 +288,10 @@ def test_deserial_errors():
     finally:
         MockSerializerForErrors.unregister(CustomList)
         ListSerializer.unregister(CustomList, name="test_name")
+        # Above unregister will remove the ListSerializer from deserializers,
+        # so we need to register ListSerializer again to make the
+        # deserializers correct.
+        ListSerializer.register(list)
 
 
 class MockSerializerForSpawn(ListSerializer):

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -40,7 +40,6 @@ from .. import dataframe as md
 from .. import tensor as mt
 from .. import utils
 from ..core import tile, TileableGraph
-from ..serialization.ray import register_ray_serializers
 from .core import require_ray
 
 
@@ -582,7 +581,6 @@ def test_estimate_pandas_size():
 
 @require_ray
 def test_web_serialize_lambda():
-    register_ray_serializers()
     df = md.DataFrame(
         mt.random.rand(10_0000, 4, chunk_size=1_0000), columns=list("abcd")
     )

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -329,9 +329,12 @@ def test_type_dispatcher():
     type1 = type("Type1", (), {})
     type2 = type("Type2", (type1,), {})
     type3 = type("Type3", (), {})
+    type4 = type("Type4", (type2,), {})
+    type5 = type("Type5", (type4,), {})
 
     dispatcher.register(object, lambda x: "Object")
     dispatcher.register(type1, lambda x: "Type1")
+    dispatcher.register(type4, lambda x: "Type4")
     dispatcher.register("pandas.DataFrame", lambda x: "DataFrame")
     dispatcher.register(utils.NamedType("ray", type1), lambda x: "RayType1")
 
@@ -339,11 +342,15 @@ def test_type_dispatcher():
     assert "DataFrame" == dispatcher(pd.DataFrame())
     assert "Object" == dispatcher(type3())
 
+    tp = utils.NamedType("ray", type1)
+    assert dispatcher.get_handler(tp)(tp) == "RayType1"
     tp = utils.NamedType("ray", type2)
     assert dispatcher.get_handler(tp)(tp) == "RayType1"
     tp = utils.NamedType("xxx", type2)
     assert dispatcher.get_handler(tp)(tp) == "Type1"
     assert "Type1" == dispatcher(type2())
+    tp = utils.NamedType("ray", type5)
+    assert dispatcher.get_handler(tp)(tp) == "Type4"
 
     dispatcher.unregister(object)
     with pytest.raises(KeyError):

--- a/mars/tests/test_utils.py
+++ b/mars/tests/test_utils.py
@@ -334,10 +334,17 @@ def test_type_dispatcher():
     dispatcher.register(object, lambda x: "Object")
     dispatcher.register(type1, lambda x: "Type1")
     dispatcher.register("pandas.DataFrame", lambda x: "DataFrame")
+    dispatcher.register(utils.NamedType("ray", type1), lambda x: "RayType1")
 
     assert "Type1" == dispatcher(type2())
     assert "DataFrame" == dispatcher(pd.DataFrame())
     assert "Object" == dispatcher(type3())
+
+    tp = utils.NamedType("ray", type2)
+    assert dispatcher.get_handler(tp)(tp) == "RayType1"
+    tp = utils.NamedType("xxx", type2)
+    assert dispatcher.get_handler(tp)(tp) == "Type1"
+    assert "Type1" == dispatcher(type2())
 
     dispatcher.unregister(object)
     with pytest.raises(KeyError):

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -65,6 +65,7 @@ from ._utils import (  # noqa: F401 # pylint: disable=unused-import
     to_binary,
     to_str,
     to_text,
+    NamedType,
     TypeDispatcher,
     tokenize,
     tokenize_int,
@@ -84,6 +85,7 @@ pd_release_version: Tuple[int] = parse_version(pd.__version__).release
 OBJECT_FIELD_OVERHEAD = 50
 
 # make flake8 happy by referencing these imports
+NamedType = NamedType
 TypeDispatcher = TypeDispatcher
 tokenize = tokenize
 register_tokenizer = register_tokenizer


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Mars serializers are not compatible with Ray serializers because Ray needs to dispatch `ActorHandle` and `ObjectRef` to Ray's serializer for reference counting. But, some `ActorHandle` and `ObjectRef` are nested in objects, then we needs to register object type to RaySerializer which is not compatible with Mars object type serializer.

This PR allows Mars to register multile serializers to one type, then Ray serializers are compatible with Mars serializers. We don't needs to `register_ray_serializers` and `unregister_ray_serializers`.


<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
