### PR TITLE
Pin xgboost_ray<0.1.14

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -104,7 +104,7 @@ jobs:
               rm -fr /tmp/etcd-$ETCD_VER-linux-amd64.tar.gz /tmp/etcd-download-test
             fi
             if [ -n "$WITH_RAY" ] || [ -n "$WITH_RAY_DAG" ] || [ -n "$WITH_RAY_DEPLOY" ]; then
-              pip install "xgboost_ray" "protobuf<4"
+              pip install "xgboost_ray<0.1.14" "protobuf<4"
               # Ray Datasets need pyarrow>=6.0.1
               pip install "pyarrow>=6.0.1"
             fi

--- a/mars/dataframe/datasource/read_sql.py
+++ b/mars/dataframe/datasource/read_sql.py
@@ -355,9 +355,9 @@ class DataFrameReadSQL(
             from sqlalchemy import sql
 
             engine = sa.create_engine(op.con, **(op.engine_kwargs or dict()))
-            try:
+            with engine.connect() as connection:
                 part_col = selectable.columns[op.partition_col]
-                range_results = engine.execute(
+                range_results = connection.execute(
                     sql.select(sql.func.min(part_col), sql.func.max(part_col))
                 )
 
@@ -365,8 +365,6 @@ class DataFrameReadSQL(
                 if op.parse_dates and op.partition_col in op.parse_dates:
                     op.low_limit = op._parse_datetime(op.low_limit)
                     op.high_limit = op._parse_datetime(op.high_limit)
-            finally:
-                engine.dispose()
 
         if isinstance(op.low_limit, (datetime.datetime, np.datetime64, pd.Timestamp)):
             seps = pd.date_range(op.low_limit, op.high_limit, op.num_partitions + 1)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

The `xgboost_ray==0.1.14` has compatibility issue with the latest Ray. This PR

- Pin `xgboost_ray<0.1.14`.
- DataFrameReadSQL compatible with `SQLAlchemy>2`.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
