### PR TITLE
[Ray] Implement Ray executor subtask GC

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,7 +77,7 @@ jobs:
           conda install -n test --quiet --yes -c pkgs/main python=$PYTHON certifi
 
           if [[ "$(mars.test.module)" == "learn" ]]; then
-            pip install "xgboost<1.7" lightgbm keras tensorflow faiss-cpu torch torchvision \
+            pip install "xgboost<1.7" lightgbm keras tensorflow "faiss-cpu<1.7.3" torch torchvision \
               statsmodels tsfresh
           fi
         fi

--- a/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
+++ b/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
@@ -184,7 +184,7 @@ def test_ray_execute_subtask_basic():
 
     subtask_id = new_task_id()
     subtask_chunk_graph = _gen_subtask_chunk_graph(b)
-    r = execute_subtask(subtask_id, serialize(subtask_chunk_graph), set(), False)
+    r = execute_subtask(subtask_id, serialize(subtask_chunk_graph), 0, False)
     np.testing.assert_array_equal(r, raw_expect)
     test_get_meta_chunk = subtask_chunk_graph.result_chunks[0]
     r = execute_subtask(subtask_id, serialize(subtask_chunk_graph), 1, False)

--- a/mars/services/task/supervisor/manager.py
+++ b/mars/services/task/supervisor/manager.py
@@ -111,8 +111,12 @@ class TaskManagerActor(mo.Actor):
         self._reserved_finish_tasks = deque(maxlen=reserved_finish_tasks)
 
     async def __pre_destroy__(self):
-        for processor_ref in self._task_id_to_processor_ref.values():
-            await processor_ref.destroy()
+        # Avoid RuntimeError: dictionary changed size during iteration.
+        coros = [
+            processor_ref.destroy()
+            for processor_ref in self._task_id_to_processor_ref.values()
+        ]
+        await asyncio.gather(*coros)
 
     @staticmethod
     def gen_uid(session_id):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Ray executor does not gc the input data and the intermediate data of subtask, then the memory usage of worker may be very high. This PR gc the chunk data after every operand finish.

- The input data are referenced by Ray core worker in _raylet.pyx, we can't gc them. 

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
