### PR TITLE
Vineyard: from unordered chunks.

### DIFF
--- a/mars/dataframe/datasource/from_vineyard.py
+++ b/mars/dataframe/datasource/from_vineyard.py
@@ -198,7 +198,7 @@ class DataFrameFromVineyardChunk(DataFrameOperand, DataFrameOperandMixin):
         # check if chunk indexes has unknown value
         has_unknown_chunk_index = False
         for infos in in_chunk_results:
-            for _, info in infos.iterrows():
+            for _, info in infos.iterrows():  # pragma: no cover
                 if len(info["index"]) == 0 or -1 in info["index"]:
                     has_unknown_chunk_index = True
                     break
@@ -214,7 +214,7 @@ class DataFrameFromVineyardChunk(DataFrameOperand, DataFrameOperandMixin):
                 dtypes = info["dtypes"]
                 columns = info["columns"]
                 shape = info["shape"]
-                if has_unknown_chunk_index:
+                if has_unknown_chunk_index:  # pragma: no cover
                     chunk_index = (chunk_location, 0)
                     chunk_location += 1
                 else:

--- a/mars/dataframe/datasource/from_vineyard.py
+++ b/mars/dataframe/datasource/from_vineyard.py
@@ -142,8 +142,8 @@ class DataFrameFromVineyard(DataFrameOperand, DataFrameOperandMixin):
                     dtypes.append(dtype)
                 dtypes = pd.Series(dtypes, index=columns)
             chunk_index = (
-                chunk_meta["partition_index_row_"],
-                chunk_meta["partition_index_column_"],
+                chunk_meta.get("partition_index_row_", -1),
+                chunk_meta.get("partition_index_column_", -1),
             )
             # chunk: (chunk_id, worker_address, dtype, shape, index, columns)
             chunks.append(
@@ -173,7 +173,13 @@ class DataFrameFromVineyardChunk(DataFrameOperand, DataFrameOperandMixin):
         super().__init__(vineyard_socket=vineyard_socket, object_id=object_id, **kw)
 
     def __call__(self, meta):
-        return self.new_dataframe([meta])
+        return self.new_dataframe(
+            [meta],
+            shape=meta.shape,
+            dtypes=meta.dtypes,
+            index_value=meta.index_value,
+            columns_value=meta.columns_value,
+        )
 
     @classmethod
     def tile(cls, op):
@@ -182,13 +188,25 @@ class DataFrameFromVineyardChunk(DataFrameOperand, DataFrameOperandMixin):
 
         ctx = get_context()
 
-        in_chunk_keys = [chunk.key for chunk in op.inputs[0].chunks]
         out_chunks = []
         chunk_map = dict()
         dtypes, columns = None, None
-        for chunk, infos in zip(
-            op.inputs[0].chunks, ctx.get_chunks_result(in_chunk_keys)
-        ):
+
+        in_chunk_keys = [chunk.key for chunk in op.inputs[0].chunks]
+        in_chunk_results = ctx.get_chunks_result(in_chunk_keys)
+
+        # check if chunk indexes has unknown value
+        has_unknown_chunk_index = False
+        for infos in in_chunk_results:
+            for _, info in infos.iterrows():
+                if len(info["index"]) == 0 or -1 in info["index"]:
+                    has_unknown_chunk_index = True
+                    break
+
+        # assume chunks are row-splitted if chunk index is unknown
+        chunk_location = 0
+
+        for chunk, infos in zip(op.inputs[0].chunks, in_chunk_results):
             for _, info in infos.iterrows():
                 chunk_op = op.copy().reset_key()
                 chunk_op.object_id = info["id"]
@@ -196,7 +214,11 @@ class DataFrameFromVineyardChunk(DataFrameOperand, DataFrameOperandMixin):
                 dtypes = info["dtypes"]
                 columns = info["columns"]
                 shape = info["shape"]
-                chunk_index = info["index"]
+                if has_unknown_chunk_index:
+                    chunk_index = (chunk_location, 0)
+                    chunk_location += 1
+                else:
+                    chunk_index = info["index"]
                 chunk_map[chunk_index] = info["shape"]
                 out_chunk = chunk_op.new_chunk(
                     [chunk],
@@ -251,7 +273,7 @@ def from_vineyard(df, vineyard_socket=None):
         gpu=None,
     )
     meta = metaop(
-        shape=(np.nan,),
+        shape=(np.nan, np.nan),
         dtypes=pd.Series([]),
         index_value=parse_index(pd.Index([])),
         columns_value=parse_index(pd.Index([])),

--- a/mars/tensor/datasource/from_vineyard.py
+++ b/mars/tensor/datasource/from_vineyard.py
@@ -137,7 +137,7 @@ class TensorFromVineyardChunk(TensorOperand, TensorOperandMixin):
         # check if chunk indexes has unknown value
         has_unknown_chunk_index = False
         for infos in in_chunk_results:
-            for info in infos[0]:
+            for info in infos[0]:  # pragma: no cover
                 if len(info[4]) == 0 or -1 in info[4]:
                     has_unknown_chunk_index = True
                     break
@@ -152,7 +152,7 @@ class TensorFromVineyardChunk(TensorOperand, TensorOperandMixin):
                 chunk_op.expect_worker = info[1]
                 dtype = info[2]
                 shape = info[3]
-                if has_unknown_chunk_index:
+                if has_unknown_chunk_index:  # pragma: no cover
                     chunk_index = (chunk_location,)
                     chunk_location += 1
                 else:

--- a/mars/tensor/datasource/from_vineyard.py
+++ b/mars/tensor/datasource/from_vineyard.py
@@ -95,7 +95,7 @@ class TensorFromVineyard(TensorNoInput):
                 chunk_meta["value_type_"], chunk_meta.get("value_type_meta_", None)
             )
             shape = tuple(json.loads(chunk_meta["shape_"]))
-            chunk_index = tuple(json.loads(chunk_meta["partition_index_"]))
+            chunk_index = tuple(json.loads(chunk_meta.get("partition_index_", "[]")))
             # chunk: (chunk_id, worker_address, dtype, shape, index)
             chunks.append(
                 (repr(chunk_meta.id), ctx.worker_address, dtype, shape, chunk_index)
@@ -119,7 +119,7 @@ class TensorFromVineyardChunk(TensorOperand, TensorOperandMixin):
         super().__init__(vineyard_socket=vineyard_socket, object_id=object_id, **kw)
 
     def __call__(self, meta):
-        return self.new_tensor([meta], shape=(np.nan,))
+        return self.new_tensor([meta], shape=meta.shape, dtype=meta.dtype)
 
     @classmethod
     def tile(cls, op):
@@ -128,20 +128,35 @@ class TensorFromVineyardChunk(TensorOperand, TensorOperandMixin):
 
         ctx = get_context()
 
-        in_chunk_keys = [chunk.key for chunk in op.inputs[0].chunks]
         out_chunks = []
         chunk_map = dict()
         dtype = None
-        for chunk, infos in zip(
-            op.inputs[0].chunks, ctx.get_chunks_result(in_chunk_keys)
-        ):
+        in_chunk_keys = [chunk.key for chunk in op.inputs[0].chunks]
+        in_chunk_results = ctx.get_chunks_result(in_chunk_keys)
+
+        # check if chunk indexes has unknown value
+        has_unknown_chunk_index = False
+        for infos in in_chunk_results:
+            for info in infos[0]:
+                if len(info[4]) == 0 or -1 in info[4]:
+                    has_unknown_chunk_index = True
+                    break
+
+        # assume chunks are row-splitted if chunk index is unknown
+        chunk_location = 0
+
+        for chunk, infos in zip(op.inputs[0].chunks, in_chunk_results):
             for info in infos[0]:  # n.b. 1-element ndarray
                 chunk_op = op.copy().reset_key()
                 chunk_op.object_id = info[0]
                 chunk_op.expect_worker = info[1]
                 dtype = info[2]
                 shape = info[3]
-                chunk_index = info[4]
+                if has_unknown_chunk_index:
+                    chunk_index = (chunk_location,)
+                    chunk_location += 1
+                else:
+                    chunk_index = info[4]
                 chunk_map[chunk_index] = info[3]
                 out_chunk = chunk_op.new_chunk(
                     [chunk], shape=shape, dtype=dtype, index=chunk_index
@@ -181,6 +196,7 @@ def fromvineyard(tensor, vineyard_socket=None):
     metaop = TensorFromVineyard(
         vineyard_socket=vineyard_socket,
         object_id=object_id,
+        shape=(np.nan,),
         dtype=np.dtype("byte"),
         gpu=None,
     )


### PR DESCRIPTION
## What do these changes do?

Fixes bugs in processing chunk index of vineyard's global dataframe.

The global dataframe may be generated by upstream systems and is row-splitted without a valid global chunk_index value.

## Related issue number

N/A

## Check code requirements

- [ ] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
