### PR TITLE
[BUG] Fix the long standing `ValueError` during the GPU/CUDA initialization

### DIFF
--- a/mars/services/task/execution/ray/executor.py
+++ b/mars/services/task/execution/ray/executor.py
@@ -178,7 +178,7 @@ def execute_subtask(
     """
     init_metrics("ray")
     started_subtask_number.record(1)
-    ray_task_id = ray.get_runtime_context().task_id
+    ray_task_id = ray.get_runtime_context().get_task_id()
     subtask_chunk_graph = deserialize(*subtask_chunk_graph)
     logger.info("Start subtask: %s, ray task id: %s.", subtask_id, ray_task_id)
     # Optimize chunk graph.


### PR DESCRIPTION
Fixes the long standing error, i.e., `ValueError: bytes is not a 16-char string`, during gpu/cuda init. 

Probably:
Fixes: https://github.com/mars-project/mars/issues/3176.
Fixes: https://github.com/mars-project/mars/issues/3231.
Fixes: https://github.com/mars-project/mars/issues/3325.

Coping from https://github.com/xprobe-inc/xorbits/pull/242. All credits belong to them.

Since Mars hasn't public GPU CI, I would test it on our internal GPU cluster later.

DON'T MERGE it temporarily, since I have to rebase it after https://github.com/mars-project/mars/pull/3336 is merged.