### PR TITLE
Optimize the display of task process bar

### DIFF
--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -1571,7 +1571,11 @@ class ProgressBar:
                 else:
                     self.progress_bar = None
             else:
-                self.progress_bar = tqdm(total=100)
+                self.progress_bar = tqdm(
+                    total=100,
+                    bar_format="{l_bar}{bar}| {n:6.2f}/{total_fmt} "
+                    "[{elapsed}<{remaining}, {rate_fmt}{postfix}]",
+                )
 
         self.last_progress: float = 0.0
 

--- a/mars/oscar/backends/ray/communication.py
+++ b/mars/oscar/backends/ray/communication.py
@@ -100,12 +100,7 @@ class _ArgWrapper:
 
 
 @lazy_import_on_load(ray)
-def _init_ray_metrics():
-    # Note: Must init metrics before using and here initializing metrics
-    # with ray backend.
-    from ....metrics import init_metrics
-
-    init_metrics("ray")
+def _init_ray_serialization_deserialization():
     _ray_serialize = ray.serialization.SerializationContext.serialize
     _ray_deserialize_object = ray.serialization.SerializationContext._deserialize_object
     serialized_bytes_counter = Metrics.counter(

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ include_package_data = True
 packages = find:
 install_requires =
     numpy>=1.14.0
-    pandas>=1.0.0
+    pandas>=1.1.0,<=1.4.4
     scipy>=1.0.0
     scikit-learn>=0.20
     numexpr>=2.6.4


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
1. Optimize the display of task process bar
With the optimization of task process bar, it will print as follows when running the codes:
```python
import mars
import mars.tensor as mt
import mars.dataframe as md


mars.new_session()
df = md.DataFrame(
    mt.random.randint(1, 100, size=(1000, 10), chunk_size=(130, 5)),
    columns=list("ABCDEFGHIJ"),
)
df.describe().execute()
```
```
  6%|████▎                                                                    |   5.92/100 [00:02<00:15,  5.91it/s]
 21%|███████████████▍                                                         |  21.07/100 [00:03<00:06, 11.34it/s]
 33%|███████████████████████▉                                                 |  32.76/100 [00:04<00:05, 11.49it/s]
 58%|██████████████████████████████████████████                               |  57.58/100 [00:06<00:03, 11.88it/s]
 70%|███████████████████████████████████████████████████▎                     |  70.27/100 [00:07<00:02, 12.15it/s]
 84%|█████████████████████████████████████████████████████████████▌           |  84.27/100 [00:08<00:01, 12.75it/s]
100%|█████████████████████████████████████████████████████████████████████████| 100.00/100 [00:08<00:00, 11.47it/s]
```

2. Remove unnecessary metric initialization in ray communication
#3233 has implemented lazy initialization of metrics ,so it's not necessary to initialize it in ray communication.

<!-- Please give a short brief about these changes. -->

## Related issue number
Fixed #3263 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
