### PR TITLE
Fix `md.concat` error when there are same fetch chunk data

### DIFF
--- a/mars/core/base.py
+++ b/mars/core/base.py
@@ -15,7 +15,6 @@
 from functools import wraps
 from typing import Dict, Tuple, Type
 
-from ..serialization.core import Placeholder, fast_id
 from ..serialization.serializables import Serializable, StringField
 from ..serialization.serializables.core import SerializableSerializer
 from ..utils import tokenize

--- a/mars/core/base.py
+++ b/mars/core/base.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import wraps
 from typing import Dict, Tuple, Type
 
 from ..serialization.serializables import Serializable, StringField

--- a/mars/core/base.py
+++ b/mars/core/base.py
@@ -133,21 +133,7 @@ class Base(Serializable):
         return kv
 
 
-def buffered_base(func):
-    @wraps(func)
-    def wrapped(self, obj: Base, context: Dict):
-        obj_id = (obj.key, obj.id)
-        if obj_id in context:
-            return Placeholder(fast_id(context[obj_id]))
-        else:
-            context[obj_id] = obj
-            return func(self, obj, context)
-
-    return wrapped
-
-
 class BaseSerializer(SerializableSerializer):
-    @buffered_base
     def serial(self, obj: Base, context: Dict):
         return super().serial(obj, context)
 

--- a/mars/utils.py
+++ b/mars/utils.py
@@ -614,7 +614,6 @@ def build_fetch_chunk(chunk: ChunkType, **kwargs) -> ChunkType:
         is_broadcaster=chunk.is_broadcaster,
         kws=[params],
         _key=chunk.key,
-        _id=chunk.id,
         **kwargs,
     )
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
There is a GraphContainsCycleError when concatenating two DataFrame in which there are same fetch chunks.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #3284 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
