### PR TITLE
Fix s3 client kwargs

### DIFF
--- a/mars/lib/filesystem/base.py
+++ b/mars/lib/filesystem/base.py
@@ -257,7 +257,7 @@ class FileSystem(ABC):
         return options
 
     @classmethod
-    def get_storage_options(cls, storage_options, path):
-        options = cls.parse_from_path(path)
+    def get_storage_options(cls, storage_options: Dict, uri: str) -> Dict:
+        options = cls.parse_from_path(uri)
         storage_options.update(options)
         return storage_options

--- a/mars/lib/filesystem/base.py
+++ b/mars/lib/filesystem/base.py
@@ -255,3 +255,9 @@ class FileSystem(ABC):
         if parsed_uri.password:
             options["password"] = parsed_uri.password
         return options
+
+    @classmethod
+    def get_storage_options(cls, storage_options, path):
+        options = cls.parse_from_path(path)
+        storage_options.update(options)
+        return storage_options

--- a/mars/lib/filesystem/core.py
+++ b/mars/lib/filesystem/core.py
@@ -54,8 +54,9 @@ def get_fs(path: path_type, storage_options: Dict = None) -> FileSystem:
             # local file systems are singletons.
             return file_system_type.get_instance()
         else:
-            options = file_system_type.parse_from_path(path)
-            storage_options.update(options)
+            storage_options = file_system_type.get_storage_options(
+                storage_options, path
+            )
             return file_system_type(**storage_options)
     elif scheme in _scheme_to_dependencies:  # pragma: no cover
         dependencies = ", ".join(_scheme_to_dependencies[scheme])

--- a/mars/lib/filesystem/s3.py
+++ b/mars/lib/filesystem/s3.py
@@ -26,8 +26,9 @@ An example to read csv from s3
 >>>         "endpoint_url": "http://192.168.1.12:9000",
 >>>         "aws_access_key_id": "<s3 access id>",
 >>>         "aws_secret_access_key": "<s3 access key>",
+>>>         "aws_session_token": "<s3 session token>",
 >>>     }})
->>> # Export environment vars AWS_ENDPOINT_URL / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.
+>>> # Export environment vars AWS_ENDPOINT_URL / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN.
 >>> mdf = md.read_csv("s3://bucket/example.csv", index_col=0)
 >>> r = mdf.head(1000).execute()
 >>> print(r)
@@ -61,6 +62,16 @@ if FsSpecAdapter is not None:  # pragma: no cover
             }
             client_kwargs = {k: v for k, v in client_kwargs.items() if v is not None}
             return {"client_kwargs": client_kwargs}
+
+        @classmethod
+        def get_storage_options(cls, storage_options, path):
+            options = cls.parse_from_path(path)
+            for k, v in storage_options.items():
+                if k == "client_kwargs":
+                    options["client_kwargs"].update(v)
+                else:
+                    options[k] = v
+            return options
 
     register_filesystem("s3", S3FileSystem)
 else:

--- a/mars/lib/filesystem/s3.py
+++ b/mars/lib/filesystem/s3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from typing import Dict
 
 """
 An example to read csv from s3
@@ -64,8 +65,8 @@ if FsSpecAdapter is not None:  # pragma: no cover
             return {"client_kwargs": client_kwargs}
 
         @classmethod
-        def get_storage_options(cls, storage_options, path):
-            options = cls.parse_from_path(path)
+        def get_storage_options(cls, storage_options: Dict, uri: str) -> Dict:
+            options = cls.parse_from_path(uri)
             for k, v in storage_options.items():
                 if k == "client_kwargs":
                     options["client_kwargs"].update(v)

--- a/mars/lib/filesystem/tests/test_s3.py
+++ b/mars/lib/filesystem/tests/test_s3.py
@@ -25,12 +25,18 @@ class KwArgsException(Exception):
         self.kwargs = kwargs
 
 
-class TestS3FileSystem(S3FileSystem):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        raise KwArgsException(kwargs)
+if S3FileSystem is not None:
+
+    class TestS3FileSystem(S3FileSystem):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            raise KwArgsException(kwargs)
+
+else:
+    TestS3FileSystem = None
 
 
+@pytest.mark.skipif(S3FileSystem is None, reason="S3 is not supported")
 def test_client_kwargs():
     register_filesystem("s3", TestS3FileSystem)
 

--- a/mars/lib/filesystem/tests/test_s3.py
+++ b/mars/lib/filesystem/tests/test_s3.py
@@ -15,6 +15,7 @@ import os
 
 import pytest
 
+from ....dataframe import read_csv
 from ..core import register_filesystem
 from ..s3 import S3FileSystem
 
@@ -31,8 +32,6 @@ class TestS3FileSystem(S3FileSystem):
 
 
 def test_client_kwargs():
-    import mars.dataframe as md
-
     register_filesystem("s3", TestS3FileSystem)
 
     test_kwargs = {
@@ -45,7 +44,7 @@ def test_client_kwargs():
     def _assert_true():
         # Pass endpoint_url / aws_access_key_id / aws_secret_access_key / aws_session_token to read_csv.
         with pytest.raises(KwArgsException) as e:
-            md.read_csv(
+            read_csv(
                 "s3://bucket/example.csv",
                 index_col=0,
                 storage_options={"client_kwargs": test_kwargs},
@@ -75,7 +74,7 @@ def test_client_kwargs():
 
         for k, v in test_kwargs.items():
             with pytest.raises(KwArgsException) as e:
-                md.read_csv(
+                read_csv(
                     "s3://bucket/example.csv",
                     index_col=0,
                     storage_options={"client_kwargs": {k: v}},

--- a/mars/lib/filesystem/tests/test_s3.py
+++ b/mars/lib/filesystem/tests/test_s3.py
@@ -1,0 +1,93 @@
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import pytest
+
+from ..core import register_filesystem
+from ..s3 import S3FileSystem
+
+
+class KwArgsException(Exception):
+    def __init__(self, kwargs):
+        self.kwargs = kwargs
+
+
+class TestS3FileSystem(S3FileSystem):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        raise KwArgsException(kwargs)
+
+
+def test_client_kwargs():
+    import mars.dataframe as md
+
+    register_filesystem("s3", TestS3FileSystem)
+
+    test_kwargs = {
+        "endpoint_url": "http://192.168.1.12:9000",
+        "aws_access_key_id": "test_id",
+        "aws_secret_access_key": "test_key",
+        "aws_session_token": "test_session_token",
+    }
+
+    def _assert_true():
+        # Pass endpoint_url / aws_access_key_id / aws_secret_access_key / aws_session_token to read_csv.
+        with pytest.raises(KwArgsException) as e:
+            md.read_csv(
+                "s3://bucket/example.csv",
+                index_col=0,
+                storage_options={"client_kwargs": test_kwargs},
+            )
+        assert e.value.kwargs == {
+            "client_kwargs": {
+                "endpoint_url": "http://192.168.1.12:9000",
+                "aws_access_key_id": "test_id",
+                "aws_secret_access_key": "test_key",
+                "aws_session_token": "test_session_token",
+            }
+        }
+
+    _assert_true()
+
+    test_env = {
+        "AWS_ENDPOINT_URL": "a",
+        "AWS_ACCESS_KEY_ID": "b",
+        "AWS_SECRET_ACCESS_KEY": "c",
+        "AWS_SESSION_TOKEN": "d",
+    }
+    for k, v in test_env.items():
+        os.environ[k] = v
+
+    try:
+        _assert_true()
+
+        for k, v in test_kwargs.items():
+            with pytest.raises(KwArgsException) as e:
+                md.read_csv(
+                    "s3://bucket/example.csv",
+                    index_col=0,
+                    storage_options={"client_kwargs": {k: v}},
+                )
+            expect = {
+                "endpoint_url": "a",
+                "aws_access_key_id": "b",
+                "aws_secret_access_key": "c",
+                "aws_session_token": "d",
+            }
+            expect[k] = v
+            assert e.value.kwargs == {"client_kwargs": expect}
+    finally:
+        for k, v in test_env.items():
+            os.environ.pop(k, None)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Fix "client_kwargs" not works for s3 storage options.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
