### PR TITLE
[Ray] Support worker_mem for ray executor

### DIFF
--- a/mars/deploy/oscar/ray.py
+++ b/mars/deploy/oscar/ray.py
@@ -410,7 +410,7 @@ class RayCluster:
         supervisor_mem: int = 1 * 1024**3,
         worker_num: int = 1,
         worker_cpu: Union[int, float] = 2,
-        worker_mem: int = 4 * 1024**3,
+        worker_mem: int = 2 * 1024**3,
         backend: str = None,
         config: Union[str, Dict] = None,
         n_supervisor_process: int = DEFAULT_SUPERVISOR_SUB_POOL_NUM,
@@ -467,6 +467,7 @@ class RayCluster:
                     n_cpu=self._worker_num * self._worker_cpu,
                     mem_bytes=self._worker_mem,
                     subtask_num_cpus=self._worker_cpu,
+                    subtask_memory=self._worker_mem,
                 )
             )
             assert self._n_supervisor_process == 0, self._n_supervisor_process

--- a/mars/services/task/execution/ray/config.py
+++ b/mars/services/task/execution/ray/config.py
@@ -54,6 +54,9 @@ class RayExecutionConfig(ExecutionConfig):
     def get_subtask_num_cpus(self) -> Union[int, float]:
         return self._ray_execution_config.get("subtask_num_cpus", 1)
 
+    def get_subtask_memory(self) -> Union[int, float]:
+        return self._ray_execution_config.get("subtask_memory", None)
+
     def get_n_cpu(self):
         return self._ray_execution_config["n_cpu"]
 

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -76,12 +76,10 @@ submitted_subtask_number = Metrics.counter(
 started_subtask_number = Metrics.counter(
     "mars.ray_dag.started_subtask_number",
     "The number of started subtask.",
-    ("subtask_id",),
 )
 completed_subtask_number = Metrics.counter(
     "mars.ray_dag.completed_subtask_number",
     "The number of completed subtask.",
-    ("subtask_id",),
 )
 
 
@@ -183,8 +181,7 @@ def execute_subtask(
         subtask outputs and meta for outputs if `output_meta_keys` is provided.
     """
     init_metrics("ray")
-    metrics_tags = {"subtask_id": subtask_id}
-    started_subtask_number.record(1, metrics_tags)
+    started_subtask_number.record(1)
     ray_task_id = ray.get_runtime_context().task_id
     subtask_chunk_graph = deserialize(*subtask_chunk_graph)
     logger.info("Start subtask: %s, ray task id: %s.", subtask_id, ray_task_id)
@@ -277,7 +274,7 @@ def execute_subtask(
     output_values.extend(normal_output.values())
     output_values.extend(mapper_output.values())
     logger.info("Complete subtask: %s, ray task id: %s.", subtask_id, ray_task_id)
-    completed_subtask_number.record(1, metrics_tags)
+    completed_subtask_number.record(1)
     return output_values[0] if len(output_values) == 1 else output_values
 
 

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -598,6 +598,7 @@ class RayTaskExecutor(TaskExecutor):
         )
         subtask_max_retries = self._config.get_subtask_max_retries()
         subtask_num_cpus = self._config.get_subtask_num_cpus()
+        subtask_memory = self._config.get_subtask_memory()
         metrics_tags = {
             "session_id": self._task.session_id,
             "task_id": self._task.task_id,
@@ -630,6 +631,7 @@ class RayTaskExecutor(TaskExecutor):
                 num_cpus=subtask_num_cpus,
                 num_returns=output_count,
                 max_retries=subtask_max_retries,
+                memory=subtask_memory,
                 scheduling_strategy="DEFAULT" if len(input_object_refs) else "SPREAD",
             ).remote(
                 subtask.subtask_id,

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -837,11 +837,9 @@ class RayTaskExecutor(TaskExecutor):
                 for pred in subtask_graph.iter_predecessors(subtask):
                     if pred in gc_subtasks:
                         continue
-                    while not all(
-                        succ in gc_targets
-                        for succ in subtask_graph.iter_successors(pred)
-                    ):
-                        yield
+                    for succ in subtask_graph.iter_successors(pred):
+                        while succ not in gc_targets:
+                            yield
                     if pred.virtual:
                         # For virtual subtask, remove all the predecessors if it is
                         # completed.

--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -33,7 +33,6 @@ from .....core.operand import (
 )
 from .....core.operand.fetch import FetchShuffle
 from .....lib.aio import alru_cache
-from .....lib.ordered_set import OrderedSet
 from .....metrics.api import init_metrics, Metrics
 from .....resource import Resource
 from .....serialization import serialize, deserialize
@@ -326,6 +325,32 @@ class _RayExecutionStage(enum.Enum):
     INIT = 0
     SUBMITTING = 1
     WAITING = 2
+
+
+class OrderedSet:
+    def __init__(self):
+        self._d = set()
+        self._l = list()
+
+    def add(self, item):
+        self._d.add(item)
+        self._l.append(item)
+        assert len(self._d) == len(self._l)
+
+    def update(self, items):
+        tmp = list(items) if isinstance(items, collections.Iterator) else items
+        self._l.extend(tmp)
+        self._d.update(tmp)
+        assert len(self._d) == len(self._l)
+
+    def __contains__(self, item):
+        return item in self._d
+
+    def __getitem__(self, item):
+        return self._l[item]
+
+    def __len__(self):
+        return len(self._d)
 
 
 @dataclass

--- a/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
+++ b/mars/services/task/execution/ray/tests/test_ray_execution_backend.py
@@ -371,6 +371,7 @@ async def test_ray_execution_config(ray_start_regular_shared2):
                 "monitor_interval_seconds": 0,
                 "subtask_max_retries": 4,
                 "subtask_num_cpus": 0.8,
+                "subtask_memory": 1001,
                 "n_cpu": 1,
                 "n_worker": 1,
             },
@@ -394,6 +395,7 @@ async def test_ray_execution_config(ray_start_regular_shared2):
 
     assert MockExecutor.opt["num_cpus"] == 0.8
     assert MockExecutor.opt["max_retries"] == 4
+    assert MockExecutor.opt["memory"] == 1001
 
 
 @require_ray


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

- Support `worker_mem` for ray executor.

```python
# supervisor actor takes 16 CPUs, `num_cpus=16`.
# each ray task takes resources `num_cpus=4, memory=6 * 1024**3`.
mars.new_ray_session(supervisor_cpu=16, worker_cpu=4, worker_mem=6 * 1024**3)
```

- Reduce CPU cost of supervisor GC.
- Use set + list instead of OrderedSet. The OrderedSet may be hangs at accessing by index sometimes.
- Remove `subtask_id` tag of ray executor metrics to reduce the agg results.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
