### PR TITLE
Fix: TypeError in sort_values after dropna

### DIFF
--- a/mars/dataframe/sort/sort_values.py
+++ b/mars/dataframe/sort/sort_values.py
@@ -111,7 +111,13 @@ class DataFrameSortValues(DataFrameSortOperand, DataFramePSRSOperandMixin):
     def __call__(self, a):
         assert self.axis == 0
         if self.ignore_index:
-            index_value = parse_index(pd.RangeIndex(a.shape[0]))
+            # Fix for the bug: handle NaN or unknown dimensions
+            if not isinstance(a.shape[0], int):
+                index_value = parse_index(
+                    pd.RangeIndex(-1)
+                )  # Handle unknown dimensions
+            else:
+                index_value = parse_index(pd.RangeIndex(a.shape[0]))
         else:
             if isinstance(a.index_value.value, IndexValue.RangeIndex):
                 index_value = parse_index(pd.Index([], dtype=np.int64))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This pull request resolves the issue where `sort_values(ignore_index=True)` raises a `TypeError` after using `dropna`.  
The fix ensures proper handling of unknown dimensions by parsing `pd.RangeIndex(-1)` when the size of the dimension is unknown.

## Related issue number

Fixes #2488

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://mars-project.readthedocs.io/en/latest/development/contributing.html#check-code-styles) for how to run them
