### PR TITLE
Fix duplicate execution

### DIFF
--- a/mars/core/graph/builder/chunk.py
+++ b/mars/core/graph/builder/chunk.py
@@ -293,10 +293,11 @@ class Tiler:
                     ):
                         _add_result_chunk(self._chunk_to_fetch[chunk])
 
-    def _iter(self, visited):
+    def _iter(self):
         chunk_graph = self._cur_chunk_graph
 
         to_update_tileables = []
+        visited = set()
 
         if chunk_graph is not None:
             # last tiled chunks, add them to processed
@@ -333,9 +334,8 @@ class Tiler:
         return to_update_tileables
 
     def __iter__(self):
-        visited = set()
         while self._tileable_handlers:
-            to_update_tileables = self._iter(visited)
+            to_update_tileables = self._iter()
             yield self._cur_chunk_graph
             for t in to_update_tileables:
                 t.refresh_params()

--- a/mars/dataframe/base/rechunk.py
+++ b/mars/dataframe/base/rechunk.py
@@ -157,7 +157,7 @@ class DataFrameRechunk(DataFrameOperand, DataFrameOperandMixin):
                 params["dtypes"] = pd.concat([c.dtypes for c in inp_chunks_arr[0]])
             if len(inp_slice_chunks) == 1:
                 c = inp_slice_chunks[0]
-                cc = c.op.copy().reset_key().new_chunk(c.op.inputs, kws=[params])
+                cc = c.op.copy().new_chunk(c.op.inputs, kws=[params])
                 out_chunks.append(cc)
             else:
                 out_chunk = DataFrameConcat(

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -91,6 +91,15 @@ def test_to_cpu_execution(setup_gpu):
 
 
 def test_rechunk_execution(setup):
+    ns = np.random.RandomState(0)
+    df = pd.DataFrame(ns.rand(100, 10), columns=["a" + str(i) for i in range(10)])
+
+    # test rechunk after sort
+    mdf = DataFrame(df, chunk_size=10)
+    result = mdf.sort_values("a0").rechunk(chunk_size=10).execute().fetch()
+    expected = df.sort_values("a0")
+    pd.testing.assert_frame_equal(result, expected)
+
     data = pd.DataFrame(np.random.rand(8, 10))
     df = from_pandas_df(pd.DataFrame(data), chunk_size=3)
     df2 = df.rechunk((3, 4))

--- a/mars/dataframe/sort/core.py
+++ b/mars/dataframe/sort/core.py
@@ -85,7 +85,7 @@ class DataFrameSortOperand(DataFrameOperand):
                 shape = tuple(shape)
                 concat_params["shape"] = shape
                 if len(to_combine_chunks) == 1:
-                    c = to_combine_chunks[0]
+                    c = to_combine_chunks[0].copy()
                     c._index = chunk_index
                 else:
                     c = DataFrameConcat(

--- a/mars/dataframe/utils.py
+++ b/mars/dataframe/utils.py
@@ -1412,7 +1412,7 @@ def auto_merge_chunks(
             # concat previous chunks
             if len(to_merge_chunks) == 1:
                 # do not generate concat op for 1 input.
-                c = to_merge_chunks[0]
+                c = to_merge_chunks[0].copy()
                 c._index = (
                     (len(n_split),) if df_or_series.ndim == 1 else (len(n_split), 0)
                 )

--- a/mars/services/task/supervisor/preprocessor.py
+++ b/mars/services/task/supervisor/preprocessor.py
@@ -70,9 +70,8 @@ class CancellableTiler(Tiler):
             return
 
     def _iter_without_check(self):
-        visited = set()
         while self._tileable_handlers:
-            to_update_tileables = self._iter(visited)
+            to_update_tileables = self._iter()
             if not self.cancelled:
                 yield self._cur_chunk_graph
             if not self.cancelled:

--- a/mars/services/task/supervisor/preprocessor.py
+++ b/mars/services/task/supervisor/preprocessor.py
@@ -36,7 +36,7 @@ class CancellableTiler(Tiler):
         self,
         tileable_graph: TileableGraph,
         tile_context: TileContext,
-        processed_chunks: Set[ChunkType],
+        processed_chunks: Set[str],
         chunk_to_fetch: Dict[ChunkType, ChunkType],
         add_nodes: Callable,
         cancelled: asyncio.Event = None,
@@ -70,8 +70,9 @@ class CancellableTiler(Tiler):
             return
 
     def _iter_without_check(self):
+        visited = set()
         while self._tileable_handlers:
-            to_update_tileables = self._iter()
+            to_update_tileables = self._iter(visited)
             if not self.cancelled:
                 yield self._cur_chunk_graph
             if not self.cancelled:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Some chunks are copied when tiling (e.g. copied chunks with new chunk index), these copied chunks can't be treated as executed, so they will be regenerated. This PR use chunk key instead of chunk object to check whether it is executed.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes https://github.com/mars-project/mars/issues/3299

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
